### PR TITLE
fix(cli): name the effective store and refuse an empty defaulted walk

### DIFF
--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -227,6 +227,30 @@ Every subcommand shares the same store flags as `ravel-server`
 `--s3-access-key`, `--s3-secret-key` (same `RAVEL_S3_*` env names as
 above).
 
+`--store` unset still means `memory`, the empty in-process store, but the
+fallback is no longer silent (issue #1024). Every command that walks tenant
+data (`maintain compact-bucket`, `compact-tenant`, `sweep`, `status`,
+`audit-versions`, `migrate`, `verify-custody`; `catalog list`, `fold`,
+`inspect`, `verify`; `commit reconstruct`) opens its report with the
+effective store:
+
+    store: memory (default)
+    store: memory
+    store: s3
+
+and, on the defaulted memory store only, refuses a walk that reaches no data
+at all rather than printing zero counters and exiting 0:
+
+    --store defaulted to memory, which holds no data for tenant "clickbench";
+    maintain compact-tenant found no objects there and would have reported a
+    healthy zero-work result. Pass --store s3 (with RAVEL_S3_BUCKET and its
+    credentials) to run against the real bucket, or load data first.
+
+`maintain compact-tenant` also refuses when the tenant prefix holds something
+but no ingest-hour bucket resolves across any shard. An explicit
+`--store memory` keeps the zero-count report: that store was chosen, so an
+empty result is an answer.
+
 | Command | Args | Does |
 |---|---|---|
 | `ravel-cli segment inspect <path>` | local file path or object store key | Parses one RSEG segment: trailer, footer fields, section list, decoded series count. |

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -19,6 +19,7 @@ use ravel_types::{Signal, TenantHash, TenantId};
 use uuid::Uuid;
 
 use crate::maintain::SignalArg;
+use crate::store::{StoreSelection, require_tenant_data_present};
 
 /// HEAD object key (docs/catalog-and-mvcc.md key layout, frozen format).
 /// Duplicated here rather than imported: `ravel-catalog` only exposes the
@@ -61,8 +62,14 @@ fn seal_margin_ns(config: &CatalogConfig) -> anyhow::Result<i64> {
 /// `clock_skew_allowance_ns` and `fold_safety_margin_ns` keep their defaults:
 /// the override asserts that no writer is still flushing, not that the
 /// folder's clock is exact.
+///
+/// `selection` is which store `--store` resolved to. It is the report's first
+/// line, and a fold over a tenant prefix that holds nothing at all on the
+/// defaulted memory store is refused rather than reported as a fold that
+/// sealed nothing (issue #1024).
 pub async fn fold(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     shard_count: u32,
     signal: SignalArg,
@@ -77,6 +84,15 @@ pub async fn fold(
         catalog_config.max_flush_lifetime_ns = ns;
     }
     let seal_margin_ns = seal_margin_ns(&catalog_config)?;
+    let tenant_hash = TenantId::new(tenant).hash();
+    require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "catalog fold",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
     // Enforcing, exactly as the server's query path (`ravel_server::query`) is:
     // an enforcing fold reads the tenant's real shard-generation history and
     // stamps a correct `shard_generation_count` and fan-out ceiling, instead of
@@ -87,7 +103,6 @@ pub async fn fold(
         .map_err(|err| anyhow::anyhow!("failed to build catalog: {err}"))?
         .with_provisioning_enforcement();
 
-    let tenant_hash = TenantId::new(tenant).hash();
     let folder_id = Uuid::new_v4();
     let report = catalog
         .fold(
@@ -102,6 +117,7 @@ pub async fn fold(
         .map_err(|err| anyhow::anyhow!("fold failed: {err}"))?;
 
     let mut out = String::new();
+    out.push_str(&format!("{}\n", selection.header()));
     out.push_str(&format!("signal: {}\n", signal_word(signal.to_signal())));
     out.push_str(&format!("no_op: {}\n", report.no_op));
     out.push_str(&format!("rebuilt: {}\n", report.rebuilt));
@@ -128,11 +144,12 @@ pub async fn fold(
 
 pub async fn inspect(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     signal: SignalArg,
 ) -> anyhow::Result<()> {
     let mut out = String::new();
-    let result = render_inspect(store, tenant, signal, &mut out).await;
+    let result = render_inspect(store, selection, tenant, signal, &mut out).await;
     // Print whatever was rendered even on error: a part fetch/decode failure
     // partway through must not discard the HEAD fields and every earlier
     // part's ref this call already rendered -- an operator inspecting a
@@ -156,11 +173,21 @@ pub async fn inspect(
 /// one part whose range starts at hour 0.
 pub async fn render_inspect(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     signal: SignalArg,
     out: &mut String,
 ) -> anyhow::Result<()> {
     let tenant_hash = TenantId::new(tenant).hash();
+    out.push_str(&format!("{}\n", selection.header()));
+    require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "catalog inspect",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
     let key = head_key(&tenant_hash, signal.to_signal());
 
     let head_bytes = match store.get(&key, GetRange::Full).await {
@@ -284,10 +311,20 @@ fn format_uuid_bytes(bytes: &[u8]) -> String {
 /// expected, not a divergence.
 pub async fn verify(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     signal: SignalArg,
 ) -> anyhow::Result<()> {
     let tenant_hash = TenantId::new(tenant).hash();
+    selection.print_header();
+    require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "catalog verify",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
 
     // The comparison itself lives in `ravel-catalog` (ADR-0059 decision 2) so
     // the scheduled scrubber and this CLI share one implementation. This
@@ -419,9 +456,15 @@ mod tests {
             .expect("put head");
 
         let mut report = String::new();
-        render_inspect(store.clone(), tenant, SignalArg::Metrics, &mut report)
-            .await
-            .expect("inspect renders");
+        render_inspect(
+            store.clone(),
+            StoreSelection::explicit(crate::store::StoreKind::Memory),
+            tenant,
+            SignalArg::Metrics,
+            &mut report,
+        )
+        .await
+        .expect("inspect renders");
 
         // Total part count.
         assert!(
@@ -478,9 +521,17 @@ mod tests {
         .await
         .expect("append generation 1");
 
-        fold(store.clone(), tenant, 1, SignalArg::Metrics, None, now)
-            .await
-            .expect("cli fold");
+        fold(
+            store.clone(),
+            StoreSelection::explicit(crate::store::StoreKind::Memory),
+            tenant,
+            1,
+            SignalArg::Metrics,
+            None,
+            now,
+        )
+        .await
+        .expect("cli fold");
 
         let head_bytes = store
             .get(&head_key(&tenant_hash, Signal::Metrics), GetRange::Full)

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -1005,6 +1005,7 @@ async fn main() -> anyhow::Result<()> {
         } => {
             ravel_cli::reconstruct::reconstruct(
                 store::build_store(&cli.store)?,
+                cli.store.selection(),
                 &tenant,
                 signal,
                 shard,
@@ -1029,6 +1030,7 @@ async fn main() -> anyhow::Result<()> {
                 },
         } => catalog::fold(
             store::build_store(&cli.store)?,
+            cli.store.selection(),
             &tenant,
             shards,
             signal,
@@ -1039,10 +1041,26 @@ async fn main() -> anyhow::Result<()> {
         .map(|_report| ()),
         Command::Catalog {
             command: CatalogCommand::Inspect { tenant, signal },
-        } => catalog::inspect(store::build_store(&cli.store)?, &tenant, signal).await,
+        } => {
+            catalog::inspect(
+                store::build_store(&cli.store)?,
+                cli.store.selection(),
+                &tenant,
+                signal,
+            )
+            .await
+        }
         Command::Catalog {
             command: CatalogCommand::Verify { tenant, signal },
-        } => catalog::verify(store::build_store(&cli.store)?, &tenant, signal).await,
+        } => {
+            catalog::verify(
+                store::build_store(&cli.store)?,
+                cli.store.selection(),
+                &tenant,
+                signal,
+            )
+            .await
+        }
         Command::Maintain {
             command:
                 MaintainCommand::CompactBucket {
@@ -1056,6 +1074,7 @@ async fn main() -> anyhow::Result<()> {
         } => {
             maintain::compact(
                 store::build_store(&cli.store)?,
+                cli.store.selection(),
                 &tenant,
                 signal,
                 shard,
@@ -1081,6 +1100,7 @@ async fn main() -> anyhow::Result<()> {
                 },
         } => maintain::compact_tenant(
             store::build_store(&cli.store)?,
+            cli.store.selection(),
             &tenant,
             signal,
             shards,
@@ -1107,6 +1127,7 @@ async fn main() -> anyhow::Result<()> {
         } => {
             maintain::sweep(
                 store::build_store(&cli.store)?,
+                cli.store.selection(),
                 &tenant,
                 signal,
                 shard,
@@ -1126,6 +1147,7 @@ async fn main() -> anyhow::Result<()> {
         } => {
             maintain::status(
                 store::build_store(&cli.store)?,
+                cli.store.selection(),
                 &tenant,
                 signal,
                 shard,
@@ -1135,7 +1157,15 @@ async fn main() -> anyhow::Result<()> {
         }
         Command::Maintain {
             command: MaintainCommand::AuditVersions { tenant, shards },
-        } => maintain::audit_versions(store::build_store(&cli.store)?, &tenant, shards).await,
+        } => {
+            maintain::audit_versions(
+                store::build_store(&cli.store)?,
+                cli.store.selection(),
+                &tenant,
+                shards,
+            )
+            .await
+        }
         Command::Maintain {
             command:
                 MaintainCommand::VerifyCustody {
@@ -1146,6 +1176,7 @@ async fn main() -> anyhow::Result<()> {
         } => {
             maintain::verify_custody(
                 store::build_store(&cli.store)?,
+                cli.store.selection(),
                 &tenant,
                 shards,
                 versioning_aware,
@@ -1165,6 +1196,7 @@ async fn main() -> anyhow::Result<()> {
         } => {
             maintain::migrate(
                 store::build_store(&cli.store)?,
+                cli.store.selection(),
                 &tenant,
                 signal,
                 shards,
@@ -2269,6 +2301,17 @@ async fn catalog_list(
     shard_count: u32,
 ) -> anyhow::Result<()> {
     let store = store::build_store(store_args)?;
+    let selection = store_args.selection();
+    let tenant_hash = TenantId::new(tenant).hash();
+    selection.print_header();
+    store::require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "catalog list",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
     let catalog_config = ravel_catalog::CatalogConfig {
         shard_count,
         ..ravel_catalog::CatalogConfig::default()
@@ -2282,7 +2325,6 @@ async fn catalog_list(
         .map_err(|err| anyhow::anyhow!("failed to build catalog: {err}"))?
         .with_provisioning_enforcement();
 
-    let tenant_hash = TenantId::new(tenant).hash();
     let now = now_ns()?;
     let range = TimeRange {
         start_ns: now.saturating_sub(hours.saturating_mul(NS_PER_HOUR)),

--- a/services/ravel-cli/src/maintain.rs
+++ b/services/ravel-cli/src/maintain.rs
@@ -21,6 +21,8 @@ use ravel_proto::commit::v1::{CompactionRecord, RetentionTombstone};
 use ravel_types::{Signal, TenantHash, TenantId};
 use uuid::Uuid;
 
+use crate::store::{DefaultedMemoryEmptyWalk, StoreSelection, require_tenant_data_present};
+
 /// CLI signal selector for the `--signal` flag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum SignalArg {
@@ -122,8 +124,14 @@ pub fn build_compactor_config(
 }
 
 /// `maintain compact-bucket`: run one compaction pass over a single bucket.
+///
+/// `selection` is which store `--store` resolved to: it heads the report, and a
+/// tenant prefix holding nothing at all on the defaulted memory store is
+/// refused rather than compacted as an empty bucket (issue #1024).
+#[allow(clippy::too_many_arguments)]
 pub async fn compact(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     signal: SignalArg,
     shard: u32,
@@ -135,6 +143,16 @@ pub async fn compact(
     let bucket = Bucket::new(tenant_hash, signal.to_signal(), shard, hour);
     let config = build_compactor_config(dry_run, max_flush_lifetime_ns, None, None, None)?;
     let clock = wall_clock()?;
+
+    selection.print_header();
+    require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "maintain compact-bucket",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
 
     let outcome = compact_bucket(store.as_ref(), &clock, &config, &bucket)
         .await
@@ -197,6 +215,10 @@ pub enum CompactTenantError {
 /// never returned, so a test can pin this whole struct.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct CompactTenantReport {
+    /// Which store the walk ran against, and whether the operator chose it.
+    /// The report header names it (`store: memory (default)`, `store: s3`), so
+    /// a zero-count report can never hide which data it looked at.
+    pub store: StoreSelection,
     /// Shards walked (`0..shards`).
     pub shards: u32,
     /// Buckets newly compacted (or, under `--dry-run`, that would have been).
@@ -312,9 +334,19 @@ async fn shard_hours(
 /// `NotSealed` is a reported outcome, not a failure; only a compaction error
 /// aborts the run (and it aborts the whole run, so the operator sees the fault
 /// instead of a summary that quietly omits shards).
+///
+/// `selection` is which store `--store` resolved to. It heads the report, and
+/// on the defaulted memory store a walk that resolves zero present ingest-hour
+/// buckets across every shard is refused with
+/// [`DefaultedMemoryEmptyWalk`] rather than reported as
+/// `compacted: 0, not_sealed: 0` with exit 0, which is indistinguishable from a
+/// tenant that had nothing left to compact (issue #1024). An explicit
+/// `--store memory` keeps that zero-count report: the operator chose the empty
+/// store.
 #[allow(clippy::too_many_arguments)]
 pub async fn compact_tenant(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     signal: SignalArg,
     shards: Option<u32>,
@@ -342,12 +374,22 @@ pub async fn compact_tenant(
         max_l1_part_bytes,
         input_read_concurrency,
     )?;
+    selection.print_header();
+    require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "maintain compact-tenant",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
     let shard_count =
         resolve_shard_count(store.as_ref(), &tenant_hash, tenant, sig, shards, now_hour).await?;
     let last_hour = to_hour.unwrap_or(now_hour);
     let first_hour = from_hour.unwrap_or(0);
     let clock = FixedClock::new(now_ns);
     let mut report = CompactTenantReport {
+        store: selection,
         shards: shard_count,
         ..CompactTenantReport::default()
     };
@@ -365,8 +407,14 @@ pub async fn compact_tenant(
     println!("input_read_concurrency: {}", config.input_read_concurrency);
     println!("dry_run: {dry_run}");
 
+    // Present ingest-hour buckets resolved across every shard, counted before
+    // the `[first_hour, last_hour]` filter: this is what the walk found in the
+    // store, which is the figure the empty-walk refusal below is about.
+    let mut hours_present = 0usize;
     for shard in 0..shard_count {
-        for hour in shard_hours(store.as_ref(), &tenant_hash, sig, shard).await? {
+        let shard_hours = shard_hours(store.as_ref(), &tenant_hash, sig, shard).await?;
+        hours_present += shard_hours.len();
+        for hour in shard_hours {
             if hour < first_hour {
                 continue;
             }
@@ -425,6 +473,15 @@ pub async fn compact_tenant(
     println!("tombstoned: {}", report.tombstoned);
     println!("parts ({verb}): {}", report.parts_written);
     println!("wall_time_ms: {}", started.elapsed().as_millis());
+    // The counters above are printed first even on the refusal path: an
+    // operator who sees the zeros also sees why they are not a result.
+    DefaultedMemoryEmptyWalk::check(
+        selection,
+        "maintain compact-tenant",
+        tenant,
+        "present ingest-hour buckets",
+        hours_present,
+    )?;
     Ok(report)
 }
 
@@ -438,6 +495,7 @@ pub async fn compact_tenant(
 /// delete pass.
 pub async fn sweep(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     signal: SignalArg,
     shard: u32,
@@ -451,6 +509,16 @@ pub async fn sweep(
         ..CompactorConfig::default()
     };
     let clock = wall_clock()?;
+
+    selection.print_header();
+    require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "maintain sweep",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
 
     let hold = LegalHoldCheck::refresh(store.as_ref(), &tenant_hash)
         .await
@@ -505,6 +573,7 @@ pub async fn sweep(
 /// mutating anything (so it needs no `--dry-run`).
 pub async fn status(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     signal: SignalArg,
     shard: u32,
@@ -515,6 +584,16 @@ pub async fn status(
     let bucket = Bucket::new(tenant_hash, sig, shard, hour);
     let config = CompactorConfig::default();
     let now = crate::now_ns()?;
+
+    selection.print_header();
+    require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "maintain status",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
 
     let listing = ravel_maintain::read::list_bucket(store.as_ref(), &bucket)
         .await
@@ -631,12 +710,22 @@ async fn generation_scan_shards(
 /// record's parts (live L1 objects). Exits nonzero if any anomaly is found.
 pub async fn audit_versions(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     shards: u32,
 ) -> anyhow::Result<()> {
     use std::collections::BTreeMap;
 
     let tenant_hash = TenantId::new(tenant).hash();
+    selection.print_header();
+    require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "maintain audit-versions",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
     let mut anomalies = 0usize;
     for signal in [Signal::Metrics, Signal::Logs, Signal::Spans] {
         let window = signal_supported_versions(signal)?;
@@ -836,6 +925,7 @@ fn signal_current_version(signal: Signal) -> anyhow::Result<u32> {
 #[allow(clippy::too_many_arguments)]
 pub async fn migrate(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     signal: SignalArg,
     shards: u32,
@@ -844,6 +934,15 @@ pub async fn migrate(
     budget_records: u64,
 ) -> anyhow::Result<()> {
     let tenant_hash = TenantId::new(tenant).hash();
+    selection.print_header();
+    require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "maintain migrate",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
     let sig = signal.to_signal();
     let target = match target_version {
         Some(v) => v,
@@ -1063,11 +1162,21 @@ fn check_object_epoch(
 /// Exits nonzero if any anomaly is found.
 pub async fn verify_custody(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     shards: u32,
     versioning_aware: bool,
 ) -> anyhow::Result<()> {
     let tenant_hash = TenantId::new(tenant).hash();
+    selection.print_header();
+    require_tenant_data_present(
+        selection,
+        store.as_ref(),
+        "maintain verify-custody",
+        tenant,
+        &tenant_hash,
+    )
+    .await?;
     let mut anomalies = 0usize;
 
     // The tenant's key-epoch history (ADR-0062 decision 1b), read once and
@@ -1522,9 +1631,14 @@ pub fn decode_retention_tombstone(bytes: &[u8]) -> anyhow::Result<()> {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::store::StoreKind;
     use ravel_commit::publish::{self, RetryPolicy};
     use ravel_commit::record::{self, NewCommitRecord};
     use ravel_object_store::memory::MemoryStore;
+
+    /// These fixtures build their own `MemoryStore`, which is the explicit
+    /// `--store memory` case (issue #1024): an empty result stays a success.
+    const MEMORY: StoreSelection = StoreSelection::explicit(StoreKind::Memory);
 
     /// Both CLI consumers of the supported-version window derive from the one
     /// crate source (ADR-0066 decision 1): `audit-versions`' anomaly predicate
@@ -1651,7 +1765,7 @@ mod tests {
         // the widened count 4).
         publish_commit_at(&store, &tenant_hash, 3, 99).await;
 
-        let err = audit_versions(store.clone(), tenant, 2)
+        let err = audit_versions(store.clone(), MEMORY, tenant, 2)
             .await
             .expect_err("audit must visit the post-reshard shard 3 and find the anomaly");
         assert!(
@@ -1678,7 +1792,7 @@ mod tests {
             .await
             .expect("record epoch 0 activated before the object's write time");
 
-        verify_custody(store.clone(), tenant, 1, false)
+        verify_custody(store.clone(), MEMORY, tenant, 1, false)
             .await
             .expect("every object's write time is inside a recorded epoch");
     }
@@ -1699,7 +1813,7 @@ mod tests {
             .await
             .expect("record epoch 0 activated after the object's write time");
 
-        let err = verify_custody(store.clone(), tenant, 1, false)
+        let err = verify_custody(store.clone(), MEMORY, tenant, 1, false)
             .await
             .expect_err("an object predating the first epoch must be a custody anomaly");
         let msg = err.to_string();
@@ -1724,7 +1838,7 @@ mod tests {
 
         publish_commit_at(&store, &tenant_hash, 0, 6).await;
 
-        verify_custody(store.clone(), tenant, 1, false)
+        verify_custody(store.clone(), MEMORY, tenant, 1, false)
             .await
             .expect("no epoch record means no epoch check; the object passes clean");
     }

--- a/services/ravel-cli/src/reconstruct.rs
+++ b/services/ravel-cli/src/reconstruct.rs
@@ -49,6 +49,7 @@ use ravel_types::{Signal, TenantHash, TenantId};
 use uuid::Uuid;
 
 use crate::maintain::SignalArg;
+use crate::store::{StoreSelection, require_tenant_data_present};
 
 /// Nanoseconds per ingest-hour bucket (mirrors `ravel_commit::record`'s own
 /// private `NS_PER_HOUR`, kept local since that one is not exported).
@@ -78,6 +79,7 @@ enum Outcome {
 /// decision 2).
 pub async fn reconstruct(
     store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
     tenant: &str,
     signal: SignalArg,
     shard: u32,
@@ -92,6 +94,10 @@ pub async fn reconstruct(
     }
     let tenant_hash = TenantId::new(tenant).hash();
     let store = store.as_ref();
+
+    selection.print_header();
+    require_tenant_data_present(selection, store, "commit reconstruct", tenant, &tenant_hash)
+        .await?;
 
     // Phase (a): list the shard's L0 data objects and the identities that
     // already have a commit record; the set difference (by identity) is the

--- a/services/ravel-cli/src/store.rs
+++ b/services/ravel-cli/src/store.rs
@@ -7,12 +7,166 @@ use clap::{Parser, ValueEnum};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::s3::{S3AuthMode, S3Config, S3Store};
 use ravel_object_store::{GetRange, ObjectStoreBackend};
+use ravel_types::TenantHash;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum StoreKind {
     Memory,
     #[value(name = "s3")]
     S3,
+}
+
+impl StoreKind {
+    /// The `--store` spelling of this backend, so a report names the store with
+    /// the same word the flag accepts.
+    pub const fn flag_value(self) -> &'static str {
+        match self {
+            StoreKind::Memory => "memory",
+            StoreKind::S3 => "s3",
+        }
+    }
+}
+
+/// Which backend a command runs against, and whether the operator chose it.
+///
+/// An explicit `--store memory` and an omitted `--store` both resolve to the
+/// in-process [`MemoryStore`], but they are different operator intents: the
+/// first asked for the empty store, the second got it by fallback. Every
+/// walk-shaped command over tenant data reports which one it is
+/// ([`StoreSelection::header`]) and refuses a walk that reaches no data at all
+/// on the fallback ([`require_tenant_data_present`]), because a walk over an
+/// unchosen empty store reports zero counters and exit 0, which reads as a
+/// healthy no-op (issue #1024).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StoreSelection {
+    kind: StoreKind,
+    defaulted: bool,
+}
+
+impl StoreSelection {
+    /// The operator passed `--store <kind>`.
+    pub const fn explicit(kind: StoreKind) -> Self {
+        Self {
+            kind,
+            defaulted: false,
+        }
+    }
+
+    /// No `--store` was given, so the command runs against the empty
+    /// in-process memory store.
+    pub const fn defaulted_memory() -> Self {
+        Self {
+            kind: StoreKind::Memory,
+            defaulted: true,
+        }
+    }
+
+    /// The backend this invocation runs against.
+    pub const fn kind(self) -> StoreKind {
+        self.kind
+    }
+
+    /// Whether this is the fallback memory store rather than a chosen one.
+    pub const fn is_defaulted_memory(self) -> bool {
+        self.defaulted && matches!(self.kind, StoreKind::Memory)
+    }
+
+    /// The `store:` line every walk-shaped command's report header carries, so
+    /// the choice of backend is never invisible in the output an operator
+    /// reads: `store: memory (default)`, `store: memory`, or `store: s3`.
+    pub fn header(self) -> String {
+        if self.defaulted {
+            format!("store: {} (default)", self.kind.flag_value())
+        } else {
+            format!("store: {}", self.kind.flag_value())
+        }
+    }
+
+    /// Print [`StoreSelection::header`] as the first line of a command's
+    /// report.
+    pub fn print_header(self) {
+        println!("{}", self.header());
+    }
+}
+
+impl Default for StoreSelection {
+    /// The fallback, matching an omitted `--store`: the shape that has to be
+    /// caught, never the safe one, so a report built without an explicit
+    /// selection cannot claim the operator chose its store.
+    fn default() -> Self {
+        Self::defaulted_memory()
+    }
+}
+
+/// A walk-shaped command found nothing to walk on a memory store the operator
+/// never asked for (issue #1024).
+///
+/// Typed so the message names the situation and the remedy rather than
+/// surfacing as zero counters and exit 0. The same emptiness under an explicit
+/// `--store memory` is a successful zero-count report: the operator chose that
+/// store, which is what every in-process test does.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error(
+    "--store defaulted to memory, which holds no data for tenant {tenant:?}; {command} found no \
+     {searched} there and would have reported a healthy zero-work result. Pass --store s3 (with \
+     RAVEL_S3_BUCKET and its credentials) to run against the real bucket, or load data first. An \
+     explicit --store memory keeps the zero-count report."
+)]
+pub struct DefaultedMemoryEmptyWalk {
+    /// The subcommand as an operator types it, e.g. `maintain compact-tenant`.
+    pub command: &'static str,
+    /// The `--tenant` the walk was asked for.
+    pub tenant: String,
+    /// What the command looked for under the tenant prefix and did not find.
+    pub searched: &'static str,
+}
+
+impl DefaultedMemoryEmptyWalk {
+    /// The refusal for `command`, or `Ok(())` when the operator chose this
+    /// store or the walk did reach something (`found > 0`).
+    pub fn check(
+        selection: StoreSelection,
+        command: &'static str,
+        tenant: &str,
+        searched: &'static str,
+        found: usize,
+    ) -> Result<(), Self> {
+        if found > 0 || !selection.is_defaulted_memory() {
+            return Ok(());
+        }
+        Err(Self {
+            command,
+            tenant: tenant.to_string(),
+            searched,
+        })
+    }
+}
+
+/// The precondition every walk-shaped command over tenant data runs before it
+/// reports anything: on a defaulted memory store, a tenant prefix that holds
+/// no object at all means the command was pointed at the empty in-process
+/// store by fallback, so it refuses instead of walking nothing.
+///
+/// Costs one `list_delimited` and only when `--store` defaulted: a real
+/// backend never pays for this check.
+pub async fn require_tenant_data_present(
+    selection: StoreSelection,
+    store: &dyn ObjectStoreBackend,
+    command: &'static str,
+    tenant: &str,
+    tenant_hash: &TenantHash,
+) -> anyhow::Result<()> {
+    if !selection.is_defaulted_memory() {
+        return Ok(());
+    }
+    let prefix = format!("t/{}/", tenant_hash.to_hex());
+    let listed = store
+        .list_delimited(&prefix)
+        .await
+        .map_err(|err| anyhow::anyhow!("failed to list {prefix}: {err}"))?;
+    let found = listed.objects.len() + listed.common_prefixes.len();
+    DefaultedMemoryEmptyWalk::check(selection, command, tenant, "objects", found)?;
+    Ok(())
 }
 
 /// Which credential source `--store s3` uses (ADR-0106). The CLI-facing mirror
@@ -42,8 +196,17 @@ impl S3Auth {
 
 #[derive(Debug, Parser)]
 pub struct StoreArgs {
-    #[arg(long, value_enum, default_value = "memory")]
-    pub store: StoreKind,
+    /// Which object store to run against. Unset means `memory`, the empty
+    /// in-process store: a walk-shaped command over tenant data then reports
+    /// `store: memory (default)` in its header, and refuses a walk that
+    /// reaches no data at all rather than reporting zero counters at exit 0.
+    /// An explicit `--store memory` keeps that zero-count report.
+    // `Option`-typed rather than `default_value = "memory"` (issue #1024), the
+    // same treatment ravel-server's resolution-sensitive flags got: a defaulted
+    // `StoreKind` cannot express "nobody asked", so an operator who meant the
+    // real bucket and one who meant the empty store would be indistinguishable.
+    #[arg(long, value_enum)]
+    pub store: Option<StoreKind>,
 
     #[arg(long, env = "RAVEL_S3_ENDPOINT")]
     pub s3_endpoint: Option<String>,
@@ -93,12 +256,27 @@ pub struct StoreArgs {
 }
 
 impl StoreArgs {
+    /// The backend this invocation runs against: `--store` when given, memory
+    /// otherwise.
+    pub fn store_kind(&self) -> StoreKind {
+        self.store.unwrap_or(StoreKind::Memory)
+    }
+
+    /// The same choice, carrying whether the operator made it, for the report
+    /// header and the empty-walk refusal.
+    pub fn selection(&self) -> StoreSelection {
+        match self.store {
+            Some(kind) => StoreSelection::explicit(kind),
+            None => StoreSelection::defaulted_memory(),
+        }
+    }
+
     /// Human-readable backend identity for display and for the
     /// `sys/qualification` record (ADR-0050 section 6): distinguishes which
     /// bucket/endpoint a qualification result belongs to, without leaking
     /// credentials.
     pub fn backend_identity(&self) -> String {
-        match self.store {
+        match self.store_kind() {
             StoreKind::Memory => "memory".to_string(),
             StoreKind::S3 => {
                 let bucket = self.s3_bucket.as_deref().unwrap_or("<unset>");
@@ -153,7 +331,7 @@ fn instance_role_credential_conflict(args: &StoreArgs) -> Option<anyhow::Error> 
 }
 
 pub fn build_store(args: &StoreArgs) -> anyhow::Result<Arc<dyn ObjectStoreBackend>> {
-    match args.store {
+    match args.store_kind() {
         StoreKind::Memory => Ok(Arc::new(MemoryStore::new())),
         StoreKind::S3 => {
             let bucket = args
@@ -549,6 +727,111 @@ mod tests {
             "--store s3 requires RAVEL_S3_SECRET_KEY",
             "the secret-key error text must be unchanged"
         );
+    }
+
+    /// Issue #1024: `--store` is `Option`-typed, so an omitted flag and an
+    /// explicit `--store memory` are distinguishable, and each parsed
+    /// invocation renders the report header line that names its effective
+    /// store. The s3 case is asserted here rather than against a live bucket:
+    /// the header comes from the parsed flag, before any construction.
+    ///
+    /// Non-vacuity (prove-the-test): restore `default_value = "memory"` on the
+    /// flag (making the field a plain `StoreKind`, so `selection()` can no
+    /// longer see the difference) and the first two assertions collapse onto
+    /// the same string.
+    #[test]
+    fn the_store_flag_distinguishes_unset_from_an_explicit_choice() {
+        let unset = StoreArgs::try_parse_from(["ravel-cli"]).expect("no flags parse");
+        assert_eq!(unset.store, None, "an omitted --store stays unset");
+        assert_eq!(unset.selection(), StoreSelection::defaulted_memory());
+        assert_eq!(unset.selection().header(), "store: memory (default)");
+        assert!(unset.selection().is_defaulted_memory());
+        // Unchanged behavior: the fallback is still the memory store.
+        assert_eq!(unset.store_kind(), StoreKind::Memory);
+        assert_eq!(unset.backend_identity(), "memory");
+        build_store(&unset).expect("an unset --store still builds the memory store");
+
+        let explicit_memory = StoreArgs::try_parse_from(["ravel-cli", "--store", "memory"])
+            .expect("--store memory parses");
+        assert_eq!(explicit_memory.store, Some(StoreKind::Memory));
+        assert_eq!(
+            explicit_memory.selection(),
+            StoreSelection::explicit(StoreKind::Memory)
+        );
+        assert_eq!(explicit_memory.selection().header(), "store: memory");
+        assert!(
+            !explicit_memory.selection().is_defaulted_memory(),
+            "a chosen memory store is never the defaulted one"
+        );
+
+        let s3 = StoreArgs::try_parse_from([
+            "ravel-cli",
+            "--store",
+            "s3",
+            "--s3-bucket",
+            "ravel-test",
+            "--s3-endpoint",
+            "http://127.0.0.1:9000",
+            "--s3-access-key",
+            "test",
+            "--s3-secret-key",
+            "test",
+        ])
+        .expect("s3 flags parse");
+        assert_eq!(s3.selection().header(), "store: s3");
+        assert!(!s3.selection().is_defaulted_memory());
+        assert_eq!(
+            s3.backend_identity(),
+            "s3://ravel-test@http://127.0.0.1:9000"
+        );
+        build_store(&s3).expect("the s3-configured invocation still constructs");
+    }
+
+    /// The empty-walk precondition (issue #1024) fires only on the defaulted
+    /// memory store with nothing under the tenant prefix, and it is silent for
+    /// an explicit choice or for a prefix that holds anything at all.
+    ///
+    /// Non-vacuity (prove-the-test): drop the `!selection.is_defaulted_memory()`
+    /// early return in `require_tenant_data_present` and the explicit-memory
+    /// case below starts failing.
+    #[tokio::test]
+    async fn the_empty_walk_precondition_fires_only_on_the_defaulted_store() {
+        let store = MemoryStore::new();
+        let tenant = "cli-empty-walk";
+        let tenant_hash = ravel_types::TenantId::new(tenant).hash();
+        let defaulted = StoreSelection::defaulted_memory();
+        let chosen = StoreSelection::explicit(StoreKind::Memory);
+
+        let err =
+            require_tenant_data_present(defaulted, &store, "maintain sweep", tenant, &tenant_hash)
+                .await
+                .expect_err("an empty tenant prefix on the defaulted store must refuse");
+        assert_eq!(
+            *err.downcast_ref::<DefaultedMemoryEmptyWalk>()
+                .expect("typed DefaultedMemoryEmptyWalk"),
+            DefaultedMemoryEmptyWalk {
+                command: "maintain sweep",
+                tenant: tenant.to_string(),
+                searched: "objects",
+            }
+        );
+
+        require_tenant_data_present(chosen, &store, "maintain sweep", tenant, &tenant_hash)
+            .await
+            .expect("an explicitly chosen empty memory store is not refused");
+
+        // One object anywhere under the tenant prefix is data reached.
+        store
+            .put(
+                &format!("t/{}/l/prov", tenant_hash.to_hex()),
+                Bytes::from_static(b"prov"),
+                PutOptions::default(),
+            )
+            .await
+            .expect("seed one object under the tenant prefix");
+        require_tenant_data_present(defaulted, &store, "maintain sweep", tenant, &tenant_hash)
+            .await
+            .expect("a tenant prefix that holds something is walked, not refused");
     }
 
     /// The ADR-0072 decision 1 flags reach `S3Config` rather than being parsed

--- a/services/ravel-cli/tests/catalog.rs
+++ b/services/ravel-cli/tests/catalog.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use ravel_cli::catalog;
 use ravel_cli::maintain::SignalArg;
+use ravel_cli::store::{DefaultedMemoryEmptyWalk, StoreKind, StoreSelection};
 use ravel_commit::keys;
 use ravel_commit::publish::{self, RetryPolicy};
 use ravel_commit::record::{self, NewCommitRecord};
@@ -30,6 +31,11 @@ use uuid::Uuid;
 /// margin with room to spare (matches `services/ravel-server/tests/fold_e2e.rs`'s
 /// `SEALED_AGE`).
 const SEALED_AGE_NS: i64 = 3 * 60 * 60 * 1_000_000_000;
+
+/// Every fixture here builds its own `MemoryStore`, which is the explicit
+/// `--store memory` case (issue #1024): the reports carry `store: memory` and
+/// an empty result stays a success, unlike a walk on the defaulted store.
+const MEMORY: StoreSelection = StoreSelection::explicit(StoreKind::Memory);
 
 fn now_ns() -> i64 {
     ravel_cli::now_ns().expect("system clock readable")
@@ -85,6 +91,7 @@ async fn fold_then_inspect_then_verify_round_trips_cleanly() {
 
     catalog::fold(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         1,
         SignalArg::Metrics,
@@ -96,6 +103,7 @@ async fn fold_then_inspect_then_verify_round_trips_cleanly() {
 
     catalog::inspect(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Metrics,
     )
@@ -104,6 +112,7 @@ async fn fold_then_inspect_then_verify_round_trips_cleanly() {
 
     catalog::verify(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Metrics,
     )
@@ -120,6 +129,7 @@ async fn verify_fails_when_a_sealed_record_is_missing_from_the_snapshot() {
 
     catalog::fold(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         1,
         SignalArg::Metrics,
@@ -135,6 +145,7 @@ async fn verify_fails_when_a_sealed_record_is_missing_from_the_snapshot() {
 
     let err = catalog::verify(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Metrics,
     )
@@ -151,12 +162,61 @@ async fn inspect_and_verify_report_cleanly_with_no_head_yet() {
     let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
     let tenant = "acme";
 
-    catalog::inspect(store.clone(), tenant, SignalArg::Metrics)
+    catalog::inspect(store.clone(), MEMORY, tenant, SignalArg::Metrics)
         .await
         .expect("inspect on an absent HEAD reports rather than errors");
-    catalog::verify(store.clone(), tenant, SignalArg::Metrics)
+    catalog::verify(store.clone(), MEMORY, tenant, SignalArg::Metrics)
         .await
         .expect("verify on an absent HEAD reports rather than errors");
+}
+
+/// Issue #1024 for `catalog fold`, the other command the incident names: with
+/// `--store` omitted the fold runs against the empty in-process store, and
+/// rather than publishing an empty HEAD and reporting `buckets_folded: 0` at
+/// exit 0 it refuses with the typed error, naming the tenant and the remedy.
+///
+/// Non-vacuity (prove-the-test): delete the `require_tenant_data_present` call
+/// in `catalog::fold` and this returns `Ok` with `buckets_folded == 0`, exactly
+/// the shape the incident reported; the HEAD assertion below then also fails,
+/// because the refused fold no longer leaves the catalog untouched.
+#[tokio::test]
+async fn fold_on_the_defaulted_memory_store_refuses_instead_of_sealing_nothing() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = "acme";
+
+    let err = catalog::fold(
+        store.clone(),
+        StoreSelection::defaulted_memory(),
+        tenant,
+        1,
+        SignalArg::Metrics,
+        None,
+        now_ns(),
+    )
+    .await
+    .expect_err("a fold over an unchosen empty store must refuse");
+
+    let typed = err
+        .downcast_ref::<DefaultedMemoryEmptyWalk>()
+        .expect("typed DefaultedMemoryEmptyWalk");
+    assert_eq!(
+        *typed,
+        DefaultedMemoryEmptyWalk {
+            command: "catalog fold",
+            tenant: tenant.to_string(),
+            searched: "objects",
+        }
+    );
+    assert!(
+        err.to_string().contains("--store s3"),
+        "the error must name the remedy: {err}"
+    );
+
+    let listed = store.list("t/", None).await.expect("list").objects;
+    assert!(
+        listed.is_empty(),
+        "the refusal happens before any catalog write; found {listed:?}"
+    );
 }
 
 #[tokio::test]
@@ -179,6 +239,7 @@ async fn inspect_rejects_a_corrupt_head() {
 
     let err = catalog::inspect(
         store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         "acme",
         SignalArg::Metrics,
     )
@@ -264,6 +325,7 @@ async fn inspect_preserves_partial_output_when_a_part_fetch_fails() {
     let mut out = String::new();
     let err = catalog::render_inspect(
         store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         "acme",
         SignalArg::Metrics,
         &mut out,

--- a/services/ravel-cli/tests/catalog_fold_max_flush_lifetime.rs
+++ b/services/ravel-cli/tests/catalog_fold_max_flush_lifetime.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use ravel_cli::catalog;
 use ravel_cli::maintain::SignalArg;
+use ravel_cli::store::{StoreKind, StoreSelection};
 use ravel_commit::keys;
 use ravel_commit::publish::{self, RetryPolicy};
 use ravel_commit::record::{self, NewCommitRecord};
@@ -30,6 +31,11 @@ use uuid::Uuid;
 
 const NS_PER_HOUR: i64 = 3_600_000_000_000;
 const NS_PER_MINUTE: i64 = 60_000_000_000;
+
+/// Every fixture here builds its own `MemoryStore`, which is the explicit
+/// `--store memory` case (issue #1024): the fold reports `store: memory` and
+/// an empty result stays a success, unlike a walk on the defaulted store.
+const MEMORY: StoreSelection = StoreSelection::explicit(StoreKind::Memory);
 
 const SHARD_COUNT: u32 = 2;
 
@@ -145,6 +151,7 @@ async fn max_flush_lifetime_zero_seals_the_finished_hour_a_default_fold_leaves_a
     //    tenant has, so it lists nothing and publishes an empty HEAD.
     let (default_report, default_printed) = catalog::fold(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SHARD_COUNT,
         SignalArg::Metrics,
@@ -173,11 +180,18 @@ async fn max_flush_lifetime_zero_seals_the_finished_hour_a_default_fold_leaves_a
         default_printed.contains("seal_margin: 1h 20m\n"),
         "the default fold reports the default margin, got:\n{default_printed}"
     );
+    // Issue #1024: the effective store heads every walk-shaped command's
+    // report, so a fold that seals nothing can never hide which store it read.
+    assert!(
+        default_printed.starts_with("store: memory\n"),
+        "the fold report must open with the effective store, got:\n{default_printed}"
+    );
 
     // 2. The same fold with the override. `0s` removes only the flush-lifetime
     //    term: 5m + 15m still stand, so the current hour stays unsealed.
     let (override_report, override_printed) = catalog::fold(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SHARD_COUNT,
         SignalArg::Metrics,
@@ -228,6 +242,7 @@ async fn a_default_fold_after_an_override_fold_is_a_no_op_at_the_reached_waterma
 
     let (override_report, _) = catalog::fold(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SHARD_COUNT,
         SignalArg::Metrics,
@@ -241,6 +256,7 @@ async fn a_default_fold_after_an_override_fold_is_a_no_op_at_the_reached_waterma
 
     let (second_report, second_printed) = catalog::fold(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SHARD_COUNT,
         SignalArg::Metrics,
@@ -356,6 +372,7 @@ async fn a_lifetime_that_overflows_the_seal_margin_is_refused() {
 
     let err = catalog::fold(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SHARD_COUNT,
         SignalArg::Metrics,

--- a/services/ravel-cli/tests/catalog_signal.rs
+++ b/services/ravel-cli/tests/catalog_signal.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use ravel_cli::catalog;
 use ravel_cli::maintain::SignalArg;
+use ravel_cli::store::{StoreKind, StoreSelection};
 use ravel_commit::keys;
 use ravel_commit::publish::{self, RetryPolicy};
 use ravel_commit::record::{self, NewCommitRecord};
@@ -28,6 +29,11 @@ use ravel_types::{Signal, TenantHash, TenantId, TimeRange};
 use uuid::Uuid;
 
 const NS_PER_HOUR: i64 = 3_600_000_000_000;
+
+/// Every fixture here builds its own `MemoryStore`, which is the explicit
+/// `--store memory` case (issue #1024): the reports carry `store: memory` and
+/// an empty result stays a success, unlike a walk on the defaulted store.
+const MEMORY: StoreSelection = StoreSelection::explicit(StoreKind::Memory);
 
 /// Default seal margins sum to 1h20m, but hour-bucket quantization means
 /// anything under ~2h20m can land on the wrong side of
@@ -189,6 +195,7 @@ async fn fold_signal_logs_folds_the_logs_snapshot_and_a_logs_resolve_reads_no_co
 
     let (report, _printed) = catalog::fold(
         inner.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SHARD_COUNT,
         FOLD_SIGNAL,
@@ -283,6 +290,7 @@ async fn inspect_signal_logs_prints_the_signal_word() {
 
     catalog::fold(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SHARD_COUNT,
         SignalArg::Logs,
@@ -295,6 +303,7 @@ async fn inspect_signal_logs_prints_the_signal_word() {
     let mut out = String::new();
     catalog::render_inspect(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Logs,
         &mut out,
@@ -324,6 +333,7 @@ async fn verify_signal_logs_checks_the_logs_snapshot() {
 
     catalog::fold(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SHARD_COUNT,
         SignalArg::Logs,
@@ -335,6 +345,7 @@ async fn verify_signal_logs_checks_the_logs_snapshot() {
 
     catalog::verify(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Logs,
     )
@@ -353,6 +364,7 @@ async fn verify_signal_logs_checks_the_logs_snapshot() {
     .await;
     let err = catalog::verify(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Logs,
     )
@@ -367,6 +379,7 @@ async fn verify_signal_logs_checks_the_logs_snapshot() {
     // reports exactly that rather than the logs divergence above.
     catalog::verify(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Metrics,
     )

--- a/services/ravel-cli/tests/compact_tenant.rs
+++ b/services/ravel-cli/tests/compact_tenant.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use ravel_cli::maintain::{CompactTenantError, SignalArg, compact_tenant};
+use ravel_cli::store::{DefaultedMemoryEmptyWalk, StoreKind, StoreSelection};
 use ravel_commit::keys;
 use ravel_commit::record::{self, NewCommitRecord};
 use ravel_logseg::{AttrValue, LogRecord, LogStreamId, ObjectIdentity, RlogConfig, RlogWriter};
@@ -29,6 +30,12 @@ const TENANT: &str = "clickbench";
 const HOUR_OLD: u32 = 500_000;
 const SHARDS: u32 = 2;
 const EPOCH: u64 = 1;
+
+/// The seeded fixtures below build their own `MemoryStore`, which is the
+/// explicit `--store memory` case (issue #1024): the report header reads
+/// `store: memory` and an empty walk stays a zero-count success. The defaulted
+/// case is [`StoreSelection::defaulted_memory`], exercised on its own below.
+const MEMORY: StoreSelection = StoreSelection::explicit(StoreKind::Memory);
 
 /// Ten minutes past the end of the newer hour. Under the default
 /// `max_flush_lifetime` (1 h) the seal margin is 1 h 5 min, so only `HOUR_OLD`
@@ -195,6 +202,7 @@ async fn compact_tenant_compacts_only_the_sealed_hour_of_every_shard() {
 
     let report = compact_tenant(
         store.clone(),
+        MEMORY,
         TENANT,
         SignalArg::Logs,
         Some(SHARDS),
@@ -211,6 +219,15 @@ async fn compact_tenant_compacts_only_the_sealed_hour_of_every_shard() {
     .expect("compact-tenant runs");
 
     assert_eq!(report.shards, 2, "walked both shards");
+    assert_eq!(
+        report.store, MEMORY,
+        "the report carries the store the walk ran against"
+    );
+    assert_eq!(
+        report.store.header(),
+        "store: memory",
+        "an explicit --store memory is reported without the (default) marker"
+    );
     assert_eq!(report.compacted, 2, "one sealed hour per shard");
     assert_eq!(
         report.not_sealed, 2,
@@ -241,6 +258,7 @@ async fn max_flush_lifetime_zero_seals_and_compacts_every_hour() {
 
     let report = compact_tenant(
         store.clone(),
+        MEMORY,
         TENANT,
         SignalArg::Logs,
         Some(SHARDS),
@@ -287,6 +305,7 @@ async fn dry_run_reports_the_same_plan_and_writes_nothing() {
 
     let dry = compact_tenant(
         store.clone(),
+        MEMORY,
         TENANT,
         SignalArg::Logs,
         Some(SHARDS),
@@ -318,6 +337,7 @@ async fn dry_run_reports_the_same_plan_and_writes_nothing() {
     // dry run said it would.
     let wet = compact_tenant(
         store.clone(),
+        MEMORY,
         TENANT,
         SignalArg::Logs,
         Some(SHARDS),
@@ -341,6 +361,7 @@ async fn missing_shards_and_no_provisioning_record_is_a_typed_error_naming_the_t
 
     let err = compact_tenant(
         store,
+        MEMORY,
         TENANT,
         SignalArg::Logs,
         None,
@@ -380,6 +401,7 @@ async fn from_hour_and_to_hour_bound_the_walk() {
     // hour is below `--from-hour` and is never visited.
     let report = compact_tenant(
         store.clone(),
+        MEMORY,
         TENANT,
         SignalArg::Logs,
         Some(SHARDS),
@@ -423,6 +445,7 @@ async fn zero_knob_is_refused_before_shard_resolution() {
 
     let err = compact_tenant(
         store,
+        MEMORY,
         TENANT,
         SignalArg::Logs,
         None,
@@ -444,5 +467,228 @@ async fn zero_knob_is_refused_before_shard_resolution() {
     assert_eq!(
         *typed,
         ravel_cli::maintain::CompactorKnobError::ZeroL1PartMemoryTarget
+    );
+}
+
+/// Issue #1024: `--store` omitted means the empty in-process memory store, and
+/// a walk over a tenant that holds nothing there is refused with a typed error
+/// naming the tenant and the remedy, instead of the healthy-looking
+/// `compacted: 0, not_sealed: 0` and exit 0 that burned two measurement runs
+/// against a 100M-row S3 tenant.
+///
+/// Non-vacuity (prove-the-test): the pre-change tree had no store selection at
+/// all and returned `Ok(CompactTenantReport { compacted: 0, .. })` here; this
+/// `expect_err` fails against it. Against the post-change tree, deleting the
+/// `require_tenant_data_present` call in `maintain::compact_tenant` flips this
+/// back to that `Ok` (the `--shards 2` override means shard resolution does not
+/// refuse first), and deleting only the `DefaultedMemoryEmptyWalk::check` call
+/// leaves this test passing but fails
+/// `defaulted_store_refuses_when_no_hour_resolves_under_a_provisioned_tenant`.
+#[tokio::test]
+async fn defaulted_store_with_nothing_under_the_tenant_prefix_is_a_typed_refusal() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+
+    let err = compact_tenant(
+        store,
+        StoreSelection::defaulted_memory(),
+        TENANT,
+        SignalArg::Logs,
+        Some(SHARDS),
+        None,
+        None,
+        false,
+        None,
+        None,
+        None,
+        None,
+        now_ns(),
+    )
+    .await
+    .expect_err("a walk over an unchosen empty store must refuse, not report zeros");
+
+    let typed = err
+        .downcast_ref::<DefaultedMemoryEmptyWalk>()
+        .expect("typed DefaultedMemoryEmptyWalk");
+    assert_eq!(
+        *typed,
+        DefaultedMemoryEmptyWalk {
+            command: "maintain compact-tenant",
+            tenant: TENANT.to_string(),
+            searched: "objects",
+        }
+    );
+    let text = err.to_string();
+    assert!(
+        text.contains(TENANT),
+        "the error must name the tenant: {text}"
+    );
+    assert!(
+        text.contains("--store defaulted to memory") && text.contains("--store s3"),
+        "the error must name the situation and the remedy: {text}"
+    );
+}
+
+/// The same refusal for the exact condition issue #1024 states: zero present
+/// ingest-hour buckets resolved across every shard. The tenant prefix here is
+/// NOT empty (it holds the shard-count provisioning record the walk resolves
+/// its shard range from), so this is the post-walk check firing, not the
+/// precondition above.
+///
+/// Non-vacuity (prove-the-test): delete the `DefaultedMemoryEmptyWalk::check`
+/// call at the end of `maintain::compact_tenant` and this returns
+/// `Ok(CompactTenantReport { shards: 2, compacted: 0, .. })`; the `expect_err`
+/// fails. The `searched` field is what separates the two guards: swap it for
+/// `"objects"` and the `assert_eq!` below fails.
+#[tokio::test]
+async fn defaulted_store_refuses_when_no_hour_resolves_under_a_provisioned_tenant() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    ravel_catalog::validate_or_adopt(
+        store.as_ref(),
+        &tenant_hash(),
+        Signal::Logs,
+        SHARDS,
+        0,
+        ravel_catalog::AbsentPolicy::CreateFromConfig,
+    )
+    .await
+    .expect("write the shard-count provisioning record");
+
+    let err = compact_tenant(
+        store,
+        StoreSelection::defaulted_memory(),
+        TENANT,
+        SignalArg::Logs,
+        // No --shards: the shard count resolves from the provisioning record,
+        // so the walk reaches the per-shard hour listing and finds nothing.
+        None,
+        None,
+        None,
+        false,
+        None,
+        None,
+        None,
+        None,
+        now_ns(),
+    )
+    .await
+    .expect_err("zero present hours across every shard must refuse on the defaulted store");
+
+    let typed = err
+        .downcast_ref::<DefaultedMemoryEmptyWalk>()
+        .expect("typed DefaultedMemoryEmptyWalk");
+    assert_eq!(
+        *typed,
+        DefaultedMemoryEmptyWalk {
+            command: "maintain compact-tenant",
+            tenant: TENANT.to_string(),
+            searched: "present ingest-hour buckets",
+        }
+    );
+}
+
+/// An EXPLICIT `--store memory` keeps today's behavior on the same emptiness:
+/// a zero-counter report, exit 0, with the header naming the store the operator
+/// chose. This is what every in-process test does, and the reason the refusal
+/// keys on the defaulted store rather than on emptiness alone.
+///
+/// Non-vacuity (prove-the-test): make `StoreSelection::is_defaulted_memory`
+/// return `self.kind == StoreKind::Memory` (dropping the `defaulted` term) and
+/// this `expect` fails with the #1024 refusal.
+#[tokio::test]
+async fn explicit_memory_with_an_empty_store_still_reports_zero_counters() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+
+    let report = compact_tenant(
+        store,
+        MEMORY,
+        TENANT,
+        SignalArg::Logs,
+        Some(SHARDS),
+        None,
+        None,
+        false,
+        None,
+        None,
+        None,
+        None,
+        now_ns(),
+    )
+    .await
+    .expect("an explicitly chosen empty memory store is a zero-count success");
+
+    assert_eq!(
+        report,
+        ravel_cli::maintain::CompactTenantReport {
+            store: MEMORY,
+            shards: SHARDS,
+            compacted: 0,
+            already: 0,
+            not_sealed: 0,
+            below_min: 0,
+            tombstoned: 0,
+            parts_written: 0,
+        },
+        "the zero-count report is unchanged from before issue #1024"
+    );
+    assert_eq!(report.store.header(), "store: memory");
+}
+
+/// The refusal keys on emptiness, not on the flag being omitted: the same
+/// defaulted selection over a populated store walks and compacts exactly as an
+/// explicit `--store memory` does, and its header carries the `(default)`
+/// marker so the choice is visible in the output either way.
+#[tokio::test]
+async fn a_defaulted_store_that_does_hold_data_walks_normally() {
+    let store = seed_tenant().await;
+    let defaulted = StoreSelection::defaulted_memory();
+
+    let report = compact_tenant(
+        store,
+        defaulted,
+        TENANT,
+        SignalArg::Logs,
+        Some(SHARDS),
+        None,
+        None,
+        false,
+        None,
+        None,
+        None,
+        None,
+        now_ns(),
+    )
+    .await
+    .expect("a defaulted store holding data is walked, not refused");
+
+    assert_eq!(report.compacted, 2, "one sealed hour per shard, as always");
+    assert_eq!(report.not_sealed, 2);
+    assert_eq!(report.store, defaulted);
+    assert_eq!(
+        report.store.header(),
+        "store: memory (default)",
+        "the header marks a store nobody chose, even when the walk finds data"
+    );
+}
+
+/// The report header text for every effective store, including the
+/// s3-configured invocation: `StoreSelection` is the report builder unit the
+/// walk commands print their first line from, so this pins all three spellings
+/// in one place.
+///
+/// Non-vacuity (prove-the-test): drop the `(default)` branch from
+/// `StoreSelection::header` and the first assertion fails.
+#[test]
+fn the_report_header_names_the_effective_store() {
+    assert_eq!(
+        StoreSelection::defaulted_memory().header(),
+        "store: memory (default)"
+    );
+    assert_eq!(
+        StoreSelection::explicit(StoreKind::Memory).header(),
+        "store: memory"
+    );
+    assert_eq!(
+        StoreSelection::explicit(StoreKind::S3).header(),
+        "store: s3"
     );
 }

--- a/services/ravel-cli/tests/maintain.rs
+++ b/services/ravel-cli/tests/maintain.rs
@@ -14,6 +14,7 @@ use ravel_cli::maintain::{
     SignalArg, audit_versions, compact, decode_compaction_record, decode_retention_tombstone,
     migrate, status, sweep, verify_custody,
 };
+use ravel_cli::store::{StoreKind, StoreSelection};
 use ravel_commit::keys;
 use ravel_commit::publish::{self, RetryPolicy};
 use ravel_commit::record::{self, NewCommitRecord};
@@ -29,6 +30,12 @@ use uuid::Uuid;
 fn store() -> Arc<dyn ObjectStoreBackend> {
     Arc::new(MemoryStore::new())
 }
+
+/// These tests build their own `MemoryStore`, which is the explicit
+/// `--store memory` case (issue #1024): each report header reads
+/// `store: memory`, and the empty-store cases below stay successes rather than
+/// becoming the defaulted-store refusal.
+const MEMORY: StoreSelection = StoreSelection::explicit(StoreKind::Memory);
 
 /// Publish one L0 metrics segment (data object + commit record) and return the
 /// content-addressed data-object key, so a test can later corrupt the object
@@ -235,14 +242,23 @@ async fn seed_orphan_l0(store: &MemoryStore, tenant: &str, shard: u32, seq: u64)
 async fn compact_empty_bucket_is_below_min() {
     // Hour 0 is long sealed; an empty bucket has zero inputs, below the
     // min-inputs trigger, so a dry run reports it and writes nothing.
-    compact(store(), "acme", SignalArg::Metrics, 0, 0, true, None)
-        .await
-        .expect("compact dry-run runs");
+    compact(
+        store(),
+        MEMORY,
+        "acme",
+        SignalArg::Metrics,
+        0,
+        0,
+        true,
+        None,
+    )
+    .await
+    .expect("compact dry-run runs");
 }
 
 #[tokio::test]
 async fn sweep_empty_shard_dry_run_is_clean() {
-    sweep(store(), "acme", SignalArg::Logs, 0, true, false)
+    sweep(store(), MEMORY, "acme", SignalArg::Logs, 0, true, false)
         .await
         .expect("sweep dry-run runs");
 }
@@ -288,6 +304,7 @@ async fn sweep_does_not_delete_data_under_legal_hold() {
 
     sweep(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Metrics,
         0,
@@ -329,6 +346,7 @@ async fn override_orphan_breaker_runs_exactly_one_forced_pass() {
     // the shard's listed L0 objects), deleting nothing.
     sweep(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Metrics,
         0,
@@ -343,6 +361,7 @@ async fn override_orphan_breaker_runs_exactly_one_forced_pass() {
     // With override: this one pass deletes despite the breaker's threshold.
     sweep(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Metrics,
         0,
@@ -365,6 +384,7 @@ async fn override_orphan_breaker_runs_exactly_one_forced_pass() {
     }
     sweep(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Metrics,
         0,
@@ -383,21 +403,21 @@ async fn override_orphan_breaker_runs_exactly_one_forced_pass() {
 
 #[tokio::test]
 async fn status_empty_bucket_is_clean() {
-    status(store(), "acme", SignalArg::Metrics, 0, 0)
+    status(store(), MEMORY, "acme", SignalArg::Metrics, 0, 0)
         .await
         .expect("status runs");
 }
 
 #[tokio::test]
 async fn audit_versions_empty_store_finds_no_anomaly() {
-    audit_versions(store(), "acme", 4)
+    audit_versions(store(), MEMORY, "acme", 4)
         .await
         .expect("audit over an empty store reports no live objects and no anomaly");
 }
 
 #[tokio::test]
 async fn verify_custody_empty_store_is_clean() {
-    verify_custody(store(), "acme", 4, false)
+    verify_custody(store(), MEMORY, "acme", 4, false)
         .await
         .expect("empty store has no live objects and no anomaly");
 }
@@ -411,9 +431,15 @@ async fn verify_custody_clean_store_verifies_every_object() {
     // that was legitimately swept (no L0 object seeded for it).
     seed_compaction(&store, "acme", &[(Uuid::new_v4(), 1, 1)]).await;
 
-    verify_custody(store as Arc<dyn ObjectStoreBackend>, "acme", 1, false)
-        .await
-        .expect("a clean store passes custody verification");
+    verify_custody(
+        store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        "acme",
+        1,
+        false,
+    )
+    .await
+    .expect("a clean store passes custody verification");
 }
 
 #[tokio::test]
@@ -431,9 +457,15 @@ async fn verify_custody_catches_a_corrupted_data_object() {
         .await
         .expect("overwrite the data object");
 
-    let err = verify_custody(store as Arc<dyn ObjectStoreBackend>, "acme", 1, false)
-        .await
-        .expect_err("a corrupted data object must fail verification");
+    let err = verify_custody(
+        store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        "acme",
+        1,
+        false,
+    )
+    .await
+    .expect_err("a corrupted data object must fail verification");
     assert!(
         err.to_string().contains("content-hash mismatch"),
         "unexpected error: {err}"
@@ -448,9 +480,15 @@ async fn verify_custody_treats_a_legitimately_swept_input_as_no_anomaly() {
     // part is present and matches. This must not be an anomaly.
     seed_compaction(&store, "acme", &[(Uuid::new_v4(), 1, 1)]).await;
 
-    verify_custody(store as Arc<dyn ObjectStoreBackend>, "acme", 1, false)
-        .await
-        .expect("a swept (missing) compaction input is expected, not an anomaly");
+    verify_custody(
+        store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        "acme",
+        1,
+        false,
+    )
+    .await
+    .expect("a swept (missing) compaction input is expected, not an anomaly");
 }
 
 #[tokio::test]
@@ -464,9 +502,15 @@ async fn verify_custody_catches_a_compaction_input_with_a_mismatched_hash() {
     put_l0_object_at(&store, "acme", 0, identity, content_hash, b"corrupted").await;
     seed_compaction(&store, "acme", &[identity]).await;
 
-    let err = verify_custody(store as Arc<dyn ObjectStoreBackend>, "acme", 1, false)
-        .await
-        .expect_err("an existing-but-mismatched input must fail verification");
+    let err = verify_custody(
+        store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        "acme",
+        1,
+        false,
+    )
+    .await
+    .expect_err("an existing-but-mismatched input must fail verification");
     assert!(
         err.to_string().contains("content-hash mismatch"),
         "unexpected error: {err}"
@@ -528,9 +572,18 @@ async fn migrate_raises_floor_on_a_clean_tenant() {
     .await
     .expect("provision");
 
-    migrate(store.clone(), tenant, SignalArg::Metrics, 4, None, None, 0)
-        .await
-        .expect("migrate raises the floor on a clean tenant");
+    migrate(
+        store.clone(),
+        MEMORY,
+        tenant,
+        SignalArg::Metrics,
+        4,
+        None,
+        None,
+        0,
+    )
+    .await
+    .expect("migrate raises the floor on a clean tenant");
 
     let floor = ravel_catalog::current_floor_from_store(
         store.as_ref(),
@@ -576,9 +629,18 @@ async fn migrate_exits_nonzero_and_holds_the_floor_when_a_straggler_survives() {
     let now = ravel_cli::now_ns().expect("wall clock");
     publish_l0(mem.as_ref(), tenant, 0, 1, now).await;
 
-    let err = migrate(store.clone(), tenant, SignalArg::Metrics, 4, None, None, 0)
-        .await
-        .expect_err("a fresh straggler must make migrate exit nonzero");
+    let err = migrate(
+        store.clone(),
+        MEMORY,
+        tenant,
+        SignalArg::Metrics,
+        4,
+        None,
+        None,
+        0,
+    )
+    .await
+    .expect_err("a fresh straggler must make migrate exit nonzero");
     assert!(
         err.to_string().contains("refused to raise"),
         "the error must report the refused floor raise: {err}"

--- a/services/ravel-cli/tests/reconstruct.rs
+++ b/services/ravel-cli/tests/reconstruct.rs
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use ravel_cli::maintain::SignalArg;
 use ravel_cli::reconstruct::reconstruct;
+use ravel_cli::store::{StoreKind, StoreSelection};
 use ravel_commit::keys;
 use ravel_commit::record::{self, NewCommitRecord};
 use ravel_logseg::{
@@ -32,6 +33,11 @@ use uuid::Uuid;
 
 const NS_PER_HOUR: i64 = 3_600_000_000_000;
 const MS_PER_HOUR: u64 = 3_600_000;
+
+/// These fixtures build their own store, which is the explicit
+/// `--store memory` case (issue #1024): the report header reads
+/// `store: memory` and an empty shard stays a success.
+const MEMORY: StoreSelection = StoreSelection::explicit(StoreKind::Memory);
 
 /// Event/ingest timestamp 30 minutes into ingest hour 495_734.
 const INGEST_HOUR: u32 = 495_734;
@@ -114,6 +120,7 @@ async fn reconstruct_makes_a_record_less_segment_resolvable_again() {
 
     reconstruct(
         store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Metrics,
         shard,
@@ -338,6 +345,7 @@ async fn create_if_absent_never_clobbers_an_existing_record() {
     // from LIST), so it genuinely attempts the write; it must not fail the run.
     reconstruct(
         store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
         tenant,
         SignalArg::Logs,
         shard,


### PR DESCRIPTION
Every walk-shaped command prints the effective store in its report header, and a walk that resolves zero present data on the DEFAULTED memory store refuses with a typed error naming the tenant and the remedy, while an explicit --store memory keeps its zero-report success. This is the trap that burned two T6 measurement runs: a compact-tenant against a 100M-row S3 tenant walked the empty default store and reported a healthy-looking no-op in 3 ms.

Local gate note: executor ran workspace clippy and affected tests on the identical tree (verified unchanged through the authorship rewrite); full workspace gates run in this PR's required CI.

Fixes: #1024