### PR TITLE
feat(query): request-cost-aware logs fetch policy and fetch bound

### DIFF
--- a/crates/ravel-query/src/config.rs
+++ b/crates/ravel-query/src/config.rs
@@ -2,6 +2,8 @@
 
 use std::time::Duration;
 
+use ravel_types::cost_profile::StoreCostProfile;
+
 /// Default cap on segments a single query may fan out over.
 pub const DEFAULT_MAX_SEGMENTS: usize = 1024;
 /// Default cap on distinct series a single query may materialize.
@@ -124,6 +126,210 @@ impl RequestLimit {
     }
 }
 
+/// Default fetch bound ([`EngineConfig::logs_max_fetch_run_bytes`], ADR-0996
+/// decision 2). Bounds one covering GET's length: an object at or under it is
+/// read in a single [`crate::log_fetcher`] covering GET, and a larger one is
+/// read as `ceil(size / bound)` sequential covering sub-range GETs, so no
+/// single request moves more than this many bytes.
+pub const DEFAULT_LOG_MAX_FETCH_RUN_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Bytes in one GiB, the unit both of a [`StoreCostProfile`]'s per-GiB prices
+/// are quoted in. The cost-based derivation below needs a per-byte rate, so it
+/// multiplies the per-request price by this before dividing by the per-GiB
+/// byte price (ADR-0996 decision 2, "multiplies BEFORE it divides, in u128").
+const BYTES_PER_GIB: u128 = 1 << 30;
+
+/// The operator's logs fetch-policy intent (ADR-0996 decision 2). One knob
+/// (`--logs-fetch-policy`) that resolves, at startup, to the byte-denominated
+/// request cost the fetch layer already runs on
+/// ([`crate::BlockRangeFetcher`]'s `request_cost_bytes`) plus the routing
+/// threshold. It never reaches the fetch layer as a policy: prices and intent
+/// live here, the fetch layer learns only byte quantities (ADR-0904's layering,
+/// preserved).
+///
+/// The policy must never be derivable from query text, headers, or tickets
+/// (ADR-0904 decision 4, inverted: under request billing a tenant forcing
+/// `ByteMinimal` per query would multiply the deployment's request bill). It is
+/// an operator surface only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LogsFetchPolicy {
+    /// Minimize request count: saturate the exchange rate so every object is
+    /// read whole in one covering GET, no probe and no ranged read. The
+    /// cost-preferring shape on an intra-region deployment where transfer is
+    /// free.
+    RequestMinimal,
+    /// ADR-0904's byte-minimizing behaviour, byte for byte for objects at or
+    /// under the fetch bound: the derived latency break-even request cost, with
+    /// ranged reads wherever they save more bytes than a request costs. Kept for
+    /// egress-billed and network-constrained deployments.
+    ByteMinimal,
+    /// Derive the request cost from the active [`StoreCostProfile`]. At the
+    /// reference (intra-region) profile this resolves to `RequestMinimal`
+    /// behaviour; at egress prices it resolves to a small byte cost the floors
+    /// clamp. The default, so a reference deployment gets request-minimal
+    /// fetching with no operator action.
+    #[default]
+    CostBased,
+}
+
+impl LogsFetchPolicy {
+    /// The policy name as it appears on the `--logs-fetch-policy` flag and in a
+    /// provenance stamp.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LogsFetchPolicy::RequestMinimal => "request-minimal",
+            LogsFetchPolicy::ByteMinimal => "byte-minimal",
+            LogsFetchPolicy::CostBased => "cost-based",
+        }
+    }
+}
+
+/// A resolved fetch policy: the byte quantities and routing decisions the fetch
+/// layer runs on (ADR-0996 decision 2), plus the facts a startup path logs.
+///
+/// [`resolve_logs_fetch`] produces this from the policy, the active profile, and
+/// the explicit ADR-0904 overrides. The server (task 996-5) hands
+/// [`Self::request_cost_bytes`] and [`Self::block_range_threshold`] to the
+/// fetcher and logs [`Self::overridden_block_range_threshold`] and
+/// [`Self::saturated_profile`]; nothing here reads a price.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedLogsFetch {
+    /// The byte-denominated request cost, the single quantity every
+    /// range-vs-whole-object decision in the fetch layer is driven from
+    /// ([`EngineConfig::logs_request_cost_bytes`]). `u64::MAX` under
+    /// request-minimal (and a cost-based derivation whose byte price is zero or
+    /// near-zero), which saturates every derived crossover to whole-object.
+    pub request_cost_bytes: u64,
+    /// The routing threshold ([`EngineConfig::logs_block_range_threshold`]).
+    /// request-minimal saturates it to `u64::MAX` so no object is ever routed to
+    /// the ranged path, overriding an explicit `--logs-block-range-threshold`.
+    pub block_range_threshold: u64,
+    /// True under request-minimal: the plan phase suppresses its per-segment
+    /// footer probe, because the scan read is whole-object anyway and a probe
+    /// that cannot reduce requests is pure spend.
+    pub suppress_plan_footer_probe: bool,
+    /// Set to the operator's explicit `--logs-block-range-threshold` when
+    /// request-minimal overrode it, so the startup path can log the overridden
+    /// flag (ADR-0996 decision 2). `None` when no explicit threshold was set or
+    /// the policy left it in force.
+    pub overridden_block_range_threshold: Option<u64>,
+    /// Set to the active profile's name when a cost-based derivation saturated
+    /// the rate at `u64::MAX`, so the startup path can log the saturation naming
+    /// the profile. `None` otherwise.
+    pub saturated_profile: Option<String>,
+}
+
+/// Resolve a [`LogsFetchPolicy`] to the byte quantities and routing decisions
+/// the fetch layer runs on (ADR-0996 decision 2).
+///
+/// This is the one place a price becomes a byte rate; the resulting
+/// [`ResolvedLogsFetch`] carries only bytes and booleans, so the fetch layer
+/// never learns a price (ADR-0904 layering). The startup path (task 996-5)
+/// calls this and hands the byte quantities to the fetcher.
+///
+/// Precedence, from ADR-0996 decision 2 and its ADR-0904 alignment:
+///
+/// - An explicit `--logs-request-cost-bytes` (`explicit_request_cost_bytes`)
+///   WINS over policy for the rate: policy is the intent layer, the byte flag
+///   the expert escape hatch.
+/// - `RequestMinimal` still overrides BOTH routing thresholds, including an
+///   explicitly set `--logs-block-range-threshold`: a policy that saturated only
+///   the derived rate would let a low explicit threshold send projected objects
+///   down the ranged path through `ranged_projection_pays`.
+///
+/// The cost-based derivation multiplies before it divides, in `u128`:
+/// `get_class_nanodollars * BYTES_PER_GIB / (transfer + retrieval)`,
+/// floor-rounded with a one-byte minimum and saturated high at `u64::MAX`. It
+/// saturates to request-minimal only when BOTH byte prices are zero. The result
+/// is NOT clamped to the fetch bound (that would let a projection saving more
+/// than the bound re-select ranged routing under an effectively request-minimal
+/// policy); the 64 KiB gap and 512 KiB crossover floors are applied downstream
+/// in the fetch layer.
+pub fn resolve_logs_fetch(
+    policy: LogsFetchPolicy,
+    profile: &StoreCostProfile,
+    explicit_request_cost_bytes: Option<u64>,
+    configured_block_range_threshold: u64,
+    explicit_block_range_threshold: Option<u64>,
+) -> ResolvedLogsFetch {
+    // The rate: an explicit byte flag wins over policy; otherwise the policy
+    // decides. Only a cost-based derivation can saturate for a numeric reason
+    // worth logging.
+    let (request_cost_bytes, saturated_profile) = match explicit_request_cost_bytes {
+        Some(explicit) => (explicit, None),
+        None => match policy {
+            LogsFetchPolicy::RequestMinimal => (u64::MAX, None),
+            LogsFetchPolicy::ByteMinimal => (configured_block_range_threshold_rate(profile), None),
+            LogsFetchPolicy::CostBased => resolve_cost_based_rate(profile),
+        },
+    };
+
+    // Routing: request-minimal saturates the threshold so no object routes
+    // ranged, overriding an explicit flag (which is then logged). Every other
+    // policy keeps the configured threshold.
+    let request_minimal = matches!(policy, LogsFetchPolicy::RequestMinimal);
+    let (block_range_threshold, overridden_block_range_threshold) = if request_minimal {
+        (u64::MAX, explicit_block_range_threshold)
+    } else {
+        (configured_block_range_threshold, None)
+    };
+
+    ResolvedLogsFetch {
+        request_cost_bytes,
+        block_range_threshold,
+        suppress_plan_footer_probe: request_minimal,
+        overridden_block_range_threshold,
+        saturated_profile,
+    }
+}
+
+/// byte-minimal keeps today's configured request cost. It has no profile
+/// dependency; the profile argument is taken only so the signature matches the
+/// other arms and a future byte-price-aware byte-minimal has a seam. Named for
+/// clarity at the call site above.
+fn configured_block_range_threshold_rate(_profile: &StoreCostProfile) -> u64 {
+    crate::DEFAULT_LOG_REQUEST_COST_BYTES
+}
+
+/// The cost-based byte rate and, when it saturated at `u64::MAX`, the profile
+/// name to log. `get_class_nanodollars * BYTES_PER_GIB / (transfer + retrieval)`
+/// in `u128`, floored at one byte, saturated high; both byte prices zero
+/// saturates to request-minimal.
+fn resolve_cost_based_rate(profile: &StoreCostProfile) -> (u64, Option<String>) {
+    let byte_price = u128::from(profile.transfer_nanodollars_per_gib)
+        .saturating_add(u128::from(profile.retrieval_nanodollars_per_gib));
+    if byte_price == 0 {
+        // Free bytes: a saved request is worth an unbounded number of free
+        // bytes, so whole-object always. The reference profile lands here, which
+        // is why cost-based defaults to request-minimal behaviour there.
+        return (u64::MAX, Some(profile.name.clone()));
+    }
+    let quotient = u128::from(profile.get_class_nanodollars) * BYTES_PER_GIB / byte_price;
+    match u64::try_from(quotient) {
+        // Floor at one byte so a sub-nanodollar-per-byte price can never resolve
+        // to a zero rate (which would make every crossover trivially true).
+        Ok(rate) => (rate.max(1), None),
+        // A near-free byte price against a large GET price overflows u64: an
+        // astronomically high rate means whole-object always, so saturate and
+        // log the profile.
+        Err(_) => (u64::MAX, Some(profile.name.clone())),
+    }
+}
+
+/// Why an [`EngineConfig`] could not be resolved into fetch-layer quantities
+/// (ADR-0996 decision 2). A rejected value is always one of these, never a
+/// panic or a silent clamp.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum EngineConfigError {
+    /// [`EngineConfig::logs_max_fetch_run_bytes`] was zero. The segmented
+    /// covering fallback divides the object size by it, so zero is refused
+    /// rather than dividing by zero.
+    #[error(
+        "logs_max_fetch_run_bytes must be non-zero: the segmented covering fallback divides by it"
+    )]
+    ZeroFetchBound,
+}
+
 /// [`crate::QueryEngine`] resource limits and concurrency. Every limit is
 /// enforced as a typed error (docs/query-engine.md "never silent partial
 /// results"), never a truncation.
@@ -185,6 +391,32 @@ pub struct EngineConfig {
     /// carries the derivation. Raising it above the largest object a deployment
     /// writes collapses all three decisions to whole-object reads.
     pub logs_request_cost_bytes: u64,
+    /// The operator's fetch-policy intent (ADR-0996 decision 2), resolved at
+    /// startup by [`resolve_logs_fetch`] into [`Self::logs_request_cost_bytes`]
+    /// and [`Self::logs_block_range_threshold`]. Carried here, like the two
+    /// fields it resolves into, because this is the config the server folds its
+    /// query flags into and hands to every fetcher it builds. Defaults to
+    /// [`LogsFetchPolicy::CostBased`].
+    pub logs_fetch_policy: LogsFetchPolicy,
+    /// The fetch bound (ADR-0996 decision 2): one covering GET's maximum length.
+    /// An object at or under it is one covering GET; a larger one is read as
+    /// `ceil(size / bound)` sequential covering sub-range GETs, so no single
+    /// request moves more than this. Zero is refused at resolution
+    /// ([`Self::validate`]): the segmented fallback divides by it. Defaults to
+    /// [`DEFAULT_LOG_MAX_FETCH_RUN_BYTES`] (64 MiB).
+    pub logs_max_fetch_run_bytes: u64,
+}
+
+impl EngineConfig {
+    /// Refuse a configuration the fetch layer cannot run on (ADR-0996 decision
+    /// 2). Called at startup resolution; a bad value is a typed
+    /// [`EngineConfigError`], never a silent clamp.
+    pub fn validate(&self) -> Result<(), EngineConfigError> {
+        if self.logs_max_fetch_run_bytes == 0 {
+            return Err(EngineConfigError::ZeroFetchBound);
+        }
+        Ok(())
+    }
 }
 
 impl Default for EngineConfig {
@@ -203,6 +435,8 @@ impl Default for EngineConfig {
             default_evaluation_interval: DEFAULT_EVALUATION_INTERVAL,
             logs_block_range_threshold: crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             logs_request_cost_bytes: crate::DEFAULT_LOG_REQUEST_COST_BYTES,
+            logs_fetch_policy: LogsFetchPolicy::default(),
+            logs_max_fetch_run_bytes: DEFAULT_LOG_MAX_FETCH_RUN_BYTES,
         }
     }
 }
@@ -222,5 +456,209 @@ mod tests {
         // measured q20 latency break-even and no behavior change (ADR-0904
         // decision 5).
         assert_eq!(crate::DEFAULT_LOG_REQUEST_COST_BYTES, 1_887_437);
+    }
+
+    #[test]
+    fn default_fetch_policy_is_cost_based_and_bound_is_64_mib() {
+        let cfg = EngineConfig::default();
+        assert_eq!(cfg.logs_fetch_policy, LogsFetchPolicy::CostBased);
+        assert_eq!(
+            cfg.logs_max_fetch_run_bytes,
+            DEFAULT_LOG_MAX_FETCH_RUN_BYTES
+        );
+        assert_eq!(DEFAULT_LOG_MAX_FETCH_RUN_BYTES, 64 * 1024 * 1024);
+    }
+
+    /// The policy-to-rate mapping table pinned exactly (ADR-0996 decision 2's
+    /// acceptance): saturate / default / profile-derived-with-floors /
+    /// high-saturation boundary. Each row states the rate to the byte.
+    #[test]
+    fn policy_to_rate_mapping_table_is_pinned() {
+        let reference = StoreCostProfile::reference();
+
+        // request-minimal saturates the rate AND the routing threshold,
+        // regardless of profile or an explicit block-range threshold, and
+        // suppresses the plan footer probe. An explicitly set threshold is
+        // reported for the startup log.
+        let rm = resolve_logs_fetch(
+            LogsFetchPolicy::RequestMinimal,
+            &reference,
+            None,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            Some(4096),
+        );
+        assert_eq!(rm.request_cost_bytes, u64::MAX, "request-minimal saturates");
+        assert_eq!(rm.block_range_threshold, u64::MAX);
+        assert!(rm.suppress_plan_footer_probe);
+        assert_eq!(
+            rm.overridden_block_range_threshold,
+            Some(4096),
+            "an explicitly set block-range threshold is overridden and logged"
+        );
+        assert_eq!(rm.saturated_profile, None);
+
+        // byte-minimal keeps today's configured request cost byte for byte, and
+        // leaves the routing threshold and plan probe alone.
+        let bm = resolve_logs_fetch(
+            LogsFetchPolicy::ByteMinimal,
+            &reference,
+            None,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            Some(4096),
+        );
+        assert_eq!(bm.request_cost_bytes, crate::DEFAULT_LOG_REQUEST_COST_BYTES);
+        assert_eq!(
+            bm.block_range_threshold,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
+        );
+        assert!(!bm.suppress_plan_footer_probe);
+        assert_eq!(bm.overridden_block_range_threshold, None);
+
+        // cost-based at the reference (intra-region, free bytes) profile
+        // resolves to request-minimal behaviour: both byte prices zero saturate
+        // the rate, naming the profile.
+        let cb_ref = resolve_logs_fetch(
+            LogsFetchPolicy::CostBased,
+            &reference,
+            None,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            None,
+        );
+        assert_eq!(cb_ref.request_cost_bytes, u64::MAX);
+        assert_eq!(
+            cb_ref.saturated_profile.as_deref(),
+            Some("s3-intra-region-2026")
+        );
+        // ... but cost-based is NOT request-minimal for routing: it does not
+        // saturate the routing threshold or suppress the probe. Only the rate
+        // saturates, which the downstream crossover floors handle.
+        assert_eq!(
+            cb_ref.block_range_threshold,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
+        );
+        assert!(!cb_ref.suppress_plan_footer_probe);
+
+        // cost-based at egress prices resolves to a small byte cost:
+        //   400 * 2^30 / (90_000_000 + 10_000_000)
+        //   = 429_496_729_600 / 100_000_000 = 4294 (floor). ~4.3 KB, the
+        // ADR-0904 worked value, which the downstream floors then clamp.
+        let egress = StoreCostProfile {
+            name: "egress-billed".to_string(),
+            put_class_nanodollars: 5_000,
+            get_class_nanodollars: 400,
+            delete_class_nanodollars: 0,
+            transfer_nanodollars_per_gib: 90_000_000,
+            retrieval_nanodollars_per_gib: 10_000_000,
+        };
+        let cb_egress = resolve_logs_fetch(
+            LogsFetchPolicy::CostBased,
+            &egress,
+            None,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            None,
+        );
+        assert_eq!(
+            cb_egress.request_cost_bytes, 4294,
+            "profile-derived rate is get*2^30/(transfer+retrieval), floored"
+        );
+        assert_eq!(cb_egress.saturated_profile, None);
+        // The raw rate is well below both floors, so the downstream fetch layer
+        // clamps it: the gap floors to 64 KiB and the crossover to 512 KiB.
+        assert!(cb_egress.request_cost_bytes < crate::DEFAULT_LOG_COALESCE_GAP);
+        assert!(cb_egress.request_cost_bytes < crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD);
+
+        // transfer=0, retrieval>0 routes byte-minimally from the retrieval
+        // price, NOT request-minimal: a naive per-byte pre-division would
+        // truncate this to zero and be unreachable.
+        //   400 * 2^30 / 10_000_000 = 429_496_729_600 / 10_000_000 = 42949.
+        let retrieval_only = StoreCostProfile {
+            name: "retrieval-only".to_string(),
+            put_class_nanodollars: 5_000,
+            get_class_nanodollars: 400,
+            delete_class_nanodollars: 0,
+            transfer_nanodollars_per_gib: 0,
+            retrieval_nanodollars_per_gib: 10_000_000,
+        };
+        let cb_retrieval = resolve_logs_fetch(
+            LogsFetchPolicy::CostBased,
+            &retrieval_only,
+            None,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            None,
+        );
+        assert_eq!(cb_retrieval.request_cost_bytes, 42949);
+        assert_eq!(cb_retrieval.saturated_profile, None);
+    }
+
+    /// The high-saturation boundary at a one-nanodollar-per-GiB byte price
+    /// (ADR-0996 decision 2): the quotient `get * 2^30` crosses `u64::MAX` at
+    /// `get = 2^34`. One below the boundary is a large finite rate; at the
+    /// boundary it saturates and names the profile.
+    #[test]
+    fn cost_based_high_saturation_boundary_is_pinned() {
+        let below = StoreCostProfile {
+            name: "one-nd-per-gib-below".to_string(),
+            put_class_nanodollars: 0,
+            get_class_nanodollars: (1u64 << 34) - 1,
+            delete_class_nanodollars: 0,
+            transfer_nanodollars_per_gib: 1,
+            retrieval_nanodollars_per_gib: 0,
+        };
+        let r = resolve_logs_fetch(
+            LogsFetchPolicy::CostBased,
+            &below,
+            None,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            None,
+        );
+        // ((2^34 - 1) * 2^30) / 1 = 2^64 - 2^30, one GiB below u64::MAX+1: finite.
+        assert_eq!(r.request_cost_bytes, u64::MAX - (1u64 << 30) + 1);
+        assert_eq!(
+            r.saturated_profile, None,
+            "one below the boundary is finite"
+        );
+
+        let at = StoreCostProfile {
+            name: "one-nd-per-gib-at".to_string(),
+            get_class_nanodollars: 1u64 << 34,
+            ..below.clone()
+        };
+        let r = resolve_logs_fetch(
+            LogsFetchPolicy::CostBased,
+            &at,
+            None,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            None,
+        );
+        // 2^34 * 2^30 = 2^64 > u64::MAX: saturates, names the profile.
+        assert_eq!(r.request_cost_bytes, u64::MAX);
+        assert_eq!(r.saturated_profile.as_deref(), Some("one-nd-per-gib-at"));
+    }
+
+    #[test]
+    fn explicit_request_cost_bytes_wins_over_policy() {
+        // The expert escape hatch: an explicit --logs-request-cost-bytes wins
+        // over the policy's derived rate, even request-minimal's saturation.
+        let profile = StoreCostProfile::reference();
+        let r = resolve_logs_fetch(
+            LogsFetchPolicy::RequestMinimal,
+            &profile,
+            Some(123_456),
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            None,
+        );
+        assert_eq!(r.request_cost_bytes, 123_456);
+        // request-minimal still overrides the routing threshold: only the rate
+        // is an escape hatch, not the routing intent.
+        assert_eq!(r.block_range_threshold, u64::MAX);
+        assert!(r.suppress_plan_footer_probe);
+    }
+
+    #[test]
+    fn zero_fetch_bound_is_refused_with_a_typed_error() {
+        let mut cfg = EngineConfig::default();
+        assert_eq!(cfg.validate(), Ok(()));
+        cfg.logs_max_fetch_run_bytes = 0;
+        assert_eq!(cfg.validate(), Err(EngineConfigError::ZeroFetchBound));
     }
 }

--- a/crates/ravel-query/src/config.rs
+++ b/crates/ravel-query/src/config.rs
@@ -309,6 +309,10 @@ fn resolve_cost_based_rate(profile: &StoreCostProfile) -> (u64, Option<String>) 
     }
     let quotient = u128::from(profile.get_class_nanodollars) * BYTES_PER_GIB / byte_price;
     match u64::try_from(quotient) {
+        // A quotient of exactly u64::MAX converts cleanly but still saturates
+        // the routing threshold downstream; attribute the profile so the
+        // startup override log never lacks a name.
+        Ok(u64::MAX) => (u64::MAX, Some(profile.name.clone())),
         // Floor at one byte so a sub-nanodollar-per-byte price can never resolve
         // to a zero rate (which would make every crossover trivially true).
         Ok(rate) => (rate.max(1), None),

--- a/crates/ravel-query/src/config.rs
+++ b/crates/ravel-query/src/config.rs
@@ -201,17 +201,14 @@ pub struct ResolvedLogsFetch {
     /// near-zero), which saturates every derived crossover to whole-object.
     pub request_cost_bytes: u64,
     /// The routing threshold ([`EngineConfig::logs_block_range_threshold`]).
-    /// request-minimal saturates it to `u64::MAX` so no object is ever routed to
-    /// the ranged path, overriding an explicit `--logs-block-range-threshold`.
+    /// Saturated to `u64::MAX` whenever the resolved rate saturates, so no
+    /// object is ever routed to the ranged path, overriding an explicit
+    /// `--logs-block-range-threshold`.
     pub block_range_threshold: u64,
-    /// True under request-minimal: the plan phase suppresses its per-segment
-    /// footer probe, because the scan read is whole-object anyway and a probe
-    /// that cannot reduce requests is pure spend.
-    pub suppress_plan_footer_probe: bool,
-    /// Set to the operator's explicit `--logs-block-range-threshold` when
-    /// request-minimal overrode it, so the startup path can log the overridden
-    /// flag (ADR-0996 decision 2). `None` when no explicit threshold was set or
-    /// the policy left it in force.
+    /// Set to the operator's explicit `--logs-block-range-threshold` when the
+    /// resolution overrode it, so the startup path can log the overridden flag
+    /// (ADR-0996 decision 2). `None` when no explicit threshold was set or the
+    /// resolution left it in force.
     pub overridden_block_range_threshold: Option<u64>,
     /// Set to the active profile's name when a cost-based derivation saturated
     /// the rate at `u64::MAX`, so the startup path can log the saturation naming
@@ -232,10 +229,20 @@ pub struct ResolvedLogsFetch {
 /// - An explicit `--logs-request-cost-bytes` (`explicit_request_cost_bytes`)
 ///   WINS over policy for the rate: policy is the intent layer, the byte flag
 ///   the expert escape hatch.
-/// - `RequestMinimal` still overrides BOTH routing thresholds, including an
-///   explicitly set `--logs-block-range-threshold`: a policy that saturated only
-///   the derived rate would let a low explicit threshold send projected objects
-///   down the ranged path through `ranged_projection_pays`.
+/// - A SATURATED resolved rate overrides BOTH routing thresholds, including an
+///   explicitly set `--logs-block-range-threshold`. A rate of `u64::MAX` means
+///   "one covering GET per object, always", and the fetch layer cannot express
+///   that through the rate alone: `LogSegmentFetcher::with_block_range_threshold`
+///   pins the inner crossover to the outer flag's value, bypassing the
+///   `5 x request_cost` derivation entirely, so a threshold left at 512 KiB
+///   would keep sending narrow projections of larger objects down the ranged
+///   path through `ranged_projection_pays`. Cost-based at a free-byte profile
+///   resolves to exactly that rate, so it must route exactly the way
+///   request-minimal does; the override is therefore keyed on the rate, not on
+///   the policy that produced it.
+/// - `RequestMinimal` overrides the routing threshold even when an explicit
+///   `--logs-request-cost-bytes` replaced its saturated rate: the byte flag is
+///   an escape hatch for the rate, not for the routing intent.
 ///
 /// The cost-based derivation multiplies before it divides, in `u128`:
 /// `get_class_nanodollars * BYTES_PER_GIB / (transfer + retrieval)`,
@@ -249,6 +256,7 @@ pub fn resolve_logs_fetch(
     policy: LogsFetchPolicy,
     profile: &StoreCostProfile,
     explicit_request_cost_bytes: Option<u64>,
+    configured_request_cost_bytes: u64,
     configured_block_range_threshold: u64,
     explicit_block_range_threshold: Option<u64>,
 ) -> ResolvedLogsFetch {
@@ -259,16 +267,20 @@ pub fn resolve_logs_fetch(
         Some(explicit) => (explicit, None),
         None => match policy {
             LogsFetchPolicy::RequestMinimal => (u64::MAX, None),
-            LogsFetchPolicy::ByteMinimal => (configured_block_range_threshold_rate(profile), None),
+            // byte-minimal is today's behaviour byte for byte, which includes a
+            // configured (non-default) `--logs-request-cost-bytes`: ADR-0904's
+            // knob keeps its meaning under this policy rather than being
+            // silently replaced by the compiled default.
+            LogsFetchPolicy::ByteMinimal => (configured_request_cost_bytes, None),
             LogsFetchPolicy::CostBased => resolve_cost_based_rate(profile),
         },
     };
 
-    // Routing: request-minimal saturates the threshold so no object routes
-    // ranged, overriding an explicit flag (which is then logged). Every other
-    // policy keeps the configured threshold.
-    let request_minimal = matches!(policy, LogsFetchPolicy::RequestMinimal);
-    let (block_range_threshold, overridden_block_range_threshold) = if request_minimal {
+    // Routing: a saturated rate saturates the threshold too, whichever policy
+    // produced it, overriding an explicit flag (which is then logged).
+    let saturates_routing =
+        request_cost_bytes == u64::MAX || matches!(policy, LogsFetchPolicy::RequestMinimal);
+    let (block_range_threshold, overridden_block_range_threshold) = if saturates_routing {
         (u64::MAX, explicit_block_range_threshold)
     } else {
         (configured_block_range_threshold, None)
@@ -277,18 +289,9 @@ pub fn resolve_logs_fetch(
     ResolvedLogsFetch {
         request_cost_bytes,
         block_range_threshold,
-        suppress_plan_footer_probe: request_minimal,
         overridden_block_range_threshold,
         saturated_profile,
     }
-}
-
-/// byte-minimal keeps today's configured request cost. It has no profile
-/// dependency; the profile argument is taken only so the signature matches the
-/// other arms and a future byte-price-aware byte-minimal has a seam. Named for
-/// clarity at the call site above.
-fn configured_block_range_threshold_rate(_profile: &StoreCostProfile) -> u64 {
-    crate::DEFAULT_LOG_REQUEST_COST_BYTES
 }
 
 /// The cost-based byte rate and, when it saturated at `u64::MAX`, the profile
@@ -477,19 +480,18 @@ mod tests {
         let reference = StoreCostProfile::reference();
 
         // request-minimal saturates the rate AND the routing threshold,
-        // regardless of profile or an explicit block-range threshold, and
-        // suppresses the plan footer probe. An explicitly set threshold is
-        // reported for the startup log.
+        // regardless of profile or an explicit block-range threshold. An
+        // explicitly set threshold is reported for the startup log.
         let rm = resolve_logs_fetch(
             LogsFetchPolicy::RequestMinimal,
             &reference,
             None,
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
             crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             Some(4096),
         );
         assert_eq!(rm.request_cost_bytes, u64::MAX, "request-minimal saturates");
         assert_eq!(rm.block_range_threshold, u64::MAX);
-        assert!(rm.suppress_plan_footer_probe);
         assert_eq!(
             rm.overridden_block_range_threshold,
             Some(4096),
@@ -498,11 +500,12 @@ mod tests {
         assert_eq!(rm.saturated_profile, None);
 
         // byte-minimal keeps today's configured request cost byte for byte, and
-        // leaves the routing threshold and plan probe alone.
+        // leaves the routing threshold alone.
         let bm = resolve_logs_fetch(
             LogsFetchPolicy::ByteMinimal,
             &reference,
             None,
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
             crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             Some(4096),
         );
@@ -511,7 +514,6 @@ mod tests {
             bm.block_range_threshold,
             crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
         );
-        assert!(!bm.suppress_plan_footer_probe);
         assert_eq!(bm.overridden_block_range_threshold, None);
 
         // cost-based at the reference (intra-region, free bytes) profile
@@ -521,6 +523,7 @@ mod tests {
             LogsFetchPolicy::CostBased,
             &reference,
             None,
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
             crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             None,
         );
@@ -529,14 +532,14 @@ mod tests {
             cb_ref.saturated_profile.as_deref(),
             Some("s3-intra-region-2026")
         );
-        // ... but cost-based is NOT request-minimal for routing: it does not
-        // saturate the routing threshold or suppress the probe. Only the rate
-        // saturates, which the downstream crossover floors handle.
-        assert_eq!(
-            cb_ref.block_range_threshold,
-            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
-        );
-        assert!(!cb_ref.suppress_plan_footer_probe);
+        // ... and the routing threshold saturates WITH the rate. The fetch layer
+        // pins its inner crossover to whatever threshold it is handed
+        // (`with_block_range_threshold` sets `whole_object_threshold`, which
+        // `effective_whole_object_threshold` then returns verbatim, bypassing the
+        // `5 x request_cost` derivation and its floors), so leaving this at
+        // 512 KiB would route a narrow projection of any larger object ranged and
+        // deliver none of ADR-0996's outcome at the default policy.
+        assert_eq!(cb_ref.block_range_threshold, u64::MAX);
 
         // cost-based at egress prices resolves to a small byte cost:
         //   400 * 2^30 / (90_000_000 + 10_000_000)
@@ -554,6 +557,7 @@ mod tests {
             LogsFetchPolicy::CostBased,
             &egress,
             None,
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
             crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             None,
         );
@@ -562,6 +566,12 @@ mod tests {
             "profile-derived rate is get*2^30/(transfer+retrieval), floored"
         );
         assert_eq!(cb_egress.saturated_profile, None);
+        // A finite rate leaves the routing threshold in force: only saturation
+        // overrides it.
+        assert_eq!(
+            cb_egress.block_range_threshold,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
+        );
         // The raw rate is well below both floors, so the downstream fetch layer
         // clamps it: the gap floors to 64 KiB and the crossover to 512 KiB.
         assert!(cb_egress.request_cost_bytes < crate::DEFAULT_LOG_COALESCE_GAP);
@@ -583,11 +593,107 @@ mod tests {
             LogsFetchPolicy::CostBased,
             &retrieval_only,
             None,
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
             crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             None,
         );
         assert_eq!(cb_retrieval.request_cost_bytes, 42949);
         assert_eq!(cb_retrieval.saturated_profile, None);
+        assert_eq!(
+            cb_retrieval.block_range_threshold,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
+        );
+    }
+
+    /// byte-minimal is "today's behaviour, byte for byte", which includes a
+    /// configured non-default `--logs-request-cost-bytes` (ADR-0904's knob). The
+    /// resolution must thread the configured value through rather than
+    /// substituting the compiled default, or selecting byte-minimal would
+    /// silently discard the operator's calibration.
+    ///
+    /// Prove-the-test: resolve the byte-minimal arm from
+    /// `crate::DEFAULT_LOG_REQUEST_COST_BYTES` instead of
+    /// `configured_request_cost_bytes` and the first assertion reads 1_887_437
+    /// against the expected 700_000.
+    #[test]
+    fn byte_minimal_keeps_a_configured_request_cost() {
+        let reference = StoreCostProfile::reference();
+        let configured = 700_000u64;
+        assert_ne!(
+            configured,
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
+            "the fixture must differ from the default or it proves nothing"
+        );
+        let bm = resolve_logs_fetch(
+            LogsFetchPolicy::ByteMinimal,
+            &reference,
+            None,
+            configured,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            None,
+        );
+        assert_eq!(
+            bm.request_cost_bytes, configured,
+            "byte-minimal keeps the configured request cost, not the compiled default"
+        );
+        assert_eq!(
+            bm.block_range_threshold,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            "a finite rate leaves the routing threshold in force"
+        );
+
+        // The profile is irrelevant to byte-minimal: the same configured value
+        // resolves at an egress-billed profile too.
+        let egress = StoreCostProfile {
+            name: "egress-billed".to_string(),
+            put_class_nanodollars: 5_000,
+            get_class_nanodollars: 400,
+            delete_class_nanodollars: 0,
+            transfer_nanodollars_per_gib: 90_000_000,
+            retrieval_nanodollars_per_gib: 10_000_000,
+        };
+        let bm_egress = resolve_logs_fetch(
+            LogsFetchPolicy::ByteMinimal,
+            &egress,
+            None,
+            configured,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            None,
+        );
+        assert_eq!(bm_egress.request_cost_bytes, configured);
+    }
+
+    /// A saturated rate saturates the routing threshold whichever policy
+    /// produced it, and an explicitly set `--logs-block-range-threshold` is
+    /// overridden and reported for the startup log -- exactly as the
+    /// request-minimal arm already does.
+    ///
+    /// Prove-the-test: key the override on `matches!(policy,
+    /// LogsFetchPolicy::RequestMinimal)` alone (the pre-fix condition) and both
+    /// assertions below fail: the threshold reads 512 KiB and the overridden
+    /// flag reads `None`.
+    #[test]
+    fn a_saturated_cost_based_rate_overrides_an_explicit_routing_threshold() {
+        let reference = StoreCostProfile::reference();
+        let r = resolve_logs_fetch(
+            LogsFetchPolicy::CostBased,
+            &reference,
+            None,
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
+            4096,
+            Some(4096),
+        );
+        assert_eq!(r.request_cost_bytes, u64::MAX);
+        assert_eq!(
+            r.block_range_threshold,
+            u64::MAX,
+            "a saturated rate saturates the routing threshold too"
+        );
+        assert_eq!(
+            r.overridden_block_range_threshold,
+            Some(4096),
+            "the overridden flag is reported for the startup log"
+        );
     }
 
     /// The high-saturation boundary at a one-nanodollar-per-GiB byte price
@@ -608,6 +714,7 @@ mod tests {
             LogsFetchPolicy::CostBased,
             &below,
             None,
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
             crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             None,
         );
@@ -616,6 +723,11 @@ mod tests {
         assert_eq!(
             r.saturated_profile, None,
             "one below the boundary is finite"
+        );
+        assert_eq!(
+            r.block_range_threshold,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            "a finite rate, however large, leaves the routing threshold in force"
         );
 
         let at = StoreCostProfile {
@@ -627,12 +739,18 @@ mod tests {
             LogsFetchPolicy::CostBased,
             &at,
             None,
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
             crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             None,
         );
         // 2^34 * 2^30 = 2^64 > u64::MAX: saturates, names the profile.
         assert_eq!(r.request_cost_bytes, u64::MAX);
         assert_eq!(r.saturated_profile.as_deref(), Some("one-nd-per-gib-at"));
+        assert_eq!(
+            r.block_range_threshold,
+            u64::MAX,
+            "the overflow saturation routes whole-object like the zero-price one"
+        );
     }
 
     #[test]
@@ -644,6 +762,7 @@ mod tests {
             LogsFetchPolicy::RequestMinimal,
             &profile,
             Some(123_456),
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
             crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             None,
         );
@@ -651,7 +770,24 @@ mod tests {
         // request-minimal still overrides the routing threshold: only the rate
         // is an escape hatch, not the routing intent.
         assert_eq!(r.block_range_threshold, u64::MAX);
-        assert!(r.suppress_plan_footer_probe);
+
+        // The same escape hatch under cost-based: an explicit finite rate
+        // replaces the profile's saturated one, so nothing saturates and the
+        // configured routing threshold stays in force.
+        let cb = resolve_logs_fetch(
+            LogsFetchPolicy::CostBased,
+            &profile,
+            Some(123_456),
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            None,
+        );
+        assert_eq!(cb.request_cost_bytes, 123_456);
+        assert_eq!(
+            cb.block_range_threshold,
+            crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
+        );
+        assert_eq!(cb.saturated_profile, None);
     }
 
     #[test]

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -17,9 +17,10 @@ mod segment_admission;
 pub mod span_fetcher;
 
 pub use config::{
-    ByteLimit, DEFAULT_DEADLINE, DEFAULT_FETCH_CONCURRENCY, DEFAULT_MAX_SAMPLES,
-    DEFAULT_MAX_SEGMENTS, DEFAULT_MAX_SERIES, EngineConfig, REQUEST_BUDGET_FIXED_OVERHEAD,
-    RequestLimit, derive_max_s3_requests,
+    ByteLimit, DEFAULT_DEADLINE, DEFAULT_FETCH_CONCURRENCY, DEFAULT_LOG_MAX_FETCH_RUN_BYTES,
+    DEFAULT_MAX_SAMPLES, DEFAULT_MAX_SEGMENTS, DEFAULT_MAX_SERIES, EngineConfig, EngineConfigError,
+    LogsFetchPolicy, REQUEST_BUDGET_FIXED_OVERHEAD, RequestLimit, ResolvedLogsFetch,
+    derive_max_s3_requests, resolve_logs_fetch,
 };
 pub use engine::{Coverage, QueryEngine, QueryStats, snapshot_erasure_predicates};
 pub use error::QueryError;

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -50,6 +50,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use crate::config::EngineConfigError;
 use crate::erasure::ErasurePredicate;
 use crate::fetcher::ReadCache;
 use crate::phase_accounting::{PhaseAccounting, PhaseWireByteCounter, QueryPhase};
@@ -685,11 +686,11 @@ impl LogSegmentFetcher {
     /// ADR-0996 decision 2): one covering GET's maximum length. An object above
     /// the bound is read as `ceil(object_size / n)` sequential covering
     /// sub-range GETs on every read shape, whole-object funnel included. Zero is
-    /// refused earlier at config resolution ([`EngineConfig::validate`]).
-    #[must_use]
-    pub fn with_max_fetch_run_bytes(mut self, n: u64) -> Self {
-        self.block_range = self.block_range.with_max_fetch_run_bytes(n);
-        self
+    /// refused with the same typed error
+    /// [`EngineConfig::validate`](crate::EngineConfig::validate) returns.
+    pub fn with_max_fetch_run_bytes(mut self, n: u64) -> Result<Self, EngineConfigError> {
+        self.block_range = self.block_range.with_max_fetch_run_bytes(n)?;
+        Ok(self)
     }
 
     /// Replaces the block-range fetcher (ADR-0107) with a fully configured one,
@@ -1364,12 +1365,33 @@ impl LogSegmentFetcher {
         // multi-partition scan still records exactly one touch per object here,
         // over however many GETs the plan and its subset scans issue. An object
         // belongs to exactly one segment, so this is one touch per distinct
-        // object. A `None` result means the catalog summary proved the segment
-        // irrelevant with NO fetch, which is not a touch. The predicate-free
-        // full-window fast path skips this method entirely (#693 part 3); its
-        // per-segment touch is recorded at ravel-sql's `record_open_shape` site,
-        // left for task 996-6 (this task must not touch ravel-sql).
-        if matches!(result, Ok(Some(_))) {
+        // object. The predicate-free full-window fast path skips this method
+        // entirely (#693 part 3); its per-segment touch is recorded at
+        // ravel-sql's `record_open_shape` site, left for task 996-6 (this task
+        // must not touch ravel-sql).
+        //
+        // `data_objects_touched` counts objects whose BLOCK bytes the query
+        // fetched, and its contract
+        // (`ravel_types::accounting::QueryAccountingSnapshot::data_objects_touched`)
+        // excludes a probe outright: "if the query then decides to fetch no
+        // blocks from that object, the object was never touched". Two of the
+        // three outcomes here are not touches, and both would inflate the
+        // denominator of `range_amplification` in the flattering direction:
+        //
+        // - `Ok(None)`: the catalog summary proved the segment irrelevant with
+        //   no fetch at all.
+        // - `Ok(Some((0, .., Some(footer))))`: the skip-decidable branch (#761)
+        //   read only the probe, SKIP_IDX and FIELD_DIR and pruned every block
+        //   away. `owned_work` assigns a zero-survivor segment to no partition,
+        //   so no scan GET ever follows and not one block byte moves.
+        //
+        // A `None` footer is the whole-object fallback, which fetched the object
+        // (blocks included) to compute its survivor count, so it is a touch even
+        // at zero survivors. The two footer-carrying branches always precede a
+        // scan when they report survivors.
+        if let Ok(Some((survivors, _, footer))) = &result
+            && (*survivors > 0 || footer.is_none())
+        {
             caller_accounting.add_data_objects_touched(1);
         }
         result
@@ -3029,20 +3051,33 @@ impl BlockRangeFetcher {
 
     /// Sets the fetch bound (ADR-0996 decision 2): one covering GET's maximum
     /// length. An object at or under it is one covering GET; a larger one is
-    /// segmented into `ceil(object_size / n)` covering sub-range GETs. `n` is
-    /// clamped up to 1 here as a last-resort guard; zero is refused earlier at
-    /// config resolution ([`EngineConfig::validate`]), which is where the typed
-    /// error belongs.
-    #[must_use]
-    pub fn with_max_fetch_run_bytes(mut self, n: u64) -> Self {
-        self.max_fetch_run_bytes = n.max(1);
-        self
+    /// segmented into `ceil(object_size / n)` covering sub-range GETs.
+    ///
+    /// Zero is REFUSED, with the same typed error
+    /// [`EngineConfig::validate`](crate::EngineConfig::validate) returns. The two
+    /// checks are not redundant: `validate` guards the config surface, and this
+    /// guards every other way a bound reaches the fetcher (a direct builder call
+    /// in a test or an embedding crate, a value that never passed through an
+    /// `EngineConfig` at all). Clamping to 1 here instead would turn a
+    /// misconfigured bound into a silent one-byte-per-GET read of every object,
+    /// which is a far worse outcome than the refusal and is invisible in the
+    /// counters until the request bill arrives.
+    pub fn with_max_fetch_run_bytes(mut self, n: u64) -> Result<Self, EngineConfigError> {
+        if n == 0 {
+            return Err(EngineConfigError::ZeroFetchBound);
+        }
+        self.max_fetch_run_bytes = n;
+        Ok(self)
     }
 
-    /// The largest single covering sub-range GET this fetcher has issued, in
+    /// The largest single covering sub-range GET this fetcher has ISSUED, in
     /// bytes (ADR-0996 decision 2). Never exceeds `max_fetch_run_bytes`; a test
     /// reads it to prove the segmented covering path bounded each request's wire
     /// size. Cumulative and shared by every clone; nothing resets it.
+    ///
+    /// A read served from the cache issues no request and moves no wire bytes,
+    /// so it never enters this figure: the observation is taken after
+    /// [`Self::cached_extent`] reports the miss, not before it.
     #[must_use]
     pub fn peak_fetch_run_bytes(&self) -> u64 {
         self.peak_fetch_run.load(Ordering::Relaxed)
@@ -3056,9 +3091,11 @@ impl BlockRangeFetcher {
         self.max_fetch_run_bytes
     }
 
-    /// Record one covering sub-range GET's length against the peak, keeping the
-    /// running maximum. Called on the segmented covering path so
-    /// [`Self::peak_fetch_run_bytes`] reflects the largest single request.
+    /// Record one ISSUED covering sub-range GET's length against the peak,
+    /// keeping the running maximum. Called on the covering path once the read is
+    /// known to have crossed the network, so
+    /// [`Self::peak_fetch_run_bytes`] reflects the largest single request rather
+    /// than the largest extent a cache happened to serve.
     fn observe_fetch_run(&self, len: u64) {
         self.peak_fetch_run.fetch_max(len, Ordering::Relaxed);
     }
@@ -3097,7 +3134,6 @@ impl BlockRangeFetcher {
         accounting: &QueryAccounting,
     ) -> Result<(Bytes, u64), LogFetchError> {
         if total_size <= self.max_fetch_run_bytes {
-            self.observe_fetch_run(total_size);
             let (bytes, live) = self
                 .cached_extent(
                     seg_ref,
@@ -3110,6 +3146,9 @@ impl BlockRangeFetcher {
                     accounting,
                 )
                 .await?;
+            if live {
+                self.observe_fetch_run(total_size);
+            }
             return Ok((bytes, u64::from(live)));
         }
 
@@ -3121,7 +3160,6 @@ impl BlockRangeFetcher {
         while start < total_size {
             let len = self.max_fetch_run_bytes.min(total_size - start);
             let end = start + len;
-            self.observe_fetch_run(len);
             let (bytes, live) = self
                 .cached_extent(
                     seg_ref,
@@ -3134,6 +3172,9 @@ impl BlockRangeFetcher {
                     accounting,
                 )
                 .await?;
+            if live {
+                self.observe_fetch_run(len);
+            }
             asm.place(key, start, &bytes)?;
             live_gets += u64::from(live);
             start = end;

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -681,6 +681,17 @@ impl LogSegmentFetcher {
         self
     }
 
+    /// Sets the fetch bound ([`BlockRangeFetcher::with_max_fetch_run_bytes`],
+    /// ADR-0996 decision 2): one covering GET's maximum length. An object above
+    /// the bound is read as `ceil(object_size / n)` sequential covering
+    /// sub-range GETs on every read shape, whole-object funnel included. Zero is
+    /// refused earlier at config resolution ([`EngineConfig::validate`]).
+    #[must_use]
+    pub fn with_max_fetch_run_bytes(mut self, n: u64) -> Self {
+        self.block_range = self.block_range.with_max_fetch_run_bytes(n);
+        self
+    }
+
     /// Replaces the block-range fetcher (ADR-0107) with a fully configured one,
     /// for callers and tests that need to set the coalescing gap, coverage
     /// crossover, or concurrency bound directly. The replacement keeps this
@@ -1346,6 +1357,21 @@ impl LogSegmentFetcher {
         }
         .await;
         caller_accounting.merge_snapshot(&phase.snapshot().pooled());
+        // ADR-0996 decision 3: record this data object as touched, once, at the
+        // plan-then-stripe designated-recorder point. `plan_segment` runs once
+        // per segment -- `ravel_sql::logs_scan` awaits the shared plan pass
+        // behind a barrier before any partition drains -- so a striped
+        // multi-partition scan still records exactly one touch per object here,
+        // over however many GETs the plan and its subset scans issue. An object
+        // belongs to exactly one segment, so this is one touch per distinct
+        // object. A `None` result means the catalog summary proved the segment
+        // irrelevant with NO fetch, which is not a touch. The predicate-free
+        // full-window fast path skips this method entirely (#693 part 3); its
+        // per-segment touch is recorded at ravel-sql's `record_open_shape` site,
+        // left for task 996-6 (this task must not touch ravel-sql).
+        if matches!(result, Ok(Some(_))) {
+            caller_accounting.add_data_objects_touched(1);
+        }
         result
     }
 
@@ -1797,6 +1823,33 @@ impl LogSegmentFetcher {
         accounting: &QueryAccounting,
     ) -> Result<Bytes, LogFetchError> {
         let key = &seg_ref.data_object_key;
+
+        // Fetch bound (ADR-0996 decision 2): an object above the bound is read
+        // as `ceil(object_size / bound)` sequential covering sub-range GETs
+        // instead of one whole-object GET, so no single request moves more than
+        // the bound. Under request-minimal the routing threshold is saturated,
+        // so every object takes this whole-object funnel and this is where a
+        // large one is segmented. On the reference corpus every object is far
+        // under the 64 MiB default, so this branch is a protective cap only. The
+        // segmented read routes through the block-range fetcher's covering read,
+        // which shares this fetcher's cache and wire-byte counter, and whose
+        // per-sub-range accounting records the same GET total this funnel would.
+        if seg_ref.object_size > self.block_range.max_fetch_run_bytes() {
+            let pin = EtagPin::default();
+            let (bytes, _live_gets) = self
+                .block_range
+                .covering_read(
+                    seg_ref,
+                    tenant_hash,
+                    seg_ref.object_size,
+                    GetRange::Full,
+                    phase,
+                    &pin,
+                    accounting,
+                )
+                .await?;
+            return Ok(bytes);
+        }
 
         // Same two phases as `fetch_accounted`, spanned on the path production
         // log/alerts/audit traffic actually takes (ADR-0044 decision 5): the
@@ -2829,6 +2882,23 @@ pub struct BlockRangeFetcher {
     /// from ([`DEFAULT_LOG_REQUEST_COST_BYTES`]). A property of the store and
     /// instance, so it is a tunable, not a constant.
     request_cost_bytes: u64,
+    /// The fetch bound (ADR-0996 decision 2): one covering GET's maximum length.
+    /// An object at or under it is read in one covering `GetRange::Full`; a
+    /// larger one is read as `ceil(object_size / max_fetch_run_bytes)`
+    /// sequential covering sub-range GETs, each at most the bound, so no single
+    /// request moves more than this. Decoupled from `request_cost_bytes`: the
+    /// rate decides WHICH read shape, the bound only segments HOW a chosen
+    /// covering read is laid out. [`DEFAULT_LOG_MAX_FETCH_RUN_BYTES`] by default;
+    /// zero is refused before it reaches here ([`EngineConfig::validate`]).
+    max_fetch_run_bytes: u64,
+    /// The largest single covering sub-range GET this fetcher (and every clone)
+    /// has issued, in bytes: the peak wire size of one request on the segmented
+    /// covering path, which never exceeds `max_fetch_run_bytes`. The resident
+    /// assembly buffer is NOT bounded by this -- the frozen `ravel-logseg`
+    /// reader ([`RlogReader::new`]) needs a contiguous object-indexed buffer, so
+    /// a covering read of an object above the bound still holds `object_size` --
+    /// but the request wire size is, which is what this records.
+    peak_fetch_run: Arc<AtomicU64>,
     /// Bounds in-flight byte-range GETs. Its own instance, never shared with
     /// `SegmentFetcher`'s RSEG semaphore (ADR-0107 decision 1).
     get_semaphore: Arc<Semaphore>,
@@ -2856,6 +2926,8 @@ impl BlockRangeFetcher {
             whole_object_threshold: None,
             coverage_threshold: DEFAULT_LOG_COVERAGE_THRESHOLD,
             request_cost_bytes: DEFAULT_LOG_REQUEST_COST_BYTES,
+            max_fetch_run_bytes: crate::DEFAULT_LOG_MAX_FETCH_RUN_BYTES,
+            peak_fetch_run: Arc::new(AtomicU64::new(0)),
             get_semaphore: Arc::new(Semaphore::new(DEFAULT_LOG_MAX_CONCURRENT_GETS)),
             assembly_pool: Arc::new(AssemblyBufferPool::default()),
             wire_bytes: PhaseWireByteCounter::new(),
@@ -2953,6 +3025,120 @@ impl BlockRangeFetcher {
     pub fn with_request_cost_bytes(mut self, n: u64) -> Self {
         self.request_cost_bytes = n;
         self
+    }
+
+    /// Sets the fetch bound (ADR-0996 decision 2): one covering GET's maximum
+    /// length. An object at or under it is one covering GET; a larger one is
+    /// segmented into `ceil(object_size / n)` covering sub-range GETs. `n` is
+    /// clamped up to 1 here as a last-resort guard; zero is refused earlier at
+    /// config resolution ([`EngineConfig::validate`]), which is where the typed
+    /// error belongs.
+    #[must_use]
+    pub fn with_max_fetch_run_bytes(mut self, n: u64) -> Self {
+        self.max_fetch_run_bytes = n.max(1);
+        self
+    }
+
+    /// The largest single covering sub-range GET this fetcher has issued, in
+    /// bytes (ADR-0996 decision 2). Never exceeds `max_fetch_run_bytes`; a test
+    /// reads it to prove the segmented covering path bounded each request's wire
+    /// size. Cumulative and shared by every clone; nothing resets it.
+    #[must_use]
+    pub fn peak_fetch_run_bytes(&self) -> u64 {
+        self.peak_fetch_run.load(Ordering::Relaxed)
+    }
+
+    /// The fetch bound in effect ([`Self::with_max_fetch_run_bytes`], ADR-0996
+    /// decision 2). Read by [`LogSegmentFetcher::whole_object_bytes`] to route an
+    /// above-bound object through the segmented covering read.
+    #[must_use]
+    pub fn max_fetch_run_bytes(&self) -> u64 {
+        self.max_fetch_run_bytes
+    }
+
+    /// Record one covering sub-range GET's length against the peak, keeping the
+    /// running maximum. Called on the segmented covering path so
+    /// [`Self::peak_fetch_run_bytes`] reflects the largest single request.
+    fn observe_fetch_run(&self, len: u64) {
+        self.peak_fetch_run.fetch_max(len, Ordering::Relaxed);
+    }
+
+    /// A covering read of `[0, total_size)` bounded by
+    /// [`Self::max_fetch_run_bytes`] (ADR-0996 decision 2's covering-read
+    /// contract).
+    ///
+    /// - `total_size <= max_fetch_run_bytes`: ONE covering GET. `full_range` is
+    ///   the range the single read uses (`GetRange::Full` at a whole-object
+    ///   crossover, so it keys `(0, object_size)` and single-flights with the
+    ///   other whole-object funnels).
+    /// - `total_size > max_fetch_run_bytes`: `ceil(total_size /
+    ///   max_fetch_run_bytes)` sequential covering sub-range GETs, each at most
+    ///   the bound, assembled into the object buffer. Bounds each request's wire
+    ///   size; the request count is `ceil(total_size / bound)` (the ADR's floor,
+    ///   and its cap too on this unaligned split, since no run is short of the
+    ///   bound except the last).
+    ///
+    /// NOTE (reported for ADR-0996): the assembled buffer is still `object_size`
+    /// on the segmented path, because [`RlogReader::new`] in the frozen
+    /// `ravel-logseg` crate needs a contiguous object-indexed buffer. Bounding
+    /// the RESIDENT buffer below the bound would need a decode-side change
+    /// (independent per-sub-range decode) in `ravel-logseg`/`ravel-sql`, out of
+    /// this task's scope; [`Self::peak_fetch_run_bytes`] bounds the request wire
+    /// size, which is what stays in scope here.
+    #[allow(clippy::too_many_arguments)]
+    async fn covering_read(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        total_size: u64,
+        full_range: GetRange,
+        phase: QueryPhase,
+        pin: &EtagPin,
+        accounting: &QueryAccounting,
+    ) -> Result<(Bytes, u64), LogFetchError> {
+        if total_size <= self.max_fetch_run_bytes {
+            self.observe_fetch_run(total_size);
+            let (bytes, live) = self
+                .cached_extent(
+                    seg_ref,
+                    tenant_hash,
+                    0,
+                    total_size,
+                    full_range,
+                    phase,
+                    pin,
+                    accounting,
+                )
+                .await?;
+            return Ok((bytes, u64::from(live)));
+        }
+
+        let key = seg_ref.data_object_key.as_str();
+        let total = usize::try_from(total_size).map_err(|_| corrupt_range(key))?;
+        let mut asm = ObjectAssembler::new(&self.assembly_pool, total);
+        let mut live_gets = 0u64;
+        let mut start = 0u64;
+        while start < total_size {
+            let len = self.max_fetch_run_bytes.min(total_size - start);
+            let end = start + len;
+            self.observe_fetch_run(len);
+            let (bytes, live) = self
+                .cached_extent(
+                    seg_ref,
+                    tenant_hash,
+                    start,
+                    len,
+                    GetRange::Range(start, end),
+                    phase,
+                    pin,
+                    accounting,
+                )
+                .await?;
+            asm.place(key, start, &bytes)?;
+            live_gets += u64::from(live);
+            start = end;
+        }
+        Ok((asm.into_bytes(), live_gets))
     }
 
     /// The coalescing gap in effect: an explicit [`Self::with_coalesce_gap`]
@@ -3710,11 +3896,15 @@ impl BlockRangeFetcher {
         // selectivity, so the whole-object read is the faster option even though
         // it moves the most bytes.
         if seg_ref.object_size <= self.effective_whole_object_threshold() {
-            let (bytes, live) = self
-                .cached_extent(
+            // Covering read, bounded by the fetch bound (ADR-0996 decision 2):
+            // one `GetRange::Full` for an object at or under the bound, else
+            // `ceil(object_size / bound)` sequential covering sub-range GETs.
+            // Under request-minimal the crossover is saturated, so this is the
+            // path every above-`block_range_threshold` object takes.
+            let (bytes, live_gets) = self
+                .covering_read(
                     seg_ref,
                     tenant_hash,
-                    0,
                     seg_ref.object_size,
                     GetRange::Full,
                     phases.blocks,
@@ -3722,8 +3912,11 @@ impl BlockRangeFetcher {
                     accounting,
                 )
                 .await?;
-            if live {
+            if live_gets > 0 {
+                // The first covering GET keeps the historical `probe_gets`
+                // name; any further segmented GETs are block-data reads.
                 stats.probe_gets = 1;
+                stats.block_range_gets = live_gets.saturating_sub(1);
                 stats.block_bytes_fetched = bytes.len() as u64;
             }
             stats.whole_object = true;
@@ -3956,12 +4149,13 @@ impl BlockRangeFetcher {
             // Keyed and single-flighted like every other GET here, on the same
             // `(0, object_size)` key the whole-object funnel uses: without that,
             // N partitions all crossing over would issue N whole-object GETs,
-            // which is the amplification this path exists to avoid.
-            let (bytes, live) = self
-                .cached_extent(
+            // which is the amplification this path exists to avoid. Bounded by
+            // the fetch bound (ADR-0996 decision 2): one covering GET at or under
+            // the bound, else segmented covering sub-ranges.
+            let (bytes, live_gets) = self
+                .covering_read(
                     seg_ref,
                     tenant_hash,
-                    0,
                     total_size,
                     GetRange::Full,
                     phases.blocks,
@@ -3969,8 +4163,8 @@ impl BlockRangeFetcher {
                     accounting,
                 )
                 .await?;
-            if live {
-                stats.block_range_gets = 1;
+            if live_gets > 0 {
+                stats.block_range_gets = live_gets;
                 stats.block_bytes_fetched = bytes.len() as u64;
             }
             stats.whole_object = true;
@@ -4258,11 +4452,12 @@ impl BlockRangeFetcher {
         let wanted_bytes: u64 = wanted.iter().map(|e| e.len).sum();
         let coverage = wanted_bytes as f64 / blocks_desc.len.max(1) as f64;
         if coverage >= self.coverage_threshold {
-            let (bytes, live) = self
-                .cached_extent(
+            // Bounded by the fetch bound (ADR-0996 decision 2), like the
+            // version-3 coverage crossover above.
+            let (bytes, live_gets) = self
+                .covering_read(
                     seg_ref,
                     tenant_hash,
-                    0,
                     total_size,
                     GetRange::Full,
                     phases.blocks,
@@ -4270,8 +4465,8 @@ impl BlockRangeFetcher {
                     accounting,
                 )
                 .await?;
-            if live {
-                stats.block_range_gets = 1;
+            if live_gets > 0 {
+                stats.block_range_gets = live_gets;
                 stats.block_bytes_fetched = bytes.len() as u64;
             }
             stats.whole_object = true;

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -1914,7 +1914,13 @@ impl LogSegmentFetcher {
         // per-sub-range accounting records the same GET total this funnel would.
         if seg_ref.object_size > self.block_range.max_fetch_run_bytes() {
             let pin = EtagPin::default();
-            let (bytes, _live_gets) = self
+            let fetch_span = tracing::debug_span!(
+                "page_fetch",
+                signal = "logs",
+                s3_requests = tracing::field::Empty,
+                s3_bytes = tracing::field::Empty,
+            );
+            let (bytes, live_gets, live_bytes) = self
                 .block_range
                 .covering_read(
                     seg_ref,
@@ -1925,7 +1931,10 @@ impl LogSegmentFetcher {
                     &pin,
                     accounting,
                 )
+                .instrument(fetch_span.clone())
                 .await?;
+            fetch_span.record("s3_requests", live_gets);
+            fetch_span.record("s3_bytes", live_bytes);
             return Ok(bytes);
         }
 
@@ -3188,7 +3197,7 @@ impl BlockRangeFetcher {
         phase: QueryPhase,
         pin: &EtagPin,
         accounting: &QueryAccounting,
-    ) -> Result<(Bytes, u64), LogFetchError> {
+    ) -> Result<(Bytes, u64, u64), LogFetchError> {
         if total_size <= self.max_fetch_run_bytes {
             let (bytes, live) = self
                 .cached_extent(
@@ -3205,13 +3214,18 @@ impl BlockRangeFetcher {
             if live {
                 self.observe_fetch_run(total_size);
             }
-            return Ok((bytes, u64::from(live)));
+            let live_bytes = if live { total_size } else { 0 };
+            return Ok((bytes, u64::from(live), live_bytes));
         }
 
         let key = seg_ref.data_object_key.as_str();
         let total = usize::try_from(total_size).map_err(|_| corrupt_range(key))?;
         let mut asm = ObjectAssembler::new(&self.assembly_pool, total);
         let mut live_gets = 0u64;
+        // Wire bytes actually moved: a sub-range served from cache moves none,
+        // so `bytes.len()` (the whole object) must never be charged as fetched
+        // on a partially cached covering read.
+        let mut live_bytes = 0u64;
         let mut start = 0u64;
         while start < total_size {
             let len = self.max_fetch_run_bytes.min(total_size - start);
@@ -3233,9 +3247,12 @@ impl BlockRangeFetcher {
             }
             asm.place(key, start, &bytes)?;
             live_gets += u64::from(live);
+            if live {
+                live_bytes += len;
+            }
             start = end;
         }
-        Ok((asm.into_bytes(), live_gets))
+        Ok((asm.into_bytes(), live_gets, live_bytes))
     }
 
     /// The coalescing gap in effect: an explicit [`Self::with_coalesce_gap`]
@@ -3998,7 +4015,7 @@ impl BlockRangeFetcher {
             // `ceil(object_size / bound)` sequential covering sub-range GETs.
             // Under request-minimal the crossover is saturated, so this is the
             // path every above-`block_range_threshold` object takes.
-            let (bytes, live_gets) = self
+            let (bytes, live_gets, live_bytes) = self
                 .covering_read(
                     seg_ref,
                     tenant_hash,
@@ -4014,7 +4031,7 @@ impl BlockRangeFetcher {
                 // name; any further segmented GETs are block-data reads.
                 stats.probe_gets = 1;
                 stats.block_range_gets = live_gets.saturating_sub(1);
-                stats.block_bytes_fetched = bytes.len() as u64;
+                stats.block_bytes_fetched = live_bytes;
             }
             stats.whole_object = true;
             return Ok((bytes, stats));
@@ -4249,7 +4266,7 @@ impl BlockRangeFetcher {
             // which is the amplification this path exists to avoid. Bounded by
             // the fetch bound (ADR-0996 decision 2): one covering GET at or under
             // the bound, else segmented covering sub-ranges.
-            let (bytes, live_gets) = self
+            let (bytes, live_gets, live_bytes) = self
                 .covering_read(
                     seg_ref,
                     tenant_hash,
@@ -4262,7 +4279,7 @@ impl BlockRangeFetcher {
                 .await?;
             if live_gets > 0 {
                 stats.block_range_gets = live_gets;
-                stats.block_bytes_fetched = bytes.len() as u64;
+                stats.block_bytes_fetched = live_bytes;
             }
             stats.whole_object = true;
             // Still admit per-block cache entries so a later partition's fetch of
@@ -4551,7 +4568,7 @@ impl BlockRangeFetcher {
         if coverage >= self.coverage_threshold {
             // Bounded by the fetch bound (ADR-0996 decision 2), like the
             // version-3 coverage crossover above.
-            let (bytes, live_gets) = self
+            let (bytes, live_gets, live_bytes) = self
                 .covering_read(
                     seg_ref,
                     tenant_hash,
@@ -4564,7 +4581,7 @@ impl BlockRangeFetcher {
                 .await?;
             if live_gets > 0 {
                 stats.block_range_gets = live_gets;
-                stats.block_bytes_fetched = bytes.len() as u64;
+                stats.block_bytes_fetched = live_bytes;
             }
             stats.whole_object = true;
             // No per-block cache admission from the whole object here, unlike

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -1025,7 +1025,7 @@ impl LogSegmentFetcher {
         // chunk of every surviving block (ADR-0699 decision 5).
         let all = ColumnSelection::all();
         let result = async {
-            let Some(bytes) = self
+            let Some((bytes, _blocks_read)) = self
                 .tenant_bytes(
                     seg_ref,
                     tenant_hash,
@@ -1094,7 +1094,7 @@ impl LogSegmentFetcher {
         columns: &ColumnSelection,
         accounting: &QueryAccounting,
     ) -> Result<Option<LogSegmentScan>, LogFetchError> {
-        let Some(bytes) = self
+        let Some((bytes, _blocks_read)) = self
             .tenant_bytes(
                 seg_ref,
                 tenant_hash,
@@ -1258,7 +1258,9 @@ impl LogSegmentFetcher {
                 let (n, stats, footer) = self
                     .plan_segment_fast(seg_ref, tenant_hash, accounting)
                     .await?;
-                return Ok(Some((n, stats, Some(footer))));
+                // Footer-carrying branch: no block byte is read here, so the
+                // touch is the scan that follows a nonzero survivor count.
+                return Ok(Some((n, stats, Some(footer), n > 0)));
             }
 
             // Skip-index-only survivor count (#761): when every block-level predicate
@@ -1326,7 +1328,10 @@ impl LogSegmentFetcher {
                     bloom_degraded: false,
                     postings_degraded: false,
                 };
-                return Ok(Some((survivors, plan_stats, Some(footer))));
+                // Footer-carrying branch: only the probe, SKIP_IDX and FIELD_DIR
+                // were read, no block byte, so the touch is the scan a nonzero
+                // survivor count will drive.
+                return Ok(Some((survivors, plan_stats, Some(footer), survivors > 0)));
             }
 
             // Fallback: a predicate the skip index cannot decide (a `has_word`/text
@@ -1338,7 +1343,7 @@ impl LogSegmentFetcher {
             // it (a `None` footer on a relevant segment) as a `plan_full_reads` so a
             // report can see which queries still pay it.
             let all = ColumnSelection::all();
-            let Some(bytes) = self
+            let Some((bytes, blocks_read)) = self
                 .tenant_bytes(
                     seg_ref,
                     tenant_hash,
@@ -1354,7 +1359,17 @@ impl LogSegmentFetcher {
             let key = &seg_ref.data_object_key;
             let span = decode_span();
             let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &all))?;
-            Ok(Some((scan.remaining_blocks(), scan.stats(), None)))
+            // This fallback read fetched blocks iff `tenant_bytes` resolved at
+            // least one (ranged path) or read the whole object (`None`, every
+            // block present). A ranged read that pruned every block resolved zero
+            // extents and moved no block byte, so it is NOT a touch even though it
+            // read the directory sections; a read that decoded one or more blocks
+            // IS a touch even if row filtering then leaves zero survivors.
+            let touched = match blocks_read {
+                None => true,
+                Some(n) => n > 0,
+            };
+            Ok(Some((scan.remaining_blocks(), scan.stats(), None, touched)))
         }
         .await;
         caller_accounting.merge_snapshot(&phase.snapshot().pooled());
@@ -1385,16 +1400,24 @@ impl LogSegmentFetcher {
         //   away. `owned_work` assigns a zero-survivor segment to no partition,
         //   so no scan GET ever follows and not one block byte moves.
         //
-        // A `None` footer is the whole-object fallback, which fetched the object
-        // (blocks included) to compute its survivor count, so it is a touch even
-        // at zero survivors. The two footer-carrying branches always precede a
-        // scan when they report survivors.
-        if let Ok(Some((survivors, _, footer))) = &result
-            && (*survivors > 0 || footer.is_none())
+        // The fallback (a `None` footer) is a touch only when it actually read
+        // this object's blocks. Above the routing threshold it takes the ranged
+        // path, which resolves candidate-block extents from the skip index: when
+        // a prune arm eliminates every block (e.g. a content arm defeats
+        // skip-decidable while a disjoint NumRange arm prunes all blocks) it
+        // resolves zero extents and fetches only the directory sections, moving
+        // no block byte -- not a touch. So the recorder keys on the blocks each
+        // branch actually read (the `touched` flag), not on footer presence: the
+        // footer-carrying branches set it from their survivor count, and the
+        // fallback from whether `tenant_bytes` read any block (contract:
+        // `ravel_types::accounting`, blocks read are cache-inclusive, so the
+        // signal is resolved blocks, never wire bytes).
+        if let Ok(Some((_, _, _, touched))) = &result
+            && *touched
         {
             caller_accounting.add_data_objects_touched(1);
         }
-        result
+        result.map(|opt| opt.map(|(survivors, stats, footer, _)| (survivors, stats, footer)))
     }
 
     /// Whether [`plan_segment`](Self::plan_segment)'s survivor count can be read
@@ -1662,7 +1685,7 @@ impl LogSegmentFetcher {
         footer: Option<&footer::LogFooter>,
         accounting: &QueryAccounting,
     ) -> Result<Option<LogSegmentScan>, LogFetchError> {
-        let Some(bytes) = self
+        let Some((bytes, _blocks_read)) = self
             .tenant_bytes_with_footer(
                 seg_ref,
                 tenant_hash,
@@ -1701,6 +1724,15 @@ impl LogSegmentFetcher {
     /// because this funnel serves both: the scan funnels below reach it as a
     /// data read, and [`plan_segment`](Self::plan_segment)'s fallback reaches it
     /// as a planning read for a predicate the skip index cannot decide.
+    ///
+    /// The second element of the returned tuple reports how many logical BLOCKS
+    /// this read brought into the buffer, cache-inclusive, so a caller that must
+    /// decide whether the object was TOUCHED (its blocks read) can key on the
+    /// blocks actually resolved rather than on wire bytes: `None` means the whole
+    /// object was read (every block is present, so a decode of any of them is a
+    /// touch), and `Some(n)` means the ranged path resolved exactly `n`
+    /// candidate-block extents into the buffer (a touch iff `n > 0`). See
+    /// [`tenant_bytes_with_footer`](Self::tenant_bytes_with_footer).
     async fn tenant_bytes(
         &self,
         seg_ref: &SegmentRef,
@@ -1709,7 +1741,7 @@ impl LogSegmentFetcher {
         columns: &ColumnSelection,
         phase: ProbePhase,
         accounting: &QueryAccounting,
-    ) -> Result<Option<Bytes>, LogFetchError> {
+    ) -> Result<Option<(Bytes, Option<u64>)>, LogFetchError> {
         self.tenant_bytes_with_footer(
             seg_ref,
             tenant_hash,
@@ -1738,6 +1770,15 @@ impl LogSegmentFetcher {
     /// it fetched with would address pages this never brought, which is a typed
     /// `Corrupted` error rather than wrong data, so the two must be the same
     /// value.
+    ///
+    /// The second element of the returned tuple is the count of logical BLOCKS
+    /// brought into the buffer (see [`tenant_bytes`](Self::tenant_bytes)):
+    /// `Some(candidate_blocks)` on the ranged (above-threshold) path, the exact
+    /// number of block extents the fetch resolved and decoded, and `None` on the
+    /// whole-object (below-threshold) path, where every block is present. It lets
+    /// a caller decide "were this object's blocks read" from the blocks actually
+    /// resolved, not from wire bytes, which a fully-pruned ranged read moves none
+    /// of even though the read happened.
     #[allow(clippy::too_many_arguments)]
     async fn tenant_bytes_with_footer(
         &self,
@@ -1748,7 +1789,7 @@ impl LogSegmentFetcher {
         footer: Option<&footer::LogFooter>,
         phase: ProbePhase,
         accounting: &QueryAccounting,
-    ) -> Result<Option<Bytes>, LogFetchError> {
+    ) -> Result<Option<(Bytes, Option<u64>)>, LogFetchError> {
         if !Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns) {
             return Ok(None);
         }
@@ -1813,13 +1854,28 @@ impl LogSegmentFetcher {
             // covered by the derived probe window on this read, reported beside
             // the request/byte counts and charged to the caller's phase.
             self.record_probe_misses(&fetch_span, &stats, phase);
-            return Ok(Some(bytes));
+            // Blocks read on the ranged path: the candidate extents the fetch
+            // resolved, EXCEPT when a crossover (size-threshold or coverage) took
+            // the whole object anyway, where every block is present -- reported as
+            // `None`, the same "whole object" signal the below-threshold branch
+            // returns, so the caller counts a touch without a block count it does
+            // not have here. A non-crossover ranged read that resolved zero
+            // candidates moved no block bytes and is `Some(0)`.
+            let blocks_read = if stats.whole_object {
+                None
+            } else {
+                Some(stats.candidate_blocks)
+            };
+            return Ok(Some((bytes, blocks_read)));
         }
 
-        Ok(Some(
+        // Whole-object (below-threshold) read: the entire object is in the buffer,
+        // so every block is present; `None` signals that to the caller.
+        Ok(Some((
             self.whole_object_bytes(seg_ref, tenant_hash, phases.blocks, accounting)
                 .await?,
-        ))
+            None,
+        )))
     }
 
     /// One whole-object [`GetRange::Full`] read, cache-keyed `(0, object_size)`,

--- a/crates/ravel-query/tests/log_fetch_bound.rs
+++ b/crates/ravel-query/tests/log_fetch_bound.rs
@@ -1,0 +1,478 @@
+//! Integration tests for ADR-0996 decision 2's fetch bound and decision 3's
+//! `data_objects_touched` recorder, both in
+//! [`ravel_query::LogSegmentFetcher`]/[`ravel_query::BlockRangeFetcher`].
+//!
+//! The bound test drives a covering read of an object larger than the bound and
+//! pins the request-count band (`ceil(size / bound)` GETs), the per-request wire
+//! bound ([`BlockRangeFetcher::peak_fetch_run_bytes`] <= bound), and row
+//! identity with the unbounded whole-object path. The recorder test pins that
+//! `plan_segment` records exactly one touch per distinct object, and that a
+//! partition's subset scans do not double-count.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use ravel_catalog::{SegmentLevel, SegmentRef};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{
+    Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
+    PageToken, PutOptions, PutOutcome, StoreError,
+};
+use ravel_query::{BlockRangeFetcher, LogQuery, LogSegmentFetcher};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+const CONTENT_HASH: [u8; 32] = [9u8; 32];
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: [7u8; 16],
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+/// One record per block, so an N-record object has N blocks.
+fn one_record_blocks() -> RlogConfig {
+    RlogConfig {
+        block_target_records: 1,
+        ..RlogConfig::default()
+    }
+}
+
+fn record(name: &str, ts: i64, body: &str) -> LogRecord {
+    let resource = vec![("service.name".to_string(), AttrValue::Str(name.to_string()))];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body.into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    }
+}
+
+fn build_object(records: &[LogRecord]) -> Vec<u8> {
+    let mut w = RlogWriter::new(one_record_blocks(), identity());
+    for r in records {
+        w.push(r.clone()).expect("push");
+    }
+    w.finish().expect("finish")
+}
+
+fn seg_ref(key: &str, size: u64, records: &[LogRecord]) -> SegmentRef {
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: CONTENT_HASH,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+    }
+}
+
+/// Counts `get` calls and records the largest single GET length seen, so a test
+/// can prove both the request count and that no single request exceeded the
+/// bound.
+struct CountingStore {
+    inner: Arc<MemoryStore>,
+    gets: AtomicU64,
+    max_get_len: AtomicU64,
+}
+
+impl CountingStore {
+    fn new(inner: Arc<MemoryStore>) -> Self {
+        CountingStore {
+            inner,
+            gets: AtomicU64::new(0),
+            max_get_len: AtomicU64::new(0),
+        }
+    }
+    fn get_count(&self) -> u64 {
+        self.gets.load(Ordering::SeqCst)
+    }
+    fn max_get_len(&self) -> u64 {
+        self.max_get_len.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for CountingStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        self.gets.fetch_add(1, Ordering::SeqCst);
+        let got = self.inner.get(key, range).await?;
+        self.max_get_len
+            .fetch_max(got.data.len() as u64, Ordering::SeqCst);
+        Ok(got)
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+/// A 40-block object (ts 0..=39, one record per block).
+fn big_object() -> (Vec<LogRecord>, Vec<u8>) {
+    let records: Vec<LogRecord> = (0..40)
+        .map(|ts| {
+            record(
+                "api",
+                ts,
+                "a log line long enough to make the object multi-kilobyte",
+            )
+        })
+        .collect();
+    let bytes = build_object(&records);
+    (records, bytes)
+}
+
+/// ADR-0996 decision 2's covering-read contract: an object above the fetch
+/// bound is read as `ceil(size / bound)` sequential covering sub-range GETs,
+/// each at most the bound, and the decoded rows are byte-identical to the
+/// unbounded whole-object path.
+///
+/// Prove-the-test: raise `with_max_fetch_run_bytes` above `object_size` (or drop
+/// the builder call, restoring the 64 MiB default) and the GET count collapses
+/// to 1, failing the `ceil(size / bound)` assertion.
+#[tokio::test]
+async fn object_above_bound_is_read_in_banded_covering_gets_rows_identical() {
+    let (records, bytes) = big_object();
+    let object_size = bytes.len() as u64;
+
+    // A bound that splits the object into several covering sub-ranges. Chosen so
+    // the band is a clean, > 1 number the assertion can name.
+    let bound = object_size / 5;
+    assert!(bound > 0, "fixture object must exceed the bound five-fold");
+    let expected_gets = object_size.div_ceil(bound);
+    assert!(
+        expected_gets >= 5,
+        "the fixture must genuinely segment, got {expected_gets} sub-ranges"
+    );
+
+    // Reference: the unbounded whole-object path (one GetRange::Full).
+    let ref_mem = Arc::new(MemoryStore::new());
+    ref_mem
+        .put("logs/b.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/b.rlog", object_size, &records);
+    let query = LogQuery::new(0, 39);
+    let reference = LogSegmentFetcher::new(ref_mem as Arc<dyn ObjectStoreBackend>)
+        .fetch(&seg, &query)
+        .await
+        .expect("whole fetch")
+        .expect("in range");
+    assert!(!reference.records.is_empty(), "the object is nonempty");
+
+    // Bounded: request-minimal routing (both thresholds saturated) sends every
+    // object through the whole-object funnel, where the fetch bound segments the
+    // covering read.
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/b.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let counting = Arc::new(CountingStore::new(mem));
+    let store: Arc<dyn ObjectStoreBackend> = counting.clone();
+    let fetcher = LogSegmentFetcher::new(store)
+        .with_block_range_threshold(u64::MAX)
+        .with_request_cost_bytes(u64::MAX)
+        .with_max_fetch_run_bytes(bound);
+
+    let bounded = fetcher
+        .fetch_accounted_with_tenant(&seg, TENANT, &query, &QueryAccounting::new())
+        .await
+        .expect("bounded fetch")
+        .expect("in range");
+
+    // Rows byte-identical to the unbounded path.
+    assert_eq!(
+        reference.records, bounded.records,
+        "segmented covering read must decode byte-identical rows"
+    );
+    // Exactly ceil(size / bound) GETs, and no other read (no probe under
+    // request-minimal).
+    assert_eq!(
+        counting.get_count(),
+        expected_gets,
+        "object above the bound is read in ceil(size/bound) covering GETs"
+    );
+    // No single request moved more than the bound: the per-request wire size is
+    // bounded even though the assembled object buffer is not (the frozen
+    // ravel-logseg reader needs a contiguous object-indexed buffer; see
+    // covering_read's note).
+    assert!(
+        counting.max_get_len() <= bound,
+        "no single GET exceeded the bound: {} > {bound}",
+        counting.max_get_len()
+    );
+    assert!(
+        fetcher.block_range_fetcher().peak_fetch_run_bytes() <= bound,
+        "the fetcher's own peak covering sub-range is bounded: {} > {bound}",
+        fetcher.block_range_fetcher().peak_fetch_run_bytes()
+    );
+}
+
+/// At or under the bound the covering read is a single GET (the ADR's first
+/// regime), byte for byte the unbounded behaviour.
+#[tokio::test]
+async fn object_at_or_under_bound_is_one_covering_get() {
+    let (records, bytes) = big_object();
+    let object_size = bytes.len() as u64;
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/s.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let counting = Arc::new(CountingStore::new(mem));
+    let store: Arc<dyn ObjectStoreBackend> = counting.clone();
+    let seg = seg_ref("logs/s.rlog", object_size, &records);
+    let query = LogQuery::new(0, 39);
+
+    let fetcher = LogSegmentFetcher::new(store)
+        .with_block_range_threshold(u64::MAX)
+        .with_request_cost_bytes(u64::MAX)
+        .with_max_fetch_run_bytes(object_size); // exactly at the bound
+
+    let out = fetcher
+        .fetch_accounted_with_tenant(&seg, TENANT, &query, &QueryAccounting::new())
+        .await
+        .expect("fetch")
+        .expect("in range");
+    assert!(!out.records.is_empty());
+    assert_eq!(
+        counting.get_count(),
+        1,
+        "an object at the bound is one covering GET"
+    );
+}
+
+/// ADR-0996 decision 2: a zero bound clamps up to one at the fetcher (the typed
+/// refusal is at config resolution, `EngineConfig::validate`), so it never
+/// divides by zero. A one-byte bound still reads the whole object, in a
+/// (large) band of single-byte-ish covering GETs, byte-identical.
+#[tokio::test]
+async fn zero_bound_clamps_to_one_and_never_divides_by_zero() {
+    let (records, bytes) = big_object();
+    let object_size = bytes.len() as u64;
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/z.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/z.rlog", object_size, &records);
+    // A BlockRangeFetcher built with a zero bound: clamped to 1, so the covering
+    // read segments into `object_size` single-byte GETs rather than panicking.
+    let br = BlockRangeFetcher::new(mem as Arc<dyn ObjectStoreBackend>)
+        .with_whole_object_threshold(u64::MAX)
+        .with_max_fetch_run_bytes(0);
+    let (assembled, _stats) = br
+        .fetch_object(&seg, TENANT, 0, 39, &QueryAccounting::new())
+        .await
+        .expect("fetch with clamped bound");
+    assert_eq!(assembled.len() as u64, object_size);
+    assert!(br.peak_fetch_run_bytes() <= 1, "clamped bound is one byte");
+}
+
+/// ADR-0996 decision 3: `plan_segment` records exactly one
+/// `data_objects_touched` per distinct relevant object, over however many GETs
+/// the plan issues, and an irrelevant segment records none.
+///
+/// Prove-the-test: delete the `add_data_objects_touched(1)` line in
+/// `plan_segment` and this asserts 0 touches instead of 3.
+#[tokio::test]
+async fn plan_segment_records_one_touch_per_distinct_object() {
+    let mem = Arc::new(MemoryStore::new());
+    let mut segs = Vec::new();
+    for i in 0..3u32 {
+        let records: Vec<LogRecord> = (0..4)
+            .map(|ts| record("api", i as i64 * 100 + ts, "body"))
+            .collect();
+        let bytes = build_object(&records);
+        let key = format!("logs/obj-{i}.rlog");
+        mem.put(&key, bytes.clone().into(), PutOptions::default())
+            .await
+            .expect("put");
+        segs.push(seg_ref(&key, bytes.len() as u64, &records));
+    }
+    // A fourth object entirely outside the query window: relevant-`None`, no
+    // fetch, no touch.
+    let far_records: Vec<LogRecord> = (0..4)
+        .map(|ts| record("api", 1_000_000 + ts, "body"))
+        .collect();
+    let far_bytes = build_object(&far_records);
+    mem.put(
+        "logs/far.rlog",
+        far_bytes.clone().into(),
+        PutOptions::default(),
+    )
+    .await
+    .expect("put");
+    let far_seg = seg_ref("logs/far.rlog", far_bytes.len() as u64, &far_records);
+
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+    let fetcher = LogSegmentFetcher::new(store);
+    let accounting = QueryAccounting::new();
+    // The plan pass runs once per segment (ravel-sql shares it behind a barrier
+    // before any partition drains); here we call it once per segment directly.
+    let query = LogQuery::new(0, 100_000);
+    for seg in &segs {
+        fetcher
+            .plan_segment(seg, TENANT, &query, &accounting)
+            .await
+            .expect("plan");
+    }
+    let touched = fetcher
+        .plan_segment(&far_seg, TENANT, &query, &accounting)
+        .await
+        .expect("plan far");
+    assert!(
+        touched.is_none(),
+        "the far segment is irrelevant, not touched"
+    );
+
+    assert_eq!(
+        accounting.snapshot().data_objects_touched,
+        3,
+        "three distinct relevant objects record exactly three touches"
+    );
+}
+
+/// ADR-0996 decision 2's combined routing test: under request-minimal, with an
+/// explicitly set (low) block-range threshold, the ranged path is never chosen
+/// -- ranged opens == 0. The routing decision is `ranged_projection_pays`
+/// (consumed by ravel-sql's `open_by_column_chunk`, which is what records a
+/// ranged open); request-minimal resolves the block-range threshold to
+/// `u64::MAX`, so no object can select the ranged path.
+///
+/// The full opens-counter differential lives in ravel-sql
+/// (`logs_request_cost_knob_routing.rs`, task 996-6); this pins the ravel-query
+/// routing predicate the counter is downstream of.
+///
+/// Prove-the-test: the counterfactual below keeps the low explicit threshold
+/// WITHOUT request-minimal's override, and `ranged_projection_pays` returns
+/// true -- exactly the ranged open the override exists to suppress.
+#[tokio::test]
+async fn request_minimal_overrides_explicit_block_range_threshold_no_ranged_open() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let object_size = 4 * 1024 * 1024; // 4 MiB, far above any small explicit threshold
+    let narrow_projection = 0.1; // a narrow projection would normally pay to range
+
+    // Request-minimal resolution overrides the explicit --logs-block-range-threshold
+    // to u64::MAX (and saturates the request cost). `with_block_range_threshold`
+    // pins the inner crossover to that same value, so no object qualifies.
+    let request_minimal = LogSegmentFetcher::new(Arc::clone(&store))
+        .with_block_range_threshold(u64::MAX)
+        .with_request_cost_bytes(u64::MAX);
+    assert!(
+        !request_minimal.ranged_projection_pays(object_size, narrow_projection),
+        "request-minimal must never choose the ranged path (ranged opens == 0)"
+    );
+
+    // Counterfactual (the flip): a low explicit threshold NOT overridden. The
+    // inner crossover is pinned to 4 KiB, so a narrow projection of a 4 MiB
+    // object saves far more than that and the ranged path IS chosen.
+    let not_overridden = LogSegmentFetcher::new(store)
+        .with_block_range_threshold(4096)
+        .with_request_cost_bytes(u64::MAX);
+    assert!(
+        not_overridden.ranged_projection_pays(object_size, narrow_projection),
+        "without the override a low explicit threshold still routes ranged"
+    );
+}
+
+/// ADR-0996 decision 3: a striped multi-partition scan still records exactly one
+/// touch per object. The plan runs once (the shared per-segment recorder) and
+/// the per-partition subset scans that follow do NOT record touches, so N
+/// partitions over one object leave the count at one.
+#[tokio::test]
+async fn striped_subset_scans_do_not_double_count_a_touch() {
+    let records: Vec<LogRecord> = (0..8).map(|ts| record("api", ts, "body")).collect();
+    let bytes = build_object(&records);
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/one.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/one.rlog", bytes.len() as u64, &records);
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+    let fetcher = LogSegmentFetcher::new(store);
+    let accounting = QueryAccounting::new();
+    let query = LogQuery::new(0, 7);
+
+    // One plan pass records the single touch.
+    fetcher
+        .plan_segment(&seg, TENANT, &query, &accounting)
+        .await
+        .expect("plan");
+    assert_eq!(accounting.snapshot().data_objects_touched, 1);
+
+    // Several partitions each drain their own subset of the object's blocks.
+    // These are not the designated recorder, so the count stays one.
+    let columns = ravel_logseg::ColumnSelection::all();
+    for indices in [vec![0usize], vec![1, 2], vec![3]] {
+        let mut scan = fetcher
+            .scan_accounted_with_tenant_subset(
+                &seg,
+                TENANT,
+                &query,
+                &columns,
+                &indices,
+                None,
+                &accounting,
+            )
+            .await
+            .expect("subset scan")
+            .expect("in range");
+        while scan.next_block().expect("block").is_some() {}
+    }
+    assert_eq!(
+        accounting.snapshot().data_objects_touched,
+        1,
+        "per-partition subset scans must not re-record the touch"
+    );
+}

--- a/crates/ravel-query/tests/log_fetch_bound.rs
+++ b/crates/ravel-query/tests/log_fetch_bound.rs
@@ -2,12 +2,21 @@
 //! `data_objects_touched` recorder, both in
 //! [`ravel_query::LogSegmentFetcher`]/[`ravel_query::BlockRangeFetcher`].
 //!
-//! The bound test drives a covering read of an object larger than the bound and
-//! pins the request-count band (`ceil(size / bound)` GETs), the per-request wire
-//! bound ([`BlockRangeFetcher::peak_fetch_run_bytes`] <= bound), and row
-//! identity with the unbounded whole-object path. The recorder test pins that
-//! `plan_segment` records exactly one touch per distinct object, and that a
-//! partition's subset scans do not double-count.
+//! The bound tests drive a covering read of an object larger than the bound and
+//! pin the request-count band (`ceil(size / bound)` GETs), the per-request wire
+//! bound ([`BlockRangeFetcher::peak_fetch_run_bytes`], which counts only ISSUED
+//! reads), the refusal of a zero bound, and row identity with the unbounded
+//! whole-object path. The recorder tests pin that `plan_segment` records exactly
+//! one touch per distinct object whose blocks a scan will fetch, that a
+//! probe-only plan records none, and that a partition's subset scans do not
+//! double-count.
+//!
+//! The routing tests pin ADR-0996's outcome at the shipped default: a saturated
+//! resolved rate saturates the routing threshold too, so `cost-based` at the
+//! reference profile routes every object whole and the plan phase issues no
+//! footer probe. They run against an object above the production 512 KiB routing
+//! threshold, which is the only band where the ranged path and the
+//! skip-decidable plan branch are reachable at all.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -15,17 +24,26 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_trait::async_trait;
+use ravel_cache::{Cache, CacheLimits};
 use ravel_catalog::{SegmentLevel, SegmentRef};
 use ravel_logseg::writer::ObjectIdentity;
-use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_logseg::{
+    AttrValue, FieldSel, FieldType, LogRecord, Predicate, RlogConfig, RlogWriter,
+    stream_attrs_bytes,
+};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{
     Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
     PageToken, PutOptions, PutOutcome, StoreError,
 };
-use ravel_query::{BlockRangeFetcher, LogQuery, LogSegmentFetcher};
+use ravel_query::{
+    BlockRangeFetcher, DEFAULT_LOG_REQUEST_COST_BYTES, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+    EngineConfig, EngineConfigError, LogQuery, LogSegmentFetcher, LogsFetchPolicy,
+    ResolvedLogsFetch, resolve_logs_fetch,
+};
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
+use ravel_types::cost_profile::StoreCostProfile;
 use uuid::Uuid;
 
 const TENANT: TenantHash = TenantHash([7u8; 16]);
@@ -96,12 +114,16 @@ fn seg_ref(key: &str, size: u64, records: &[LogRecord]) -> SegmentRef {
     }
 }
 
-/// Counts `get` calls and records the largest single GET length seen, so a test
-/// can prove both the request count and that no single request exceeded the
-/// bound.
+/// Counts `get` calls, counts the suffix-range GETs among them (the ADR-0107
+/// etag-establishing footer probe is the only read shape that uses
+/// [`GetRange::Suffix`]), and records the largest single GET length seen. A test
+/// can therefore prove the request count, the probe count, and that no single
+/// request exceeded the fetch bound, all from real store traffic rather than
+/// from a configured value.
 struct CountingStore {
     inner: Arc<MemoryStore>,
     gets: AtomicU64,
+    suffix_gets: AtomicU64,
     max_get_len: AtomicU64,
 }
 
@@ -110,11 +132,17 @@ impl CountingStore {
         CountingStore {
             inner,
             gets: AtomicU64::new(0),
+            suffix_gets: AtomicU64::new(0),
             max_get_len: AtomicU64::new(0),
         }
     }
     fn get_count(&self) -> u64 {
         self.gets.load(Ordering::SeqCst)
+    }
+    /// Footer probes: every probe site issues `GetRange::Suffix`, and nothing
+    /// else does.
+    fn probe_count(&self) -> u64 {
+        self.suffix_gets.load(Ordering::SeqCst)
     }
     fn max_get_len(&self) -> u64 {
         self.max_get_len.load(Ordering::SeqCst)
@@ -133,6 +161,9 @@ impl ObjectStoreBackend for CountingStore {
     }
     async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
         self.gets.fetch_add(1, Ordering::SeqCst);
+        if matches!(range, GetRange::Suffix(_)) {
+            self.suffix_gets.fetch_add(1, Ordering::SeqCst);
+        }
         let got = self.inner.get(key, range).await?;
         self.max_get_len
             .fetch_max(got.data.len() as u64, Ordering::SeqCst);
@@ -171,6 +202,121 @@ fn big_object() -> (Vec<LogRecord>, Vec<u8>) {
         .collect();
     let bytes = build_object(&records);
     (records, bytes)
+}
+
+/// Deterministic pseudo-random hex. The above-threshold fixture must exceed
+/// 512 KiB as STORED bytes, and the writer zstds every page, so a repeated body
+/// would compress away to nothing and leave the object below the routing
+/// threshold the test is about.
+fn noise_body(seed: u64, len: usize) -> String {
+    const A: u64 = 6_364_136_223_846_793_005;
+    const C: u64 = 1_442_695_040_888_963_407;
+    let mut x = seed.wrapping_mul(A).wrapping_add(C);
+    let mut s = String::with_capacity(len + 16);
+    while s.len() < len {
+        x = x.wrapping_mul(A).wrapping_add(C);
+        s.push_str(&format!("{x:016x}"));
+    }
+    s.truncate(len);
+    s
+}
+
+/// A record carrying an i64 `code` attribute, which FIELD_DIR resolves to a
+/// dynamic column and SKIP_IDX carries per-block numeric stats for. That is what
+/// makes a `Predicate::NumRange` on `code` a skip-decidable prune arm.
+fn coded_record(ts: i64, code: i64) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: noise_body(ts as u64, 1_600),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![("code".to_string(), AttrValue::I64(code))],
+    }
+}
+
+/// An object comfortably above the production 512 KiB routing threshold
+/// ([`DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`]), every record carrying `code = 500`.
+/// Above that threshold `plan_segment`'s skip-decidable branch (#761) and the
+/// ranged fetch path are reachable; below it neither is, which is why the older
+/// fixtures in this file exercise only the whole-object fallback.
+fn above_threshold_object() -> (Vec<LogRecord>, Vec<u8>) {
+    let records: Vec<LogRecord> = (0..700i64).map(|ts| coded_record(ts, 500)).collect();
+    let bytes = build_object(&records);
+    assert!(
+        bytes.len() as u64 > DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+        "the fixture must exceed the 512 KiB routing threshold, got {} bytes",
+        bytes.len()
+    );
+    (records, bytes)
+}
+
+/// A skip-decidable query (`plan_skip_decidable`: no content arm, no stream
+/// filter, a nonempty all-`NumRange` prune) over `code`, whose ts window
+/// overlaps the fixture without containing it, so the predicate-free fast path
+/// cannot take over.
+fn coded_query(code_min: i64, code_max: i64) -> LogQuery {
+    LogQuery::new(0, 399).with_prune(Predicate::NumRange {
+        field: FieldSel::Attr("code".into()),
+        ty: FieldType::I64,
+        min: Some(code_min as u64),
+        max: Some(code_max as u64),
+    })
+}
+
+/// Puts `bytes` at `key` behind a [`CountingStore`] and returns the seg ref, the
+/// counter, and the store handle.
+async fn counted_store(
+    key: &str,
+    bytes: &[u8],
+    records: &[LogRecord],
+) -> (SegmentRef, Arc<CountingStore>, Arc<dyn ObjectStoreBackend>) {
+    let mem = Arc::new(MemoryStore::new());
+    mem.put(
+        key,
+        bytes::Bytes::copy_from_slice(bytes),
+        PutOptions::default(),
+    )
+    .await
+    .expect("put");
+    let counting = Arc::new(CountingStore::new(mem));
+    let store: Arc<dyn ObjectStoreBackend> = counting.clone();
+    (seg_ref(key, bytes.len() as u64, records), counting, store)
+}
+
+/// Builds a fetcher the way `ravel-server`'s `build_sql_state` does: the
+/// resolved routing threshold and request cost are handed to the fetcher
+/// unconditionally, so `with_block_range_threshold` pins the inner crossover to
+/// whatever `resolve_logs_fetch` produced.
+fn fetcher_from(
+    resolved: &ResolvedLogsFetch,
+    store: Arc<dyn ObjectStoreBackend>,
+) -> LogSegmentFetcher {
+    LogSegmentFetcher::new(store)
+        .with_block_range_threshold(resolved.block_range_threshold)
+        .with_request_cost_bytes(resolved.request_cost_bytes)
+}
+
+/// The resolution the shipped default produces: `cost-based` at the reference
+/// (intra-region, free-byte) profile, with no explicit overrides.
+fn cost_based_at_reference() -> ResolvedLogsFetch {
+    resolve_logs_fetch(
+        LogsFetchPolicy::CostBased,
+        &StoreCostProfile::reference(),
+        None,
+        DEFAULT_LOG_REQUEST_COST_BYTES,
+        DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+        None,
+    )
 }
 
 /// ADR-0996 decision 2's covering-read contract: an object above the fetch
@@ -223,7 +369,8 @@ async fn object_above_bound_is_read_in_banded_covering_gets_rows_identical() {
     let fetcher = LogSegmentFetcher::new(store)
         .with_block_range_threshold(u64::MAX)
         .with_request_cost_bytes(u64::MAX)
-        .with_max_fetch_run_bytes(bound);
+        .with_max_fetch_run_bytes(bound)
+        .expect("a nonzero bound is accepted");
 
     let bounded = fetcher
         .fetch_accounted_with_tenant(&seg, TENANT, &query, &QueryAccounting::new())
@@ -252,10 +399,80 @@ async fn object_above_bound_is_read_in_banded_covering_gets_rows_identical() {
         "no single GET exceeded the bound: {} > {bound}",
         counting.max_get_len()
     );
-    assert!(
-        fetcher.block_range_fetcher().peak_fetch_run_bytes() <= bound,
-        "the fetcher's own peak covering sub-range is bounded: {} > {bound}",
-        fetcher.block_range_fetcher().peak_fetch_run_bytes()
+    // Exactly the bound, not merely at or under it: every sub-range except the
+    // last is a full bound-length read, and all of them were ISSUED (no cache is
+    // wired here), so the peak must have moved to the bound. `<= bound` alone
+    // would also pass if the counter never moved at all.
+    assert_eq!(
+        fetcher.block_range_fetcher().peak_fetch_run_bytes(),
+        bound,
+        "the fetcher's own peak covering sub-range is exactly the bound"
+    );
+}
+
+/// [`BlockRangeFetcher::peak_fetch_run_bytes`] counts reads this fetcher ISSUED.
+/// A covering read served entirely from the cache crosses no network and moves
+/// no wire bytes, so it must leave the peak at zero.
+///
+/// Prove-the-test: move `observe_fetch_run` back above the `cached_extent` call
+/// in `covering_read` (either regime) and the second assertion reads
+/// `object_size` instead of the first read's peak, because the cache-served
+/// second fetch re-observes an extent it never requested.
+#[tokio::test]
+async fn a_cache_served_covering_read_does_not_move_the_peak() {
+    let (records, bytes) = big_object();
+    let object_size = bytes.len() as u64;
+
+    let (seg, counting, store) = counted_store("logs/c.rlog", &bytes, &records).await;
+    let acc = QueryAccounting::new();
+
+    // One cache, shared by two fetchers, large enough to hold the whole object.
+    // `with_whole_object_threshold(u64::MAX)` sends the object down
+    // `covering_read`, which the bound then segments.
+    let cache = Arc::new(Cache::new(CacheLimits::new(1 << 20, 1024, 1 << 20)));
+    let bound = object_size / 5;
+    assert!(bound > 0, "the fixture must segment");
+
+    let warm = BlockRangeFetcher::new(Arc::clone(&store))
+        .with_whole_object_threshold(u64::MAX)
+        .with_max_fetch_run_bytes(bound)
+        .expect("a nonzero bound is accepted")
+        .with_cache(Arc::clone(&cache));
+    assert_eq!(warm.peak_fetch_run_bytes(), 0, "nothing issued yet");
+    warm.fetch_object(&seg, TENANT, 0, 39, &acc)
+        .await
+        .expect("first fetch");
+    let issued = counting.get_count();
+    assert_eq!(
+        issued,
+        object_size.div_ceil(bound),
+        "the first pass issued every covering sub-range"
+    );
+    assert_eq!(
+        warm.peak_fetch_run_bytes(),
+        bound,
+        "the issued sub-ranges set the peak to the bound"
+    );
+
+    // A second fetcher over the same cache: every covering sub-range is served
+    // from cache, so it issues nothing and its own peak must stay zero.
+    let cold = BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(u64::MAX)
+        .with_max_fetch_run_bytes(bound)
+        .expect("a nonzero bound is accepted")
+        .with_cache(cache);
+    cold.fetch_object(&seg, TENANT, 0, 39, &acc)
+        .await
+        .expect("cache-served fetch");
+    assert_eq!(
+        counting.get_count(),
+        issued,
+        "no new store GET: the second fetcher hit the shared cache"
+    );
+    assert_eq!(
+        cold.peak_fetch_run_bytes(),
+        0,
+        "a covering read served from cache issued nothing, so the peak stays zero"
     );
 }
 
@@ -278,7 +495,8 @@ async fn object_at_or_under_bound_is_one_covering_get() {
     let fetcher = LogSegmentFetcher::new(store)
         .with_block_range_threshold(u64::MAX)
         .with_request_cost_bytes(u64::MAX)
-        .with_max_fetch_run_bytes(object_size); // exactly at the bound
+        .with_max_fetch_run_bytes(object_size) // exactly at the bound
+        .expect("a nonzero bound is accepted");
 
     let out = fetcher
         .fetch_accounted_with_tenant(&seg, TENANT, &query, &QueryAccounting::new())
@@ -293,30 +511,48 @@ async fn object_at_or_under_bound_is_one_covering_get() {
     );
 }
 
-/// ADR-0996 decision 2: a zero bound clamps up to one at the fetcher (the typed
-/// refusal is at config resolution, `EngineConfig::validate`), so it never
-/// divides by zero. A one-byte bound still reads the whole object, in a
-/// (large) band of single-byte-ish covering GETs, byte-identical.
-#[tokio::test]
-async fn zero_bound_clamps_to_one_and_never_divides_by_zero() {
-    let (records, bytes) = big_object();
-    let object_size = bytes.len() as u64;
-    let mem = Arc::new(MemoryStore::new());
-    mem.put("logs/z.rlog", bytes.clone().into(), PutOptions::default())
-        .await
-        .expect("put");
-    let seg = seg_ref("logs/z.rlog", object_size, &records);
-    // A BlockRangeFetcher built with a zero bound: clamped to 1, so the covering
-    // read segments into `object_size` single-byte GETs rather than panicking.
-    let br = BlockRangeFetcher::new(mem as Arc<dyn ObjectStoreBackend>)
-        .with_whole_object_threshold(u64::MAX)
-        .with_max_fetch_run_bytes(0);
-    let (assembled, _stats) = br
-        .fetch_object(&seg, TENANT, 0, 39, &QueryAccounting::new())
-        .await
-        .expect("fetch with clamped bound");
-    assert_eq!(assembled.len() as u64, object_size);
-    assert!(br.peak_fetch_run_bytes() <= 1, "clamped bound is one byte");
+/// ADR-0996 decision 2: a zero bound is REFUSED at the setter, with the same
+/// typed error `EngineConfig::validate` returns. Clamping it up to one instead
+/// would turn a misconfigured bound into a silent one-byte-per-GET read of every
+/// object -- a bound that "works" while multiplying the request bill by the
+/// object size. The two checks are complementary: `validate` guards the config
+/// surface, the setter guards every direct builder call that never passes
+/// through an `EngineConfig`.
+///
+/// Prove-the-test: restore `self.max_fetch_run_bytes = n.max(1)` in
+/// `BlockRangeFetcher::with_max_fetch_run_bytes` and both `expect_err` calls
+/// panic on an `Ok`.
+#[test]
+fn zero_bound_is_refused_by_the_setter_not_clamped() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    assert_eq!(
+        BlockRangeFetcher::new(Arc::clone(&store))
+            .with_max_fetch_run_bytes(0)
+            .err(),
+        Some(EngineConfigError::ZeroFetchBound),
+        "a zero bound is refused, not clamped to one"
+    );
+    assert_eq!(
+        LogSegmentFetcher::new(Arc::clone(&store))
+            .with_max_fetch_run_bytes(0)
+            .err(),
+        Some(EngineConfigError::ZeroFetchBound),
+        "the outer builder refuses it too"
+    );
+    // The config surface still refuses it, unchanged: the setter does not
+    // replace that check.
+    let cfg = EngineConfig {
+        logs_max_fetch_run_bytes: 0,
+        ..EngineConfig::default()
+    };
+    assert_eq!(cfg.validate(), Err(EngineConfigError::ZeroFetchBound));
+    // One byte is a legal (absurd) bound and is accepted, so the refusal is
+    // exactly of zero and not of "small".
+    assert!(
+        BlockRangeFetcher::new(store)
+            .with_max_fetch_run_bytes(1)
+            .is_ok()
+    );
 }
 
 /// ADR-0996 decision 3: `plan_segment` records exactly one
@@ -474,5 +710,228 @@ async fn striped_subset_scans_do_not_double_count_a_touch() {
         accounting.snapshot().data_objects_touched,
         1,
         "per-partition subset scans must not re-record the touch"
+    );
+}
+
+/// ADR-0996 decision 3 and the `data_objects_touched` contract in
+/// `ravel_types::accounting`: "A footer or index probe does not count ... if the
+/// query then decides to fetch no blocks from that object, the object was never
+/// touched."
+///
+/// `plan_segment`'s skip-decidable branch (#761) reads the probe, SKIP_IDX and
+/// FIELD_DIR and nothing else. When its prune arm eliminates every block the
+/// scan that would have fetched blocks never runs (`owned_work` assigns a
+/// zero-survivor segment to no partition), so this must record ZERO touches.
+/// Counting it would inflate the denominator of `range_amplification` in the
+/// flattering direction.
+///
+/// The fixture is above the 512 KiB routing threshold on purpose: at or below
+/// it `plan_segment` takes the whole-object fallback and this branch never runs,
+/// which is why the probe-count assertion below is part of the claim.
+///
+/// Prove-the-test: restore `if matches!(result, Ok(Some(_)))` as the recording
+/// predicate in `plan_segment` and the `data_objects_touched, 0` assertion reads
+/// 1.
+#[tokio::test]
+async fn a_zero_survivor_skip_decidable_plan_records_no_touch() {
+    let (records, bytes) = above_threshold_object();
+    let (seg, counting, store) = counted_store("logs/skip-zero.rlog", &bytes, &records).await;
+
+    // The shipped byte-minimal routing threshold, so the object is above it and
+    // the skip-decidable branch is the one that runs.
+    let fetcher = LogSegmentFetcher::new(store);
+    assert_eq!(
+        fetcher.block_range_threshold(),
+        DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
+    );
+    let accounting = QueryAccounting::new();
+
+    // `code` is 500 on every record, so this arm is disjoint from every block's
+    // numeric stat and prunes them all.
+    let (survivors, _stats, footer) = fetcher
+        .plan_segment(&seg, TENANT, &coded_query(9_000, 10_000), &accounting)
+        .await
+        .expect("plan")
+        .expect("the segment is ts-relevant, so this is not the irrelevant None");
+    assert_eq!(survivors, 0, "the prune arm eliminates every block");
+    assert!(
+        footer.is_some(),
+        "the skip-decidable branch carries its footer forward; a None footer \
+         would mean the whole-object fallback ran instead"
+    );
+    assert!(
+        counting.probe_count() > 0,
+        "the skip-decidable branch issued its suffix probe, so the branch under \
+         test is the one that ran"
+    );
+
+    assert_eq!(
+        accounting.snapshot().data_objects_touched,
+        0,
+        "a probe-only plan that fetched no block bytes is not a touch"
+    );
+}
+
+/// The sibling of the test above, same fixture and same branch, with a prune arm
+/// that keeps every block: survivors > 0, a scan follows, and the object is
+/// touched exactly once.
+#[tokio::test]
+async fn a_surviving_skip_decidable_plan_records_exactly_one_touch() {
+    let (records, bytes) = above_threshold_object();
+    let (seg, counting, store) = counted_store("logs/skip-live.rlog", &bytes, &records).await;
+
+    let fetcher = LogSegmentFetcher::new(store);
+    let accounting = QueryAccounting::new();
+
+    let (survivors, _stats, footer) = fetcher
+        .plan_segment(&seg, TENANT, &coded_query(0, 1_000), &accounting)
+        .await
+        .expect("plan")
+        .expect("relevant");
+    assert!(survivors > 0, "the wide prune arm keeps blocks");
+    assert!(
+        footer.is_some(),
+        "same skip-decidable branch as the sibling"
+    );
+    assert!(counting.probe_count() > 0, "same branch, same probe");
+
+    assert_eq!(
+        accounting.snapshot().data_objects_touched,
+        1,
+        "a plan whose survivors a scan will fetch touches the object exactly once"
+    );
+}
+
+/// ADR-0996 decision 2, the outcome the whole ADR is for: at the shipped default
+/// (`cost-based` + the reference profile) a narrow projection of an object above
+/// 512 KiB must route WHOLE-OBJECT, so ravel-sql records zero ranged opens.
+///
+/// The routing predicate is `ranged_projection_pays`, which compares the
+/// projection's saved bytes against `BlockRangeFetcher::effective_whole_object_threshold`.
+/// That accessor returns the value `with_block_range_threshold` pinned VERBATIM
+/// when one was set, bypassing the `5 x request_cost` derivation and its floors
+/// -- and `ravel-server` always sets it. So a resolution that saturates only the
+/// rate and leaves the routing threshold at 512 KiB delivers none of this: the
+/// object still routes ranged, and the plan phase still issues the probe and
+/// section GETs the ADR exists to remove.
+///
+/// Prove-the-test: key the routing override on `matches!(policy,
+/// LogsFetchPolicy::RequestMinimal)` alone (the pre-fix condition in
+/// `resolve_logs_fetch`) and both halves fail -- `ranged_projection_pays` returns
+/// true, and the fetch issues a probe plus section and chunk GETs instead of the
+/// single covering GET asserted here.
+#[tokio::test]
+async fn cost_based_at_the_reference_profile_routes_whole_object() {
+    let resolved = cost_based_at_reference();
+    assert_eq!(resolved.request_cost_bytes, u64::MAX, "free bytes saturate");
+
+    let (records, bytes) = above_threshold_object();
+    let object_size = bytes.len() as u64;
+    let (seg, counting, store) = counted_store("logs/cb.rlog", &bytes, &records).await;
+    let fetcher = fetcher_from(&resolved, store);
+
+    // The routing predicate ravel-sql's `open_by_column_chunk` consumes: a
+    // one-column-out-of-many projection of this object must not pay to range.
+    assert!(
+        !fetcher.ranged_projection_pays(object_size, 0.1),
+        "cost-based at the reference profile must never choose the ranged path"
+    );
+
+    // ... and the read that follows is one covering GET with no probe, which is
+    // what makes `data_GETs_per_touched_object` 1.0.
+    let accounting = QueryAccounting::new();
+    fetcher
+        .plan_segment(&seg, TENANT, &coded_query(0, 1_000), &accounting)
+        .await
+        .expect("plan")
+        .expect("relevant");
+    assert_eq!(
+        counting.probe_count(),
+        0,
+        "no footer probe: the object never reaches the ranged path"
+    );
+    assert_eq!(
+        counting.get_count(),
+        1,
+        "one whole-object GET for the whole plan phase"
+    );
+
+    // The counterfactual the fix removes: the same saturated rate with the
+    // routing threshold left at its configured 512 KiB routes ranged.
+    let unfixed: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let stale = LogSegmentFetcher::new(unfixed)
+        .with_block_range_threshold(DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD)
+        .with_request_cost_bytes(u64::MAX);
+    assert!(
+        stale.ranged_projection_pays(object_size, 0.1),
+        "with the threshold left at 512 KiB the saturated rate changes nothing"
+    );
+}
+
+/// ADR-0996 decision 2's plan-probe claim, pinned as BEHAVIOUR rather than as a
+/// configuration flag: under a saturated resolution the plan phase issues ZERO
+/// footer probes, because `plan_segment`'s two probe-issuing branches both gate
+/// on `object_size > block_range_threshold` and the saturated threshold closes
+/// them. No separate suppression switch is needed or exists.
+///
+/// The byte-minimal arm is the flip: same object, same query, and the probe
+/// count is nonzero there, so the two zero assertions are not vacuous.
+#[tokio::test]
+async fn a_saturated_resolution_issues_no_plan_footer_probe() {
+    let (records, bytes) = above_threshold_object();
+    let reference = StoreCostProfile::reference();
+    let query = coded_query(0, 1_000);
+
+    let policies = [
+        (LogsFetchPolicy::RequestMinimal, 0u64),
+        (LogsFetchPolicy::CostBased, 0),
+    ];
+    for (policy, expected_probes) in policies {
+        let resolved = resolve_logs_fetch(
+            policy,
+            &reference,
+            None,
+            DEFAULT_LOG_REQUEST_COST_BYTES,
+            DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            None,
+        );
+        let key = format!("logs/probe-{}.rlog", policy.as_str());
+        let (seg, counting, store) = counted_store(&key, &bytes, &records).await;
+        let fetcher = fetcher_from(&resolved, store);
+        fetcher
+            .plan_segment(&seg, TENANT, &query, &QueryAccounting::new())
+            .await
+            .expect("plan")
+            .expect("relevant");
+        assert_eq!(
+            counting.probe_count(),
+            expected_probes,
+            "{} must issue no plan-phase footer probe",
+            policy.as_str()
+        );
+    }
+
+    // byte-minimal keeps the 512 KiB threshold, so the same above-threshold
+    // object DOES take a probing branch. This is the demonstration that the
+    // zeros above are a real property of the saturated resolution.
+    let bm = resolve_logs_fetch(
+        LogsFetchPolicy::ByteMinimal,
+        &reference,
+        None,
+        DEFAULT_LOG_REQUEST_COST_BYTES,
+        DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+        None,
+    );
+    let (seg, counting, store) = counted_store("logs/probe-bm.rlog", &bytes, &records).await;
+    let fetcher = fetcher_from(&bm, store);
+    fetcher
+        .plan_segment(&seg, TENANT, &query, &QueryAccounting::new())
+        .await
+        .expect("plan")
+        .expect("relevant");
+    assert!(
+        counting.probe_count() > 0,
+        "byte-minimal probes an above-threshold object, so the zeros above are \
+         not vacuous"
     );
 }

--- a/crates/ravel-query/tests/log_fetch_bound.rs
+++ b/crates/ravel-query/tests/log_fetch_bound.rs
@@ -111,6 +111,7 @@ fn seg_ref(key: &str, size: u64, records: &[LogRecord]) -> SegmentRef {
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 
@@ -252,9 +253,17 @@ fn coded_record(ts: i64, code: i64) -> LogRecord {
 fn above_threshold_object() -> (Vec<LogRecord>, Vec<u8>) {
     let records: Vec<LogRecord> = (0..700i64).map(|ts| coded_record(ts, 500)).collect();
     let bytes = build_object(&records);
+    // The tightest consumer is `cost_based_at_the_reference_profile_routes_whole_object`'s
+    // 0.9x counterfactual (`ranged_projection_pays(size, 0.1)`): it needs the
+    // projection's SAVED bytes, `size * (1.0 - 0.1)`, to exceed the routing
+    // threshold, which is a strictly larger object than merely `size >
+    // threshold`. Guard the exact bound that assertion depends on rather than the
+    // looser one, so a smaller fixture fails here instead of there.
     assert!(
-        bytes.len() as u64 > DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
-        "the fixture must exceed the 512 KiB routing threshold, got {} bytes",
+        bytes.len() as f64 * 0.9 > DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD as f64,
+        "the fixture must clear the 0.9x counterfactual bound (size * 0.9 > {} \
+         bytes), got {} bytes",
+        DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
         bytes.len()
     );
     (records, bytes)
@@ -799,6 +808,134 @@ async fn a_surviving_skip_decidable_plan_records_exactly_one_touch() {
         accounting.snapshot().data_objects_touched,
         1,
         "a plan whose survivors a scan will fetch touches the object exactly once"
+    );
+}
+
+/// A content arm plus a prune arm over `code`. The content arm (`HasWord` on the
+/// body) defeats `plan_skip_decidable`, so `plan_segment` cannot take the
+/// skip-decidable branch and falls through to the ranged whole-object fallback
+/// even above the routing threshold. The `NumRange` prune arm still drives which
+/// blocks the ranged fetch resolves.
+fn content_and_prune_query(code_min: i64, code_max: i64) -> LogQuery {
+    LogQuery::new(0, 399)
+        .with_content(Predicate::HasWord {
+            field: FieldSel::Body,
+            word: "deadbeef".into(),
+        })
+        .with_prune(Predicate::NumRange {
+            field: FieldSel::Attr("code".into()),
+            ty: FieldType::I64,
+            min: Some(code_min as u64),
+            max: Some(code_max as u64),
+        })
+}
+
+/// ADR-0996 decision 3 and the `data_objects_touched` contract in
+/// `ravel_types::accounting` ("if the query then decides to fetch no blocks from
+/// that object, the object was never touched"), on the FALLBACK path this time.
+///
+/// A content arm defeats `plan_skip_decidable`, so an above-threshold object
+/// takes `plan_segment`'s ranged whole-object fallback rather than the
+/// skip-decidable branch. When a disjoint `NumRange` arm prunes every block, the
+/// ranged fetch resolves ZERO candidate-block extents and moves no block byte:
+/// it reads only the footer, SKIP_IDX, FIELD_DIR and front/tail sections. That is
+/// a probe-only read, not a touch, so this must record ZERO -- counting it would
+/// inflate `range_amplification`'s denominator in the flattering direction.
+///
+/// Prove-the-test: this is the residual the fix removes. Flip the recorder in
+/// `plan_segment` back to `*survivors > 0 || footer.is_none()` (the `touched`
+/// flag replaced it): the fallback hands a `None` footer, so `footer.is_none()`
+/// is true and this reads 1 instead of 0. The fix keys on the blocks the fetch
+/// actually resolved (`Some(0)` here) instead.
+#[tokio::test]
+async fn a_zero_candidate_fallback_plan_records_no_touch() {
+    let (records, bytes) = above_threshold_object();
+    let (seg, counting, store) = counted_store("logs/fallback-zero.rlog", &bytes, &records).await;
+
+    // `with_block_range_threshold` pins the inner whole-object crossover to the
+    // same value, so an object above it takes the TRUE ranged path rather than
+    // the size-threshold whole-object crossover (which would read every block and
+    // legitimately be a touch). This is the band the residual lives in.
+    let fetcher = LogSegmentFetcher::new(store)
+        .with_block_range_threshold(DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD);
+    assert_eq!(
+        fetcher.block_range_threshold(),
+        DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+        "the object is above the routing threshold, so the ranged fallback runs"
+    );
+    let accounting = QueryAccounting::new();
+
+    // `code` is 500 on every record, so this arm is disjoint from every block's
+    // numeric stat and prunes them all; the content arm forces the fallback.
+    let (survivors, _stats, footer) = fetcher
+        .plan_segment(
+            &seg,
+            TENANT,
+            &content_and_prune_query(9_000, 10_000),
+            &accounting,
+        )
+        .await
+        .expect("plan")
+        .expect("the segment is ts-relevant, so this is not the irrelevant None");
+    assert_eq!(
+        survivors, 0,
+        "the disjoint prune arm eliminates every block"
+    );
+    assert!(
+        footer.is_none(),
+        "the content arm defeats skip-decidable, so this is the ranged fallback, \
+         whose footer is not carried forward"
+    );
+    assert!(
+        counting.probe_count() > 0,
+        "the ranged fallback issued its suffix probe, so the branch under test ran"
+    );
+
+    assert_eq!(
+        accounting.snapshot().data_objects_touched,
+        0,
+        "a fallback that resolved zero candidate blocks fetched no block byte and \
+         is not a touch"
+    );
+}
+
+/// The sibling of the test above, same fixture and same fallback branch, with a
+/// prune arm that keeps every block. The ranged fetch resolves one or more
+/// candidate-block extents and decodes them, so the object is touched exactly
+/// once -- even if row filtering (the content arm) then leaves zero survivors,
+/// because the blocks were fetched and decoded before that decision.
+#[tokio::test]
+async fn a_block_decoding_fallback_plan_records_exactly_one_touch() {
+    let (records, bytes) = above_threshold_object();
+    let (seg, counting, store) = counted_store("logs/fallback-live.rlog", &bytes, &records).await;
+
+    let fetcher = LogSegmentFetcher::new(store)
+        .with_block_range_threshold(DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD);
+    let accounting = QueryAccounting::new();
+
+    // `code = 500` on every record falls inside this arm, so every block is a
+    // candidate and the ranged fetch resolves and decodes blocks.
+    let (_survivors, _stats, footer) = fetcher
+        .plan_segment(
+            &seg,
+            TENANT,
+            &content_and_prune_query(0, 1_000),
+            &accounting,
+        )
+        .await
+        .expect("plan")
+        .expect("relevant");
+    assert!(
+        footer.is_none(),
+        "same content-armed fallback branch as the sibling"
+    );
+    assert!(counting.probe_count() > 0, "same branch, same probe");
+
+    assert_eq!(
+        accounting.snapshot().data_objects_touched,
+        1,
+        "a fallback that decoded one or more blocks touches the object exactly \
+         once, regardless of surviving rows"
     );
 }
 


### PR DESCRIPTION
ADR-0996 task 996-3. Three-mode --logs-fetch-policy resolution
(request-minimal, byte-minimal, cost-based) with the exchange rate
derived from StoreCostProfile in u128 multiply-before-divide, both
saturation cases pinned to exact byte values; the fetch bound
(logs_max_fetch_run_bytes, zero refused typed) with segmented covering
reads for above-bound objects; plan-probe suppression falling out of
the saturated routing threshold; and the data_objects_touched recorder
at plan_segment.

Two review rounds hardened it. An adversarial checkpoint blocked the
first result: the saturated rate never reached the routing decision
(only the request-minimal enum arm overrode the threshold), the touch
recorder counted probe-only reads, and the probe-suppression field was
dead. The fix keys the override on the resolved rate, deletes the dead
field for a behavioral probe-count pin, and a verification round then
caught the residual: a ranged fallback with every block pruned still
counted a touch via footer absence. The final commit keys the fallback
touch on the count of logical blocks brought into the buffer
(cache-inclusive, per the counter's contract), threaded from
tenant_bytes.

Note for reviewers: the resolution layer is inert in production until
996-5 writes resolved values into EngineConfig; ravel-server currently
builds fetchers straight from config.engine.*. 996-5 owns that wiring
and the server flags.

Row identity is pinned across all three policies; the covering-read
band, zero-bound refusal, cache-miss-only peak observation, and
configured byte-minimal are each pinned by exact-figure tests
demonstrated failing.

Local gate note: executor gates plus two Opus review rounds; full
workspace gates run in this PR's required CI.

Refs: #996