### PR TITLE
feat(sql): answer declared-column MIN/MAX and COUNT from SegmentRef stamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5127,6 +5127,7 @@ dependencies = [
  "criterion",
  "datafusion",
  "futures",
+ "hex",
  "proptest",
  "prost",
  "rand 0.10.2",

--- a/crates/ravel-commit/src/declared_stats.rs
+++ b/crates/ravel-commit/src/declared_stats.rs
@@ -28,9 +28,10 @@
 //!   of the predicate compare `null_count` against the segment's row count,
 //!   which no `DeclaredColumnMinMax` carries: for a stamp it is the carrying
 //!   record's own `sample_count` (`CommitRecord` field 11, `CompactionPart`
-//!   field 6). So [`decode`] stays carrier-agnostic and [`read_commit_record`]
-//!   and [`read_compaction_part`] are where those two clauses bind — and,
-//!   because those two clauses are exactly the row-count gate, they are the
+//!   field 6). So [`decode`] stays carrier-agnostic and [`read_commit_record`],
+//!   [`read_compaction_part`], and [`read_snapshot_entry_twin`] are where those
+//!   two clauses bind, and because those two clauses are exactly the row-count
+//!   gate, they are the
 //!   only functions that produce a [`ValidatedDeclaredStats`] (ADR-0873
 //!   decision 2, "where the predicate binds": coverage is unconstructable
 //!   without the full predicate).
@@ -49,36 +50,129 @@ use ravel_types::declared_stats::{
     DeclaredColumnStat, DeclaredStatError, DeclaredStatType, DeclaredStatValue,
 };
 
-/// Process-wide tally behind [`dropped_stamp_entries`].
-static DROPPED_STAMP_ENTRIES: AtomicU64 = AtomicU64::new(0);
+/// Which carrier a drop observation belongs to (ADR-0873 decision 2: the
+/// defect metric carries a carrier label, because "which writer do I look at"
+/// is the first question a nonzero value asks).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StatCarrier {
+    /// `CommitRecord.declared_column_stats` (field 20), read by
+    /// [`read_commit_record`]: a flush's own stamp.
+    CommitRecord,
+    /// `CompactionPart.declared_column_stats` (field 12), read by
+    /// [`read_compaction_part`]: a compaction or erasure-rewrite output part's
+    /// recomputed stamp.
+    CompactionPart,
+    /// `SnapshotEntry.declared_column_stats` (field 15), the fold's copy, read
+    /// through [`read_snapshot_entry_twin`].
+    SnapshotEntry,
+    /// The ADR-0850/0942 `.cstat` object's `ColumnStat` entries. Not a stamp
+    /// carrier and not read by this module at all: it is the second carrier of
+    /// the same statistics (ADR-0873 decision 4), its reader lives in
+    /// `ravel_sql`, and its refusals are reported here through
+    /// [`observe_declared_stat_drops`] so one metric covers both carriers of
+    /// one union.
+    Cstat,
+}
 
-/// How many declared-column stamp entries this process has dropped since it
-/// started: the ADR-0873 decision 2 defect metric, counted one per dropped
-/// entry.
+impl StatCarrier {
+    /// Every label, for a scrape that reports the whole set rather than only
+    /// the carriers that happened to move.
+    pub const ALL: [StatCarrier; 4] = [
+        StatCarrier::CommitRecord,
+        StatCarrier::CompactionPart,
+        StatCarrier::SnapshotEntry,
+        StatCarrier::Cstat,
+    ];
+
+    /// The stable metric label, in the dashed form ADR-0873 decision 2 names
+    /// the carriers in.
+    pub fn label(self) -> &'static str {
+        match self {
+            StatCarrier::CommitRecord => "commit-record",
+            StatCarrier::CompactionPart => "compaction-part",
+            StatCarrier::SnapshotEntry => "snapshot-entry",
+            StatCarrier::Cstat => "cstat",
+        }
+    }
+
+    /// Index into [`DROPS_OBSERVED`]. Private: the numbering is an
+    /// implementation detail of the tally, not part of the label contract.
+    fn index(self) -> usize {
+        match self {
+            StatCarrier::CommitRecord => 0,
+            StatCarrier::CompactionPart => 1,
+            StatCarrier::SnapshotEntry => 2,
+            StatCarrier::Cstat => 3,
+        }
+    }
+}
+
+/// Per-carrier tallies behind [`declared_stat_drops_observed`], indexed by
+/// [`StatCarrier::index`].
+static DROPS_OBSERVED: [AtomicU64; 4] = [
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+];
+
+/// How many declared-column statistic drops this process has OBSERVED under
+/// `carrier` since it started: the ADR-0873 decision 2 defect metric.
 ///
-/// Every read route funnels through the one predicate pass, so this covers all
-/// three carriers: a commit record ([`read_commit_record`]), a compaction or
-/// erasure-rewrite part ([`read_compaction_part`]), and a snapshot entry
-/// (`ravel_catalog::read_snapshot_entry`, which reads its entries through the
-/// same pass). A nonzero value means a writer produced a stamp no reader will
-/// spend, which is a writer defect and not a query problem: the query merely
-/// scans. Absence of stamps never touches it -- an unstamped record is the
-/// permanent, legal state of everything written before ADR-0873.
+/// Observation semantics, and the name says so because the difference matters
+/// when reading the number. Each READ of a defective carrier increments this by
+/// that read's drop count, so one defective commit record read by a thousand
+/// queries is a thousand observations, not one defect. The magnitude therefore
+/// scales with query rate and states nothing about how many distinct defective
+/// entries exist; what it states is that a defect is still being read. Alert on
+/// "nonzero", and compare rates over equal windows, never magnitudes over
+/// windows of different query volume.
+///
+/// Per-entry deduplication is deliberately absent rather than pending: it would
+/// need unbounded state keyed by (object, column) on a path walked once per
+/// segment per query, which is a memory leak in exchange for a figure whose
+/// only use is "nonzero means investigate".
+///
+/// The label names the carrier the read was over, which is what points at a
+/// writer: `commit-record` and `compaction-part` are read here,
+/// `snapshot-entry` through [`read_snapshot_entry_twin`], and `cstat` is
+/// reported by `ravel_sql`'s `.cstat` reader through
+/// [`observe_declared_stat_drops`]. Absence of statistics never touches any
+/// label: an unstamped record is the permanent, legal state of everything
+/// written before ADR-0873, and a `.cstat` object that simply carries no entry
+/// for a column is the ordinary uncovered case.
 ///
 /// Monotonic and process-local, like every other in-process anomaly tally
 /// here: a scrape reads the delta between samples.
-pub fn dropped_stamp_entries() -> u64 {
-    DROPPED_STAMP_ENTRIES.load(Ordering::Relaxed)
+pub fn declared_stat_drops_observed(carrier: StatCarrier) -> u64 {
+    DROPS_OBSERVED[carrier.index()].load(Ordering::Relaxed)
 }
 
-/// Add `count` dropped entries to the defect metric. Called once per read
-/// pass, with the pass's whole drop count, so the metric moves by exactly the
-/// number of entries no reader will spend.
-fn record_dropped(count: usize) {
+/// The same metric summed over every carrier label, for a caller that wants the
+/// one-number "is anything defective at all" signal. Same observation
+/// semantics as [`declared_stat_drops_observed`], and the sum of a set of
+/// per-carrier reads that are not taken atomically together, so it is a
+/// snapshot for alerting and not an accounting identity.
+pub fn declared_stat_drops_observed_total() -> u64 {
+    StatCarrier::ALL
+        .iter()
+        .map(|carrier| declared_stat_drops_observed(*carrier))
+        .sum()
+}
+
+/// Record `count` drop observations under `carrier`.
+///
+/// Public because one carrier of the ADR-0873 decision 4 union is read outside
+/// this crate: `ravel_sql`'s `.cstat` reader refuses a duplicated column name
+/// and an entry whose extrema presence disagrees with its row accounting, and
+/// those refusals are the same defect class as a dropped stamp entry, under the
+/// [`StatCarrier::Cstat`] label. Call it once per refusal, at the site that
+/// refuses.
+pub fn observe_declared_stat_drops(carrier: StatCarrier, count: usize) {
     if count == 0 {
         return;
     }
-    DROPPED_STAMP_ENTRIES.fetch_add(count as u64, Ordering::Relaxed);
+    DROPS_OBSERVED[carrier.index()].fetch_add(count as u64, Ordering::Relaxed);
 }
 
 /// Why one `DeclaredColumnMinMax` entry was dropped on decode.
@@ -147,8 +241,9 @@ pub struct DroppedStatEntry {
 /// record's own row count. That guarantee is enforced by construction, not by
 /// convention: the fields are private and the constructor
 /// ([`decode_all_against_rows`]) is private to this module, so the only paths
-/// to a `ValidatedDeclaredStats` outside this module are [`read_commit_record`]
-/// and [`read_compaction_part`], each of which supplies the carrier's row
+/// to a `ValidatedDeclaredStats` outside this module are [`read_commit_record`],
+/// [`read_compaction_part`], and [`read_snapshot_entry_twin`], each of which
+/// supplies the carrier's row
 /// count. There is no public constructor and no public `decode_all`: a caller
 /// cannot obtain coverage without the row count, which is the whole point of
 /// binding the predicate at the point of use rather than at the decode
@@ -280,10 +375,15 @@ fn row_count_defect(stat: &DeclaredColumnStat, sample_count: u64) -> Option<Decl
 ///
 /// Private to the module by design (ADR-0873 decision 2): coverage must be
 /// unconstructable without the full predicate, so the only public entry points
-/// are [`read_commit_record`] and [`read_compaction_part`], which always pass
-/// `Some(sample_count)`. `sample_count` is `None` only for the module's own
-/// tests exercising the entry-local clauses in isolation, in which case clauses
-/// 4 and 5 are not decidable and the pass checks the entry-local clauses only.
+/// are [`read_commit_record`], [`read_compaction_part`], and
+/// [`read_snapshot_entry_twin`], which always pass `Some(sample_count)`.
+/// `sample_count` is `None` only for the module's own tests exercising the
+/// entry-local clauses in isolation, in which case clauses 4 and 5 are not
+/// decidable and the pass checks the entry-local clauses only.
+///
+/// `carrier` labels this pass's drop observations. It is a parameter rather
+/// than a property of the entries because the entries of all three stamp
+/// carriers are the same message: only the caller knows which record it read.
 ///
 /// Never fails: a defective statistic leaves its column uncovered, it does not
 /// make the record unreadable. Never fails on entry count either: the list is
@@ -295,6 +395,7 @@ fn row_count_defect(stat: &DeclaredColumnStat, sample_count: u64) -> Option<Decl
 fn decode_all_against_rows(
     entries: &[DeclaredColumnMinMax],
     sample_count: Option<u64>,
+    carrier: StatCarrier,
 ) -> ValidatedDeclaredStats {
     let mut covered = Vec::new();
     let mut dropped = Vec::new();
@@ -337,7 +438,7 @@ fn decode_all_against_rows(
             reason,
         });
     }
-    record_dropped(dropped.len());
+    observe_declared_stat_drops(carrier, dropped.len());
     ValidatedDeclaredStats { covered, dropped }
 }
 
@@ -349,12 +450,41 @@ pub fn stamp_commit_record(record: &mut CommitRecord, stats: &[DeclaredColumnSta
 }
 
 /// Read a commit record's declared-column statistics, reconciled against the
-/// record's own row count (`sample_count`, field 11). This is one of the only
-/// two functions that yield a [`ValidatedDeclaredStats`]: passing the row count
+/// record's own row count (`sample_count`, field 11). This is one of the three
+/// functions that yield a [`ValidatedDeclaredStats`]: passing the row count
 /// here is what makes clauses 4 and 5 bind, so the returned coverage cannot
 /// exist without them.
 pub fn read_commit_record(record: &CommitRecord) -> ValidatedDeclaredStats {
-    decode_all_against_rows(&record.declared_column_stats, Some(record.sample_count))
+    decode_all_against_rows(
+        &record.declared_column_stats,
+        Some(record.sample_count),
+        StatCarrier::CommitRecord,
+    )
+}
+
+/// Read a snapshot entry's stamps through the commit-record twin the catalog
+/// side builds for them (`SnapshotEntry.declared_column_stats`, field 15, whose
+/// message is a field-for-field mirror of the commit-side one, ADR-0873
+/// decision 1), labelling this pass's drop observations
+/// [`StatCarrier::SnapshotEntry`].
+///
+/// The predicate is identical to [`read_commit_record`]'s -- a second
+/// implementation is a second thing to keep in agreement -- and so is the row
+/// count it binds against: `twin.sample_count` must be the ENTRY's own row
+/// count. The only thing this function adds is the label, which exists because a
+/// drop on the fold's copy points at a different writer than a drop on the
+/// record the fold copied from.
+///
+/// `ravel_catalog::read_snapshot_entry` still calls [`read_commit_record`] on
+/// its twin, so today's snapshot-entry drops are observed under the
+/// `commit-record` label; re-pointing that one call site here is the remaining
+/// step, and lives in a crate ADR-0873 wave 4 does not touch.
+pub fn read_snapshot_entry_twin(twin: &CommitRecord) -> ValidatedDeclaredStats {
+    decode_all_against_rows(
+        &twin.declared_column_stats,
+        Some(twin.sample_count),
+        StatCarrier::SnapshotEntry,
+    )
 }
 
 /// Stamp one compaction/rewrite output part's declared-column statistics
@@ -366,10 +496,14 @@ pub fn stamp_compaction_part(part: &mut CompactionPart, stats: &[DeclaredColumnS
 
 /// Read one compaction/rewrite output part's declared-column statistics,
 /// reconciled against the part's own row count (`sample_count`, field 6). Like
-/// [`read_commit_record`], this is one of the only two producers of a
+/// [`read_commit_record`], this is one of the three producers of a
 /// [`ValidatedDeclaredStats`].
 pub fn read_compaction_part(part: &CompactionPart) -> ValidatedDeclaredStats {
-    decode_all_against_rows(&part.declared_column_stats, Some(part.sample_count))
+    decode_all_against_rows(
+        &part.declared_column_stats,
+        Some(part.sample_count),
+        StatCarrier::CompactionPart,
+    )
 }
 
 #[cfg(test)]
@@ -394,7 +528,7 @@ mod tests {
     /// functions wrap, exposed here only to pin the entry-local clauses in
     /// isolation.
     fn decode_all(entries: &[DeclaredColumnMinMax]) -> ValidatedDeclaredStats {
-        super::decode_all_against_rows(entries, None)
+        super::decode_all_against_rows(entries, None, StatCarrier::CommitRecord)
     }
 
     /// A `CommitRecord` as a writer that predates ADR-0873 encodes it: the

--- a/crates/ravel-commit/src/declared_stats.rs
+++ b/crates/ravel-commit/src/declared_stats.rs
@@ -38,7 +38,8 @@
 //!   takes only [`DeclaredColumnStat`]s, whose constructor is the typed
 //!   boundary that refuses ineligible types (ADR-0873 decision 2).
 
-use std::collections::HashSet;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use ravel_proto::commit::v1::{
     CommitRecord, CompactionPart, DeclaredColumnMinMax, DeclaredColumnStatValue,
@@ -47,6 +48,38 @@ use ravel_proto::commit::v1::{
 use ravel_types::declared_stats::{
     DeclaredColumnStat, DeclaredStatError, DeclaredStatType, DeclaredStatValue,
 };
+
+/// Process-wide tally behind [`dropped_stamp_entries`].
+static DROPPED_STAMP_ENTRIES: AtomicU64 = AtomicU64::new(0);
+
+/// How many declared-column stamp entries this process has dropped since it
+/// started: the ADR-0873 decision 2 defect metric, counted one per dropped
+/// entry.
+///
+/// Every read route funnels through the one predicate pass, so this covers all
+/// three carriers: a commit record ([`read_commit_record`]), a compaction or
+/// erasure-rewrite part ([`read_compaction_part`]), and a snapshot entry
+/// (`ravel_catalog::read_snapshot_entry`, which reads its entries through the
+/// same pass). A nonzero value means a writer produced a stamp no reader will
+/// spend, which is a writer defect and not a query problem: the query merely
+/// scans. Absence of stamps never touches it -- an unstamped record is the
+/// permanent, legal state of everything written before ADR-0873.
+///
+/// Monotonic and process-local, like every other in-process anomaly tally
+/// here: a scrape reads the delta between samples.
+pub fn dropped_stamp_entries() -> u64 {
+    DROPPED_STAMP_ENTRIES.load(Ordering::Relaxed)
+}
+
+/// Add `count` dropped entries to the defect metric. Called once per read
+/// pass, with the pass's whole drop count, so the metric moves by exactly the
+/// number of entries no reader will spend.
+fn record_dropped(count: usize) {
+    if count == 0 {
+        return;
+    }
+    DROPPED_STAMP_ENTRIES.fetch_add(count as u64, Ordering::Relaxed);
+}
 
 /// Why one `DeclaredColumnMinMax` entry was dropped on decode.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
@@ -83,8 +116,11 @@ pub enum DeclaredStatDefect {
         null_count: u64,
         sample_count: u64,
     },
-    /// Two entries name the same column. Which one wins is undefined, so
-    /// neither is trusted beyond the first.
+    /// Two or more entries name the same column. Which one wins is undefined,
+    /// so ALL of them are dropped and the column is uncovered for this segment
+    /// (ADR-0873 clause 6: keeping any one duplicate is silently picking
+    /// between two claims about one immutable record). Every occurrence of the
+    /// name carries this reason, including the first.
     #[error("duplicate entry for declared column {0:?}")]
     DuplicateName(String),
 }
@@ -262,17 +298,26 @@ fn decode_all_against_rows(
 ) -> ValidatedDeclaredStats {
     let mut covered = Vec::new();
     let mut dropped = Vec::new();
-    // Names, not decoded stats: the name is stored verbatim, and borrowing
-    // from `entries` keeps the set independent of the pushes into `covered`.
-    let mut seen: HashSet<&str> = HashSet::with_capacity(entries.len());
+    // Clause 6 needs the whole entry set before any entry can be judged: a
+    // duplicated name yields NO coverage, so whether the first occurrence is
+    // trustworthy depends on an entry that comes after it. One counting pass,
+    // then one judging pass. Names, not decoded stats: the name is stored
+    // verbatim, so borrowing from `entries` costs no allocation per entry.
+    let mut occurrences: HashMap<&str, usize> = HashMap::with_capacity(entries.len());
+    for entry in entries.iter() {
+        *occurrences.entry(entry.name.as_str()).or_insert(0) += 1;
+    }
     for (index, entry) in entries.iter().enumerate() {
-        // The name is claimed by its FIRST occurrence in record order, valid
-        // or not: which of two same-name entries wins is undefined, so a
-        // later entry must never gain coverage because an earlier one was
-        // dropped for its own defect. Reserving before validation is what
-        // enforces that.
-        let first_occurrence = seen.insert(entry.name.as_str());
-        let reason = if !first_occurrence {
+        // A duplicated name is dropped in EVERY occurrence, first included:
+        // which of two same-name entries wins is undefined, and a reader that
+        // keeps one is silently picking between two claims about one immutable
+        // record -- the divergence ADR-0873 clause 6 forbids ("no coverage at
+        // all, from every reader, under either ordering"). The defect belongs
+        // to the name, so it is reported before the entry's own validity is
+        // consulted: an individually valid entry beside a duplicate of itself
+        // is still no coverage.
+        let duplicated = occurrences.get(entry.name.as_str()).is_some_and(|n| *n > 1);
+        let reason = if duplicated {
             DeclaredStatDefect::DuplicateName(entry.name.clone())
         } else {
             match decode(entry) {
@@ -292,6 +337,7 @@ fn decode_all_against_rows(
             reason,
         });
     }
+    record_dropped(dropped.len());
     ValidatedDeclaredStats { covered, dropped }
 }
 
@@ -738,35 +784,48 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_column_entries_keep_only_the_first() {
-        // Both orderings of the same duplicate pair. A resolution that keeps
-        // whichever entry it prefers (widest range, highest null count, last
-        // seen) satisfies one ordering and fails the other; only first-wins
-        // satisfies both.
+    fn duplicate_column_entries_all_drop() {
+        // Both orderings of the same duplicate pair, which is what makes this
+        // test able to fail: any pick-one resolution (first-wins, last-wins,
+        // widest range, highest null count) satisfies whichever ordering puts
+        // its pick where the assertion looks, so a single ordering cannot
+        // distinguish "no coverage" from "a pick that happens to match".
+        // ADR-0873 clause 6 fixes the agreed answer as no coverage at all.
         let narrow = i64_stat("EventDate", 1, 2, 0);
         let wide = i64_stat("EventDate", 100, 200, 5);
         for (first, second) in [(&narrow, &wide), (&wide, &narrow)] {
             let entries = vec![encode(first), encode(second)];
             let read = decode_all(&entries);
-            // The exact surviving entry, not just its name or its count.
-            assert_eq!(read.covered().to_vec(), vec![first.clone()]);
-            assert_eq!(read.dropped().len(), 1);
-            // The exact dropped index, which the defect counter attributes by.
+            assert!(
+                read.covered().is_empty(),
+                "a duplicated name grants no coverage at all"
+            );
+            assert_eq!(read.column("EventDate"), None);
+            // BOTH occurrences are dropped, at their exact indices, which is
+            // what the defect counter attributes by.
             assert_eq!(
-                read.dropped()[0],
-                DroppedStatEntry {
-                    index: 1,
-                    name: "EventDate".to_string(),
-                    reason: DeclaredStatDefect::DuplicateName("EventDate".to_string()),
-                }
+                read.dropped().to_vec(),
+                vec![
+                    DroppedStatEntry {
+                        index: 0,
+                        name: "EventDate".to_string(),
+                        reason: DeclaredStatDefect::DuplicateName("EventDate".to_string()),
+                    },
+                    DroppedStatEntry {
+                        index: 1,
+                        name: "EventDate".to_string(),
+                        reason: DeclaredStatDefect::DuplicateName("EventDate".to_string()),
+                    },
+                ]
             );
         }
     }
 
     #[test]
     fn duplicates_do_not_disturb_the_order_of_the_entries_around_them() {
-        // Order is record order for both lists, and a duplicate drops out of
-        // the middle without reordering what follows it.
+        // Order is record order for both lists, and a duplicated name drops
+        // out entirely -- every occurrence of it -- without reordering the
+        // singly-named entries around it.
         let entries = vec![
             encode(&i64_stat("Aaa", 1, 2, 0)),
             encode(&i64_stat("Bbb", 3, 4, 0)),
@@ -775,20 +834,13 @@ mod tests {
             encode(&i64_stat("Bbb", 9, 10, 0)),
         ];
         let read = decode_all(&entries);
-        assert_eq!(
-            read.covered().to_vec(),
-            vec![
-                i64_stat("Aaa", 1, 2, 0),
-                i64_stat("Bbb", 3, 4, 0),
-                i64_stat("Ccc", 7, 8, 0),
-            ]
-        );
+        assert_eq!(read.covered().to_vec(), vec![i64_stat("Ccc", 7, 8, 0)]);
         assert_eq!(
             read.dropped()
                 .iter()
                 .map(|d| (d.index, d.name.as_str()))
                 .collect::<Vec<_>>(),
-            vec![(2, "Aaa"), (4, "Bbb")]
+            vec![(0, "Aaa"), (1, "Bbb"), (2, "Aaa"), (4, "Bbb")]
         );
     }
 
@@ -1035,16 +1087,17 @@ mod tests {
     }
 
     #[test]
-    fn an_invalid_first_duplicate_never_lets_a_later_one_gain_coverage() {
-        // A name is claimed by its FIRST occurrence in record order, valid or
-        // not: which of two same-name entries wins is undefined (the
-        // DuplicateName clause), so the column stays uncovered even when the
-        // first occurrence was dropped for a defect of its own and the later
-        // occurrence is individually valid. Before the reserve-first fix the
-        // later entry entered `covered`.
+    fn an_invalid_duplicate_never_lets_its_twin_gain_coverage() {
+        // A duplicated name grants no coverage in any occurrence (ADR-0873
+        // clause 6), so an individually valid entry stays uncovered when
+        // another entry claims its name -- even one dropped for a defect of
+        // its own. The name is the conviction boundary, not the entry, so both
+        // occurrences report DuplicateName rather than the first reporting its
+        // own defect: the reader never got far enough to judge either entry on
+        // its merits.
         let entries = vec![
-            // Index 0: row-count defect (extrema present over an all-NULL
-            // column) -- dropped for its own reason, but it still claims "d".
+            // Index 0: individually defective too (extrema present over an
+            // all-NULL column), and it claims "d".
             encode(&i64_stat("d", 1, 9, 7)),
             // Index 1: individually valid, same name -- must NOT be covered.
             encode(&i64_stat("d", 1, 9, 3)),
@@ -1056,17 +1109,17 @@ mod tests {
         assert_eq!(read.column("d"), None);
         assert_eq!(read.column("ok").map(|s| s.name()), Some("ok"));
         assert_eq!(read.dropped().len(), 2);
-        assert_eq!(read.dropped()[0].index, 0);
-        assert!(matches!(
-            read.dropped()[0].reason,
-            DeclaredStatDefect::Invalid(DeclaredStatError::PresenceMismatch { .. })
-                | DeclaredStatDefect::PresenceDisagreesWithNullCount { .. }
-        ));
-        assert_eq!(read.dropped()[1].index, 1);
-        assert!(matches!(
-            read.dropped()[1].reason,
-            DeclaredStatDefect::DuplicateName(ref n) if n == "d"
-        ));
+        for (slot, index) in [(0usize, 0usize), (1, 1)] {
+            assert_eq!(read.dropped()[slot].index, index);
+            assert!(
+                matches!(
+                    read.dropped()[slot].reason,
+                    DeclaredStatDefect::DuplicateName(ref n) if n == "d"
+                ),
+                "got {:?}",
+                read.dropped()[slot].reason
+            );
+        }
     }
 
     #[test]

--- a/crates/ravel-commit/tests/declared_stat_drop_counter.rs
+++ b/crates/ravel-commit/tests/declared_stat_drop_counter.rs
@@ -241,11 +241,25 @@ fn a_snapshot_entry_twin_observes_under_its_own_label() {
 /// else. The total is the sum over labels, so it moves with them.
 #[test]
 fn the_cstat_label_is_reportable_from_outside_this_crate() {
+    // Hold the serialising lock across the WHOLE assertion: with_delta's
+    // internal guard alone leaves windows before and after it in which a
+    // parallel test in this binary can move the process-wide total.
+    let _guard = counter_lock();
     let before_total = declared_stat_drops_observed_total();
-    let ((), delta, others) = with_delta(StatCarrier::Cstat, || {
-        observe_declared_stat_drops(StatCarrier::Cstat, 3);
-    });
-    assert_eq!(delta, 3);
+    let before = observed_all();
+    observe_declared_stat_drops(StatCarrier::Cstat, 3);
+    let after = observed_all();
+    let mut mine = 0;
+    let mut others = 0;
+    for ((label, b), a) in StatCarrier::ALL.iter().zip(before.iter()).zip(after.iter()) {
+        let delta = a - b;
+        if *label == StatCarrier::Cstat {
+            mine = delta;
+        } else {
+            others += delta;
+        }
+    }
+    assert_eq!(mine, 3);
     assert_eq!(others, 0, "a .cstat refusal is not a stamp-carrier drop");
     assert_eq!(
         declared_stat_drops_observed_total() - before_total,
@@ -254,11 +268,13 @@ fn the_cstat_label_is_reportable_from_outside_this_crate() {
     );
 
     // Zero is not an event: a reader that refuses nothing must not move the
-    // metric, or every clean read would look like a defect.
-    let ((), delta, others) = with_delta(StatCarrier::Cstat, || {
-        observe_declared_stat_drops(StatCarrier::Cstat, 0);
-    });
-    assert_eq!((delta, others), (0, 0));
+    // metric, or every clean read would look like a defect. Still under the
+    // held guard above, so no parallel test can interleave (and calling
+    // with_delta here would deadlock on the same lock).
+    let zero_before = observed_all();
+    observe_declared_stat_drops(StatCarrier::Cstat, 0);
+    let zero_after = observed_all();
+    assert_eq!(zero_before, zero_after, "a zero observation moves nothing");
 }
 
 /// The label set is complete and its strings are the ones ADR-0873 decision 2

--- a/crates/ravel-commit/tests/declared_stat_drop_counter.rs
+++ b/crates/ravel-commit/tests/declared_stat_drop_counter.rs
@@ -1,14 +1,19 @@
 //! The ADR-0873 decision 2 defect metric: every stamp entry a reader drops is
-//! counted, so a writer emitting stamps no reader will spend is detectable
-//! exactly where coverage is spent rather than showing up as a mysteriously
-//! slow query.
+//! counted, under the label of the carrier that was read, so a writer emitting
+//! stamps no reader will spend is detectable exactly where coverage is spent
+//! rather than showing up as a mysteriously slow query.
+//!
+//! The metric has OBSERVATION semantics, which the tests here pin as intended
+//! behaviour rather than as an accident: each read of a defective carrier
+//! increments it again, because a per-entry dedup would need unbounded state
+//! keyed by (object, column) on a path walked once per segment per query.
 //!
 //! This lives in its own integration binary on purpose.
-//! `ravel_commit::declared_stats::dropped_stamp_entries` is a process-wide
-//! monotonic tally, so an exact-delta assertion is only meaningful when the
-//! test knows every other reader running in the same process. Here that set is
-//! this file, and the lock below serialises it; in the crate's `--lib` binary
-//! it would be every predicate test at once, racing.
+//! `ravel_commit::declared_stats::declared_stat_drops_observed` is a
+//! process-wide monotonic tally, so an exact-delta assertion is only meaningful
+//! when the test knows every other reader running in the same process. Here
+//! that set is this file, and the lock below serialises it; in the crate's
+//! `--lib` binary it would be every predicate test at once, racing.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -16,8 +21,9 @@ use std::sync::{Mutex, MutexGuard};
 
 use prost::Message;
 use ravel_commit::declared_stats::{
-    DeclaredStatDefect, ValidatedDeclaredStats, dropped_stamp_entries, encode, read_commit_record,
-    read_compaction_part, stamp_commit_record,
+    DeclaredStatDefect, StatCarrier, ValidatedDeclaredStats, declared_stat_drops_observed,
+    declared_stat_drops_observed_total, encode, observe_declared_stat_drops, read_commit_record,
+    read_compaction_part, read_snapshot_entry_twin, stamp_commit_record,
 };
 use ravel_commit::record::{self, NewCommitRecord};
 use ravel_proto::commit::v1::{
@@ -113,13 +119,36 @@ fn decoded_part(entries: Vec<DeclaredColumnMinMax>) -> CompactionPart {
     CompactionPart::decode(p.encode_to_vec().as_slice()).expect("part decodes")
 }
 
-/// Run `read` and return its result plus the exact movement of the defect
-/// metric across it.
-fn with_delta<T>(read: impl FnOnce() -> T) -> (T, u64) {
+/// Every label's tally, in [`StatCarrier::ALL`] order.
+fn observed_all() -> Vec<u64> {
+    StatCarrier::ALL
+        .iter()
+        .map(|carrier| declared_stat_drops_observed(*carrier))
+        .collect()
+}
+
+/// Run `read` and return its result, `carrier`'s observation delta across it,
+/// and the summed delta of every OTHER label.
+///
+/// The second figure is the label assertion: a metric that counts the right
+/// number of drops under the wrong carrier is as unusable as one that does not
+/// count them, since the label is what names the writer to look at.
+fn with_delta<T>(carrier: StatCarrier, read: impl FnOnce() -> T) -> (T, u64, u64) {
     let _guard = counter_lock();
-    let before = dropped_stamp_entries();
+    let before = observed_all();
     let out = read();
-    (out, dropped_stamp_entries() - before)
+    let after = observed_all();
+    let mut mine = 0;
+    let mut others = 0;
+    for ((label, b), a) in StatCarrier::ALL.iter().zip(before.iter()).zip(after.iter()) {
+        let delta = a - b;
+        if *label == carrier {
+            mine = delta;
+        } else {
+            others += delta;
+        }
+    }
+    (out, mine, others)
 }
 
 /// A stamp entry whose `declared_type` is ADR-0101's `F64` tag: representable
@@ -140,12 +169,15 @@ fn f64_tagged_entry(name: &str) -> DeclaredColumnMinMax {
 }
 
 /// Test 5: a validation-failed stamp moves the metric exactly once per dropped
-/// entry, on both commit-side read routes, and the valid entries beside it
-/// keep their coverage (the metric counts drops, not records).
+/// entry, on both commit-side read routes and under each route's OWN label, and
+/// the valid entries beside it keep their coverage (the metric counts drops, not
+/// records).
 ///
-/// Prove-the-test: delete the `record_dropped(dropped.len())` call in
-/// `decode_all_against_rows` (crates/ravel-commit/src/declared_stats.rs) and
-/// both delta assertions read 0 instead of 2.
+/// Prove-the-test: delete the `observe_declared_stat_drops(carrier,
+/// dropped.len())` call in `decode_all_against_rows`
+/// (crates/ravel-commit/src/declared_stats.rs) and both delta assertions read 0
+/// instead of 2; pass `StatCarrier::CommitRecord` from `read_compaction_part`
+/// and the part route's `others` assertion reads 2 with `mine` at 0.
 #[test]
 fn validation_failures_move_the_metric_once_per_dropped_entry() {
     let entries = vec![
@@ -159,8 +191,11 @@ fn validation_failures_move_the_metric_once_per_dropped_entry() {
         encode(&i64_stat("Latency", 1, 2, 0)),
     ];
 
-    let (read, delta) = with_delta(|| read_commit_record(&decoded_record(entries.clone())));
+    let (read, delta, others) = with_delta(StatCarrier::CommitRecord, || {
+        read_commit_record(&decoded_record(entries.clone()))
+    });
     assert_eq!(delta, 2, "exactly the two defective entries");
+    assert_eq!(others, 0, "under the commit-record label only");
     assert_eq!(read.dropped().len(), 2);
     assert_eq!(read.covered().len(), 2);
     assert!(matches!(
@@ -172,9 +207,75 @@ fn validation_failures_move_the_metric_once_per_dropped_entry() {
         DeclaredStatDefect::Invalid(_)
     ));
 
-    let (read, delta) = with_delta(|| read_compaction_part(&decoded_part(entries)));
+    let (read, delta, others) = with_delta(StatCarrier::CompactionPart, || {
+        read_compaction_part(&decoded_part(entries))
+    });
     assert_eq!(delta, 2, "the part route counts the same two drops");
+    assert_eq!(
+        others, 0,
+        "and counts them under compaction-part, not under the record label"
+    );
     assert_eq!(read.covered().len(), 2);
+}
+
+/// The third stamp carrier's label: a snapshot entry read through
+/// [`read_snapshot_entry_twin`] observes its drops under `snapshot-entry`, so a
+/// defective fold copy is distinguishable from a defective record.
+///
+/// Prove-the-test: change `read_snapshot_entry_twin` to pass
+/// `StatCarrier::CommitRecord` and `mine` reads 0 with `others` at 1.
+#[test]
+fn a_snapshot_entry_twin_observes_under_its_own_label() {
+    let twin = decoded_record(vec![f64_tagged_entry("Ratio")]);
+    let (read, delta, others) = with_delta(StatCarrier::SnapshotEntry, || {
+        read_snapshot_entry_twin(&twin)
+    });
+    assert_eq!(delta, 1, "one ineligible entry on the fold's copy");
+    assert_eq!(others, 0);
+    assert!(read.covered().is_empty());
+}
+
+/// The `.cstat` label, which no reader in this crate produces: `ravel_sql`'s
+/// `.cstat` reader reports its refusals through
+/// [`observe_declared_stat_drops`], and they land under `cstat` and nowhere
+/// else. The total is the sum over labels, so it moves with them.
+#[test]
+fn the_cstat_label_is_reportable_from_outside_this_crate() {
+    let before_total = declared_stat_drops_observed_total();
+    let ((), delta, others) = with_delta(StatCarrier::Cstat, || {
+        observe_declared_stat_drops(StatCarrier::Cstat, 3);
+    });
+    assert_eq!(delta, 3);
+    assert_eq!(others, 0, "a .cstat refusal is not a stamp-carrier drop");
+    assert_eq!(
+        declared_stat_drops_observed_total() - before_total,
+        3,
+        "the total sums the labels"
+    );
+
+    // Zero is not an event: a reader that refuses nothing must not move the
+    // metric, or every clean read would look like a defect.
+    let ((), delta, others) = with_delta(StatCarrier::Cstat, || {
+        observe_declared_stat_drops(StatCarrier::Cstat, 0);
+    });
+    assert_eq!((delta, others), (0, 0));
+}
+
+/// The label set is complete and its strings are the ones ADR-0873 decision 2
+/// names, since a dashboard query is written against the string and a renamed
+/// label is a silently empty panel.
+#[test]
+fn every_carrier_has_its_adr_label() {
+    let labels: Vec<&str> = StatCarrier::ALL.iter().map(|c| c.label()).collect();
+    assert_eq!(
+        labels,
+        vec![
+            "commit-record",
+            "compaction-part",
+            "snapshot-entry",
+            "cstat"
+        ]
+    );
 }
 
 /// Test 4, metric half: a record stamping one name twice drops BOTH entries
@@ -192,8 +293,11 @@ fn a_duplicated_name_moves_the_metric_by_both_entries() {
             encode(&i64_stat("EventDate", b, b + 10, 0)),
             encode(&i64_stat("Latency", 7, 8, 0)),
         ];
-        let (read, delta) = with_delta(|| read_commit_record(&decoded_record(entries)));
+        let (read, delta, others) = with_delta(StatCarrier::CommitRecord, || {
+            read_commit_record(&decoded_record(entries))
+        });
         assert_eq!(delta, 2, "both occurrences of the duplicated name");
+        assert_eq!(others, 0);
         assert_eq!(
             read.column("EventDate"),
             None,
@@ -209,28 +313,53 @@ fn a_duplicated_name_moves_the_metric_by_both_entries() {
 /// report every pre-ADR-0873 record in the tenant as a writer bug.
 #[test]
 fn absence_and_full_validity_leave_the_metric_untouched() {
-    let (read, delta) = with_delta(|| read_commit_record(&base_record()));
+    let (read, delta, others) = with_delta(StatCarrier::CommitRecord, || {
+        read_commit_record(&base_record())
+    });
     assert_eq!(delta, 0, "an unstamped record is not a defect");
+    assert_eq!(others, 0, "and moves no other label either");
     assert!(read.covered().is_empty());
     assert!(read.dropped().is_empty());
 
     let mut stamped = base_record();
     stamp_commit_record(&mut stamped, &[i64_stat("EventDate", 0, 19_000, 3)]);
     let stamped = record::decode(&record::encode(&stamped)).expect("decodes");
-    let (read, delta) = with_delta(|| read_commit_record(&stamped));
+    let (read, delta, others) =
+        with_delta(StatCarrier::CommitRecord, || read_commit_record(&stamped));
     assert_eq!(delta, 0, "a valid stamp is not a defect");
+    assert_eq!(others, 0);
     assert_eq!(read.covered().len(), 1);
 }
 
-/// The metric only ever moves forward, and only through the predicate pass:
-/// reading the same defective record twice counts two drops, because coverage
-/// is judged per read and each read spent (and refused) the entry again.
+/// Observation semantics, asserted as the intended contract and not as an
+/// incidental consequence: the metric counts one observation per READ of a
+/// defective carrier, so reading the same defective record twice moves it twice.
+///
+/// This is what the name `declared_stat_drops_observed` states, and it is a
+/// deliberate trade rather than a missing dedup. A "distinct defective entries"
+/// figure would need unbounded state keyed by (object, column) held for the life
+/// of the process, on a path walked once per segment per query; the figure it
+/// would buy is only ever read as "nonzero, go look". The consequence a reader
+/// of the metric must know is exactly what this test pins: the magnitude scales
+/// with read rate, so it is comparable across equal windows and meaningless as
+/// an absolute count of defects.
+///
+/// Prove-the-test: memoise the pass's drop count per record (or count only the
+/// first read of a given `content_hash`) and the second delta reads 0.
 #[test]
-fn the_metric_is_monotonic_across_repeated_reads() {
+fn each_read_of_a_defective_record_is_its_own_observation() {
     let record = decoded_record(vec![f64_tagged_entry("Ratio")]);
-    let (_, first) = with_delta(|| read_commit_record(&record));
-    let (_, second) = with_delta(|| read_commit_record(&record));
-    assert_eq!((first, second), (1, 1));
+    let (_, first, first_others) =
+        with_delta(StatCarrier::CommitRecord, || read_commit_record(&record));
+    let (_, second, second_others) =
+        with_delta(StatCarrier::CommitRecord, || read_commit_record(&record));
+    assert_eq!(
+        (first, second),
+        (1, 1),
+        "one observation per read, by design: the second read spent and refused \
+         the same entry again"
+    );
+    assert_eq!((first_others, second_others), (0, 0));
 }
 
 /// A `ValidatedDeclaredStats` is the coverage grant, and this file reads one

--- a/crates/ravel-commit/tests/declared_stat_drop_counter.rs
+++ b/crates/ravel-commit/tests/declared_stat_drop_counter.rs
@@ -1,0 +1,245 @@
+//! The ADR-0873 decision 2 defect metric: every stamp entry a reader drops is
+//! counted, so a writer emitting stamps no reader will spend is detectable
+//! exactly where coverage is spent rather than showing up as a mysteriously
+//! slow query.
+//!
+//! This lives in its own integration binary on purpose.
+//! `ravel_commit::declared_stats::dropped_stamp_entries` is a process-wide
+//! monotonic tally, so an exact-delta assertion is only meaningful when the
+//! test knows every other reader running in the same process. Here that set is
+//! this file, and the lock below serialises it; in the crate's `--lib` binary
+//! it would be every predicate test at once, racing.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::{Mutex, MutexGuard};
+
+use prost::Message;
+use ravel_commit::declared_stats::{
+    DeclaredStatDefect, ValidatedDeclaredStats, dropped_stamp_entries, encode, read_commit_record,
+    read_compaction_part, stamp_commit_record,
+};
+use ravel_commit::record::{self, NewCommitRecord};
+use ravel_proto::commit::v1::{
+    CommitRecord, CompactionPart, DeclaredColumnMinMax, DeclaredColumnStatValue,
+    declared_column_stat_value::Kind,
+};
+use ravel_types::declared_stats::{
+    DeclaredColumnStat, DeclaredStatType, DeclaredStatValue, TYPED_ATTR_COLUMN_TYPE_F64,
+};
+use ravel_types::{Signal, TenantHash};
+use uuid::Uuid;
+
+/// Serialises every test in this file, so a delta on the process-wide counter
+/// is attributable to exactly the read this test performed.
+static COUNTER: Mutex<()> = Mutex::new(());
+
+fn counter_lock() -> MutexGuard<'static, ()> {
+    match COUNTER.lock() {
+        Ok(guard) => guard,
+        // A poisoned lock means a sibling test panicked; the counter is still
+        // sound to read, and reporting the sibling's failure twice would only
+        // obscure it.
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+/// Row count of every carrier here, and the figure clauses 4 and 5 bind
+/// against.
+const SAMPLE_COUNT: u64 = 100;
+
+fn base_record() -> CommitRecord {
+    record::build(NewCommitRecord {
+        tenant_hash: TenantHash([0x11; 16]),
+        signal: Signal::Logs,
+        shard: 3,
+        writer_id: Uuid::from_u128(7),
+        writer_epoch: 100,
+        writer_seq: 9,
+        object_size: 4096,
+        content_hash: [0x22; 32],
+        sample_count: SAMPLE_COUNT,
+        series_count: 4,
+        min_event_ts_ns: 1_000,
+        max_event_ts_ns: 2_000,
+        min_ingest_ts_ns: 1_500,
+        max_ingest_ts_ns: 2_500,
+        segment_format_version: 4,
+        created_unix_ns: 495_734 * 3_600_000_000_000,
+        ingest_hour_bucket: 495_734,
+    })
+    .expect("valid record")
+}
+
+fn base_part() -> CompactionPart {
+    CompactionPart {
+        part_index: 0,
+        first_series_id: vec![0x01; 16],
+        last_series_id: vec![0x02; 16],
+        content_hash: vec![0x03; 32],
+        object_size: 8192,
+        sample_count: SAMPLE_COUNT,
+        series_count: 8,
+        run_count: 1,
+        min_event_ts_ns: 10,
+        max_event_ts_ns: 20,
+        segment_format_version: 3,
+        declared_column_stats: vec![],
+    }
+}
+
+fn i64_stat(name: &str, min: i64, max: i64, null_count: u64) -> DeclaredColumnStat {
+    DeclaredColumnStat::new(
+        name,
+        DeclaredStatType::I64,
+        Some(DeclaredStatValue::I64(min)),
+        Some(DeclaredStatValue::I64(max)),
+        null_count,
+    )
+    .expect("valid i64 stat")
+}
+
+/// A record carrying `entries`, round-tripped through the wire so every read
+/// under test reads a decoded record.
+fn decoded_record(entries: Vec<DeclaredColumnMinMax>) -> CommitRecord {
+    let mut r = base_record();
+    r.declared_column_stats = entries;
+    record::decode(&record::encode(&r)).expect("record decodes")
+}
+
+fn decoded_part(entries: Vec<DeclaredColumnMinMax>) -> CompactionPart {
+    let mut p = base_part();
+    p.declared_column_stats = entries;
+    CompactionPart::decode(p.encode_to_vec().as_slice()).expect("part decodes")
+}
+
+/// Run `read` and return its result plus the exact movement of the defect
+/// metric across it.
+fn with_delta<T>(read: impl FnOnce() -> T) -> (T, u64) {
+    let _guard = counter_lock();
+    let before = dropped_stamp_entries();
+    let out = read();
+    (out, dropped_stamp_entries() - before)
+}
+
+/// A stamp entry whose `declared_type` is ADR-0101's `F64` tag: representable
+/// on the wire (a broken or future writer can emit one), never eligible
+/// (ADR-0873 decision 2's allowlist refuses it by name).
+fn f64_tagged_entry(name: &str) -> DeclaredColumnMinMax {
+    DeclaredColumnMinMax {
+        name: name.to_string(),
+        declared_type: TYPED_ATTR_COLUMN_TYPE_F64,
+        min: Some(DeclaredColumnStatValue {
+            kind: Some(Kind::I64(1)),
+        }),
+        max: Some(DeclaredColumnStatValue {
+            kind: Some(Kind::I64(9)),
+        }),
+        null_count: 0,
+    }
+}
+
+/// Test 5: a validation-failed stamp moves the metric exactly once per dropped
+/// entry, on both commit-side read routes, and the valid entries beside it
+/// keep their coverage (the metric counts drops, not records).
+///
+/// Prove-the-test: delete the `record_dropped(dropped.len())` call in
+/// `decode_all_against_rows` (crates/ravel-commit/src/declared_stats.rs) and
+/// both delta assertions read 0 instead of 2.
+#[test]
+fn validation_failures_move_the_metric_once_per_dropped_entry() {
+    let entries = vec![
+        // Valid.
+        encode(&i64_stat("EventDate", -5, 5, 1)),
+        // Clause 5, both-present over an all-NULL column.
+        encode(&i64_stat("Status", 200, 500, SAMPLE_COUNT)),
+        // Clause 1, an ineligible declared type.
+        f64_tagged_entry("Ratio"),
+        // Valid.
+        encode(&i64_stat("Latency", 1, 2, 0)),
+    ];
+
+    let (read, delta) = with_delta(|| read_commit_record(&decoded_record(entries.clone())));
+    assert_eq!(delta, 2, "exactly the two defective entries");
+    assert_eq!(read.dropped().len(), 2);
+    assert_eq!(read.covered().len(), 2);
+    assert!(matches!(
+        read.dropped()[0].reason,
+        DeclaredStatDefect::PresenceDisagreesWithNullCount { .. }
+    ));
+    assert!(matches!(
+        read.dropped()[1].reason,
+        DeclaredStatDefect::Invalid(_)
+    ));
+
+    let (read, delta) = with_delta(|| read_compaction_part(&decoded_part(entries)));
+    assert_eq!(delta, 2, "the part route counts the same two drops");
+    assert_eq!(read.covered().len(), 2);
+}
+
+/// Test 4, metric half: a record stamping one name twice drops BOTH entries
+/// (ADR-0873 clause 6), so the metric moves by exactly 2 -- once per dropped
+/// entry, not once per name and not once for the loser only.
+///
+/// Prove-the-test: restore the first-wins arm (reserve the name with a
+/// `HashSet` and drop only later occurrences) in `decode_all_against_rows` and
+/// this reads 1 with `EventDate` covered.
+#[test]
+fn a_duplicated_name_moves_the_metric_by_both_entries() {
+    for (a, b) in [(1i64, 2i64), (2, 1)] {
+        let entries = vec![
+            encode(&i64_stat("EventDate", a, a + 10, 0)),
+            encode(&i64_stat("EventDate", b, b + 10, 0)),
+            encode(&i64_stat("Latency", 7, 8, 0)),
+        ];
+        let (read, delta) = with_delta(|| read_commit_record(&decoded_record(entries)));
+        assert_eq!(delta, 2, "both occurrences of the duplicated name");
+        assert_eq!(
+            read.column("EventDate"),
+            None,
+            "no coverage for a duplicate"
+        );
+        assert_eq!(read.covered().len(), 1, "only Latency survives");
+    }
+}
+
+/// The metric is silent on the permanent, legal state: a record with no stamps
+/// at all, and a record whose every stamp is valid, move it by zero. Absence
+/// is not a defect (ADR-0873 decision 4), so a counter that fired on it would
+/// report every pre-ADR-0873 record in the tenant as a writer bug.
+#[test]
+fn absence_and_full_validity_leave_the_metric_untouched() {
+    let (read, delta) = with_delta(|| read_commit_record(&base_record()));
+    assert_eq!(delta, 0, "an unstamped record is not a defect");
+    assert!(read.covered().is_empty());
+    assert!(read.dropped().is_empty());
+
+    let mut stamped = base_record();
+    stamp_commit_record(&mut stamped, &[i64_stat("EventDate", 0, 19_000, 3)]);
+    let stamped = record::decode(&record::encode(&stamped)).expect("decodes");
+    let (read, delta) = with_delta(|| read_commit_record(&stamped));
+    assert_eq!(delta, 0, "a valid stamp is not a defect");
+    assert_eq!(read.covered().len(), 1);
+}
+
+/// The metric only ever moves forward, and only through the predicate pass:
+/// reading the same defective record twice counts two drops, because coverage
+/// is judged per read and each read spent (and refused) the entry again.
+#[test]
+fn the_metric_is_monotonic_across_repeated_reads() {
+    let record = decoded_record(vec![f64_tagged_entry("Ratio")]);
+    let (_, first) = with_delta(|| read_commit_record(&record));
+    let (_, second) = with_delta(|| read_commit_record(&record));
+    assert_eq!((first, second), (1, 1));
+}
+
+/// A `ValidatedDeclaredStats` is the coverage grant, and this file reads one
+/// through both public producers; naming the type here keeps the import
+/// honest about what the metric is attached to.
+#[test]
+fn both_read_routes_yield_the_validated_form() {
+    let entries = vec![encode(&i64_stat("EventDate", 1, 2, 0))];
+    let from_record: ValidatedDeclaredStats = read_commit_record(&decoded_record(entries.clone()));
+    let from_part: ValidatedDeclaredStats = read_compaction_part(&decoded_part(entries));
+    assert_eq!(from_record.covered(), from_part.covered());
+}

--- a/crates/ravel-sql/Cargo.toml
+++ b/crates/ravel-sql/Cargo.toml
@@ -12,6 +12,15 @@ workspace = true
 ravel-types = { workspace = true }
 ravel-segment = { workspace = true }
 ravel-catalog = { workspace = true }
+# Was dev-only (the endpoint tests publish real commit records rather than
+# hand-building `Snapshot`s) and is now also a library dependency: the
+# ADR-0873 decision 2 defect metric lives in
+# `ravel_commit::declared_stats`, labelled by carrier, and the `.cstat` reader
+# in `logs_scan` is the carrier whose refusals only this crate can report.
+# Splitting that metric in two would mean two things to scrape for one defect
+# class. ravel-commit does not depend on ravel-sql, and ravel-catalog already
+# depends on it, so this adds no cycle and no new crate to the build graph.
+ravel-commit = { workspace = true }
 ravel-query = { workspace = true }
 ravel-promql = { workspace = true }
 ravel-object-store = { workspace = true }
@@ -87,8 +96,6 @@ arrow-flight = { workspace = true, optional = true }
 #  - `bytes` supplies the `Bytes` the Flight protobuf fields are typed as.
 #  - `uuid` types `SegmentPin::writer_id`, one of the `SegmentRef` fields the
 #    snapshot-pinning ticket carries.
-#  - `tracing` records the full, unredacted error at the Flight error
-#    boundary, the same discipline the HTTP endpoint follows.
 #  - `blake3` keys the ticket's integrity MAC; already a
 #    workspace pin, used the same way `content_hash` fields are hashed
 #    elsewhere in the workspace, just keyed here instead of unkeyed.
@@ -97,7 +104,6 @@ tonic = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
-tracing = { workspace = true, optional = true }
 blake3 = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 
@@ -106,6 +112,18 @@ futures = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
+# `tracing` is unconditional, not gated behind `flight-sql`: two base-build
+# paths log through it. The Flight error boundary records the full, unredacted
+# error (the same discipline the HTTP endpoint follows), and
+# `logs_scan::record_carrier_conflict` records the declared-statistics carrier
+# conflict ADR-0873 decision 4 requires an operator be able to attribute to a
+# segment, which happens in `partition_statistics` with no Flight surface in
+# sight.
+tracing = { workspace = true }
+# Renders the conflicting segment's `content_hash` for that same log line: the
+# hash is what names the exact bytes both carriers claim to describe, so it is
+# the identity a report is filed against.
+hex = { workspace = true }
 # `ravel-proto` is a hard dependency, not gated behind `flight-sql`: ADR-0850's
 # metadata-only aggregate path (`logs_scan`/`metadata_agg`) reads
 # `ravel_catalog::LoadedColumnStats`, whose per-segment entries are the raw
@@ -135,7 +153,6 @@ flight-sql = [
     "dep:prost",
     "dep:bytes",
     "dep:uuid",
-    "dep:tracing",
     "dep:blake3",
     "dep:rand",
     "dep:ravel-maintain",
@@ -156,9 +173,6 @@ blake3 = { workspace = true }
 # span's bounded fields (ADR-0044 section 5), the same way
 # services/ravel-server's own span tests do.
 tracing-subscriber = { workspace = true }
-# The endpoint-level tests drive a real `Catalog`, so they publish real
-# commit records rather than hand-building `Snapshot`s.
-ravel-commit = { workspace = true }
 # Dev-only: the `alerts` table's own tests build fixtures by hand-encoding
 # RLOG attrs matching the assumed `ravel-alerting` convention, never checked
 # against that crate's actual writer. This dependency lets one test build a

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -140,7 +140,7 @@ pub use late_materialization::{
 };
 pub use logs_provider::LogsTableProvider;
 pub use logs_pushdown::{LogsPushdown, extract_logs};
-pub use logs_scan::LogsScanExec;
+pub use logs_scan::{LogsScanExec, declared_stat_carrier_conflicts};
 pub use logs_schema::{
     FIRST_DECLARED_COL, LOG_COL_ATTRS, LOG_COL_BODY, LOG_COL_FLAGS, LOG_COL_OBSERVED_TS,
     LOG_COL_SEVERITY_NUM, LOG_COL_SEVERITY_TEXT, LOG_COL_SPAN_ID, LOG_COL_TRACE_ID, LOG_COL_TS,

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -226,6 +226,7 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
 
 use datafusion::arrow::array::{
@@ -264,6 +265,7 @@ use ravel_query::{
 };
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
+use ravel_types::declared_stats::{DeclaredColumnStat, DeclaredStatType, DeclaredStatValue};
 use ravel_types::logstream::AttrValue;
 use tokio::sync::OnceCell;
 
@@ -591,6 +593,182 @@ fn declared_scalar(ty: DeclaredType, value: &ColumnValue) -> Option<ScalarValue>
         }
         _ => None,
     }
+}
+
+/// Process-wide tally behind [`declared_stat_carrier_conflicts`].
+static CARRIER_CONFLICTS: AtomicU64 = AtomicU64::new(0);
+
+/// How many times this process has found the two declared-statistics carriers
+/// disagreeing about one segment and one column (ADR-0873 decision 4).
+///
+/// A segment is immutable and both the `SegmentRef` stamp and the `.cstat`
+/// entry claim to be exact derivations of its contents, so a disagreement in
+/// `min`, `max`, or `null_count` means the writer's stamp fold, the fold's
+/// copy, the `.cstat` build, or the object itself is wrong. The query degrades
+/// to a scan (never a wrong answer), which is exactly why the tally exists: it
+/// makes the defect a ticket instead of a mysteriously slow query.
+///
+/// Monotonic and process-local; a scrape reads the delta between samples.
+pub fn declared_stat_carrier_conflicts() -> u64 {
+    CARRIER_CONFLICTS.load(Ordering::Relaxed)
+}
+
+fn record_carrier_conflict() {
+    CARRIER_CONFLICTS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// One segment's coverage of one declared column as one carrier states it.
+///
+/// `min`/`max` both absent is a coverage statement, not a gap: the column had
+/// zero non-null values in that segment, which is exact. `null_count_proven`
+/// records whether the carrier's NULL count was reconciled against the
+/// segment's row count before it got here (true for a stamp, whose validated
+/// form is proof of clauses 4 and 5; false for a `.cstat` entry, whose row
+/// accounting this path does not reconcile).
+#[derive(Clone)]
+struct SegmentCoverage {
+    min: Option<ScalarValue>,
+    max: Option<ScalarValue>,
+    null_count: u64,
+    null_count_proven: bool,
+}
+
+impl SegmentCoverage {
+    /// Whether two carriers state the same triple for one segment and column.
+    /// Exact equality on all three fields, with no widening, narrowing, or
+    /// preference for the fresher carrier: the union has no arithmetic in it.
+    fn agrees_with(&self, other: &SegmentCoverage) -> bool {
+        self.min == other.min && self.max == other.max && self.null_count == other.null_count
+    }
+}
+
+/// The exact statistics one declared column's carriers prove over every
+/// segment a scan touches, from [`LogsScanExec::declared_min_max_all`].
+///
+/// `null_count` is `None` when at least one covering carrier's NULL count was
+/// not reconciled against the segment's row count; the extrema are still
+/// exact in that case (see the method's docs).
+#[derive(Clone)]
+pub(crate) struct DeclaredExactStats {
+    pub(crate) min: ScalarValue,
+    pub(crate) max: ScalarValue,
+    pub(crate) null_count: Option<u64>,
+}
+
+/// Keep whichever of `current` and `candidate` is the extreme in the `want`
+/// direction, under `ScalarValue`'s own ordering (the comparator DataFusion's
+/// `MIN`/`MAX` accumulators apply, which is what makes the shortcut answer the
+/// same question the scan would). A tie keeps the incumbent.
+fn keep_extreme(
+    current: Option<ScalarValue>,
+    candidate: ScalarValue,
+    want: std::cmp::Ordering,
+) -> Option<ScalarValue> {
+    match current {
+        Some(cur) if candidate.partial_cmp(&cur) != Some(want) => Some(cur),
+        _ => Some(candidate),
+    }
+}
+
+/// The stamp type a declared column of `ty` may carry, or `None` when the
+/// ADR-0873 decision 2 allowlist excludes the type.
+///
+/// The float gate is here, and it is a gate rather than an accident of the
+/// current vocabulary: `DeclaredType` has no float variant today (ADR-0090
+/// declares four types), and when ADR-0101's declarable `f64` lands, this
+/// exhaustive match stops compiling until someone decides its comparator, its
+/// NaN rule, and its `-0.0` rule -- rather than the new type quietly reaching
+/// a `Precision::Exact` extremum through a wildcard arm. The stamp side of the
+/// union is simply empty for an excluded type, which is not an error: `.cstat`
+/// carries `Str`/`Bytes` extrema under ADR-0850 and keeps answering them.
+fn stamp_type_of(ty: DeclaredType) -> Option<DeclaredStatType> {
+    match ty {
+        DeclaredType::I64 => Some(DeclaredStatType::I64),
+        DeclaredType::Bool => Some(DeclaredStatType::Bool),
+        // Unbounded byte strings: a stamped extremum would put arbitrary user
+        // data on the commit record and the hot resolve path, and truncating
+        // it would make the stat a bound rather than an extremum.
+        DeclaredType::Str | DeclaredType::Bytes => None,
+    }
+}
+
+/// One stamped extremum as the Arrow scalar `ty` projects to, or `None` when
+/// the stamp's value kind disagrees with `ty`.
+fn stamp_scalar(ty: DeclaredType, value: DeclaredStatValue) -> Option<ScalarValue> {
+    match (ty, value) {
+        (DeclaredType::I64, DeclaredStatValue::I64(v)) => Some(ScalarValue::Int64(Some(v))),
+        (DeclaredType::Bool, DeclaredStatValue::Bool(b)) => Some(ScalarValue::Boolean(Some(b))),
+        _ => None,
+    }
+}
+
+/// What the `SegmentRef` stamps say about `declared` for one segment, or
+/// `None` when the stamp side of the union is empty for it: an excluded type,
+/// no entry for the column, or an entry this query cannot read (its
+/// `declared_type` or a value kind disagreeing with the type the tenant
+/// declares the column as). An entry that grants nothing is absent from the
+/// union, never one side of a conflict.
+///
+/// The list is the validated form, so at most one entry names the column
+/// (ADR-0873 clause 6 drops every occurrence of a duplicated name, so a
+/// duplicate arrives here as no entry at all) and `find` is a lookup rather
+/// than a pick between claims.
+fn stamp_coverage(
+    declared: &DeclaredColumn,
+    stamps: &[DeclaredColumnStat],
+) -> Option<SegmentCoverage> {
+    let stat_type = stamp_type_of(declared.ty)?;
+    let stat = stamps.iter().find(|s| s.name() == declared.key)?;
+    if stat.declared_type() != stat_type {
+        return None;
+    }
+    // A one-sided pair cannot exist in the validated form (clause 2), so
+    // mapping each side independently cannot produce one here either.
+    let min = match stat.min() {
+        Some(v) => Some(stamp_scalar(declared.ty, v)?),
+        None => None,
+    };
+    let max = match stat.max() {
+        Some(v) => Some(stamp_scalar(declared.ty, v)?),
+        None => None,
+    };
+    Some(SegmentCoverage {
+        min,
+        max,
+        null_count: stat.null_count(),
+        null_count_proven: true,
+    })
+}
+
+/// What the loaded `.cstat` object says about `declared` for one segment, or
+/// `None` when that carrier grants nothing: no object, no entry for this
+/// segment, no entry for the column, more than one entry under the column's
+/// name (`unique_column_stat` refuses to pick), an entry whose extrema
+/// presence disagrees with its `non_null_count` in either direction (#970), or
+/// a value of the wrong kind.
+fn cstat_coverage(
+    declared: &DeclaredColumn,
+    seg_stats: Option<&ravel_proto::catalog::v1::ColumnStatsSegment>,
+) -> Option<SegmentCoverage> {
+    let stat = unique_column_stat(seg_stats?, &declared.key)?;
+    // The presence clause is called, not restated: `LoadedColumnStats` has
+    // public fields and can be populated by a carrier that never decoded an
+    // object, so the check has to bind here, where coverage is granted.
+    validate_min_max_presence(stat).ok()?;
+    let min = match stat.min.as_ref() {
+        Some(v) => Some(declared_scalar(declared.ty, v)?),
+        None => None,
+    };
+    let max = match stat.max.as_ref() {
+        Some(v) => Some(declared_scalar(declared.ty, v)?),
+        None => None,
+    };
+    Some(SegmentCoverage {
+        min,
+        max,
+        null_count: stat.null_count,
+        null_count_proven: false,
+    })
 }
 
 /// The `None`-valued Arrow scalar `ty` projects to, for a declared column
@@ -1175,58 +1353,67 @@ impl LogsScanExec {
                 .all(|seg| self.ts_min <= seg.min_event_ts_ns && seg.max_event_ts_ns <= self.ts_max)
     }
 
-    /// Exact MIN/MAX for the declared column at schema index
-    /// `FIRST_DECLARED_COL + k` over every segment this scan touches
-    /// (ADR-0850), joined against `self.column_stats` by identity. `None`
-    /// means the safety lemma from #849 requires falling back to scanning:
-    /// no loaded column-stats object at all, an unsupported declared type
-    /// (`Str`, projected as `Dictionary(Int32, Utf8)`; not implemented here),
-    /// a relevant segment with no entry in the loaded stats (never built, or
-    /// postdates the fold that built them), or a segment whose stat for this
-    /// column has no entry or decodes to a value of the wrong kind (a
-    /// corrupt/version-mismatched stat).
-    ///
-    /// `Some((min, max))` with both a `None`-valued scalar is still an exact
-    /// answer, not a fallback: every covered segment's column was entirely
-    /// null, or there are zero segments, and SQL `MIN`/`MAX` over all-NULL or
-    /// zero-row input is `NULL`.
-    /// Exact MIN/MAX for every declared column at once, indexed by `k`
+    /// Exact MIN/MAX (plus the exact NULL count, where a carrier proves one)
+    /// for every declared column at once, indexed by `k`
     /// (`FIRST_DECLARED_COL + k`), resolved in a SINGLE pass over the touched
-    /// segments (ADR-0850). `result[k]` is `None` with the same meaning the
-    /// per-column form would give -- the safety lemma requires falling back to
-    /// scanning for that column: no loaded column-stats object, an unsupported
-    /// declared type (`Str`), a relevant segment with no entry in the loaded
-    /// stats, or a segment whose stat for this column is missing, invalid
-    /// (#970: two entries under one name, or `min`/`max` presence disagreeing
-    /// with `non_null_count` in either direction), or decodes to a value of the
-    /// wrong kind.
+    /// segments.
     ///
-    /// `Some((min, max))` with both a `None`-valued scalar is still exact, not
-    /// a fallback: every covered segment's column was entirely null, or there
-    /// are zero segments, and SQL `MIN`/`MAX` over all-NULL or zero-row input
-    /// is `NULL`.
+    /// Two carriers, unioned per segment and per column (ADR-0873 decision 4):
     ///
-    /// Resolving every column in one segment walk (with a per-segment
-    /// name->stat map) instead of one full walk per column keeps
-    /// `partition_statistics` cost at `O(segments x columns_per_segment)`
-    /// rather than `O(segments x declared x columns_per_segment)`; DataFusion
-    /// may call `partition_statistics` several times per plan, so the per-call
-    /// cost matters.
-    fn declared_min_max_all(&self) -> Vec<Option<(ScalarValue, ScalarValue)>> {
+    /// - the `SegmentRef` stamp (`SegmentRef::declared_column_stats`,
+    ///   ADR-0873), which rides snapshot resolution itself and so covers the
+    ///   live tail and token-resolved segments that no fold-built object can
+    ///   reach. Its entries are the constructor-gated validated form: holding
+    ///   one is proof the statistics validity predicate ran, row-count clauses
+    ///   included, so this reader re-checks only what is local to the query
+    ///   (the declared type it was resolved under);
+    /// - the ADR-0850/0942 `.cstat` entry from `self.column_stats`, joined by
+    ///   segment identity, which is the only carrier for pre-stamp sealed
+    ///   history and for `Str`/`Bytes` extrema the stamp vocabulary excludes.
+    ///
+    /// `result[k]` is `None` when the #849 safety lemma requires falling back
+    /// to scanning for that column: a touched segment that neither carrier
+    /// covers (never stamped, no `.cstat` built, or an entry either carrier's
+    /// reader refuses), the two carriers disagreeing about one segment
+    /// (counted on [`declared_stat_carrier_conflicts`]), or an unsupported
+    /// declared type (`Str`, projected as `Dictionary(Int32, Utf8)`, has no
+    /// scalar form on this path).
+    ///
+    /// A result whose `min`/`max` are `None`-valued scalars is still exact,
+    /// not a fallback: every covered segment's column was entirely null, or
+    /// there are zero segments, and SQL `MIN`/`MAX` over all-NULL or zero-row
+    /// input is `NULL`.
+    ///
+    /// [`DeclaredExactStats::null_count`] is `Some` only when every covering
+    /// carrier proved its figure, which today means the stamp: a stamp's
+    /// `null_count` passed clauses 4 and 5 against the carrying record's own
+    /// row count before the type existed, while a `.cstat` entry's row
+    /// accounting is not reconciled against the joined
+    /// `SegmentRef::sample_count` anywhere on this path (ADR-0873 decision 2
+    /// requires it of that carrier; the tree does not yet do it). An
+    /// unreconciled `null_count` reported as `Precision::Exact` would answer
+    /// `COUNT(col)` from a figure nothing checked, so it stays `Absent` and
+    /// only the extrema are claimed.
+    ///
+    /// Resolving every column in one segment walk instead of one full walk per
+    /// column keeps `partition_statistics` cost at
+    /// `O(segments x columns_per_segment)` rather than
+    /// `O(segments x declared x columns_per_segment)`; DataFusion may call
+    /// `partition_statistics` several times per plan, so the per-call cost
+    /// matters.
+    fn declared_min_max_all(&self) -> Vec<Option<DeclaredExactStats>> {
         let n = self.declared.len();
-        let mut result: Vec<Option<(ScalarValue, ScalarValue)>> = vec![None; n];
-        let Some(stats) = self.column_stats.as_ref() else {
-            return result;
-        };
+        let mut result: Vec<Option<DeclaredExactStats>> = vec![None; n];
 
-        // Per-column running extrema plus a "declined" flag: a column declines
-        // its whole answer the moment any touched segment lacks its entry or
-        // carries a wrong-kind value, exactly as the per-column form does. A
+        // Per-column running extrema and NULL-count sum, plus a "declined"
+        // flag: a column declines its whole answer the moment one touched
+        // segment is covered by neither carrier or the carriers conflict. A
         // `Str` column declines up front.
         struct Acc {
             declined: bool,
             min: Option<ScalarValue>,
             max: Option<ScalarValue>,
+            null_count: Option<u64>,
         }
         let mut acc: Vec<Acc> = self
             .declared
@@ -1235,95 +1422,73 @@ impl LogsScanExec {
                 declined: matches!(d.ty, DeclaredType::Str),
                 min: None,
                 max: None,
+                null_count: Some(0),
             })
             .collect();
 
         for seg in self.segments.iter() {
-            let Some(seg_stats) = stats.segments.get(&segment_identity(seg)) else {
-                // A touched segment with no stats: every column must decline.
-                for a in acc.iter_mut() {
-                    a.declined = true;
-                }
-                break;
-            };
-            // One entry per name, and a name carrying more than one entry maps
-            // to `None`: collecting the pairs straight into a map would keep
-            // the LAST duplicate and answer from it, while the dictionary
-            // readers below resolve the same list with `find` and would keep
-            // the FIRST. A duplicate name is malformed either way
-            // (`decode_column_stats` refuses an object carrying one), and no
-            // rule could pick the right entry, so the name is poisoned and its
-            // column declines. Still one walk of the segment's columns.
-            let mut by_name: HashMap<&str, Option<&ravel_proto::catalog::v1::ColumnStat>> =
-                HashMap::with_capacity(seg_stats.columns.len());
-            for c in seg_stats.columns.iter() {
-                by_name
-                    .entry(c.name.as_str())
-                    .and_modify(|slot| *slot = None)
-                    .or_insert(Some(c));
-            }
+            // Either carrier may be absent for this segment, and neither
+            // absence short-circuits the other: a live-tail segment has a
+            // stamp and no `.cstat`, a pre-stamp sealed segment the reverse.
+            let seg_stats = self
+                .column_stats
+                .as_ref()
+                .and_then(|stats| stats.segments.get(&segment_identity(seg)));
+            let stamps = seg.declared_column_stats.as_slice();
             for (k, a) in acc.iter_mut().enumerate() {
                 if a.declined {
                     continue;
                 }
                 let declared = &self.declared[k];
-                let Some(Some(stat)) = by_name.get(declared.key.as_str()) else {
-                    // No entry (the ordinary not-covered case) or a poisoned
-                    // one (a duplicate name).
-                    a.declined = true;
-                    continue;
+                let coverage = match (
+                    stamp_coverage(declared, stamps),
+                    cstat_coverage(declared, seg_stats),
+                ) {
+                    // Covered by neither: the ordinary uncovered state,
+                    // never an error, and the column falls back to a scan.
+                    (None, None) => {
+                        a.declined = true;
+                        continue;
+                    }
+                    (Some(only), None) | (None, Some(only)) => only,
+                    (Some(stamp), Some(cstat)) => {
+                        // Nothing is combined across carriers: both claim
+                        // to describe the same rows of the same immutable
+                        // object exactly, so they agree (use either) or
+                        // one of them is wrong and no answer is safe. A
+                        // conflict is a writer/fold/build defect, so it is
+                        // counted rather than only degraded.
+                        if !stamp.agrees_with(&cstat) {
+                            record_carrier_conflict();
+                            a.declined = true;
+                            continue;
+                        }
+                        SegmentCoverage {
+                            null_count_proven: stamp.null_count_proven || cstat.null_count_proven,
+                            ..stamp
+                        }
+                    }
                 };
-                // `min`/`max` presence must agree with `non_null_count` in both
-                // directions, or this path reports a wrong extremum as
-                // `Precision::Exact`: non-null rows with no recorded extremum
-                // leave the accumulator `None` and the loop below substitutes a
-                // NULL scalar, claiming the extremum of non-null data is exactly
-                // NULL, while an all-null column carrying extrema contributes a
-                // value describing no live row. `decode_column_stats` refuses
-                // either shape, and this calls the same clause it enforces
-                // rather than restating it, because `LoadedColumnStats` has
-                // public fields and can be populated by a carrier that never
-                // decoded an object. Fail closed and let the scan answer.
-                if validate_min_max_presence(stat).is_err() {
-                    a.declined = true;
-                    continue;
+
+                if let Some(min) = coverage.min {
+                    a.min = keep_extreme(a.min.take(), min, std::cmp::Ordering::Less);
                 }
-                if let Some(min_val) = stat.min.as_ref() {
-                    match declared_scalar(declared.ty, min_val) {
-                        Some(v) => {
-                            a.min = Some(match a.min.take() {
-                                Some(cur)
-                                    if v.partial_cmp(&cur) != Some(std::cmp::Ordering::Less) =>
-                                {
-                                    cur
-                                }
-                                _ => v,
-                            });
-                        }
-                        None => {
-                            a.declined = true;
-                            continue;
-                        }
-                    }
+                if let Some(max) = coverage.max {
+                    a.max = keep_extreme(a.max.take(), max, std::cmp::Ordering::Greater);
                 }
-                if let Some(max_val) = stat.max.as_ref() {
-                    match declared_scalar(declared.ty, max_val) {
-                        Some(v) => {
-                            a.max = Some(match a.max.take() {
-                                Some(cur)
-                                    if v.partial_cmp(&cur) != Some(std::cmp::Ordering::Greater) =>
-                                {
-                                    cur
-                                }
-                                _ => v,
-                            });
-                        }
-                        None => {
-                            a.declined = true;
-                            continue;
-                        }
-                    }
-                }
+                a.null_count = if coverage.null_count_proven {
+                    a.null_count
+                        .and_then(|sum| sum.checked_add(coverage.null_count))
+                } else {
+                    None
+                };
+            }
+            // Nothing left to resolve once every column has declined, which is
+            // the common shape on a tenant with neither carrier: one segment
+            // decides it and the remaining segments would only be walked to
+            // re-skip every column.
+            if acc.iter().all(|a| a.declined) {
+                break;
             }
         }
 
@@ -1332,10 +1497,11 @@ impl LogsScanExec {
                 continue;
             }
             let null_scalar = declared_null_scalar(self.declared[k].ty);
-            result[k] = Some((
-                a.min.unwrap_or_else(|| null_scalar.clone()),
-                a.max.unwrap_or(null_scalar),
-            ));
+            result[k] = Some(DeclaredExactStats {
+                min: a.min.unwrap_or_else(|| null_scalar.clone()),
+                max: a.max.unwrap_or(null_scalar),
+                null_count: a.null_count,
+            });
         }
         result
     }
@@ -1921,23 +2087,33 @@ impl ExecutionPlan for LogsScanExec {
                 col.max_value = Precision::Exact(ScalarValue::TimestampNanosecond(Some(max), None));
             }
 
-            // ADR-0850: the same gate widens to a declared column's exact
-            // min/max, joined against `self.column_stats` by identity rather
-            // than ordinal position. `declared_min_max_all` resolves every
-            // declared column in one segment walk and enforces the per-column
-            // fallback (an uncovered segment, a corrupt/type-mismatched stat,
-            // or an unsupported declared type all report `None`, leaving the
-            // column `Absent`); this loop only decides which output index to
-            // fill.
+            // ADR-0850 and ADR-0873: the same gate widens to a declared
+            // column's exact min/max (and its exact NULL count, where a
+            // carrier proves one), taken from the union of the `SegmentRef`
+            // stamp and the `.cstat` entry, both joined by segment identity
+            // rather than ordinal position. `declared_min_max_all` resolves
+            // every declared column in one segment walk and enforces the
+            // per-column fallback (a segment covered by neither carrier,
+            // carriers that disagree, a refused entry, or an unsupported
+            // declared type all report `None`, leaving the column `Absent`);
+            // this loop only decides which output index to fill.
             let declared_min_max = self.declared_min_max_all();
-            for (k, min_max) in declared_min_max.into_iter().enumerate() {
+            for (k, exact) in declared_min_max.into_iter().enumerate() {
                 let schema_idx = FIRST_DECLARED_COL + k;
                 if let Some(out_idx) = self.projection.iter().position(|&i| i == schema_idx)
-                    && let Some((min, max)) = min_max
+                    && let Some(exact) = exact
                 {
                     let col = &mut stats.column_statistics[out_idx];
-                    col.min_value = Precision::Exact(min);
-                    col.max_value = Precision::Exact(max);
+                    col.min_value = Precision::Exact(exact.min);
+                    col.max_value = Precision::Exact(exact.max);
+                    // An unproven NULL count leaves `null_count` `Absent`
+                    // rather than reporting an unreconciled figure as exact;
+                    // the extrema stay exact either way.
+                    if let Some(nulls) = exact.null_count
+                        && let Ok(nulls) = usize::try_from(nulls)
+                    {
+                        col.null_count = Precision::Exact(nulls);
+                    }
                 }
             }
         }

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -251,7 +251,11 @@ use datafusion::physical_plan::{
 };
 use datafusion::scalar::ScalarValue;
 use futures::{Stream, StreamExt, TryStreamExt};
-use ravel_catalog::{LoadedColumnStats, SegmentRef, unique_column_stat, validate_min_max_presence};
+use ravel_catalog::{
+    DeclaredColumnStats, LoadedColumnStats, SegmentRef, unique_column_stat,
+    validate_min_max_presence,
+};
+use ravel_commit::declared_stats::{StatCarrier, observe_declared_stat_drops};
 use ravel_logseg::footer::LogFooter;
 use ravel_logseg::{
     AttrColumn, BoolCursor, BytesCursor, ColumnSelection, ColumnarBlockView, F64BitsCursor,
@@ -265,7 +269,7 @@ use ravel_query::{
 };
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
-use ravel_types::declared_stats::{DeclaredColumnStat, DeclaredStatType, DeclaredStatValue};
+use ravel_types::declared_stats::{DeclaredStatType, DeclaredStatValue};
 use ravel_types::logstream::AttrValue;
 use tokio::sync::OnceCell;
 
@@ -598,8 +602,8 @@ fn declared_scalar(ty: DeclaredType, value: &ColumnValue) -> Option<ScalarValue>
 /// Process-wide tally behind [`declared_stat_carrier_conflicts`].
 static CARRIER_CONFLICTS: AtomicU64 = AtomicU64::new(0);
 
-/// How many times this process has found the two declared-statistics carriers
-/// disagreeing about one segment and one column (ADR-0873 decision 4).
+/// How many times this process has OBSERVED the two declared-statistics
+/// carriers disagreeing about one segment and one column (ADR-0873 decision 4).
 ///
 /// A segment is immutable and both the `SegmentRef` stamp and the `.cstat`
 /// entry claim to be exact derivations of its contents, so a disagreement in
@@ -608,13 +612,63 @@ static CARRIER_CONFLICTS: AtomicU64 = AtomicU64::new(0);
 /// to a scan (never a wrong answer), which is exactly why the tally exists: it
 /// makes the defect a ticket instead of a mysteriously slow query.
 ///
+/// Call multiplicity, stated rather than deduplicated: one increment per
+/// (declared column, conflicting segment, `partition_statistics` call). Within
+/// one call a column increments at most once, because the first conflicting
+/// segment declines the column and the remaining segments skip it. Across
+/// calls nothing is deduplicated, and DataFusion may call
+/// `partition_statistics` several times while building one plan, so N
+/// statements over one defective segment observe some multiple of N. A
+/// per-query dedup is deliberately not built: it would need per-plan state
+/// keyed by (segment, column) threaded through a `&self` statistics call, for a
+/// figure whose only use is "nonzero, go read the log line". Alert on nonzero
+/// and compare rates over equal windows; the magnitude is not a count of
+/// defective segments. [`record_carrier_conflict`] logs each observation with
+/// the segment's content hash and both triples, which is the artefact that
+/// names the defect; this counter only says how often one was hit.
+///
+/// A per-query coverage figure (segments stamped over segments touched, per
+/// carrier) belongs beside this under phase accounting and is owed to the
+/// 996-9 measurement wave, not built here.
+///
 /// Monotonic and process-local; a scrape reads the delta between samples.
 pub fn declared_stat_carrier_conflicts() -> u64 {
     CARRIER_CONFLICTS.load(Ordering::Relaxed)
 }
 
-fn record_carrier_conflict() {
+/// Count one conflict observation and log what conflicted, at `warn`.
+///
+/// The log line is the ADR-0873 decision 4 artefact and the counter is only its
+/// rate: an operator who sees the tally move needs the segment and both claimed
+/// triples to file anything, and neither is recoverable from a number. The
+/// segment is named by `content_hash` rather than by object key because the
+/// hash names the exact bytes both carriers claim to describe, which is what a
+/// stamp-fold or `.cstat`-build report is filed against.
+///
+/// Emitted once per observation, so it inherits the multiplicity documented on
+/// [`declared_stat_carrier_conflicts`]: a hot statement over a defective
+/// segment repeats this line. It stays at `warn` and unsampled anyway, because
+/// the defect it reports is a durable object disagreeing with itself, which no
+/// amount of repetition makes less urgent.
+fn record_carrier_conflict(
+    seg: &SegmentRef,
+    column: &str,
+    stamp: &SegmentCoverage,
+    cstat: &SegmentCoverage,
+) {
     CARRIER_CONFLICTS.fetch_add(1, Ordering::Relaxed);
+    tracing::warn!(
+        column,
+        segment_content_hash = %hex::encode(seg.content_hash),
+        segment_key = %seg.data_object_key,
+        stamp_min = ?stamp.min,
+        stamp_max = ?stamp.max,
+        stamp_null_count = stamp.null_count,
+        cstat_min = ?cstat.min,
+        cstat_max = ?cstat.max,
+        cstat_null_count = cstat.null_count,
+        "declared-column statistics carriers disagree about one segment; the column degrades to a scan"
+    );
 }
 
 /// One segment's coverage of one declared column as one carrier states it.
@@ -622,9 +676,11 @@ fn record_carrier_conflict() {
 /// `min`/`max` both absent is a coverage statement, not a gap: the column had
 /// zero non-null values in that segment, which is exact. `null_count_proven`
 /// records whether the carrier's NULL count was reconciled against the
-/// segment's row count before it got here (true for a stamp, whose validated
-/// form is proof of clauses 4 and 5; false for a `.cstat` entry, whose row
-/// accounting this path does not reconcile).
+/// segment's row count before it got here: true for a stamp, where the proof is
+/// [`stamp_coverage`]'s parameter type ([`DeclaredColumnStats`], constructable
+/// non-empty only from a `ValidatedDeclaredStats`) rather than a convention its
+/// caller is trusted to have followed; false for a `.cstat` entry, whose row
+/// accounting this path does not reconcile.
 #[derive(Clone)]
 struct SegmentCoverage {
     min: Option<ScalarValue>,
@@ -709,16 +765,26 @@ fn stamp_scalar(ty: DeclaredType, value: DeclaredStatValue) -> Option<ScalarValu
 /// declares the column as). An entry that grants nothing is absent from the
 /// union, never one side of a conflict.
 ///
-/// The list is the validated form, so at most one entry names the column
-/// (ADR-0873 clause 6 drops every occurrence of a duplicated name, so a
-/// duplicate arrives here as no entry at all) and `find` is a lookup rather
+/// The parameter is [`DeclaredColumnStats`], the validated container, not a
+/// slice of entries, and the signature is the argument: `null_count_proven` is
+/// set unconditionally below, so this function's correctness rests on the
+/// entries having passed the full statistics validity predicate, row-count
+/// clauses included. `DeclaredColumnStats`'s only non-empty constructor is
+/// `from_validated`, so possessing one is that proof (ADR-0873 decision 2), and
+/// a caller cannot satisfy this signature with entries it decoded itself. A
+/// `&[DeclaredColumnStat]` parameter would leave the same claim resting on a
+/// caller invariant nothing checks, which is the #970 shape.
+///
+/// Because the container is the validated form, at most one entry names the
+/// column (ADR-0873 clause 6 drops every occurrence of a duplicated name, so a
+/// duplicate arrives here as no entry at all) and the lookup is a lookup rather
 /// than a pick between claims.
 fn stamp_coverage(
     declared: &DeclaredColumn,
-    stamps: &[DeclaredColumnStat],
+    stamps: &DeclaredColumnStats,
 ) -> Option<SegmentCoverage> {
     let stat_type = stamp_type_of(declared.ty)?;
-    let stat = stamps.iter().find(|s| s.name() == declared.key)?;
+    let stat = stamps.column(&declared.key)?;
     if stat.declared_type() != stat_type {
         return None;
     }
@@ -746,15 +812,47 @@ fn stamp_coverage(
 /// name (`unique_column_stat` refuses to pick), an entry whose extrema
 /// presence disagrees with its `non_null_count` in either direction (#970), or
 /// a value of the wrong kind.
+///
+/// Two of those refusals are DEFECTS rather than absences, and each reports one
+/// drop observation under [`StatCarrier::Cstat`] (ADR-0873 decision 2's metric,
+/// whose stamp-carrier labels are fed by the carrier reads in `ravel-commit`):
+/// a duplicated column name, and a presence/row-accounting contradiction. The
+/// other refusals are not counted, and the distinction is the point of the
+/// metric: an absent object, an absent segment entry, and an absent column
+/// entry are the ordinary uncovered state of every tenant whose fold never
+/// built that column, while a value of a kind the tenant's current declared
+/// type does not match is a legal consequence of re-declaring a column, not a
+/// writer bug.
 fn cstat_coverage(
     declared: &DeclaredColumn,
     seg_stats: Option<&ravel_proto::catalog::v1::ColumnStatsSegment>,
 ) -> Option<SegmentCoverage> {
-    let stat = unique_column_stat(seg_stats?, &declared.key)?;
+    let seg_stats = seg_stats?;
+    let stat = match unique_column_stat(seg_stats, &declared.key) {
+        Some(stat) => stat,
+        None => {
+            // `unique_column_stat` folds "no entry" and "more than one entry"
+            // into one `None`, and only the second is a defect: a duplicated
+            // name means no rule can pick the right claim about one immutable
+            // object. Re-deriving which case it was costs one pass over the
+            // entries of one segment, on the refusal path only.
+            let duplicated = seg_stats
+                .columns
+                .iter()
+                .any(|column| column.name == declared.key);
+            if duplicated {
+                observe_declared_stat_drops(StatCarrier::Cstat, 1);
+            }
+            return None;
+        }
+    };
     // The presence clause is called, not restated: `LoadedColumnStats` has
     // public fields and can be populated by a carrier that never decoded an
     // object, so the check has to bind here, where coverage is granted.
-    validate_min_max_presence(stat).ok()?;
+    if validate_min_max_presence(stat).is_err() {
+        observe_declared_stat_drops(StatCarrier::Cstat, 1);
+        return None;
+    }
     let min = match stat.min.as_ref() {
         Some(v) => Some(declared_scalar(declared.ty, v)?),
         None => None,
@@ -1363,10 +1461,12 @@ impl LogsScanExec {
     /// - the `SegmentRef` stamp (`SegmentRef::declared_column_stats`,
     ///   ADR-0873), which rides snapshot resolution itself and so covers the
     ///   live tail and token-resolved segments that no fold-built object can
-    ///   reach. Its entries are the constructor-gated validated form: holding
-    ///   one is proof the statistics validity predicate ran, row-count clauses
-    ///   included, so this reader re-checks only what is local to the query
-    ///   (the declared type it was resolved under);
+    ///   reach. It is a `DeclaredColumnStats`, the constructor-gated validated
+    ///   container, and [`stamp_coverage`] takes that type rather than a slice
+    ///   of its entries: holding one is proof the statistics validity predicate
+    ///   ran, row-count clauses included, so this reader re-checks only what is
+    ///   local to the query (the declared type it was resolved under) and its
+    ///   `null_count` needs no reconciliation here;
     /// - the ADR-0850/0942 `.cstat` entry from `self.column_stats`, joined by
     ///   segment identity, which is the only carrier for pre-stamp sealed
     ///   history and for `Str`/`Bytes` extrema the stamp vocabulary excludes.
@@ -1434,7 +1534,7 @@ impl LogsScanExec {
                 .column_stats
                 .as_ref()
                 .and_then(|stats| stats.segments.get(&segment_identity(seg)));
-            let stamps = seg.declared_column_stats.as_slice();
+            let stamps = &seg.declared_column_stats;
             for (k, a) in acc.iter_mut().enumerate() {
                 if a.declined {
                     continue;
@@ -1459,7 +1559,7 @@ impl LogsScanExec {
                         // conflict is a writer/fold/build defect, so it is
                         // counted rather than only degraded.
                         if !stamp.agrees_with(&cstat) {
-                            record_carrier_conflict();
+                            record_carrier_conflict(seg, &declared.key, &stamp, &cstat);
                             a.declined = true;
                             continue;
                         }
@@ -2042,8 +2142,15 @@ impl ExecutionPlan for LogsScanExec {
     /// request gets `Absent`, because a partition's count is its lazily
     /// resolved striped share of the blocks, not known here. Under the same
     /// condition the `ts` column's `column_statistics` report an `Exact`
-    /// min/max spanning every touched segment; every other column's stays
-    /// `Absent`. `total_byte_size` stays `Absent`.
+    /// min/max spanning every touched segment.
+    ///
+    /// A declared typed column reports an `Exact` min/max too, and an `Exact`
+    /// `null_count` where a carrier proves one, whenever
+    /// [`Self::declared_min_max_all`] resolves it from the ADR-0850 `.cstat`
+    /// entry, the ADR-0873 `SegmentRef` stamp, or both in agreement. Every
+    /// column that is neither `ts` nor a resolved declared column stays
+    /// `Absent`, as does a declared column any touched segment leaves
+    /// uncovered. `total_byte_size` stays `Absent`.
     fn partition_statistics(&self, partition: Option<usize>) -> DFResult<Arc<Statistics>> {
         // Validate the partition index exactly as the trait default does, so an
         // out-of-range request is an internal error, never a silent answer.

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -1484,8 +1484,10 @@ impl LogsScanExec {
     /// there are zero segments, and SQL `MIN`/`MAX` over all-NULL or zero-row
     /// input is `NULL`.
     ///
-    /// [`DeclaredExactStats::null_count`] is `Some` only when every covering
-    /// carrier proved its figure, which today means the stamp: a stamp's
+    /// [`DeclaredExactStats::null_count`] is `Some` when the carriers agree
+    /// on the figure AND at least one carrier proved it (`agrees_with` has
+    /// already pinned both to the same value, so one proof covers both);
+    /// today the proving carrier is the stamp: a stamp's
     /// `null_count` passed clauses 4 and 5 against the carrying record's own
     /// row count before the type existed, while a `.cstat` entry's row
     /// accounting is not reconciled against the joined
@@ -2204,7 +2206,15 @@ impl ExecutionPlan for LogsScanExec {
             // carriers that disagree, a refused entry, or an unsupported
             // declared type all report `None`, leaving the column `Absent`);
             // this loop only decides which output index to fill.
-            let declared_min_max = self.declared_min_max_all();
+            // Skip the whole walk when the projection carries no declared
+            // column: partition_statistics runs several times per plan, and a
+            // ts-only statement must not pay one lookup per (segment, column).
+            let projects_declared = self.projection.iter().any(|&i| i >= FIRST_DECLARED_COL);
+            let declared_min_max = if projects_declared {
+                self.declared_min_max_all()
+            } else {
+                Vec::new()
+            };
             for (k, exact) in declared_min_max.into_iter().enumerate() {
                 let schema_idx = FIRST_DECLARED_COL + k;
                 if let Some(out_idx) = self.projection.iter().position(|&i| i == schema_idx)

--- a/crates/ravel-sql/tests/declared_stat_carrier_conflicts.rs
+++ b/crates/ravel-sql/tests/declared_stat_carrier_conflicts.rs
@@ -1,0 +1,264 @@
+//! The ADR-0873 decision 4 conflict metric: when the `SegmentRef` stamp and
+//! the ADR-0850 `.cstat` entry disagree about one segment and one column, the
+//! column degrades to a scan AND the disagreement is counted, so an operator
+//! sees a ticket-shaped signal instead of a mysteriously slow query.
+//!
+//! Own integration binary, all tests synchronous, all tests holding one lock:
+//! `ravel_sql::declared_stat_carrier_conflicts` is a process-wide monotonic
+//! tally, so an exact-delta assertion means something only when the test knows
+//! every other reader in the process. Nothing here reads an object -- the
+//! statistics path is pure plan-time work over the resolved snapshot -- so the
+//! segments are fabricated and no store is needed.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use datafusion::common::stats::Precision;
+use datafusion::scalar::ScalarValue;
+use ravel_catalog::{
+    DeclaredColumnStats, EntryIdentity, LoadedColumnStats, SegmentLevel, SegmentRef, Snapshot,
+};
+use ravel_commit::declared_stats::{encode as encode_stamp, read_commit_record};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue};
+use ravel_proto::commit::v1::CommitRecord;
+use ravel_query::LogSegmentFetcher;
+use ravel_sql::{DeclaredColumn, DeclaredType, LogsTableProvider, declared_stat_carrier_conflicts};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use ravel_types::declared_stats::{DeclaredColumnStat, DeclaredStatType, DeclaredStatValue};
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+const COL: &str = "EventDate";
+/// Rows per fabricated segment, and the figure the stamps' NULL counts are
+/// reconciled against.
+const SAMPLE_COUNT: u64 = 4;
+
+/// Serialises every test here so a delta on the process-wide tally is
+/// attributable to exactly the statistics resolution this test ran.
+static CONFLICTS: Mutex<()> = Mutex::new(());
+
+fn conflict_lock() -> MutexGuard<'static, ()> {
+    match CONFLICTS.lock() {
+        Ok(guard) => guard,
+        // A poisoned lock means a sibling test panicked; the tally is still
+        // sound to read, and re-reporting the sibling's failure here would
+        // only obscure it.
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn seg_ref(seq: u64) -> SegmentRef {
+    SegmentRef {
+        data_object_key: format!("logs/seg-{seq}.rlog"),
+        object_size: 1,
+        min_event_ts_ns: 0,
+        max_event_ts_ns: 1_000,
+        ingest_hour_bucket: 0,
+        sample_count: SAMPLE_COUNT,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: seq,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: DeclaredColumnStats::default(),
+    }
+}
+
+fn identity_of(seg: &SegmentRef) -> EntryIdentity {
+    (
+        seg.ingest_hour_bucket,
+        seg.shard,
+        *seg.writer_id.as_bytes(),
+        seg.writer_epoch,
+        seg.writer_seq,
+    )
+}
+
+/// Stamp `seg` with one I64 triple, through the carrier read that binds the
+/// row-count clauses (the only route to a non-empty [`DeclaredColumnStats`]).
+fn stamped(seg: &SegmentRef, min: i64, max: i64, null_count: u64) -> SegmentRef {
+    let stat = DeclaredColumnStat::new(
+        COL,
+        DeclaredStatType::I64,
+        Some(DeclaredStatValue::I64(min)),
+        Some(DeclaredStatValue::I64(max)),
+        null_count,
+    )
+    .expect("valid stamp");
+    let record = CommitRecord {
+        sample_count: seg.sample_count,
+        declared_column_stats: vec![encode_stamp(&stat)],
+        ..CommitRecord::default()
+    };
+    let mut out = seg.clone();
+    out.declared_column_stats = DeclaredColumnStats::from_validated(&read_commit_record(&record));
+    assert_eq!(out.declared_column_stats.len(), 1, "fixture stamp is valid");
+    out
+}
+
+fn i64_value(v: i64) -> ColumnValue {
+    ColumnValue {
+        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(v)),
+    }
+}
+
+/// The `.cstat` entry for the same column: `min`/`max` plus the row
+/// accounting, with no value dictionary (this path reads neither).
+fn cstat(min: i64, max: i64, null_count: u64) -> ColumnStat {
+    ColumnStat {
+        name: COL.to_string(),
+        declared_type: 2, // ravel.sys.v1.TypedAttrColumnType::I64
+        non_null_count: SAMPLE_COUNT - null_count,
+        null_count,
+        min: Some(i64_value(min)),
+        max: Some(i64_value(max)),
+        dictionary_present: false,
+        dictionary: Vec::new(),
+        sum: None,
+    }
+}
+
+fn loaded(seg: &SegmentRef, stat: ColumnStat) -> Arc<LoadedColumnStats> {
+    let mut segments = HashMap::new();
+    segments.insert(
+        identity_of(seg),
+        ColumnStatsSegment {
+            ingest_hour_bucket: seg.ingest_hour_bucket,
+            shard: seg.shard,
+            writer_id: seg.writer_id.as_bytes().to_vec(),
+            writer_epoch: seg.writer_epoch,
+            writer_seq: seg.writer_seq,
+            columns: vec![stat],
+        },
+    );
+    Arc::new(LoadedColumnStats {
+        segments,
+        part_blake3: Vec::new(),
+    })
+}
+
+/// The declared column's plan-time statistics over one stamped segment plus
+/// one `.cstat` entry, and the exact movement of the conflict tally across
+/// resolving them.
+fn resolve(
+    seg: SegmentRef,
+    stats: Arc<LoadedColumnStats>,
+) -> (datafusion::common::ColumnStatistics, u64) {
+    let guard = conflict_lock();
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let provider = LogsTableProvider::new(
+        Snapshot {
+            segments: vec![seg],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        },
+        TENANT,
+        LogSegmentFetcher::new(backend),
+        QueryAccounting::new(),
+    )
+    .with_declared_columns(vec![DeclaredColumn::new(COL, DeclaredType::I64)])
+    .with_column_stats(Some(stats));
+    let plan = provider.plan_filters(4, &[]).expect("plan_filters");
+    let before = declared_stat_carrier_conflicts();
+    let resolved = plan
+        .partition_statistics(None)
+        .expect("partition_statistics");
+    let delta = declared_stat_carrier_conflicts() - before;
+    drop(guard);
+    (
+        resolved.column_statistics[ravel_sql::FIRST_DECLARED_COL].clone(),
+        delta,
+    )
+}
+
+/// A disagreement on `min` leaves the column `Absent` and moves the tally by
+/// exactly one.
+///
+/// Prove-the-test: delete the `record_carrier_conflict()` call in
+/// `declared_min_max_all` (crates/ravel-sql/src/logs_scan.rs) and the delta
+/// reads 0; replace the `agrees_with` check with `true` and the precision
+/// assertion fails as well.
+#[test]
+fn a_min_disagreement_declines_and_counts_once() {
+    let seg = stamped(&seg_ref(1), 200, 500, 1);
+    let (col, delta) = resolve(seg.clone(), loaded(&seg, cstat(-1, 500, 1)));
+    assert_eq!(col.min_value, Precision::Absent);
+    assert_eq!(col.max_value, Precision::Absent);
+    assert_eq!(delta, 1, "one conflicted segment, counted once");
+}
+
+/// The same for a disagreement on `null_count` alone, with identical extrema:
+/// the union compares all three fields, because a `COUNT(col)` answer rides on
+/// the NULL count exactly as `MIN`/`MAX` ride on the extrema.
+///
+/// Prove-the-test: drop `self.null_count == other.null_count` from
+/// `SegmentCoverage::agrees_with` and this reads `(Exact(200), 0)`.
+#[test]
+fn a_null_count_disagreement_declines_and_counts_once() {
+    let seg = stamped(&seg_ref(2), 200, 500, 1);
+    let (col, delta) = resolve(seg.clone(), loaded(&seg, cstat(200, 500, 2)));
+    assert_eq!(col.min_value, Precision::Absent);
+    assert_eq!(delta, 1);
+}
+
+/// Agreement costs nothing: the tally stays put and the column is exact, with
+/// the NULL count reported once (never the sum of the two carriers).
+#[test]
+fn agreeing_carriers_move_nothing() {
+    let seg = stamped(&seg_ref(3), 200, 500, 1);
+    let (col, delta) = resolve(seg.clone(), loaded(&seg, cstat(200, 500, 1)));
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Int64(Some(200)))
+    );
+    assert_eq!(
+        col.max_value,
+        Precision::Exact(ScalarValue::Int64(Some(500)))
+    );
+    assert_eq!(
+        col.null_count,
+        Precision::Exact(1),
+        "counted once, not twice"
+    );
+    assert_eq!(delta, 0, "no conflict, no increment");
+}
+
+/// A segment only one carrier covers is not a conflict: the union degenerating
+/// to one carrier is the normal state (a live tail has stamps only, pre-stamp
+/// sealed history `.cstat` only), so it must not touch the defect tally.
+#[test]
+fn one_carrier_alone_is_not_a_conflict() {
+    // Stamp only: the `.cstat` object describes a different segment.
+    let seg = stamped(&seg_ref(4), 200, 500, 1);
+    let other = seg_ref(99);
+    let (col, delta) = resolve(seg, loaded(&other, cstat(1, 2, 0)));
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Int64(Some(200)))
+    );
+    assert_eq!(delta, 0);
+
+    // `.cstat` only: the segment carries no stamp at all.
+    let bare = seg_ref(5);
+    let (col, delta) = resolve(bare.clone(), loaded(&bare, cstat(200, 500, 1)));
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Int64(Some(200)))
+    );
+    assert_eq!(
+        col.null_count,
+        Precision::Absent,
+        "a .cstat NULL count is not reconciled against the joined sample_count \
+         on this path, so it is never reported as exact"
+    );
+    assert_eq!(delta, 0);
+}

--- a/crates/ravel-sql/tests/declared_stat_carrier_conflicts.rs
+++ b/crates/ravel-sql/tests/declared_stat_carrier_conflicts.rs
@@ -1,7 +1,14 @@
 //! The ADR-0873 decision 4 conflict metric: when the `SegmentRef` stamp and
 //! the ADR-0850 `.cstat` entry disagree about one segment and one column, the
-//! column degrades to a scan AND the disagreement is counted, so an operator
-//! sees a ticket-shaped signal instead of a mysteriously slow query.
+//! column degrades to a scan AND the disagreement is counted and logged, so an
+//! operator sees a ticket-shaped signal instead of a mysteriously slow query.
+//!
+//! The counter is observations, not distinct defective segments: one increment
+//! per (column, conflicting segment, `partition_statistics` call), with no
+//! dedup across calls. Each delta asserted here is therefore scoped to exactly
+//! one `partition_statistics` call. The log line that carries the detail a
+//! report is filed from is asserted in tests/declared_stat_conflict_log.rs,
+//! which needs a process to itself.
 //!
 //! Own integration binary, all tests synchronous, all tests holding one lock:
 //! `ravel_sql::declared_stat_carrier_conflicts` is a process-wide monotonic
@@ -183,7 +190,7 @@ fn resolve(
 /// A disagreement on `min` leaves the column `Absent` and moves the tally by
 /// exactly one.
 ///
-/// Prove-the-test: delete the `record_carrier_conflict()` call in
+/// Prove-the-test: delete the `record_carrier_conflict(...)` call in
 /// `declared_min_max_all` (crates/ravel-sql/src/logs_scan.rs) and the delta
 /// reads 0; replace the `agrees_with` check with `true` and the precision
 /// assertion fails as well.

--- a/crates/ravel-sql/tests/declared_stat_conflict_log.rs
+++ b/crates/ravel-sql/tests/declared_stat_conflict_log.rs
@@ -1,0 +1,231 @@
+//! The ADR-0873 decision 4 conflict LOG LINE: when the `SegmentRef` stamp and
+//! the ADR-0850 `.cstat` entry disagree about one segment and one column, the
+//! disagreement is not only counted but recorded with the segment's content
+//! hash and both claimed triples.
+//!
+//! The counter alone cannot be acted on: it says how often a conflict was
+//! observed, never which object or which two claims, and neither is
+//! recoverable from a number. This file pins the line that carries them.
+//!
+//! ONE test, in its own integration binary, and both are load-bearing.
+//! `tracing` caches a callsite's interest process-wide: a sibling test that
+//! reaches the same `warn!` with no subscriber installed on ITS thread can have
+//! the callsite cached as uninteresting, after which the line is never emitted
+//! for anyone and this assertion fails for a reason that has nothing to do with
+//! the code under test. `tests/declared_stat_carrier_conflicts.rs` holds the
+//! counter assertions for exactly that reason; adding a second test here would
+//! reintroduce the race.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use datafusion::common::stats::Precision;
+use ravel_catalog::{
+    DeclaredColumnStats, EntryIdentity, LoadedColumnStats, SegmentLevel, SegmentRef, Snapshot,
+};
+use ravel_commit::declared_stats::{encode as encode_stamp, read_commit_record};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue};
+use ravel_proto::commit::v1::CommitRecord;
+use ravel_query::LogSegmentFetcher;
+use ravel_sql::{DeclaredColumn, DeclaredType, LogsTableProvider, declared_stat_carrier_conflicts};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use ravel_types::declared_stats::{DeclaredColumnStat, DeclaredStatType, DeclaredStatValue};
+use tracing::Level;
+use tracing_subscriber::fmt::MakeWriter;
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+const COL: &str = "EventDate";
+/// Rows in the fabricated segment, and the figure the stamp's NULL count is
+/// reconciled against.
+const SAMPLE_COUNT: u64 = 4;
+/// The conflicting segment's content hash, distinct from the all-zero default
+/// so the assertion cannot pass on an unrelated field.
+const CONTENT_HASH: [u8; 32] = [0xab; 32];
+
+/// A `tracing` writer that appends every emitted byte to a shared buffer so the
+/// test can assert what was logged.
+#[derive(Clone)]
+struct CapturedLog(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for CapturedLog {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("log buffer lock")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CapturedLog {
+    type Writer = CapturedLog;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// One segment carrying `CONTENT_HASH`, stamped with `(min, max, null_count)`
+/// through the carrier read that binds the row-count clauses (the only route to
+/// a non-empty [`DeclaredColumnStats`]).
+fn stamped_segment(min: i64, max: i64, null_count: u64) -> SegmentRef {
+    let stat = DeclaredColumnStat::new(
+        COL,
+        DeclaredStatType::I64,
+        Some(DeclaredStatValue::I64(min)),
+        Some(DeclaredStatValue::I64(max)),
+        null_count,
+    )
+    .expect("valid stamp");
+    let record = CommitRecord {
+        sample_count: SAMPLE_COUNT,
+        declared_column_stats: vec![encode_stamp(&stat)],
+        ..CommitRecord::default()
+    };
+    let seg = SegmentRef {
+        data_object_key: "logs/seg-1.rlog".to_string(),
+        object_size: 1,
+        min_event_ts_ns: 0,
+        max_event_ts_ns: 1_000,
+        ingest_hour_bucket: 0,
+        sample_count: SAMPLE_COUNT,
+        series_count: 0,
+        shard: 0,
+        content_hash: CONTENT_HASH,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: DeclaredColumnStats::from_validated(&read_commit_record(&record)),
+    };
+    assert_eq!(seg.declared_column_stats.len(), 1, "fixture stamp is valid");
+    seg
+}
+
+fn identity_of(seg: &SegmentRef) -> EntryIdentity {
+    (
+        seg.ingest_hour_bucket,
+        seg.shard,
+        *seg.writer_id.as_bytes(),
+        seg.writer_epoch,
+        seg.writer_seq,
+    )
+}
+
+/// The `.cstat` entry for the same segment and column, with no value dictionary
+/// (this path reads neither).
+fn loaded_cstat(seg: &SegmentRef, min: i64, max: i64, null_count: u64) -> Arc<LoadedColumnStats> {
+    let stat = ColumnStat {
+        name: COL.to_string(),
+        declared_type: 2, // ravel.sys.v1.TypedAttrColumnType::I64
+        non_null_count: SAMPLE_COUNT - null_count,
+        null_count,
+        min: Some(ColumnValue {
+            kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(min)),
+        }),
+        max: Some(ColumnValue {
+            kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(max)),
+        }),
+        dictionary_present: false,
+        dictionary: Vec::new(),
+        sum: None,
+    };
+    let mut segments = HashMap::new();
+    segments.insert(
+        identity_of(seg),
+        ColumnStatsSegment {
+            ingest_hour_bucket: seg.ingest_hour_bucket,
+            shard: seg.shard,
+            writer_id: seg.writer_id.as_bytes().to_vec(),
+            writer_epoch: seg.writer_epoch,
+            writer_seq: seg.writer_seq,
+            columns: vec![stat],
+        },
+    );
+    Arc::new(LoadedColumnStats {
+        segments,
+        part_blake3: Vec::new(),
+    })
+}
+
+/// A stamp and a `.cstat` entry that disagree on every field of the triple, so
+/// the line has three pairs to distinguish and a partial line cannot pass:
+/// the column is `Absent`, the tally moves once, and the log line names the
+/// segment by content hash plus both triples.
+///
+/// Prove-the-test: delete the `tracing::warn!` call in
+/// `record_carrier_conflict` (crates/ravel-sql/src/logs_scan.rs) and every
+/// `contains` assertion fails while the `Absent` and tally assertions still
+/// pass, which is the state before this line existed. Drop the
+/// `segment_content_hash` field alone and only the hash assertion fails; log
+/// the stamp triple only and the three `cstat_*` assertions fail.
+#[test]
+fn a_conflict_logs_the_segment_content_hash_and_both_triples() {
+    let seg = stamped_segment(200, 500, 1);
+    let stats = loaded_cstat(&seg, -1, 499, 2);
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let provider = LogsTableProvider::new(
+        Snapshot {
+            segments: vec![seg],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        },
+        TENANT,
+        LogSegmentFetcher::new(backend),
+        QueryAccounting::new(),
+    )
+    .with_declared_columns(vec![DeclaredColumn::new(COL, DeclaredType::I64)])
+    .with_column_stats(Some(stats));
+    let plan = provider.plan_filters(4, &[]).expect("plan_filters");
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(CapturedLog(Arc::clone(&buffer)))
+        .with_max_level(Level::WARN)
+        .with_ansi(false)
+        .finish();
+    let before = declared_stat_carrier_conflicts();
+    let resolved = tracing::subscriber::with_default(subscriber, || {
+        plan.partition_statistics(None)
+            .expect("partition_statistics")
+    });
+    let delta = declared_stat_carrier_conflicts() - before;
+
+    assert_eq!(
+        resolved.column_statistics[ravel_sql::FIRST_DECLARED_COL].min_value,
+        Precision::Absent,
+        "conflicting carriers grant no coverage"
+    );
+    assert_eq!(delta, 1, "one conflicted segment, observed once");
+
+    let logged = String::from_utf8(buffer.lock().expect("log buffer lock").clone())
+        .expect("utf8 log output");
+    for needle in [
+        COL,
+        &hex::encode(CONTENT_HASH),
+        "stamp_min=Some(Int64(200))",
+        "stamp_max=Some(Int64(500))",
+        "stamp_null_count=1",
+        "cstat_min=Some(Int64(-1))",
+        "cstat_max=Some(Int64(499))",
+        "cstat_null_count=2",
+    ] {
+        assert!(
+            logged.contains(needle),
+            "the conflict log line must carry {needle:?}; logged:\n{logged}"
+        );
+    }
+}

--- a/crates/ravel-sql/tests/declared_stat_conflict_log.rs
+++ b/crates/ravel-sql/tests/declared_stat_conflict_log.rs
@@ -213,14 +213,22 @@ fn a_conflict_logs_the_segment_content_hash_and_both_triples() {
 
     let logged = String::from_utf8(buffer.lock().expect("log buffer lock").clone())
         .expect("utf8 log output");
+    // Field NAMES and the exact plain-integer figures are the contract; the
+    // Option/ScalarValue wrapper text is DataFusion's Debug representation
+    // and may change across upgrades without changing conflict behaviour, so
+    // the extrema are matched by their digits, not their wrapper.
     for needle in [
         COL,
         &hex::encode(CONTENT_HASH),
-        "stamp_min=Some(Int64(200))",
-        "stamp_max=Some(Int64(500))",
+        "stamp_min=",
+        "200",
+        "stamp_max=",
+        "500",
         "stamp_null_count=1",
-        "cstat_min=Some(Int64(-1))",
-        "cstat_max=Some(Int64(499))",
+        "cstat_min=",
+        "-1",
+        "cstat_max=",
+        "499",
         "cstat_null_count=2",
     ] {
         assert!(

--- a/crates/ravel-sql/tests/declared_stat_conflict_log.rs
+++ b/crates/ravel-sql/tests/declared_stat_conflict_log.rs
@@ -213,27 +213,54 @@ fn a_conflict_logs_the_segment_content_hash_and_both_triples() {
 
     let logged = String::from_utf8(buffer.lock().expect("log buffer lock").clone())
         .expect("utf8 log output");
-    // Field NAMES and the exact plain-integer figures are the contract; the
+    // Field NAMES bound to their exact figures are the contract; the
     // Option/ScalarValue wrapper text is DataFusion's Debug representation
-    // and may change across upgrades without changing conflict behaviour, so
-    // the extrema are matched by their digits, not their wrapper.
-    for needle in [
-        COL,
-        &hex::encode(CONTENT_HASH),
-        "stamp_min=",
-        "200",
-        "stamp_max=",
-        "500",
-        "stamp_null_count=1",
-        "cstat_min=",
-        "-1",
-        "cstat_max=",
-        "499",
-        "cstat_null_count=2",
-    ] {
+    // and may change across upgrades without changing conflict behaviour. For
+    // each field, the FIRST numeric token after `name=` must equal the
+    // expected value exactly -- independent substring checks would accept
+    // swapped extrema or a superstring like -10 for -1.
+    for needle in [COL, hex::encode(CONTENT_HASH).as_str()] {
         assert!(
             logged.contains(needle),
             "the conflict log line must carry {needle:?}; logged:\n{logged}"
+        );
+    }
+    // The field's whitespace-delimited token (e.g. `stamp_min=Some(Int64(200))`
+    // or a future plain `stamp_min=200`) carries the value as its LAST numeric
+    // run -- the first can be the wrapper's own `64`.
+    let value_of = |field: &str| -> String {
+        let at = logged
+            .find(field)
+            .unwrap_or_else(|| panic!("field {field:?} absent; logged:\n{logged}"))
+            + field.len();
+        let token: &str = logged[at..].split_whitespace().next().unwrap_or("");
+        let mut runs: Vec<String> = Vec::new();
+        let mut cur = String::new();
+        for c in token.chars() {
+            if c.is_ascii_digit() || (c == '-' && cur.is_empty()) {
+                cur.push(c);
+            } else if !cur.is_empty() {
+                runs.push(std::mem::take(&mut cur));
+            }
+        }
+        if !cur.is_empty() {
+            runs.push(cur);
+        }
+        runs.pop()
+            .unwrap_or_else(|| panic!("no numeric token in {token:?} after {field:?}"))
+    };
+    for (field, expected) in [
+        ("stamp_min=", "200"),
+        ("stamp_max=", "500"),
+        ("stamp_null_count=", "1"),
+        ("cstat_min=", "-1"),
+        ("cstat_max=", "499"),
+        ("cstat_null_count=", "2"),
+    ] {
+        assert_eq!(
+            value_of(field),
+            expected,
+            "field {field:?} must bind exactly to {expected:?}; logged:\n{logged}"
         );
     }
 }

--- a/crates/ravel-sql/tests/declared_stat_cstat_drops.rs
+++ b/crates/ravel-sql/tests/declared_stat_cstat_drops.rs
@@ -1,0 +1,256 @@
+//! The `.cstat` half of the ADR-0873 decision 2 defect metric: the second
+//! carrier of the declared-statistics union is read in `ravel_sql`, so its
+//! refusals are reported to
+//! `ravel_commit::declared_stats::declared_stat_drops_observed` under the
+//! `cstat` label. One metric, four carrier labels; a defect in the `.cstat`
+//! build would otherwise be the one carrier whose refusals nothing counts.
+//!
+//! The metric has observation semantics (one increment per READ of a defective
+//! entry, no per-entry dedup), which is why every assertion here is a delta
+//! across exactly one `partition_statistics` call.
+//!
+//! Own integration binary, all tests synchronous, all tests holding one lock:
+//! the tally is process-wide and monotonic, so an exact-delta assertion means
+//! something only when the test knows every other reader in the process.
+//! Nothing here reads an object -- the statistics path is pure plan-time work
+//! over the resolved snapshot -- so the segments are fabricated and no store is
+//! needed.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use datafusion::common::stats::Precision;
+use datafusion::scalar::ScalarValue;
+use ravel_catalog::{
+    DeclaredColumnStats, EntryIdentity, LoadedColumnStats, SegmentLevel, SegmentRef, Snapshot,
+};
+use ravel_commit::declared_stats::{StatCarrier, declared_stat_drops_observed};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue};
+use ravel_query::LogSegmentFetcher;
+use ravel_sql::{DeclaredColumn, DeclaredType, LogsTableProvider};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+const COL: &str = "EventDate";
+/// Rows per fabricated segment.
+const SAMPLE_COUNT: u64 = 4;
+
+/// Serialises every test here so a delta on the process-wide tally is
+/// attributable to exactly the statistics resolution this test ran.
+static DROPS: Mutex<()> = Mutex::new(());
+
+fn drops_lock() -> MutexGuard<'static, ()> {
+    match DROPS.lock() {
+        Ok(guard) => guard,
+        // A poisoned lock means a sibling test panicked; the tally is still
+        // sound to read, and re-reporting the sibling's failure here would only
+        // obscure it.
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+/// An unstamped segment: the `.cstat` object is then the only carrier, so every
+/// refusal under test is this reader's own.
+fn seg_ref(seq: u64) -> SegmentRef {
+    SegmentRef {
+        data_object_key: format!("logs/seg-{seq}.rlog"),
+        object_size: 1,
+        min_event_ts_ns: 0,
+        max_event_ts_ns: 1_000,
+        ingest_hour_bucket: 0,
+        sample_count: SAMPLE_COUNT,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: seq,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: DeclaredColumnStats::default(),
+    }
+}
+
+fn identity_of(seg: &SegmentRef) -> EntryIdentity {
+    (
+        seg.ingest_hour_bucket,
+        seg.shard,
+        *seg.writer_id.as_bytes(),
+        seg.writer_epoch,
+        seg.writer_seq,
+    )
+}
+
+fn i64_value(v: i64) -> ColumnValue {
+    ColumnValue {
+        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(v)),
+    }
+}
+
+/// A well-formed `.cstat` entry for `name`.
+fn cstat(name: &str, min: i64, max: i64, null_count: u64) -> ColumnStat {
+    ColumnStat {
+        name: name.to_string(),
+        declared_type: 2, // ravel.sys.v1.TypedAttrColumnType::I64
+        non_null_count: SAMPLE_COUNT - null_count,
+        null_count,
+        min: Some(i64_value(min)),
+        max: Some(i64_value(max)),
+        dictionary_present: false,
+        dictionary: Vec::new(),
+        sum: None,
+    }
+}
+
+fn loaded(seg: &SegmentRef, columns: Vec<ColumnStat>) -> Arc<LoadedColumnStats> {
+    let mut segments = HashMap::new();
+    segments.insert(
+        identity_of(seg),
+        ColumnStatsSegment {
+            ingest_hour_bucket: seg.ingest_hour_bucket,
+            shard: seg.shard,
+            writer_id: seg.writer_id.as_bytes().to_vec(),
+            writer_epoch: seg.writer_epoch,
+            writer_seq: seg.writer_seq,
+            columns,
+        },
+    );
+    Arc::new(LoadedColumnStats {
+        segments,
+        part_blake3: Vec::new(),
+    })
+}
+
+/// Every label's tally, in [`StatCarrier::ALL`] order.
+fn observed_all() -> Vec<u64> {
+    StatCarrier::ALL
+        .iter()
+        .map(|carrier| declared_stat_drops_observed(*carrier))
+        .collect()
+}
+
+/// The declared column's plan-time statistics over one segment plus its
+/// `.cstat` entries, the `cstat`-labelled drop delta across resolving them, and
+/// the summed delta of every other label (which must stay zero: a `.cstat`
+/// refusal is not a stamp-carrier drop).
+fn resolve(
+    seg: SegmentRef,
+    columns: Vec<ColumnStat>,
+) -> (datafusion::common::ColumnStatistics, u64, u64) {
+    let guard = drops_lock();
+    let stats = loaded(&seg, columns);
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let provider = LogsTableProvider::new(
+        Snapshot {
+            segments: vec![seg],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        },
+        TENANT,
+        LogSegmentFetcher::new(backend),
+        QueryAccounting::new(),
+    )
+    .with_declared_columns(vec![DeclaredColumn::new(COL, DeclaredType::I64)])
+    .with_column_stats(Some(stats));
+    let plan = provider.plan_filters(4, &[]).expect("plan_filters");
+    let before = observed_all();
+    let resolved = plan
+        .partition_statistics(None)
+        .expect("partition_statistics");
+    let after = observed_all();
+    drop(guard);
+
+    let mut mine = 0;
+    let mut others = 0;
+    for ((label, b), a) in StatCarrier::ALL.iter().zip(before.iter()).zip(after.iter()) {
+        let delta = a - b;
+        if *label == StatCarrier::Cstat {
+            mine = delta;
+        } else {
+            others += delta;
+        }
+    }
+    (
+        resolved.column_statistics[ravel_sql::FIRST_DECLARED_COL].clone(),
+        mine,
+        others,
+    )
+}
+
+/// Two `.cstat` entries under one column name: no rule can pick between two
+/// claims about one immutable object, so the column is uncovered AND the
+/// refusal is counted once under `cstat`.
+///
+/// Prove-the-test: delete the `observe_declared_stat_drops(StatCarrier::Cstat,
+/// 1)` call in the `unique_column_stat` `None` arm of `cstat_coverage`
+/// (crates/ravel-sql/src/logs_scan.rs) and the delta reads 0 while the
+/// `Absent` assertion still passes, which is exactly the state this finding
+/// was filed about.
+#[test]
+fn a_duplicated_cstat_column_name_is_counted_once() {
+    let seg = seg_ref(1);
+    let (col, mine, others) = resolve(seg, vec![cstat(COL, 200, 500, 1), cstat(COL, 1, 2, 0)]);
+    assert_eq!(col.min_value, Precision::Absent, "no coverage from either");
+    assert_eq!(mine, 1, "one refused entry set, counted once");
+    assert_eq!(others, 0, "and under the cstat label only");
+}
+
+/// An entry claiming extrema over a column with zero non-null rows, and its
+/// mirror image (non-null rows with no recorded extremum): both are #970's
+/// defect, both leave the column uncovered, and both are counted.
+///
+/// Prove-the-test: replace the `if validate_min_max_presence(stat).is_err()`
+/// block in `cstat_coverage` with `let _ = validate_min_max_presence(stat);`
+/// and both deltas read 0 while the extrema come from a record that describes
+/// no live row.
+#[test]
+fn a_presence_contradiction_is_counted_once_in_either_direction() {
+    // Extrema present, zero non-null rows.
+    let mut fabricated = cstat(COL, 200, 500, SAMPLE_COUNT);
+    fabricated.non_null_count = 0;
+    let (col, mine, others) = resolve(seg_ref(2), vec![fabricated]);
+    assert_eq!(col.min_value, Precision::Absent);
+    assert_eq!((mine, others), (1, 0));
+
+    // Non-null rows, no recorded extremum.
+    let mut missing = cstat(COL, 200, 500, 0);
+    missing.min = None;
+    missing.max = None;
+    let (col, mine, others) = resolve(seg_ref(3), vec![missing]);
+    assert_eq!(col.min_value, Precision::Absent);
+    assert_eq!((mine, others), (1, 0));
+}
+
+/// Absence is not a defect, in any of its three shapes: a valid entry, an entry
+/// for a different column, and a segment the `.cstat` object does not cover all
+/// leave the metric where it was. A counter that fired on absence would report
+/// every tenant whose fold never built a column as a writer bug.
+#[test]
+fn absence_and_validity_leave_the_cstat_label_untouched() {
+    let (col, mine, others) = resolve(seg_ref(4), vec![cstat(COL, 200, 500, 1)]);
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Int64(Some(200))),
+        "a valid entry still answers"
+    );
+    assert_eq!((mine, others), (0, 0), "a valid entry is not a defect");
+
+    let (col, mine, others) = resolve(seg_ref(5), vec![cstat("SomethingElse", 1, 2, 0)]);
+    assert_eq!(col.min_value, Precision::Absent);
+    assert_eq!(
+        (mine, others),
+        (0, 0),
+        "an uncovered column is the ordinary state, not a defect"
+    );
+
+    let (col, mine, others) = resolve(seg_ref(6), Vec::new());
+    assert_eq!(col.min_value, Precision::Absent);
+    assert_eq!((mine, others), (0, 0), "nor is an entryless segment");
+}

--- a/crates/ravel-sql/tests/logs_declared_minmax_from_stamps.rs
+++ b/crates/ravel-sql/tests/logs_declared_minmax_from_stamps.rs
@@ -3,6 +3,11 @@
 //! GETs (issue #873's ClickBench q07 shape, `SELECT MIN(EventDate),
 //! MAX(EventDate) FROM hits`).
 //!
+//! `COUNT(<declared column>)` rides the same statistics object, since the exact
+//! NULL count is reported beside the extrema and DataFusion rewrites the
+//! aggregate into `num_rows - null_count`; both statement shapes are covered
+//! here, over both stamp-eligible types (`I64` and `BOOL`).
+//!
 //! Every positive test pins the same four facts, the way
 //! `logs_count_from_stats.rs` pins them for `COUNT(*)`: the answer equals what
 //! a scan of the same objects returns, the physical plan carries no
@@ -29,7 +34,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, Int64Array};
+use datafusion::arrow::array::{Array, BooleanArray, Int64Array};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::stats::Precision;
 use datafusion::physical_plan::{Statistics, collect, displayable};
@@ -76,6 +81,20 @@ const COL: &str = "EventDate";
 const SEG_A_ROWS: &[(i64, Option<i64>)] = &[(100, Some(19_000)), (101, None), (102, Some(18_500))];
 /// Segment B's rows, holding both the corpus minimum and its maximum.
 const SEG_B_ROWS: &[(i64, Option<i64>)] = &[(200, Some(17_100)), (201, Some(19_400))];
+/// A segment whose declared column reads NULL in every row: the stamp carries
+/// no extrema and `null_count == sample_count`, which is the exact statement
+/// "zero non-null values" rather than a gap (ADR-0873 clause 5).
+const ALL_NULL_ROWS: &[(i64, Option<i64>)] = &[(300, None), (301, None), (302, None)];
+
+/// The BOOL declared column under test, the other half of ADR-0873 decision
+/// 2's stamp allowlist. ClickBench's `IsRefresh` is the shape.
+const BOOL_COL: &str = "IsRefresh";
+/// The BOOL corpus, split over two objects: every value in the first is
+/// `false`, so the corpus maximum lives in the second and an implementation
+/// that answered from one segment alone would report `false` for `MAX`.
+const BOOL_SEG_A_ROWS: &[(i64, Option<bool>)] =
+    &[(100, Some(false)), (101, None), (102, Some(false))];
+const BOOL_SEG_B_ROWS: &[(i64, Option<bool>)] = &[(200, Some(true)), (201, Some(false))];
 
 /// The true extrema and NULL count over both segments, computed from the same
 /// constants the objects are written from.
@@ -88,13 +107,15 @@ fn true_answer() -> (Option<i64>, Option<i64>) {
     (vals.iter().min().copied(), vals.iter().max().copied())
 }
 
-fn record(ts: i64, event_date: Option<i64>) -> LogRecord {
+/// One record carrying `value` under `attr_key`, or carrying no attribute at
+/// all when `value` is `None` (which is how a NULL declared column reads).
+fn record(ts: i64, attr_key: &str, value: Option<AttrValue>) -> LogRecord {
     let resource: Vec<(String, AttrValue)> = vec![(
         "service.name".to_string(),
         AttrValue::Str("api".to_string()),
     )];
-    let attrs = match event_date {
-        Some(v) => vec![(COL.to_string(), AttrValue::I64(v))],
+    let attrs = match value {
+        Some(v) => vec![(attr_key.to_string(), v)],
         None => Vec::new(),
     };
     LogRecord {
@@ -112,13 +133,15 @@ fn record(ts: i64, event_date: Option<i64>) -> LogRecord {
     }
 }
 
-/// Write `rows` as one real RLOG object and return its unstamped
-/// [`SegmentRef`].
-async fn write_segment(
+/// Write `rows` (`(ts, attribute value)`, a `None` value meaning the record
+/// carries no such attribute) as one real RLOG object under `attr_key`, and
+/// return its unstamped [`SegmentRef`].
+async fn write_attr_segment(
     store: &Arc<CountingStore>,
     key: &str,
     seq: u64,
-    rows: &[(i64, Option<i64>)],
+    attr_key: &str,
+    rows: &[(i64, Option<AttrValue>)],
 ) -> SegmentRef {
     let mut w = RlogWriter::new(
         RlogConfig::default(),
@@ -131,7 +154,7 @@ async fn write_segment(
         },
     );
     for (ts, v) in rows {
-        w.push(record(*ts, *v)).expect("push");
+        w.push(record(*ts, attr_key, v.clone())).expect("push");
     }
     let bytes = w.finish().expect("finish");
     let object_size = bytes.len() as u64;
@@ -159,6 +182,34 @@ async fn write_segment(
     }
 }
 
+/// The I64 corpus writer: `rows` as one real RLOG object under [`COL`].
+async fn write_segment(
+    store: &Arc<CountingStore>,
+    key: &str,
+    seq: u64,
+    rows: &[(i64, Option<i64>)],
+) -> SegmentRef {
+    let rows: Vec<(i64, Option<AttrValue>)> = rows
+        .iter()
+        .map(|(ts, v)| (*ts, v.map(AttrValue::I64)))
+        .collect();
+    write_attr_segment(store, key, seq, COL, &rows).await
+}
+
+/// The same for the BOOL corpus, under [`BOOL_COL`].
+async fn write_bool_segment(
+    store: &Arc<CountingStore>,
+    key: &str,
+    seq: u64,
+    rows: &[(i64, Option<bool>)],
+) -> SegmentRef {
+    let rows: Vec<(i64, Option<AttrValue>)> = rows
+        .iter()
+        .map(|(ts, v)| (*ts, v.map(AttrValue::Bool)))
+        .collect();
+    write_attr_segment(store, key, seq, BOOL_COL, &rows).await
+}
+
 /// The exact stamp a correct writer produces for `rows`: extrema over the
 /// non-null values, absent when there are none, and the exact NULL count.
 fn stamp_for(rows: &[(i64, Option<i64>)]) -> DeclaredColumnStat {
@@ -172,6 +223,21 @@ fn stamp_for(rows: &[(i64, Option<i64>)]) -> DeclaredColumnStat {
         null_count,
     )
     .expect("valid stamp")
+}
+
+/// The same for the BOOL corpus: `false` sorts below `true`, so the extrema of
+/// a mixed segment are exactly `(false, true)`.
+fn bool_stamp_for(rows: &[(i64, Option<bool>)]) -> DeclaredColumnStat {
+    let vals: Vec<bool> = rows.iter().filter_map(|(_, v)| *v).collect();
+    let null_count = u64::try_from(rows.len() - vals.len()).expect("fits");
+    DeclaredColumnStat::new(
+        BOOL_COL,
+        DeclaredStatType::Bool,
+        vals.iter().min().map(|v| DeclaredStatValue::Bool(*v)),
+        vals.iter().max().map(|v| DeclaredStatValue::Bool(*v)),
+        null_count,
+    )
+    .expect("valid bool stamp")
 }
 
 fn i64_stamp_entry(name: &str, min: i64, max: i64, null_count: u64) -> DeclaredColumnMinMax {
@@ -301,11 +367,19 @@ fn declared_cols() -> Vec<DeclaredColumn> {
     vec![DeclaredColumn::new(COL, DeclaredType::I64)]
 }
 
-fn provider(
+/// The tenant's declaration for the BOOL tests: one BOOL column, so it sits at
+/// [`ravel_sql::FIRST_DECLARED_COL`] exactly as the I64 column does in the
+/// others.
+fn bool_declared_cols() -> Vec<DeclaredColumn> {
+    vec![DeclaredColumn::new(BOOL_COL, DeclaredType::Bool)]
+}
+
+fn provider_with(
     store: &Arc<CountingStore>,
     snapshot: Snapshot,
     accounting: &QueryAccounting,
     stats: Option<Arc<LoadedColumnStats>>,
+    declared: Vec<DeclaredColumn>,
 ) -> LogsTableProvider {
     let backend: Arc<dyn ObjectStoreBackend> = Arc::clone(store) as Arc<dyn ObjectStoreBackend>;
     LogsTableProvider::new(
@@ -314,7 +388,7 @@ fn provider(
         LogSegmentFetcher::new(backend),
         accounting.clone(),
     )
-    .with_declared_columns(declared_cols())
+    .with_declared_columns(declared)
     .with_column_stats(stats)
 }
 
@@ -329,6 +403,52 @@ fn logs_session(provider: LogsTableProvider) -> datafusion::error::Result<Sessio
         false,
         SpillDecision::Disabled,
     )
+}
+
+/// The single `COUNT(...)` value from a one-row, one-column result, or `None`
+/// when the aggregate is SQL NULL (which `COUNT` never is, so a `None` here is
+/// a failure the caller should assert on).
+fn count_value(batches: &[RecordBatch]) -> Option<i64> {
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 count");
+        return if arr.is_null(0) {
+            None
+        } else {
+            Some(arr.value(0))
+        };
+    }
+    None
+}
+
+/// `(min, max)` from `SELECT MIN(bool_col), MAX(bool_col)`; a component is
+/// `None` when the aggregate is SQL NULL.
+fn min_max_bool(batches: &[RecordBatch]) -> (Option<bool>, Option<bool>) {
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let col = |i: usize| {
+            let arr = batch
+                .column(i)
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("boolean aggregate");
+            if arr.is_null(0) {
+                None
+            } else {
+                Some(arr.value(0))
+            }
+        };
+        return (col(0), col(1));
+    }
+    (None, None)
 }
 
 /// `(min, max)` from `SELECT MIN(col), MAX(col)`; a component is `None` when
@@ -365,18 +485,31 @@ struct Outcome {
     objects_touched: u64,
 }
 
-/// Run `SELECT MIN("EventDate"), MAX("EventDate") FROM logs` over `snapshot`,
-/// against the objects already written into `store`.
-async fn min_max_over_store(
+/// One statement's raw outcome, for the statements whose answer the caller
+/// reads out of the batches itself.
+struct Run {
+    plan: String,
+    batches: Vec<RecordBatch>,
+    gets: u64,
+    accounted_gets: u64,
+    objects_touched: u64,
+}
+
+/// Run `sql` over `snapshot` against the objects already written into `store`,
+/// with `declared` as the tenant's declared columns.
+async fn run_over_store(
     store: &Arc<CountingStore>,
     snapshot: Snapshot,
     stats: Option<Arc<LoadedColumnStats>>,
-) -> Outcome {
+    declared: Vec<DeclaredColumn>,
+    sql: &str,
+) -> Run {
     let accounting = QueryAccounting::new();
     let before_gets = store.gets();
-    let ctx = logs_session(provider(store, snapshot, &accounting, stats)).expect("session");
+    let ctx = logs_session(provider_with(store, snapshot, &accounting, stats, declared))
+        .expect("session");
     let plan = ctx
-        .sql(&format!("SELECT MIN(\"{COL}\"), MAX(\"{COL}\") FROM logs"))
+        .sql(sql)
         .await
         .expect("plan")
         .create_physical_plan()
@@ -387,24 +520,56 @@ async fn min_max_over_store(
         .await
         .expect("collect");
     let snap = accounting.snapshot();
-    Outcome {
+    Run {
         plan: text,
-        answer: min_max_i64(&batches),
+        batches,
         gets: store.gets() - before_gets,
         accounted_gets: snap.s3_requests[AccountedOp::Get.index()],
         objects_touched: snap.data_objects_touched,
     }
 }
 
+/// Run `SELECT MIN("EventDate"), MAX("EventDate") FROM logs` over `snapshot`,
+/// against the objects already written into `store`.
+async fn min_max_over_store(
+    store: &Arc<CountingStore>,
+    snapshot: Snapshot,
+    stats: Option<Arc<LoadedColumnStats>>,
+) -> Outcome {
+    let run = run_over_store(
+        store,
+        snapshot,
+        stats,
+        declared_cols(),
+        &format!("SELECT MIN(\"{COL}\"), MAX(\"{COL}\") FROM logs"),
+    )
+    .await;
+    Outcome {
+        answer: min_max_i64(&run.batches),
+        plan: run.plan,
+        gets: run.gets,
+        accounted_gets: run.accounted_gets,
+        objects_touched: run.objects_touched,
+    }
+}
+
 /// The whole-plan statistics of the bare scan over `snapshot`, which is the
 /// entry point `AggregateStatistics` consults. No object-store I/O.
-fn scan_stats(snapshot: Snapshot, stats: Option<Arc<LoadedColumnStats>>) -> Arc<Statistics> {
+fn scan_stats_for(
+    snapshot: Snapshot,
+    stats: Option<Arc<LoadedColumnStats>>,
+    declared: Vec<DeclaredColumn>,
+) -> Arc<Statistics> {
     let store = CountingStore::new(Arc::new(MemoryStore::new()));
     let accounting = QueryAccounting::new();
-    let provider = provider(&store, snapshot, &accounting, stats);
+    let provider = provider_with(&store, snapshot, &accounting, stats, declared);
     let plan = provider.plan_filters(4, &[]).expect("plan_filters");
     plan.partition_statistics(None)
         .expect("partition_statistics")
+}
+
+fn scan_stats(snapshot: Snapshot, stats: Option<Arc<LoadedColumnStats>>) -> Arc<Statistics> {
+    scan_stats_for(snapshot, stats, declared_cols())
 }
 
 /// The declared column's statistics in `stats`. The scan projects every schema
@@ -837,4 +1002,309 @@ async fn carriers_disagreeing_about_one_segment_decline() {
         (Some(18_500), Some(19_000)),
         "the scan answers segment A's real extrema, not the fabricated -1"
     );
+}
+
+// ---------------------------------------------------------------------------
+// `COUNT(<declared column>)`, the second statement shape this statistics
+// object answers (ADR-0873: the exact NULL count is reported beside the
+// extrema, so DataFusion's `Count::value_from_stats` rewrites the aggregate
+// into `num_rows - null_count`).
+// ---------------------------------------------------------------------------
+
+/// `COUNT(<declared column>)` over a stamped tenant is a plan-time literal,
+/// equal to `sample_count - null_count` with the NULL count taken ONCE.
+///
+/// Both segments here are covered by BOTH carriers, in agreement, which is what
+/// makes the exact value the assertion: a union that summed the carriers'
+/// `null_count`s instead of taking one would answer 3, and one that dropped the
+/// NULL count entirely would leave the column `Absent` and scan. The corpus has
+/// 5 rows and exactly one NULL, so the only correct answer is 4.
+///
+/// Prove-the-test: in `LogsScanExec::declared_min_max_all`
+/// (crates/ravel-sql/src/logs_scan.rs) replace the union's
+/// `null_count_proven: stamp.null_count_proven || cstat.null_count_proven,
+/// ..stamp` arm with an arm that sums (`null_count: stamp.null_count +
+/// cstat.null_count`) and this reads 3; delete the `col.null_count =
+/// Precision::Exact(nulls)` assignment in `partition_statistics` and the plan
+/// keeps its `LogsScanExec` with 2 GETs while the count still answers 4.
+#[tokio::test]
+async fn count_of_a_stamped_column_subtracts_the_null_count_exactly_once() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let b = write_segment(&store, "logs/b.rlog", 2, SEG_B_ROWS).await;
+    let stats = loaded_stats(vec![
+        (&a, vec![cstat_for(SEG_A_ROWS, Some(18_500), Some(19_000))]),
+        (&b, vec![cstat_for(SEG_B_ROWS, Some(17_100), Some(19_400))]),
+    ]);
+    let snapshot = snapshot_of(vec![
+        stamped(&a, vec![encode_stamp(&stamp_for(SEG_A_ROWS))]),
+        stamped(&b, vec![encode_stamp(&stamp_for(SEG_B_ROWS))]),
+    ]);
+
+    // The seam `Count::value_from_stats` reads: both figures exact, and the
+    // NULL count is 1 rather than the 2 a carrier-summing union would report.
+    let col_stats = scan_stats(snapshot.clone(), Some(Arc::clone(&stats)));
+    assert_eq!(col_stats.num_rows, Precision::Exact(5), "3 + 2 rows");
+    assert_eq!(
+        declared_col_stats(&col_stats).null_count,
+        Precision::Exact(1),
+        "one NULL row, counted once across two agreeing carriers"
+    );
+
+    let run = run_over_store(
+        &store,
+        snapshot,
+        Some(stats),
+        declared_cols(),
+        &format!("SELECT COUNT(\"{COL}\") FROM logs"),
+    )
+    .await;
+    assert!(
+        !run.plan.contains("LogsScanExec"),
+        "a stamped COUNT(col) must be a plan-time literal; plan was:\n{}",
+        run.plan
+    );
+    assert_eq!(
+        count_value(&run.batches),
+        Some(4),
+        "5 rows minus the one NULL row, taken once (3 if the carriers were summed)"
+    );
+    assert_eq!(run.gets, 0, "no data object may be read");
+    assert_eq!(run.accounted_gets, 0, "and none may be accounted either");
+    assert_eq!(run.objects_touched, 0);
+}
+
+/// The same count is what a scan of the same objects returns, which is what
+/// makes the test above a statistics test rather than an agreement between two
+/// fabrications.
+#[tokio::test]
+async fn the_stamped_count_equals_the_scanned_count() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let b = write_segment(&store, "logs/b.rlog", 2, SEG_B_ROWS).await;
+    let sql = format!("SELECT COUNT(\"{COL}\") FROM logs");
+
+    let scanned = run_over_store(
+        &store,
+        snapshot_of(vec![a.clone(), b.clone()]),
+        None,
+        declared_cols(),
+        &sql,
+    )
+    .await;
+    assert!(
+        scanned.plan.contains("LogsScanExec"),
+        "an unstamped snapshot has nothing to answer from; plan was:\n{}",
+        scanned.plan
+    );
+    assert!(scanned.gets > 0, "the reference answer comes from the data");
+
+    let from_stats = run_over_store(
+        &store,
+        snapshot_of(vec![
+            stamped(&a, vec![encode_stamp(&stamp_for(SEG_A_ROWS))]),
+            stamped(&b, vec![encode_stamp(&stamp_for(SEG_B_ROWS))]),
+        ]),
+        None,
+        declared_cols(),
+        &sql,
+    )
+    .await;
+    assert_eq!(
+        count_value(&from_stats.batches),
+        count_value(&scanned.batches)
+    );
+    assert_eq!(count_value(&from_stats.batches), Some(4));
+    assert_eq!(from_stats.gets, 0);
+}
+
+/// An all-NULL declared column: the stamp carries no extrema and
+/// `null_count == sample_count`, which is an exact statement about the segment
+/// and not a gap. `COUNT(col)` is then exactly 0, answered at plan time with
+/// zero GETs, and `MIN`/`MAX` are SQL NULL.
+///
+/// The `MIN`/`MAX` half of that answer does NOT come from statistics, and the
+/// assertions say so: this scan reports `Precision::Exact(Int64(None))`, but
+/// DataFusion's `FromColumnStatistics for Min`/`for Max`
+/// (datafusion-functions-aggregate, `min_max.rs`) refuse an exact extremum that
+/// is null (`!val.is_null()`), so the rule does not fire and the statement
+/// scans to the same NULL. Only the count is a literal here.
+///
+/// Prove-the-test: replace `row_count_defect`'s `(Some(_), Some(_)) if
+/// null_count == sample_count => "present"` arm with `_ => return None`
+/// (crates/ravel-commit/src/declared_stats.rs) and a fabricated-extrema stamp
+/// over an all-NULL column becomes coverage; delete the
+/// `col.null_count = Precision::Exact(nulls)` assignment in
+/// `partition_statistics` (crates/ravel-sql/src/logs_scan.rs) and the count
+/// assertion fails with a `LogsScanExec` in the plan and 1 GET.
+#[tokio::test]
+async fn an_all_null_stamped_column_counts_zero_and_answers_null() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let seg = write_segment(&store, "logs/all-null.rlog", 3, ALL_NULL_ROWS).await;
+    let stamp = stamp_for(ALL_NULL_ROWS);
+    assert_eq!(
+        (stamp.min(), stamp.max(), stamp.null_count()),
+        (None, None, 3),
+        "zero non-null values, stated exactly"
+    );
+    let snapshot = snapshot_of(vec![stamped(&seg, vec![encode_stamp(&stamp)])]);
+
+    let col_stats = scan_stats(snapshot.clone(), None);
+    let col = declared_col_stats(&col_stats);
+    assert_eq!(col_stats.num_rows, Precision::Exact(3));
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Int64(None)),
+        "the exact extremum of zero non-null values is NULL"
+    );
+    assert_eq!(col.max_value, Precision::Exact(ScalarValue::Int64(None)));
+    assert_eq!(col.null_count, Precision::Exact(3), "every row is NULL");
+
+    let counted = run_over_store(
+        &store,
+        snapshot.clone(),
+        None,
+        declared_cols(),
+        &format!("SELECT COUNT(\"{COL}\") FROM logs"),
+    )
+    .await;
+    assert!(
+        !counted.plan.contains("LogsScanExec"),
+        "COUNT over an all-NULL stamped column is a plan-time literal; plan was:\n{}",
+        counted.plan
+    );
+    assert_eq!(
+        count_value(&counted.batches),
+        Some(0),
+        "3 rows minus 3 NULLs, exactly"
+    );
+    assert_eq!(counted.gets, 0);
+    assert_eq!(counted.accounted_gets, 0);
+    assert_eq!(counted.objects_touched, 0);
+
+    let out = min_max_over_store(&store, snapshot, None).await;
+    assert_eq!(
+        out.answer,
+        (None, None),
+        "SQL MIN/MAX over an all-NULL column is NULL"
+    );
+    assert!(
+        out.plan.contains("LogsScanExec"),
+        "DataFusion refuses a null exact extremum, so MIN/MAX scans here even \
+         though the statistics are exact; plan was:\n{}",
+        out.plan
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The BOOL half of the stamp allowlist.
+// ---------------------------------------------------------------------------
+
+/// `MIN`/`MAX` over a stamped BOOL declared column is answered at plan time
+/// with zero GETs, under `false < true`: the corpus holds `false` in both
+/// objects and `true` only in the second, so the exact answer is
+/// `(false, true)` and an implementation that reversed the comparator or read
+/// one segment alone would answer `(false, false)` or `(true, true)`.
+///
+/// Prove-the-test: return `None` from `stamp_type_of`'s
+/// `DeclaredType::Bool` arm (crates/ravel-sql/src/logs_scan.rs) and the plan
+/// regains its `LogsScanExec` with 2 GETs; swap the `Ordering::Less`/
+/// `Ordering::Greater` arguments in the `keep_extreme` calls in
+/// `declared_min_max_all` and the answer becomes `(true, false)`.
+#[tokio::test]
+async fn stamped_bool_min_max_orders_false_below_true_with_zero_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_bool_segment(&store, "logs/bool-a.rlog", 1, BOOL_SEG_A_ROWS).await;
+    let b = write_bool_segment(&store, "logs/bool-b.rlog", 2, BOOL_SEG_B_ROWS).await;
+    let a_stamp = bool_stamp_for(BOOL_SEG_A_ROWS);
+    assert_eq!(
+        (a_stamp.min(), a_stamp.max()),
+        (
+            Some(DeclaredStatValue::Bool(false)),
+            Some(DeclaredStatValue::Bool(false))
+        ),
+        "the all-false segment stamps false for both extrema"
+    );
+    let snapshot = snapshot_of(vec![
+        stamped(&a, vec![encode_stamp(&a_stamp)]),
+        stamped(&b, vec![encode_stamp(&bool_stamp_for(BOOL_SEG_B_ROWS))]),
+    ]);
+
+    let col_stats = scan_stats_for(snapshot.clone(), None, bool_declared_cols());
+    let col = declared_col_stats(&col_stats);
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Boolean(Some(false)))
+    );
+    assert_eq!(
+        col.max_value,
+        Precision::Exact(ScalarValue::Boolean(Some(true)))
+    );
+    assert_eq!(col.null_count, Precision::Exact(1), "one NULL row, in A");
+
+    let run = run_over_store(
+        &store,
+        snapshot,
+        None,
+        bool_declared_cols(),
+        &format!("SELECT MIN(\"{BOOL_COL}\"), MAX(\"{BOOL_COL}\") FROM logs"),
+    )
+    .await;
+    assert!(
+        !run.plan.contains("LogsScanExec"),
+        "a stamped BOOL MIN/MAX must be a plan-time literal; plan was:\n{}",
+        run.plan
+    );
+    assert_eq!(
+        min_max_bool(&run.batches),
+        (Some(false), Some(true)),
+        "false < true, over both objects"
+    );
+    assert_eq!(run.gets, 0, "no data object may be read");
+    assert_eq!(run.accounted_gets, 0);
+    assert_eq!(run.objects_touched, 0);
+}
+
+/// And the stamped BOOL answer is the scanned BOOL answer: the stamps are
+/// derived from the same rows the objects were written from, so the scan is the
+/// reference implementation for the comparator too.
+#[tokio::test]
+async fn the_stamped_bool_answer_equals_the_scanned_answer() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_bool_segment(&store, "logs/bool-a.rlog", 1, BOOL_SEG_A_ROWS).await;
+    let b = write_bool_segment(&store, "logs/bool-b.rlog", 2, BOOL_SEG_B_ROWS).await;
+    let sql = format!("SELECT MIN(\"{BOOL_COL}\"), MAX(\"{BOOL_COL}\") FROM logs");
+
+    let scanned = run_over_store(
+        &store,
+        snapshot_of(vec![a.clone(), b.clone()]),
+        None,
+        bool_declared_cols(),
+        &sql,
+    )
+    .await;
+    assert!(
+        scanned.plan.contains("LogsScanExec"),
+        "an unstamped snapshot has nothing to answer from; plan was:\n{}",
+        scanned.plan
+    );
+    assert!(scanned.gets > 0);
+    assert_eq!(min_max_bool(&scanned.batches), (Some(false), Some(true)));
+
+    let from_stats = run_over_store(
+        &store,
+        snapshot_of(vec![
+            stamped(&a, vec![encode_stamp(&bool_stamp_for(BOOL_SEG_A_ROWS))]),
+            stamped(&b, vec![encode_stamp(&bool_stamp_for(BOOL_SEG_B_ROWS))]),
+        ]),
+        None,
+        bool_declared_cols(),
+        &sql,
+    )
+    .await;
+    assert_eq!(
+        min_max_bool(&from_stats.batches),
+        min_max_bool(&scanned.batches)
+    );
+    assert_eq!(from_stats.gets, 0);
 }

--- a/crates/ravel-sql/tests/logs_declared_minmax_from_stamps.rs
+++ b/crates/ravel-sql/tests/logs_declared_minmax_from_stamps.rs
@@ -1,0 +1,840 @@
+//! ADR-0873 wave 4: `MIN`/`MAX` over a declared column answered from the
+//! `SegmentRef` stamps that snapshot resolution already read, with zero data
+//! GETs (issue #873's ClickBench q07 shape, `SELECT MIN(EventDate),
+//! MAX(EventDate) FROM hits`).
+//!
+//! Every positive test pins the same four facts, the way
+//! `logs_count_from_stats.rs` pins them for `COUNT(*)`: the answer equals what
+//! a scan of the same objects returns, the physical plan carries no
+//! `LogsScanExec` (the scan was elided by DataFusion's stock
+//! `AggregateStatistics` rule, not merely pruned), the store served exactly
+//! zero GETs, and `data_objects_touched` is zero -- a statement answered from
+//! statistics touches no object at all, so neither
+//! `record_open_shape` (the fast path) nor `plan_segment` (the planned route)
+//! can have run.
+//!
+//! Every negative test pins the #849 safety lemma extended to the new carrier:
+//! whenever exactness cannot be proven for a column (one segment unstamped, a
+//! stamp of an ineligible type, a duplicated stamp name, or the two carriers
+//! disagreeing) the column's statistics stay `Precision::Absent`, the rule
+//! does not fire, and the query scans to the correct answer.
+//!
+//! The objects here are real RLOG objects and every stamp is derived from the
+//! same rows the object was written from, so a rewrite that answers a
+//! different question than the one asked shows up as a wrong number rather
+//! than as an agreement between two fabrications.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, Int64Array};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::stats::Precision;
+use datafusion::physical_plan::{Statistics, collect, displayable};
+use datafusion::prelude::SessionContext;
+use datafusion::scalar::ScalarValue;
+use ravel_catalog::{
+    DeclaredColumnStats, EntryIdentity, LoadedColumnStats, SegmentLevel, SegmentRef, Snapshot,
+};
+use ravel_commit::declared_stats::{
+    encode as encode_stamp, read_commit_record, read_compaction_part,
+};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue};
+use ravel_proto::commit::v1::{
+    CommitRecord, CompactionPart, DeclaredColumnMinMax, DeclaredColumnStatValue,
+    declared_column_stat_value::Kind as StampKind,
+};
+use ravel_query::LogSegmentFetcher;
+use ravel_sql::{
+    DeclaredColumn, DeclaredType, LogsTableProvider, SessionTable, SpillDecision, SqlConfig,
+    TenantMemoryAccountant, build_session,
+};
+use ravel_types::TenantHash;
+use ravel_types::accounting::{AccountedOp, QueryAccounting};
+use ravel_types::declared_stats::{
+    DeclaredColumnStat, DeclaredStatType, DeclaredStatValue, TYPED_ATTR_COLUMN_TYPE_F64,
+};
+use ravel_types::logstream::log_stream_id;
+use uuid::Uuid;
+
+mod util;
+use util::CountingStore;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+
+/// The declared column under test, an I64 attribute, named the way issue
+/// #873's ClickBench shape names it (so the SQL needs double quotes).
+const COL: &str = "EventDate";
+
+/// Segment A's rows: `(ts, EventDate)`, one NULL.
+const SEG_A_ROWS: &[(i64, Option<i64>)] = &[(100, Some(19_000)), (101, None), (102, Some(18_500))];
+/// Segment B's rows, holding both the corpus minimum and its maximum.
+const SEG_B_ROWS: &[(i64, Option<i64>)] = &[(200, Some(17_100)), (201, Some(19_400))];
+
+/// The true extrema and NULL count over both segments, computed from the same
+/// constants the objects are written from.
+fn true_answer() -> (Option<i64>, Option<i64>) {
+    let vals: Vec<i64> = SEG_A_ROWS
+        .iter()
+        .chain(SEG_B_ROWS.iter())
+        .filter_map(|(_, v)| *v)
+        .collect();
+    (vals.iter().min().copied(), vals.iter().max().copied())
+}
+
+fn record(ts: i64, event_date: Option<i64>) -> LogRecord {
+    let resource: Vec<(String, AttrValue)> = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )];
+    let attrs = match event_date {
+        Some(v) => vec![(COL.to_string(), AttrValue::I64(v))],
+        None => Vec::new(),
+    };
+    LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".to_string(),
+        body: format!("row at {ts}"),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs,
+    }
+}
+
+/// Write `rows` as one real RLOG object and return its unstamped
+/// [`SegmentRef`].
+async fn write_segment(
+    store: &Arc<CountingStore>,
+    key: &str,
+    seq: u64,
+    rows: &[(i64, Option<i64>)],
+) -> SegmentRef {
+    let mut w = RlogWriter::new(
+        RlogConfig::default(),
+        ObjectIdentity {
+            tenant_hash: TENANT.0,
+            shard: 0,
+            writer_id: [2u8; 16],
+            writer_epoch: 1,
+            writer_seq: seq,
+        },
+    );
+    for (ts, v) in rows {
+        w.push(record(*ts, *v)).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let object_size = bytes.len() as u64;
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size,
+        min_event_ts_ns: rows.iter().map(|(ts, _)| *ts).min().expect("nonempty"),
+        max_event_ts_ns: rows.iter().map(|(ts, _)| *ts).max().expect("nonempty"),
+        ingest_hour_bucket: 0,
+        sample_count: rows.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: [u8::try_from(seq).expect("small seq"); 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: seq,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: DeclaredColumnStats::default(),
+    }
+}
+
+/// The exact stamp a correct writer produces for `rows`: extrema over the
+/// non-null values, absent when there are none, and the exact NULL count.
+fn stamp_for(rows: &[(i64, Option<i64>)]) -> DeclaredColumnStat {
+    let vals: Vec<i64> = rows.iter().filter_map(|(_, v)| *v).collect();
+    let null_count = u64::try_from(rows.len() - vals.len()).expect("fits");
+    DeclaredColumnStat::new(
+        COL,
+        DeclaredStatType::I64,
+        vals.iter().min().map(|v| DeclaredStatValue::I64(*v)),
+        vals.iter().max().map(|v| DeclaredStatValue::I64(*v)),
+        null_count,
+    )
+    .expect("valid stamp")
+}
+
+fn i64_stamp_entry(name: &str, min: i64, max: i64, null_count: u64) -> DeclaredColumnMinMax {
+    encode_stamp(
+        &DeclaredColumnStat::new(
+            name,
+            DeclaredStatType::I64,
+            Some(DeclaredStatValue::I64(min)),
+            Some(DeclaredStatValue::I64(max)),
+            null_count,
+        )
+        .expect("valid stamp"),
+    )
+}
+
+/// A stamp entry carrying ADR-0101's `F64` declared type: representable on the
+/// wire (a broken or future writer can emit one) and never eligible, since
+/// ADR-0873 decision 2's allowlist refuses `F64` by name pending a decided
+/// comparator, NaN rule, and `-0.0` rule.
+fn f64_stamp_entry(name: &str) -> DeclaredColumnMinMax {
+    DeclaredColumnMinMax {
+        name: name.to_string(),
+        declared_type: TYPED_ATTR_COLUMN_TYPE_F64,
+        min: Some(DeclaredColumnStatValue {
+            kind: Some(StampKind::I64(17_100)),
+        }),
+        max: Some(DeclaredColumnStatValue {
+            kind: Some(StampKind::I64(19_400)),
+        }),
+        null_count: 0,
+    }
+}
+
+/// Put `entries` on `seg` the way resolution does: through the carrier read
+/// whose row-count clauses bind against the record's own `sample_count`, so
+/// the stamps a `SegmentRef` carries are exactly the ones the predicate
+/// admitted. There is no other way to build a non-empty
+/// [`DeclaredColumnStats`], which is the point of ADR-0873 decision 2.
+fn stamped(seg: &SegmentRef, entries: Vec<DeclaredColumnMinMax>) -> SegmentRef {
+    let record = CommitRecord {
+        sample_count: seg.sample_count,
+        declared_column_stats: entries,
+        ..CommitRecord::default()
+    };
+    let mut out = seg.clone();
+    out.declared_column_stats = DeclaredColumnStats::from_validated(&read_commit_record(&record));
+    out
+}
+
+/// The same carriage through the compaction/rewrite part route (`CompactionPart`
+/// field 12), for the tests that must hold on every read route.
+fn stamped_via_part(seg: &SegmentRef, entries: Vec<DeclaredColumnMinMax>) -> SegmentRef {
+    let part = CompactionPart {
+        sample_count: seg.sample_count,
+        declared_column_stats: entries,
+        ..CompactionPart::default()
+    };
+    let mut out = seg.clone();
+    out.declared_column_stats = DeclaredColumnStats::from_validated(&read_compaction_part(&part));
+    out
+}
+
+fn identity_of(seg: &SegmentRef) -> EntryIdentity {
+    (
+        seg.ingest_hour_bucket,
+        seg.shard,
+        *seg.writer_id.as_bytes(),
+        seg.writer_epoch,
+        seg.writer_seq,
+    )
+}
+
+fn i64_value(v: i64) -> ColumnValue {
+    ColumnValue {
+        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(v)),
+    }
+}
+
+/// A `.cstat` entry for `rows`, with no value dictionary: this path reads only
+/// the extrema and the row accounting.
+fn cstat_for(rows: &[(i64, Option<i64>)], min: Option<i64>, max: Option<i64>) -> ColumnStat {
+    let non_null_count =
+        u64::try_from(rows.iter().filter(|(_, v)| v.is_some()).count()).expect("fits");
+    ColumnStat {
+        name: COL.to_string(),
+        declared_type: 2, // ravel.sys.v1.TypedAttrColumnType::I64
+        non_null_count,
+        null_count: u64::try_from(rows.len()).expect("fits") - non_null_count,
+        min: min.map(i64_value),
+        max: max.map(i64_value),
+        dictionary_present: false,
+        dictionary: Vec::new(),
+        sum: None,
+    }
+}
+
+fn loaded_stats(entries: Vec<(&SegmentRef, Vec<ColumnStat>)>) -> Arc<LoadedColumnStats> {
+    let mut segments = HashMap::new();
+    for (seg, columns) in entries {
+        segments.insert(
+            identity_of(seg),
+            ColumnStatsSegment {
+                ingest_hour_bucket: seg.ingest_hour_bucket,
+                shard: seg.shard,
+                writer_id: seg.writer_id.as_bytes().to_vec(),
+                writer_epoch: seg.writer_epoch,
+                writer_seq: seg.writer_seq,
+                columns,
+            },
+        );
+    }
+    Arc::new(LoadedColumnStats {
+        segments,
+        part_blake3: Vec::new(),
+    })
+}
+
+fn snapshot_of(segments: Vec<SegmentRef>) -> Snapshot {
+    Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    }
+}
+
+fn declared_cols() -> Vec<DeclaredColumn> {
+    vec![DeclaredColumn::new(COL, DeclaredType::I64)]
+}
+
+fn provider(
+    store: &Arc<CountingStore>,
+    snapshot: Snapshot,
+    accounting: &QueryAccounting,
+    stats: Option<Arc<LoadedColumnStats>>,
+) -> LogsTableProvider {
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::clone(store) as Arc<dyn ObjectStoreBackend>;
+    LogsTableProvider::new(
+        snapshot,
+        TENANT,
+        LogSegmentFetcher::new(backend),
+        accounting.clone(),
+    )
+    .with_declared_columns(declared_cols())
+    .with_column_stats(stats)
+}
+
+fn logs_session(provider: LogsTableProvider) -> datafusion::error::Result<SessionContext> {
+    let config = SqlConfig::default();
+    let tenant = TenantMemoryAccountant::new(1 << 30);
+    let (pool, _breach) = config.query_pool(tenant, QueryAccounting::new());
+    build_session(
+        &config,
+        pool,
+        SessionTable::Logs(Arc::new(provider)),
+        false,
+        SpillDecision::Disabled,
+    )
+}
+
+/// `(min, max)` from `SELECT MIN(col), MAX(col)`; a component is `None` when
+/// the aggregate is SQL NULL.
+fn min_max_i64(batches: &[RecordBatch]) -> (Option<i64>, Option<i64>) {
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let col = |i: usize| {
+            let arr = batch
+                .column(i)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("int64 aggregate");
+            if arr.is_null(0) {
+                None
+            } else {
+                Some(arr.value(0))
+            }
+        };
+        return (col(0), col(1));
+    }
+    (None, None)
+}
+
+/// One statement's outcome: the plan text, the answer, the store's GET count,
+/// the accounted data GETs, and `data_objects_touched`.
+struct Outcome {
+    plan: String,
+    answer: (Option<i64>, Option<i64>),
+    gets: u64,
+    accounted_gets: u64,
+    objects_touched: u64,
+}
+
+/// Run `SELECT MIN("EventDate"), MAX("EventDate") FROM logs` over `snapshot`,
+/// against the objects already written into `store`.
+async fn min_max_over_store(
+    store: &Arc<CountingStore>,
+    snapshot: Snapshot,
+    stats: Option<Arc<LoadedColumnStats>>,
+) -> Outcome {
+    let accounting = QueryAccounting::new();
+    let before_gets = store.gets();
+    let ctx = logs_session(provider(store, snapshot, &accounting, stats)).expect("session");
+    let plan = ctx
+        .sql(&format!("SELECT MIN(\"{COL}\"), MAX(\"{COL}\") FROM logs"))
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let text = displayable(plan.as_ref()).indent(true).to_string();
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    let snap = accounting.snapshot();
+    Outcome {
+        plan: text,
+        answer: min_max_i64(&batches),
+        gets: store.gets() - before_gets,
+        accounted_gets: snap.s3_requests[AccountedOp::Get.index()],
+        objects_touched: snap.data_objects_touched,
+    }
+}
+
+/// The whole-plan statistics of the bare scan over `snapshot`, which is the
+/// entry point `AggregateStatistics` consults. No object-store I/O.
+fn scan_stats(snapshot: Snapshot, stats: Option<Arc<LoadedColumnStats>>) -> Arc<Statistics> {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let accounting = QueryAccounting::new();
+    let provider = provider(&store, snapshot, &accounting, stats);
+    let plan = provider.plan_filters(4, &[]).expect("plan_filters");
+    plan.partition_statistics(None)
+        .expect("partition_statistics")
+}
+
+/// The declared column's statistics in `stats`. The scan projects every schema
+/// column when `plan_filters` is handed no projection, so the declared column
+/// sits at its schema index.
+fn declared_col_stats(stats: &Statistics) -> &datafusion::common::ColumnStatistics {
+    &stats.column_statistics[ravel_sql::FIRST_DECLARED_COL]
+}
+
+/// Two real objects, both stamped by a correct writer.
+async fn stamped_corpus(store: &Arc<CountingStore>) -> Snapshot {
+    let a = write_segment(store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let b = write_segment(store, "logs/b.rlog", 2, SEG_B_ROWS).await;
+    let a = stamped(&a, vec![encode_stamp(&stamp_for(SEG_A_ROWS))]);
+    let b = stamped(&b, vec![encode_stamp(&stamp_for(SEG_B_ROWS))]);
+    snapshot_of(vec![a, b])
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: the issue's acceptance criterion.
+// ---------------------------------------------------------------------------
+
+/// `SELECT MIN(EventDate), MAX(EventDate)` over a fully stamped tenant is a
+/// plan-time literal: no `LogsScanExec`, exactly zero GETs (store-level and
+/// accounted), and `data_objects_touched == 0`, because a statement answered
+/// from statistics never opens a segment on either route.
+///
+/// Prove-the-test: comment out the `min_value`/`max_value` assignment in
+/// `LogsScanExec::partition_statistics`
+/// (crates/ravel-sql/src/logs_scan.rs, the `declared_min_max` loop) and the
+/// plan keeps its `LogsScanExec` with 2 GETs and 2 objects touched; every
+/// assertion below fails but the answer, which the scan then computes.
+/// Narrower flip: return `None` from `stamp_coverage` and the same happens,
+/// since no `.cstat` is loaded here.
+#[tokio::test]
+async fn stamped_min_max_is_answered_with_zero_gets_and_no_touches() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let snapshot = stamped_corpus(&store).await;
+    let out = min_max_over_store(&store, snapshot, None).await;
+
+    assert!(
+        !out.plan.contains("LogsScanExec"),
+        "a stamped MIN/MAX must be a plan-time literal; plan was:\n{}",
+        out.plan
+    );
+    assert_eq!(out.answer, true_answer(), "17_100 .. 19_400");
+    assert_eq!(out.gets, 0, "no data object may be read");
+    assert_eq!(out.accounted_gets, 0, "and none may be accounted either");
+    assert_eq!(
+        out.objects_touched, 0,
+        "a stats-answered statement touches no object on either route"
+    );
+}
+
+/// The same corpus, read by a scan (stamps removed), answers identically. This
+/// is what makes the test above a statistics test rather than an agreement
+/// between two fabrications: the stamps are derived from the same rows the
+/// objects were written from, and the scan is the reference implementation.
+#[tokio::test]
+async fn the_stamped_answer_equals_the_scanned_answer() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let b = write_segment(&store, "logs/b.rlog", 2, SEG_B_ROWS).await;
+
+    let scanned = min_max_over_store(&store, snapshot_of(vec![a.clone(), b.clone()]), None).await;
+    assert!(
+        scanned.plan.contains("LogsScanExec"),
+        "an unstamped snapshot has nothing to answer from; plan was:\n{}",
+        scanned.plan
+    );
+    assert!(scanned.gets > 0, "the reference answer comes from the data");
+
+    let stamped_snapshot = snapshot_of(vec![
+        stamped(&a, vec![encode_stamp(&stamp_for(SEG_A_ROWS))]),
+        stamped(&b, vec![encode_stamp(&stamp_for(SEG_B_ROWS))]),
+    ]);
+    let from_stats = min_max_over_store(&store, stamped_snapshot, None).await;
+    assert_eq!(from_stats.answer, scanned.answer);
+    assert_eq!(from_stats.gets, 0);
+}
+
+/// The exact statistics the stamps prove, asserted at the seam
+/// `AggregateStatistics` reads: `Exact` extrema, and an `Exact` NULL count
+/// summed over the segments (one NULL row in segment A, none in B). The
+/// row count stays exact too, so `COUNT(*)` and `COUNT(col)` are both
+/// answerable from this one statistics object.
+#[tokio::test]
+async fn stamped_statistics_are_exact_per_column() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let snapshot = stamped_corpus(&store).await;
+    let stats = scan_stats(snapshot, None);
+    let col = declared_col_stats(&stats);
+    assert_eq!(stats.num_rows, Precision::Exact(5), "3 + 2 rows");
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Int64(Some(17_100)))
+    );
+    assert_eq!(
+        col.max_value,
+        Precision::Exact(ScalarValue::Int64(Some(19_400)))
+    );
+    assert_eq!(col.null_count, Precision::Exact(1), "one NULL row, in A");
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: one unstamped segment leaves the column Absent and the query scans.
+// ---------------------------------------------------------------------------
+
+/// Coverage is per segment and per column: one touched segment carrying no
+/// stamp leaves the whole column `Absent`, so the rule cannot fire and the
+/// statement scans (#849's safety lemma, extended to the stamp carrier). The
+/// unstamped segment holds the corpus maximum, so an implementation that
+/// answered from the stamped segment alone would report 19_000 instead of
+/// 19_400.
+///
+/// Prove-the-test: replace the `(None, None) => { a.declined = true; continue }`
+/// arm in `declared_min_max_all` with `continue` (skip the segment instead of
+/// declining) and the plan loses its `LogsScanExec` while the answer becomes
+/// `(18_500, 19_000)`: both assertions fail.
+#[tokio::test]
+async fn one_unstamped_segment_leaves_the_column_absent_and_scans() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let b = write_segment(&store, "logs/b.rlog", 2, SEG_B_ROWS).await;
+    let snapshot = snapshot_of(vec![
+        stamped(&a, vec![encode_stamp(&stamp_for(SEG_A_ROWS))]),
+        b,
+    ]);
+
+    let stats = scan_stats(snapshot.clone(), None);
+    let col = declared_col_stats(&stats);
+    assert_eq!(col.min_value, Precision::Absent);
+    assert_eq!(col.max_value, Precision::Absent);
+    assert_eq!(col.null_count, Precision::Absent);
+
+    let out = min_max_over_store(&store, snapshot, None).await;
+    assert!(
+        out.plan.contains("LogsScanExec"),
+        "an uncovered segment must fail closed to a scan; plan was:\n{}",
+        out.plan
+    );
+    assert_eq!(
+        out.answer,
+        true_answer(),
+        "the scan answers over both objects"
+    );
+    assert!(out.gets > 0, "a scanning statement reads the data");
+    assert_eq!(out.objects_touched, 2, "both objects, once each");
+}
+
+/// A stamp for a DIFFERENT column covers nothing for this one: the column is
+/// uncovered even though the segment carries stamps.
+#[tokio::test]
+async fn a_stamp_for_another_column_leaves_this_one_absent() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let b = write_segment(&store, "logs/b.rlog", 2, SEG_B_ROWS).await;
+    let snapshot = snapshot_of(vec![
+        stamped(&a, vec![i64_stamp_entry("SomethingElse", 1, 2, 0)]),
+        stamped(&b, vec![encode_stamp(&stamp_for(SEG_B_ROWS))]),
+    ]);
+    let stats = scan_stats(snapshot, None);
+    assert_eq!(declared_col_stats(&stats).min_value, Precision::Absent);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: the float gate.
+// ---------------------------------------------------------------------------
+
+/// A float-typed stamp never takes the shortcut, and the gate is explicit
+/// rather than a consequence of today's vocabulary: ADR-0101 (Accepted) adds
+/// `TYPED_ATTR_COLUMN_TYPE_F64 = 5`, so the tag is representable now and only
+/// the allowlist refuses it. The entry is dropped at the carrier read, so the
+/// segment is uncovered, the column is `Absent`, and the statement scans --
+/// exactly as it would with no stamp at all.
+///
+/// Prove-the-test: add `TYPED_ATTR_COLUMN_TYPE_F64 => Ok(DeclaredStatType::I64)`
+/// to `DeclaredStatType::from_tag`
+/// (crates/ravel-types/src/declared_stats.rs) and the plan loses its
+/// `LogsScanExec` while the answer comes from the fabricated float stamp.
+#[tokio::test]
+async fn a_float_typed_stamp_never_takes_the_shortcut() {
+    // The allowlist refuses the tag by name, which is what makes the stamp
+    // unrepresentable in the validated form rather than merely unused.
+    assert!(
+        DeclaredStatType::from_tag(TYPED_ATTR_COLUMN_TYPE_F64).is_err(),
+        "F64 is not stamp-eligible (ADR-0873 decision 2)"
+    );
+
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let b = write_segment(&store, "logs/b.rlog", 2, SEG_B_ROWS).await;
+    let a_float = stamped(&a, vec![f64_stamp_entry(COL)]);
+    assert!(
+        a_float.declared_column_stats.is_empty(),
+        "an F64 stamp grants no coverage at all"
+    );
+    let snapshot = snapshot_of(vec![
+        a_float,
+        stamped(&b, vec![encode_stamp(&stamp_for(SEG_B_ROWS))]),
+    ]);
+
+    let stats = scan_stats(snapshot.clone(), None);
+    assert_eq!(declared_col_stats(&stats).min_value, Precision::Absent);
+
+    let out = min_max_over_store(&store, snapshot, None).await;
+    assert!(
+        out.plan.contains("LogsScanExec"),
+        "an ineligible stamp must fail closed to a scan; plan was:\n{}",
+        out.plan
+    );
+    assert_eq!(out.answer, true_answer());
+}
+
+/// A stamp whose eligible type disagrees with the type the tenant declares the
+/// column as is refused too: the reader will not reinterpret a BOOL extremum
+/// as an Int64 one.
+#[tokio::test]
+async fn a_stamp_of_the_wrong_eligible_type_is_refused() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let b = write_segment(&store, "logs/b.rlog", 2, SEG_B_ROWS).await;
+    let bool_stamp = encode_stamp(
+        &DeclaredColumnStat::new(
+            COL,
+            DeclaredStatType::Bool,
+            Some(DeclaredStatValue::Bool(false)),
+            Some(DeclaredStatValue::Bool(true)),
+            1,
+        )
+        .expect("valid bool stamp"),
+    );
+    let a_bool = stamped(&a, vec![bool_stamp]);
+    // The stamp itself is valid -- it is the join against the I64 declaration
+    // that refuses it -- so it does reach the query as coverage-shaped input.
+    assert_eq!(a_bool.declared_column_stats.len(), 1);
+    let snapshot = snapshot_of(vec![
+        a_bool,
+        stamped(&b, vec![encode_stamp(&stamp_for(SEG_B_ROWS))]),
+    ]);
+    let stats = scan_stats(snapshot, None);
+    assert_eq!(declared_col_stats(&stats).min_value, Precision::Absent);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: duplicate stamp names, on every read route and in both orderings.
+// ---------------------------------------------------------------------------
+
+/// A record stamping one name twice yields NO coverage for that name, from
+/// every read route and under either ordering of the pair (ADR-0873 clause 6).
+/// Both orderings are what make this a test: any pick-one resolution satisfies
+/// whichever ordering places its pick where the assertion looks.
+///
+/// Prove-the-test: restore the first-wins arm in `decode_all_against_rows`
+/// (crates/ravel-commit/src/declared_stats.rs: reserve the name in a `HashSet`
+/// before validating and drop only later occurrences) and every
+/// `is_empty`/`Absent` assertion here fails, with the extremum coming from
+/// whichever duplicate was written first (17_000 in one ordering, 1 in the
+/// other).
+#[tokio::test]
+async fn duplicate_stamp_names_grant_no_coverage_on_any_read_route() {
+    for (first, second) in [(1i64, 17_000i64), (17_000, 1)] {
+        let pair = vec![
+            i64_stamp_entry(COL, first, first + 1, 0),
+            i64_stamp_entry(COL, second, second + 1, 0),
+        ];
+        let store = CountingStore::new(Arc::new(MemoryStore::new()));
+        let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+        let b = write_segment(&store, "logs/b.rlog", 2, SEG_B_ROWS).await;
+
+        // Route 1: the commit record (a listed or token-resolved L0 segment).
+        let via_record = stamped(&a, pair.clone());
+        // Route 2: the compaction/rewrite part (an L1 segment).
+        let via_part = stamped_via_part(&a, pair.clone());
+        for (route, seg) in [
+            ("commit record", &via_record),
+            ("compaction part", &via_part),
+        ] {
+            assert!(
+                seg.declared_column_stats.is_empty(),
+                "{route}: a duplicated name grants no coverage (order {first},{second})"
+            );
+            assert_eq!(seg.declared_column_stats.column(COL), None);
+        }
+
+        let snapshot = snapshot_of(vec![
+            via_record,
+            stamped(&b, vec![encode_stamp(&stamp_for(SEG_B_ROWS))]),
+        ]);
+        let stats = scan_stats(snapshot.clone(), None);
+        assert_eq!(
+            declared_col_stats(&stats).min_value,
+            Precision::Absent,
+            "order {first},{second}"
+        );
+
+        let out = min_max_over_store(&store, snapshot, None).await;
+        assert!(
+            out.plan.contains("LogsScanExec"),
+            "a duplicated stamp name must fail closed to a scan (order {first},{second}); \
+             plan was:\n{}",
+            out.plan
+        );
+        assert_eq!(
+            out.answer,
+            true_answer(),
+            "the scan answers over the real rows, not from either duplicate \
+             (order {first},{second})"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The union of the two carriers (ADR-0873 decision 4).
+// ---------------------------------------------------------------------------
+
+/// A snapshot split between carriers -- one segment stamped only, the other
+/// covered only by `.cstat` -- is still fully covered: that split is the
+/// normal state of every tenant after this ADR ships (a live tail with stamps
+/// above a pre-stamp sealed history), so a reader consulting one carrier alone
+/// would answer nothing.
+///
+/// Prove-the-test: drop the `.cstat` half of the union (`(None, Some(only))`
+/// arm) and this plan regains its `LogsScanExec`.
+#[tokio::test]
+async fn one_carrier_each_still_covers_the_whole_snapshot() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let b = write_segment(&store, "logs/b.rlog", 2, SEG_B_ROWS).await;
+    let stats = loaded_stats(vec![(
+        &b,
+        vec![cstat_for(SEG_B_ROWS, Some(17_100), Some(19_400))],
+    )]);
+    let snapshot = snapshot_of(vec![
+        stamped(&a, vec![encode_stamp(&stamp_for(SEG_A_ROWS))]),
+        b.clone(),
+    ]);
+
+    let out = min_max_over_store(&store, snapshot.clone(), Some(Arc::clone(&stats))).await;
+    assert!(
+        !out.plan.contains("LogsScanExec"),
+        "stamp for A plus .cstat for B covers everything; plan was:\n{}",
+        out.plan
+    );
+    assert_eq!(out.answer, true_answer());
+    assert_eq!(out.gets, 0);
+
+    // The NULL count, by contrast, stays `Absent`: segment B's figure comes
+    // from a `.cstat` entry, whose row accounting nothing on this path
+    // reconciles against the joined `sample_count`. The extrema are exact
+    // regardless.
+    let col_stats = scan_stats(snapshot, Some(stats));
+    let col = declared_col_stats(&col_stats);
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Int64(Some(17_100)))
+    );
+    assert_eq!(col.null_count, Precision::Absent);
+}
+
+/// Both carriers covering one segment and agreeing: the answer is that value,
+/// counted once. A union that summed the two `null_count`s would report 2 for
+/// segment A's single NULL row, which is what the NULL-count assertion here
+/// fails on.
+#[tokio::test]
+async fn both_carriers_agreeing_answer_once() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let a_stamped = stamped(&a, vec![encode_stamp(&stamp_for(SEG_A_ROWS))]);
+    let stats = loaded_stats(vec![(
+        &a,
+        vec![cstat_for(SEG_A_ROWS, Some(18_500), Some(19_000))],
+    )]);
+    let snapshot = snapshot_of(vec![a_stamped]);
+
+    let col_stats = scan_stats(snapshot.clone(), Some(Arc::clone(&stats)));
+    let col = declared_col_stats(&col_stats);
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Int64(Some(18_500)))
+    );
+    assert_eq!(
+        col.max_value,
+        Precision::Exact(ScalarValue::Int64(Some(19_000)))
+    );
+    assert_eq!(col.null_count, Precision::Exact(1), "one NULL row, once");
+
+    let out = min_max_over_store(&store, snapshot, Some(stats)).await;
+    assert!(
+        !out.plan.contains("LogsScanExec"),
+        "plan was:\n{}",
+        out.plan
+    );
+    assert_eq!(out.answer, (Some(18_500), Some(19_000)));
+    assert_eq!(out.gets, 0);
+}
+
+/// Both carriers covering one segment and disagreeing: the column is `Absent`
+/// for the whole query and the statement scans. One conflicted segment poisons
+/// the column exactly as one uncovered segment does -- the segment is
+/// immutable and both carriers claim exactness, so a disagreement means one of
+/// them is wrong and no answer is safe.
+///
+/// Prove-the-test: replace the `agrees_with` check in `declared_min_max_all`
+/// with `true` and the plan loses its `LogsScanExec` while the answer becomes
+/// whichever carrier the union happens to keep.
+#[tokio::test]
+async fn carriers_disagreeing_about_one_segment_decline() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/a.rlog", 1, SEG_A_ROWS).await;
+    let a_stamped = stamped(&a, vec![encode_stamp(&stamp_for(SEG_A_ROWS))]);
+    // Same segment, same column, a min the stamp does not agree with.
+    let stats = loaded_stats(vec![(
+        &a,
+        vec![cstat_for(SEG_A_ROWS, Some(-1), Some(19_000))],
+    )]);
+    let snapshot = snapshot_of(vec![a_stamped]);
+
+    let col_stats = scan_stats(snapshot.clone(), Some(Arc::clone(&stats)));
+    assert_eq!(declared_col_stats(&col_stats).min_value, Precision::Absent);
+
+    let out = min_max_over_store(&store, snapshot, Some(stats)).await;
+    assert!(
+        out.plan.contains("LogsScanExec"),
+        "conflicting carriers must fail closed to a scan; plan was:\n{}",
+        out.plan
+    );
+    assert_eq!(
+        out.answer,
+        (Some(18_500), Some(19_000)),
+        "the scan answers segment A's real extrema, not the fabricated -1"
+    );
+}

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -223,15 +223,29 @@ Two carriers feed it, unioned per segment and per column (ADR-0873 decision
 4):
 
 - the `SegmentRef` stamp (`SegmentRef::declared_column_stats`, ADR-0873), an
-  exact whole-object min/max and NULL count per eligible declared column,
-  written by the flush and compaction writers onto the commit record and the
-  compaction part and carried through the fold onto `SnapshotEntry`. Because
-  it rides the records resolution already reads, it covers the live tail above
-  the fold watermark and token-resolved segments, which no fold-built sibling
-  object can;
+  exact whole-object min/max and NULL count per eligible declared column, read
+  off the commit record (field 20), the compaction part (field 12), or the
+  snapshot entry (field 15) that resolution already reads. Because it rides
+  those records, it covers the live tail above the fold watermark and
+  token-resolved segments, which no fold-built sibling object can;
 - the ADR-0850/0942 `.cstat` entry, joined by segment identity, which is the
   carrier for pre-stamp sealed history and the only carrier for `Str`/`Bytes`
   extrema.
+
+**The write side of the stamp carrier does not exist yet.** Nothing in the
+flush or compaction path calls the stamp writers in
+`ravel_commit::declared_stats` (`stamp_commit_record`,
+`stamp_compaction_part`); their only callers are tests.
+Issue #1022 (ADR-0873 wave 5) is where the writers start emitting stamps. Until
+it lands, every record a real tenant has ever written carries an empty list, so
+the stamp half of the union is empty for every segment of every tenant, every
+answer above comes from `.cstat` alone, and the stamp path is exercised only by
+tests that stamp a record directly and by the fold's carriage of whatever a
+record happens to carry. The read side landed first on purpose (a reader that
+refuses a defective stamp has to exist before any writer can emit one), but the
+consequence is worth stating plainly: on today's deployments this shortcut is
+inert on the stamp side, and no coverage change is observable from it until
+#1022 ships.
 
 Stamp eligibility is an allowlist, `I64` and `BOOL`
 (`ravel_types::declared_stats`). `Str`/`Bytes` are excluded because a stamped
@@ -256,16 +270,56 @@ of the `stats_are_exact` gate above:
   describe the same rows of one immutable object exactly, so a disagreement
   means one of them is wrong and no answer is safe.
 
+A `null_count` is reported `Exact` only when every covering carrier proved it,
+which means the stamp: a `.cstat` entry's row accounting is not reconciled
+against the joined `SegmentRef::sample_count` on this path, and an unreconciled
+figure would answer `COUNT(col)` from something nothing checked. The extrema are
+exact either way.
+
+One statistics shape is exact and still does not shortcut the query. A declared
+column that reads NULL in every touched row has an exactly-NULL extremum, and
+this scan reports it as `Precision::Exact(<typed null>)`, but DataFusion's
+`FromColumnStatistics` implementations for `Min`/`Max` refuse an exact extremum
+that is null, so `MIN`/`MAX` over such a column keeps its `LogsScanExec` and
+scans to the same NULL. `COUNT(<declared column>)` on that same column is still
+a plan-time literal (`num_rows - null_count`, exactly 0).
+
+### Defect metrics for the two carriers
+
 Two process-wide tallies make the defect classes visible, since a coverage
-regression otherwise reads as a slow query:
-`ravel_commit::declared_stats::dropped_stamp_entries` counts every stamp entry
-a reader dropped (one per entry, on every read route), and
-`ravel_sql::declared_stat_carrier_conflicts` counts every carrier
-disagreement. A `null_count` is reported `Exact` only when every covering
-carrier proved it, which today means the stamp: a `.cstat` entry's row
-accounting is not reconciled against the joined `SegmentRef::sample_count` on
-this path, and an unreconciled figure would answer `COUNT(col)` from something
-nothing checked. The extrema are exact either way.
+regression otherwise reads as a slow query. Both count OBSERVATIONS, which is
+what their names and these paragraphs say, because the distinction decides how
+the numbers may be read.
+
+`ravel_commit::declared_stats::declared_stat_drops_observed(carrier)` counts
+statistics entries a reader dropped, one per dropped entry, labelled by the
+carrier that was read: `commit-record`, `compaction-part`, `snapshot-entry`, and
+`cstat`. The first three are the stamp reads in `ravel-commit`; the `cstat`
+label is reported by `ravel-sql`'s `.cstat` reader, which counts exactly two
+refusals as defects (a duplicated column name, and extrema presence that
+contradicts the row accounting) and treats a missing object, segment, or column
+entry as the ordinary uncovered state. Each READ of a defective carrier
+increments the label again: there is no per-entry deduplication, because it
+would need unbounded state keyed by (object, column) on a path walked once per
+segment per query. So the magnitude scales with query rate and is not a count of
+distinct defects. `ravel_catalog::read_snapshot_entry` still reads its entries
+through `read_commit_record`, so snapshot-entry drops are observed under the
+`commit-record` label until that call site moves to
+`read_snapshot_entry_twin`.
+
+`ravel_sql::declared_stat_carrier_conflicts` counts carrier disagreements, one
+per (declared column, conflicting segment, `partition_statistics` call).
+Within one call a column counts at most once, since the first conflicting
+segment declines it; across calls nothing is deduplicated, and DataFusion may
+call `partition_statistics` several times while building one plan, so repeated
+statements over one defective segment keep incrementing it. Each observation
+also emits a `warn` log line carrying the segment's `content_hash` and both
+claimed `(min, max, null_count)` triples, which is the artefact a report is
+filed from; the counter is only its rate.
+
+A per-query coverage figure (segments stamped over segments touched, per
+carrier, under phase accounting) is owed to the 996-9 measurement wave and is
+deliberately not built here.
 
 ## Predicate-free full-window logs scan: request count
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -208,6 +208,65 @@ The ts/content/prune declines are gated by `LogsScanExec::stats_are_exact`,
 which requires no pending erasure, an empty `content`, an empty `prune`, and a
 `ts` bound that contains every touched segment.
 
+## Declared-column MIN/MAX from two statistics carriers
+
+`SELECT MIN(<declared column>), MAX(<declared column>) FROM logs` (ClickBench
+q07's shape) is answered at plan time, with no `LogsScanExec` in the plan and
+zero data GETs, through DataFusion's stock `AggregateStatistics` rule rather
+than through `MetadataOnlyAggregate`: `LogsScanExec::partition_statistics`
+reports the column's `min_value`/`max_value` as `Precision::Exact`, and its
+`null_count` too where that figure is proven, so `COUNT(<declared column>)`
+takes the same path. A statement answered this way records zero
+`data_objects_touched`, since no segment is opened on either read route.
+
+Two carriers feed it, unioned per segment and per column (ADR-0873 decision
+4):
+
+- the `SegmentRef` stamp (`SegmentRef::declared_column_stats`, ADR-0873), an
+  exact whole-object min/max and NULL count per eligible declared column,
+  written by the flush and compaction writers onto the commit record and the
+  compaction part and carried through the fold onto `SnapshotEntry`. Because
+  it rides the records resolution already reads, it covers the live tail above
+  the fold watermark and token-resolved segments, which no fold-built sibling
+  object can;
+- the ADR-0850/0942 `.cstat` entry, joined by segment identity, which is the
+  carrier for pre-stamp sealed history and the only carrier for `Str`/`Bytes`
+  extrema.
+
+Stamp eligibility is an allowlist, `I64` and `BOOL`
+(`ravel_types::declared_stats`). `Str`/`Bytes` are excluded because a stamped
+extremum is an unbounded byte string on the hot resolve path, and `F64`
+(ADR-0101) is excluded pending a decided comparator, NaN rule, and `-0.0` rule
+that provably agree with the scan-path aggregate's.
+
+The column reports `Absent` -- the rule silently does not fire and the query
+scans, ADR-0849's safety lemma -- whenever any of the following holds, on top
+of the `stats_are_exact` gate above:
+
+- a touched segment that neither carrier covers: never stamped and no `.cstat`
+  entry, which is the permanent state of every pre-ADR-0873 record and of
+  every metrics/spans segment;
+- an entry either carrier's reader refuses: a stamp of an ineligible type, a
+  stamp whose type disagrees with the tenant's declaration, a duplicated
+  entry name (ADR-0873 clause 6 drops every occurrence, so a duplicate never
+  reaches a reader as coverage), or a `.cstat` entry whose extrema presence
+  disagrees with its `non_null_count`;
+- the two carriers disagreeing about one segment in `min`, `max`, or
+  `null_count`. Nothing is ever combined across carriers: both claim to
+  describe the same rows of one immutable object exactly, so a disagreement
+  means one of them is wrong and no answer is safe.
+
+Two process-wide tallies make the defect classes visible, since a coverage
+regression otherwise reads as a slow query:
+`ravel_commit::declared_stats::dropped_stamp_entries` counts every stamp entry
+a reader dropped (one per entry, on every read route), and
+`ravel_sql::declared_stat_carrier_conflicts` counts every carrier
+disagreement. A `null_count` is reported `Exact` only when every covering
+carrier proved it, which today means the stamp: a `.cstat` entry's row
+accounting is not reconciled against the joined `SegmentRef::sample_count` on
+this path, and an unreconciled figure would answer `COUNT(col)` from something
+nothing checked. The extrema are exact either way.
+
 ## Predicate-free full-window logs scan: request count
 
 Every OTHER predicate-free, full-window logs statement — `SUM`, `AVG`,

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -244,8 +244,8 @@ tests that stamp a record directly and by the fold's carriage of whatever a
 record happens to carry. The read side landed first on purpose (a reader that
 refuses a defective stamp has to exist before any writer can emit one), but the
 consequence is worth stating plainly: on today's deployments this shortcut is
-inert on the stamp side, and no coverage change is observable from it until
-#1022 ships.
+inert on the stamp side, and no coverage change is observable from it
+until issue #1022 ships.
 
 Stamp eligibility is an allowlist, `I64` and `BOOL`
 (`ravel_types::declared_stats`). `Str`/`Bytes` are excluded because a stamped
@@ -1001,8 +1001,8 @@ distributed slice set against a local read of the same segments.
 
 The two sections above describe the engine-level (queryfrag) machinery. The SQL
 surface has its own distributed scan that drives log and trace *search* over the
-`logs`, `alerts`, `audit`, and `spans` tables (ADR-0071 task T6, shipped as T6a
-#326 for the RLOG family and T6b #327 for spans;
+`logs`, `alerts`, `audit`, and `spans` tables (ADR-0071 task T6, shipped
+as T6a #326 for the RLOG family and T6b #327 for spans;
 `crates/ravel-sql/src/distributed_rlog.rs`). It fans a table scan out to worker
 slices instead of scanning the local snapshot, then merges the per-slice streams
 at the coordinator.


### PR DESCRIPTION
ADR-0873 wave 4, the q7 collapse. MIN/MAX/COUNT over eligible declared
columns (I64, BOOL) rewrite to plan-time literals via DataFusion's
AggregateStatistics rule when every segment in the partition carries a
valid stamp for the column and no erasure is pending, the same path the
zero-GET COUNT(*) already takes. Partial coverage, rewrite parts,
Flight-pin rebuilds, floats, and pending erasures all fail closed to a
scan. Ships the ADR clause-6 precondition: duplicate stamp names now
drop ALL occurrences (first-wins silently picked between two claims on
one immutable record).

An adversarial checkpoint verified the core down to the DataFusion 54.1
sources and blocked on honesty gaps, all fixed in the second commit:
the doc no longer claims writers that do not exist (write-side stamping
is #1022, and until it lands the shortcut is inert outside tests -- an
inertness this PR states rather than hides), the drop tally is
declared_stat_drops_observed with carrier labels and observation
semantics, the conflict site logs the content hash and both triples,
stamp_coverage takes the validated container, and the two ADR-mandated
COUNT cases (carrier-summing detection at exactly 3-not-4; all-NULL
counting exactly 0 while MIN/MAX answer NULL) plus a BOOL read-path
test with its scanned reference are in.

One interaction discovered and documented: an all-NULL declared column
still scans for MIN/MAX because DataFusion refuses a null exact
extremum, while its COUNT stays a plan-time literal.

Local gate note: executor gates plus the checkpoint's verification;
full workspace gates run in this PR's required CI.

Refs: #873
Refs: #996