### PR TITLE
feat(ravel-maintain): overlap-gated cursor admission and merge budget

### DIFF
--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -156,6 +156,15 @@ struct MergeMemoryInner {
     peak_writer: AtomicU64,
     /// High-water of the published compaction record's encoded protobuf payload.
     peak_publish_record: AtomicU64,
+    /// High-water of the number of cursors open at once for one stream
+    /// (ADR-0979 decision 2). The RLOG merge admits a stream's per-input cursors
+    /// only when their SKIP_IDX ts-envelope overlaps the merge frontier and
+    /// releases each as it drains, so this is the max concurrent ts-overlap `D`
+    /// of the stream's input slices, not the number `n` of inputs carrying the
+    /// stream. `fetch_max` across streams keeps the largest per-stream peak, so
+    /// the field answers "the most cursors any single stream needed open at
+    /// once", the quantity that bounds the merge's cursor fan-out.
+    max_open_cursors: AtomicU64,
 }
 
 /// A compaction merge's peak resident memory split by the phase that caused it
@@ -292,6 +301,25 @@ impl MergeMemoryTracker {
             .fetch_max(bytes, Ordering::Relaxed);
     }
 
+    /// Note that `open` cursors are simultaneously open for the stream being
+    /// merged (ADR-0979 decision 2). Called by the RLOG merge each time a
+    /// cursor is admitted, so the recorded high-water is the largest number of
+    /// cursors any single stream held open at once. `fetch_max`, so a later
+    /// stream that opened fewer never lowers it.
+    pub fn note_open_cursors(&self, open: u64) {
+        self.inner
+            .max_open_cursors
+            .fetch_max(open, Ordering::Relaxed);
+    }
+
+    /// High-water of the number of cursors open at once for any single stream
+    /// (ADR-0979 decision 2): the max concurrent ts-overlap `D` of a stream's
+    /// input slices, the quantity overlap-gated admission bounds. Read like
+    /// [`Self::peak_cursor_decoded_bytes`], after the merge.
+    pub fn max_open_cursors_per_stream(&self) -> u64 {
+        self.inner.max_open_cursors.load(Ordering::Relaxed)
+    }
+
     /// High-water of the merge's decode-side buffers (`fetched + decoded`).
     /// Bounded by `O(input_count * block_size)`, independent of stream size.
     pub fn peak_transient_bytes(&self) -> u64 {
@@ -363,6 +391,7 @@ impl MergeMemoryTracker {
             &self.inner.peak_catalog_directory,
             &self.inner.peak_writer,
             &self.inner.peak_publish_record,
+            &self.inner.max_open_cursors,
         ] {
             field.store(0, Ordering::Relaxed);
         }
@@ -446,6 +475,35 @@ pub const DEFAULT_MIN_COMPACTION_INPUTS: usize = 2;
 pub const DEFAULT_FOOTER_PROBE_BYTES: u64 = 64 * 1024;
 /// Default `input_read_concurrency`: 8 input reads in flight at once.
 pub const DEFAULT_INPUT_READ_CONCURRENCY: usize = 8;
+/// Default `merge_cursor_budget_bytes`: 20 GiB (ADR-0979 decision 4). Sized so
+/// the reference box completes the ClickBench worst case: the top stream's ~617
+/// inputs at a per-cursor ceiling of ~25 MB reserve ~15.4 GiB, under 20 GiB,
+/// leaving headroom on a 30 GB box for the writer buffer, catalogs, and process
+/// overhead. See [`CompactorConfig::merge_cursor_budget_bytes`] for what the
+/// budget bounds and what happens at the limit.
+pub const DEFAULT_MERGE_CURSOR_BUDGET_BYTES: u64 = 20 * 1024 * 1024 * 1024;
+
+/// How the RLOG merge admits a stream's per-input cursors (ADR-0979 decision 2).
+/// A knob only because the differential test asserts the two modes produce
+/// byte-identical parts; production always uses [`Self::Overlap`], the bounded
+/// path, and no code changes output bytes between the two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AdmissionMode {
+    /// Overlap-gated admission: a stream's cursor on an input opens only once
+    /// the merge frontier reaches that input's SKIP_IDX ts lower bound, so the
+    /// number of simultaneously open cursors is the max concurrent ts-overlap
+    /// `D` of the stream's input slices rather than the input count `n`. This is
+    /// the bound this ADR exists to establish; the default.
+    #[default]
+    Overlap,
+    /// Eagerly open every input's cursor for the stream up front, the pre-D2
+    /// behaviour. Retained so the differential test can assert the emitted
+    /// record sequence, every part boundary, and every part `content_hash` are
+    /// identical to the overlap-gated path. The [`CompactorConfig::merge_cursor_budget_bytes`]
+    /// reservation still applies (every cursor is charged), so this is not an
+    /// escape from the budget, only from the deferral.
+    EagerAll,
+}
 
 /// Default `grace`: 24 hours (docs/consistency-model.md "Deletion and GC").
 /// A shared floor for the orphan and unreferenced-part age gates.
@@ -673,6 +731,36 @@ pub struct CompactorConfig {
     /// order -- so raising it can change timing but never content. Default
     /// [`DEFAULT_INPUT_READ_CONCURRENCY`] (8).
     pub input_read_concurrency: usize,
+    /// The RLOG merge's per-stream cursor-memory budget (ADR-0979 decision 4).
+    /// Unlike the two part-split targets and `input_read_concurrency`, this one
+    /// DOES bound resident memory: it caps the sum, over the cursors open at
+    /// once for one stream, of each cursor's pre-decode reservation ceiling (two
+    /// row groups' stored bytes, the cursor's location metadata, and the
+    /// decoded columnar block sized from the block's PAGE_DIR `uncomp_len`
+    /// times an allocation-overhead factor).
+    ///
+    /// The reservation is charged BEFORE a cursor fetches or decodes anything,
+    /// so the budget is enforced at reserve time and the merge fails closed
+    /// rather than after allocating: if opening a cursor that merge order
+    /// requires would push the charge over the budget, the run aborts with a
+    /// typed [`crate::error::MaintainError::MergeCursorBudgetExceeded`] naming
+    /// the stream, the reservation, and the budget, before publishing anything.
+    /// Nothing is published, the L0 inputs stay live and queryable, and any
+    /// parts already PUT age out under the unreferenced-part sweep exactly like
+    /// an abandoned run's. This converts an out-of-memory kill at an arbitrary
+    /// point into a refusal naming the stream and the number to raise. Because
+    /// overlap-gated admission ([`AdmissionMode::Overlap`]) releases each
+    /// cursor's reservation as it drains, the charge tracks the concurrent
+    /// overlap `D`, not the input count. Default
+    /// [`DEFAULT_MERGE_CURSOR_BUDGET_BYTES`] (20 GiB); a budget so small that
+    /// even one stream's minimum admissible cursor set does not fit refuses that
+    /// stream's merge.
+    pub merge_cursor_budget_bytes: u64,
+    /// How the RLOG merge admits a stream's cursors (ADR-0979 decision 2).
+    /// Default [`AdmissionMode::Overlap`] (the bounded path). Only the
+    /// differential part-hash test sets [`AdmissionMode::EagerAll`]; output
+    /// bytes are identical either way.
+    pub merge_admission: AdmissionMode,
     /// This compactor process's uuid. Informational only: it is recorded in
     /// each part's footer `writer_id` and never enters dedup priority.
     /// Default is the nil uuid; the service sets a real one.
@@ -779,6 +867,8 @@ impl Default for CompactorConfig {
             min_compaction_inputs: DEFAULT_MIN_COMPACTION_INPUTS,
             footer_probe_bytes: DEFAULT_FOOTER_PROBE_BYTES,
             input_read_concurrency: DEFAULT_INPUT_READ_CONCURRENCY,
+            merge_cursor_budget_bytes: DEFAULT_MERGE_CURSOR_BUDGET_BYTES,
+            merge_admission: AdmissionMode::Overlap,
             compactor_writer_id: Uuid::nil(),
             grace_ns: DEFAULT_GRACE_NS,
             protection_horizon_ns: DEFAULT_PROTECTION_HORIZON_NS,

--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -481,19 +481,21 @@ pub const DEFAULT_INPUT_READ_CONCURRENCY: usize = 8;
 ///
 /// The charge a stream carries is the sum over its open cursors of what each
 /// holds, plus, for the instant between reserving and decoding, the pre-decode
-/// ceiling of the batch being admitted. For the ClickBench worst case the ADR
+/// ceiling of the batch being admitted or of the one block an open cursor is
+/// about to decode. For the ClickBench worst case the ADR
 /// sizes against (tenant `cb-20260831140539`, top stream carried by ~617 inputs,
 /// ~3.5 MB stored per row group, 105 mapped columns of which ~28 are
 /// string-typed, 8192-record blocks):
 ///
 /// ```text
 /// per-cursor pre-decode ceiling (rlog::cursor_reservation_bytes)
-///   16 B x 8192 rows x 115 column ids            = 14.4 MiB   shape term
-///   + string-page uncomp_len (~4 MiB measured)   =  4.0 MiB   string payload
-///   + 40 B x 8192 rows x 33 string columns       = 10.3 MiB   string slots
-///   + 2 x 3.5 MB row group                       =  6.7 MiB   raw, two locs
-///                                                  ---------
-///                                                   35.4 MiB
+///   16 B x 8192 rows x 115 column ids            = 14.375 MiB shape term
+///   + string-page uncomp_len (~4 MiB measured)   =  4.000 MiB string payload
+///   + 40 B x 8192 rows x 33 string columns       = 10.313 MiB string slots
+///   + 48 B x 115 column ids x 5 x 2 growth       =  0.053 MiB decoder spines
+///   + 2 x 3.5 MB row group                       =  6.676 MiB raw, two locs
+///                                                  ----------
+///                                                   35.416 MiB (37,136,224 B)
 ///
 /// per-cursor reconciled residency (rlog::StreamCursor::resident_bytes)
 ///   heap_estimate of the decoded block           = 17-24 MiB  (ADR: 18-25 MB)
@@ -501,9 +503,20 @@ pub const DEFAULT_INPUT_READ_CONCURRENCY: usize = 8;
 ///                                                  ---------
 ///                                                   24-30 MiB
 ///
-/// 617 cursors reconciled       617 x 30 MiB = 18.1 GiB  < 20 GiB
-/// 617 cursors at the ceiling   617 x 35.4 MiB = 21.3 GiB > 20 GiB
+/// 617 cursors reconciled       617 x 30 MiB     = 18.1 GiB  < 20 GiB
+/// 617 cursors at the ceiling   617 x 35.416 MiB = 21.3 GiB  > 20 GiB
 /// ```
+///
+/// The decoder-spine term is the five per-kind slot vectors a decoded block
+/// holds, each indexed by column id and so sized by the id-space width whatever
+/// the block carries. It does not scale with rows, so at 8192-record blocks it
+/// is 55,200 B, 0.15% of the per-cursor ceiling: adding it moves that ceiling
+/// from 37,081,024 B to 37,136,224 B and the 617-cursor line from 21.307 GiB to
+/// 21.339 GiB, both still the same rounded figures and the same side of the
+/// 20 GiB budget. It is in the ceiling for the other end of the range, a block
+/// of a few rows, where it is the dominant term and a ceiling without it is not
+/// a ceiling at all. The reconciled line is unchanged either way: it is
+/// measured, and `heap_estimate` has always counted the slot vectors.
 ///
 /// So the default admits the worst case because the reconcile is mandatory
 /// (ADR-0979 decision 4 as amended): held at their admission ceilings, the same
@@ -775,10 +788,12 @@ pub struct CompactorConfig {
     /// A cursor is admitted against a pre-decode CEILING on those terms, priced
     /// from resident directory metadata: the block's decoded size is
     /// `16 B x rows x column-id width + its string pages' uncomp_len +
-    /// 40 B x rows x string columns`, maximized over the cursor's candidate
-    /// blocks. That is a shape formula, not a stored-size one, because the page
-    /// codecs are size-adaptive: a constant column stores a few bytes per block
-    /// and still decodes to `16 B x rows`.
+    /// 40 B x rows x string columns + 48 B x column-id width x 5 slot vectors
+    /// x 2 for their growth step`,
+    /// maximized over the cursor's candidate blocks. That is a shape formula,
+    /// not a stored-size one, because the page codecs are size-adaptive: a
+    /// constant column stores a few bytes per block and still decodes to
+    /// `16 B x rows`.
     ///
     /// The reservation is charged BEFORE a cursor fetches or decodes anything,
     /// so the budget is enforced at reserve time and the merge fails closed
@@ -789,7 +804,13 @@ pub struct CompactorConfig {
     /// Once the decode completes, the charge is reconciled down to the cursor's
     /// actual residency (its decoded block's `heap_estimate`, the raw bytes it
     /// actually holds, and its location metadata), which is the basis
-    /// [`DEFAULT_MERGE_CURSOR_BUDGET_BYTES`] is sized from.
+    /// [`DEFAULT_MERGE_CURSOR_BUDGET_BYTES`] is sized from. The reconcile is a
+    /// lowering, never a release of the bound: before an open cursor decodes a
+    /// LATER block, its charge grows back to cover that block's ceiling on top
+    /// of what it still holds, and a growth the budget cannot take refuses with
+    /// the same typed error before the decode starts. Without that, the freed
+    /// budget could be spent admitting more cursors and every one of them could
+    /// then grow toward its own ceiling with nothing checking the sum again.
     /// Nothing is published, the L0 inputs stay live and queryable, and any
     /// parts already PUT age out under the unreferenced-part sweep exactly like
     /// an abandoned run's. This converts an out-of-memory kill at an arbitrary

--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -475,12 +475,47 @@ pub const DEFAULT_MIN_COMPACTION_INPUTS: usize = 2;
 pub const DEFAULT_FOOTER_PROBE_BYTES: u64 = 64 * 1024;
 /// Default `input_read_concurrency`: 8 input reads in flight at once.
 pub const DEFAULT_INPUT_READ_CONCURRENCY: usize = 8;
-/// Default `merge_cursor_budget_bytes`: 20 GiB (ADR-0979 decision 4). Sized so
-/// the reference box completes the ClickBench worst case: the top stream's ~617
-/// inputs at a per-cursor ceiling of ~25 MB reserve ~15.4 GiB, under 20 GiB,
-/// leaving headroom on a 30 GB box for the writer buffer, catalogs, and process
-/// overhead. See [`CompactorConfig::merge_cursor_budget_bytes`] for what the
-/// budget bounds and what happens at the limit.
+/// Default `merge_cursor_budget_bytes`: 20 GiB (ADR-0979 decision 4), re-derived
+/// below from the arithmetic `crate::rlog` implements rather than from the ADR's
+/// summary figure.
+///
+/// The charge a stream carries is the sum over its open cursors of what each
+/// holds, plus, for the instant between reserving and decoding, the pre-decode
+/// ceiling of the batch being admitted. For the ClickBench worst case the ADR
+/// sizes against (tenant `cb-20260831140539`, top stream carried by ~617 inputs,
+/// ~3.5 MB stored per row group, 105 mapped columns of which ~28 are
+/// string-typed, 8192-record blocks):
+///
+/// ```text
+/// per-cursor pre-decode ceiling (rlog::cursor_reservation_bytes)
+///   16 B x 8192 rows x 115 column ids            = 14.4 MiB   shape term
+///   + string-page uncomp_len (~4 MiB measured)   =  4.0 MiB   string payload
+///   + 40 B x 8192 rows x 33 string columns       = 10.3 MiB   string slots
+///   + 2 x 3.5 MB row group                       =  6.7 MiB   raw, two locs
+///                                                  ---------
+///                                                   35.4 MiB
+///
+/// per-cursor reconciled residency (rlog::StreamCursor::resident_bytes)
+///   heap_estimate of the decoded block           = 17-24 MiB  (ADR: 18-25 MB)
+///   + the raw locs actually held                 <= 6.7 MiB
+///                                                  ---------
+///                                                   24-30 MiB
+///
+/// 617 cursors reconciled       617 x 30 MiB = 18.1 GiB  < 20 GiB
+/// 617 cursors at the ceiling   617 x 35.4 MiB = 21.3 GiB > 20 GiB
+/// ```
+///
+/// So the default admits the worst case because the reconcile is mandatory
+/// (ADR-0979 decision 4 as amended): held at their admission ceilings, the same
+/// 617 cursors would be refused. The residual corner is a stream whose whole
+/// 617-input queue is admitted in ONE batch (every input's SKIP_IDX lower bound
+/// at or below the first frontier), where the batch is charged at its ceiling
+/// before any of it decodes: that transient is the 21.3 GiB line and fails
+/// closed with [`crate::error::MaintainError::MergeCursorBudgetExceeded`] naming
+/// the number to raise, which is the designed behaviour at the limit rather than
+/// an out-of-memory kill. Under 20 GiB the reference box keeps ~10 GB of its
+/// 30 GB for the writer buffer, the catalogs, and process overhead. See
+/// [`CompactorConfig::merge_cursor_budget_bytes`] for what the budget bounds.
 pub const DEFAULT_MERGE_CURSOR_BUDGET_BYTES: u64 = 20 * 1024 * 1024 * 1024;
 
 /// How the RLOG merge admits a stream's per-input cursors (ADR-0979 decision 2).
@@ -734,10 +769,16 @@ pub struct CompactorConfig {
     /// The RLOG merge's per-stream cursor-memory budget (ADR-0979 decision 4).
     /// Unlike the two part-split targets and `input_read_concurrency`, this one
     /// DOES bound resident memory: it caps the sum, over the cursors open at
-    /// once for one stream, of each cursor's pre-decode reservation ceiling (two
-    /// row groups' stored bytes, the cursor's location metadata, and the
-    /// decoded columnar block sized from the block's PAGE_DIR `uncomp_len`
-    /// times an allocation-overhead factor).
+    /// once for one stream, of what each cursor holds -- two row groups' stored
+    /// bytes, the cursor's location metadata, and its decoded columnar block.
+    ///
+    /// A cursor is admitted against a pre-decode CEILING on those terms, priced
+    /// from resident directory metadata: the block's decoded size is
+    /// `16 B x rows x column-id width + its string pages' uncomp_len +
+    /// 40 B x rows x string columns`, maximized over the cursor's candidate
+    /// blocks. That is a shape formula, not a stored-size one, because the page
+    /// codecs are size-adaptive: a constant column stores a few bytes per block
+    /// and still decodes to `16 B x rows`.
     ///
     /// The reservation is charged BEFORE a cursor fetches or decodes anything,
     /// so the budget is enforced at reserve time and the merge fails closed
@@ -745,6 +786,10 @@ pub struct CompactorConfig {
     /// requires would push the charge over the budget, the run aborts with a
     /// typed [`crate::error::MaintainError::MergeCursorBudgetExceeded`] naming
     /// the stream, the reservation, and the budget, before publishing anything.
+    /// Once the decode completes, the charge is reconciled down to the cursor's
+    /// actual residency (its decoded block's `heap_estimate`, the raw bytes it
+    /// actually holds, and its location metadata), which is the basis
+    /// [`DEFAULT_MERGE_CURSOR_BUDGET_BYTES`] is sized from.
     /// Nothing is published, the L0 inputs stay live and queryable, and any
     /// parts already PUT age out under the unreferenced-part sweep exactly like
     /// an abandoned run's. This converts an out-of-memory kill at an arbitrary

--- a/crates/ravel-maintain/src/error.rs
+++ b/crates/ravel-maintain/src/error.rs
@@ -10,6 +10,59 @@ use ravel_object_store::StoreError;
 use ravel_rspan::SpanSegError;
 use ravel_segment::SegmentError;
 
+/// Where in a cursor's life the merge cursor budget refused
+/// (ADR-0979 decision 4 as amended). Both sites check the same budget against
+/// the same running charge; they differ in what the refused bytes would have
+/// paid for, and an operator reading the error needs to know which, because
+/// only the admission site is fixed by admitting fewer cursors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeCursorBudgetSite {
+    /// Admitting a new cursor: the reservation of the batch member at
+    /// `batch_position` (0-based) of a batch of `batch_len` crossed the budget.
+    /// The whole batch is what merge order requires before the next emit, so a
+    /// refusal at any position aborts the run.
+    Admission {
+        /// Position, within the admission batch, of the cursor whose
+        /// reservation crossed the budget (0-based).
+        batch_position: usize,
+        /// How many cursors the refused admission batch holds.
+        batch_len: usize,
+    },
+    /// Growing an already-open cursor's charge to cover the block it is about
+    /// to decode. The growth is checked BEFORE the decode starts, so the
+    /// refusal costs nothing but the run: the larger block was never
+    /// materialized.
+    BlockGrow {
+        /// Whole-object index of the block whose decode was refused.
+        block_index: usize,
+        /// How much the cursor's charge had to grow to cover that block's
+        /// pre-decode ceiling on top of the metadata and raw bytes it already
+        /// holds.
+        grow_bytes: u64,
+    },
+}
+
+impl std::fmt::Display for MergeCursorBudgetSite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Admission {
+                batch_position,
+                batch_len,
+            } => write!(
+                f,
+                "admitting the batch merge order requires (position {batch_position} of {batch_len})"
+            ),
+            Self::BlockGrow {
+                block_index,
+                grow_bytes,
+            } => write!(
+                f,
+                "growing an open cursor by {grow_bytes} bytes to decode block {block_index} before that decode starts"
+            ),
+        }
+    }
+}
+
 /// A compaction run's failure. Retryable store faults surface as
 /// [`MaintainError::Store`] carrying the underlying [`StoreError`]; the caller
 /// decides whether to re-run the whole bucket (the idempotent recovery path). The `*Divergence` and `*Mismatch` variants are invariant
@@ -98,36 +151,33 @@ pub enum MaintainError {
         part_key: String,
     },
     #[error(
-        "bounded RLOG compaction merge for stream {stream_id} would exceed its cursor-memory budget: {open_cursors} cursors already open charging {charged_bytes} bytes, and admitting the batch merge order requires (position {admission_batch_position} of {admission_batch_len}) needs {required_bytes} bytes total against a budget of {budget_bytes} ({inputs_carrying_stream} inputs carry this stream); nothing published, the L0 inputs stay live, any parts already PUT age out under the unreferenced-part sweep (ADR-0979 decision 4). Raise merge_cursor_budget_bytes to at least {required_bytes} to compact this bucket"
+        "bounded RLOG compaction merge for stream {stream_id} would exceed its cursor-memory budget: {open_cursors} cursors already open charging {charged_bytes} bytes, and {site} needs {required_bytes} bytes total against a budget of {budget_bytes} ({inputs_carrying_stream} inputs carry this stream); nothing published, the L0 inputs stay live, any parts already PUT age out under the unreferenced-part sweep (ADR-0979 decision 4). Raise merge_cursor_budget_bytes to at least {required_bytes} to compact this bucket"
     )]
     MergeCursorBudgetExceeded {
         /// Hex canonical id of the stream whose cursor set overran the budget.
         stream_id: String,
-        /// Cursors already open for this stream when the reservation was refused.
-        /// Batch members before the refused one are not counted here: they were
-        /// never opened, so they hold nothing.
+        /// Cursors already open for this stream when the charge was refused.
+        /// On the admission site, batch members before the refused one are not
+        /// counted here: they were never opened, so they hold nothing. On the
+        /// block-growth site the cursor asking to grow IS open and is counted.
         open_cursors: usize,
         /// What the OPEN cursors charge at the point of refusal: their reconciled
         /// residency, not counting any member of the refused admission batch.
         charged_bytes: u64,
         /// The configured [`crate::config::CompactorConfig::merge_cursor_budget_bytes`].
         budget_bytes: u64,
-        /// Prospective total had the batch been admitted through this position:
-        /// `charged_bytes` plus the reservations of batch members `0..=
-        /// admission_batch_position`. The whole batch is what merge order
-        /// requires before the next record can be emitted, so this is the figure
-        /// a retry must budget for, and a first admission already over budget
-        /// still names a number.
+        /// Prospective total had the refused charge been taken: `charged_bytes`
+        /// plus the reservations of batch members `0..=batch_position` on the
+        /// admission site, `charged_bytes + grow_bytes` on the block-growth
+        /// site. Either way it is what merge order requires before the next
+        /// record can be emitted, so it is the figure a retry must budget for,
+        /// and a first admission already over budget still names a number.
         required_bytes: u64,
         /// How many inputs carry this stream, so the operator can size the fix.
         inputs_carrying_stream: usize,
-        /// Position, within the admission batch, of the cursor whose reservation
-        /// crossed the budget (0-based).
-        admission_batch_position: usize,
-        /// How many cursors the refused admission batch holds. The whole batch is
-        /// admitted before the next emit, so a refusal at any position aborts the
-        /// run.
-        admission_batch_len: usize,
+        /// Which point in a cursor's life refused, and its site-specific
+        /// figures.
+        site: MergeCursorBudgetSite,
     },
     #[error(
         "bounded RLOG compaction cannot admission-price input {object_key:?}: it carries no PAGE_DIR section, so a cursor's decode cost is unknowable before the fetch and the pre-decode reservation (ADR-0979 decision 4) cannot be charged. PAGE_DIR is mandatory in RLOG format version {format_version} (ADR-0699 decision 2), so this is a version/corruption gate, not a live path on a current-format fleet; nothing published, the L0 inputs stay live"

--- a/crates/ravel-maintain/src/error.rs
+++ b/crates/ravel-maintain/src/error.rs
@@ -98,23 +98,36 @@ pub enum MaintainError {
         part_key: String,
     },
     #[error(
-        "bounded RLOG compaction merge for stream {stream_id} would exceed its cursor-memory budget: {open_cursors} cursors already open charging {charged_bytes} bytes, admitting the next cursor merge order requires needs {required_bytes} bytes total against a budget of {budget_bytes} ({inputs_carrying_stream} inputs carry this stream); nothing published, the L0 inputs stay live, any parts already PUT age out under the unreferenced-part sweep (ADR-0979 decision 4). Raise merge_cursor_budget_bytes to at least {required_bytes} to compact this bucket"
+        "bounded RLOG compaction merge for stream {stream_id} would exceed its cursor-memory budget: {open_cursors} cursors already open charging {charged_bytes} bytes, and admitting the batch merge order requires (position {admission_batch_position} of {admission_batch_len}) needs {required_bytes} bytes total against a budget of {budget_bytes} ({inputs_carrying_stream} inputs carry this stream); nothing published, the L0 inputs stay live, any parts already PUT age out under the unreferenced-part sweep (ADR-0979 decision 4). Raise merge_cursor_budget_bytes to at least {required_bytes} to compact this bucket"
     )]
     MergeCursorBudgetExceeded {
         /// Hex canonical id of the stream whose cursor set overran the budget.
         stream_id: String,
         /// Cursors already open for this stream when the reservation was refused.
+        /// Batch members before the refused one are not counted here: they were
+        /// never opened, so they hold nothing.
         open_cursors: usize,
-        /// Sum of the open cursors' reservations at the point of refusal.
+        /// What the OPEN cursors charge at the point of refusal: their reconciled
+        /// residency, not counting any member of the refused admission batch.
         charged_bytes: u64,
         /// The configured [`crate::config::CompactorConfig::merge_cursor_budget_bytes`].
         budget_bytes: u64,
-        /// Prospective total had the refused cursor been admitted (`charged_bytes`
-        /// plus its reservation), so a first admission already over budget still
-        /// names the number a retry must budget for.
+        /// Prospective total had the batch been admitted through this position:
+        /// `charged_bytes` plus the reservations of batch members `0..=
+        /// admission_batch_position`. The whole batch is what merge order
+        /// requires before the next record can be emitted, so this is the figure
+        /// a retry must budget for, and a first admission already over budget
+        /// still names a number.
         required_bytes: u64,
         /// How many inputs carry this stream, so the operator can size the fix.
         inputs_carrying_stream: usize,
+        /// Position, within the admission batch, of the cursor whose reservation
+        /// crossed the budget (0-based).
+        admission_batch_position: usize,
+        /// How many cursors the refused admission batch holds. The whole batch is
+        /// admitted before the next emit, so a refusal at any position aborts the
+        /// run.
+        admission_batch_len: usize,
     },
     #[error(
         "bounded RLOG compaction cannot admission-price input {object_key:?}: it carries no PAGE_DIR section, so a cursor's decode cost is unknowable before the fetch and the pre-decode reservation (ADR-0979 decision 4) cannot be charged. PAGE_DIR is mandatory in RLOG format version {format_version} (ADR-0699 decision 2), so this is a version/corruption gate, not a live path on a current-format fleet; nothing published, the L0 inputs stay live"

--- a/crates/ravel-maintain/src/error.rs
+++ b/crates/ravel-maintain/src/error.rs
@@ -97,6 +97,34 @@ pub enum MaintainError {
         /// convergence HEAD verification and could not be re-PUT from RAM.
         part_key: String,
     },
+    #[error(
+        "bounded RLOG compaction merge for stream {stream_id} would exceed its cursor-memory budget: {open_cursors} cursors already open charging {charged_bytes} bytes, admitting the next cursor merge order requires needs {required_bytes} bytes total against a budget of {budget_bytes} ({inputs_carrying_stream} inputs carry this stream); nothing published, the L0 inputs stay live, any parts already PUT age out under the unreferenced-part sweep (ADR-0979 decision 4). Raise merge_cursor_budget_bytes to at least {required_bytes} to compact this bucket"
+    )]
+    MergeCursorBudgetExceeded {
+        /// Hex canonical id of the stream whose cursor set overran the budget.
+        stream_id: String,
+        /// Cursors already open for this stream when the reservation was refused.
+        open_cursors: usize,
+        /// Sum of the open cursors' reservations at the point of refusal.
+        charged_bytes: u64,
+        /// The configured [`crate::config::CompactorConfig::merge_cursor_budget_bytes`].
+        budget_bytes: u64,
+        /// Prospective total had the refused cursor been admitted (`charged_bytes`
+        /// plus its reservation), so a first admission already over budget still
+        /// names the number a retry must budget for.
+        required_bytes: u64,
+        /// How many inputs carry this stream, so the operator can size the fix.
+        inputs_carrying_stream: usize,
+    },
+    #[error(
+        "bounded RLOG compaction cannot admission-price input {object_key:?}: it carries no PAGE_DIR section, so a cursor's decode cost is unknowable before the fetch and the pre-decode reservation (ADR-0979 decision 4) cannot be charged. PAGE_DIR is mandatory in RLOG format version {format_version} (ADR-0699 decision 2), so this is a version/corruption gate, not a live path on a current-format fleet; nothing published, the L0 inputs stay live"
+    )]
+    MergeCursorInputMissingPageDir {
+        /// Data-object key of the input that carries no PAGE_DIR section.
+        object_key: String,
+        /// The RLOG output format version PAGE_DIR is mandatory in.
+        format_version: u32,
+    },
     #[error("compaction invariant breach: {0}")]
     Invariant(String),
     #[error(

--- a/crates/ravel-maintain/src/lib.rs
+++ b/crates/ravel-maintain/src/lib.rs
@@ -82,7 +82,7 @@ pub use erasure_rewrite::{
     bucket_may_overlap, build_rewrite, erasure_rewrite_bucket, pending_erasure_requests,
     publish_rewrite_record,
 };
-pub use error::{MaintainError, Result};
+pub use error::{MaintainError, MergeCursorBudgetSite, Result};
 pub use gc_config::{
     GC_CONFIG_KEY, GcConfigError, GcConfigValues, SetOutcome, bootstrap_gc_config, read_gc_config,
     set_gc_config, validate_flight_ceiling, validate_maintain, validate_maintain_skew,

--- a/crates/ravel-maintain/src/lib.rs
+++ b/crates/ravel-maintain/src/lib.rs
@@ -72,8 +72,8 @@ pub use clock::{Clock, FixedClock};
 pub use codec::{RsegCodec, SegmentCodec};
 pub use compact::{CompactionOutcome, compact_bucket};
 pub use config::{
-    AuditMode, AuditPipelineConfig, CompactorConfig, MergeMemoryTracker, MergePhasePeaks,
-    RetentionConfig, RetentionConfigError, RetentionPolicy,
+    AdmissionMode, AuditMode, AuditPipelineConfig, CompactorConfig, MergeMemoryTracker,
+    MergePhasePeaks, RetentionConfig, RetentionConfigError, RetentionPolicy,
 };
 pub use discover::discover_tenants;
 pub use erasure_rewrite::{

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -190,6 +190,7 @@ use futures::stream::{StreamExt, TryStreamExt, iter as stream_iter};
 use ravel_commit::keys;
 use ravel_logseg::field_dir::FieldDir;
 use ravel_logseg::footer::{self, SuffixOutcome, kind};
+use ravel_logseg::page_dir::PageDir;
 use ravel_logseg::postings::PostingsSection;
 use ravel_logseg::{
     AttrValue, LogRecord, LogStreamId, RlogConfig, RlogRangeReader, RlogWriter, StreamBlockLoc,
@@ -201,7 +202,7 @@ use ravel_proto::commit::v1::CompactionPart;
 use crate::bucket::Bucket;
 use crate::build::{BuiltPart, put_part};
 use crate::codec::SegmentCodec;
-use crate::config::{CompactorConfig, MergeMemoryTracker};
+use crate::config::{AdmissionMode, CompactorConfig, MergeMemoryTracker};
 use crate::error::{MaintainError, Result};
 use crate::read::InputRecord;
 
@@ -256,6 +257,17 @@ pub struct RlogInputCatalog {
     /// it from here is what lets that gate keep working without the
     /// whole-object GET it used to read the footer from.
     pub record_count: u64,
+    /// Per whole-object block index, the sum of that block's PAGE_DIR
+    /// `uncomp_len` values: the decompressed page-byte total the block expands
+    /// to before per-cell allocation overhead. This is the term the bounded
+    /// merge's pre-decode cursor reservation is sized from (ADR-0979
+    /// decision 4): a cursor's decoded columnar block costs about this times an
+    /// allocation-overhead factor, and it is known from the resident PAGE_DIR
+    /// before any BLOCKS byte is fetched. A candidate block index from
+    /// [`RlogRangeReader::stream_blocks`] indexes straight into it. Never empty
+    /// on a loaded catalog: an input with no PAGE_DIR is refused at load with
+    /// [`MaintainError::MergeCursorInputMissingPageDir`].
+    pub block_uncomp_lens: Vec<u64>,
 }
 
 /// The logs codec: implements the [`SegmentCodec`] seam for `.rlog` objects.
@@ -376,12 +388,27 @@ pub(crate) async fn load_catalog_from_object(
         Vec::new()
     };
 
-    // PAGE_DIR is present exactly on a version-4 input (ADR-0699
-    // decision 2), and locating its blocks' pages is impossible without it.
-    let page_dir_raw = match ftr.section(kind::PAGE_DIR) {
-        Some(_) => Some(fetch_section(store, &object_key, &ftr, kind::PAGE_DIR, &cfg).await?),
-        None => None,
+    // PAGE_DIR is present exactly on a version-4 input (ADR-0699 decision 2),
+    // and the bounded merge cannot admission-price a cursor over an input
+    // without it (its decoded string-page term is unknowable before the fetch,
+    // ADR-0979 decision 4), so refuse it by object key and format version
+    // rather than read it under a guessed cost. PAGE_DIR is mandatory in v4, so
+    // in practice this is a version/corruption gate, not a live path.
+    let Some(_) = ftr.section(kind::PAGE_DIR) else {
+        return Err(MaintainError::MergeCursorInputMissingPageDir {
+            object_key,
+            format_version: OUTPUT_FORMAT_VERSION,
+        });
     };
+    let page_dir_raw = fetch_section(store, &object_key, &ftr, kind::PAGE_DIR, &cfg).await?;
+    // The per-block decompressed page-byte totals the bounded merge reserves a
+    // cursor's decode against (ADR-0979 decision 4). Decoded here, once, from
+    // the PAGE_DIR bytes already fetched: `PageDir::decode` is the same decode
+    // the range reader runs internally, and this keeps only the per-block sum
+    // (one u64 per block) rather than a second copy of the directory. The
+    // reader's own `from_sections_with_page_dir` below re-decodes and fully
+    // validates the same bytes, so a corrupt directory still fails loud there.
+    let block_uncomp_lens = block_uncomp_lens_from_page_dir(&page_dir_raw)?;
     // Input read / catalog load phase (issue #977): the reader below retains a
     // decoded form of these directory sections for the whole merge. Charge the
     // decoded section payload lengths (what `fetch_section` returns after
@@ -391,7 +418,11 @@ pub(crate) async fn load_catalog_from_object(
         let dir_bytes = stream_dir_raw.len() as u64
             + field_dir_raw.len() as u64
             + skip_idx_raw.len() as u64
-            + page_dir_raw.as_ref().map(|d| d.len() as u64).unwrap_or(0);
+            + page_dir_raw.len() as u64
+            // The retained per-block reservation figures are derived from
+            // PAGE_DIR but held past it, so charge them too: one u64 per block.
+            + (block_uncomp_lens.len() as u64)
+                .saturating_mul(std::mem::size_of::<u64>() as u64);
         t.add_catalog_directory_bytes(dir_bytes);
     }
     let record_count = ftr.record_count;
@@ -400,14 +431,41 @@ pub(crate) async fn load_catalog_from_object(
         &stream_dir_raw,
         &field_dir_raw,
         &skip_idx_raw,
-        page_dir_raw.as_deref(),
+        Some(&page_dir_raw),
     )?;
     Ok(RlogInputCatalog {
         object_key,
         reader,
         indexed_fields,
         record_count,
+        block_uncomp_lens,
     })
+}
+
+/// The per-block decompressed page-byte totals a bounded merge reserves cursor
+/// decode against (ADR-0979 decision 4), decoded from one input's PAGE_DIR
+/// section bytes. Entry `b` is the sum of `uncomp_len` over every page whole-
+/// object block `b` contributes to any column chunk of its row group -- the
+/// decompressed columnar payload the block decodes to, which the cursor's
+/// [`StreamBlockRows::heap_estimate`] scales with. Read from resident PAGE_DIR
+/// alone; the decode is the same one the range reader runs internally.
+fn block_uncomp_lens_from_page_dir(page_dir_raw: &[u8]) -> Result<Vec<u64>> {
+    let page_dir = PageDir::decode(page_dir_raw)?;
+    let block_count = page_dir.block_count();
+    let mut out = Vec::with_capacity(block_count as usize);
+    for b in 0..block_count {
+        let index = u32::try_from(b)
+            .map_err(|_| MaintainError::Invariant("page_dir block index range".to_string()))?;
+        let pages = page_dir.block_pages(index).ok_or_else(|| {
+            MaintainError::Invariant("page_dir block absent from its own directory".to_string())
+        })?;
+        let mut sum = 0u64;
+        for p in pages {
+            sum = sum.saturating_add(p.desc.uncomp_len);
+        }
+        out.push(sum);
+    }
+    Ok(out)
 }
 
 /// One catalog per object key, `input_read_concurrency` loads in flight.
@@ -885,6 +943,13 @@ struct StreamCursor<'a> {
     /// the prefetch is one loc ahead, so the cursor's raw-byte residency is
     /// two locs, not the stream.
     prefetched: Option<(StreamBlockLoc, bytes::Bytes)>,
+    /// The pre-decode reservation charged against
+    /// [`CompactorConfig::merge_cursor_budget_bytes`] when this cursor was
+    /// admitted (ADR-0979 decision 4). Held for the cursor's lifetime and
+    /// released back to the stream's running charge when the cursor drains, so
+    /// the charge tracks the concurrent overlap `D`, not the input count. Set by
+    /// the merge after [`Self::open`]; 0 until then.
+    reservation: u64,
 }
 
 impl<'a> StreamCursor<'a> {
@@ -911,6 +976,7 @@ impl<'a> StreamCursor<'a> {
             block: None,
             block_bytes: 0,
             prefetched: None,
+            reservation: 0,
         }))
     }
 
@@ -1109,6 +1175,89 @@ async fn fetch_block(
     Ok(got.data)
 }
 
+/// One input queued for overlap-gated admission (ADR-0979 decision 2): its
+/// canonical `input_index`, the SKIP_IDX ts lower bound its cursor's first
+/// record cannot precede, and the pre-decode reservation admitting it charges
+/// against the merge budget (ADR-0979 decision 4).
+struct PendingCursor {
+    input_index: usize,
+    lower_bound: i64,
+    reservation: u64,
+}
+
+/// Allocation-overhead factor applied to a block's decompressed page bytes to
+/// size the decoded columnar block's reservation ceiling (ADR-0979
+/// decision 4). A cursor's [`StreamBlockRows::heap_estimate`] is the decoded
+/// column buffers plus per-cell allocation headers and `Vec` slack over the raw
+/// decompressed page payload PAGE_DIR's `uncomp_len` measures, so a factor above
+/// one is needed for the reservation to bound the decoded residency. Two is a
+/// documented heuristic ceiling over that payload, consistent with
+/// `heap_estimate` itself being an estimate rather than a measurement. The
+/// reservation is held at this ceiling for the cursor's lifetime rather than
+/// reconciled down to the decoded figure after decode: the ceiling already
+/// covers the cursor's whole lifetime residency, so holding it keeps the budget
+/// conservative (it never under-charges) and the reserve-time check
+/// deterministic.
+const CURSOR_DECODE_OVERHEAD_FACTOR: u64 = 2;
+
+/// The pre-decode reservation one input's cursor over `stream_id` is charged
+/// against the merge budget (ADR-0979 decision 4), or `None` if the input does
+/// not carry the stream. Computed from resident metadata alone, before any
+/// BLOCKS byte is fetched:
+///
+/// - `2 * G`: the two row groups' stored bytes a cursor holds at once (the loc
+///   being decoded from plus the one prefetched behind it), sized as twice the
+///   largest of the stream's locs so a later, larger group cannot exceed it;
+/// - the cursor's location metadata: its owned `Vec<StreamBlockLoc>` and each
+///   loc's block-index list;
+/// - `B_dec`: the MAXIMUM over the stream's candidate blocks of that block's
+///   decompressed page-byte total ([`RlogInputCatalog::block_uncomp_lens`]),
+///   times [`CURSOR_DECODE_OVERHEAD_FACTOR`]. The max, not the first block's
+///   cost, because [`StreamCursor::refill`] decodes later blocks after
+///   releasing earlier ones, so a later, larger block must not exceed the
+///   reservation.
+fn cursor_reservation_bytes(
+    catalog: &RlogInputCatalog,
+    stream_id: &LogStreamId,
+) -> Result<Option<u64>> {
+    let Some(locs) = catalog.reader.stream_blocks(stream_id)? else {
+        return Ok(None);
+    };
+    if locs.is_empty() {
+        return Ok(None);
+    }
+    // 2*G: twice the largest loc's stored row-group bytes.
+    let max_group = locs.iter().map(|l| l.byte_len()).max().unwrap_or(0);
+    let two_g = max_group.saturating_mul(2);
+    // Location metadata: the owned locs vector plus each loc's block-index list.
+    let loc_slot = std::mem::size_of::<StreamBlockLoc>() as u64;
+    let idx_slot = std::mem::size_of::<usize>() as u64;
+    let mut loc_meta = (locs.len() as u64).saturating_mul(loc_slot);
+    for l in &locs {
+        loc_meta =
+            loc_meta.saturating_add((l.block_indices().len() as u64).saturating_mul(idx_slot));
+    }
+    // B_dec: the max decompressed page bytes over the stream's candidate blocks.
+    let mut max_b_dec = 0u64;
+    for l in &locs {
+        for &block in l.block_indices() {
+            let uncomp = catalog
+                .block_uncomp_lens
+                .get(block)
+                .copied()
+                .ok_or_else(|| {
+                    MaintainError::Invariant(
+                        "stream candidate block index past the input's PAGE_DIR block count"
+                            .to_string(),
+                    )
+                })?;
+            max_b_dec = max_b_dec.max(uncomp);
+        }
+    }
+    let b_dec = max_b_dec.saturating_mul(CURSOR_DECODE_OVERHEAD_FACTOR);
+    Ok(Some(two_g.saturating_add(loc_meta).saturating_add(b_dec)))
+}
+
 /// K-way merge one stream from every input carrying it into `part`, in
 /// ts-ascending order with ties broken by canonical input order. This is
 /// byte-for-byte the ordering the old "concatenate every input's decoded
@@ -1126,10 +1275,39 @@ async fn fetch_block(
 /// rejects is released here, so the ADR-0064 erasure rewrite's peak memory is
 /// bounded by its survivors' part, not by everything it read (issue #725).
 ///
-/// The cursors are opened concurrently (`input_read_concurrency` at a time):
-/// each open costs one ranged GET for the stream's first block, so a stream
-/// carried by hundreds of inputs would otherwise serialize hundreds of round
-/// trips before the first record merges.
+/// # Overlap-gated cursor admission (ADR-0979 decision 2)
+///
+/// Cursors are not all opened up front. Each input carrying the stream is
+/// queued with its SKIP_IDX ts lower bound (`stream_ts_bounds`, a sound lower
+/// bound on the first timestamp that input's cursor can yield). The merge
+/// maintains the invariant: before emitting a record with key `(ts,
+/// input_index)`, every queued cursor whose lower bound is `<= ts` is opened.
+/// Because a queued cursor's true first timestamp is `>= its lower bound`, an
+/// unopened cursor left behind (lower bound `> ts`) can hold no record that
+/// precedes the candidate, and equality forces admission so exact-`ts` ties
+/// still resolve by `input_index` exactly as an all-open merge would. The
+/// emitted sequence -- and therefore every part boundary and every part byte --
+/// is identical to opening every cursor at once; only WHEN a cursor opens
+/// changes. The number of simultaneously open cursors becomes `D`, the max
+/// concurrent ts-overlap of the stream's input slices, instead of `n`, the
+/// input count. Admitted cursors open `input_read_concurrency` at a time in
+/// canonical order (so a stream carried by hundreds of inputs does not
+/// serialize hundreds of round trips), and a drained cursor releases its
+/// residency immediately. [`AdmissionMode::EagerAll`] opens every cursor up
+/// front instead, the pre-decision-2 behaviour, retained so the differential
+/// test can assert the two produce byte-identical parts.
+///
+/// # Fail-closed cursor budget (ADR-0979 decision 4)
+///
+/// Admitting a cursor first reserves its ceiling cost
+/// ([`cursor_reservation_bytes`]) against
+/// [`CompactorConfig::merge_cursor_budget_bytes`]. The reservation is charged
+/// BEFORE the cursor fetches or decodes anything, so the budget is enforced at
+/// reserve time and the merge fails closed rather than after allocating: if
+/// admitting a cursor that merge order requires would exceed the budget, the
+/// run aborts with [`MaintainError::MergeCursorBudgetExceeded`] before
+/// publishing. A drained cursor releases its reservation, so the charge tracks
+/// `D`, not `n`.
 async fn merge_stream_into_parts(
     store: &dyn ObjectStoreBackend,
     catalogs: &[RlogInputCatalog],
@@ -1140,32 +1318,138 @@ async fn merge_stream_into_parts(
     counts: &mut RecordCounts,
 ) -> Result<()> {
     let concurrency = sink.config.input_read_concurrency.max(1);
+    let budget = sink.config.merge_cursor_budget_bytes;
+    let mode = sink.config.merge_admission;
+
+    // The admission queue: one entry per input carrying the stream, ordered by
+    // (lower_bound, input_index) so opens follow the frontier and ties keep
+    // canonical order.
+    let mut pending: Vec<PendingCursor> = Vec::new();
+    for (idx, catalog) in catalogs.iter().enumerate() {
+        let Some((lower_bound, _upper)) = catalog.reader.stream_ts_bounds(stream_id) else {
+            continue;
+        };
+        let Some(reservation) = cursor_reservation_bytes(catalog, stream_id)? else {
+            continue;
+        };
+        pending.push(PendingCursor {
+            input_index: idx,
+            lower_bound,
+            reservation,
+        });
+    }
+    pending.sort_by_key(|a| (a.lower_bound, a.input_index));
+
     // Box each open-and-first-refill with an explicit `+ Send` bound before
-    // `buffered`, the workaround `crate::build::fetch_batch_pages` documents
-    // for futures that borrow the `&dyn ObjectStoreBackend`. `buffered` keeps
+    // `buffered`, the workaround `crate::build::fetch_batch_pages` documents for
+    // futures that borrow the `&dyn ObjectStoreBackend`. `buffered` keeps
     // canonical input order, which is the k-way merge's tie-break.
     type CursorFuture<'f, 'a> =
         Pin<Box<dyn Future<Output = Result<Option<StreamCursor<'a>>>> + Send + 'f>>;
-    let opens: Vec<CursorFuture<'_, '_>> = catalogs
-        .iter()
-        .enumerate()
-        .map(|(idx, catalog)| {
-            Box::pin(open_cursor(store, catalog, idx, stream_id, tracker)) as CursorFuture<'_, '_>
-        })
-        .collect();
-    let opened: Vec<Option<StreamCursor>> = stream_iter(opens)
-        .buffered(concurrency)
-        .try_collect()
-        .await?;
-    let mut cursors: Vec<StreamCursor> = opened.into_iter().flatten().collect();
+
+    let mut open: Vec<StreamCursor> = Vec::new();
+    let mut charged: u64 = 0;
+    let mut pos = 0usize;
+
     loop {
+        // Admission (ADR-0979 decision 2): open every queued cursor the
+        // invariant requires before the next emit. The frontier is the min
+        // peek_ts over open cursors; under `Overlap` a queued cursor is admitted
+        // when its lower bound is at or below the frontier (with a single
+        // bootstrap open when nothing is open yet so a frontier exists), under
+        // `EagerAll` every remaining cursor is admitted regardless.
+        loop {
+            let frontier = open.iter().filter_map(|c| c.peek_ts()).min();
+            // The prefix of `pending` (sorted by lower bound) to admit this
+            // round.
+            let mut batch_len = 0usize;
+            while let Some(p) = pending.get(pos + batch_len) {
+                let admit = match mode {
+                    AdmissionMode::EagerAll => true,
+                    AdmissionMode::Overlap => match frontier {
+                        // Nothing open yet: bootstrap with the single
+                        // lowest-lower-bound cursor, then re-derive the frontier
+                        // from it on the next round.
+                        None => batch_len == 0,
+                        Some(ts) => p.lower_bound <= ts,
+                    },
+                };
+                if !admit {
+                    break;
+                }
+                batch_len += 1;
+                if matches!(mode, AdmissionMode::Overlap) && frontier.is_none() {
+                    break;
+                }
+            }
+            if batch_len == 0 {
+                break;
+            }
+            // Reserve the whole batch at reserve time (ADR-0979 decision 4):
+            // check the budget before any cursor fetches or decodes, so the
+            // merge fails closed rather than after allocating.
+            for k in 0..batch_len {
+                let reservation = pending[pos + k].reservation;
+                let required = charged.saturating_add(reservation);
+                if required > budget {
+                    return Err(MaintainError::MergeCursorBudgetExceeded {
+                        stream_id: stream_id.to_hex(),
+                        open_cursors: open.len(),
+                        charged_bytes: charged,
+                        budget_bytes: budget,
+                        required_bytes: required,
+                        inputs_carrying_stream: pending.len(),
+                    });
+                }
+                charged = required;
+            }
+            let opens: Vec<CursorFuture<'_, '_>> = (0..batch_len)
+                .map(|k| {
+                    let p = &pending[pos + k];
+                    Box::pin(open_cursor(
+                        store,
+                        &catalogs[p.input_index],
+                        p.input_index,
+                        stream_id,
+                        tracker,
+                    )) as CursorFuture<'_, '_>
+                })
+                .collect();
+            let opened: Vec<Option<StreamCursor>> = stream_iter(opens)
+                .buffered(concurrency)
+                .try_collect()
+                .await?;
+            for (k, cursor_opt) in opened.into_iter().enumerate() {
+                let reservation = pending[pos + k].reservation;
+                match cursor_opt {
+                    Some(mut cursor) => {
+                        cursor.reservation = reservation;
+                        open.push(cursor);
+                    }
+                    // Carried the stream in STREAM_DIR but materialized no row
+                    // (its candidate blocks were all a neighbour's boundary
+                    // blocks): it holds nothing, so release its reservation.
+                    None => charged = charged.saturating_sub(reservation),
+                }
+            }
+            pos += batch_len;
+            if let Some(t) = tracker {
+                t.note_open_cursors(open.len() as u64);
+            }
+        }
+
         // Pick the cursor whose next row has the minimum (ts_ns, input_index).
         // input_index is unique per cursor, so the key is a total order and the
-        // tie-break is deterministic. The comparison reads each cursor's
-        // decoded ts column and materializes nothing (ADR-0979 decision 1);
-        // only the winner rebuilds a record.
+        // tie-break is deterministic. peek_ts is only valid immediately after a
+        // refill: every open cursor was refilled when it was admitted or after
+        // it last emitted, so the column read here is live. Skipping a refill
+        // would leave a drained block reading as exhausted and silently drop the
+        // records behind it; the record-count conservation gate downstream is
+        // what fails closed if that protocol is ever broken. The comparison
+        // reads each cursor's decoded ts column and materializes nothing
+        // (ADR-0979 decision 1); only the winner rebuilds a record.
         let mut best: Option<(usize, i64, usize)> = None;
-        for (i, cursor) in cursors.iter().enumerate() {
+        for (i, cursor) in open.iter().enumerate() {
             if let Some(ts) = cursor.peek_ts() {
                 let key = (ts, cursor.input_index);
                 match best {
@@ -1174,17 +1458,27 @@ async fn merge_stream_into_parts(
                 }
             }
         }
+        // No open cursor has a record: since admission above opens every queued
+        // cursor the invariant needs (and bootstraps when nothing is open),
+        // reaching here with an empty best means the queue is drained too.
         let Some((bi, _, _)) = best else {
             break;
         };
-        if let Some(rec) = cursors[bi].next_record()? {
+        if let Some(rec) = open[bi].next_record()? {
             counts.add_input()?;
             if keep(&rec)? {
                 counts.add_output()?;
                 sink.push(rec).await?;
             }
         }
-        cursors[bi].refill(store, tracker).await?;
+        open[bi].refill(store, tracker).await?;
+        // A drained cursor releases its residency (refill already dropped its
+        // last block) and its reservation, so both the open-cursor high-water
+        // and the budget charge track the concurrent overlap `D`, not `n`.
+        if open[bi].peek_ts().is_none() {
+            let cursor = open.swap_remove(bi);
+            charged = charged.saturating_sub(cursor.reservation);
+        }
     }
     Ok(())
 }
@@ -1664,7 +1958,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        Bucket, CompactionOutcome, CompactorConfig, FixedClock, MergeMemoryTracker, compact_bucket,
+        AdmissionMode, Bucket, CompactionOutcome, CompactorConfig, FixedClock, MergeMemoryTracker,
+        compact_bucket,
     };
 
     /// FIELD_DIR entry-count cap for the test-only `field_dir_len` decode (a
@@ -4101,10 +4396,13 @@ mod tests {
     /// The fixture pins the geometry so the expected value is arithmetic, not
     /// an observation: three inputs, one stream, one row group of one block
     /// each, and records identical in every column but `ts_ns`, so all three
-    /// blocks cost the same and all three cursors are open at once (the merge
-    /// opens every input's cursor before it emits a record, and releases a
-    /// block only when it is drained). The peak is therefore `3 x
-    /// heap_estimate` and nothing else.
+    /// blocks cost the same. Their timestamps INTERLEAVE across the three inputs
+    /// (input `j` carries `i * 3 + j`), so the three slices fully overlap in ts
+    /// and overlap-gated admission (ADR-0979 decision 2) opens all three cursors
+    /// at once -- the case where `D = n`, worst for admission and the one that
+    /// keeps this a `3 x heap_estimate` peak. A block is released only when it is
+    /// drained, so at the peak all three are resident and the peak is therefore
+    /// `3 x heap_estimate` and nothing else.
     ///
     /// Demonstrated red by adding the old charge back beside the new one in
     /// `StreamCursor::decode_next_block` -- `let decoded_bytes =
@@ -4126,7 +4424,10 @@ mod tests {
                 .map(|i| {
                     record(
                         0,
-                        (j as i64) * 1_000 + i,
+                        // Interleave ts across the three inputs so their slices
+                        // overlap and overlap-gated admission opens all three
+                        // cursors at once (ADR-0979 decision 2).
+                        i * (INPUTS as i64) + (j as i64),
                         "row",
                         vec![
                             ("svc".into(), AttrValue::Str("v".into())),
@@ -4198,6 +4499,342 @@ mod tests {
             "a cursor must never be charged under both the columnar and the \
              row-form term in one phase snapshot"
         );
+    }
+
+    // --- ADR-0979 D2/D4 admission and budget ---------------------------------
+
+    /// Compact `inputs` on a fresh store under `config` and return each L1
+    /// part's `content_hash`, in `part_index` order.
+    async fn compact_part_hashes(
+        inputs: &[(Uuid, u64, Vec<LogRecord>)],
+        config: &CompactorConfig,
+    ) -> Vec<Vec<u8>> {
+        let store = MemoryStore::new();
+        for (writer_id, seq, recs) in inputs {
+            seed(&store, *writer_id, *seq, recs).await;
+        }
+        let clock = FixedClock::new(sealed_now_ns());
+        compact_bucket(&store, &clock, config, &bucket())
+            .await
+            .expect("compact");
+        let (rec, _parts) = read_output(&store).await;
+        rec.parts.iter().map(|p| p.content_hash.clone()).collect()
+    }
+
+    /// A three-input fixture whose stream bounds are disjoint on one stream and
+    /// overlapping on another: stream 0 is carried by inputs A and B with
+    /// interleaved (overlapping) timestamps, and stream 1 is carried by A and C
+    /// with time-disjoint slices (A's `[1000, 1014]` ahead-of-C's... C's
+    /// `[5000, 5007]`). So both admission regimes -- concurrent overlap and
+    /// admit-only-after-drain -- are exercised in one merge.
+    fn admission_mixed_fixture() -> Vec<(Uuid, u64, Vec<LogRecord>)> {
+        let a: Vec<LogRecord> = (0..8i64)
+            .map(|i| record(0, i * 2, "a0", vec![("k".into(), AttrValue::I64(i))]))
+            .chain((0..8i64).map(|i| record(1, 1000 + i * 2, "a1", Vec::new())))
+            .collect();
+        let b: Vec<LogRecord> = (0..8i64)
+            .map(|i| record(0, i * 2 + 1, "b0", vec![("k".into(), AttrValue::I64(i))]))
+            .collect();
+        let c: Vec<LogRecord> = (0..8i64)
+            .map(|i| record(1, 5000 + i, "c1", Vec::new()))
+            .collect();
+        vec![
+            (Uuid::from_u128(1), 1, a),
+            (Uuid::from_u128(2), 2, b),
+            (Uuid::from_u128(3), 3, c),
+        ]
+    }
+
+    /// ADR-0979 decision 2's named test: overlap-gated admission
+    /// ([`AdmissionMode::Overlap`]) and eager all-open admission
+    /// ([`AdmissionMode::EagerAll`]) produce byte-identical parts. D2 changes
+    /// only WHEN a cursor opens, never which record is the `(ts, input_index)`
+    /// minimum, so every part boundary and every part `content_hash` must match.
+    ///
+    /// Demonstrated red by making the overlap predicate drop the second input:
+    /// in the admission loop, replacing `AdmissionMode::Overlap => match frontier
+    /// { ... Some(ts) => p.lower_bound <= ts }` so `p.input_index != 1` is
+    /// additionally required to admit -- input 1 (B) is then never opened, B's
+    /// stream-0 records vanish from the overlap run, and the two hash vectors
+    /// diverge (or the record-count gate aborts the run).
+    #[tokio::test]
+    async fn admission_on_and_off_produce_identical_part_hashes() {
+        let inputs = admission_mixed_fixture();
+        // A small memory split target so the bucket splits into several parts
+        // and the equality pin covers part boundaries and `part_index`, not one
+        // object; identical for both modes.
+        let overlap = CompactorConfig {
+            merge_admission: AdmissionMode::Overlap,
+            l1_part_memory_target_bytes: 1024,
+            ..CompactorConfig::default()
+        };
+        let eager = CompactorConfig {
+            merge_admission: AdmissionMode::EagerAll,
+            l1_part_memory_target_bytes: 1024,
+            ..CompactorConfig::default()
+        };
+        let on = compact_part_hashes(&inputs, &overlap).await;
+        let off = compact_part_hashes(&inputs, &eager).await;
+        assert!(on.len() > 1, "the fixture must split into several parts");
+        assert_eq!(
+            on, off,
+            "overlap-gated admission must produce byte-identical parts to eager all-open admission"
+        );
+    }
+
+    /// Compact `inputs` (all on stream 0) with a tracker installed and return the
+    /// recorded `max_open_cursors_per_stream`.
+    async fn max_open_cursors_for(inputs: &[(Uuid, u64, Vec<LogRecord>)]) -> u64 {
+        let tracker = MergeMemoryTracker::new();
+        let config = CompactorConfig {
+            merge_memory_tracker: Some(tracker.clone()),
+            ..CompactorConfig::default()
+        };
+        let store = MemoryStore::new();
+        for (writer_id, seq, recs) in inputs {
+            seed(&store, *writer_id, *seq, recs).await;
+        }
+        let clock = FixedClock::new(sealed_now_ns());
+        compact_bucket(&store, &clock, &config, &bucket())
+            .await
+            .expect("compact");
+        tracker.max_open_cursors_per_stream()
+    }
+
+    /// ADR-0979 decision 2's acceptance phrasing: with all three inputs'
+    /// stream-0 slices overlapping, `max_open_cursors_per_stream` is exactly 3;
+    /// making one input's slice time-disjoint (far ahead of the other two) drops
+    /// it by exactly 1, to 2 -- the assertion that admission, not luck, bounds
+    /// the count. The disjoint slice's cursor is admitted only after the other
+    /// two drain, so it is never open alongside them.
+    ///
+    /// Demonstrated red by making admission ignore the frontier (admit every
+    /// queued cursor immediately, as `AdmissionMode::EagerAll` does): the
+    /// disjoint slice then opens up front alongside the other two and both
+    /// fixtures report 3, so the `2` assertion fails.
+    #[tokio::test]
+    async fn admission_bounds_open_cursors_to_the_overlap_degree() {
+        // input j carries ts i*3 + j, so all three stream-0 slices overlap.
+        let overlap_all: Vec<(Uuid, u64, Vec<LogRecord>)> = (0..3u128)
+            .map(|j| {
+                let recs = (0..10i64)
+                    .map(|i| record(0, i * 3 + j as i64, "r", Vec::new()))
+                    .collect();
+                (Uuid::from_u128(j + 1), (j + 1) as u64, recs)
+            })
+            .collect();
+        // Two inputs interleave in [0, 19]; the third sits far ahead in
+        // [10_000, 10_009], time-disjoint from them.
+        let one_disjoint: Vec<(Uuid, u64, Vec<LogRecord>)> = vec![
+            (
+                Uuid::from_u128(1),
+                1,
+                (0..10i64)
+                    .map(|i| record(0, i * 2, "r", Vec::new()))
+                    .collect(),
+            ),
+            (
+                Uuid::from_u128(2),
+                2,
+                (0..10i64)
+                    .map(|i| record(0, i * 2 + 1, "r", Vec::new()))
+                    .collect(),
+            ),
+            (
+                Uuid::from_u128(3),
+                3,
+                (0..10i64)
+                    .map(|i| record(0, 10_000 + i, "r", Vec::new()))
+                    .collect(),
+            ),
+        ];
+        assert_eq!(
+            max_open_cursors_for(&overlap_all).await,
+            3,
+            "three overlapping slices need all three cursors open at once"
+        );
+        assert_eq!(
+            max_open_cursors_for(&one_disjoint).await,
+            2,
+            "the disjoint third slice admits only after the first two drain, so at most two are open"
+        );
+    }
+
+    /// The pre-decode reservation the merge charges one input's cursor over
+    /// stream 0, loaded and computed exactly as the merge does.
+    async fn stream0_reservation(
+        store: &MemoryStore,
+        writer_id: Uuid,
+        seq: u64,
+        bytes: &Bytes,
+    ) -> u64 {
+        let key = seeded_data_key(writer_id, seq, bytes);
+        let catalog = load_catalog_from_object(store, &CompactorConfig::default(), key, true)
+            .await
+            .expect("catalog");
+        let (stream_id, _) = stream_ident(0);
+        cursor_reservation_bytes(&catalog, &stream_id)
+            .expect("reservation")
+            .expect("input carries stream 0")
+    }
+
+    /// ADR-0979 decision 4: a budget one byte below the minimum admissible
+    /// cursor set fails with [`MaintainError::MergeCursorBudgetExceeded`] naming
+    /// the exact figures, and one byte above succeeds with part hashes identical
+    /// to an unbudgeted run.
+    ///
+    /// The fixture is two inputs carrying stream 0 with interleaved (fully
+    /// overlapping) timestamps, so both cursors must be open at the merge's
+    /// peak: the minimum admissible set is both, and its reservation is
+    /// `r_a + r_b`, computed here from the same [`cursor_reservation_bytes`] the
+    /// merge uses so the threshold is exact, not observed.
+    ///
+    /// Demonstrated red by raising the budget the failing run is given from
+    /// `min_admissible - 1` to `min_admissible`: the second cursor then fits and
+    /// no error is returned, so `expect_err` panics.
+    #[tokio::test]
+    async fn cursor_budget_fails_closed_one_byte_below_the_minimum_admissible_set() {
+        let a: Vec<LogRecord> = (0..10i64)
+            .map(|i| record(0, i * 2, "a", Vec::new()))
+            .collect();
+        let b: Vec<LogRecord> = (0..10i64)
+            .map(|i| record(0, i * 2 + 1, "b", Vec::new()))
+            .collect();
+
+        // Reservations, from a throwaway store seeded identically.
+        let probe = MemoryStore::new();
+        let a_bytes = seed(&probe, Uuid::from_u128(1), 1, &a).await;
+        let b_bytes = seed(&probe, Uuid::from_u128(2), 2, &b).await;
+        let r_a = stream0_reservation(&probe, Uuid::from_u128(1), 1, &a_bytes).await;
+        let r_b = stream0_reservation(&probe, Uuid::from_u128(2), 2, &b_bytes).await;
+        let min_admissible = r_a + r_b;
+
+        let inputs = vec![(Uuid::from_u128(1), 1, a), (Uuid::from_u128(2), 2, b)];
+        let (stream_id, _) = stream_ident(0);
+
+        // One byte below the minimum admissible set: the second cursor's
+        // admission overruns and the run fails closed, naming the exact figures.
+        let under = CompactorConfig {
+            merge_cursor_budget_bytes: min_admissible - 1,
+            ..CompactorConfig::default()
+        };
+        let store = MemoryStore::new();
+        for (writer_id, seq, recs) in &inputs {
+            seed(&store, *writer_id, *seq, recs).await;
+        }
+        let clock = FixedClock::new(sealed_now_ns());
+        let err = compact_bucket(&store, &clock, &under, &bucket())
+            .await
+            .expect_err("a budget below the minimum admissible set must fail closed");
+        match err {
+            MaintainError::MergeCursorBudgetExceeded {
+                stream_id: got_stream,
+                open_cursors,
+                charged_bytes,
+                budget_bytes,
+                required_bytes,
+                inputs_carrying_stream,
+            } => {
+                assert_eq!(got_stream, stream_id.to_hex());
+                assert_eq!(
+                    open_cursors, 1,
+                    "the first cursor was open when the second was refused"
+                );
+                assert_eq!(
+                    charged_bytes, r_a,
+                    "only the first cursor's reservation was charged"
+                );
+                assert_eq!(budget_bytes, min_admissible - 1);
+                assert_eq!(
+                    required_bytes, min_admissible,
+                    "charged + the refused cursor's reservation"
+                );
+                assert_eq!(inputs_carrying_stream, 2);
+            }
+            other => panic!("expected MergeCursorBudgetExceeded, got {other:?}"),
+        }
+
+        // One byte above: the whole minimum admissible set fits, the merge
+        // completes, and the parts are byte-identical to an unbudgeted run.
+        let exact = CompactorConfig {
+            merge_cursor_budget_bytes: min_admissible,
+            ..CompactorConfig::default()
+        };
+        let with_budget = compact_part_hashes(&inputs, &exact).await;
+        let unbudgeted = compact_part_hashes(&inputs, &CompactorConfig::default()).await;
+        assert!(!with_budget.is_empty());
+        assert_eq!(
+            with_budget, unbudgeted,
+            "a budget at exactly the minimum admissible set must not change the output"
+        );
+    }
+
+    /// Rewrite `obj` with its PAGE_DIR descriptor dropped from the footer,
+    /// leaving an object that still OPENS (PAGE_DIR is not one of the
+    /// footer-mandatory section kinds) but that the bounded merge cannot
+    /// admission-price. The section's bytes stay in the body; only its footer
+    /// descriptor is removed, and the footer crc is recomputed by
+    /// [`footer::write_footer_and_trailer`].
+    fn strip_page_dir_descriptor(obj: &[u8]) -> Vec<u8> {
+        // footer_len(4) + footer_crc(4) + version(2) + signal(1) + reserved(1)
+        // + magic(4).
+        const TRAILER_LEN: usize = 16;
+        let total = obj.len();
+        let footer_len = u32::from_le_bytes([
+            obj[total - TRAILER_LEN],
+            obj[total - TRAILER_LEN + 1],
+            obj[total - TRAILER_LEN + 2],
+            obj[total - TRAILER_LEN + 3],
+        ]) as usize;
+        let footer_start = total - TRAILER_LEN - footer_len;
+        let mut ftr = footer::open(obj).expect("open seeded object");
+        assert!(
+            ftr.section(kind::PAGE_DIR).is_some(),
+            "the seeded v4 object must carry PAGE_DIR to strip it"
+        );
+        ftr.sections.retain(|s| s.kind != kind::PAGE_DIR);
+        let mut out = obj[..footer_start].to_vec();
+        footer::write_footer_and_trailer(&mut out, &ftr);
+        out
+    }
+
+    /// ADR-0979 decision 4: an input carrying no PAGE_DIR cannot be
+    /// admission-priced (its decoded page term is unknowable before the fetch),
+    /// so the bounded merge refuses it at catalog load with a typed error naming
+    /// the object and its format version, rather than reading it under a guessed
+    /// cost. PAGE_DIR is mandatory in v4, so this is a version/corruption gate.
+    #[tokio::test]
+    async fn page_dir_less_input_is_refused_with_typed_error() {
+        let store = MemoryStore::new();
+        let recs = vec![record(0, 1, "x", Vec::new())];
+        let bytes = seed(&store, Uuid::from_u128(1), 1, &recs).await;
+        let stripped = strip_page_dir_descriptor(&bytes);
+        // Re-open to confirm the stripped object still parses (the refusal is a
+        // deliberate policy, not a decode failure).
+        let reopened = footer::open(&stripped).expect("stripped object still opens");
+        assert!(
+            reopened.section(kind::PAGE_DIR).is_none(),
+            "the stripped object must carry no PAGE_DIR"
+        );
+
+        let key = "l0/synthetic-no-page-dir".to_string();
+        store
+            .put(&key, Bytes::from(stripped), PutOptions::default())
+            .await
+            .expect("put");
+        let err = load_catalog_from_object(&store, &CompactorConfig::default(), key.clone(), true)
+            .await
+            .expect_err("a PAGE_DIR-less input must be refused");
+        match err {
+            MaintainError::MergeCursorInputMissingPageDir {
+                object_key,
+                format_version,
+            } => {
+                assert_eq!(object_key, key);
+                assert_eq!(format_version, OUTPUT_FORMAT_VERSION);
+            }
+            other => panic!("expected MergeCursorInputMissingPageDir, got {other:?}"),
+        }
     }
 
     // --- keystone differential property test ---------------------------------

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -513,9 +513,13 @@ const DECODED_STRING_SLOT_BYTES: u64 = 40;
 /// arm holds two vectors (a dictionary's distinct values and its per-row ids),
 /// so 48 bytes covers every kind.
 ///
-/// ADR-0979 decision 1 states this term as `24 B x (max column id + 1) x 5`.
-/// That figure is the narrow slot's, and it does not bound the string kind's or
-/// the growth step below: on the eight-one-record-block fixture of
+/// ADR-0979's amended ceiling states this term as `2 x SUM(slot sizes) x
+/// width` -- 288 B per width unit at the current sizes (24/24/24/48/24). The
+/// 48-B-per-kind constant here covers the widest slot uniformly, so 48 x 5 x
+/// the growth factor = 480 B per width unit sits above that floor at every
+/// width: a valid, deliberately conservative instantiation. A flat 24 B per
+/// kind at exact width would not bound the string kind or the growth step:
+/// on the eight-one-record-block fixture of
 /// `the_slot_spine_term_is_what_bounds_a_small_block` it prices a block at
 /// 2,154 B against the 2,232 B it decodes to.
 const DECODED_SLOT_SPINE_BYTES: u64 = 48;
@@ -5299,7 +5303,8 @@ mod tests {
     }
 
     /// ADR-0979 decision 1's ceiling includes the decoder's five per-kind slot
-    /// vectors (`24 B x column-id width x 5`), and on a small block that term is
+    /// vectors (the ADR's amended `2 x SUM(slot sizes) x width` floor, priced
+    /// here at the conservative 480 B per width unit), and on a small block that term is
     /// what makes the ceiling a ceiling: the vectors are indexed by column id,
     /// so they cost the id-space width whatever the block holds, while every
     /// other term scales with rows.
@@ -5311,7 +5316,7 @@ mod tests {
     /// holds.
     ///
     /// It also pins the two corrections this crate applies to ADR-0979's
-    /// `24 B x width x 5` statement of the term. At the ADR's figure the
+    /// flat 24-B-per-kind exact-width pricing of the term. At that figure the
     /// ceiling here is 2,154 B, below the 2,232 B the block decodes to: the
     /// string kind's slot is an enum wider than a `Vec` handle, and a slot
     /// vector's capacity is a `Vec` growth step above the id-space width rather

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -208,7 +208,7 @@ use crate::bucket::Bucket;
 use crate::build::{BuiltPart, put_part};
 use crate::codec::SegmentCodec;
 use crate::config::{AdmissionMode, CompactorConfig, MergeMemoryTracker};
-use crate::error::{MaintainError, Result};
+use crate::error::{MaintainError, MergeCursorBudgetSite, Result};
 use crate::read::InputRecord;
 
 /// The RLOG output trailer version every L1 part carries (currently 3:
@@ -507,6 +507,30 @@ const DECODED_CELL_BYTES: u64 = 16;
 /// `uncomp_len`.
 const DECODED_STRING_SLOT_BYTES: u64 = 40;
 
+/// Decoded bytes one column id costs in ONE of the decoder's per-kind slot
+/// vectors. Four of the five slots are an `Option<Vec<..>>`, 24 bytes by the
+/// null-pointer niche; the string kind's slot is a two-variant enum whose wider
+/// arm holds two vectors (a dictionary's distinct values and its per-row ids),
+/// so 48 bytes covers every kind.
+///
+/// ADR-0979 decision 1 states this term as `24 B x (max column id + 1) x 5`.
+/// That figure is the narrow slot's, and it does not bound the string kind's or
+/// the growth step below: on the eight-one-record-block fixture of
+/// `the_slot_spine_term_is_what_bounds_a_small_block` it prices a block at
+/// 2,154 B against the 2,232 B it decodes to.
+const DECODED_SLOT_SPINE_BYTES: u64 = 48;
+
+/// How many such per-kind slot vectors a decoded block holds: i64, f64, bool,
+/// string, and fixed-width (`ravel_logseg::block::DecodedBlock`).
+const DECODER_SLOT_KINDS: u64 = 5;
+
+/// A slot vector is grown to reach the id being inserted, so its capacity is a
+/// `Vec` growth step at or above the id-space width, never the width exactly.
+/// `Vec` reserves `max(2 x capacity, needed)`, so twice the width bounds it
+/// (the id space is at least `FIRST_DYNAMIC_COL` wide, above the minimum
+/// non-zero capacity a `Vec` of these element sizes starts at).
+const DECODED_SLOT_SPINE_CAPACITY_FACTOR: u64 = 2;
+
 /// One input's pre-decode admission pricing metadata (ADR-0979 decision 4),
 /// decoded from the FIELD_DIR, SKIP_IDX, and PAGE_DIR section bytes the catalog
 /// load already fetched. See [`InputCursorPricing`] for why each term is read
@@ -571,6 +595,7 @@ fn input_cursor_pricing(
 /// 16 B x rows x total_cols          every column's per-row cell slot
 ///   + string-page uncomp_len        the string cells' own buffers
 ///   + 40 B x rows x string_cols     those cells' per-row handles
+///   + 48 B x total_cols x 5 x 2     the decoder's five per-kind slot vectors
 /// ```
 ///
 /// Each term is priced from the source that actually bounds it: `rows` and the
@@ -578,6 +603,11 @@ fn input_cursor_pricing(
 /// from FIELD_DIR, the string payload from PAGE_DIR's per-page `uncomp_len`
 /// restricted to string pages. Every string column is priced as plain, the
 /// conservative arm.
+///
+/// The last term does not scale with rows: the decoder's slot vectors are
+/// indexed by column id, so they cost the id-space width whatever the block
+/// holds. On a block of a few rows they exceed the per-row terms, so a ceiling
+/// that omits them is not a ceiling there.
 fn block_decode_ceiling_bytes(pricing: &InputCursorPricing, block: usize) -> Result<u64> {
     let rows = u64::from(*pricing.block_rows.get(block).ok_or_else(|| {
         MaintainError::Invariant(
@@ -595,9 +625,14 @@ fn block_decode_ceiling_bytes(pricing: &InputCursorPricing, block: usize) -> Res
     let string_slots = DECODED_STRING_SLOT_BYTES
         .saturating_mul(rows)
         .saturating_mul(pricing.string_cols);
+    let slot_spines = DECODED_SLOT_SPINE_BYTES
+        .saturating_mul(pricing.total_cols)
+        .saturating_mul(DECODER_SLOT_KINDS)
+        .saturating_mul(DECODED_SLOT_SPINE_CAPACITY_FACTOR);
     Ok(cells
         .saturating_add(string_bytes)
-        .saturating_add(string_slots))
+        .saturating_add(string_slots)
+        .saturating_add(slot_spines))
 }
 
 /// One catalog per object key, `input_read_concurrency` loads in flight.
@@ -1048,6 +1083,10 @@ struct StreamCursor<'a> {
     input_index: usize,
     object_key: &'a str,
     reader: &'a RlogRangeReader,
+    /// This input's pre-decode pricing metadata, the source of the per-block
+    /// decode ceiling the cursor's charge grows to before each later block's
+    /// decode ([`StreamCursor::refill`], ADR-0979 decision 4 as amended).
+    pricing: &'a InputCursorPricing,
     /// Candidate blocks for the stream, ascending (ts-ascending for the
     /// stream), one loc per row group under version 4 and one per block under
     /// version 3, consumed front to back via `next_loc`.
@@ -1106,6 +1145,7 @@ impl<'a> StreamCursor<'a> {
             input_index,
             object_key: &catalog.object_key,
             reader: &catalog.reader,
+            pricing: &catalog.pricing,
             locs,
             next_loc: 0,
             group: None,
@@ -1191,10 +1231,21 @@ impl<'a> StreamCursor<'a> {
     /// stream is exhausted in this input. At most one decoded block plus at most
     /// two locs' raw bytes (the one being decoded from and the one prefetched
     /// behind it) are resident at a time, and no record is materialized here.
+    ///
+    /// `budget`, when present, is the merge's live cursor-budget accounting.
+    /// Every decode this call performs is preceded by a grow-and-check on it
+    /// (ADR-0979 decision 4 as amended): the charge rises to cover the block
+    /// about to be decoded BEFORE the decode starts, and a growth that would
+    /// cross the budget refuses instead, so a later, larger block cannot be
+    /// materialized past a budget the reconcile has already lowered the charge
+    /// below. `None` is for the first refill of a freshly admitted cursor,
+    /// whose reservation already covers every block it can decode, and for
+    /// tests driving a cursor with no budget in play.
     async fn refill(
         &mut self,
         store: &dyn ObjectStoreBackend,
         tracker: Option<&MergeMemoryTracker>,
+        mut budget: Option<&mut CursorBudget<'_>>,
     ) -> Result<()> {
         loop {
             if self.block.as_ref().is_some_and(|b| !b.is_exhausted()) {
@@ -1205,6 +1256,10 @@ impl<'a> StreamCursor<'a> {
             // neighbour's boundary block) simply comes back exhausted and is
             // released on the next turn of this loop.
             self.release_block(tracker);
+            if let (Some(b), Some(block)) = (budget.as_deref_mut(), self.pending_block_index()) {
+                let required = self.decode_charge_requirement(block)?;
+                b.grow_to(&mut self.charged, block, required)?;
+            }
             if self.decode_next_block(tracker)? {
                 continue;
             }
@@ -1218,6 +1273,32 @@ impl<'a> StreamCursor<'a> {
                 None => return Ok(()),
             }
         }
+    }
+
+    /// The whole-object index of the block [`Self::decode_next_block`] would
+    /// decode right now, or `None` when the loc it decodes out of is spent or
+    /// absent (a fetch has to come first, and the block that follows it is only
+    /// known once that loc is held).
+    fn pending_block_index(&self) -> Option<usize> {
+        let (loc, _) = self.group.as_ref()?;
+        loc.block_indices().get(self.decoded_in_group).copied()
+    }
+
+    /// What this cursor must be charged before decoding `block`: everything it
+    /// will hold at the instant that decode completes, priced from metadata
+    /// alone (ADR-0979 decision 4 as amended). Its location metadata and the raw
+    /// row-group bytes it still holds are measured -- both are already resident
+    /// -- and the block itself is priced at its pre-decode ceiling, since its
+    /// decoded size is exactly what is not knowable yet.
+    ///
+    /// The current decoded block is NOT in the sum: `refill` releases it before
+    /// the decode this figure gates, so charging it would price memory the
+    /// cursor no longer holds.
+    fn decode_charge_requirement(&self, block: usize) -> Result<u64> {
+        let ceiling = block_decode_ceiling_bytes(self.pricing, block)?;
+        Ok(loc_metadata_bytes(&self.locs)
+            .saturating_add(self.raw_resident_bytes())
+            .saturating_add(ceiling))
     }
 
     /// Decode the current loc's next undecoded block into `block`, returning
@@ -1351,6 +1432,75 @@ struct PendingCursor {
     input_index: usize,
     lower_bound: i64,
     reservation: u64,
+}
+
+/// The merge's live cursor-budget accounting, handed to
+/// [`StreamCursor::refill`] so a cursor cannot decode a block its charge does
+/// not already cover (ADR-0979 decision 4 as amended).
+///
+/// Admission checks the same budget against the same running `charged` before
+/// a cursor opens; this is the same check moved to the other point in a
+/// cursor's life where its residency can rise, the decode of a later, larger
+/// block after the reconcile has lowered its charge. Without it the reconcile
+/// would convert the reservation from a bound into a transient: charges lowered
+/// to actuals free budget for further admissions, and every one of those
+/// cursors could then grow back toward its ceiling with nothing checking the
+/// sum again.
+struct CursorBudget<'m> {
+    /// [`CompactorConfig::merge_cursor_budget_bytes`].
+    budget: u64,
+    /// The stream's running charge over its open cursors, the same variable
+    /// admission reserves against.
+    charged: &'m mut u64,
+    /// Hex stream id, for the refusal.
+    stream_id: &'m LogStreamId,
+    /// Cursors open at the moment of the grow, including the growing one.
+    open_cursors: usize,
+    /// Inputs carrying this stream, for the refusal.
+    inputs_carrying_stream: usize,
+}
+
+impl CursorBudget<'_> {
+    /// Raise one cursor's charge to `required` before it decodes `block`,
+    /// refusing with [`MaintainError::MergeCursorBudgetExceeded`] if the
+    /// stream's running charge cannot take the growth.
+    ///
+    /// A charge already at or above `required` is left alone: the reconcile
+    /// after the previous decode may have left it above what the next block
+    /// needs, and lowering it here would be a reconcile, which belongs after a
+    /// decode, not before one.
+    ///
+    /// The check and the decode it gates are not separated by an `.await`: this
+    /// runs inside [`StreamCursor::refill`] between releasing the previous
+    /// block and calling the synchronous [`StreamCursor::decode_next_block`],
+    /// and the merge loop drives one cursor's refill at a time. So no other
+    /// cursor can be admitted, and no other block decoded, between a growth
+    /// passing and the memory it accounts for being taken -- the same
+    /// serialization the admission reservation has.
+    fn grow_to(&mut self, cursor_charged: &mut u64, block: usize, required: u64) -> Result<()> {
+        let Some(grow) = required.checked_sub(*cursor_charged).filter(|g| *g > 0) else {
+            return Ok(());
+        };
+        let charged_bytes = *self.charged;
+        let required_bytes = charged_bytes.saturating_add(grow);
+        if required_bytes > self.budget {
+            return Err(MaintainError::MergeCursorBudgetExceeded {
+                stream_id: self.stream_id.to_hex(),
+                open_cursors: self.open_cursors,
+                charged_bytes,
+                budget_bytes: self.budget,
+                required_bytes,
+                inputs_carrying_stream: self.inputs_carrying_stream,
+                site: MergeCursorBudgetSite::BlockGrow {
+                    block_index: block,
+                    grow_bytes: grow,
+                },
+            });
+        }
+        *self.charged = required_bytes;
+        *cursor_charged = required;
+        Ok(())
+    }
 }
 
 /// The heap a cursor's own location metadata holds for its whole lifetime: the
@@ -1562,8 +1712,10 @@ async fn merge_stream_into_parts(
                         budget_bytes: budget,
                         required_bytes: required,
                         inputs_carrying_stream: pending.len(),
-                        admission_batch_position: k,
-                        admission_batch_len: batch_len,
+                        site: MergeCursorBudgetSite::Admission {
+                            batch_position: k,
+                            batch_len,
+                        },
                     });
                 }
             }
@@ -1642,7 +1794,23 @@ async fn merge_stream_into_parts(
                 sink.push(rec).await?;
             }
         }
-        open[bi].refill(store, tracker).await?;
+        // The refill carries the budget: if it crosses into a block whose
+        // pre-decode ceiling the cursor's reconciled charge no longer covers, it
+        // grows the charge first and refuses before the decode rather than
+        // after it (ADR-0979 decision 4 as amended). Nothing else touches
+        // `charged` while this borrow is live, which is the serialization the
+        // grow needs: one cursor refills at a time, and the admission round for
+        // this emit is already complete.
+        let mut cursor_budget = CursorBudget {
+            budget,
+            charged: &mut charged,
+            stream_id,
+            open_cursors: open.len(),
+            inputs_carrying_stream: pending.len(),
+        };
+        open[bi]
+            .refill(store, tracker, Some(&mut cursor_budget))
+            .await?;
         // A drained cursor releases its residency (refill already dropped its
         // last block) and its charge, so both the open-cursor high-water and the
         // budget charge track the concurrent overlap `D`, not `n`. A cursor that
@@ -1695,7 +1863,10 @@ async fn open_cursor<'a>(
     let Some(mut cursor) = StreamCursor::open(catalog, input_index, stream_id)? else {
         return Ok(None);
     };
-    cursor.refill(store, tracker).await?;
+    // No budget: the caller reserved this cursor's ceiling before calling, and
+    // that reservation is the maximum over every block the cursor can decode,
+    // so this first refill is covered whichever blocks it decodes.
+    cursor.refill(store, tracker, None).await?;
     Ok(cursor.peek_ts().is_some().then_some(cursor))
 }
 
@@ -5014,74 +5185,107 @@ mod tests {
             .collect()
     }
 
-    /// Drive one input's stream-0 cursor to exhaustion, returning each decoded
-    /// block's `heap_estimate` as the cursor charged it.
-    async fn stream0_decoded_block_bytes(
+    /// Every candidate block of stream 0, decoded one at a time exactly as
+    /// [`StreamCursor::refill`] decodes them, as
+    /// `(whole-object block index, heap_estimate at decode)`. Driving the
+    /// primitives directly rather than `refill` itself is what keeps one entry
+    /// per block, named by the block it prices, so a per-block ceiling can be
+    /// checked against the block it is a ceiling for.
+    async fn stream0_decoded_blocks(
         store: &MemoryStore,
         catalog: &RlogInputCatalog,
         stream_id: &LogStreamId,
-    ) -> Vec<u64> {
-        let mut cursor = open_cursor(store, catalog, 0, stream_id, None)
-            .await
+    ) -> Vec<(usize, u64)> {
+        let mut cursor = StreamCursor::open(catalog, 0, stream_id)
             .expect("open cursor")
             .expect("input carries the stream");
-        let mut seen: Vec<u64> = Vec::new();
-        while cursor.peek_ts().is_some() {
-            let bytes = cursor.decoded_bytes();
-            if seen.last() != Some(&bytes) {
-                seen.push(bytes);
-            }
-            cursor.next_record().expect("record");
-            cursor.refill(store, None).await.expect("refill");
+        let mut out: Vec<(usize, u64)> = Vec::new();
+        loop {
+            let Some(block) = cursor.pending_block_index() else {
+                match cursor.next_raw_block(store, None).await.expect("fetch") {
+                    Some((loc, data)) => {
+                        cursor.group_raw_bytes = data.len() as u64;
+                        cursor.decoded_in_group = 0;
+                        cursor.group = Some((loc, data));
+                        continue;
+                    }
+                    None => break,
+                }
+            };
+            cursor.release_block(None);
+            assert!(
+                cursor.decode_next_block(None).expect("decode"),
+                "a pending block index must decode"
+            );
+            out.push((block, cursor.decoded_bytes()));
         }
-        seen
+        out
     }
 
-    /// ADR-0979 decision 4 as amended, the ceiling direction: the pre-decode
-    /// reservation is a real ceiling on every block the cursor decodes, on a
-    /// fixture built from CONSTANT columns -- the shape the pre-amendment basis
-    /// mispriced.
+    /// ADR-0979 decision 4 as amended, the ceiling direction: the PER-BLOCK
+    /// ceiling [`block_decode_ceiling_bytes`] -- the `B_dec` term alone, without
+    /// the reservation's `2 * G` and location-metadata slack -- bounds what
+    /// every one of an input's blocks actually decodes to, on a fixture built
+    /// from CONSTANT columns, the shape the pre-amendment basis mispriced.
     ///
-    /// The fixture is 500 records of one stream with an identical body, severity,
-    /// and no attributes, so `stream_ref`, `severity_num`, `flags`, and the two
-    /// string columns all encode to a handful of stored bytes per block while
-    /// still decoding to a slot per row per column. The test asserts both halves:
-    /// the repriced reservation covers every decoded block, and twice the block's
-    /// total page `uncomp_len` -- the basis this amendment removed -- does NOT,
-    /// so the old code charged less than the memory the block actually takes.
+    /// The fixture is 500 records of one stream with an identical body,
+    /// severity, and no attributes, written in 64-record blocks so it spans
+    /// EIGHT of them (the default 8192-record blocking would put the whole
+    /// fixture in one, and a one-block fixture cannot distinguish a per-block
+    /// ceiling from a whole-input one). `stream_ref`, `severity_num`, `flags`,
+    /// and the two string columns all encode to a handful of stored bytes per
+    /// block while still decoding to a slot per row per column.
+    ///
+    /// The second half pins the fixture's teeth: twice the block's total page
+    /// `uncomp_len` -- the basis this amendment removed -- is below the decoded
+    /// heap, so the old code charged less than the memory the block takes.
+    ///
+    /// On this fixture the largest block's ceiling is 27,863 B against a
+    /// 7,673 B decoded heap, and the removed basis would have charged 256 B.
     ///
     /// Demonstrated red by restoring the old basis in the two lines that define
     /// it: dropping the `string_ids.contains` filter in `input_cursor_pricing`
-    /// (so the per-block figure is every page's `uncomp_len` again) and returning
-    /// `string_bytes * 2` from `block_decode_ceiling_bytes` in place of the three
-    /// terms. The `reservation >= heap` assert then fails 4,168 against 54,905 on
-    /// this 500-record fixture, and the ratio grows with rows and column count.
+    /// (so the per-block figure is every page's `uncomp_len` again) and
+    /// returning `string_bytes * 2` from `block_decode_ceiling_bytes` in place
+    /// of its terms. The `ceiling >= heap` assert then fails 256 against 7,673
+    /// on block 0, and the ratio grows with rows and column count.
     #[tokio::test]
-    async fn reservation_ceiling_bounds_every_decoded_block_of_a_constant_column_input() {
+    async fn block_ceiling_bounds_every_decoded_block_of_a_constant_column_input() {
         let recs: Vec<LogRecord> = (0..500i64)
             .map(|i| record(0, 1_000 + i, "constant body", Vec::new()))
             .collect();
+        let cfg = RlogConfig {
+            block_target_records: 64,
+            ..RlogConfig::default()
+        };
         let store = MemoryStore::new();
-        let bytes = seed(&store, Uuid::from_u128(1), 1, &recs).await;
+        let bytes = seed_l0(&store, Uuid::from_u128(1), 1, &recs, cfg, &[]).await;
         let catalog = stream_catalog(&store, Uuid::from_u128(1), 1, &bytes).await;
         let (stream_id, _) = stream_ident(0);
 
-        let reservation = cursor_reservation_bytes(&catalog, &stream_id)
-            .expect("reservation")
-            .expect("input carries stream 0");
-        let decoded = stream0_decoded_block_bytes(&store, &catalog, &stream_id).await;
-        assert!(!decoded.is_empty(), "the cursor decoded at least one block");
-        let max_decoded = decoded.iter().copied().max().expect("a decoded block");
+        assert!(
+            catalog.pricing.block_rows.len() > 1,
+            "the fixture must span more than one block, or a per-block ceiling is untested"
+        );
+        let decoded = stream0_decoded_blocks(&store, &catalog, &stream_id).await;
+        assert_eq!(
+            decoded.len(),
+            catalog.pricing.block_rows.len(),
+            "the cursor decodes every one of the input's blocks on a single-stream fixture"
+        );
 
-        for (i, heap) in decoded.iter().enumerate() {
+        for (block, heap) in &decoded {
+            let ceiling =
+                block_decode_ceiling_bytes(&catalog.pricing, *block).expect("block ceiling");
             assert!(
-                reservation >= *heap,
-                "block {i}: the admission reservation ({reservation} B) must bound the decoded \
-                 block's heap_estimate ({heap} B)"
+                ceiling >= *heap,
+                "block {block}: its pre-decode ceiling ({ceiling} B) must bound its decoded \
+                 heap_estimate ({heap} B)"
             );
         }
 
         // What the removed basis would have charged for the same blocks.
+        let max_decoded = decoded.iter().map(|(_, h)| *h).max().expect("a block");
         let old_basis = block_all_page_uncomp_lens(&bytes)
             .into_iter()
             .max()
@@ -5092,6 +5296,87 @@ mod tests {
             "the fixture must exercise the under-charge: 2 x page uncomp_len ({old_basis} B) has \
              to be below the decoded heap ({max_decoded} B) for this pin to mean anything"
         );
+    }
+
+    /// ADR-0979 decision 1's ceiling includes the decoder's five per-kind slot
+    /// vectors (`24 B x column-id width x 5`), and on a small block that term is
+    /// what makes the ceiling a ceiling: the vectors are indexed by column id,
+    /// so they cost the id-space width whatever the block holds, while every
+    /// other term scales with rows.
+    ///
+    /// The fixture is eight one-record blocks over four dynamic attribute
+    /// columns (a 14-wide column-id space). On it the ceiling is 7,194 B per
+    /// block, of which the spine term is 6,720 B, against a decoded heap of
+    /// 2,232 B: the per-row terms alone come to 474 B, a fifth of what the block
+    /// holds.
+    ///
+    /// It also pins the two corrections this crate applies to ADR-0979's
+    /// `24 B x width x 5` statement of the term. At the ADR's figure the
+    /// ceiling here is 2,154 B, below the 2,232 B the block decodes to: the
+    /// string kind's slot is an enum wider than a `Vec` handle, and a slot
+    /// vector's capacity is a `Vec` growth step above the id-space width rather
+    /// than the width itself.
+    ///
+    /// Demonstrated red by dropping the `slot_spines` term from
+    /// `block_decode_ceiling_bytes`'s sum: the ceiling falls to 474 B and the
+    /// bound assert fails against the 2,232 B the block decodes to. Demonstrated
+    /// red for the corrections by setting `DECODED_SLOT_SPINE_BYTES` back to 24
+    /// and `DECODED_SLOT_SPINE_CAPACITY_FACTOR` to 1: the same assert fails
+    /// 2,154 against 2,232.
+    #[tokio::test]
+    async fn the_slot_spine_term_is_what_bounds_a_small_block() {
+        let recs: Vec<LogRecord> = (0..8i64)
+            .map(|i| {
+                record(
+                    0,
+                    1_000 + i,
+                    "b",
+                    vec![
+                        ("k0".into(), AttrValue::I64(i)),
+                        ("k1".into(), AttrValue::F64(i as f64)),
+                        ("k2".into(), AttrValue::Bool(i % 2 == 0)),
+                        ("k3".into(), AttrValue::Str(format!("v{i}"))),
+                    ],
+                )
+            })
+            .collect();
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        let store = MemoryStore::new();
+        let bytes = seed_l0(&store, Uuid::from_u128(1), 1, &recs, cfg, &[]).await;
+        let catalog = stream_catalog(&store, Uuid::from_u128(1), 1, &bytes).await;
+        let (stream_id, _) = stream_ident(0);
+
+        assert_eq!(
+            catalog.pricing.block_rows,
+            vec![1; 8],
+            "the fixture must be eight one-record blocks"
+        );
+        let spine_term = DECODED_SLOT_SPINE_BYTES
+            * catalog.pricing.total_cols
+            * DECODER_SLOT_KINDS
+            * DECODED_SLOT_SPINE_CAPACITY_FACTOR;
+        let decoded = stream0_decoded_blocks(&store, &catalog, &stream_id).await;
+        assert_eq!(decoded.len(), 8);
+
+        for (block, heap) in &decoded {
+            let ceiling =
+                block_decode_ceiling_bytes(&catalog.pricing, *block).expect("block ceiling");
+            assert!(
+                ceiling >= *heap,
+                "block {block}: its pre-decode ceiling ({ceiling} B) must bound its decoded \
+                 heap_estimate ({heap} B)"
+            );
+            assert!(
+                ceiling - spine_term < *heap,
+                "block {block}: without the slot-spine term the ceiling ({} B) would be below \
+                 the block's decoded heap ({heap} B), which is what makes the term load-bearing \
+                 rather than margin",
+                ceiling - spine_term
+            );
+        }
     }
 
     /// ADR-0979 decision 4 as amended, the reconcile direction: after a cursor's
@@ -5294,8 +5579,7 @@ mod tests {
                 budget_bytes,
                 required_bytes,
                 inputs_carrying_stream,
-                admission_batch_position,
-                admission_batch_len,
+                site,
             } => {
                 assert_eq!(got_stream, stream_id.to_hex());
                 assert_eq!(
@@ -5312,8 +5596,14 @@ mod tests {
                     "charged + the refused cursor's reservation"
                 );
                 assert_eq!(inputs_carrying_stream, 2);
-                assert_eq!(admission_batch_position, 0);
-                assert_eq!(admission_batch_len, 1);
+                assert_eq!(
+                    site,
+                    MergeCursorBudgetSite::Admission {
+                        batch_position: 0,
+                        batch_len: 1,
+                    },
+                    "the refusal is an admission, not an open cursor's block growth"
+                );
             }
             other => panic!("expected MergeCursorBudgetExceeded, got {other:?}"),
         }
@@ -5395,17 +5685,17 @@ mod tests {
                 required_bytes,
                 budget_bytes,
                 inputs_carrying_stream,
-                admission_batch_position,
-                admission_batch_len,
+                site,
                 ..
             } => {
                 assert_eq!(
-                    admission_batch_len, 2,
-                    "the two late cursors admit together"
-                );
-                assert_eq!(
-                    admission_batch_position, 1,
-                    "the second member of the batch is the one that crossed the budget"
+                    site,
+                    MergeCursorBudgetSite::Admission {
+                        batch_position: 1,
+                        batch_len: 2,
+                    },
+                    "the two late cursors admit together, and the second member of the batch is \
+                     the one that crossed the budget"
                 );
                 assert_eq!(open_cursors, 1, "only the bootstrap cursor was ever opened");
                 assert_eq!(
@@ -5422,6 +5712,426 @@ mod tests {
             }
             other => panic!("expected MergeCursorBudgetExceeded, got {other:?}"),
         }
+    }
+
+    /// One input's stream-0 records for the grow-before-a-larger-decode tests:
+    /// four tiny bodies at even timestamps `base..base+6`, then four 2,000-byte
+    /// bodies at `base+8..base+14`. Written with [`grow_fixture_cfg`] these are
+    /// two four-record blocks of ONE row group, so a cursor crosses from the
+    /// small decoded block to the large one with no fetch in between: the
+    /// transition ADR-0979 decision 4's grow clause gates.
+    fn grow_fixture_records(base: i64) -> Vec<LogRecord> {
+        let long_body = "x".repeat(2_000);
+        (0..4i64)
+            .map(|i| record(0, base + i * 2, "tiny", Vec::new()))
+            .chain(
+                (0..4i64)
+                    .map(|i| record(0, base + 8 + i * 2, &format!("{long_body}{i}"), Vec::new())),
+            )
+            .collect()
+    }
+
+    /// Four-record blocks, two blocks per row group: one loc holding both of
+    /// [`grow_fixture_records`]'s blocks.
+    fn grow_fixture_cfg() -> RlogConfig {
+        RlogConfig {
+            block_target_records: 4,
+            group_target_blocks: 2,
+            ..RlogConfig::default()
+        }
+    }
+
+    /// Seed one [`grow_fixture_records`] input and load its catalog.
+    async fn grow_fixture_catalog(
+        store: &MemoryStore,
+        writer_id: Uuid,
+        seq: u64,
+        records: &[LogRecord],
+    ) -> RlogInputCatalog {
+        let bytes = seed_l0(store, writer_id, seq, records, grow_fixture_cfg(), &[]).await;
+        stream_catalog(store, writer_id, seq, &bytes).await
+    }
+
+    /// ADR-0979 decision 4 as amended, the grow-before-a-larger-decode clause,
+    /// observed ACROSS a refill: before an open cursor decodes a block bigger
+    /// than the one it just released, its charge GROWS to
+    /// `location metadata + retained raw + that block's pre-decode ceiling`, and
+    /// the growth is checked against the budget BEFORE the decode starts.
+    ///
+    /// This is the invariant "at every point in a cursor's life the charge is at
+    /// or above its actual resident footprint" at the one point the reconcile
+    /// alone cannot hold it: the reconcile lowers the charge to the SMALL first
+    /// block's residency, and the next block is larger. The three arms are the
+    /// grown figure (exact, computed from the same functions the merge uses), a
+    /// budget one byte below it refusing with the decode never having run, and
+    /// the budget at that figure decoding the block the run needs.
+    ///
+    /// On this fixture the charge before the second decode is 14,413 B against
+    /// the 1,338 B the reconcile left after the first block, so the growth the
+    /// budget must take is 13,075 B.
+    ///
+    /// Demonstrated red by deleting the grow-and-check from
+    /// `StreamCursor::refill` (the `if let (Some(b), Some(block)) = ...` arm
+    /// before `decode_next_block`): the refusal arm returns `Ok(())` and
+    /// `expect_err` panics, and the charge arm finds 1,338 B where the grown
+    /// 14,413 B belongs. Demonstrated red for the ordering by moving that arm to
+    /// AFTER the `decode_next_block` call: that decode drops the row group's raw
+    /// bytes, so the requirement computed behind it is smaller than the one this
+    /// budget is set below, no refusal fires at all, and `expect_err` panics on
+    /// a cursor that has already materialized the block.
+    #[tokio::test]
+    async fn cursor_charge_grows_before_it_decodes_a_larger_later_block() {
+        let recs = grow_fixture_records(0);
+        let store = MemoryStore::new();
+        let catalog = grow_fixture_catalog(&store, Uuid::from_u128(1), 1, &recs).await;
+        let (stream_id, _) = stream_ident(0);
+
+        assert_eq!(
+            catalog.pricing.block_rows,
+            vec![4, 4],
+            "the fixture must be two four-record blocks"
+        );
+        let locs = catalog
+            .reader
+            .stream_blocks(&stream_id)
+            .expect("stream blocks")
+            .expect("input carries stream 0")
+            .clone();
+        assert_eq!(
+            locs.len(),
+            1,
+            "both blocks must sit in ONE row group, so the second decode needs no fetch"
+        );
+        assert_eq!(locs[0].block_indices(), &[0, 1]);
+        let ceiling_1 = block_decode_ceiling_bytes(&catalog.pricing, 1).expect("block 1 ceiling");
+
+        // Open the cursor and reconcile it exactly as the merge does after an
+        // admission: the charge is now the SMALL first block's residency.
+        let tracker = MergeMemoryTracker::new();
+        let mut cursor = open_cursor(&store, &catalog, 0, &stream_id, Some(&tracker))
+            .await
+            .expect("open cursor")
+            .expect("input carries stream 0");
+        let reservation = cursor_reservation_bytes(&catalog, &stream_id)
+            .expect("reservation")
+            .expect("input carries stream 0");
+        cursor.reservation = reservation;
+        cursor.charged = reservation;
+        let mut charged = reservation;
+        reconcile_cursor_charge(&mut cursor, &mut charged);
+        let heap_0 = cursor.decoded_bytes();
+        let after_first_block = charged;
+
+        // The figure the charge must grow to before block 1 is decoded, from the
+        // same terms the implementation prices: what the cursor still holds
+        // (metadata plus the row group's raw bytes, the decoded block having
+        // been released) plus block 1's pre-decode ceiling.
+        let grown = loc_metadata_bytes(&locs) + cursor.raw_resident_bytes() + ceiling_1;
+        assert!(
+            grown > after_first_block,
+            "the fixture must need a real growth: block 1's ceiling ({ceiling_1} B) on top of \
+             {} B held has to exceed the {after_first_block} B the reconcile left",
+            grown - ceiling_1
+        );
+
+        // Drain block 0's four rows so the next refill has to decode block 1.
+        for _ in 0..4 {
+            cursor.next_record().expect("record").expect("a row");
+        }
+        assert!(
+            cursor.peek_ts().is_none(),
+            "block 0 is drained but not yet released"
+        );
+
+        // (b) One byte below the grown figure: refused, before the decode.
+        let mut refused_charged = charged;
+        let mut budget = CursorBudget {
+            budget: grown - 1,
+            charged: &mut refused_charged,
+            stream_id: &stream_id,
+            open_cursors: 1,
+            inputs_carrying_stream: 1,
+        };
+        let err = cursor
+            .refill(&store, Some(&tracker), Some(&mut budget))
+            .await
+            .expect_err("a budget below the grown figure must refuse the decode");
+        match err {
+            MaintainError::MergeCursorBudgetExceeded {
+                stream_id: got_stream,
+                open_cursors,
+                charged_bytes,
+                budget_bytes,
+                required_bytes,
+                inputs_carrying_stream,
+                site,
+            } => {
+                assert_eq!(got_stream, stream_id.to_hex());
+                assert_eq!(open_cursors, 1, "the growing cursor is itself open");
+                assert_eq!(
+                    charged_bytes, after_first_block,
+                    "the charge at refusal is what the cursor held after the reconcile"
+                );
+                assert_eq!(budget_bytes, grown - 1);
+                assert_eq!(
+                    required_bytes, grown,
+                    "the number a retry must budget for is the grown figure"
+                );
+                assert_eq!(inputs_carrying_stream, 1);
+                assert_eq!(
+                    site,
+                    MergeCursorBudgetSite::BlockGrow {
+                        block_index: 1,
+                        grow_bytes: grown - after_first_block,
+                    },
+                    "the refusal names the block whose decode it refused and the growth it \
+                     could not take"
+                );
+            }
+            other => panic!("expected MergeCursorBudgetExceeded, got {other:?}"),
+        }
+        // The decode never ran: no block is held, the loc still has one
+        // undecoded block, the charge never rose, and the tracker's decoded
+        // high-water is still the FIRST block's heap.
+        assert!(
+            cursor.block.is_none(),
+            "no block is decoded after a refusal"
+        );
+        assert_eq!(cursor.decoded_bytes(), 0);
+        assert_eq!(
+            cursor.decoded_in_group, 1,
+            "block 1 of the row group is still undecoded"
+        );
+        assert_eq!(
+            refused_charged, after_first_block,
+            "a refused grow charges nothing"
+        );
+        assert_eq!(
+            tracker.peak_cursor_decoded_bytes(),
+            heap_0,
+            "the decoded high-water is still the first block's heap, so the larger block was \
+             never materialized"
+        );
+
+        // (a) and (c). A fresh cursor at exactly the grown figure: the refill
+        // decodes block 1, and the charge at that moment IS the grown figure --
+        // the ceiling, held until the caller reconciles it back down.
+        let tracker = MergeMemoryTracker::new();
+        let mut cursor = open_cursor(&store, &catalog, 0, &stream_id, Some(&tracker))
+            .await
+            .expect("open cursor")
+            .expect("input carries stream 0");
+        cursor.reservation = reservation;
+        cursor.charged = reservation;
+        let mut charged = reservation;
+        reconcile_cursor_charge(&mut cursor, &mut charged);
+        for _ in 0..4 {
+            cursor.next_record().expect("record").expect("a row");
+        }
+        let mut budget = CursorBudget {
+            budget: grown,
+            charged: &mut charged,
+            stream_id: &stream_id,
+            open_cursors: 1,
+            inputs_carrying_stream: 1,
+        };
+        cursor
+            .refill(&store, Some(&tracker), Some(&mut budget))
+            .await
+            .expect("a budget at the grown figure admits the decode");
+        assert_eq!(
+            cursor.charged, grown,
+            "the charge at the moment before the second decode is the grown figure"
+        );
+        assert_eq!(
+            *budget.charged, grown,
+            "the stream's running charge moved with the cursor's"
+        );
+        let heap_1 = cursor.decoded_bytes();
+        assert!(
+            heap_1 > heap_0,
+            "the fixture's second block ({heap_1} B) must decode larger than its first \
+             ({heap_0} B), or the growth this test pins is not a growth"
+        );
+        assert!(
+            cursor.charged >= cursor.resident_bytes(),
+            "the grown charge must still bound what the cursor now holds"
+        );
+        // The rows behind the larger block are the ones the merge needs.
+        let mut got = Vec::new();
+        while cursor.peek_ts().is_some() {
+            got.push(cursor.next_record().expect("record").expect("a row").ts_ns);
+            cursor
+                .refill(&store, Some(&tracker), Some(&mut budget))
+                .await
+                .expect("refill");
+        }
+        assert_eq!(
+            got,
+            vec![8, 10, 12, 14],
+            "the second block's rows are yielded in order once the growth is admitted"
+        );
+        // And the reconcile takes the ceiling back down to the actuals.
+        reconcile_cursor_charge(&mut cursor, &mut charged);
+        assert_eq!(charged, cursor.resident_bytes());
+        assert!(
+            charged < grown,
+            "the reconcile lowers the grown ceiling again"
+        );
+    }
+
+    /// ADR-0979 decision 4 as amended, end to end: the reconcile lowers a
+    /// cursor's charge, another cursor is admitted into the budget that freed,
+    /// and the first cursor then refills into a LARGER block. The grow-and-check
+    /// is what keeps the sum of both cursors under the budget at that moment;
+    /// without it the reservation stops being a bound the moment it is
+    /// reconciled, and a run whose true peak is above the budget proceeds.
+    ///
+    /// Input A is [`grow_fixture_records`] (four tiny rows, then four 2,000-byte
+    /// rows in a second block); input B is four tiny rows interleaved with A's
+    /// first block, so B is admitted after A's first emit and is still open when
+    /// A crosses into its second block. The threshold is computed, not observed:
+    /// `resident_B + (A's metadata + A's raw + A's block-1 ceiling)`.
+    ///
+    /// On this fixture the threshold is 15,653 B (B's 1,240 B resident plus A's
+    /// 14,413 B grown figure, a 13,075 B growth on A's 1,338 B reconciled
+    /// charge), above both the admission figures it has to dominate for the grow
+    /// to be the binding check (A's reservation 14,503 B, B's admission
+    /// 7,698 B).
+    ///
+    /// Demonstrated red by deleting the grow-and-check from
+    /// `StreamCursor::refill` (the `if let (Some(b), Some(block)) = ...` arm):
+    /// the run one byte below the threshold then completes and `expect_err`
+    /// panics -- the merge decoded a block that took it past its budget, which
+    /// is the fail-open this test exists for.
+    #[tokio::test]
+    async fn merge_refuses_a_later_larger_block_the_budget_cannot_take() {
+        let a = grow_fixture_records(0);
+        let b: Vec<LogRecord> = (0..4i64)
+            .map(|i| record(0, 1 + i * 2, "tiny", Vec::new()))
+            .collect();
+        let inputs = vec![(Uuid::from_u128(1), 1, a), (Uuid::from_u128(2), 2, b)];
+
+        // Every figure below comes from the same functions the merge uses, on a
+        // throwaway store seeded identically.
+        let probe = MemoryStore::new();
+        let cat_a = grow_fixture_catalog(&probe, Uuid::from_u128(1), 1, &inputs[0].2).await;
+        let cat_b = grow_fixture_catalog(&probe, Uuid::from_u128(2), 2, &inputs[1].2).await;
+        let (stream_id, _) = stream_ident(0);
+
+        let r_a = cursor_reservation_bytes(&cat_a, &stream_id)
+            .expect("reservation")
+            .expect("A carries stream 0");
+        let r_b = cursor_reservation_bytes(&cat_b, &stream_id)
+            .expect("reservation")
+            .expect("B carries stream 0");
+        let cursor_a = open_cursor(&probe, &cat_a, 0, &stream_id, None)
+            .await
+            .expect("open A")
+            .expect("A carries stream 0");
+        let cursor_b = open_cursor(&probe, &cat_b, 1, &stream_id, None)
+            .await
+            .expect("open B")
+            .expect("B carries stream 0");
+        let resident_a = cursor_a.resident_bytes();
+        let resident_b = cursor_b.resident_bytes();
+        let ceiling_a1 = block_decode_ceiling_bytes(&cat_a.pricing, 1).expect("block 1 ceiling");
+        // What A must be charged before it decodes its second block, and the
+        // stream total at that moment: B is open and reconciled by then.
+        let a_grown =
+            loc_metadata_bytes(&cursor_a.locs) + cursor_a.raw_resident_bytes() + ceiling_a1;
+        let threshold = resident_b + a_grown;
+
+        // The fixture only pins the grow if the grow is the run's binding
+        // figure: both admissions have to fit strictly below it, or a budget of
+        // `threshold - 1` would refuse at an admission instead.
+        assert!(
+            threshold > r_a,
+            "A's admission ({r_a} B) must fit below the grow threshold ({threshold} B)"
+        );
+        assert!(
+            threshold > resident_a + r_b,
+            "B's admission ({} B) must fit below the grow threshold ({threshold} B)",
+            resident_a + r_b
+        );
+
+        let store = MemoryStore::new();
+        for (writer_id, seq, recs) in &inputs {
+            seed_l0(&store, *writer_id, *seq, recs, grow_fixture_cfg(), &[]).await;
+        }
+        let clock = FixedClock::new(sealed_now_ns());
+        let under = CompactorConfig {
+            merge_cursor_budget_bytes: threshold - 1,
+            ..CompactorConfig::default()
+        };
+        let err = compact_bucket(&store, &clock, &under, &bucket())
+            .await
+            .expect_err("a budget below the grow threshold must fail closed");
+        match err {
+            MaintainError::MergeCursorBudgetExceeded {
+                stream_id: got_stream,
+                open_cursors,
+                charged_bytes,
+                budget_bytes,
+                required_bytes,
+                inputs_carrying_stream,
+                site,
+            } => {
+                assert_eq!(got_stream, stream_id.to_hex());
+                assert_eq!(
+                    open_cursors, 2,
+                    "both cursors are open when A crosses into its larger block"
+                );
+                assert_eq!(
+                    charged_bytes,
+                    resident_a + resident_b,
+                    "the charge at refusal is both cursors' reconciled residency"
+                );
+                assert_eq!(budget_bytes, threshold - 1);
+                assert_eq!(required_bytes, threshold);
+                assert_eq!(inputs_carrying_stream, 2);
+                assert_eq!(
+                    site,
+                    MergeCursorBudgetSite::BlockGrow {
+                        block_index: 1,
+                        grow_bytes: a_grown - resident_a,
+                    },
+                    "the refusal is the block growth, not an admission"
+                );
+            }
+            other => panic!("expected MergeCursorBudgetExceeded, got {other:?}"),
+        }
+
+        // One byte above the refused budget -- the threshold itself -- the run
+        // completes, with parts byte-identical to an unbudgeted run.
+        let exact = CompactorConfig {
+            merge_cursor_budget_bytes: threshold,
+            ..CompactorConfig::default()
+        };
+        let with_budget = compact_grow_fixture_hashes(&inputs, &exact).await;
+        let unbudgeted = compact_grow_fixture_hashes(&inputs, &CompactorConfig::default()).await;
+        assert!(!with_budget.is_empty());
+        assert_eq!(
+            with_budget, unbudgeted,
+            "a budget at exactly the grow threshold must not change the output"
+        );
+    }
+
+    /// [`compact_part_hashes`] for inputs written with [`grow_fixture_cfg`].
+    async fn compact_grow_fixture_hashes(
+        inputs: &[(Uuid, u64, Vec<LogRecord>)],
+        config: &CompactorConfig,
+    ) -> Vec<Vec<u8>> {
+        let store = MemoryStore::new();
+        for (writer_id, seq, recs) in inputs {
+            seed_l0(&store, *writer_id, *seq, recs, grow_fixture_cfg(), &[]).await;
+        }
+        let clock = FixedClock::new(sealed_now_ns());
+        compact_bucket(&store, &clock, config, &bucket())
+            .await
+            .expect("compact");
+        let (rec, _parts) = read_output(&store).await;
+        rec.parts.iter().map(|p| p.content_hash.clone()).collect()
     }
 
     /// Rewrite `obj` with its PAGE_DIR descriptor dropped from the footer,

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -192,9 +192,14 @@ use ravel_logseg::field_dir::FieldDir;
 use ravel_logseg::footer::{self, SuffixOutcome, kind};
 use ravel_logseg::page_dir::PageDir;
 use ravel_logseg::postings::PostingsSection;
+use ravel_logseg::reader::MAX_BLOCKS;
+use ravel_logseg::record::{
+    COL_ATTRS_RAW, COL_BODY, COL_SEVERITY_TEXT, COL_SPAN_ID, COL_TRACE_ID, FIRST_DYNAMIC_COL,
+};
+use ravel_logseg::skip_index::SkipIndex;
 use ravel_logseg::{
-    AttrValue, LogRecord, LogStreamId, RlogConfig, RlogRangeReader, RlogWriter, StreamBlockLoc,
-    StreamBlockRows, decode_section, writer::ObjectIdentity,
+    AttrValue, FieldType, LogRecord, LogStreamId, RlogConfig, RlogRangeReader, RlogWriter,
+    StreamBlockLoc, StreamBlockRows, decode_section, writer::ObjectIdentity,
 };
 use ravel_object_store::{GetRange, ObjectStoreBackend};
 use ravel_proto::commit::v1::CompactionPart;
@@ -257,17 +262,48 @@ pub struct RlogInputCatalog {
     /// it from here is what lets that gate keep working without the
     /// whole-object GET it used to read the footer from.
     pub record_count: u64,
-    /// Per whole-object block index, the sum of that block's PAGE_DIR
-    /// `uncomp_len` values: the decompressed page-byte total the block expands
-    /// to before per-cell allocation overhead. This is the term the bounded
-    /// merge's pre-decode cursor reservation is sized from (ADR-0979
-    /// decision 4): a cursor's decoded columnar block costs about this times an
-    /// allocation-overhead factor, and it is known from the resident PAGE_DIR
-    /// before any BLOCKS byte is fetched. A candidate block index from
-    /// [`RlogRangeReader::stream_blocks`] indexes straight into it. Never empty
-    /// on a loaded catalog: an input with no PAGE_DIR is refused at load with
-    /// [`MaintainError::MergeCursorInputMissingPageDir`].
-    pub block_uncomp_lens: Vec<u64>,
+    /// Everything the bounded merge needs to price a cursor's decoded residency
+    /// from this input before any BLOCKS byte is fetched (ADR-0979 decision 4).
+    /// Never empty on a loaded catalog: an input with no PAGE_DIR is refused at
+    /// load with [`MaintainError::MergeCursorInputMissingPageDir`].
+    pub pricing: InputCursorPricing,
+}
+
+/// The pre-decode admission pricing metadata of one input: the per-block shape
+/// and string-payload figures [`block_decode_ceiling_bytes`] evaluates the
+/// ADR-0979 decision 1 decoded-block ceiling from, all read from directories the
+/// catalog already holds resident (SKIP_IDX, FIELD_DIR, PAGE_DIR).
+///
+/// The decoded block's dominant term scales with the block's SHAPE (rows times
+/// the column-id width), not with its stored or encoded size: `encode_i64` picks
+/// the smallest codec per page, so a constant or run-length column -- every
+/// one-stream block's `stream_ref`, usually `severity` and `flags` too -- stores
+/// a handful of bytes and decodes to `16 B x rows`. Only the string payload
+/// scales with page contents, and PAGE_DIR carries it per page. Pricing a
+/// cursor from raw page `uncomp_len` alone therefore under-charges by a ratio
+/// that can exceed 10,000x, which is the under-charge the budget exists to
+/// refuse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputCursorPricing {
+    /// Rows in each whole-object block, from the resident SKIP_IDX level-0
+    /// entries' `record_count`. A candidate block index from
+    /// [`RlogRangeReader::stream_blocks`] indexes straight into it.
+    pub block_rows: Vec<u32>,
+    /// Per whole-object block index, the sum of PAGE_DIR `uncomp_len` over that
+    /// block's STRING pages only: the decompressed payload the block's string
+    /// and byte-valued cells own after decode. The numeric pages' `uncomp_len`
+    /// is deliberately NOT in here; their decoded cost is the shape term.
+    pub block_string_uncomp_lens: Vec<u64>,
+    /// The width of this input's column-id space: the largest column id plus
+    /// one, over the reserved fixed ids and every dynamic id FIELD_DIR names. A
+    /// width rather than a count, because a decoded block's per-column slot
+    /// vectors are sized by the largest id it carries.
+    pub total_cols: u64,
+    /// How many of those columns decode to owned per-cell buffers (the fixed
+    /// string and byte columns plus every FIELD_DIR `Str`/`Bytes` entry). Every
+    /// one is priced as PLAIN, the conservative arm: dictionary encoding stores
+    /// the distinct values once and only shrinks the figure.
+    pub string_cols: u64,
 }
 
 /// The logs codec: implements the [`SegmentCodec`] seam for `.rlog` objects.
@@ -401,14 +437,14 @@ pub(crate) async fn load_catalog_from_object(
         });
     };
     let page_dir_raw = fetch_section(store, &object_key, &ftr, kind::PAGE_DIR, &cfg).await?;
-    // The per-block decompressed page-byte totals the bounded merge reserves a
-    // cursor's decode against (ADR-0979 decision 4). Decoded here, once, from
-    // the PAGE_DIR bytes already fetched: `PageDir::decode` is the same decode
-    // the range reader runs internally, and this keeps only the per-block sum
-    // (one u64 per block) rather than a second copy of the directory. The
+    // The per-block shape and string-payload figures the bounded merge reserves
+    // a cursor's decode against (ADR-0979 decision 4). Decoded here, once, from
+    // directory bytes already fetched: these are the same decodes the range
+    // reader runs internally, and this keeps only the per-block figures (one u32
+    // and one u64 per block) rather than a second copy of the directories. The
     // reader's own `from_sections_with_page_dir` below re-decodes and fully
     // validates the same bytes, so a corrupt directory still fails loud there.
-    let block_uncomp_lens = block_uncomp_lens_from_page_dir(&page_dir_raw)?;
+    let pricing = input_cursor_pricing(&field_dir_raw, &skip_idx_raw, &page_dir_raw)?;
     // Input read / catalog load phase (issue #977): the reader below retains a
     // decoded form of these directory sections for the whole merge. Charge the
     // decoded section payload lengths (what `fetch_section` returns after
@@ -419,9 +455,12 @@ pub(crate) async fn load_catalog_from_object(
             + field_dir_raw.len() as u64
             + skip_idx_raw.len() as u64
             + page_dir_raw.len() as u64
-            // The retained per-block reservation figures are derived from
-            // PAGE_DIR but held past it, so charge them too: one u64 per block.
-            + (block_uncomp_lens.len() as u64)
+            // The retained per-block reservation figures are derived from the
+            // directories but held past them, so charge them too: one u32 (rows)
+            // and one u64 (string payload) per block.
+            + (pricing.block_rows.len() as u64)
+                .saturating_mul(std::mem::size_of::<u32>() as u64)
+            + (pricing.block_string_uncomp_lens.len() as u64)
                 .saturating_mul(std::mem::size_of::<u64>() as u64);
         t.add_catalog_directory_bytes(dir_bytes);
     }
@@ -438,21 +477,64 @@ pub(crate) async fn load_catalog_from_object(
         reader,
         indexed_fields,
         record_count,
-        block_uncomp_lens,
+        pricing,
     })
 }
 
-/// The per-block decompressed page-byte totals a bounded merge reserves cursor
-/// decode against (ADR-0979 decision 4), decoded from one input's PAGE_DIR
-/// section bytes. Entry `b` is the sum of `uncomp_len` over every page whole-
-/// object block `b` contributes to any column chunk of its row group -- the
-/// decompressed columnar payload the block decodes to, which the cursor's
-/// [`StreamBlockRows::heap_estimate`] scales with. Read from resident PAGE_DIR
-/// alone; the decode is the same one the range reader runs internally.
-fn block_uncomp_lens_from_page_dir(page_dir_raw: &[u8]) -> Result<Vec<u64>> {
+/// The fixed column ids whose cells decode to owned per-row byte buffers:
+/// `severity_text`, `body`, `trace_id`, `span_id`, and the canonical
+/// `attrs_raw` overflow blob (docs/log-segment-format.md FIELD_DIR). The
+/// remaining reserved ids (`ts`, `observed_ts`, `stream_ref`, `severity_num`,
+/// `flags`) decode to `Option<i64>` slots and are priced by the shape term.
+const FIXED_STRING_COLS: [u32; 5] = [
+    COL_SEVERITY_TEXT,
+    COL_BODY,
+    COL_TRACE_ID,
+    COL_SPAN_ID,
+    COL_ATTRS_RAW,
+];
+
+/// Decoded bytes a numeric cell slot costs: `Option<i64>` and `Option<u64>` are
+/// 16 bytes, and every column of the decoded block carries one slot per row of
+/// the block whether or not that row has a value (`Option<bool>` is smaller,
+/// so pricing every column at this width is the conservative arm).
+const DECODED_CELL_BYTES: u64 = 16;
+
+/// Decoded bytes a string cell's SLOT costs on top of the shape term, covering
+/// the `Option<Vec<u8>>` handle a plain string column keeps per row (24 bytes)
+/// with margin for the dictionary form's id plus its distinct-value handle.
+/// The cell CONTENTS are priced separately, from the block's string-page
+/// `uncomp_len`.
+const DECODED_STRING_SLOT_BYTES: u64 = 40;
+
+/// One input's pre-decode admission pricing metadata (ADR-0979 decision 4),
+/// decoded from the FIELD_DIR, SKIP_IDX, and PAGE_DIR section bytes the catalog
+/// load already fetched. See [`InputCursorPricing`] for why each term is read
+/// from the source it is read from.
+fn input_cursor_pricing(
+    field_dir_raw: &[u8],
+    skip_idx_raw: &[u8],
+    page_dir_raw: &[u8],
+) -> Result<InputCursorPricing> {
+    let field_dir = FieldDir::decode(field_dir_raw, MAX_FIELD_DIR_ENTRIES)?;
+    // The reserved fixed ids 0..FIRST_DYNAMIC_COL never appear in FIELD_DIR but
+    // are always part of the block's column-id space, so the width starts there.
+    let mut total_cols = u64::from(FIRST_DYNAMIC_COL);
+    let mut string_ids: BTreeSet<u32> = FIXED_STRING_COLS.iter().copied().collect();
+    for entry in field_dir.entries() {
+        total_cols = total_cols.max(u64::from(entry.column_id).saturating_add(1));
+        if matches!(entry.ty, FieldType::Str | FieldType::Bytes) {
+            string_ids.insert(entry.column_id);
+        }
+    }
+    let string_cols = string_ids.len() as u64;
+
+    let skip = SkipIndex::decode(skip_idx_raw, MAX_BLOCKS)?;
+    let block_rows: Vec<u32> = skip.l0.iter().map(|e| e.record_count).collect();
+
     let page_dir = PageDir::decode(page_dir_raw)?;
     let block_count = page_dir.block_count();
-    let mut out = Vec::with_capacity(block_count as usize);
+    let mut block_string_uncomp_lens = Vec::with_capacity(block_count as usize);
     for b in 0..block_count {
         let index = u32::try_from(b)
             .map_err(|_| MaintainError::Invariant("page_dir block index range".to_string()))?;
@@ -461,11 +543,61 @@ fn block_uncomp_lens_from_page_dir(page_dir_raw: &[u8]) -> Result<Vec<u64>> {
         })?;
         let mut sum = 0u64;
         for p in pages {
-            sum = sum.saturating_add(p.desc.uncomp_len);
+            if string_ids.contains(&p.desc.column_id) {
+                sum = sum.saturating_add(p.desc.uncomp_len);
+            }
         }
-        out.push(sum);
+        block_string_uncomp_lens.push(sum);
     }
-    Ok(out)
+    if block_rows.len() != block_string_uncomp_lens.len() {
+        return Err(MaintainError::Invariant(format!(
+            "input block framing disagrees: SKIP_IDX frames {} blocks, PAGE_DIR covers {}",
+            block_rows.len(),
+            block_string_uncomp_lens.len()
+        )));
+    }
+    Ok(InputCursorPricing {
+        block_rows,
+        block_string_uncomp_lens,
+        total_cols,
+        string_cols,
+    })
+}
+
+/// The ADR-0979 decision 1 ceiling on what ONE block of `pricing`'s input
+/// decodes to, evaluated from pre-decode metadata alone:
+///
+/// ```text
+/// 16 B x rows x total_cols          every column's per-row cell slot
+///   + string-page uncomp_len        the string cells' own buffers
+///   + 40 B x rows x string_cols     those cells' per-row handles
+/// ```
+///
+/// Each term is priced from the source that actually bounds it: `rows` and the
+/// block framing from SKIP_IDX, the column-id width and the string-column count
+/// from FIELD_DIR, the string payload from PAGE_DIR's per-page `uncomp_len`
+/// restricted to string pages. Every string column is priced as plain, the
+/// conservative arm.
+fn block_decode_ceiling_bytes(pricing: &InputCursorPricing, block: usize) -> Result<u64> {
+    let rows = u64::from(*pricing.block_rows.get(block).ok_or_else(|| {
+        MaintainError::Invariant(
+            "stream candidate block index past the input's SKIP_IDX block count".to_string(),
+        )
+    })?);
+    let string_bytes = *pricing.block_string_uncomp_lens.get(block).ok_or_else(|| {
+        MaintainError::Invariant(
+            "stream candidate block index past the input's PAGE_DIR block count".to_string(),
+        )
+    })?;
+    let cells = DECODED_CELL_BYTES
+        .saturating_mul(rows)
+        .saturating_mul(pricing.total_cols);
+    let string_slots = DECODED_STRING_SLOT_BYTES
+        .saturating_mul(rows)
+        .saturating_mul(pricing.string_cols);
+    Ok(cells
+        .saturating_add(string_bytes)
+        .saturating_add(string_slots))
 }
 
 /// One catalog per object key, `input_read_concurrency` loads in flight.
@@ -943,13 +1075,19 @@ struct StreamCursor<'a> {
     /// the prefetch is one loc ahead, so the cursor's raw-byte residency is
     /// two locs, not the stream.
     prefetched: Option<(StreamBlockLoc, bytes::Bytes)>,
-    /// The pre-decode reservation charged against
-    /// [`CompactorConfig::merge_cursor_budget_bytes`] when this cursor was
-    /// admitted (ADR-0979 decision 4). Held for the cursor's lifetime and
-    /// released back to the stream's running charge when the cursor drains, so
-    /// the charge tracks the concurrent overlap `D`, not the input count. Set by
-    /// the merge after [`Self::open`]; 0 until then.
+    /// The pre-decode reservation ceiling this cursor was admitted under
+    /// (ADR-0979 decision 4). Kept after the reconcile as the ceiling the
+    /// cursor's residency is bounded by; the live charge is [`Self::charged`].
+    /// Set by the merge after [`Self::open`]; 0 until then.
     reservation: u64,
+    /// What this cursor currently charges against
+    /// [`CompactorConfig::merge_cursor_budget_bytes`]: the pre-decode
+    /// reservation ceiling from admission until its first decode completes, then
+    /// its actual residency ([`Self::resident_bytes`]), re-derived after every
+    /// block decode (ADR-0979 decision 4 as amended). Released back to the
+    /// stream's running charge when the cursor drains, so the charge tracks the
+    /// concurrent overlap `D`, not the input count.
+    charged: u64,
 }
 
 impl<'a> StreamCursor<'a> {
@@ -977,7 +1115,37 @@ impl<'a> StreamCursor<'a> {
             block_bytes: 0,
             prefetched: None,
             reservation: 0,
+            charged: 0,
         }))
+    }
+
+    /// The raw (still stored-form) bytes this cursor holds right now: the row
+    /// group it is decoding blocks out of plus the one prefetched behind it, at
+    /// most two. These are the same bytes the #977 tracker's fetched term counts.
+    fn raw_resident_bytes(&self) -> u64 {
+        let group = self.group.as_ref().map_or(0, |(_, d)| d.len() as u64);
+        let prefetched = self.prefetched.as_ref().map_or(0, |(_, d)| d.len() as u64);
+        group.saturating_add(prefetched)
+    }
+
+    /// The decoded columnar block this cursor holds right now, as
+    /// [`StreamBlockRows::heap_estimate`] reported it at decode. Zero between
+    /// blocks and once the cursor is exhausted. This is the same figure the #977
+    /// tracker's decoded term carries for this cursor.
+    fn decoded_bytes(&self) -> u64 {
+        self.block_bytes
+    }
+
+    /// What this cursor actually holds resident: its location metadata, its raw
+    /// row-group bytes, and its decoded block. This is what the merge reconciles
+    /// the pre-decode reservation down to once a decode completes (ADR-0979
+    /// decision 4 as amended), and it is bounded above by that reservation --
+    /// the raw term by `2 * G` and the decoded term by the per-block ceiling the
+    /// reservation took the maximum of.
+    fn resident_bytes(&self) -> u64 {
+        loc_metadata_bytes(&self.locs)
+            .saturating_add(self.raw_resident_bytes())
+            .saturating_add(self.decoded_bytes())
     }
 
     /// The `ts_ns` of the record this cursor would yield next, or `None` once
@@ -1185,20 +1353,19 @@ struct PendingCursor {
     reservation: u64,
 }
 
-/// Allocation-overhead factor applied to a block's decompressed page bytes to
-/// size the decoded columnar block's reservation ceiling (ADR-0979
-/// decision 4). A cursor's [`StreamBlockRows::heap_estimate`] is the decoded
-/// column buffers plus per-cell allocation headers and `Vec` slack over the raw
-/// decompressed page payload PAGE_DIR's `uncomp_len` measures, so a factor above
-/// one is needed for the reservation to bound the decoded residency. Two is a
-/// documented heuristic ceiling over that payload, consistent with
-/// `heap_estimate` itself being an estimate rather than a measurement. The
-/// reservation is held at this ceiling for the cursor's lifetime rather than
-/// reconciled down to the decoded figure after decode: the ceiling already
-/// covers the cursor's whole lifetime residency, so holding it keeps the budget
-/// conservative (it never under-charges) and the reserve-time check
-/// deterministic.
-const CURSOR_DECODE_OVERHEAD_FACTOR: u64 = 2;
+/// The heap a cursor's own location metadata holds for its whole lifetime: the
+/// owned `Vec<StreamBlockLoc>` and each loc's block-index list. Charged in the
+/// pre-decode reservation and again in the reconciled residency, because the
+/// cursor holds it in both states.
+fn loc_metadata_bytes(locs: &[StreamBlockLoc]) -> u64 {
+    let loc_slot = std::mem::size_of::<StreamBlockLoc>() as u64;
+    let idx_slot = std::mem::size_of::<usize>() as u64;
+    let mut total = (locs.len() as u64).saturating_mul(loc_slot);
+    for l in locs {
+        total = total.saturating_add((l.block_indices().len() as u64).saturating_mul(idx_slot));
+    }
+    total
+}
 
 /// The pre-decode reservation one input's cursor over `stream_id` is charged
 /// against the merge budget (ADR-0979 decision 4), or `None` if the input does
@@ -1208,14 +1375,19 @@ const CURSOR_DECODE_OVERHEAD_FACTOR: u64 = 2;
 /// - `2 * G`: the two row groups' stored bytes a cursor holds at once (the loc
 ///   being decoded from plus the one prefetched behind it), sized as twice the
 ///   largest of the stream's locs so a later, larger group cannot exceed it;
-/// - the cursor's location metadata: its owned `Vec<StreamBlockLoc>` and each
-///   loc's block-index list;
+/// - the cursor's location metadata ([`loc_metadata_bytes`]);
 /// - `B_dec`: the MAXIMUM over the stream's candidate blocks of that block's
-///   decompressed page-byte total ([`RlogInputCatalog::block_uncomp_lens`]),
-///   times [`CURSOR_DECODE_OVERHEAD_FACTOR`]. The max, not the first block's
-///   cost, because [`StreamCursor::refill`] decodes later blocks after
-///   releasing earlier ones, so a later, larger block must not exceed the
+///   decoded-block ceiling ([`block_decode_ceiling_bytes`]). The max, not the
+///   first block's cost, because [`StreamCursor::refill`] decodes later blocks
+///   after releasing earlier ones, so a later, larger block must not exceed the
 ///   reservation.
+///
+/// This is a ceiling on the cursor's residency for its whole lifetime, not a
+/// measurement of it: [`StreamCursor::resident_bytes`] is what the cursor
+/// actually holds, and the merge reconciles the charge down to that figure as
+/// soon as the decode completes (ADR-0979 decision 4 as amended; the default
+/// budget is sized from reconciled residency, so holding the ceiling for a
+/// cursor's lifetime would refuse runs the default exists to admit).
 fn cursor_reservation_bytes(
     catalog: &RlogInputCatalog,
     stream_id: &LogStreamId,
@@ -1229,32 +1401,14 @@ fn cursor_reservation_bytes(
     // 2*G: twice the largest loc's stored row-group bytes.
     let max_group = locs.iter().map(|l| l.byte_len()).max().unwrap_or(0);
     let two_g = max_group.saturating_mul(2);
-    // Location metadata: the owned locs vector plus each loc's block-index list.
-    let loc_slot = std::mem::size_of::<StreamBlockLoc>() as u64;
-    let idx_slot = std::mem::size_of::<usize>() as u64;
-    let mut loc_meta = (locs.len() as u64).saturating_mul(loc_slot);
-    for l in &locs {
-        loc_meta =
-            loc_meta.saturating_add((l.block_indices().len() as u64).saturating_mul(idx_slot));
-    }
-    // B_dec: the max decompressed page bytes over the stream's candidate blocks.
-    let mut max_b_dec = 0u64;
+    let loc_meta = loc_metadata_bytes(&locs);
+    // B_dec: the max decoded-block ceiling over the stream's candidate blocks.
+    let mut b_dec = 0u64;
     for l in &locs {
         for &block in l.block_indices() {
-            let uncomp = catalog
-                .block_uncomp_lens
-                .get(block)
-                .copied()
-                .ok_or_else(|| {
-                    MaintainError::Invariant(
-                        "stream candidate block index past the input's PAGE_DIR block count"
-                            .to_string(),
-                    )
-                })?;
-            max_b_dec = max_b_dec.max(uncomp);
+            b_dec = b_dec.max(block_decode_ceiling_bytes(&catalog.pricing, block)?);
         }
     }
-    let b_dec = max_b_dec.saturating_mul(CURSOR_DECODE_OVERHEAD_FACTOR);
     Ok(Some(two_g.saturating_add(loc_meta).saturating_add(b_dec)))
 }
 
@@ -1304,10 +1458,12 @@ fn cursor_reservation_bytes(
 /// [`CompactorConfig::merge_cursor_budget_bytes`]. The reservation is charged
 /// BEFORE the cursor fetches or decodes anything, so the budget is enforced at
 /// reserve time and the merge fails closed rather than after allocating: if
-/// admitting a cursor that merge order requires would exceed the budget, the
+/// admitting the batch that merge order requires would exceed the budget, the
 /// run aborts with [`MaintainError::MergeCursorBudgetExceeded`] before
-/// publishing. A drained cursor releases its reservation, so the charge tracks
-/// `D`, not `n`.
+/// publishing. Once a cursor's decode completes, its charge is reconciled down
+/// to what it actually holds ([`reconcile_cursor_charge`]), which is what the
+/// default budget is sized from. A drained cursor releases its charge, so the
+/// charge tracks `D`, not `n`.
 async fn merge_stream_into_parts(
     store: &dyn ObjectStoreBackend,
     catalogs: &[RlogInputCatalog],
@@ -1387,22 +1543,31 @@ async fn merge_stream_into_parts(
             }
             // Reserve the whole batch at reserve time (ADR-0979 decision 4):
             // check the budget before any cursor fetches or decodes, so the
-            // merge fails closed rather than after allocating.
+            // merge fails closed rather than after allocating. The refusal's
+            // figures separate the two: `open_charge` is what the cursors that
+            // exist hold, and the required total names the batch position that
+            // crossed the budget. Batch members before that position were never
+            // opened, so folding their reservations into the "already charged"
+            // figure would report memory nothing holds.
+            let open_charge = charged;
+            let mut batch_charge = 0u64;
             for k in 0..batch_len {
-                let reservation = pending[pos + k].reservation;
-                let required = charged.saturating_add(reservation);
+                batch_charge = batch_charge.saturating_add(pending[pos + k].reservation);
+                let required = open_charge.saturating_add(batch_charge);
                 if required > budget {
                     return Err(MaintainError::MergeCursorBudgetExceeded {
                         stream_id: stream_id.to_hex(),
                         open_cursors: open.len(),
-                        charged_bytes: charged,
+                        charged_bytes: open_charge,
                         budget_bytes: budget,
                         required_bytes: required,
                         inputs_carrying_stream: pending.len(),
+                        admission_batch_position: k,
+                        admission_batch_len: batch_len,
                     });
                 }
-                charged = required;
             }
+            charged = open_charge.saturating_add(batch_charge);
             let opens: Vec<CursorFuture<'_, '_>> = (0..batch_len)
                 .map(|k| {
                     let p = &pending[pos + k];
@@ -1424,6 +1589,12 @@ async fn merge_stream_into_parts(
                 match cursor_opt {
                     Some(mut cursor) => {
                         cursor.reservation = reservation;
+                        cursor.charged = reservation;
+                        // `open_cursor` fetched and decoded this cursor's first
+                        // block, so its actual residency is known now: reconcile
+                        // the ceiling down to it before the next admission round
+                        // reads the charge.
+                        reconcile_cursor_charge(&mut cursor, &mut charged);
                         open.push(cursor);
                     }
                     // Carried the stream in STREAM_DIR but materialized no row
@@ -1473,14 +1644,40 @@ async fn merge_stream_into_parts(
         }
         open[bi].refill(store, tracker).await?;
         // A drained cursor releases its residency (refill already dropped its
-        // last block) and its reservation, so both the open-cursor high-water
-        // and the budget charge track the concurrent overlap `D`, not `n`.
+        // last block) and its charge, so both the open-cursor high-water and the
+        // budget charge track the concurrent overlap `D`, not `n`. A cursor that
+        // is still live may have crossed into a new block or a new row group in
+        // that refill, so its charge is re-derived from what it now holds.
         if open[bi].peek_ts().is_none() {
             let cursor = open.swap_remove(bi);
-            charged = charged.saturating_sub(cursor.reservation);
+            charged = charged.saturating_sub(cursor.charged);
+        } else {
+            reconcile_cursor_charge(&mut open[bi], &mut charged);
         }
     }
     Ok(())
+}
+
+/// Reconcile one cursor's budget charge to what it actually holds resident
+/// (ADR-0979 decision 4 as amended), updating the stream's running `charged`
+/// total by the difference.
+///
+/// Mandatory, not an optimization. The pre-decode reservation is a ceiling over
+/// every block the cursor may decode, evaluated before any of them is fetched;
+/// the default budget is sized from a cursor's ACTUAL residency, so a merge that
+/// held the ceiling for each cursor's lifetime would refuse corpora the default
+/// was chosen to admit. Called once the fetch and decode that follow an
+/// admission complete, and again after each later block decode, so the charge is
+/// the cursor's residency for all but the instant between reserving and
+/// decoding. The reconciled figure can only be at or below the reservation: the
+/// raw term is bounded by the reservation's `2 * G` and the decoded term by the
+/// per-block ceiling the reservation took the maximum over.
+fn reconcile_cursor_charge(cursor: &mut StreamCursor<'_>, charged: &mut u64) {
+    let actual = cursor.resident_bytes();
+    *charged = charged
+        .saturating_sub(cursor.charged)
+        .saturating_add(actual);
+    cursor.charged = actual;
 }
 
 /// Open one input's cursor over `stream_id` and load its first block. Named
@@ -4582,6 +4779,98 @@ mod tests {
         );
     }
 
+    /// ADR-0979 decision 2, the `<=` admission boundary: a queued cursor whose
+    /// SKIP_IDX lower bound EQUALS the merge frontier exactly is admitted before
+    /// the next record is emitted, so an equal-`ts` tie between that cursor's
+    /// first record and the already-open cursor's next record resolves by
+    /// `input_index` -- and here the deferred input holds the LOWER index, so it
+    /// must be emitted FIRST.
+    ///
+    /// Geometry. Inputs sort canonically by `(writer_id, writer_epoch,
+    /// writer_seq)`, so uuid 1 is `input_index` 0 and uuid 2 is 1:
+    ///
+    /// ```text
+    /// input_index 0 (uuid 1): stream 0 at ts 30 ("b30"), 40   lower bound 30
+    /// input_index 1 (uuid 2): stream 0 at ts 10, 20, 30 ("a30")   lower bound 10
+    /// ```
+    ///
+    /// Input 1 bootstraps (lowest bound). Input 0 stays queued while the frontier
+    /// is 10 and 20, and is admitted exactly when the frontier reaches 30 --
+    /// `lower_bound <= ts` with equality. Both cursors then head at ts 30, and
+    /// the `(ts, input_index)` minimum is input 0's "b30".
+    ///
+    /// Under a `<` regression at the admission predicate, input 0 is not admitted
+    /// at the boundary: input 1 emits "a30" and drains, and only then does input 0
+    /// bootstrap. The record sequence reorders to a30-before-b30 and the part's
+    /// bytes -- and so its `content_hash` -- change. Demonstrated red by editing
+    /// the `AdmissionMode::Overlap` arm of the admission predicate in
+    /// `merge_stream_into_parts` from `p.lower_bound <= ts` to `p.lower_bound <
+    /// ts`: the decoded-sequence assertion below fails with `["a30", "b30"]` and
+    /// the pinned hash no longer matches.
+    #[tokio::test]
+    async fn admission_boundary_tie_orders_by_input_index() {
+        // The premise the fixture rests on: the DEFERRED input is the one with
+        // the lower canonical index.
+        assert!(
+            Uuid::from_u128(1).to_string() < Uuid::from_u128(2).to_string(),
+            "uuid 1 must sort before uuid 2, so the deferred input is input_index 0"
+        );
+        let deferred: Vec<LogRecord> = vec![
+            record(0, 30, "b30", Vec::new()),
+            record(0, 40, "b40", Vec::new()),
+        ];
+        let open_first: Vec<LogRecord> = vec![
+            record(0, 10, "a10", Vec::new()),
+            record(0, 20, "a20", Vec::new()),
+            record(0, 30, "a30", Vec::new()),
+        ];
+        let inputs = vec![
+            (Uuid::from_u128(1), 1, deferred),
+            (Uuid::from_u128(2), 2, open_first),
+        ];
+
+        let store = MemoryStore::new();
+        for (writer_id, seq, recs) in &inputs {
+            seed(&store, *writer_id, *seq, recs).await;
+        }
+        let clock = FixedClock::new(sealed_now_ns());
+        compact_bucket(&store, &clock, &CompactorConfig::default(), &bucket())
+            .await
+            .expect("compact");
+        let (_rec, parts) = read_output(&store).await;
+        assert_eq!(parts.len(), 1, "the fixture is one part");
+        let bodies: Vec<String> = decode_all(&parts[0]).into_iter().map(|r| r.body).collect();
+        assert_eq!(
+            bodies,
+            vec!["a10", "a20", "b30", "a30", "b40"],
+            "at the ts-30 tie the admitted-at-the-boundary input (input_index 0) sorts first"
+        );
+
+        // The exact bytes, not only the order: the part hashes under overlap-gated
+        // and eager all-open admission, pinned as literals.
+        const EXPECTED_HASHES: [&str; 1] =
+            ["bcb041dad935c2e867f943330601f9bf04da1e171faa3ebdf67cadd14eefef39"];
+        let overlap = compact_part_hashes(&inputs, &CompactorConfig::default()).await;
+        let eager = compact_part_hashes(
+            &inputs,
+            &CompactorConfig {
+                merge_admission: AdmissionMode::EagerAll,
+                ..CompactorConfig::default()
+            },
+        )
+        .await;
+        let hex: Vec<String> = overlap.iter().map(hex::encode).collect();
+        assert_eq!(
+            hex,
+            EXPECTED_HASHES.map(String::from).to_vec(),
+            "the boundary-tie fixture's part content_hash"
+        );
+        assert_eq!(
+            overlap, eager,
+            "admitting at the boundary reproduces the all-open order exactly"
+        );
+    }
+
     /// Compact `inputs` (all on stream 0) with a tracker installed and return the
     /// recorded `max_open_cursors_per_stream`.
     async fn max_open_cursors_for(inputs: &[(Uuid, u64, Vec<LogRecord>)]) -> u64 {
@@ -4660,6 +4949,19 @@ mod tests {
         );
     }
 
+    /// One seeded input's catalog, loaded exactly as the merge loads it.
+    async fn stream_catalog(
+        store: &MemoryStore,
+        writer_id: Uuid,
+        seq: u64,
+        bytes: &Bytes,
+    ) -> RlogInputCatalog {
+        let key = seeded_data_key(writer_id, seq, bytes);
+        load_catalog_from_object(store, &CompactorConfig::default(), key, true)
+            .await
+            .expect("catalog")
+    }
+
     /// The pre-decode reservation the merge charges one input's cursor over
     /// stream 0, loaded and computed exactly as the merge does.
     async fn stream0_reservation(
@@ -4668,14 +4970,256 @@ mod tests {
         seq: u64,
         bytes: &Bytes,
     ) -> u64 {
-        let key = seeded_data_key(writer_id, seq, bytes);
-        let catalog = load_catalog_from_object(store, &CompactorConfig::default(), key, true)
-            .await
-            .expect("catalog");
+        let catalog = stream_catalog(store, writer_id, seq, bytes).await;
         let (stream_id, _) = stream_ident(0);
         cursor_reservation_bytes(&catalog, &stream_id)
             .expect("reservation")
             .expect("input carries stream 0")
+    }
+
+    /// What one input's stream-0 cursor actually holds once its first block is
+    /// fetched and decoded: the figure the merge reconciles the pre-decode
+    /// reservation down to (ADR-0979 decision 4 as amended).
+    async fn stream0_resident_bytes(
+        store: &MemoryStore,
+        writer_id: Uuid,
+        seq: u64,
+        bytes: &Bytes,
+    ) -> u64 {
+        let catalog = stream_catalog(store, writer_id, seq, bytes).await;
+        let (stream_id, _) = stream_ident(0);
+        let cursor = open_cursor(store, &catalog, 0, &stream_id, None)
+            .await
+            .expect("open cursor")
+            .expect("input carries stream 0");
+        cursor.resident_bytes()
+    }
+
+    /// Per whole-object block, the sum of PAGE_DIR `uncomp_len` over EVERY page
+    /// of the block: the pre-amendment reservation basis, kept in the tests only
+    /// so the ceiling test can show what it under-charges by.
+    fn block_all_page_uncomp_lens(obj: &[u8]) -> Vec<u64> {
+        let cfg = RlogConfig::default();
+        let ftr = footer::open(obj).expect("open");
+        let raw = read_section(obj, ftr.section(kind::PAGE_DIR).unwrap(), &cfg).expect("page_dir");
+        let dir = PageDir::decode(&raw).expect("decode page_dir");
+        (0..dir.block_count() as u32)
+            .map(|b| {
+                dir.block_pages(b)
+                    .expect("block pages")
+                    .iter()
+                    .map(|p| p.desc.uncomp_len)
+                    .sum()
+            })
+            .collect()
+    }
+
+    /// Drive one input's stream-0 cursor to exhaustion, returning each decoded
+    /// block's `heap_estimate` as the cursor charged it.
+    async fn stream0_decoded_block_bytes(
+        store: &MemoryStore,
+        catalog: &RlogInputCatalog,
+        stream_id: &LogStreamId,
+    ) -> Vec<u64> {
+        let mut cursor = open_cursor(store, catalog, 0, stream_id, None)
+            .await
+            .expect("open cursor")
+            .expect("input carries the stream");
+        let mut seen: Vec<u64> = Vec::new();
+        while cursor.peek_ts().is_some() {
+            let bytes = cursor.decoded_bytes();
+            if seen.last() != Some(&bytes) {
+                seen.push(bytes);
+            }
+            cursor.next_record().expect("record");
+            cursor.refill(store, None).await.expect("refill");
+        }
+        seen
+    }
+
+    /// ADR-0979 decision 4 as amended, the ceiling direction: the pre-decode
+    /// reservation is a real ceiling on every block the cursor decodes, on a
+    /// fixture built from CONSTANT columns -- the shape the pre-amendment basis
+    /// mispriced.
+    ///
+    /// The fixture is 500 records of one stream with an identical body, severity,
+    /// and no attributes, so `stream_ref`, `severity_num`, `flags`, and the two
+    /// string columns all encode to a handful of stored bytes per block while
+    /// still decoding to a slot per row per column. The test asserts both halves:
+    /// the repriced reservation covers every decoded block, and twice the block's
+    /// total page `uncomp_len` -- the basis this amendment removed -- does NOT,
+    /// so the old code charged less than the memory the block actually takes.
+    ///
+    /// Demonstrated red by restoring the old basis in the two lines that define
+    /// it: dropping the `string_ids.contains` filter in `input_cursor_pricing`
+    /// (so the per-block figure is every page's `uncomp_len` again) and returning
+    /// `string_bytes * 2` from `block_decode_ceiling_bytes` in place of the three
+    /// terms. The `reservation >= heap` assert then fails 4,168 against 54,905 on
+    /// this 500-record fixture, and the ratio grows with rows and column count.
+    #[tokio::test]
+    async fn reservation_ceiling_bounds_every_decoded_block_of_a_constant_column_input() {
+        let recs: Vec<LogRecord> = (0..500i64)
+            .map(|i| record(0, 1_000 + i, "constant body", Vec::new()))
+            .collect();
+        let store = MemoryStore::new();
+        let bytes = seed(&store, Uuid::from_u128(1), 1, &recs).await;
+        let catalog = stream_catalog(&store, Uuid::from_u128(1), 1, &bytes).await;
+        let (stream_id, _) = stream_ident(0);
+
+        let reservation = cursor_reservation_bytes(&catalog, &stream_id)
+            .expect("reservation")
+            .expect("input carries stream 0");
+        let decoded = stream0_decoded_block_bytes(&store, &catalog, &stream_id).await;
+        assert!(!decoded.is_empty(), "the cursor decoded at least one block");
+        let max_decoded = decoded.iter().copied().max().expect("a decoded block");
+
+        for (i, heap) in decoded.iter().enumerate() {
+            assert!(
+                reservation >= *heap,
+                "block {i}: the admission reservation ({reservation} B) must bound the decoded \
+                 block's heap_estimate ({heap} B)"
+            );
+        }
+
+        // What the removed basis would have charged for the same blocks.
+        let old_basis = block_all_page_uncomp_lens(&bytes)
+            .into_iter()
+            .max()
+            .expect("a block")
+            * 2;
+        assert!(
+            old_basis < max_decoded,
+            "the fixture must exercise the under-charge: 2 x page uncomp_len ({old_basis} B) has \
+             to be below the decoded heap ({max_decoded} B) for this pin to mean anything"
+        );
+    }
+
+    /// ADR-0979 decision 4 as amended, the reconcile direction: after a cursor's
+    /// decode completes, the charge held against the budget is the cursor's ACTUAL
+    /// residency, and its decoded term equals `heap_estimate()` exactly -- not the
+    /// pre-decode ceiling, which is strictly larger here.
+    ///
+    /// Demonstrated red by making `reconcile_cursor_charge` a no-op (an early
+    /// `return` before it reads `resident_bytes`): the charge stays at the
+    /// pre-decode ceiling, and the equality assert fails 76,508 against 26,496.
+    #[tokio::test]
+    async fn reconcile_charges_actual_residency_with_the_decoded_term_exact() {
+        let recs: Vec<LogRecord> = (0..200i64)
+            .map(|i| record(0, 1_000 + i, "body", vec![("k".into(), AttrValue::I64(i))]))
+            .collect();
+        let store = MemoryStore::new();
+        let bytes = seed(&store, Uuid::from_u128(1), 1, &recs).await;
+        let catalog = stream_catalog(&store, Uuid::from_u128(1), 1, &bytes).await;
+        let (stream_id, _) = stream_ident(0);
+
+        let reservation = cursor_reservation_bytes(&catalog, &stream_id)
+            .expect("reservation")
+            .expect("input carries stream 0");
+        let mut cursor = open_cursor(&store, &catalog, 0, &stream_id, None)
+            .await
+            .expect("open cursor")
+            .expect("input carries stream 0");
+        cursor.reservation = reservation;
+        cursor.charged = reservation;
+
+        // Exactly what the merge does once the admission's fetch and decode
+        // complete.
+        let mut charged = reservation;
+        reconcile_cursor_charge(&mut cursor, &mut charged);
+
+        let heap = cursor
+            .block
+            .as_ref()
+            .expect("a decoded block")
+            .heap_estimate();
+        let loc_meta = loc_metadata_bytes(&cursor.locs);
+        let raw = cursor.raw_resident_bytes();
+        assert_eq!(
+            charged, cursor.charged,
+            "the stream's running charge and the cursor's own figure move together"
+        );
+        assert_eq!(
+            charged,
+            loc_meta + raw + heap,
+            "the reconciled charge is location metadata + raw bytes held + decoded heap"
+        );
+        assert_eq!(
+            charged - loc_meta - raw,
+            heap,
+            "the reconciled decoded term equals heap_estimate() exactly"
+        );
+        assert!(
+            charged < reservation,
+            "the pre-decode ceiling ({reservation} B) must exceed the reconciled residency \
+             ({charged} B) on this fixture, or the reconcile pins nothing"
+        );
+    }
+
+    /// ADR-0979 decision 4's owed first-small/next-large test: a cursor whose
+    /// FIRST candidate block is cheaper than its SECOND must reserve the larger
+    /// figure, because `StreamCursor::refill` decodes the second block after
+    /// releasing the first.
+    ///
+    /// The fixture is one stream in one input written with 4-record blocks and
+    /// one block per row group: block 0 holds four 4-byte bodies, block 1 four
+    /// 2,000-byte bodies, so the two blocks differ only in their string-page
+    /// payload and block 1's ceiling is the larger.
+    ///
+    /// Demonstrated red by changing `cursor_reservation_bytes`'s fold from
+    /// `b_dec = b_dec.max(block_decode_ceiling_bytes(..)?)` to taking the first
+    /// candidate block's ceiling only (`if b_dec == 0 { b_dec = ... }`): the
+    /// reservation comes back as 1,696 B against the 9,701 B the second block
+    /// needs, and the equality assert fails.
+    #[tokio::test]
+    async fn reservation_takes_the_max_over_candidate_blocks_not_the_first() {
+        let long_body = "x".repeat(2_000);
+        let recs: Vec<LogRecord> = (0..4i64)
+            .map(|i| record(0, 100 + i, "tiny", Vec::new()))
+            .chain((0..4i64).map(|i| record(0, 200 + i, &format!("{long_body}{i}"), Vec::new())))
+            .collect();
+        let cfg = RlogConfig {
+            block_target_records: 4,
+            // One block per row group, so the two blocks are two locs and the
+            // cursor really releases the first before decoding the second.
+            group_target_blocks: 1,
+            ..RlogConfig::default()
+        };
+        let store = MemoryStore::new();
+        let bytes = seed_l0(&store, Uuid::from_u128(1), 1, &recs, cfg, &[]).await;
+        let catalog = stream_catalog(&store, Uuid::from_u128(1), 1, &bytes).await;
+        let (stream_id, _) = stream_ident(0);
+
+        assert_eq!(
+            catalog.pricing.block_rows,
+            vec![4, 4],
+            "the fixture must be two four-record blocks"
+        );
+        let first = block_decode_ceiling_bytes(&catalog.pricing, 0).expect("block 0 ceiling");
+        let second = block_decode_ceiling_bytes(&catalog.pricing, 1).expect("block 1 ceiling");
+        assert!(
+            first < second,
+            "the fixture's first block ({first} B) must be cheaper than its second ({second} B)"
+        );
+
+        let locs = catalog
+            .reader
+            .stream_blocks(&stream_id)
+            .expect("stream blocks")
+            .expect("input carries stream 0");
+        assert_eq!(
+            locs.len(),
+            2,
+            "one loc per block under group_target_blocks 1"
+        );
+        let two_g = locs.iter().map(|l| l.byte_len()).max().expect("a loc") * 2;
+        let expected = two_g + loc_metadata_bytes(&locs) + second;
+        let reservation = cursor_reservation_bytes(&catalog, &stream_id)
+            .expect("reservation")
+            .expect("input carries stream 0");
+        assert_eq!(
+            reservation, expected,
+            "the reservation is 2*G + location metadata + the LARGER block's ceiling"
+        );
     }
 
     /// ADR-0979 decision 4: a budget one byte below the minimum admissible
@@ -4685,13 +5229,23 @@ mod tests {
     ///
     /// The fixture is two inputs carrying stream 0 with interleaved (fully
     /// overlapping) timestamps, so both cursors must be open at the merge's
-    /// peak: the minimum admissible set is both, and its reservation is
-    /// `r_a + r_b`, computed here from the same [`cursor_reservation_bytes`] the
-    /// merge uses so the threshold is exact, not observed.
+    /// peak. The minimum admissible figure is `resident_a + r_b`, NOT
+    /// `r_a + r_b`: the first cursor is admitted at its pre-decode ceiling and
+    /// then reconciled down to what it actually holds before the second cursor's
+    /// admission reads the charge (ADR-0979 decision 4 as amended). Both terms
+    /// are computed here from the same functions the merge uses, so the
+    /// threshold is exact rather than observed, and the run at
+    /// `resident_a + r_b` only completes because the reconcile happened.
     ///
     /// Demonstrated red by raising the budget the failing run is given from
     /// `min_admissible - 1` to `min_admissible`: the second cursor then fits and
-    /// no error is returned, so `expect_err` panics.
+    /// no error is returned, so `expect_err` panics. Demonstrated red for the
+    /// reconcile by deleting BOTH `reconcile_cursor_charge` calls in
+    /// `merge_stream_into_parts` (the admission arm and the post-refill arm --
+    /// deleting only the admission one leaves this fixture reconciled by the
+    /// other, since its second cursor is admitted after the first has emitted a
+    /// record): the charge stays at `r_a` and the `charged_bytes` assert fails
+    /// 3,731 against 1,957.
     #[tokio::test]
     async fn cursor_budget_fails_closed_one_byte_below_the_minimum_admissible_set() {
         let a: Vec<LogRecord> = (0..10i64)
@@ -4707,7 +5261,13 @@ mod tests {
         let b_bytes = seed(&probe, Uuid::from_u128(2), 2, &b).await;
         let r_a = stream0_reservation(&probe, Uuid::from_u128(1), 1, &a_bytes).await;
         let r_b = stream0_reservation(&probe, Uuid::from_u128(2), 2, &b_bytes).await;
-        let min_admissible = r_a + r_b;
+        let resident_a = stream0_resident_bytes(&probe, Uuid::from_u128(1), 1, &a_bytes).await;
+        assert!(
+            resident_a < r_a,
+            "the reconcile must lower the first cursor's charge ({r_a} B ceiling, {resident_a} B \
+             resident), or this test's threshold is not the reconciled one"
+        );
+        let min_admissible = resident_a + r_b;
 
         let inputs = vec![(Uuid::from_u128(1), 1, a), (Uuid::from_u128(2), 2, b)];
         let (stream_id, _) = stream_ident(0);
@@ -4734,6 +5294,8 @@ mod tests {
                 budget_bytes,
                 required_bytes,
                 inputs_carrying_stream,
+                admission_batch_position,
+                admission_batch_len,
             } => {
                 assert_eq!(got_stream, stream_id.to_hex());
                 assert_eq!(
@@ -4741,8 +5303,8 @@ mod tests {
                     "the first cursor was open when the second was refused"
                 );
                 assert_eq!(
-                    charged_bytes, r_a,
-                    "only the first cursor's reservation was charged"
+                    charged_bytes, resident_a,
+                    "the open cursor charges its reconciled residency, not its ceiling"
                 );
                 assert_eq!(budget_bytes, min_admissible - 1);
                 assert_eq!(
@@ -4750,6 +5312,8 @@ mod tests {
                     "charged + the refused cursor's reservation"
                 );
                 assert_eq!(inputs_carrying_stream, 2);
+                assert_eq!(admission_batch_position, 0);
+                assert_eq!(admission_batch_len, 1);
             }
             other => panic!("expected MergeCursorBudgetExceeded, got {other:?}"),
         }
@@ -4767,6 +5331,97 @@ mod tests {
             with_budget, unbudgeted,
             "a budget at exactly the minimum admissible set must not change the output"
         );
+    }
+
+    /// ADR-0979 decision 4: a refusal partway through an admission BATCH reports
+    /// only what the open cursors hold, and names the position in the batch that
+    /// crossed the budget. Batch members before that position were never opened,
+    /// so their reservations are in `required_bytes` (the number a retry must
+    /// budget for) and NOT in `charged_bytes` (what memory is actually held).
+    ///
+    /// The fixture is three inputs whose stream-0 slices all start at ts 0, so
+    /// their SKIP_IDX lower bounds are equal: the first cursor bootstraps alone,
+    /// and the remaining two are admitted together as one batch of 2. The budget
+    /// is set one byte below what the whole batch needs, so the refusal lands at
+    /// batch position 1 with one cursor open.
+    ///
+    /// Demonstrated red by restoring the pre-fix accumulation (reporting
+    /// `charged_bytes` as the open charge plus the batch members already
+    /// reserved, which is what the running `charged` held before this fix):
+    /// `charged_bytes` comes back as 3,756 B against the 1,477 B the one open
+    /// cursor holds, counting a cursor that was never opened.
+    #[tokio::test]
+    async fn cursor_budget_refusal_mid_batch_reports_only_open_cursors() {
+        // Three identical-shape inputs on stream 0, all starting at ts 0, so
+        // every lower bound is 0 and the two non-bootstrap cursors are admitted
+        // in one batch.
+        let recs = |tag: &str| -> Vec<LogRecord> {
+            (0..6i64)
+                .map(|i| record(0, i * 10, tag, Vec::new()))
+                .collect()
+        };
+        let inputs = vec![
+            (Uuid::from_u128(1), 1, recs("a")),
+            (Uuid::from_u128(2), 2, recs("b")),
+            (Uuid::from_u128(3), 3, recs("c")),
+        ];
+
+        let probe = MemoryStore::new();
+        let mut seeded = Vec::new();
+        for (writer_id, seq, r) in &inputs {
+            seeded.push(seed(&probe, *writer_id, *seq, r).await);
+        }
+        let resident_a = stream0_resident_bytes(&probe, Uuid::from_u128(1), 1, &seeded[0]).await;
+        let r_b = stream0_reservation(&probe, Uuid::from_u128(2), 2, &seeded[1]).await;
+        let r_c = stream0_reservation(&probe, Uuid::from_u128(3), 3, &seeded[2]).await;
+        let batch_total = resident_a + r_b + r_c;
+
+        let store = MemoryStore::new();
+        for (writer_id, seq, r) in &inputs {
+            seed(&store, *writer_id, *seq, r).await;
+        }
+        let config = CompactorConfig {
+            merge_cursor_budget_bytes: batch_total - 1,
+            ..CompactorConfig::default()
+        };
+        let clock = FixedClock::new(sealed_now_ns());
+        let err = compact_bucket(&store, &clock, &config, &bucket())
+            .await
+            .expect_err("a budget below the batch's total must fail closed");
+        match err {
+            MaintainError::MergeCursorBudgetExceeded {
+                open_cursors,
+                charged_bytes,
+                required_bytes,
+                budget_bytes,
+                inputs_carrying_stream,
+                admission_batch_position,
+                admission_batch_len,
+                ..
+            } => {
+                assert_eq!(
+                    admission_batch_len, 2,
+                    "the two late cursors admit together"
+                );
+                assert_eq!(
+                    admission_batch_position, 1,
+                    "the second member of the batch is the one that crossed the budget"
+                );
+                assert_eq!(open_cursors, 1, "only the bootstrap cursor was ever opened");
+                assert_eq!(
+                    charged_bytes, resident_a,
+                    "the charge names what the open cursor holds, not the batch members before \
+                     the refused one"
+                );
+                assert_eq!(
+                    required_bytes, batch_total,
+                    "the retry figure is the open charge plus the batch through this position"
+                );
+                assert_eq!(budget_bytes, batch_total - 1);
+                assert_eq!(inputs_carrying_stream, 3);
+            }
+            other => panic!("expected MergeCursorBudgetExceeded, got {other:?}"),
+        }
     }
 
     /// Rewrite `obj` with its PAGE_DIR descriptor dropped from the footer,


### PR DESCRIPTION
ADR-0979 decisions 2 and 4, completing the rlog.rs chain. Cursors admit
only when their SKIP_IDX stream bounds overlap the merge frontier;
admission reserves a pre-decode ceiling priced from block shape (rows
from SKIP_IDX, columns from FIELD_DIR, string pages from PAGE_DIR, the
decoder slot spines at a conservative 480 B per width unit above the
ADR's 288 B floor), reconciles to actual residency after each decode,
and grows back to the next block's ceiling BEFORE that block decodes,
refusing typed with no await between check and decode. Once the pending
queue drains the budget still binds: every increase of the charge is
checked. MergeCursorBudgetExceeded names its site (admission batch
position, or the block a growth refused).

Three adversarial review rounds shaped this: round 1 proved the
original uncomp_len basis under-priced constant columns 10,000x and
forced the ADR amendment (PR #1015); round 2 proved the reconcile
without the grow turned the reservation sum into a transient; the final
round PASSED with every charge mutation site walked. The admission
boundary tie (deferred lower input_index at an equal-ts frontier) is
pinned by exact part hashes and reorders under a < predicate; the
admission-on/off hash equality, time-disjoint cursor drop, and
conservation tests are untouched.

Default budget re-derived with the spine term: 21.339 GiB at the
per-cursor ceiling, 18.08 GiB reconciled, either side of the 20 GiB
default. Follow-up #1019 tracks the pre-existing ungated 2*G prefetch
window the final round found.

Local gate note: crate tests green here and in the reviews' cold
worktrees; full workspace gates run in this PR's required CI.

Refs: #979