### PR TITLE
test(object-store): pin clean multipart upload moves neither abort counter

### DIFF
--- a/crates/ravel-object-store/tests/s3_http_faults.rs
+++ b/crates/ravel-object-store/tests/s3_http_faults.rs
@@ -1542,6 +1542,56 @@ async fn successful_multipart_abort_leaves_failure_counter_at_zero() {
     );
 }
 
+/// The happy path moves neither #864 counter: a multipart upload whose parts
+/// and `CompleteMultipartUpload` all succeed is reaped by the completion, so no
+/// abort is ever attempted and both counters read exactly 0. Without this, a
+/// counter that also fired on success would still pass the two failure tests
+/// above; this pins that a clean upload is silent, which is the baseline the
+/// failure counts are read against.
+#[tokio::test]
+async fn successful_multipart_upload_moves_neither_counter() {
+    let fake = FakeS3::start().await;
+    let store = fake.store();
+    // No fault scripted anywhere: every UploadPart and the CompleteMultipart
+    // succeed, so the upload is reaped by completion and never aborted.
+    let payload = Bytes::from(vec![4u8; MULTIPART_THRESHOLD + 1]);
+    store
+        .put("multipart/clean", payload.clone(), PutOptions::default())
+        .await
+        .expect("a clean multipart put must succeed");
+
+    assert_eq!(
+        fake.count(Op::CreateMultipart),
+        1,
+        "the put must have taken the multipart path"
+    );
+    assert_eq!(
+        fake.count(Op::CompleteMultipart),
+        1,
+        "a clean multipart put completes exactly once"
+    );
+    assert_eq!(
+        fake.count(Op::AbortMultipart),
+        0,
+        "a completed upload issues no abort"
+    );
+    assert_eq!(
+        store.multipart_abort_failures(),
+        0,
+        "no abort was attempted, so the failed-abort counter must be exactly 0"
+    );
+    assert_eq!(
+        store.multipart_uploads_unreaped(),
+        0,
+        "a cleanly completed upload did not end without a successful reap"
+    );
+    assert_eq!(
+        fake.object("multipart/clean").as_deref(),
+        Some(&payload[..]),
+        "the completed object must hold the uploaded bytes"
+    );
+}
+
 /// `SlowDown` inside a 200 response body is S3's documented behavior for
 /// `CompleteMultipartUpload`, and it is a protocol signal rather than a
 /// success: the client must retry it, and the upload must complete correctly

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -1450,7 +1450,9 @@ One of those lifecycle-rule requirements is not optional for any bucket Ravel
 writes to: **configure `AbortIncompleteMultipartUpload`** with a cleanup period
 of 7 days or less. Nothing in `ravel-server` reaps orphaned multipart parts, so
 a best-effort abort that itself fails, or an upload future dropped mid-flight,
-leaves parts billed until this rule reaps them. Two `S3Store` counters make that
+leaves cleanup unconfirmed: S3 can apply an abort and still return an error
+(docs/object-store-contract.md), so parts may remain billed until this rule
+reaps them. Two `S3Store` counters make that
 otherwise-silent failure observable: `multipart_abort_failures` (best-effort
 aborts whose request returned an error) and `multipart_uploads_unreaped`
 (multipart uploads that ended without a confirmed successful abort for any

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -1446,6 +1446,20 @@ and lifecycle-rule requirements, is enforced at the bucket/IAM layer
 (ADR-0042 decision 3) -- nothing in `ravel-server` configures or verifies it
 in-process, because `object_store` 0.14 exposes no such API.
 
+One of those lifecycle-rule requirements is not optional for any bucket Ravel
+writes to: **configure `AbortIncompleteMultipartUpload`** with a cleanup period
+of 7 days or less. Nothing in `ravel-server` reaps orphaned multipart parts, so
+a best-effort abort that itself fails, or an upload future dropped mid-flight,
+leaves parts billed until this rule reaps them. Two `S3Store` counters make that
+otherwise-silent failure observable: `multipart_abort_failures` (best-effort
+aborts whose request returned an error) and `multipart_uploads_unreaped`
+(multipart uploads that ended without a confirmed successful abort for any
+reason -- a failed abort, or a future dropped with its abort unresolved). A
+sustained rise in either means the lifecycle rule is the only thing bounding
+orphaned-part cost on that bucket; confirm the rule is present. See
+`docs/object-store-contract.md`'s "Required bucket configuration" for the
+normative statement and the exact semantics of both counters.
+
 `--require-bucket-protection` turns the existing, previously
 informational-only conformance probes into a startup gate so a deployment
 cannot go into production silently unprotected:


### PR DESCRIPTION
Completes #864. The counters themselves landed in ee527524 (Refs only, so the issue stayed open); the remainder was the clean-path zero-movement pin and the operations guide stating the bucket lifecycle-rule requirement beside the two metric names. The dispatched fleet task hit the 4h runtime ceiling during its gate run; this is its committed checkpoint, salvaged, rebased, and verified (s3_http_faults: 23 passed).

Fixes: #864