### PR TITLE
docs(adr-0979): reprice the D4 reservation from the D1 ceiling, mandate the reconcile

### DIFF
--- a/docs/adrs/0979-bounded-memory-rlog-compaction-merge.md
+++ b/docs/adrs/0979-bounded-memory-rlog-compaction-merge.md
@@ -246,11 +246,22 @@ completes. The reconcile is MANDATORY, not an optimization: the default
 budget's sizing (the config doc's per-cursor residency figure) is
 derived from actual residency, so an implementation that holds the
 pre-decode ceiling for the cursor's lifetime over-charges against that
-sizing and aborts runs the default was chosen to admit. The paired
-invariant is pinned by a test in both directions: for every decoded
-block, `reservation ≥ heap_estimate()` (the ceiling really is a
-ceiling), and after reconcile the charged figure equals
-`heap_estimate()` exactly. Reservations are taken under the same admission lock that
+sizing and aborts runs the default was chosen to admit. The reconcile
+target is the cursor's COMPLETE resident footprint, all three D4 terms
+at their actuals: loc metadata + raw group bytes still retained (the
+cursor keeps raw bytes while decoding non-final blocks) +
+`heap_estimate()` for the decoded block. `reservation ==
+heap_estimate()` alone is wrong while raw bytes remain resident. On
+`refill`, before decoding block k+1 the charge GROWS atomically (under
+the same admission lock as the initial reserve) to at least
+`metadata + retained raw + ceiling(block k+1)` — a later, larger block
+must clear the budget before its decode starts, never after — then
+reconciles down to actuals once the decode completes. The paired
+invariant is pinned by a test in both directions and across the
+first-small/next-large sequence: at every point in a cursor's life the
+charge is ≥ its actual resident footprint (the ceiling really is a
+ceiling), and after each reconcile the charge equals that footprint
+exactly. Reservations are taken under the same admission lock that
 orders cursor opens, so concurrent admissions cannot each pass the check
 and then jointly allocate past the budget: the budget is enforced at
 reserve time, which is what makes D4 fail-closed rather than

--- a/docs/adrs/0979-bounded-memory-rlog-compaction-merge.md
+++ b/docs/adrs/0979-bounded-memory-rlog-compaction-merge.md
@@ -215,14 +215,26 @@ and the ceiling covers everything the cursor retains for its lifetime:
 `2·G` from the section descriptors' raw lengths; the cursor's location
 metadata (the owned `Vec<StreamBlockLoc>` and each loc's block list,
 sized from the same resident directory that produced it); and `B_dec`
-taken as the MAXIMUM over the cursor's candidate blocks of the per-block
-sum of PAGE_DIR `uncomp_len` values, times a documented
-allocation-overhead factor — the max, not the first block's cost, because
-`refill` decodes later blocks after releasing earlier ones and a later,
-larger block must not exceed the reconciled reservation (the owed test is
-first-small/next-large). Page contents, not a shape formula, are what
-decoded string buffers scale with, and PAGE_DIR is resident before any
-BLOCKS byte is fetched. An input WITHOUT a PAGE_DIR cannot be
+taken as the MAXIMUM over the cursor's candidate blocks of the D1
+ceiling evaluated per block from pre-decode metadata:
+`16 B × rows × total_cols + string-page uncomp_len + 40 B × rows ×
+string_cols` — rows from the resident loc metadata, `total_cols` from
+FIELD_DIR, the string-page term as the block's PAGE_DIR `uncomp_len`
+restricted to string pages, and every string column priced as plain
+(the conservative arm; dictionary encoding only shrinks it). The max,
+not the first block's cost, because `refill` decodes later blocks after
+releasing earlier ones and a later, larger block must not exceed the
+reconciled reservation (the owed test is first-small/next-large).
+A per-block sum of raw `uncomp_len` alone is NOT a valid basis and this
+amendment removes it: `encode_i64` picks the smallest codec, so a
+constant or run-length column (every one-stream block's `stream_ref`,
+usually `severity` and `flags` too) stores a few bytes and decodes to
+`16 B × rows` — a ratio that can exceed 10,000×, which is exactly the
+under-charge D4 exists to refuse. The numeric decoded term scales with
+a shape formula (rows × columns), and only the string term scales with
+page contents; the basis above prices each term from the source that
+actually bounds it, and PAGE_DIR plus loc metadata are resident before
+any BLOCKS byte is fetched. An input WITHOUT a PAGE_DIR cannot be
 admission-priced (its string-page term is unknowable before the fetch),
 so the bounded merge refuses it with a typed error naming the object and
 its format version rather than guessing — in practice the fleet is
@@ -230,7 +242,15 @@ RLOG v4 everywhere (PAGE_DIR is mandatory in v4), so the refusal arm is
 a version gate, not a live path. The reservation is reconciled down to the
 cursor's actual residency (raw bytes as fetched, `heap_estimate()` once
 decoded — the same numbers the #977 tracker sees) after the decode
-completes. Reservations are taken under the same admission lock that
+completes. The reconcile is MANDATORY, not an optimization: the default
+budget's sizing (the config doc's per-cursor residency figure) is
+derived from actual residency, so an implementation that holds the
+pre-decode ceiling for the cursor's lifetime over-charges against that
+sizing and aborts runs the default was chosen to admit. The paired
+invariant is pinned by a test in both directions: for every decoded
+block, `reservation ≥ heap_estimate()` (the ceiling really is a
+ceiling), and after reconcile the charged figure equals
+`heap_estimate()` exactly. Reservations are taken under the same admission lock that
 orders cursor opens, so concurrent admissions cannot each pass the check
 and then jointly allocate past the budget: the budget is enforced at
 reserve time, which is what makes D4 fail-closed rather than


### PR DESCRIPTION
The T4 checkpoint proved D4's stated basis self-contradictory: a
per-block sum of PAGE_DIR uncomp_len times a factor cannot bound the
decoded residency D1's own ceiling formula describes, because encode_i64
picks the smallest codec and a constant stream_ref column stores a few
bytes while decoding to 16 B per row, a ratio past 10,000x. The
reservation now evaluates the D1 ceiling per block from pre-decode
metadata (rows from loc metadata, columns from FIELD_DIR, the string
term from PAGE_DIR's string pages, plain assumed conservatively), keeps
the max-over-blocks rule, and the reconcile down to heap_estimate() is
stated as mandatory with the two-direction invariant pinned by test:
the ceiling really is a ceiling, and the post-reconcile charge equals
actual residency exactly, which is what the default budget's sizing is
derived from.

Refs: #979