### PR TITLE
feat(server): resolve the logs fetch policy at startup

### DIFF
--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -28,6 +28,13 @@ The cache stores byte ranges read from two kinds of objects:
   threshold to `18446744073709551615` to read every log object whole, as
   before this split existed.
 
+  On default flags the whole-object read is what happens anyway:
+  `--logs-fetch-policy` defaults to `cost-based`, and at the shipped
+  reference cost profile (intra-region, where transferred bytes are free
+  and the bill is requests) it resolves to reading every object whole in
+  one GET. Set `--logs-fetch-policy byte-minimal` for the block-range
+  shape, where the threshold above governs. See the flag table below.
+
 Both PromQL queries and SQL queries over the `samples` table use the
 metric path. SQL queries over the `logs` table use the log path.
 
@@ -79,7 +86,10 @@ provide it at the filesystem/volume layer (an encrypted volume mounted at
 | `--cache-max-bytes <n>` | `268435456` (256 MiB) | Maximum bytes the RAM tier holds. Bounds **every** ADR-0046 cache in the process from one number: the fetcher cache and the catalog's byte cache both. Read once at startup; there is no live resize. |
 | `--cache-dir <path>` | none | Directory for the local-disk tier. Set, both the fetcher cache and the catalog byte cache gain a disk tier at this path, each bounded by the same `--cache-max-bytes` number (there is no separate disk-tier capacity flag). Absent, only the RAM tier exists. Bytes written here are not SSE-KMS encrypted (see "Two tiers" above). |
 | `--disable-cache` | off | Turns **every** ADR-0046 cache off: the fetcher cache and the catalog's byte cache both. No cache is constructed at all, so query *results* are byte-for-byte the same as a build with no cache code, and the process holds no read-cache memory. This is the flag to set in a memory-constrained container. |
-| `--logs-block-range-threshold <bytes>` | `524288` (512 KiB) | Log-object size above which a `logs` query reads only the pruning-relevant blocks (a tail probe plus per-block ranges, cached per block) instead of the whole object. Set it to `18446744073709551615` to read every log object whole, the shape before this split existed; set it to `0` to use the block-range path for every object. Read once at startup. |
+| `--logs-block-range-threshold <bytes>` | `524288` (512 KiB) | Log-object size above which a `logs` query reads only the pruning-relevant blocks (a tail probe plus per-block ranges, cached per block) instead of the whole object. Set it to `18446744073709551615` to read every log object whole, the shape before this split existed; set it to `0` to use the block-range path for every object. Read once at startup. Under a resolved fetch policy that reads every object whole (`--logs-fetch-policy request-minimal`, or `cost-based` at a profile whose bytes are free) this flag is **overridden**, and startup logs a WARN naming the value it overrode. |
+| `--logs-fetch-policy <policy>` | `cost-based` | The logs read shape (ADR-0996). `request-minimal` reads every object whole in one covering GET, with no tail probe and no ranged read: the cost-preferring shape where transfer is free and the object-store bill is requests. `byte-minimal` is the older behaviour, ranged reads wherever they save more bytes than a request costs, for egress-billed and network-constrained deployments. `cost-based` derives the choice from `--store-cost-profile`; at the shipped reference profile (intra-region, transfer free) that resolves to request-minimal behaviour, so **a deployment on default flags reads log objects whole**. Read once at startup; the running process never changes its own policy. The resolved policy, profile, and byte quantities are logged at startup on the `logs fetch policy resolved` line. |
+| `--store-cost-profile <path>` | reference profile (`s3-intra-region-2026`) | TOML file carrying this deployment's object-store prices in integer nanodollars: `name`, `put_class_nanodollars`, `get_class_nanodollars`, `transfer_nanodollars_per_gib`, `retrieval_nanodollars_per_gib`, and optionally `delete_class_nanodollars`. Only `--logs-fetch-policy cost-based` reads it, to derive how many transferred bytes one saved request is worth; no price reaches the fetch layer. An unreadable file, invalid TOML, an unknown key, or a blank `name` fails startup rather than falling back to the reference prices. |
+| `--logs-max-fetch-run-bytes <bytes>` | `67108864` (64 MiB) | The fetch bound: the maximum length of one covering GET on the log path, on every policy. An object at or under it is read in a single request; a larger one is read as sequential block-aligned covering sub-ranges of at most this many bytes each, so one oversized object cannot pull an unbounded response into memory. `0` is refused at startup. |
 
 ### Disk-tier max-age sweep
 

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -2368,6 +2368,12 @@ impl Cli {
         // it so a malformed future extension fails startup, not first ingest.
         self.parse_ingest_buffer_budget()?;
 
+        // Read the cost profile here, not only at ServerConfig build: by the
+        // time query_budgets runs, startup has already written qualification,
+        // tenancy, and key-epoch state. A mistyped path must be a pure
+        // pre-flight failure, like --limits-file and the credential files.
+        self.resolve_store_cost_profile()?;
+
         if self.max_inflight_flushes == 0 {
             anyhow::bail!(
                 "--max-inflight-flushes '0' would deadlock every flush: a shard could never \
@@ -4433,6 +4439,29 @@ mod tests {
     /// `resolve_store_cost_profile` with `.unwrap_or_else(|_|
     /// StoreCostProfile::reference())` and the three `expect_err` calls below
     /// panic instead.
+    /// A bad --store-cost-profile fails Cli::validate itself (PR #1017 review):
+    /// the refusal must precede the qualification gate, tenancy pin, and
+    /// key-epoch writes that run before ServerConfig is built.
+    ///
+    /// Non-vacuity: remove the resolve_store_cost_profile call from
+    /// Cli::validate and this assertion fails (validate returns Ok).
+    #[test]
+    fn bad_store_cost_profile_fails_cli_validate_preflight() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nope.toml");
+        std::fs::write(&path, "not toml at all [").expect("write");
+        let mut cli = Cli::parse_from(["ravel-server"]);
+        cli.store_cost_profile = Some(path);
+        let err = cli
+            .validate()
+            .expect_err("a bad profile must fail pre-flight");
+        assert!(
+            err.to_string().contains("store-cost-profile")
+                || err.to_string().contains("cost profile"),
+            "the pre-flight error names the flag: {err}"
+        );
+    }
+
     #[test]
     fn store_cost_profile_reaches_the_derivation_and_refuses_a_bad_file() {
         // An egress-billed profile: 400 * 2^30 / (90_000_000 + 10_000_000)

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use clap::{Parser, ValueEnum};
 use ravel_maintain::RetentionPolicy;
+use ravel_types::cost_profile::StoreCostProfile;
 use ravel_types::{TenantHash, TenantId};
 
 use crate::alert_sink::{AlertSink, Credential};
@@ -54,6 +55,37 @@ impl S3Auth {
         match self {
             S3Auth::Static => ravel_object_store::s3::S3AuthMode::Static,
             S3Auth::InstanceRole => ravel_object_store::s3::S3AuthMode::InstanceRole,
+        }
+    }
+}
+
+/// The `--logs-fetch-policy` values (ADR-0996 decision 2). The CLI-facing
+/// mirror of [`ravel_query::LogsFetchPolicy`], which lives in a crate that does
+/// not depend on clap. The spellings clap derives from these variant names are
+/// the ADR's: `request-minimal`, `byte-minimal`, `cost-based`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub enum LogsFetchPolicyArg {
+    /// Minimize object-store requests: every object is read whole in one
+    /// covering GET, with no probe and no ranged read.
+    RequestMinimal,
+    /// ADR-0904's byte-minimizing behaviour: ranged reads wherever they save
+    /// more bytes than a request costs. The setting for an egress-billed or
+    /// network-constrained deployment.
+    ByteMinimal,
+    /// Derive the request cost from the active store cost profile. At the
+    /// reference (intra-region) profile this resolves to request-minimal
+    /// behaviour; at egress prices it resolves to a small byte cost.
+    #[default]
+    CostBased,
+}
+
+impl LogsFetchPolicyArg {
+    /// The engine-level policy this flag value selects.
+    pub fn policy(self) -> ravel_query::LogsFetchPolicy {
+        match self {
+            LogsFetchPolicyArg::RequestMinimal => ravel_query::LogsFetchPolicy::RequestMinimal,
+            LogsFetchPolicyArg::ByteMinimal => ravel_query::LogsFetchPolicy::ByteMinimal,
+            LogsFetchPolicyArg::CostBased => ravel_query::LogsFetchPolicy::CostBased,
         }
     }
 }
@@ -515,15 +547,22 @@ pub struct Cli {
     /// `ravel_query::EngineConfig::logs_block_range_threshold` and from there
     /// into `LogSegmentFetcher::with_block_range_threshold`.
     ///
-    /// Defaults to [`DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD`] (512 KiB), the
-    /// compiled-in crossover, so an unset flag is byte-identical to before it
-    /// existed. This is the mitigation knob for that path: set it to
+    /// Unset, the crossover is [`DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD`]
+    /// (512 KiB), the compiled-in value, so an unset flag is byte-identical to
+    /// before it existed. This is the mitigation knob for that path: set it to
     /// `18446744073709551615` (`u64::MAX`) to read every object whole, the
     /// pre-ADR-0107 shape, without a rollback; set it to `0` to send every
     /// object through the block-range path. Read at startup only, like
     /// `--disable-cache` and every other cache/read knob here.
-    #[arg(long = "logs-block-range-threshold", value_name = "BYTES", default_value_t = DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD)]
-    pub logs_block_range_threshold: u64,
+    ///
+    /// `Option`-typed rather than defaulted (ADR-0996 decision 2's "Knob
+    /// relations"): the fetch-policy resolution must distinguish a value the
+    /// operator set from the compiled-in one, because a saturated policy
+    /// OVERRIDES an explicitly set threshold and says so at startup. A
+    /// defaulted `u64` cannot express "unset", so a threshold left alone and a
+    /// threshold pinned to 512 KiB would log identically.
+    #[arg(long = "logs-block-range-threshold", value_name = "BYTES")]
+    pub logs_block_range_threshold: Option<u64>,
 
     /// One saved object-store round trip is worth this many saved transfer
     /// bytes; a property of the store and the instance, not of the RLOG data
@@ -537,12 +576,66 @@ pub struct Cli {
     /// cannot disagree. Raising it above the largest segment object the process
     /// serves collapses all three to whole-object reads, which is the setting
     /// for a backend that bills requests and not transfer; the existing 64 KiB
-    /// and 512 KiB floors bound the low end. Omitted defaults to
-    /// [`ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES`], whose doc comment
-    /// carries the derivation of that number, so behavior is byte-identical
-    /// when unset. Read at startup only, like every other read knob here.
-    #[arg(long = "logs-request-cost-bytes", value_name = "BYTES", default_value_t = ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES)]
-    pub logs_request_cost_bytes: u64,
+    /// and 512 KiB floors bound the low end. Read at startup only, like every
+    /// other read knob here.
+    ///
+    /// The expert escape hatch of ADR-0996 decision 2: SET, it WINS over
+    /// `--logs-fetch-policy`'s derived rate and the deployment keeps exactly
+    /// the ADR-0904 behaviour it had. UNSET, the policy derives the rate (at
+    /// the default `cost-based` policy, from the active store cost profile).
+    /// `Option`-typed for that reason: "the operator asked for this many bytes"
+    /// and "nobody asked, use the compiled-in default" are different inputs to
+    /// the resolution, and a `default_value_t` would erase the difference.
+    #[arg(long = "logs-request-cost-bytes", value_name = "BYTES")]
+    pub logs_request_cost_bytes: Option<u64>,
+
+    /// The operator's logs fetch-policy intent (ADR-0996 decision 2), resolved
+    /// at startup into the byte quantities the fetch layer runs on
+    /// (`--logs-request-cost-bytes` and `--logs-block-range-threshold`'s
+    /// engine-side fields) by `ravel_query::resolve_logs_fetch`.
+    ///
+    /// `request-minimal` reads every object whole in one covering GET (the
+    /// cost-preferring shape where transfer is free and the bill is requests);
+    /// `byte-minimal` is ADR-0904's behaviour, ranged reads wherever they save
+    /// more bytes than a request costs; `cost-based` (the default) derives the
+    /// rate from `--store-cost-profile`, which at the reference intra-region
+    /// profile means request-minimal behaviour. Read at startup only: the
+    /// running engine never changes its own policy, so the stamped effective
+    /// policy describes the whole process lifetime.
+    #[arg(long = "logs-fetch-policy", value_enum, default_value_t = LogsFetchPolicyArg::CostBased)]
+    pub logs_fetch_policy: LogsFetchPolicyArg,
+
+    /// Path to a TOML `StoreCostProfile` (ADR-0996 decision 1): this
+    /// deployment's object-store prices, in integer nanodollars per request
+    /// class and per GiB. Omitted, the reference profile
+    /// (`s3-intra-region-2026`: PUT-class $5.00/M, GET-class $0.40/M, transfer
+    /// and retrieval free) is used.
+    ///
+    /// The only consumer at startup is `--logs-fetch-policy cost-based`, which
+    /// derives the byte-denominated request cost from the profile's ratio; no
+    /// price ever reaches the fetch layer (ADR-0904's layering, preserved). A
+    /// file that is unreadable, is not valid TOML, carries an unknown key, or
+    /// names no profile fails startup with the typed error rather than falling
+    /// back to the reference profile: a silent fallback would make every
+    /// figure the deployment reports irreconcilable with the prices its
+    /// operator believes are in force.
+    #[arg(long = "store-cost-profile", value_name = "PATH")]
+    pub store_cost_profile: Option<PathBuf>,
+
+    /// The fetch bound (ADR-0996 decision 2): the maximum length of one
+    /// covering GET on the logs read path, threaded into
+    /// `ravel_query::EngineConfig::logs_max_fetch_run_bytes` and from there
+    /// into `LogSegmentFetcher::with_max_fetch_run_bytes`.
+    ///
+    /// An object at or under it is read in a single covering GET; a larger one
+    /// is read as sequential block-aligned covering sub-range GETs of at most
+    /// this many bytes each, so no single request moves more than this however
+    /// large an object grows. Applies on every policy. Defaults to
+    /// [`ravel_query::DEFAULT_LOG_MAX_FETCH_RUN_BYTES`] (64 MiB). `0` is
+    /// refused at config resolution with a typed error: the segmented covering
+    /// fallback divides the object size by it.
+    #[arg(long = "logs-max-fetch-run-bytes", value_name = "BYTES", default_value_t = ravel_query::DEFAULT_LOG_MAX_FETCH_RUN_BYTES)]
+    pub logs_max_fetch_run_bytes: u64,
 
     /// Bound on concurrent in-flight segment fetches per query (ADR-0088),
     /// threaded into `ravel_query::EngineConfig::fetch_concurrency`. This is a
@@ -1026,7 +1119,7 @@ pub const DEFAULT_SQL_TENANT_MAX_BYTES: usize = 1024 * 1024 * 1024;
 /// ceilings to `build_sql_state`. Every field's [`Default`] is exactly today's
 /// compiled-in value, so a server built with none of the four flags carries a
 /// budget bit-for-bit identical to before they existed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryBudgets {
     /// Per-query segment fetch concurrency, also the SQL scan partition count
     /// and S3 GET concurrency (ADR-0087; not decoupled). Reaches
@@ -1045,16 +1138,31 @@ pub struct QueryBudgets {
     /// `--sql-parallel-final-aggregation=false` opt-out restores the
     /// single-partition final.
     pub sql_parallel_final_aggregation: bool,
-    /// Object size above which a logs scan reads only the pruning-relevant RLOG
-    /// blocks instead of the whole object (ADR-0107). Reaches
-    /// `EngineConfig::logs_block_range_threshold` and from there
-    /// `LogSegmentFetcher::with_block_range_threshold`.
-    pub logs_block_range_threshold: u64,
-    /// How many transferred bytes one saved object-store round trip is worth to
-    /// this deployment (ADR-0904). Reaches
-    /// `EngineConfig::logs_request_cost_bytes` and from there
-    /// `LogSegmentFetcher::with_request_cost_bytes`.
-    pub logs_request_cost_bytes: u64,
+    /// The operator's explicit `--logs-block-range-threshold`, or `None` when
+    /// the flag was not set (ADR-0107). Feeds the ADR-0996 resolution as both
+    /// the configured value (`None` meaning
+    /// [`DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD`]) and the explicit-flag input a
+    /// saturated policy overrides and reports.
+    pub logs_block_range_threshold: Option<u64>,
+    /// The operator's explicit `--logs-request-cost-bytes`: how many
+    /// transferred bytes one saved object-store round trip is worth to this
+    /// deployment (ADR-0904). `None` when the flag was not set, which is what
+    /// lets [`Self::logs_fetch_resolution`] derive the rate from the policy
+    /// instead; `Some` wins over the policy (ADR-0996 decision 2).
+    pub logs_request_cost_bytes: Option<u64>,
+    /// The operator's `--logs-fetch-policy` intent (ADR-0996 decision 2),
+    /// resolved into the two byte quantities above by
+    /// [`Self::logs_fetch_resolution`].
+    pub logs_fetch_policy: ravel_query::LogsFetchPolicy,
+    /// The active store cost profile (ADR-0996 decision 1), from
+    /// `--store-cost-profile` or the reference profile. Read only by the
+    /// cost-based rate derivation; no price reaches the fetch layer.
+    pub store_cost_profile: StoreCostProfile,
+    /// The fetch bound: one covering GET's maximum length, from
+    /// `--logs-max-fetch-run-bytes`. Reaches
+    /// `EngineConfig::logs_max_fetch_run_bytes` and from there
+    /// `LogSegmentFetcher::with_max_fetch_run_bytes`.
+    pub logs_max_fetch_run_bytes: u64,
 }
 
 impl Default for QueryBudgets {
@@ -1065,29 +1173,168 @@ impl Default for QueryBudgets {
             sql_max_query_bytes: DEFAULT_SQL_MAX_QUERY_BYTES,
             sql_tenant_max_bytes: DEFAULT_SQL_TENANT_MAX_BYTES,
             sql_parallel_final_aggregation: true,
-            logs_block_range_threshold: DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD,
-            logs_request_cost_bytes: ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
+            logs_block_range_threshold: None,
+            logs_request_cost_bytes: None,
+            logs_fetch_policy: ravel_query::LogsFetchPolicy::default(),
+            store_cost_profile: StoreCostProfile::reference(),
+            logs_max_fetch_run_bytes: ravel_query::DEFAULT_LOG_MAX_FETCH_RUN_BYTES,
         }
     }
 }
 
 impl QueryBudgets {
-    /// Fold the `EngineConfig`-bound budgets (`fetch_concurrency`,
-    /// `max_segments`, `logs_block_range_threshold`, `logs_request_cost_bytes`)
-    /// onto a base `EngineConfig` that already carries the
-    /// separately-resolved deadline, bytes-scanned budget, and S3 request
-    /// budget. [`crate::start`] calls this so the one process-wide engine both
-    /// query surfaces share enforces the operator's `--fetch-concurrency` /
-    /// `--max-segments`, not `EngineConfig::default()`'s compiled-in 8 / 1024.
-    /// The single wiring point, so a reachability test that drives it proves the
-    /// running engine carries the flag values.
-    pub fn apply_to_engine(&self, base: ravel_query::EngineConfig) -> ravel_query::EngineConfig {
-        ravel_query::EngineConfig {
+    /// Resolve `--logs-fetch-policy` against the active profile and the two
+    /// ADR-0904 byte flags (ADR-0996 decision 2). This is the server's single
+    /// call into `ravel_query::resolve_logs_fetch`, and what turns the policy
+    /// from an intent into the byte quantities [`Self::apply_to_engine`] hands
+    /// the fetcher builders.
+    ///
+    /// The explicit/configured split the resolution takes is exactly the
+    /// `Option`-typing of the two flags: `Some` is "the operator set this", and
+    /// the fallback inside `unwrap_or` is the compiled-in value a policy that
+    /// keeps today's behaviour (`byte-minimal`) resolves to.
+    pub fn logs_fetch_resolution(&self) -> ravel_query::ResolvedLogsFetch {
+        ravel_query::resolve_logs_fetch(
+            self.logs_fetch_policy,
+            &self.store_cost_profile,
+            self.logs_request_cost_bytes,
+            self.logs_request_cost_bytes
+                .unwrap_or(ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES),
+            self.logs_block_range_threshold
+                .unwrap_or(DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD),
+            self.logs_block_range_threshold,
+        )
+    }
+
+    /// The effective logs fetch configuration this process resolved, for the
+    /// startup stamp (ADR-0996 decision 2: "the stamped effective policy is
+    /// what makes the state auditable"). Built from the same
+    /// [`Self::logs_fetch_resolution`] the engine config is, so the stamp
+    /// cannot describe a resolution the engine did not get.
+    pub fn logs_fetch_stamp(&self) -> LogsFetchStamp {
+        let resolved = self.logs_fetch_resolution();
+        LogsFetchStamp {
+            policy: self.logs_fetch_policy.as_str(),
+            profile: self.store_cost_profile.name.clone(),
+            request_cost_bytes: resolved.request_cost_bytes,
+            request_cost_source: match self.logs_request_cost_bytes {
+                Some(_) => REQUEST_COST_SOURCE_EXPLICIT_FLAG,
+                None => REQUEST_COST_SOURCE_POLICY,
+            },
+            block_range_threshold: resolved.block_range_threshold,
+            overridden_block_range_threshold: resolved.overridden_block_range_threshold,
+            saturated_profile: resolved.saturated_profile,
+            max_fetch_run_bytes: self.logs_max_fetch_run_bytes,
+        }
+    }
+
+    /// Fold the `EngineConfig`-bound budgets onto a base `EngineConfig` that
+    /// already carries the separately-resolved deadline, bytes-scanned budget,
+    /// and S3 request budget. [`crate::start`] calls this so the one
+    /// process-wide engine both query surfaces share enforces the operator's
+    /// `--fetch-concurrency` / `--max-segments`, not
+    /// `EngineConfig::default()`'s compiled-in 8 / 1024. The single wiring
+    /// point, so a reachability test that drives it proves the running engine
+    /// carries the flag values.
+    ///
+    /// The two logs fetch quantities folded here are the RESOLVED ones
+    /// ([`Self::logs_fetch_resolution`]), not the raw flags: `--logs-fetch-policy`
+    /// would otherwise be inert, since the fetcher builders in
+    /// [`crate::query::build_sql_state`] read `EngineConfig` and nothing else.
+    ///
+    /// Fallible because this is the config resolution ADR-0996 decision 2 puts
+    /// the fetch bound's validation at: a zero `--logs-max-fetch-run-bytes`
+    /// comes back as [`ravel_query::EngineConfigError::ZeroFetchBound`] and
+    /// refuses startup, rather than reaching a fetch layer that divides by it.
+    pub fn apply_to_engine(
+        &self,
+        base: ravel_query::EngineConfig,
+    ) -> Result<ravel_query::EngineConfig, ravel_query::EngineConfigError> {
+        let resolved = self.logs_fetch_resolution();
+        let config = ravel_query::EngineConfig {
             fetch_concurrency: self.fetch_concurrency,
             max_segments: self.max_segments,
-            logs_block_range_threshold: self.logs_block_range_threshold,
-            logs_request_cost_bytes: self.logs_request_cost_bytes,
+            logs_block_range_threshold: resolved.block_range_threshold,
+            logs_request_cost_bytes: resolved.request_cost_bytes,
+            logs_fetch_policy: self.logs_fetch_policy,
+            logs_max_fetch_run_bytes: self.logs_max_fetch_run_bytes,
             ..base
+        };
+        config.validate()?;
+        Ok(config)
+    }
+}
+
+/// [`LogsFetchStamp::request_cost_source`] when `--logs-request-cost-bytes` was
+/// set: the explicit byte flag won over the policy's derivation (ADR-0996
+/// decision 2's expert escape hatch).
+pub const REQUEST_COST_SOURCE_EXPLICIT_FLAG: &str = "explicit-flag";
+/// [`LogsFetchStamp::request_cost_source`] when the flag was unset and
+/// `--logs-fetch-policy` derived the rate.
+pub const REQUEST_COST_SOURCE_POLICY: &str = "policy";
+
+/// The effective logs fetch configuration a process resolved at startup, the
+/// provenance stamp of ADR-0996 decision 2.
+///
+/// The server exposes no config-provenance endpoint, so this is emitted as one
+/// structured startup log line ([`Self::emit`]) naming the effective policy,
+/// the active profile, and every resolved quantity. It is a value rather than a
+/// bare `tracing::info!` at the call site so a test can assert on exactly what
+/// the operator reads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogsFetchStamp {
+    /// `--logs-fetch-policy` as the operator spelled it.
+    pub policy: &'static str,
+    /// The active profile's name, from `--store-cost-profile` or the reference
+    /// profile.
+    pub profile: String,
+    /// The resolved byte-denominated request cost the fetch layer runs on.
+    pub request_cost_bytes: u64,
+    /// Whether [`Self::request_cost_bytes`] came from the explicit byte flag or
+    /// from the policy: [`REQUEST_COST_SOURCE_EXPLICIT_FLAG`] or
+    /// [`REQUEST_COST_SOURCE_POLICY`].
+    pub request_cost_source: &'static str,
+    /// The resolved logs routing threshold.
+    pub block_range_threshold: u64,
+    /// The operator's `--logs-block-range-threshold` when the resolution
+    /// overrode it (a saturated rate routes every object whole-object
+    /// regardless of the flag), for the override log line. `None` when the flag
+    /// was unset or left in force.
+    pub overridden_block_range_threshold: Option<u64>,
+    /// The profile whose prices saturated a cost-based derivation at
+    /// `u64::MAX`, for the saturation log line. `None` when the derived rate is
+    /// finite or the policy derived nothing.
+    pub saturated_profile: Option<String>,
+    /// The resolved fetch bound (`--logs-max-fetch-run-bytes`).
+    pub max_fetch_run_bytes: u64,
+}
+
+impl LogsFetchStamp {
+    /// Emit this stamp at startup. One INFO line with the whole effective
+    /// configuration, plus a WARN naming the overridden
+    /// `--logs-block-range-threshold` when the resolution saturated past it:
+    /// an operator who set a flag that no longer governs must be told, not left
+    /// to infer it from a query's shape.
+    pub fn emit(&self) {
+        tracing::info!(
+            policy = self.policy,
+            profile = %self.profile,
+            request_cost_bytes = self.request_cost_bytes,
+            request_cost_source = self.request_cost_source,
+            block_range_threshold = self.block_range_threshold,
+            max_fetch_run_bytes = self.max_fetch_run_bytes,
+            saturated_profile = self.saturated_profile.as_deref().unwrap_or(""),
+            "logs fetch policy resolved"
+        );
+        if let Some(overridden) = self.overridden_block_range_threshold {
+            tracing::warn!(
+                policy = self.policy,
+                profile = %self.profile,
+                overridden_block_range_threshold = overridden,
+                effective_block_range_threshold = self.block_range_threshold,
+                "--logs-block-range-threshold is overridden by the resolved fetch policy: \
+                 every logs object is read whole-object"
+            );
         }
     }
 }
@@ -1748,15 +1995,20 @@ impl Cli {
         })
     }
 
-    /// The four ADR-0088 query budgets sourced directly from the CLI flags.
-    /// `main` threads this into [`crate::ServerConfig::query_budgets`], and
-    /// [`crate::start`] folds it into the process-wide `EngineConfig` and the
-    /// SQL executor, so a flag set here is the value the query/SQL execution
-    /// path enforces. Infallible: clap has already parsed each flag to its
-    /// typed field (an unset flag is its compiled-in default), and none of the
-    /// four has a rejected value the way `--max-s3-requests 0` does.
-    pub fn query_budgets(&self) -> QueryBudgets {
-        QueryBudgets {
+    /// The ADR-0088 query budgets and the ADR-0996 logs fetch configuration,
+    /// sourced from the CLI flags. `main` threads this into
+    /// [`crate::ServerConfig::query_budgets`], and [`crate::start`] folds it
+    /// into the process-wide `EngineConfig` and the SQL executor, so a flag set
+    /// here is the value the query/SQL execution path enforces.
+    ///
+    /// Fallible only for `--store-cost-profile`, which reads a file: every
+    /// other field is a clap-parsed value (an unset flag is its compiled-in
+    /// default). A profile that cannot be read or parsed refuses startup here
+    /// rather than falling back to the reference profile, so the prices a
+    /// deployment's figures are modelled at are always the ones its operator
+    /// declared.
+    pub fn query_budgets(&self) -> anyhow::Result<QueryBudgets> {
+        Ok(QueryBudgets {
             fetch_concurrency: self.fetch_concurrency,
             max_segments: self.max_segments,
             sql_max_query_bytes: self.sql_max_query_bytes,
@@ -1764,7 +2016,33 @@ impl Cli {
             sql_parallel_final_aggregation: self.sql_parallel_final_aggregation,
             logs_block_range_threshold: self.logs_block_range_threshold,
             logs_request_cost_bytes: self.logs_request_cost_bytes,
-        }
+            logs_fetch_policy: self.logs_fetch_policy.policy(),
+            store_cost_profile: self.resolve_store_cost_profile()?,
+            logs_max_fetch_run_bytes: self.logs_max_fetch_run_bytes,
+        })
+    }
+
+    /// The active store cost profile (ADR-0996 decision 1): the TOML document
+    /// at `--store-cost-profile`, or [`StoreCostProfile::reference`] when the
+    /// flag is unset.
+    ///
+    /// Every failure is a startup refusal naming the path and the typed
+    /// [`ravel_types::cost_profile::CostProfileError`] beneath it. There is no
+    /// fallback path: a deployment that names a profile file and silently gets
+    /// the reference prices would stamp one profile into its reports while
+    /// resolving its fetch policy from another.
+    pub fn resolve_store_cost_profile(&self) -> anyhow::Result<StoreCostProfile> {
+        let Some(path) = self.store_cost_profile.as_deref() else {
+            return Ok(StoreCostProfile::reference());
+        };
+        let raw = std::fs::read_to_string(path).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to read --store-cost-profile {}: {e}",
+                path.display()
+            )
+        })?;
+        StoreCostProfile::from_toml_str(&raw)
+            .map_err(|e| anyhow::anyhow!("invalid --store-cost-profile {}: {e}", path.display()))
     }
 
     /// Parse `--max-inflight-ingest-requests` into an
@@ -3746,7 +4024,7 @@ mod tests {
 
         let cli = Cli::try_parse_from(["ravel-server", "--fetch-concurrency", "16"])
             .expect("flag parses");
-        let engine = cli.query_budgets().apply_to_engine(EngineConfig::default());
+        let engine = engine_from(&cli);
         assert_eq!(
             engine.fetch_concurrency, 16,
             "the running engine's fetch_concurrency must be the configured flag, \
@@ -3756,9 +4034,7 @@ mod tests {
         // Default path: unset flag leaves the engine's value byte-identical.
         let cli = Cli::try_parse_from(["ravel-server"]).expect("defaults parse");
         assert_eq!(
-            cli.query_budgets()
-                .apply_to_engine(EngineConfig::default())
-                .fetch_concurrency,
+            engine_from(&cli).fetch_concurrency,
             EngineConfig::default().fetch_concurrency,
         );
     }
@@ -3774,7 +4050,7 @@ mod tests {
 
         let cli =
             Cli::try_parse_from(["ravel-server", "--max-segments", "4096"]).expect("flag parses");
-        let engine = cli.query_budgets().apply_to_engine(EngineConfig::default());
+        let engine = engine_from(&cli);
         assert_eq!(
             engine.max_segments, 4096,
             "the running engine's max_segments must be the configured flag, \
@@ -3783,9 +4059,7 @@ mod tests {
 
         let cli = Cli::try_parse_from(["ravel-server"]).expect("defaults parse");
         assert_eq!(
-            cli.query_budgets()
-                .apply_to_engine(EngineConfig::default())
-                .max_segments,
+            engine_from(&cli).max_segments,
             EngineConfig::default().max_segments,
         );
     }
@@ -3800,10 +4074,14 @@ mod tests {
     /// `u64::MAX` is the value under test because it is the operator-facing
     /// point of the flag: it turns the ADR-0107 block-range path off for every
     /// object, which is the mitigation for a regression on that path.
+    ///
+    /// Driven under `--logs-fetch-policy byte-minimal` (ADR-0996 decision 2's
+    /// "Knob relations"): that is the policy under which this flag keeps its
+    /// ADR-0904 role. Under a saturated policy the resolution overrides it on
+    /// purpose, which
+    /// [`request_minimal_overrides_an_explicit_block_range_threshold`] pins.
     #[test]
     fn logs_block_range_threshold_is_reachable_from_cli() {
-        use ravel_query::EngineConfig;
-
         assert_ne!(
             u64::MAX,
             ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
@@ -3812,24 +4090,24 @@ mod tests {
 
         let cli = Cli::try_parse_from([
             "ravel-server",
+            "--logs-fetch-policy",
+            "byte-minimal",
             "--logs-block-range-threshold",
             "18446744073709551615",
         ])
         .expect("flag parses");
-        let engine = cli.query_budgets().apply_to_engine(EngineConfig::default());
         assert_eq!(
-            engine.logs_block_range_threshold,
+            engine_from(&cli).logs_block_range_threshold,
             u64::MAX,
             "the logs fetcher's crossover must be the configured flag, not the compiled-in 512 KiB"
         );
 
         // Default path: unset flag leaves the crossover at the fetcher's own
         // compiled-in constant.
-        let cli = Cli::try_parse_from(["ravel-server"]).expect("defaults parse");
+        let cli = Cli::try_parse_from(["ravel-server", "--logs-fetch-policy", "byte-minimal"])
+            .expect("defaults parse");
         assert_eq!(
-            cli.query_budgets()
-                .apply_to_engine(EngineConfig::default())
-                .logs_block_range_threshold,
+            engine_from(&cli).logs_block_range_threshold,
             ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
         );
     }
@@ -3849,8 +4127,6 @@ mod tests {
     /// setting for a backend that bills requests and not transfer.
     #[test]
     fn logs_request_cost_bytes_is_reachable_from_cli() {
-        use ravel_query::EngineConfig;
-
         // Sanity: the value under test differs from the compiled-in default, so
         // the assertion cannot pass by the flag being ignored.
         assert_ne!(
@@ -3860,21 +4136,22 @@ mod tests {
 
         let cli = Cli::try_parse_from(["ravel-server", "--logs-request-cost-bytes", "1073741824"])
             .expect("flag parses");
-        let engine = cli.query_budgets().apply_to_engine(EngineConfig::default());
         assert_eq!(
-            engine.logs_request_cost_bytes,
+            engine_from(&cli).logs_request_cost_bytes,
             1024 * 1024 * 1024,
             "the logs fetcher's request cost must be the configured flag, not the compiled-in \
              DEFAULT_LOG_REQUEST_COST_BYTES"
         );
 
-        // Default path: unset flag leaves the request cost at the fetcher's own
-        // compiled-in constant.
-        let cli = Cli::try_parse_from(["ravel-server"]).expect("defaults parse");
+        // Default path: with the flag unset, `byte-minimal` is the policy that
+        // means "today's behaviour byte for byte", so the request cost is the
+        // fetcher's own compiled-in constant. (Unset under the default
+        // `cost-based` policy resolves from the profile instead, which
+        // [`logs_fetch_policy_is_reachable_from_cli`] pins.)
+        let cli = Cli::try_parse_from(["ravel-server", "--logs-fetch-policy", "byte-minimal"])
+            .expect("defaults parse");
         assert_eq!(
-            cli.query_budgets()
-                .apply_to_engine(EngineConfig::default())
-                .logs_request_cost_bytes,
+            engine_from(&cli).logs_request_cost_bytes,
             ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
         );
     }
@@ -3889,7 +4166,8 @@ mod tests {
 
         let budgets = Cli::try_parse_from(["ravel-server"])
             .expect("defaults parse")
-            .query_budgets();
+            .query_budgets()
+            .expect("budgets resolve");
         assert_eq!(budgets, QueryBudgets::default());
         assert_eq!(
             budgets.fetch_concurrency,
@@ -3902,11 +4180,350 @@ mod tests {
             budgets.sql_parallel_final_aggregation,
             "ADR-0094 amendment (#741): exact-typed final-aggregation repartitioning defaults on"
         );
-        // The two EngineConfig-bound defaults leave a base config untouched.
         assert_eq!(
-            budgets.apply_to_engine(EngineConfig::default()),
-            EngineConfig::default(),
-            "unset --fetch-concurrency/--max-segments must not perturb the engine config"
+            budgets.logs_max_fetch_run_bytes,
+            EngineConfig::default().logs_max_fetch_run_bytes,
+            "the --logs-max-fetch-run-bytes default is the engine's own 64 MiB bound"
+        );
+        // The concurrency/segment defaults leave a base config untouched. The
+        // two logs fetch quantities do NOT: ADR-0996 decision 2 ships
+        // `cost-based` as the default policy, and at the reference profile
+        // (transfer and retrieval free) that resolves to request-minimal
+        // behaviour. That is the ADR's argued default, not an accident, so it
+        // is pinned to the exact resolved values here.
+        let engine = budgets
+            .apply_to_engine(EngineConfig::default())
+            .expect("the default configuration resolves");
+        assert_eq!(
+            engine,
+            EngineConfig {
+                logs_request_cost_bytes: u64::MAX,
+                logs_block_range_threshold: u64::MAX,
+                ..EngineConfig::default()
+            },
+            "unset flags must perturb only the two quantities the default cost-based policy \
+             resolves at the reference profile"
+        );
+    }
+
+    /// The `EngineConfig` a parsed CLI produces through the exact wiring
+    /// `crate::start` uses: `Cli::query_budgets` ->
+    /// `QueryBudgets::apply_to_engine`. Every reachability assertion below
+    /// drives this rather than reading a parsed field, so a green result means
+    /// a running binary's engine carries the value.
+    fn engine_from(cli: &Cli) -> ravel_query::EngineConfig {
+        cli.query_budgets()
+            .expect("budgets resolve")
+            .apply_to_engine(ravel_query::EngineConfig::default())
+            .expect("engine config resolves")
+    }
+
+    /// The [`LogsFetchStamp`] a parsed CLI resolves, the provenance surface
+    /// `start` logs.
+    fn stamp_from(cli: &Cli) -> LogsFetchStamp {
+        cli.query_budgets()
+            .expect("budgets resolve")
+            .logs_fetch_stamp()
+    }
+
+    /// Write `contents` to a uniquely named TOML file in a fresh temp dir and
+    /// return its path (the dir is returned too, and dropping it deletes the
+    /// file). A per-call temp dir, not a shared name: these tests run on
+    /// threads inside one binary.
+    fn profile_file(contents: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("cost-profile.toml");
+        std::fs::write(&path, contents).expect("write profile");
+        (dir, path)
+    }
+
+    /// ADR-0996 decision 2 reachability, the flag this task exists for:
+    /// `--logs-fetch-policy` must reach the two byte quantities
+    /// `crate::query::build_sql_state` hands the logs fetcher, RESOLVED. Before
+    /// the wiring, `apply_to_engine` copied the raw flags and the policy
+    /// resolution ran nowhere, so a server started with `request-minimal` still
+    /// routed ranged.
+    ///
+    /// Prove-the-test: restore `logs_block_range_threshold: self
+    /// .logs_block_range_threshold.unwrap_or(DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD)`
+    /// and `logs_request_cost_bytes: self.logs_request_cost_bytes
+    /// .unwrap_or(ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES)` in
+    /// `apply_to_engine` (the pre-wiring body) and the first two assertions
+    /// read 524288 and 1887437 against the expected `u64::MAX`.
+    #[test]
+    fn logs_fetch_policy_is_reachable_from_cli() {
+        // request-minimal: both quantities saturate, so every object is read
+        // whole in one covering GET.
+        let cli = Cli::try_parse_from(["ravel-server", "--logs-fetch-policy", "request-minimal"])
+            .expect("flag parses");
+        let engine = engine_from(&cli);
+        assert_eq!(
+            engine.logs_request_cost_bytes,
+            u64::MAX,
+            "request-minimal must reach the fetcher as a saturated request cost"
+        );
+        assert_eq!(
+            engine.logs_block_range_threshold,
+            u64::MAX,
+            "request-minimal must also saturate the routing threshold, or a narrow projection \
+             of a larger object still routes ranged"
+        );
+        assert_eq!(
+            engine.logs_fetch_policy,
+            ravel_query::LogsFetchPolicy::RequestMinimal
+        );
+
+        // cost-based at the reference profile (the shipped default, with no
+        // flags at all) resolves to the same two quantities.
+        let cli = Cli::try_parse_from(["ravel-server"]).expect("defaults parse");
+        let engine = engine_from(&cli);
+        assert_eq!(engine.logs_request_cost_bytes, u64::MAX);
+        assert_eq!(engine.logs_block_range_threshold, u64::MAX);
+        assert_eq!(
+            engine.logs_fetch_policy,
+            ravel_query::LogsFetchPolicy::CostBased,
+            "cost-based is the shipped default (ADR-0996 decision 2)"
+        );
+
+        // byte-minimal is today's behaviour byte for byte: the exact
+        // pre-wiring values, asserted as the constants themselves.
+        let cli = Cli::try_parse_from(["ravel-server", "--logs-fetch-policy", "byte-minimal"])
+            .expect("flag parses");
+        let engine = engine_from(&cli);
+        assert_eq!(
+            engine.logs_request_cost_bytes,
+            ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES
+        );
+        assert_eq!(engine.logs_request_cost_bytes, 1_887_437);
+        assert_eq!(
+            engine.logs_block_range_threshold,
+            ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
+        );
+        assert_eq!(engine.logs_block_range_threshold, 524_288);
+    }
+
+    /// ADR-0996 decision 2's "Knob relations": `request-minimal` overrides an
+    /// explicitly set `--logs-block-range-threshold`, and the overridden flag
+    /// is reported in the startup stamp rather than silently dropped.
+    ///
+    /// Prove-the-test: pass the resolution `None` for
+    /// `explicit_block_range_threshold` in `logs_fetch_resolution` and the
+    /// overridden-flag assertion reads `None` against the expected
+    /// `Some(4096)`.
+    #[test]
+    fn request_minimal_overrides_an_explicit_block_range_threshold() {
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--logs-fetch-policy",
+            "request-minimal",
+            "--logs-block-range-threshold",
+            "4096",
+        ])
+        .expect("flags parse");
+        assert_eq!(
+            engine_from(&cli).logs_block_range_threshold,
+            u64::MAX,
+            "the explicit low threshold must not survive request-minimal"
+        );
+        let stamp = stamp_from(&cli);
+        assert_eq!(stamp.overridden_block_range_threshold, Some(4096));
+        assert_eq!(stamp.policy, "request-minimal");
+
+        // Unset, there is nothing to report as overridden.
+        let cli = Cli::try_parse_from(["ravel-server", "--logs-fetch-policy", "request-minimal"])
+            .expect("flag parses");
+        assert_eq!(stamp_from(&cli).overridden_block_range_threshold, None);
+    }
+
+    /// ADR-0996 decision 2's expert escape hatch, end to end through the
+    /// server's own resolution: an explicit `--logs-request-cost-bytes` WINS
+    /// over the policy's derived rate and is reported as explicit; unset, the
+    /// policy derives it and the stamp says so. This is the
+    /// configured-vs-explicit seam the `Option`-typed flag exists for -- with a
+    /// `default_value_t` the two cases are indistinguishable at this layer.
+    ///
+    /// Prove-the-test: pass `Some(self.logs_request_cost_bytes.unwrap_or(
+    /// ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES))` as the resolution's
+    /// explicit input (erasing the unset case) and the derived-rate assertion
+    /// reads 1887437 against the expected `u64::MAX`.
+    #[test]
+    fn explicit_request_cost_wins_over_policy_and_unset_derives() {
+        // Explicit, under the default cost-based policy whose derived rate
+        // would otherwise saturate at the reference profile.
+        let cli = Cli::try_parse_from(["ravel-server", "--logs-request-cost-bytes", "123456"])
+            .expect("flag parses");
+        let engine = engine_from(&cli);
+        assert_eq!(
+            engine.logs_request_cost_bytes, 123_456,
+            "the explicit byte flag wins over the policy's derivation"
+        );
+        assert_eq!(
+            engine.logs_block_range_threshold,
+            ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            "a finite resolved rate leaves the routing threshold in force, so a deployment \
+             that already passes the flag keeps byte-identical behaviour"
+        );
+        let stamp = stamp_from(&cli);
+        assert_eq!(stamp.request_cost_bytes, 123_456);
+        assert_eq!(stamp.request_cost_source, REQUEST_COST_SOURCE_EXPLICIT_FLAG);
+
+        // Explicit under request-minimal: the rate is the operator's, but the
+        // routing intent is still the policy's (ADR-0996 decision 2).
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--logs-fetch-policy",
+            "request-minimal",
+            "--logs-request-cost-bytes",
+            "123456",
+        ])
+        .expect("flags parse");
+        let engine = engine_from(&cli);
+        assert_eq!(engine.logs_request_cost_bytes, 123_456);
+        assert_eq!(engine.logs_block_range_threshold, u64::MAX);
+
+        // Unset: the policy derives the rate, and the stamp attributes it to
+        // the policy rather than to a flag nobody passed.
+        let cli = Cli::try_parse_from(["ravel-server"]).expect("defaults parse");
+        let stamp = stamp_from(&cli);
+        assert_eq!(stamp.request_cost_bytes, u64::MAX);
+        assert_eq!(stamp.request_cost_source, REQUEST_COST_SOURCE_POLICY);
+        assert_eq!(
+            stamp.saturated_profile.as_deref(),
+            Some("s3-intra-region-2026"),
+            "the saturated-override log names the profile that saturated the rate"
+        );
+    }
+
+    /// ADR-0996 decision 2: a zero fetch bound is refused AT SERVER CONFIG
+    /// RESOLUTION with the typed error, not clamped and not left to divide by
+    /// zero in the fetch layer. This is what makes `EngineConfig::validate`
+    /// reachable from a running binary: before this wiring nothing called it.
+    ///
+    /// Prove-the-test: drop the `config.validate()?` line from
+    /// `apply_to_engine` and this reads `Ok` against the expected
+    /// `Err(ZeroFetchBound)`.
+    #[test]
+    fn zero_fetch_bound_is_refused_at_server_config_resolution() {
+        let cli = Cli::try_parse_from(["ravel-server", "--logs-max-fetch-run-bytes", "0"])
+            .expect("flag parses");
+        let resolved = cli
+            .query_budgets()
+            .expect("budgets resolve")
+            .apply_to_engine(ravel_query::EngineConfig::default());
+        assert_eq!(
+            resolved.err(),
+            Some(ravel_query::EngineConfigError::ZeroFetchBound),
+            "a zero --logs-max-fetch-run-bytes must refuse startup with the typed error"
+        );
+
+        // One byte is a legal (absurd) bound, so the refusal is exactly of
+        // zero and not of "small", and a real bound reaches the engine.
+        let cli = Cli::try_parse_from(["ravel-server", "--logs-max-fetch-run-bytes", "1048576"])
+            .expect("flag parses");
+        assert_eq!(engine_from(&cli).logs_max_fetch_run_bytes, 1024 * 1024);
+    }
+
+    /// ADR-0996 decision 1: `--store-cost-profile` reaches the cost-based
+    /// derivation, and a profile that fails validation refuses startup with the
+    /// typed `CostProfileError` beneath a message naming the path. Never a
+    /// silent fallback to the reference profile: that would resolve the fetch
+    /// policy from prices the operator did not declare.
+    ///
+    /// Prove-the-test: replace the `from_toml_str` error arm in
+    /// `resolve_store_cost_profile` with `.unwrap_or_else(|_|
+    /// StoreCostProfile::reference())` and the three `expect_err` calls below
+    /// panic instead.
+    #[test]
+    fn store_cost_profile_reaches_the_derivation_and_refuses_a_bad_file() {
+        // An egress-billed profile: 400 * 2^30 / (90_000_000 + 10_000_000)
+        // = 4294 bytes per saved request, the ADR-0904 worked value.
+        let (_dir, path) = profile_file(
+            "name = \"egress-billed\"\n\
+             put_class_nanodollars = 5000\n\
+             get_class_nanodollars = 400\n\
+             transfer_nanodollars_per_gib = 90000000\n\
+             retrieval_nanodollars_per_gib = 10000000\n",
+        );
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--store-cost-profile",
+            &path.display().to_string(),
+        ])
+        .expect("flag parses");
+        let engine = engine_from(&cli);
+        assert_eq!(
+            engine.logs_request_cost_bytes, 4294,
+            "cost-based must derive the rate from the loaded profile's prices"
+        );
+        assert_eq!(
+            engine.logs_block_range_threshold,
+            ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            "a finite derived rate leaves the routing threshold in force"
+        );
+        assert_eq!(stamp_from(&cli).profile, "egress-billed");
+
+        // A misspelled price key: refused, naming the key and the path.
+        let (_dir, path) = profile_file(
+            "name = \"typo\"\n\
+             put_class_nanodollars = 5000\n\
+             get_class_nanodollars = 400\n\
+             transfer_nanodollars_per_gib = 0\n\
+             retrieval_nanodollars_per_gib = 0\n\
+             get_class_nanodollar = 1\n",
+        );
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--store-cost-profile",
+            &path.display().to_string(),
+        ])
+        .expect("flag parses");
+        let err = cli
+            .query_budgets()
+            .expect_err("an unknown key must refuse startup")
+            .to_string();
+        assert!(
+            err.contains("invalid --store-cost-profile") && err.contains("get_class_nanodollar"),
+            "the refusal names the flag and the offending key: {err}"
+        );
+
+        // A blank name: refused, because a profile that cannot be stamped
+        // cannot govern a figure.
+        let (_dir, path) = profile_file(
+            "name = \"   \"\n\
+             put_class_nanodollars = 5000\n\
+             get_class_nanodollars = 400\n\
+             transfer_nanodollars_per_gib = 0\n\
+             retrieval_nanodollars_per_gib = 0\n",
+        );
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--store-cost-profile",
+            &path.display().to_string(),
+        ])
+        .expect("flag parses");
+        let err = cli
+            .query_budgets()
+            .expect_err("a blank profile name must refuse startup")
+            .to_string();
+        assert!(
+            err.contains("name must not be empty"),
+            "the refusal carries the typed cost-profile error: {err}"
+        );
+
+        // A path that does not exist: refused, not silently ignored.
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--store-cost-profile",
+            "/nonexistent/ravel-cost-profile.toml",
+        ])
+        .expect("flag parses");
+        let err = cli
+            .query_budgets()
+            .expect_err("an unreadable profile must refuse startup")
+            .to_string();
+        assert!(
+            err.contains("failed to read --store-cost-profile"),
+            "the refusal names the flag and the path: {err}"
         );
     }
 

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -1222,6 +1222,12 @@ pub async fn start(
         // would keep `EngineConfig::default()`'s compiled-in 8 / 1024.
         // `fetch_concurrency` is the same knob that sets the SQL scan partition
         // count and S3 GET concurrency (ADR-0087).
+        // ADR-0996 decision 2: `apply_to_engine` also RESOLVES
+        // `--logs-fetch-policy` against the active store cost profile and the
+        // two ADR-0904 byte flags, so the quantities the fetcher builders read
+        // off this `EngineConfig` are the resolved ones. It is fallible for the
+        // fetch bound's validation (a zero `--logs-max-fetch-run-bytes` is
+        // refused here, not at a division inside the fetch layer).
         let engine_config = config
             .query_budgets
             .apply_to_engine(ravel_query::EngineConfig {
@@ -1234,7 +1240,15 @@ pub async fn start(
                 // no-deployment-context fallback.
                 max_s3_requests: config.max_s3_requests,
                 ..ravel_query::EngineConfig::default()
-            });
+            })
+            .map_err(|err| anyhow::anyhow!("invalid query engine configuration: {err}"))?;
+        // The provenance stamp of the resolved policy (ADR-0996 decision 2).
+        // The server exposes no config endpoint, so this startup line is where
+        // an operator reads which policy, profile, and byte quantities the
+        // process is actually running, and where an overridden explicit flag is
+        // reported. Emitted only in the query-serving modes, beside the engine
+        // it describes.
+        config.query_budgets.logs_fetch_stamp().emit();
         // ADR-0071 cross-cluster federation: build one gRPC
         // federation client per configured remote and install a `Federation` on
         // the engine. `None` when no `--remote-cluster` is set, leaving the

--- a/services/ravel-server/src/main.rs
+++ b/services/ravel-server/src/main.rs
@@ -453,7 +453,9 @@ async fn main() -> anyhow::Result<()> {
         max_s3_requests: cli
             .resolve_max_s3_requests()
             .context("failed to resolve --max-s3-requests")?,
-        query_budgets: cli.query_budgets(),
+        query_budgets: cli
+            .query_budgets()
+            .context("failed to resolve the query budgets and logs fetch policy")?,
         scrub_period: cli
             .parse_scrub_period()
             .context("failed to parse --scrub-period")?,

--- a/services/ravel-server/src/query.rs
+++ b/services/ravel-server/src/query.rs
@@ -319,10 +319,21 @@ pub fn build_sql_state(
     // compiled-in `DEFAULT_LOG_REQUEST_COST_BYTES` whatever the flag says, and
     // with it the coalescing gap, the whole-object crossover, and the fast
     // path's projection routing that are all derived from it.
+    // ADR-0996 decision 2: the two quantities above are the RESOLVED ones.
+    // `QueryBudgets::apply_to_engine` runs `--logs-fetch-policy` through
+    // `ravel_query::resolve_logs_fetch` before this config exists, so
+    // `request-minimal` (and `cost-based` at a free-byte profile) arrives here
+    // as a saturated request cost AND a saturated routing threshold, which is
+    // what makes the policy select the read shape instead of being inert.
+    // `--logs-max-fetch-run-bytes` is the fetch bound: it caps one covering
+    // GET's length on every policy, so it has to be handed to the fetcher here
+    // like the other three or the fetcher keeps its compiled-in 64 MiB.
     let mut logs_fetcher = LogSegmentFetcher::new(store.clone())
         .with_block_range_threshold(config.engine.logs_block_range_threshold)
         .with_max_concurrent_gets(config.engine.fetch_concurrency)
-        .with_request_cost_bytes(config.engine.logs_request_cost_bytes);
+        .with_request_cost_bytes(config.engine.logs_request_cost_bytes)
+        .with_max_fetch_run_bytes(config.engine.logs_max_fetch_run_bytes)
+        .map_err(|err| anyhow::anyhow!("invalid logs fetch bound: {err}"))?;
     // The spans fetcher (RSPAN) reads the same object store, with the default
     // RspanConfig (ADR-0045 decision 5). It attaches no fetcher cache: unlike
     // the RSEG/RLOG fetchers it has no `with_cache` seam, and none is wired
@@ -630,7 +641,8 @@ mod tests {
         .expect("catalog");
         let budgets = crate::Cli::try_parse_from(argv)
             .expect("flags parse")
-            .query_budgets();
+            .query_budgets()
+            .expect("budgets resolve");
         build_sql_state(
             catalog,
             store,

--- a/services/ravel-server/tests/logs_fetch_policy_e2e.rs
+++ b/services/ravel-server/tests/logs_fetch_policy_e2e.rs
@@ -1,0 +1,443 @@
+//! ADR-0996 task 996-5 reachability: `--logs-fetch-policy` selects the logs
+//! read SHAPE of a running server, resolved through the server's own config
+//! path.
+//!
+//! The whole point of this file is that it does not call
+//! `ravel_query::resolve_logs_fetch`. It parses a real argv with clap, runs it
+//! through `Cli::query_budgets` -> `QueryBudgets::apply_to_engine` ->
+//! `ravel_server::query::build_sql_state` (the three hops `ravel_server::start`
+//! uses, in that order), and then executes a real statement over real RLOG
+//! objects on a `MemoryStore`. What is asserted is the accounting handle's
+//! opens-by-shape counters, which only `PartitionCtx::record_open_shape` writes
+//! -- the route that ran, not the value that was configured (the ADR-0904
+//! 904-4 rule).
+//!
+//! Before this task's wiring the policy was inert: `apply_to_engine` copied the
+//! raw ADR-0904 byte flags onto the `EngineConfig` and nothing anywhere called
+//! the resolution, so a server started with `--logs-fetch-policy
+//! request-minimal` still routed a projected scan down the ranged path. The
+//! `request_minimal` assertions below are what that failure fails.
+//!
+//! # Why the fixture's objects are about a megabyte
+//!
+//! The route is decided by `LogSegmentFetcher::ranged_projection_pays`: an
+//! object routes ranged when the bytes its projection SKIPS
+//! (`object_size * (1 - projected_fraction)`) exceed the fetcher's effective
+//! whole-object crossover. Under `byte-minimal` at default flags that crossover
+//! is the 512 KiB `--logs-block-range-threshold`, and the projection here is
+//! `ts` alone, which `ResolvedColumns::fraction_of` scores as 2 object columns
+//! (`ts` plus the always-decoded `stream_ref`) out of the 10 fixed ones. So an
+//! object must clear roughly 640 KiB before the ranged route is reachable at
+//! all; [`byte_minimal_fixture_clears_the_ranged_route_precondition`] pins that
+//! as a fixture property, so a fixture that shrinks below it fails as a fixture
+//! bug rather than silently pinning nothing. The bodies are pseudo-random text
+//! because the writer's compression would otherwise shrink the objects back
+//! under the threshold.
+
+#![cfg(feature = "sql")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::Parser;
+use ravel_commit::publish::RetryPolicy;
+use ravel_commit::record::NewCommitRecord;
+use ravel_commit::{keys, publish, record};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::http::StaticBearerTokenResolver;
+use ravel_server::Cli;
+use ravel_server::query::{build_catalog, build_sql_state};
+use ravel_sql::SqlRequest;
+use ravel_types::logstream::log_stream_id;
+use ravel_types::{Signal, TenantId, TimeRange};
+use uuid::Uuid;
+
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+/// Frozen clock reading. Small on purpose: `Catalog::resolve` lists one prefix
+/// per (shard, ingest-hour) across the window.
+const NOW_NS: i64 = 4 * NS_PER_HOUR;
+
+/// RLOG objects in the fixture, and the SQL scan partition count the runs are
+/// driven at (`--fetch-concurrency`). Equal, so the whole-segment fast path's
+/// `relevant_segments >= target_partitions` conjunct holds: that fast path is
+/// where both routes and the `record_open_shape` recording site live. This is
+/// also the exact count both counters are pinned to.
+const SEGMENTS: usize = 2;
+
+/// Records per object, and body bytes per record: 320 x 4 KiB is about 1.3 MB
+/// of incompressible body text per object, comfortably past the ~640 KiB the
+/// ranged route needs (see the header).
+const RECORDS_PER_SEGMENT: usize = 320;
+const BODY_BYTES: usize = 4096;
+
+/// The share of an object's columns the `SELECT ts` projection reads, as
+/// `crates/ravel-sql/src/logs_scan.rs`'s `ResolvedColumns::fraction_of` scores
+/// it: `ts` and the always-decoded `stream_ref`, of the 10 fixed object columns
+/// (this tenant declares no typed attribute columns). Restated here so the
+/// precondition test can check the fixture without executing a plan.
+const NARROW_FRACTION: f64 = 2.0 / 10.0;
+
+/// The compiled-in ADR-0107 crossover, which is also the effective one under
+/// `byte-minimal` at default flags: `build_sql_state` sets the block-range
+/// fetcher's whole-object crossover explicitly from the resolved threshold.
+const BYTE_MINIMAL_CROSSOVER: u64 = ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD;
+
+/// Pseudo-random printable filler, so the writer's compression cannot shrink an
+/// object back under the crossover this fixture has to clear.
+fn filler(seed: u64, len: usize) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut state = seed;
+    let mut out = String::with_capacity(len);
+    for _ in 0..len {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        out.push(ALPHABET[(z & 63) as usize] as char);
+    }
+    out
+}
+
+fn log_record(seg: usize, index: usize) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("checkout".to_string()),
+    )];
+    let ts = (seg * 1_000_000 + index) as i64 + 1;
+    LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: filler((seg as u64) << 32 | index as u64, BODY_BYTES),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    }
+}
+
+/// Publish one RLOG object plus its `Signal::Logs` commit record, exactly as
+/// `ravel-ingest`'s log shard actor does. Returns the object's size, which the
+/// precondition test scores the ranged route against.
+async fn publish_segment(store: &dyn ObjectStoreBackend, tenant: &TenantId, seg: usize) -> u64 {
+    let tenant_hash = tenant.hash();
+    let records: Vec<LogRecord> = (0..RECORDS_PER_SEGMENT)
+        .map(|index| log_record(seg, index))
+        .collect();
+    let writer_id = Uuid::from_u128(4_000 + seg as u128);
+    let writer_seq = seg as u64 + 1;
+    let mut writer = RlogWriter::new(
+        RlogConfig::default(),
+        ObjectIdentity {
+            tenant_hash: tenant_hash.0,
+            shard: 0,
+            writer_id: writer_id.into_bytes(),
+            writer_epoch: 1,
+            writer_seq,
+        },
+    );
+    for rec in &records {
+        writer.push(rec.clone()).expect("push log record");
+    }
+    let bytes = writer.finish().expect("finish rlog object");
+    let object_size = bytes.len() as u64;
+    let content_hash: [u8; 32] = *blake3::hash(&bytes).as_bytes();
+    let min_event_ts_ns = records.iter().map(|r| r.ts_ns).min().expect("records");
+    let max_event_ts_ns = records.iter().map(|r| r.ts_ns).max().expect("records");
+
+    let rec = record::build(NewCommitRecord {
+        tenant_hash,
+        signal: Signal::Logs,
+        shard: 0,
+        writer_id,
+        writer_epoch: 1,
+        writer_seq,
+        object_size,
+        content_hash,
+        sample_count: records.len() as u64,
+        series_count: 1,
+        min_event_ts_ns,
+        max_event_ts_ns,
+        min_ingest_ts_ns: min_event_ts_ns,
+        max_ingest_ts_ns: max_event_ts_ns,
+        segment_format_version: u32::from(ravel_ingest::LOG_SEGMENT_FORMAT_VERSION),
+        created_unix_ns: 10 + seg as i64,
+        ingest_hour_bucket: 0,
+    })
+    .expect("valid log commit record");
+
+    let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+    store
+        .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put log data object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish log commit");
+    object_size
+}
+
+/// What one run of the statement routed and returned.
+struct Routed {
+    whole_object_opens: u64,
+    ranged_opens: u64,
+    rows: usize,
+    /// Every `ts` the run emitted, for the cross-policy row comparison: the
+    /// policy selects a read path, never a result.
+    timestamps: Vec<i64>,
+    /// The object sizes the fixture published, so a precondition can be scored
+    /// against the objects the run actually read.
+    object_sizes: Vec<u64>,
+    /// The `EngineConfig` the server's own resolution produced for this argv.
+    engine: ravel_query::EngineConfig,
+}
+
+/// Publish the fixture, resolve `argv` the way `ravel_server::start` does, and
+/// run the narrow-projection statement through the resulting SQL state.
+async fn run(argv: &[&str]) -> Routed {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = TenantId::new("acme");
+    let mut object_sizes = Vec::with_capacity(SEGMENTS);
+    for seg in 0..SEGMENTS {
+        object_sizes.push(publish_segment(store.as_ref(), &tenant, seg).await);
+    }
+
+    // The three hops `start` uses, in order. `apply_to_engine` is where
+    // `--logs-fetch-policy` is resolved into the byte quantities below.
+    let cli = Cli::try_parse_from(argv).expect("flags parse");
+    let budgets = cli.query_budgets().expect("budgets resolve");
+    let engine = budgets
+        .apply_to_engine(ravel_query::EngineConfig::default())
+        .expect("engine config resolves");
+
+    let catalog = build_catalog(
+        Arc::clone(&store),
+        1,
+        cli.disable_cache,
+        cli.cache_max_bytes,
+        cli.cache_dir.clone(),
+    )
+    .expect("catalog");
+    let state = build_sql_state(
+        catalog,
+        Arc::clone(&store),
+        Arc::new(StaticBearerTokenResolver::new(HashMap::from([(
+            "acme-token".to_string(),
+            tenant.clone(),
+        )]))),
+        None,
+        engine,
+        ravel_server::query::DEFAULT_MAX_QUERY_BYTES,
+        ravel_server::query::DEFAULT_MAX_TENANT_BYTES,
+        budgets.sql_parallel_final_aggregation,
+        Arc::new(ravel_server::metrics::QueryAccountingMetrics::new(
+            std::collections::HashSet::new(),
+        )),
+        ravel_query::QueryAdmissionController::shared(
+            ravel_query::QueryConcurrencyLimit::Unlimited,
+        ),
+        None,
+    )
+    .expect("sql state");
+
+    let outcome = state
+        .executor
+        .execute(
+            tenant.hash(),
+            &SqlRequest {
+                // `ts` alone: the narrow projection the route hinges on. No
+                // predicate, so the whole-segment fast path is not rejected for
+                // a block predicate.
+                sql: "SELECT ts FROM logs".to_string(),
+                window: TimeRange {
+                    start_ns: 0,
+                    end_ns: NOW_NS,
+                },
+                min_tokens: Vec::new(),
+                now_ns: NOW_NS,
+                deadline: Duration::from_secs(120),
+            },
+        )
+        .await
+        .expect("statement executes");
+
+    let json = outcome.output.to_json().expect("rows render");
+    let timestamps: Vec<i64> = json["rows"]
+        .as_array()
+        .expect("rows array")
+        .iter()
+        .map(|row| row[0].as_i64().expect("ts is an integer"))
+        .collect();
+
+    Routed {
+        whole_object_opens: outcome.accounting.logs_whole_object_opens,
+        ranged_opens: outcome.accounting.logs_ranged_opens,
+        rows: outcome.output.num_rows(),
+        timestamps,
+        object_sizes,
+        engine,
+    }
+}
+
+/// Every run passes `--fetch-concurrency 2`, one partition per fixture segment
+/// (see [`SEGMENTS`]), so the policy flag is the only variable between runs.
+const BASE_ARGV: [&str; 3] = ["ravel-server", "--fetch-concurrency", "2"];
+
+/// Fixture precondition: the objects are large enough that the ranged route is
+/// REACHABLE at all under `byte-minimal`. Without this a shrunken fixture would
+/// make every policy route whole-object and the differential below would pin
+/// nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn byte_minimal_fixture_clears_the_ranged_route_precondition() {
+    let routed = run(&[
+        BASE_ARGV.as_slice(),
+        &["--logs-fetch-policy", "byte-minimal"],
+    ]
+    .concat())
+    .await;
+    for size in &routed.object_sizes {
+        let skipped = *size as f64 * (1.0 - NARROW_FRACTION);
+        assert!(
+            skipped > BYTE_MINIMAL_CROSSOVER as f64,
+            "fixture object of {size} bytes skips only {skipped} bytes under the narrow \
+             projection, which does not clear the {BYTE_MINIMAL_CROSSOVER}-byte crossover: \
+             the ranged route would be unreachable and this file would pin nothing"
+        );
+    }
+}
+
+/// The acceptance test (ADR-0996 task 996-5): a server configured with
+/// `--logs-fetch-policy request-minimal` genuinely routes whole-object, and so
+/// does the shipped default (`cost-based` at the reference profile), while
+/// `byte-minimal` keeps today's ranged routing byte for byte. The counters
+/// invert exactly, in both directions, against the fixture's segment count.
+///
+/// Prove-the-test: revert `QueryBudgets::apply_to_engine` to copying the raw
+/// flags (`logs_block_range_threshold: self.logs_block_range_threshold
+/// .unwrap_or(DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD)` and `logs_request_cost_bytes:
+/// self.logs_request_cost_bytes.unwrap_or(
+/// ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES)`), which is the pre-wiring body,
+/// and the request-minimal run reports `(ranged, whole) = (2, 0)` against the
+/// expected `(0, 2)`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fetch_policy_selects_the_logs_read_shape_end_to_end() {
+    let request_minimal = run(&[
+        BASE_ARGV.as_slice(),
+        &["--logs-fetch-policy", "request-minimal"],
+    ]
+    .concat())
+    .await;
+    assert_eq!(
+        (
+            request_minimal.ranged_opens,
+            request_minimal.whole_object_opens
+        ),
+        (0, SEGMENTS as u64),
+        "--logs-fetch-policy request-minimal must route every projected object whole-object"
+    );
+
+    // The shipped default: no policy flag at all, cost-based at the reference
+    // profile (transfer and retrieval free), which resolves to the same shape.
+    let default_policy = run(&BASE_ARGV).await;
+    assert_eq!(
+        (
+            default_policy.ranged_opens,
+            default_policy.whole_object_opens
+        ),
+        (0, SEGMENTS as u64),
+        "the shipped default (cost-based at the reference profile) must route whole-object too"
+    );
+
+    // byte-minimal keeps today's routing, and the resolved quantities are the
+    // pre-wiring values exactly.
+    let byte_minimal = run(&[
+        BASE_ARGV.as_slice(),
+        &["--logs-fetch-policy", "byte-minimal"],
+    ]
+    .concat())
+    .await;
+    assert_eq!(
+        (byte_minimal.ranged_opens, byte_minimal.whole_object_opens),
+        (SEGMENTS as u64, 0),
+        "--logs-fetch-policy byte-minimal must keep the ADR-0107 ranged route"
+    );
+    assert_eq!(
+        byte_minimal.engine.logs_block_range_threshold, BYTE_MINIMAL_CROSSOVER,
+        "byte-minimal must resolve the routing threshold to the exact pre-wiring 512 KiB"
+    );
+    assert_eq!(
+        byte_minimal.engine.logs_request_cost_bytes,
+        ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
+        "byte-minimal must resolve the request cost to the exact pre-wiring constant"
+    );
+
+    // The row-identity invariant (ADR-0996 decision 2): for any policy the
+    // statement returns exactly the same rows; only counters may differ. A
+    // counters-only differential would pass on a route that dropped rows.
+    let expected_rows = SEGMENTS * RECORDS_PER_SEGMENT;
+    assert_eq!(request_minimal.rows, expected_rows);
+    assert_eq!(byte_minimal.rows, expected_rows);
+    assert_eq!(default_policy.rows, expected_rows);
+    let sorted = |mut ts: Vec<i64>| {
+        ts.sort_unstable();
+        ts
+    };
+    let whole = sorted(request_minimal.timestamps);
+    assert_eq!(
+        whole,
+        sorted(byte_minimal.timestamps),
+        "the two read shapes must return identical rows"
+    );
+    assert_eq!(whole, sorted(default_policy.timestamps));
+}
+
+/// The explicit-flag seam, end to end: an operator who already passes
+/// `--logs-request-cost-bytes` keeps their routing when the policy default
+/// changes under them, because the explicit byte flag wins over the policy's
+/// derivation (ADR-0996 decision 2). At the ADR-0904 default value that is the
+/// ranged route this fixture's objects take today.
+///
+/// Prove-the-test: pass the resolution `Some(...unwrap_or(default))` as its
+/// explicit input, erasing the unset case, and the unset run below routes
+/// ranged `(2, 0)` instead of the expected whole-object `(0, 2)`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_explicit_request_cost_flag_keeps_its_deployment_on_the_ranged_route() {
+    let explicit = run(&[
+        BASE_ARGV.as_slice(),
+        &["--logs-request-cost-bytes", "1887437"],
+    ]
+    .concat())
+    .await;
+    assert_eq!(
+        (explicit.ranged_opens, explicit.whole_object_opens),
+        (SEGMENTS as u64, 0),
+        "an explicit --logs-request-cost-bytes must win over the default cost-based policy, \
+         leaving an existing deployment's routing byte-identical"
+    );
+    assert_eq!(
+        explicit.engine.logs_request_cost_bytes,
+        ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES
+    );
+    assert_eq!(
+        explicit.engine.logs_block_range_threshold, BYTE_MINIMAL_CROSSOVER,
+        "a finite explicit rate leaves the routing threshold in force"
+    );
+
+    // The same server with the flag UNSET derives the rate from the policy and
+    // routes whole-object: the two cases are distinguishable end to end, which
+    // is what the Option-typed flag buys.
+    let derived = run(&BASE_ARGV).await;
+    assert_eq!(
+        (derived.ranged_opens, derived.whole_object_opens),
+        (0, SEGMENTS as u64)
+    );
+}


### PR DESCRIPTION
ADR-0996 decision 2's operator knob goes live: QueryBudgets::
apply_to_engine now runs resolve_logs_fetch and folds the RESOLVED
request cost and routing threshold onto the EngineConfig both query
surfaces share, so the fetcher builders read resolved values and
EngineConfig::validate finally has a caller (a zero fetch bound refuses
startup typed).

Three new flags: --logs-fetch-policy (default cost-based per the ADR),
--store-cost-profile (TOML, reference default, unreadable or invalid
refuses startup rather than silently repricing), and
--logs-max-fetch-run-bytes. The two ADR-0904 byte flags become
Option-typed so explicit-vs-unset is expressible: an explicit request
cost wins over the policy, and a saturated policy overrides an explicit
threshold and reports it. The effective resolution is stamped as one
structured startup line built from a value a test asserts exactly.

Behaviour change on default flags, deliberately: cost-based at the
reference profile resolves to request-minimal routing, which is the
ADR's argued default for the deployment this project runs.

End-to-end tests drive the server's own config resolution: request-
minimal and cost-based-at-reference route a projected above-threshold
statement whole-object (ranged opens exactly zero), byte-minimal keeps
today's routing byte-for-byte, and each refusal is pinned typed.

Local gate note: executor ran workspace clippy, affected tests, and
both server feature lanes; full workspace gates run in this PR's
required CI.

Refs: #996