### PR TITLE
fix(maintain): bound RLOG L1 part size by encoded bytes

### DIFF
--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -64,7 +64,13 @@ use uuid::Uuid;
 ///   overshoots by up to one whole trace
 ///   ([`CompactorConfig::l1_part_memory_target_bytes`]). The RLOG merge may
 ///   also close a part earlier on the stored-size target `max_l1_part_bytes`
-///   (issue #872), which only lowers this term.
+///   (issue #872), which only lowers this term. Testing that target does add a
+///   short-lived, uncharged transient: the exact-encode probe encodes a CLONE
+///   of the buffered records, so while it runs the resident set briefly holds a
+///   second copy of the part's row heap plus its encoded object bytes (bounded
+///   by `2 * writer + max_l1_part_bytes`, released as the probe returns). It
+///   only runs once the payload proxy reaches the stored target, so never at the
+///   shipped defaults where the memory target binds first.
 ///
 /// # Phase-attributed peaks (issue #977)
 ///
@@ -417,8 +423,8 @@ impl MergeMemoryTracker {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record that a part was closed by the stored-size target (its
-    /// encoded-bytes estimate reached `max_l1_part_bytes`).
+    /// Record that a part was closed by the stored-size target (an exact-encode
+    /// probe showed its object bytes reaching `max_l1_part_bytes`).
     pub fn note_stored_target_flush(&self) {
         self.inner
             .stored_target_flushes
@@ -449,13 +455,14 @@ pub const DEFAULT_CLOCK_SKEW_ALLOWANCE_NS: i64 = 300_000_000_000;
 pub const DEFAULT_MAX_COMPACTION_LIFETIME_NS: i64 = NS_PER_HOUR;
 /// Default `max_l1_part_bytes`: 256 MiB. This is the **stored-size target**:
 /// the encoded/on-object byte budget a part is closed at, estimated per section
-/// in `build.rs` and per record plus per stream in the RLOG merge. It is
+/// in `build.rs` and measured by an exact-encode probe in the RLOG merge. It is
 /// deliberately equal to the memory-target default so this crate's geometry is
 /// unchanged from when one knob did both jobs: on a wide schema the memory
 /// target reaches 256 MiB of decoded record heap long before a part's stored
-/// bytes reach 256 MiB, so the memory target stays binding and the stored
-/// target does not fire. Lowering it to `8..=16 MiB` is the follow-up that
-/// grows objects (issue #872); see [`CompactorConfig::max_l1_part_bytes`].
+/// bytes reach 256 MiB, so the memory target stays binding, the RLOG payload
+/// proxy never reaches 256 MiB, and no probe runs. Lowering it to `8..=16 MiB`
+/// is the follow-up that grows objects (issue #872); see
+/// [`CompactorConfig::max_l1_part_bytes`].
 pub const DEFAULT_MAX_L1_PART_BYTES: u64 = 256 * 1024 * 1024;
 /// Default `l1_part_memory_target_bytes`: 256 MiB. This is the **memory split
 /// target**: the decoded record-heap estimate the in-progress part is closed
@@ -704,26 +711,34 @@ pub struct CompactorConfig {
     /// measured from the run's start via the clock.
     pub max_compaction_lifetime_ns: i64,
     /// The **stored-size target**: close the in-progress L1 part once its
-    /// encoded/on-object bytes reach this. On the RSEG path (`build.rs`) this
-    /// is the part's stored-size estimate, which charges every section that
-    /// grows with what the part carries: the TS/VAL/HIST pages (ADR-0092
-    /// decision 3), each series' SERIES_IDS entry and SERIES_META cells, the
-    /// per-sample provenance columns a run-merged run adds, each distinct
-    /// LABEL_DICT string, and the EXEMPLARS records. On the
-    /// RLOG path (`rlog.rs`) it is an encoded-bytes estimate summed per record
-    /// ([`crate::rlog::estimate_stored_record`]) plus one STREAM_DIR entry per
-    /// distinct stream in the part, because the RLOG writer holds
-    /// row-major records and does not expose an incremental encoded size. Both
-    /// estimates are pre-compression proxies over zstd-compressed sections, so
-    /// they charge at or above what those sections store, which is the
-    /// conservative direction. Named
-    /// for the bytes it measures: it governs object geometry (object count and
-    /// per-object stored size), which is what the historical `max_l1_part_bytes`
-    /// name always implied. It does NOT bound memory; neither does
-    /// [`Self::l1_part_memory_target_bytes`], which is a split target in decoded
-    /// heap. A part closes on whichever of the two
-    /// is reached first. Default [`DEFAULT_MAX_L1_PART_BYTES`] (256 MiB), chosen
-    /// so today's geometry is unchanged (issue #872); lower it to grow objects.
+    /// encoded/on-object bytes reach this. Measured in on-object bytes on both
+    /// paths, so a part closes when the object it is about to write reaches this
+    /// size (issue #872).
+    ///
+    /// - RSEG (`build.rs`): the part's stored-size estimate, which charges every
+    ///   section that grows with what the part carries: the TS/VAL/HIST pages
+    ///   (ADR-0092 decision 3, actual encoded page bytes), each series'
+    ///   SERIES_IDS entry and SERIES_META cells, the per-sample provenance
+    ///   columns a run-merged run adds, each distinct LABEL_DICT string, and the
+    ///   EXEMPLARS records. The page bytes are exact; the metadata sections are a
+    ///   pre-compression proxy over their zstd-compressed form (an upper bound).
+    /// - RLOG (`rlog.rs`): the ACTUAL encoded object size. The RLOG writer holds
+    ///   row-major records and only encodes at
+    ///   [`ravel_logseg::RlogWriter::finish_compacted`], so it exposes no
+    ///   incremental encoded size; the merge keeps a cheap pre-compression
+    ///   payload proxy ([`crate::rlog::estimate_stored_record`] per record plus
+    ///   one STREAM_DIR entry per distinct stream) only to SCHEDULE an
+    ///   exact-encode probe, and closes the part on the probe's real byte count.
+    ///   A part overshoots by at most one probe interval, the same
+    ///   at-most-one-unit discipline the memory split target has.
+    ///
+    /// Named for the bytes it measures: it governs object geometry (object count
+    /// and per-object stored size), which is what the historical
+    /// `max_l1_part_bytes` name always implied. It does NOT bound memory; neither
+    /// does [`Self::l1_part_memory_target_bytes`], which is a split target in
+    /// decoded heap. A part closes on whichever of the two is reached first.
+    /// Default [`DEFAULT_MAX_L1_PART_BYTES`] (256 MiB), chosen so today's geometry
+    /// is unchanged (issue #872); lower it to grow objects.
     pub max_l1_part_bytes: u64,
     /// The **memory split target**: close the in-progress L1 part once its
     /// decoded record-heap estimate reaches this

--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -144,6 +144,12 @@ struct MergeMemoryInner {
     /// Parts closed because the encoded-bytes estimate reached
     /// `max_l1_part_bytes` (the stored-size target fired).
     stored_target_flushes: AtomicU64,
+    /// Exact-encode probes the RLOG merge ran: one per
+    /// [`crate::rlog::PartBuilder::encode_clone`] call, whether or not it closed
+    /// the part. A probe is an O(part) encode, so this is the cost side of the
+    /// stored-size target, and it is zero whenever the payload proxy never
+    /// reaches `max_l1_part_bytes` (the shipped defaults).
+    probes_run: AtomicU64,
     /// Live sum of the encoded/on-object bytes of closed parts still retained in
     /// [`crate::rlog::PartSink::parts`] after PUT. Zero on the bounded RLOG
     /// compaction path, which releases each part's bytes at PUT (ADR-0979
@@ -391,6 +397,7 @@ impl MergeMemoryTracker {
             &self.inner.peak_total,
             &self.inner.memory_target_flushes,
             &self.inner.stored_target_flushes,
+            &self.inner.probes_run,
             &self.inner.retained_parts,
             &self.inner.peak_retained_parts,
             &self.inner.catalog_directory,
@@ -440,6 +447,19 @@ impl MergeMemoryTracker {
     pub fn stored_target_flushes(&self) -> u64 {
         self.inner.stored_target_flushes.load(Ordering::Relaxed)
     }
+
+    /// Record that the RLOG merge ran one exact-encode probe (an O(part)
+    /// encode), whether or not it closed the part.
+    pub fn note_probe_run(&self) {
+        self.inner.probes_run.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// How many exact-encode probes the run made. Zero when the payload proxy
+    /// never reached `max_l1_part_bytes`, which is the case at the shipped
+    /// defaults; a test asserts that rather than assuming it.
+    pub fn probes_run(&self) -> u64 {
+        self.inner.probes_run.load(Ordering::Relaxed)
+    }
 }
 
 /// Nanoseconds in one hour; an ingest-hour bucket spans exactly this.
@@ -460,8 +480,16 @@ pub const DEFAULT_MAX_COMPACTION_LIFETIME_NS: i64 = NS_PER_HOUR;
 /// unchanged from when one knob did both jobs: on a wide schema the memory
 /// target reaches 256 MiB of decoded record heap long before a part's stored
 /// bytes reach 256 MiB, so the memory target stays binding, the RLOG payload
-/// proxy never reaches 256 MiB, and no probe runs. Lowering it to `8..=16 MiB`
-/// is the follow-up that grows objects (issue #872); see
+/// proxy never reaches 256 MiB, and no probe runs.
+///
+/// Which target binds at these defaults therefore decides object size: it is
+/// [`DEFAULT_L1_PART_MEMORY_TARGET_BYTES`], and objects come out at 256 MiB
+/// divided by the schema's decoded-heap-to-stored ratio, well under this knob.
+/// Lowering this one does not grow objects, it caps them lower: once it drops
+/// below the size the memory target already yields it becomes the binding
+/// target and every part closes at it. Growing objects means raising
+/// `l1_part_memory_target_bytes` (with this knob at or above the object size
+/// wanted), which is the issue #872 follow-up; see
 /// [`CompactorConfig::max_l1_part_bytes`].
 pub const DEFAULT_MAX_L1_PART_BYTES: u64 = 256 * 1024 * 1024;
 /// Default `l1_part_memory_target_bytes`: 256 MiB. This is the **memory split
@@ -729,8 +757,18 @@ pub struct CompactorConfig {
     ///   payload proxy ([`crate::rlog::estimate_stored_record`] per record plus
     ///   one STREAM_DIR entry per distinct stream) only to SCHEDULE an
     ///   exact-encode probe, and closes the part on the probe's real byte count.
-    ///   A part overshoots by at most one probe interval, the same
-    ///   at-most-one-unit discipline the memory split target has.
+    ///   Overshoot is bounded by how the probes are spaced: they sit at least a
+    ///   4 KiB floor apart on the proxy axis (`PROBE_MIN_STEP_BYTES` in
+    ///   `rlog.rs`), and the next one is never aimed past the proxy value where
+    ///   the part would reach this target at the highest encoded-per-proxy rate
+    ///   any interval of it has measured so far (never assumed below 1:1). So a
+    ///   part closes at this target plus at most that floor plus the last
+    ///   record's proxy charge. The rate model inside that cap is an ESTIMATE,
+    ///   not a bound: it only shortens the step, when the proxy is
+    ///   undercharging. The band holds while the records still to come encode no
+    ///   denser per proxy byte than the densest interval already measured; a
+    ///   section the proxy does not model (POSTINGS, SKIP_IDX, PAGE_DIR) growing
+    ///   faster than the payload it does model can carry a part past it.
     ///
     /// Named for the bytes it measures: it governs object geometry (object count
     /// and per-object stored size), which is what the historical
@@ -738,7 +776,12 @@ pub struct CompactorConfig {
     /// does [`Self::l1_part_memory_target_bytes`], which is a split target in
     /// decoded heap. A part closes on whichever of the two is reached first.
     /// Default [`DEFAULT_MAX_L1_PART_BYTES`] (256 MiB), chosen so today's geometry
-    /// is unchanged (issue #872); lower it to grow objects.
+    /// is unchanged (issue #872): at the defaults the binding target is
+    /// [`Self::l1_part_memory_target_bytes`], not this one, so objects come out
+    /// at the memory target divided by the schema's heap-to-stored ratio.
+    /// Lowering this knob therefore does not grow objects, it caps them lower;
+    /// growing objects means raising [`Self::l1_part_memory_target_bytes`] and
+    /// keeping this one at or above the object size wanted.
     pub max_l1_part_bytes: u64,
     /// The **memory split target**: close the in-progress L1 part once its
     /// decoded record-heap estimate reaches this

--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -219,6 +219,11 @@ pub struct MergePhasePeaks {
     /// payload, the only allocation the publish phase adds on top of the
     /// retained parts. Encoded bytes.
     pub publish_record_encoded_bytes: u64,
+    /// In-progress part measurement: high-water of the exact-encode probe term
+    /// (the cloned record heap plus the encoded probe object, mixed decoded
+    /// plus encoded kinds). Zero for a run that never probed, which is the
+    /// case at the shipped defaults where the two split targets coincide.
+    pub probe_bytes: u64,
 }
 
 impl MergeMemoryTracker {
@@ -456,6 +461,7 @@ impl MergeMemoryTracker {
             writer_heap_bytes: self.peak_writer_bytes(),
             retained_part_encoded_bytes: self.peak_retained_part_bytes(),
             publish_record_encoded_bytes: self.peak_publish_record_bytes(),
+            probe_bytes: self.peak_probe_bytes(),
         }
     }
 

--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -53,8 +53,9 @@ use uuid::Uuid;
 ///   decode-side buffers. This is the quantity these merges bound: at most
 ///   one raw block plus one decoded block per input, so it is
 ///   `O(input_count * block_size)` and does NOT scale with stream/trace size.
-/// - [`Self::peak_total_bytes`]: `fetched + decoded + writer`, adding the
-///   in-progress part's writer buffer. The writer term tracks the memory split
+/// - [`Self::peak_total_bytes`]: `fetched + decoded + writer + probe`, adding
+///   the in-progress part's writer buffer and the in-flight exact-encode probe.
+///   The writer term tracks the memory split
 ///   target `l1_part_memory_target_bytes` (a part is flushed once its
 ///   record-heap estimate reaches that target) and is the unavoidable
 ///   content-addressing cost the ADR calls out: a part's key does not exist
@@ -64,13 +65,15 @@ use uuid::Uuid;
 ///   overshoots by up to one whole trace
 ///   ([`CompactorConfig::l1_part_memory_target_bytes`]). The RLOG merge may
 ///   also close a part earlier on the stored-size target `max_l1_part_bytes`
-///   (issue #872), which only lowers this term. Testing that target does add a
-///   short-lived, uncharged transient: the exact-encode probe encodes a CLONE
-///   of the buffered records, so while it runs the resident set briefly holds a
-///   second copy of the part's row heap plus its encoded object bytes (bounded
-///   by `2 * writer + max_l1_part_bytes`, released as the probe returns). It
-///   only runs once the payload proxy reaches the stored target, so never at the
-///   shipped defaults where the memory target binds first.
+///   (issue #872), which only lowers the writer term but adds the probe term:
+///   the exact-encode probe encodes a CLONE of the buffered records, so while
+///   it runs the resident set holds a second copy of the part's row heap plus
+///   the encoded object those records produce. That is charged, not assumed
+///   away ([`Self::set_probe_bytes`]), so a probing run's high-water is roughly
+///   `2 * writer + one part's object bytes` rather than the `writer` a run
+///   without probes reports. The probe only runs once the payload proxy reaches
+///   the stored target, so this term stays zero at the shipped defaults, where
+///   the memory target binds first.
 ///
 /// # Phase-attributed peaks (issue #977)
 ///
@@ -134,9 +137,15 @@ struct MergeMemoryInner {
     peak_decoded: AtomicU64,
     /// The in-progress part's accumulated record-byte estimate in the writer.
     writer: AtomicU64,
+    /// What an in-flight exact-encode probe holds on top of the writer buffer:
+    /// the clone of the part's records plus, once the encode returns, the
+    /// encoded object bytes. Zero whenever no probe is running.
+    probe: AtomicU64,
+    /// High-water of `probe` alone.
+    peak_probe: AtomicU64,
     /// High-water of `fetched + decoded`.
     peak_transient: AtomicU64,
-    /// High-water of `fetched + decoded + writer`.
+    /// High-water of `fetched + decoded + writer + probe`.
     peak_total: AtomicU64,
     /// Parts closed because the decoded record-heap estimate reached
     /// `l1_part_memory_target_bytes` (the memory split target fired).
@@ -253,18 +262,43 @@ impl MergeMemoryTracker {
         self.note();
     }
 
+    /// Set what the in-flight exact-encode probe holds resident, or 0 once it
+    /// has returned and its buffers are dropped.
+    ///
+    /// The RLOG stored-size target measures a part by encoding a CLONE of its
+    /// buffered records ([`crate::rlog::PartBuilder::encode_clone`]), so for the
+    /// duration of that encode the run holds a second copy of the part's record
+    /// heap and then the encoded object it produces. The merge charges the clone
+    /// before the encode and the clone plus the object as it returns, so
+    /// [`Self::peak_total_bytes`] covers the probe's residency instead of
+    /// under-reporting the peak of every run where a probe fires. Mixed byte
+    /// kinds, like [`Self::peak_total_bytes`] itself: decoded heap for the clone,
+    /// encoded object bytes for the object.
+    pub fn set_probe_bytes(&self, bytes: u64) {
+        self.inner.probe.store(bytes, Ordering::Relaxed);
+        self.note();
+    }
+
+    /// High-water of the exact-encode probe term alone (cloned record heap plus
+    /// the encoded object, mixed kinds). Zero for a run that never probed.
+    pub fn peak_probe_bytes(&self) -> u64 {
+        self.inner.peak_probe.load(Ordering::Relaxed)
+    }
+
     /// Recompute both high-water marks from the live counters.
     fn note(&self) {
         let fetched = self.inner.fetched.load(Ordering::Relaxed);
         let decoded = self.inner.decoded.load(Ordering::Relaxed);
         let writer = self.inner.writer.load(Ordering::Relaxed);
+        let probe = self.inner.probe.load(Ordering::Relaxed);
         let transient = fetched.saturating_add(decoded);
-        let total = transient.saturating_add(writer);
+        let total = transient.saturating_add(writer).saturating_add(probe);
         self.inner
             .peak_transient
             .fetch_max(transient, Ordering::Relaxed);
         self.inner.peak_total.fetch_max(total, Ordering::Relaxed);
         self.inner.peak_writer.fetch_max(writer, Ordering::Relaxed);
+        self.inner.peak_probe.fetch_max(probe, Ordering::Relaxed);
         self.inner
             .peak_decoded
             .fetch_max(decoded, Ordering::Relaxed);
@@ -350,8 +384,9 @@ impl MergeMemoryTracker {
     }
 
     /// High-water of the merge's total residency
-    /// (`fetched + decoded + writer`), the decode-side buffers plus the
-    /// in-progress part's writer buffer.
+    /// (`fetched + decoded + writer + probe`), the decode-side buffers plus the
+    /// in-progress part's writer buffer plus whatever an in-flight exact-encode
+    /// probe holds ([`Self::set_probe_bytes`]).
     pub fn peak_total_bytes(&self) -> u64 {
         self.inner.peak_total.load(Ordering::Relaxed)
     }
@@ -392,6 +427,8 @@ impl MergeMemoryTracker {
             &self.inner.fetched,
             &self.inner.decoded,
             &self.inner.writer,
+            &self.inner.probe,
+            &self.inner.peak_probe,
             &self.inner.peak_transient,
             &self.inner.peak_decoded,
             &self.inner.peak_total,
@@ -757,18 +794,18 @@ pub struct CompactorConfig {
     ///   payload proxy ([`crate::rlog::estimate_stored_record`] per record plus
     ///   one STREAM_DIR entry per distinct stream) only to SCHEDULE an
     ///   exact-encode probe, and closes the part on the probe's real byte count.
-    ///   Overshoot is bounded by how the probes are spaced: they sit at least a
-    ///   4 KiB floor apart on the proxy axis (`PROBE_MIN_STEP_BYTES` in
-    ///   `rlog.rs`), and the next one is never aimed past the proxy value where
-    ///   the part would reach this target at the highest encoded-per-proxy rate
-    ///   any interval of it has measured so far (never assumed below 1:1). So a
-    ///   part closes at this target plus at most that floor plus the last
-    ///   record's proxy charge. The rate model inside that cap is an ESTIMATE,
-    ///   not a bound: it only shortens the step, when the proxy is
-    ///   undercharging. The band holds while the records still to come encode no
-    ///   denser per proxy byte than the densest interval already measured; a
-    ///   section the proxy does not model (POSTINGS, SKIP_IDX, PAGE_DIR) growing
-    ///   faster than the payload it does model can carry a part past it.
+    ///   Overshoot is bounded by how the probes are spaced: the next probe is
+    ///   aimed the remaining encoded deficit further along the proxy axis, or a
+    ///   4 KiB floor (`PROBE_MIN_STEP_BYTES` in `rlog.rs`) if that deficit is
+    ///   smaller. The step therefore assumes only that over the interval that
+    ///   closes the part, encoded bytes grow at most 1:1 with the uncompressed
+    ///   payload proxy, and the enforced band is `[target, target + 4 KiB + one
+    ///   record's proxy charge]`. That assumption holds for the sections the
+    ///   proxy models -- the payload columns and STREAM_DIR, where the proxy
+    ///   counts uncompressed bytes and the object stores compressed ones -- and
+    ///   is the disclosed condition on the band: a section the proxy does not
+    ///   model (POSTINGS, SKIP_IDX, PAGE_DIR) growing faster than the payload it
+    ///   does model can carry a part past it.
     ///
     /// Named for the bytes it measures: it governs object geometry (object count
     /// and per-object stored size), which is what the historical

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -168,6 +168,7 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
             writer_heap_bytes = peaks.writer_heap_bytes,
             retained_part_encoded_bytes = peaks.retained_part_encoded_bytes,
             publish_record_encoded_bytes = peaks.publish_record_encoded_bytes,
+            probe_bytes = peaks.probe_bytes,
             "compaction peak memory by phase (byte kinds differ per term; do not sum)"
         );
     }

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -4537,6 +4537,12 @@ mod tests {
              the part heap: peak_total={peak_total} is {multiple:.2}x \
              peak_writer={peak_writer}, expected 2x to 3x"
         );
+        assert_eq!(
+            tracker.phase_peaks().probe_bytes,
+            peak_probe,
+            "the operator-facing phase split must carry the probe term the \
+             total already includes"
+        );
     }
 
     /// Padding bytes in a fat stream's resource blob. The padding is

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -156,7 +156,9 @@
 //! closes on whichever target is reached first. With the shipped defaults (both
 //! 256 MiB) the memory split target still fires first on every real schema and
 //! the payload proxy never reaches 256 MiB, so no probe runs and this split is
-//! behaviour-neutral until an operator lowers the stored target to grow objects.
+//! behaviour-neutral until an operator lowers the stored target below the size
+//! the memory split target already yields. Lowering it caps objects lower;
+//! growing them means raising `l1_part_memory_target_bytes`.
 //!
 //! The first RLOG merge held every input object whole (RLOG then had no ranged
 //! section reader); [`ravel_logseg::open_from_suffix`] is now the RLOG analogue
@@ -916,6 +918,12 @@ impl PartSink<'_> {
                 // encodes a clone of the buffered records, so the builder can
                 // keep accumulating when the part is not yet full.
                 let (object, stats) = part.encode_clone(self.input_set_hash, self.part_index)?;
+                if let Some(t) = self.tracker {
+                    // Counted whether or not it closes the part: this is the
+                    // O(part) encode the stored target costs, and "no probe runs
+                    // at the shipped defaults" is a claim a test asserts on.
+                    t.note_probe_run();
+                }
                 let encoded = object.len() as u64;
                 if encoded >= self.config.max_l1_part_bytes {
                     stored_close = Some((object, stats));
@@ -1004,10 +1012,15 @@ impl PartSink<'_> {
 /// proxy axis. A probe encodes the whole part (an O(part) cost), so the
 /// scheduler in [`PartBuilder::schedule_next_probe`] aims the next one near the
 /// target rather than running one per record; this floor keeps a momentarily
-/// flat encoded/proxy rate from scheduling the next probe in the past. It also
-/// bounds how far a part overshoots the stored target: a closing probe fires at
-/// most one interval's worth of records past the crossing, the same
-/// at-most-one-unit discipline the memory split target has (issue #711).
+/// flat encoded/proxy rate from scheduling the next probe in the past.
+///
+/// It is also the width of the stored target's overshoot band. The scheduler
+/// never aims a probe past the proxy value where the part would reach the target
+/// at the densest encoded-per-proxy rate it has already measured (and never
+/// assumes a rate below 1:1), so between two probes the encoded size can grow by
+/// at most the remaining deficit plus this floor plus the last record's proxy
+/// charge -- see [`PartBuilder::schedule_next_probe`] for the derivation and for
+/// what the band is conditional on.
 const PROBE_MIN_STEP_BYTES: u64 = 4096;
 
 /// One in-progress L1 part: the merged records buffered in canonical order, the
@@ -1048,6 +1061,20 @@ struct PartBuilder {
     /// past a probe that found the part still short of the target, so probing is
     /// a few encodes per part, not one per record.
     next_probe_stored: u64,
+    /// `stored_estimate` as of the last probe (0 before the first): the left edge
+    /// of the interval [`Self::schedule_next_probe`] measures the MARGINAL
+    /// encoded-per-proxy rate over. A cumulative rate (encoded/proxy since the
+    /// part opened) is the wrong estimator for a part whose compressibility
+    /// changes along the record sequence, which is the case that overshoots.
+    last_probe_stored: u64,
+    /// Encoded object bytes the last probe measured (0 before the first), the
+    /// other end of that interval.
+    last_probe_encoded: u64,
+    /// The densest encoded-per-proxy rate any probe interval of this part has
+    /// shown. The scheduler assumes the next interval runs at least this dense
+    /// (and never below 1:1), which is what bounds the overshoot; see
+    /// [`Self::schedule_next_probe`].
+    max_probe_rate: f64,
     /// The streams whose STREAM_DIR entry this part has already been charged for
     /// in `stored_estimate`. A set rather than a "did the stream change" check so
     /// the charge is once per distinct stream whatever order records arrive in;
@@ -1068,6 +1095,9 @@ impl PartBuilder {
             estimate: 0,
             stored_estimate: 0,
             next_probe_stored: 0,
+            last_probe_stored: 0,
+            last_probe_encoded: 0,
+            max_probe_rate: 1.0,
             charged_streams: BTreeSet::new(),
             min_stream: None,
             max_stream: None,
@@ -1157,22 +1187,62 @@ impl PartBuilder {
     }
 
     /// Schedule the next stored-target probe after one found the part still
-    /// short of the target. Models encoded size as ~linear in the payload proxy
-    /// and aims the next probe at the proxy value where the encoded size should
-    /// reach `target`, so a part converges to the target in a few probes even
-    /// when the compression ratio is large, rather than encoding once per
-    /// record. The step is floored at [`PROBE_MIN_STEP_BYTES`] so a momentarily
-    /// flat rate cannot schedule the probe in the past.
+    /// short of the target, and bound how far past the target the part can then
+    /// close.
+    ///
+    /// The step is the proxy distance to the next probe. Two things set it:
+    ///
+    /// - a CAP, which is what bounds the overshoot. The step never exceeds the
+    ///   deficit divided by [`Self::max_probe_rate`], the densest
+    ///   encoded-per-proxy rate any interval of this part has shown, held at 1:1
+    ///   or above. So if the records over the next interval encode at that rate,
+    ///   the part lands exactly on the target; they have to encode DENSER than
+    ///   every interval so far to go past it.
+    /// - the [`PROBE_MIN_STEP_BYTES`] floor, so a part whose deficit is a
+    ///   handful of bytes does not encode once per record.
+    ///
+    /// The band that follows: a probe found `encoded_now < target`, the next one
+    /// fires at the first record on or after `stored_estimate + step`, so the
+    /// proxy advances by at most `step` plus that record's own charge, and the
+    /// encoded size by at most that interval's rate times that. While that rate
+    /// stays at or below [`Self::max_probe_rate`] the close lands in
+    /// `[target, target + PROBE_MIN_STEP_BYTES + one record's proxy charge]`, and
+    /// the same arithmetic bounds a trailing part (its records simply run out
+    /// before the next probe). It is conditional on that rate assumption, which
+    /// holds for the sections the proxy models -- the payload columns and
+    /// STREAM_DIR, where the proxy counts uncompressed bytes and the object
+    /// stores compressed ones -- and not on the ones it does not (POSTINGS,
+    /// SKIP_IDX, PAGE_DIR). It is not the "one record" tightness the memory
+    /// split target has, and the rate model inside the cap is an estimate, never
+    /// a guarantee: without the cap, a compressible prefix followed by an
+    /// incompressible suffix closes tens of times past the target.
+    ///
+    /// The cost of the cap is probes: a part converges on the target from below
+    /// in steps of the remaining deficit, so a stream whose payload compresses
+    /// `r`-fold takes on the order of `r` encodes per part rather than the two
+    /// or three an uncapped rate model would take. That cost is only paid when
+    /// an operator lowers `max_l1_part_bytes` below the memory split target; at
+    /// the shipped defaults no probe runs at all.
     fn schedule_next_probe(&mut self, encoded_now: u64, target: u64) {
         let deficit = target.saturating_sub(encoded_now);
-        // Encoded bytes produced per unit of payload proxy so far. A probe only
-        // runs once `stored_estimate >= target > 0` and an encoded part is never
-        // empty, so `encoded_now` and `stored_estimate` are both positive; the
-        // clamp guards the ratio against a degenerate zero rather than being a
-        // live case.
-        let rate = (encoded_now as f64 / self.stored_estimate.max(1) as f64).max(f64::MIN_POSITIVE);
-        let step = ((deficit as f64) / rate).ceil() as u64;
+        // The rate over THIS interval, not since the part opened. Both ends are
+        // measured quantities: `d_proxy` is at least PROBE_MIN_STEP_BYTES after
+        // the first probe and at least `target` at it, so the `max(1)` guards a
+        // degenerate zero rather than being a live case.
+        let d_proxy = self
+            .stored_estimate
+            .saturating_sub(self.last_probe_stored)
+            .max(1);
+        let d_encoded = encoded_now.saturating_sub(self.last_probe_encoded);
+        let marginal = d_encoded as f64 / d_proxy as f64;
+        if marginal > self.max_probe_rate {
+            self.max_probe_rate = marginal;
+        }
+        // `max_probe_rate` starts at 1.0 and only grows, so `step <= deficit`.
+        let step = ((deficit as f64) / self.max_probe_rate).ceil() as u64;
         let step = step.max(PROBE_MIN_STEP_BYTES);
+        self.last_probe_stored = self.stored_estimate;
+        self.last_probe_encoded = encoded_now;
         self.next_probe_stored = self.stored_estimate.saturating_add(step);
     }
 }
@@ -3953,13 +4023,19 @@ mod tests {
     /// this corpus reaches in heap), so the stored target is the only thing that
     /// can fire.
     ///
-    /// The band is exact from the fixture, never merely `> 0`: a part closes the
-    /// moment a probe shows its object reaching `STORED_TARGET`, and probes are
-    /// spaced at least [`PROBE_MIN_STEP_BYTES`] of payload proxy apart, whose
-    /// records encode to fewer than that many object bytes (the proxy is an upper
-    /// bound over the compressed sections). So every stored-closed part sits in
-    /// `[STORED_TARGET, STORED_TARGET + PROBE_MIN_STEP_BYTES]`; only the trailing
-    /// part, closed by `finish` on the remainder, sits below.
+    /// The band is exact from the fixture, never merely `> 0`, and its width is
+    /// the scheduler's guarantee rather than this fixture's luck. A part closes
+    /// the moment a probe shows its object reaching `STORED_TARGET`. Probes sit
+    /// at least [`PROBE_MIN_STEP_BYTES`] of payload proxy apart, and
+    /// [`PartBuilder::schedule_next_probe`] never aims one further ahead than the
+    /// remaining deficit at the densest encoded-per-proxy rate the part has
+    /// measured (never assumed below 1:1), so between two probes the encoded size
+    /// grows by at most that deficit plus the floor plus the charge of the record
+    /// that crosses. Every part therefore sits in `[STORED_TARGET, STORED_TARGET
+    /// + PROBE_MIN_STEP_BYTES + one record's proxy charge]`. The trailing part
+    /// loses only the lower bound (its records run out before the next probe
+    /// rather than a probe closing it); the same upper bound covers it by the
+    /// same arithmetic, so it is asserted, not excused.
     ///
     /// Demonstrated red against the old proxy-as-close design: replace the probe
     /// block in `PartSink::push` with `over_stored = part.stored_estimate >=
@@ -3968,7 +4044,9 @@ mod tests {
     /// out `ratio` times smaller -- below `STORED_TARGET / 2` -- and the
     /// lower-bound assertion below fails. The `ratio` sub-assertion pins that
     /// this fixture's gap is well above 2, so the old design provably misses the
-    /// band low.
+    /// band low. This corpus is uniformly compressible, so it cannot show the
+    /// upper bound failing: the fixture that does is
+    /// [`stored_target_overshoot_is_bounded_when_compressibility_collapses`].
     #[tokio::test]
     async fn stored_target_closes_parts_on_actual_encoded_object_bytes() {
         const PER_INPUT: i64 = 2500;
@@ -3996,17 +4074,7 @@ mod tests {
         // above 2 is what puts the old design's parts (~STORED_TARGET / ratio)
         // below the STORED_TARGET/2 band floor.
         let sample: Vec<LogRecord> = (0..200).map(ratio_record).collect();
-        let proxy: u64 = sample.iter().map(estimate_stored_record).sum::<u64>()
-            + estimate_stored_stream(&ratio_record(0).stream_attrs);
-        let identity = compactor_identity(&bucket(), &CompactorConfig::default());
-        let mut w = RlogWriter::new(RlogConfig::default(), identity);
-        for r in &sample {
-            w.push(r.clone()).expect("push");
-        }
-        let object_len = w
-            .finish_compacted(1, vec![0u8; 32], 0)
-            .expect("encode")
-            .len() as u64;
+        let (proxy, object_len) = proxy_and_object_bytes(&sample);
         let ratio = proxy as f64 / object_len as f64;
         assert!(
             ratio > 2.0,
@@ -4043,26 +4111,37 @@ mod tests {
             "every closed part (all but the trailing one) closed on the stored target"
         );
 
-        // The geometry band: every non-final part reached the target, and none
-        // ran more than one probe interval past it. The lower bound is the
-        // target itself, which the old proxy-close (object ~ STORED_TARGET /
-        // ratio) could not clear.
+        // The geometry band: every non-final part reached the target, and no
+        // part -- trailing one included -- ran past the scheduler's overshoot
+        // bound. The upper edge is the probe-spacing floor plus the proxy charge
+        // of one record (the granularity at which a probe can fire), computed
+        // from the fixture rather than guessed; the lower edge is the target
+        // itself, which the old proxy-close (object ~ STORED_TARGET / ratio)
+        // could not clear.
+        let max_record_charge = estimate_stored_record(&ratio_record(0))
+            + estimate_stored_stream(&ratio_record(0).stream_attrs);
+        let band_top = STORED_TARGET + PROBE_MIN_STEP_BYTES + max_record_charge;
+        println!(
+            "[geom:rlog #872] target={STORED_TARGET}B parts={} probes={} band_top={band_top}B \
+             sizes={:?}",
+            parts.len(),
+            tracker.probes_run(),
+            rec.parts.iter().map(|p| p.object_size).collect::<Vec<_>>()
+        );
         let last = parts.len() - 1;
         for (i, p) in rec.parts.iter().enumerate() {
-            if i == last {
+            assert!(
+                p.object_size > 0 && p.object_size <= band_top,
+                "part {i} of {} bytes ran past the overshoot bound {band_top} \
+                 (= {STORED_TARGET} + {PROBE_MIN_STEP_BYTES} + {max_record_charge})",
+                p.object_size
+            );
+            if i != last {
                 assert!(
-                    p.object_size > 0 && p.object_size <= STORED_TARGET + PROBE_MIN_STEP_BYTES,
-                    "trailing part of {} bytes out of band",
-                    p.object_size
-                );
-            } else {
-                assert!(
-                    p.object_size >= STORED_TARGET
-                        && p.object_size <= STORED_TARGET + PROBE_MIN_STEP_BYTES,
-                    "part {i} of {} bytes is outside [{STORED_TARGET}, {}] -- the stored \
+                    p.object_size >= STORED_TARGET,
+                    "part {i} of {} bytes is below {STORED_TARGET} -- the stored \
                      target must close on real object bytes, not {}x-smaller payload",
                     p.object_size,
-                    STORED_TARGET + PROBE_MIN_STEP_BYTES,
                     ratio as u64
                 );
             }
@@ -4085,6 +4164,208 @@ mod tests {
         assert_eq!(
             split_rows, baseline,
             "the decoded record sequence must be identical whatever the split"
+        );
+    }
+
+    /// Body bytes every [`collapsing_record`] carries, compressible or not. Equal
+    /// widths keep the payload proxy advancing at exactly the same rate on both
+    /// sides of the switch, so the fixture's only variable is how many object
+    /// bytes those proxy bytes turn into. 13 * 20: the filler's unit width.
+    const COLLAPSE_BODY_BYTES: usize = 260;
+
+    /// Record `i` of a corpus whose compressibility COLLAPSES at ordinal
+    /// `prefix`: below it a repeated filler zstd takes to almost nothing, from it
+    /// pseudo-random alphanumerics that do not compress.
+    ///
+    /// This is the adversarial shape for the probe scheduler. A rate model fitted
+    /// on the prefix concludes the part needs a very large number of further
+    /// payload bytes to reach the stored target; if the next probe may be aimed
+    /// that far ahead, every record of the incompressible suffix in between lands
+    /// in the same part.
+    fn collapsing_record(i: i64, prefix: i64) -> LogRecord {
+        let body = if i < prefix {
+            "compressible-".repeat(COLLAPSE_BODY_BYTES / 13)
+        } else {
+            incompressible_pad(i as u64, COLLAPSE_BODY_BYTES)
+        };
+        record(0, SPLIT_BASE_NS + i, &body, Vec::new())
+    }
+
+    /// Encode `recs` exactly as the merge encodes a part, and return
+    /// `(payload proxy bytes, object bytes)` for them.
+    fn proxy_and_object_bytes(recs: &[LogRecord]) -> (u64, u64) {
+        let proxy: u64 = recs.iter().map(estimate_stored_record).sum::<u64>()
+            + recs
+                .first()
+                .map_or(0, |r| estimate_stored_stream(&r.stream_attrs));
+        let identity = compactor_identity(&bucket(), &CompactorConfig::default());
+        let mut w = RlogWriter::new(RlogConfig::default(), identity);
+        for r in recs {
+            w.push(r.clone()).expect("push");
+        }
+        let object = w
+            .finish_compacted(1, vec![0u8; 32], 0)
+            .expect("encode")
+            .len() as u64;
+        (proxy, object)
+    }
+
+    /// Issue #872 finding 2: the stored target's overshoot is bounded by the
+    /// scheduler's DESIGN, not by a corpus happening to compress uniformly.
+    ///
+    /// A rate model on its own only says how far ahead the next probe should sit
+    /// to be worth running; it puts no ceiling on the object that probe then
+    /// measures. Fitted on a compressible prefix, the step it asks for is tens of
+    /// times the remaining deficit, and an incompressible suffix inside that step
+    /// closes a part many times over the target. What bounds
+    /// it is the cap in [`PartBuilder::schedule_next_probe`]: the step never
+    /// exceeds the remaining deficit at the densest encoded-per-proxy rate the
+    /// part has measured, and never assumes a rate below 1:1, so the encoded size
+    /// cannot pass the target by more than [`PROBE_MIN_STEP_BYTES`] plus the
+    /// proxy charge of the record that crosses -- the same band the uniform
+    /// fixture asserts, now over a corpus that breaks the rate model.
+    ///
+    /// Demonstrated red against the uncapped scheduler this replaced: restore the
+    /// cumulative rate and the uncapped step in `schedule_next_probe` --
+    /// `let rate = (encoded_now as f64 / self.stored_estimate.max(1) as f64)
+    /// .max(f64::MIN_POSITIVE); let step = ((deficit as f64) / rate).ceil() as
+    /// u64;` (dropping the `max_probe_rate` update, whose floor of 1.0 is the
+    /// cap) -- and this fixture emits 29 parts whose first object is 150_646
+    /// bytes, 9.2x the 16 KiB target, failing the band assertion below at part 0.
+    /// The remaining parts land between 16_853 and 18_893 bytes, inside the band,
+    /// which is why the assertion covers every part and not just the largest. The
+    /// uniformly compressible corpus of
+    /// [`stored_target_closes_parts_on_actual_encoded_object_bytes`] passes under
+    /// both schedulers, which is exactly why this fixture exists.
+    #[tokio::test]
+    async fn stored_target_overshoot_is_bounded_when_compressibility_collapses() {
+        const PER_INPUT: i64 = 2000;
+        const INPUTS: i64 = 2;
+        /// Ordinal where the corpus stops compressing. Enough compressible
+        /// payload ahead of it that the first part's early probes all land inside
+        /// it and fit a low rate (its 200 records charge the proxy 56_061 bytes,
+        /// 3.4 targets' worth, and encode to 1_220), and thousands of incompressible
+        /// records after it for that rate to be wrong about.
+        const PREFIX: i64 = 200;
+        const STORED_TARGET: u64 = 16 * 1024;
+        let total = (PER_INPUT * INPUTS) as u64;
+
+        let store = Arc::new(MemoryStore::new());
+        for j in 0..INPUTS {
+            let recs: Vec<LogRecord> = (0..PER_INPUT)
+                .map(|i| collapsing_record(i * INPUTS + j, PREFIX))
+                .collect();
+            seed(
+                store.as_ref(),
+                Uuid::from_u128(j as u128 + 1),
+                j as u64 + 1,
+                &recs,
+            )
+            .await;
+        }
+
+        // The collapse is real, measured in the quantity the scheduler fits: the
+        // encoded bytes each phase produces per payload proxy byte. Both samples
+        // are the same width and the same record count, so only compressibility
+        // differs.
+        const SAMPLE: i64 = 200;
+        let pre: Vec<LogRecord> = (0..SAMPLE).map(|i| collapsing_record(i, PREFIX)).collect();
+        let post: Vec<LogRecord> = (PREFIX..PREFIX + SAMPLE)
+            .map(|i| collapsing_record(i, PREFIX))
+            .collect();
+        let (pre_proxy, pre_object) = proxy_and_object_bytes(&pre);
+        let (post_proxy, post_object) = proxy_and_object_bytes(&post);
+        assert_eq!(
+            pre_proxy, post_proxy,
+            "both phases must charge the same proxy"
+        );
+        let pre_rate = pre_object as f64 / pre_proxy as f64;
+        let post_rate = post_object as f64 / post_proxy as f64;
+        println!(
+            "[geom:rlog #872] collapse proxy={pre_proxy}B pre_object={pre_object}B \
+             post_object={post_object}B pre_rate={pre_rate:.4} post_rate={post_rate:.4}"
+        );
+        assert!(
+            post_rate > 10.0 * pre_rate,
+            "fixture must collapse: pre_rate {pre_rate:.4} vs post_rate {post_rate:.4} is \
+             only {:.1}x, too flat to break a rate model",
+            post_rate / pre_rate
+        );
+
+        let tracker = MergeMemoryTracker::new();
+        let config = CompactorConfig {
+            max_l1_part_bytes: STORED_TARGET,
+            merge_memory_tracker: Some(tracker.clone()),
+            ..CompactorConfig::default()
+        };
+        let clock = FixedClock::new(sealed_now_ns());
+        compact_bucket(store.as_ref(), &clock, &config, &bucket())
+            .await
+            .expect("compact");
+
+        let (rec, parts) = read_output(store.as_ref()).await;
+        assert_eq!(
+            tracker.memory_target_flushes(),
+            0,
+            "the memory split target is at its 256 MiB default and must not fire"
+        );
+        assert_eq!(
+            tracker.stored_target_flushes() as usize,
+            parts.len() - 1,
+            "every closed part must have closed on the stored target"
+        );
+        assert!(
+            tracker.probes_run() > 0,
+            "the fixture must actually exercise the probe scheduler"
+        );
+
+        // The band, identical to the uniform fixture's because it is the
+        // scheduler's guarantee and not the corpus's: the probe-spacing floor
+        // plus one record's proxy charge above the target. Every part is checked,
+        // trailing one included.
+        let max_record_charge = estimate_stored_record(&collapsing_record(PREFIX, PREFIX))
+            + estimate_stored_stream(&collapsing_record(0, PREFIX).stream_attrs);
+        let band_top = STORED_TARGET + PROBE_MIN_STEP_BYTES + max_record_charge;
+        let sizes: Vec<u64> = rec.parts.iter().map(|p| p.object_size).collect();
+        let largest = sizes.iter().copied().max().unwrap_or(0);
+        println!(
+            "[geom:rlog #872] collapse target={STORED_TARGET}B parts={} probes={} \
+             band_top={band_top}B largest={largest}B",
+            parts.len(),
+            tracker.probes_run()
+        );
+        assert!(
+            parts.len() >= 4,
+            "fixture must split several times, got {}",
+            parts.len()
+        );
+        let last = parts.len() - 1;
+        for (i, p) in rec.parts.iter().enumerate() {
+            assert!(
+                p.object_size > 0 && p.object_size <= band_top,
+                "part {i} of {} bytes ran past the overshoot bound {band_top} \
+                 (= {STORED_TARGET} + {PROBE_MIN_STEP_BYTES} + {max_record_charge}); \
+                 sizes {sizes:?}",
+                p.object_size
+            );
+            if i != last {
+                assert!(
+                    p.object_size >= STORED_TARGET,
+                    "non-final part {i} of {} bytes did not reach the target",
+                    p.object_size
+                );
+            }
+        }
+
+        // Content is conserved across the collapse boundary too.
+        let mut split_rows: Vec<LogRecord> = Vec::new();
+        for p in &parts {
+            split_rows.extend(decode_all(p));
+        }
+        assert_eq!(
+            split_rows.len() as u64,
+            total,
+            "every record survives the split exactly once"
         );
     }
 
@@ -4319,6 +4600,109 @@ mod tests {
         );
     }
 
+    /// Issue #872: at the shipped defaults NO exact-encode probe runs. The
+    /// "geometry is unchanged" argument for shipping equal targets rests on that
+    /// claim, and the equal-geometry test above cannot see it: a probe that runs
+    /// and finds the part short changes no object byte, it just spends an O(part)
+    /// encode. So this asserts the probe counter directly.
+    ///
+    /// The relationship under test is the shipped one -- both targets equal --
+    /// scaled to 64 KiB each so a small corpus reaches it. Why it holds is the
+    /// two estimators, not this corpus: `estimate_record` charges strictly more
+    /// per record than `estimate_stored_record`, term for term (the same payload
+    /// lengths plus `ALLOC_OVERHEAD_BYTES` per allocation, `RECORD_SLOT_BYTES` =
+    /// `size_of::<LogRecord>()` against the proxy's flat
+    /// `STORED_RECORD_FIXED_BYTES`, and a per-record copy of `stream_attrs` the
+    /// proxy charges once per stream instead). With equal targets the heap sum
+    /// therefore crosses first on every record shape, the part closes on the
+    /// memory split target, the proxy never reaches `max_l1_part_bytes`, and the
+    /// probe is never even scheduled. The per-record figures are asserted below
+    /// on two fixtures of opposite shape (wide rows, and the compressible
+    /// single-stream row the stored-target tests use), so an estimator change
+    /// that inverts the inequality fails here rather than silently starting to
+    /// probe at the defaults.
+    ///
+    /// Demonstrated red by probing early: in `PartSink::push`, relax the probe
+    /// gate to `part.stored_estimate >= self.config.max_l1_part_bytes / 8`. The
+    /// geometry is untouched -- 15 parts and 14 memory-target closes either way,
+    /// since a probe that finds the part short changes nothing -- and
+    /// `probes_run` goes from 0 to 14, so the counter assertion below is the only
+    /// thing in the suite that catches it.
+    #[tokio::test]
+    async fn no_probe_runs_when_both_targets_are_equal() {
+        const PER_INPUT: i64 = 400;
+        const INPUTS: i64 = 2;
+        /// The shipped defaults are equal (256 MiB each); this is that same
+        /// relationship at a size an 800-record corpus reaches.
+        const BOTH: u64 = 64 * 1024;
+        assert_eq!(
+            crate::config::DEFAULT_MAX_L1_PART_BYTES,
+            crate::config::DEFAULT_L1_PART_MEMORY_TARGET_BYTES,
+            "this test stands in for the shipped defaults, which are equal"
+        );
+
+        for (name, mk) in [
+            ("wide", wide_record as fn(i64) -> LogRecord),
+            ("ratio", ratio_record as fn(i64) -> LogRecord),
+        ] {
+            let heap = estimate_record(&mk(0));
+            let stored =
+                estimate_stored_record(&mk(0)) + estimate_stored_stream(&mk(0).stream_attrs);
+            assert!(
+                heap > stored,
+                "{name}: the memory target can only fire first if the heap charge {heap} \
+                 exceeds the proxy charge {stored} per record"
+            );
+        }
+
+        let store = Arc::new(MemoryStore::new());
+        for j in 0..INPUTS {
+            let recs: Vec<LogRecord> = (0..PER_INPUT)
+                .map(|i| wide_record(i * INPUTS + j))
+                .collect();
+            seed(
+                store.as_ref(),
+                Uuid::from_u128(j as u128 + 1),
+                j as u64 + 1,
+                &recs,
+            )
+            .await;
+        }
+
+        let tracker = MergeMemoryTracker::new();
+        let config = CompactorConfig {
+            l1_part_memory_target_bytes: BOTH,
+            max_l1_part_bytes: BOTH,
+            merge_memory_tracker: Some(tracker.clone()),
+            ..CompactorConfig::default()
+        };
+        let clock = FixedClock::new(sealed_now_ns());
+        compact_bucket(store.as_ref(), &clock, &config, &bucket())
+            .await
+            .expect("compact");
+
+        let (_rec, parts) = read_output(store.as_ref()).await;
+        assert!(parts.len() > 1, "the fixture must split");
+        assert_eq!(
+            tracker.memory_target_flushes() as usize,
+            parts.len() - 1,
+            "every closed part must have closed on the memory split target"
+        );
+        assert_eq!(
+            tracker.stored_target_flushes(),
+            0,
+            "the stored target must not fire when the targets are equal"
+        );
+        assert_eq!(
+            tracker.probes_run(),
+            0,
+            "no exact-encode probe may run when the memory target fires first: \
+             {} parts, {} memory flushes",
+            parts.len(),
+            tracker.memory_target_flushes()
+        );
+    }
+
     /// Issue #872 constraint: raising the stored target far above the memory
     /// bound does not weaken the memory split target. With the stored target at
     /// `u64::MAX` the memory split target is the only thing that can close a part, so
@@ -4390,11 +4774,32 @@ mod tests {
     /// simultaneously while at concurrency 1 only ever 1 is. Without the
     /// fan-out the `wait_until_held(8)` below never returns and the test hangs
     /// rather than passing vacuously.
+    ///
+    /// Run at BOTH split targets (issue #872), because the two close paths write
+    /// the object differently: a memory-target close consumes the builder's
+    /// records into a fresh writer, while a stored-target close reuses the bytes
+    /// an exact-encode probe already produced. Byte-identity across concurrency
+    /// has to hold on both, and it is the probe-reuse path -- where the object
+    /// comes from an encode taken at a moment the concurrency could in principle
+    /// influence -- that most needs saying. Each run asserts which target fired,
+    /// so neither config can silently fall back to the other and cover the same
+    /// path twice: give the `SplitOn::Memory` arm the stored config
+    /// (`max_l1_part_bytes: 8 * 1024`) and it fails with "memory mode closed 0 on
+    /// memory and 3 on stored" rather than passing on a duplicated path.
     #[tokio::test]
     async fn input_read_concurrency_changes_timing_not_bytes() {
         const INPUTS: u64 = 16;
 
-        async fn compact_at(concurrency: usize) -> (Vec<[u8; 32]>, usize) {
+        /// Which target the run under test closes its parts on.
+        #[derive(Copy, Clone, Debug)]
+        enum SplitOn {
+            /// The memory split target: closes by consuming the builder.
+            Memory,
+            /// The stored-size target: closes on the bytes a probe measured.
+            Stored,
+        }
+
+        async fn compact_at(concurrency: usize, split: SplitOn) -> (Vec<[u8; 32]>, usize) {
             let store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
             for j in 0..INPUTS {
                 let recs: Vec<LogRecord> = (0..40i64)
@@ -4412,15 +4817,24 @@ mod tests {
             // Hold every commit-record GET (".cmt" names commit records and
             // nothing else) so the in-flight count is observable.
             let gate = store.hold(Op::Get, Some(".cmt".to_string()), Occurrence::Always);
-            // Split on the memory target: wide records are far larger in heap
-            // than on the object, so this reliably produces several parts, and
-            // (unlike the stored target) needs no encoded-size probe. The point
-            // under test is byte-identity across concurrency, not which target
-            // fires.
-            let config = CompactorConfig {
-                l1_part_memory_target_bytes: 64 * 1024,
-                input_read_concurrency: concurrency,
-                ..CompactorConfig::default()
+            // Wide records are far larger in heap than on the object, so a 64 KiB
+            // memory target and an 8 KiB stored target each split this corpus
+            // several times while leaving the other target far away, which is
+            // what the flush-counter assertions below check.
+            let tracker = MergeMemoryTracker::new();
+            let config = match split {
+                SplitOn::Memory => CompactorConfig {
+                    l1_part_memory_target_bytes: 64 * 1024,
+                    input_read_concurrency: concurrency,
+                    merge_memory_tracker: Some(tracker.clone()),
+                    ..CompactorConfig::default()
+                },
+                SplitOn::Stored => CompactorConfig {
+                    max_l1_part_bytes: 8 * 1024,
+                    input_read_concurrency: concurrency,
+                    merge_memory_tracker: Some(tracker.clone()),
+                    ..CompactorConfig::default()
+                },
             };
             let task = tokio::spawn({
                 let store = Arc::clone(&store);
@@ -4459,6 +4873,22 @@ mod tests {
 
             let (_rec, parts) = read_output(store.as_ref()).await;
             releaser.abort();
+            // The run really closed its parts on the target this config names,
+            // so neither mode can quietly exercise the other's close path.
+            let (memory, stored) = (
+                tracker.memory_target_flushes(),
+                tracker.stored_target_flushes(),
+            );
+            match split {
+                SplitOn::Memory => assert!(
+                    memory > 0 && stored == 0,
+                    "memory mode closed {memory} on memory and {stored} on stored"
+                ),
+                SplitOn::Stored => assert!(
+                    stored > 0 && memory == 0,
+                    "stored mode closed {stored} on stored and {memory} on memory"
+                ),
+            }
             let hashes = parts
                 .iter()
                 .map(|p| *blake3::hash(p).as_bytes())
@@ -4466,25 +4896,28 @@ mod tests {
             (hashes, peak_in_flight)
         }
 
-        let (serial_hashes, serial_in_flight) = compact_at(1).await;
-        let (concurrent_hashes, concurrent_in_flight) = compact_at(8).await;
+        for split in [SplitOn::Memory, SplitOn::Stored] {
+            let (serial_hashes, serial_in_flight) = compact_at(1, split).await;
+            let (concurrent_hashes, concurrent_in_flight) = compact_at(8, split).await;
 
-        assert_eq!(
-            serial_in_flight, 1,
-            "concurrency 1 must never have two commit-record GETs in flight"
-        );
-        assert_eq!(
-            concurrent_in_flight, 8,
-            "concurrency 8 must hold exactly 8 commit-record GETs at once"
-        );
-        assert!(
-            serial_hashes.len() > 1,
-            "the fixture must split into several parts"
-        );
-        assert_eq!(
-            serial_hashes, concurrent_hashes,
-            "concurrent input reads must produce byte-identical parts"
-        );
+            assert_eq!(
+                serial_in_flight, 1,
+                "{split:?}: concurrency 1 must never have two commit-record GETs in flight"
+            );
+            assert_eq!(
+                concurrent_in_flight, 8,
+                "{split:?}: concurrency 8 must hold exactly 8 commit-record GETs at once"
+            );
+            assert!(
+                serial_hashes.len() > 1,
+                "{split:?}: the fixture must split into several parts, got {}",
+                serial_hashes.len()
+            );
+            assert_eq!(
+                serial_hashes, concurrent_hashes,
+                "{split:?}: concurrent input reads must produce byte-identical parts"
+            );
+        }
     }
 
     // --- bounded-memory k-way merge ------------------------------
@@ -4882,27 +5315,37 @@ mod tests {
     /// stream-boundary blocks, and the run splits into several parts on the
     /// memory split target.
     ///
-    /// The vector was REGENERATED for issue #872: the original pin was taken
-    /// under `max_l1_part_bytes: 4096` on commit 76c90a3 (the last commit before
-    /// the ADR-0979 D1 columnar-cursor swap), but #872 changed the stored-size
-    /// target to close a part on its ACTUAL encoded bytes rather than the payload
-    /// proxy, which moves every stored-target boundary the original pin used, so
-    /// those hashes are unreproducible. This run instead splits on the #711
-    /// memory split target, which neither D1 nor #872 touches; the pre-D1
-    /// record-level equivalence the original pin guarded now rests on
-    /// [`streaming_merge_output_is_byte_identical_to_stable_sort_order`] and
-    /// [`admission_on_and_off_produce_identical_part_hashes`], and content
-    /// preservation across the moved #872 boundaries on
-    /// [`stored_target_closes_parts_on_actual_encoded_object_bytes`]'s
-    /// decode-equality check.
+    /// The vector is a RE-CAPTURE, not a regeneration from the code under
+    /// review. The original pin was taken under `max_l1_part_bytes: 4096`, a
+    /// stored-target split, and issue #872 moved every stored-target boundary by
+    /// closing on actual encoded bytes instead of the payload proxy, so those
+    /// constants are genuinely unreproducible. Rather than accept whatever the
+    /// new code prints, the fixture was ported back onto commit 76c90a3 -- the
+    /// last commit before the ADR-0979 D1 columnar-cursor swap, where
+    /// `l1_part_memory_target_bytes` already existed -- in a scratch checkout,
+    /// run there with the config below (`l1_part_memory_target_bytes: 32 *
+    /// 1024`, `max_l1_part_bytes` at its 256 MiB default, which this corpus's
+    /// payload proxy never approaches), and the six hashes it printed there are
+    /// the six constants below. So this still compares the current merge against
+    /// the pre-D1 path's real bytes, now over the memory-target boundaries: the
+    /// memory-target close, the trailing-part close, and every part in between,
+    /// which is what the #872 change moved onto records plus a fresh writer at
+    /// close. The comparison is meaningful because `ravel-logseg` (the frozen
+    /// writer that turns a record set into bytes) has no commits between 76c90a3
+    /// and here, so a diff can only come from this crate.
+    ///
+    /// The stored-target geometry #872 introduced is pinned separately, by
+    /// [`stored_target_closes_parts_on_actual_encoded_object_bytes`] (band plus
+    /// decode-equality against a single-part baseline) and
+    /// [`stored_target_overshoot_is_bounded_when_compressibility_collapses`].
     #[tokio::test]
     async fn differential_part_hashes_match_the_pre_columnar_cursor() {
         /// Total records seeded across the three inputs: 4 streams x
         /// (30 + 1) + 4 x (30 + 1) + 4 x (40 + 1).
         const EXPECTED_ROWS: usize = 4 * 31 + 4 * 31 + 4 * 41;
-        /// Part `content_hash` values, in `part_index` order, as produced by the
-        /// current merge under a 32 KiB memory split target (see the note above
-        /// on why they were regenerated for issue #872).
+        /// Part `content_hash` values, in `part_index` order, as printed by this
+        /// fixture ported onto commit 76c90a3 under
+        /// `l1_part_memory_target_bytes: 32 * 1024` (see the note above).
         const EXPECTED_PART_HASHES: &[&str] = &[
             "853fb59210a344a2e656f6e1a29aa2feeeab0ec486373f3d37fd8975f74cb7ac",
             "dca4d7e8b9729de6c64f132fa1eb52028ab85de629d17e1f8b85d7b916c883a4",

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -142,15 +142,21 @@
 //! geometry: on a wide schema it reaches 256 MiB of heap after only a few MB of
 //! stored bytes, so every L1 object was tiny (~3.5 MB on ClickBench, a 74x gap
 //! below the 256 MiB the knob's old name implied). Object geometry is a second,
-//! independent knob, the **stored-size target** `max_l1_part_bytes`: [`PartSink`]
-//! also sums [`estimate_stored_record`] (an encoded-bytes proxy) per record,
-//! plus [`estimate_stored_stream`] once per distinct stream in the part (the
-//! STREAM_DIR entry the object stores once per stream), and closes the part when
-//! that total reaches the target. A part closes on
-//! whichever target is reached first. With the shipped defaults (both 256 MiB)
-//! the memory split target still fires first on every real schema, so this split is
-//! behaviour-neutral until an operator lowers the stored target to grow
-//! objects.
+//! independent knob, the **stored-size target** `max_l1_part_bytes`, and it is
+//! measured in the bytes its name promises: the part's ACTUAL encoded object
+//! size (issue #872). The RLOG writer holds row-major records and only encodes
+//! at [`RlogWriter::finish_compacted`], so there is no incremental encoded size
+//! to read; instead [`PartBuilder`] keeps a cheap pre-compression payload proxy
+//! ([`estimate_stored_record`] per record plus [`estimate_stored_stream`] once
+//! per distinct stream) that SCHEDULES an exact-encode probe once it reaches the
+//! target, and the part closes on the probe's real byte count. Closing on the
+//! proxy directly would have sized every object at the target divided by the
+//! compression ratio (the proxy is an upper bound over the zstd-compressed
+//! sections), the same ratio-times-smaller objects issue #872 names. A part
+//! closes on whichever target is reached first. With the shipped defaults (both
+//! 256 MiB) the memory split target still fires first on every real schema and
+//! the payload proxy never reaches 256 MiB, so no probe runs and this split is
+//! behaviour-neutral until an operator lowers the stored target to grow objects.
 //!
 //! The first RLOG merge held every input object whole (RLOG then had no ranged
 //! section reader); [`ravel_logseg::open_from_suffix`] is now the RLOG analogue
@@ -199,7 +205,8 @@ use ravel_logseg::record::{
 use ravel_logseg::skip_index::SkipIndex;
 use ravel_logseg::{
     AttrValue, FieldType, LogRecord, LogStreamId, RlogConfig, RlogRangeReader, RlogWriter,
-    StreamBlockLoc, StreamBlockRows, decode_section, writer::ObjectIdentity,
+    StreamBlockLoc, StreamBlockRows, decode_section,
+    writer::{ObjectIdentity, WriteStats},
 };
 use ravel_object_store::{GetRange, ObjectStoreBackend};
 use ravel_proto::commit::v1::CompactionPart;
@@ -767,11 +774,11 @@ pub(crate) async fn merge_catalogs(
     // k-way merged from every input carrying it (ts-ascending, canonical
     // input-order tie-break) straight into the current part's writer, and
     // the part flushes the moment its accumulated record-heap estimate
-    // reaches `l1_part_memory_target_bytes` (the memory split target) or its encoded
-    // estimate reaches `max_l1_part_bytes` (the stored target), whichever comes
-    // first -- mid-stream if that is where the target falls (issue #711 for the
-    // memory split target, issue #872 for the stored target, ADR-0032 amendment
-    // 2026-08-26). No intermediate
+    // reaches `l1_part_memory_target_bytes` (the memory split target) or an
+    // exact-encode probe shows its object bytes reaching `max_l1_part_bytes`
+    // (the stored target), whichever comes first -- mid-stream if that is where
+    // the target falls (issue #711 for the memory split target, issue #872 for
+    // the stored target, ADR-0032 amendment 2026-08-26). No intermediate
     // `Vec<LogRecord>` and no per-stream dedup: distinct submissions of
     // identical content are distinct records (ADR-0032).
     for stream_id in merged.keys() {
@@ -823,14 +830,31 @@ impl RecordCounts {
 /// closed and a new one opened.
 ///
 /// The split rule pushes records in the merge's canonical order and closes the
-/// in-progress part as soon as EITHER target is reached (issue #872): its
-/// [`PartBuilder::estimate`] (decoded heap) reaches the memory split target
-/// `l1_part_memory_target_bytes`, or its [`PartBuilder::stored_estimate`] (encoded
-/// bytes) reaches the stored target `max_l1_part_bytes`, wherever in the record
-/// sequence that falls. The memory split target is the whole of issue #711: the check
-/// used to run only between streams, so a bucket whose records all belong to
-/// one stream (one OTLP resource/scope, the common shape for a single busy
-/// service) held its entire row set live in one writer.
+/// in-progress part as soon as EITHER target is reached (issue #872), whichever
+/// falls first in the record sequence:
+///
+/// - the **memory split target** `l1_part_memory_target_bytes`, reached when the
+///   part's [`PartBuilder::estimate`] (decoded record heap) does. This is
+///   checked after every record, so the writer buffer exceeds it by at most one
+///   record; it is the whole of issue #711 (the check used to run only between
+///   streams, so a bucket whose records all belong to one stream held its entire
+///   row set live in one writer).
+/// - the **stored-size target** `max_l1_part_bytes`, reached when the part's
+///   ACTUAL encoded object bytes do. The RLOG writer holds row-major records and
+///   only encodes at [`RlogWriter::finish_compacted`], so there is no incremental
+///   encoded size to read; instead [`PartBuilder::stored_estimate`] (a cheap
+///   pre-compression payload proxy) schedules an exact-encode probe
+///   ([`PartBuilder::encode_clone`]), and the part closes on the probe's real
+///   byte count, not on the proxy. The proxy only decides WHEN to probe, never
+///   whether to close, so the compression ratio between payload and object no
+///   longer sizes the part: on a wide, compressible schema a proxy-driven close
+///   produced objects a ratio-times smaller than the target
+///   (`estimate_stored_record` is documented as an upper bound over the
+///   zstd-compressed sections), which is the bug issue #872 names. The probe is
+///   gated on the proxy first reaching the target, so at the shipped defaults
+///   (both 256 MiB) it never fires: the memory target closes every part on a
+///   real schema long before the payload proxy reaches 256 MiB, so this crate's
+///   geometry is unchanged until an operator lowers the stored target.
 ///
 /// Consecutive parts may therefore carry the same `stream_id` at their shared
 /// boundary, with adjacent, non-overlapping `(series_id, ts)` ranges. Records
@@ -864,39 +888,52 @@ struct PartSink<'a> {
 
 impl PartSink<'_> {
     /// Push one merged record, opening a part if none is in progress and
-    /// closing it once the cap is reached.
+    /// closing it once a target is reached.
     async fn push(&mut self, r: LogRecord) -> Result<()> {
         if self.current.is_none() {
             self.current = Some(PartBuilder::new(&self.identity, &self.indexed_fields));
         }
         let mut over_memory = false;
-        let mut over_stored = false;
+        // Encoded object bytes from a stored-target probe that showed the part
+        // reached the target, carried to `flush` so the closing object is
+        // encoded once, not re-encoded (the probe already produced the exact
+        // bytes for this `part_index` and `input_set_hash`).
+        let mut stored_close: Option<(Vec<u8>, WriteStats)> = None;
         if let Some(part) = self.current.as_mut() {
             part.push(r, self.tracker)?;
-            // Two independent targets; a part closes when EITHER is reached
-            // (issue #872). The memory split target sizes compactor peak memory
-            // (issue #711); the stored target governs object geometry. Both are
-            // checked here, after every record, so a part exceeds whichever
-            // fires by at most one record. On a
-            // wide schema the heap estimate reaches its target first (small
-            // objects); on a narrow, highly compressible schema the encoded
-            // estimate reaches its target first. With the shipped defaults
-            // (both 256 MiB) the memory split target fires and the stored target
-            // does not, so this crate's geometry is unchanged.
+            // The memory split target sizes compactor peak memory (issue #711)
+            // and is checked cheaply after every record, so it takes priority
+            // when both would fire.
             over_memory = part.estimate >= self.config.l1_part_memory_target_bytes;
-            over_stored = part.stored_estimate >= self.config.max_l1_part_bytes;
-        }
-        if over_memory || over_stored {
-            if let Some(t) = self.tracker {
-                // The memory split target is the one that keeps the host alive;
-                // when both fire at once attribute the flush to it.
-                if over_memory {
-                    t.note_memory_target_flush();
+            if !over_memory
+                && part.stored_estimate >= self.config.max_l1_part_bytes
+                && part.stored_estimate >= part.next_probe_stored
+            {
+                // The stored target governs object geometry, so it closes on the
+                // object's ACTUAL encoded size, not on the payload proxy (issue
+                // #872). The proxy only schedules this probe; encoding is what
+                // measures the bytes the knob is named for. `encode_clone`
+                // encodes a clone of the buffered records, so the builder can
+                // keep accumulating when the part is not yet full.
+                let (object, stats) = part.encode_clone(self.input_set_hash, self.part_index)?;
+                let encoded = object.len() as u64;
+                if encoded >= self.config.max_l1_part_bytes {
+                    stored_close = Some((object, stats));
                 } else {
-                    t.note_stored_target_flush();
+                    part.schedule_next_probe(encoded, self.config.max_l1_part_bytes);
                 }
             }
-            self.flush().await?;
+        }
+        if over_memory {
+            if let Some(t) = self.tracker {
+                t.note_memory_target_flush();
+            }
+            self.flush(None).await?;
+        } else if let Some(enc) = stored_close {
+            if let Some(t) = self.tracker {
+                t.note_stored_target_flush();
+            }
+            self.flush(Some(enc)).await?;
         }
         Ok(())
     }
@@ -904,20 +941,36 @@ impl PartSink<'_> {
     /// Close the in-progress part, if any, and PUT it. A part is never empty
     /// here: [`Self::push`] only ever calls this after pushing a record, and
     /// [`Self::finish`] guards on `is_empty`.
-    async fn flush(&mut self) -> Result<()> {
+    ///
+    /// `pre_encoded` reuses the bytes a stored-target probe already produced for
+    /// this part; `None` (a memory-target close or the trailing part) encodes
+    /// the part here, consuming its records so no clone is made on the common
+    /// path.
+    async fn flush(&mut self, pre_encoded: Option<(Vec<u8>, WriteStats)>) -> Result<()> {
         // The `if let` (rather than an `unwrap`/`expect`) keeps the critical
         // path free of a panic path; a `None` here is a no-op, not a lie.
         if let Some(builder) = self.current.take() {
-            let built = builder
-                .finish(
-                    self.store,
-                    self.bucket,
-                    self.input_set_hash,
-                    self.part_index,
-                    self.dry_run,
-                    self.retain_bytes,
-                )
-                .await?;
+            // Copy the Copy-typed stream bounds before the encode consumes the
+            // builder.
+            let first_stream_id = builder.min_stream;
+            let last_stream_id = builder.max_stream;
+            let (object, stats) = match pre_encoded {
+                Some(enc) => enc,
+                None => builder.into_encoded(self.input_set_hash, self.part_index)?,
+            };
+            let built = finalize_part(
+                self.store,
+                self.bucket,
+                object,
+                stats,
+                first_stream_id,
+                last_stream_id,
+                self.input_set_hash,
+                self.part_index,
+                self.dry_run,
+                self.retain_bytes,
+            )
+            .await?;
             // Only bytes actually retained past PUT count toward the
             // retained-parts term. On the compaction path (`retain_bytes =
             // false`) `finalize_part` released them at PUT, so this is 0 and the
@@ -941,37 +994,64 @@ impl PartSink<'_> {
     /// Close the trailing part and yield every part built, in part-index order.
     async fn finish(mut self) -> Result<Vec<BuiltPart>> {
         if self.current.as_ref().is_some_and(|p| !p.is_empty()) {
-            self.flush().await?;
+            self.flush(None).await?;
         }
         Ok(self.parts)
     }
 }
 
-/// One in-progress L1 part: the shared [`RlogWriter`] the merged records push
-/// into directly, plus the two running estimates that decide where the part
-/// splits (the decoded-heap `estimate` against the memory split target and the encoded
-/// `stored_estimate` against the stored target, whichever is reached first, see
-/// [`PartSink`]); the heap estimate also feeds the [`MergeMemoryTracker`]'s
-/// writer term. Holding a
-/// whole part's records before [`PartBuilder::finish`] stamps its
-/// content-addressed key is unavoidable (the key is a hash of the whole
-/// object); the k-way merge is what keeps everything *else* bounded.
+/// The floor on how far apart two stored-target probes may sit on the payload
+/// proxy axis. A probe encodes the whole part (an O(part) cost), so the
+/// scheduler in [`PartBuilder::schedule_next_probe`] aims the next one near the
+/// target rather than running one per record; this floor keeps a momentarily
+/// flat encoded/proxy rate from scheduling the next probe in the past. It also
+/// bounds how far a part overshoots the stored target: a closing probe fires at
+/// most one interval's worth of records past the crossing, the same
+/// at-most-one-unit discipline the memory split target has (issue #711).
+const PROBE_MIN_STEP_BYTES: u64 = 4096;
+
+/// One in-progress L1 part: the merged records buffered in canonical order, the
+/// decoded-heap estimate that drives the memory split target and the tracker's
+/// writer term, and the payload proxy that schedules the stored-target probe
+/// (see [`PartSink`]).
+///
+/// Holding one whole part's records before its content-addressed key exists is
+/// unavoidable (the key hashes the whole object); the k-way merge keeps
+/// everything *else* bounded. The records are buffered here rather than pushed
+/// into one long-lived [`RlogWriter`] so the part can be encoded to measure its
+/// real size ([`Self::encode_clone`]) without being consumed.
 struct PartBuilder {
-    writer: RlogWriter,
-    /// Sum of [`estimate_record`] over every pushed record: the **memory
-    /// bound**'s trigger (compared against `l1_part_memory_target_bytes`) and the
-    /// writer-buffer term the tracker records. This is decoded Rust heap, not
-    /// stored bytes.
+    /// The compaction identity every encode stamps into the footer. Combined
+    /// with the caller's `input_set_hash` and `part_index` it makes each encode
+    /// deterministic, so a probe's bytes are byte-identical to the close's.
+    identity: ObjectIdentity,
+    /// The POSTINGS field list every part is written with (ADR-0049 decision 6).
+    indexed_fields: Vec<String>,
+    /// The merged records buffered for this part, in canonical `(stream_id, ts)`
+    /// order.
+    records: Vec<LogRecord>,
+    /// Sum of [`estimate_record`] over every pushed record: the **memory split
+    /// target**'s trigger (compared against `l1_part_memory_target_bytes`) and
+    /// the writer-buffer term the tracker records. Decoded Rust heap, not stored
+    /// bytes.
     estimate: u64,
     /// Sum of [`estimate_stored_record`] over every pushed record, plus
-    /// [`estimate_stored_stream`] once per distinct stream in this part: the
-    /// **stored-size target**'s trigger (compared against `max_l1_part_bytes`).
-    /// This estimates encoded/on-object bytes, not heap.
+    /// [`estimate_stored_stream`] once per distinct stream in this part: a cheap
+    /// pre-compression payload proxy. It does NOT close the part (issue #872):
+    /// it only schedules the exact-encode probe that measures the object's real
+    /// bytes, the quantity `max_l1_part_bytes` is named for. See
+    /// [`PartSink::push`] and [`Self::next_probe_stored`].
     stored_estimate: u64,
-    /// The streams whose STREAM_DIR entry this part has already been charged
-    /// for. A set rather than a "did the stream change" check so the charge is
-    /// once per distinct stream whatever order records arrive in; it holds one
-    /// 16-byte id per stream in the part, which is negligible beside the part's
+    /// The `stored_estimate` value at which the next stored-target probe runs.
+    /// Starts at 0, so the first probe runs as soon as `stored_estimate` first
+    /// reaches `max_l1_part_bytes`; [`Self::schedule_next_probe`] advances it
+    /// past a probe that found the part still short of the target, so probing is
+    /// a few encodes per part, not one per record.
+    next_probe_stored: u64,
+    /// The streams whose STREAM_DIR entry this part has already been charged for
+    /// in `stored_estimate`. A set rather than a "did the stream change" check so
+    /// the charge is once per distinct stream whatever order records arrive in;
+    /// it holds one 16-byte id per stream in the part, negligible beside the
     /// records.
     charged_streams: BTreeSet<LogStreamId>,
     min_stream: Option<LogStreamId>,
@@ -981,12 +1061,13 @@ struct PartBuilder {
 
 impl PartBuilder {
     fn new(identity: &ObjectIdentity, indexed_fields: &[String]) -> Self {
-        let writer = RlogWriter::new(RlogConfig::default(), *identity)
-            .with_indexed_fields(indexed_fields.to_vec());
         PartBuilder {
-            writer,
+            identity: *identity,
+            indexed_fields: indexed_fields.to_vec(),
+            records: Vec::new(),
             estimate: 0,
             stored_estimate: 0,
+            next_probe_stored: 0,
             charged_streams: BTreeSet::new(),
             min_stream: None,
             max_stream: None,
@@ -998,15 +1079,15 @@ impl PartBuilder {
         self.count == 0
     }
 
-    /// Push one merged record into the part's writer, updating both running
-    /// estimates (heap for the memory split target, encoded for the stored target) and
-    /// the part's inclusive stream-id bounds.
+    /// Push one merged record, updating the decoded-heap estimate (the memory
+    /// split target's trigger and the tracker's writer term), the payload proxy
+    /// that schedules the stored-target probe, and the part's inclusive
+    /// stream-id bounds.
     ///
     /// A record whose stream this part has not seen before also charges the
-    /// stored estimate for that stream's STREAM_DIR entry
-    /// ([`estimate_stored_stream`]): the blob is written once per stream in the
-    /// object, so it belongs in the encoded estimate once per stream, not once
-    /// per record and not never.
+    /// proxy for that stream's STREAM_DIR entry ([`estimate_stored_stream`]): the
+    /// blob is written once per stream in the object, so it belongs in the proxy
+    /// once per stream, not once per record and not never.
     fn push(&mut self, r: LogRecord, tracker: Option<&MergeMemoryTracker>) -> Result<()> {
         self.min_stream = Some(self.min_stream.map_or(r.stream_id, |m| m.min(r.stream_id)));
         self.max_stream = Some(self.max_stream.map_or(r.stream_id, |m| m.max(r.stream_id)));
@@ -1020,37 +1101,79 @@ impl PartBuilder {
             .stored_estimate
             .saturating_add(estimate_stored_record(&r));
         self.count += 1;
-        self.writer.push(r)?;
+        self.records.push(r);
         if let Some(t) = tracker {
             t.set_writer_bytes(self.estimate);
         }
         Ok(())
     }
 
-    /// Encode and PUT the part through the shared writer pipeline. See
-    /// [`finalize_part`] for the encode/summary/PUT detail this reuses.
-    #[allow(clippy::too_many_arguments)]
-    async fn finish(
-        self,
-        store: &dyn ObjectStoreBackend,
-        bucket: &Bucket,
+    /// Build a fresh writer over `records`. `RlogConfig::default()` and the
+    /// indexed-field list match the L0 write path, so an L0 write and this L1
+    /// merge cannot drift on encoding.
+    fn build_writer(
+        identity: &ObjectIdentity,
+        indexed_fields: &[String],
+        records: Vec<LogRecord>,
+    ) -> Result<RlogWriter> {
+        let mut w = RlogWriter::new(RlogConfig::default(), *identity)
+            .with_indexed_fields(indexed_fields.to_vec());
+        for r in records {
+            w.push(r)?;
+        }
+        Ok(w)
+    }
+
+    /// Encode this part WITHOUT consuming the builder, by cloning its records.
+    /// Used by the stored-target probe to measure the object's real encoded
+    /// size; when the probe decides to close, the caller reuses the returned
+    /// bytes as the closing object (they are byte-identical to what
+    /// [`Self::into_encoded`] would produce for the same `part_index`, the encode
+    /// being deterministic).
+    fn encode_clone(
+        &self,
         input_set_hash: &[u8; 32],
         part_index: u32,
-        dry_run: bool,
-        retain_bytes: bool,
-    ) -> Result<BuiltPart> {
-        finalize_part(
-            store,
-            bucket,
-            self.writer,
-            self.min_stream,
-            self.max_stream,
-            input_set_hash,
-            part_index,
-            dry_run,
-            retain_bytes,
-        )
-        .await
+    ) -> Result<(Vec<u8>, WriteStats)> {
+        let w = Self::build_writer(&self.identity, &self.indexed_fields, self.records.clone())?;
+        Ok(w.finish_compacted_with_stats(1, input_set_hash.to_vec(), part_index)?)
+    }
+
+    /// Encode this part, consuming the builder (no clone). Used to close a part
+    /// on the memory split target, or the trailing part.
+    fn into_encoded(
+        self,
+        input_set_hash: &[u8; 32],
+        part_index: u32,
+    ) -> Result<(Vec<u8>, WriteStats)> {
+        let PartBuilder {
+            identity,
+            indexed_fields,
+            records,
+            ..
+        } = self;
+        let w = Self::build_writer(&identity, &indexed_fields, records)?;
+        Ok(w.finish_compacted_with_stats(1, input_set_hash.to_vec(), part_index)?)
+    }
+
+    /// Schedule the next stored-target probe after one found the part still
+    /// short of the target. Models encoded size as ~linear in the payload proxy
+    /// and aims the next probe at the proxy value where the encoded size should
+    /// reach `target`, so a part converges to the target in a few probes even
+    /// when the compression ratio is large, rather than encoding once per
+    /// record. The step is floored at [`PROBE_MIN_STEP_BYTES`] so a momentarily
+    /// flat rate cannot schedule the probe in the past.
+    fn schedule_next_probe(&mut self, encoded_now: u64, target: u64) {
+        let deficit = target.saturating_sub(encoded_now);
+        // Encoded bytes produced per unit of payload proxy so far. A probe only
+        // runs once `stored_estimate >= target > 0` and an encoded part is never
+        // empty, so `encoded_now` and `stored_estimate` are both positive; the
+        // clamp guards the ratio against a degenerate zero rather than being a
+        // live case.
+        let rate = (encoded_now as f64 / self.stored_estimate.max(1) as f64).max(f64::MIN_POSITIVE);
+        let step = ((deficit as f64) / rate).ceil() as u64;
+        let step = step.max(PROBE_MIN_STEP_BYTES);
+        self.next_probe_stored = self.stored_estimate.saturating_add(step);
     }
 }
 
@@ -1874,20 +1997,21 @@ async fn open_cursor<'a>(
     Ok(cursor.peek_ts().is_some().then_some(cursor))
 }
 
-/// Encode one in-progress part's writer into an L1 object and PUT it: run the
-/// shared writer pipeline via [`RlogWriter::finish_compacted_with_stats`]
-/// (stamping `level = 1`, the `input_set_hash`, and `part_index`), then PUT it
-/// `CreateIfAbsent`. The part's summary stats are read back from the produced
-/// object's own footer, so they describe exactly what was written.
+/// Turn one part's already-encoded L1 object bytes into a [`BuiltPart`] and PUT
+/// it `CreateIfAbsent`. The object was produced by
+/// [`PartBuilder::into_encoded`]/[`PartBuilder::encode_clone`] via the shared
+/// [`RlogWriter::finish_compacted_with_stats`] pipeline (stamping `level = 1`,
+/// the `input_set_hash`, and `part_index`); the part's summary stats are read
+/// back from the object's own footer, so they describe exactly what was
+/// written.
 ///
-/// The writer was built with the same [`RlogWriter::with_indexed_fields`] the
-/// L0 write path uses, so this part's POSTINGS is built by the one writer
-/// implementation from this part's own blocks (ADR-0049 decision 6). The
-/// per-field distinct-value cap therefore applies to the merged part; when it
-/// fires the writer drops that field's postings and reports it in
-/// `WriteStats`, which is logged here because a silently unindexed field is
-/// invisible in the object bytes (they are simply absent, which is always
-/// legal).
+/// The object was encoded with the same [`RlogWriter::with_indexed_fields`] the
+/// L0 write path uses, so its POSTINGS is built by the one writer implementation
+/// from this part's own blocks (ADR-0049 decision 6). The per-field
+/// distinct-value cap therefore applies to the merged part; when it fires the
+/// writer drops that field's postings and reports it in `stats`, logged here
+/// because a silently unindexed field is invisible in the object bytes (they are
+/// simply absent, which is always legal).
 ///
 /// `first_stream_id`/`last_stream_id` are the part's inclusive stream-id bounds
 /// accumulated as records were pushed (streams are merged in sorted id order,
@@ -1899,7 +2023,8 @@ async fn open_cursor<'a>(
 pub(crate) async fn finalize_part(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,
-    writer: RlogWriter,
+    object: Vec<u8>,
+    stats: WriteStats,
     first_stream_id: Option<LogStreamId>,
     last_stream_id: Option<LogStreamId>,
     input_set_hash: &[u8; 32],
@@ -1907,8 +2032,6 @@ pub(crate) async fn finalize_part(
     dry_run: bool,
     retain_bytes: bool,
 ) -> Result<BuiltPart> {
-    let (object, stats) =
-        writer.finish_compacted_with_stats(1, input_set_hash.to_vec(), part_index)?;
     if stats.postings_capped_fields > 0 {
         tracing::warn!(
             part_index,
@@ -2095,15 +2218,20 @@ fn attr_value_estimate(v: &AttrValue) -> u64 {
 /// figure in the range those fixed-width columns cost before compression.
 const STORED_RECORD_FIXED_BYTES: u64 = 16;
 
-/// The encoded/on-object bytes one merged [`LogRecord`] is estimated to add to
-/// a part, the quantity `max_l1_part_bytes` (the stored-size target) caps.
+/// A cheap upper bound on the encoded/on-object bytes one merged [`LogRecord`]
+/// adds to a part. It does NOT close the part on `max_l1_part_bytes` (the
+/// stored-size target): the part closes on its object's ACTUAL encoded size,
+/// measured by an exact-encode probe ([`PartBuilder::encode_clone`]). This
+/// figure's only job is to SCHEDULE that probe -- summed per record into
+/// [`PartBuilder::stored_estimate`], it says when the object is plausibly large
+/// enough to be worth encoding to check (issue #872).
 ///
 /// This is deliberately NOT [`estimate_record`], which measures the record's
-/// Rust *heap* for the memory split target. The two answer different questions and are
-/// an order of magnitude apart on a wide schema, which is the whole point of
-/// issue #872: the memory split target reached 256 MiB of heap after only ~3.5 MB of
-/// stored bytes on the ClickBench tenant, so a single knob measured in heap
-/// could not also govern object geometry.
+/// Rust *heap* for the memory split target. The two answer different questions
+/// and are an order of magnitude apart on a wide schema: the memory split target
+/// reaches 256 MiB of heap after only ~3.5 MB of stored bytes on the ClickBench
+/// tenant, so a single knob measured in heap could not also govern object
+/// geometry.
 ///
 /// It is a pre-compression payload proxy: the sum of the value bytes that
 /// actually enter this part's columns (timestamps and identifiers as a small
@@ -2112,21 +2240,18 @@ const STORED_RECORD_FIXED_BYTES: u64 = 16;
 ///
 /// - `stream_attrs` (the resource/scope blob) is stored once per stream in
 ///   STREAM_DIR, not once per record, so charging it per record would inflate
-///   the estimate on exactly the wide-stream shape this is meant to size. It is
+///   the proxy on exactly the wide-stream shape this is meant to size. It is
 ///   not free, though: [`estimate_stored_stream`] charges each distinct stream's
-///   blob once per part it appears in, so a part carrying many streams with
-///   large resource blobs still reaches the target. Charging neither made the
-///   estimate blind to the whole STREAM_DIR section, and a many-stream,
-///   fat-blob bucket then ran far past the target while the estimate stayed
-///   small.
-/// - zstd compression. The estimate is the uncompressed column payload, so it
-///   is an upper bound on the bytes those columns compress to; a target of `T`
-///   payload bytes yields an object of `T / compression_ratio` stored bytes.
-///   That makes the target conservative (objects no larger than `T`), which is
-///   the safe direction for a memory-adjacent geometry knob, and it is why the
-///   size-target default is left at 256 MiB: on the current corpus the memory
-///   bound still fires first, so no stored target value can change today's
-///   geometry.
+///   blob once per part it appears in, so the proxy over a part carrying many
+///   streams with large resource blobs still grows toward the probe threshold.
+///   Charging neither made the proxy blind to the whole STREAM_DIR section.
+/// - zstd compression. The proxy is the uncompressed column payload, so it is an
+///   upper bound on the bytes those columns compress to. That is the direction
+///   that matters for a scheduling gate: the proxy reaches the target no later
+///   than the object's real bytes would, so the probe is never scheduled too
+///   late to catch the crossing. (Under the old proxy-as-close design this same
+///   upper bound made objects `T / compression_ratio` in size, a ratio-times
+///   miss; closing on the probe removes it.)
 ///
 /// Like [`estimate_record`] it only decides where parts split, never
 /// correctness: the frozen [`RlogWriter`] produces identical bytes for a given
@@ -2159,11 +2284,11 @@ const STORED_STREAM_DIR_ENTRY_BYTES: u64 = 32;
 /// it out). A part that opens a stream, closes, and reopens the same stream in
 /// the next part is charged in both, because both parts carry the entry.
 ///
-/// Without this charge the stored estimate ignored STREAM_DIR entirely, so a
-/// bucket with many streams and large resource or scope blobs could run far past
-/// `max_l1_part_bytes` in real object bytes while its estimate stayed near the
-/// (tiny) sum of its record payloads. The estimate is only meaningful as a
-/// proxy for object size if it counts every section that grows with the data.
+/// Without this charge the proxy would ignore STREAM_DIR entirely, so a bucket
+/// with many streams and large resource or scope blobs would grow real object
+/// bytes the proxy could not see, scheduling the exact-encode probe too late and
+/// overshooting `max_l1_part_bytes`. The proxy is only a sound probe-scheduling
+/// coordinate if it counts every section that grows with the data.
 fn estimate_stored_stream(stream_attrs: &[u8]) -> u64 {
     STORED_STREAM_DIR_ENTRY_BYTES.saturating_add(stream_attrs.len() as u64)
 }
@@ -3478,10 +3603,10 @@ mod tests {
     /// straddles every boundary.
     ///
     /// Demonstrated red by restoring the pre-#711 between-streams-only check:
-    /// delete the `if over_memory || over_stored { .. self.flush().await?; }`
-    /// block from `PartSink::push` and re-add the flush to `build_parts`'s
-    /// `for stream_id in merged.keys()` loop (`if part.estimate >=
-    /// config.l1_part_memory_target_bytes { sink.flush().await?; }` after
+    /// delete the `if over_memory { .. self.flush(None).await?; }` block from
+    /// `PartSink::push` and re-add the flush to `build_parts`'s `for stream_id in
+    /// merged.keys()` loop (`if part.estimate >=
+    /// config.l1_part_memory_target_bytes { sink.flush(None).await?; }` after
     /// `merge_stream_into_parts`). The part count collapses to 1 and this test
     /// fails at `assert_eq!(parts.len() as u64, expected_parts)` with
     /// `1 != 10`.
@@ -3684,14 +3809,28 @@ mod tests {
 
     // --- memory split target vs stored-size target (issue #872) ---------------------
 
-    /// One narrow record of stream 0: a tiny body and no attributes, so its
-    /// encoded [`estimate_stored_record`] is a handful of bytes while its
-    /// decoded [`estimate_record`] still carries the per-record Rust-slot and
-    /// resource-blob overhead. This is the "narrow rows, high compression"
-    /// direction: stored bytes accumulate far slower than heap, so the
-    /// stored-size target can be made to fire first.
-    fn narrow_record(i: i64) -> LogRecord {
-        record(0, SPLIT_BASE_NS + i, "x", Vec::new())
+    /// One record of stream 0 with a deliberately KNOWN encoded/decoded ratio: a
+    /// short per-ordinal-unique prefix (so blocks do not collapse to nothing and
+    /// parts fill in a bounded record count) followed by a long repeated filler
+    /// (so the pre-compression payload proxy runs several times ahead of the
+    /// bytes the columns actually compress to). Every record is the same width,
+    /// so each contributes about the same object bytes and the geometry band is
+    /// uniform. Fixed single stream, so STREAM_DIR is a one-time per-part charge.
+    ///
+    /// This is the fixture the stored-target geometry rests on: the gap between
+    /// its payload proxy and its compressed object bytes is exactly the ratio the
+    /// old proxy-as-close design mis-sized parts by (issue #872).
+    fn ratio_record(i: i64) -> LogRecord {
+        // A high-entropy prefix (does not compress, so it sets the object bytes
+        // and parts fill in a bounded record count) followed by a long
+        // compressible filler (inflates the payload proxy well past the object
+        // bytes). The gap is a stable ratio near 4.
+        let body = format!(
+            "{}{}",
+            incompressible_pad(i as u64, 48),
+            "compressible-".repeat(16)
+        );
+        record(0, SPLIT_BASE_NS + i, &body, Vec::new())
     }
 
     /// Issue #872: on a wide schema the MEMORY bound fires first. With both
@@ -3776,23 +3915,71 @@ mod tests {
         }
     }
 
-    /// Issue #872: on a narrow, highly compressible schema the STORED target
-    /// fires first. The memory split target is left at its 256 MiB default (far above
-    /// anything this corpus reaches in heap) and the stored target is set small,
-    /// so every part closes on encoded bytes and none on memory. This is the
-    /// follow-up's shape: lowering the stored target is what grows/shrinks
-    /// objects, independently of the memory invariant.
+    /// Compact the [`ratio_record`] fixture into a FRESH store with both targets
+    /// effectively disabled, so the whole bucket is one part, and return its
+    /// decoded record sequence: the pre-split baseline the differential check
+    /// compares against.
+    async fn ratio_fixture_single_part(per_input: i64, inputs: i64) -> Vec<LogRecord> {
+        let store = MemoryStore::new();
+        for j in 0..inputs {
+            let recs: Vec<LogRecord> = (0..per_input)
+                .map(|i| ratio_record(i * inputs + j))
+                .collect();
+            seed(&store, Uuid::from_u128(j as u128 + 1), j as u64 + 1, &recs).await;
+        }
+        let config = CompactorConfig {
+            max_l1_part_bytes: u64::MAX,
+            l1_part_memory_target_bytes: u64::MAX,
+            ..CompactorConfig::default()
+        };
+        let clock = FixedClock::new(sealed_now_ns());
+        compact_bucket(&store, &clock, &config, &bucket())
+            .await
+            .expect("compact");
+        let (_rec, parts) = read_output(&store).await;
+        assert_eq!(parts.len(), 1, "baseline must be a single part");
+        let mut rows = Vec::new();
+        for p in &parts {
+            rows.extend(decode_all(p));
+        }
+        rows
+    }
+
+    /// Issue #872 acceptance (geometry): the stored-size target closes each part
+    /// on its ACTUAL encoded object bytes, so every non-final part reaches the
+    /// target rather than coming out a compression-ratio-times-smaller object,
+    /// which is what closing on the pre-compression payload proxy produced. The
+    /// memory split target is left at its 256 MiB default (far above anything
+    /// this corpus reaches in heap), so the stored target is the only thing that
+    /// can fire.
+    ///
+    /// The band is exact from the fixture, never merely `> 0`: a part closes the
+    /// moment a probe shows its object reaching `STORED_TARGET`, and probes are
+    /// spaced at least [`PROBE_MIN_STEP_BYTES`] of payload proxy apart, whose
+    /// records encode to fewer than that many object bytes (the proxy is an upper
+    /// bound over the compressed sections). So every stored-closed part sits in
+    /// `[STORED_TARGET, STORED_TARGET + PROBE_MIN_STEP_BYTES]`; only the trailing
+    /// part, closed by `finish` on the remainder, sits below.
+    ///
+    /// Demonstrated red against the old proxy-as-close design: replace the probe
+    /// block in `PartSink::push` with `over_stored = part.stored_estimate >=
+    /// self.config.max_l1_part_bytes` and flush on it. The same fixture then
+    /// closes each part when its PAYLOAD reaches the target, so the objects come
+    /// out `ratio` times smaller -- below `STORED_TARGET / 2` -- and the
+    /// lower-bound assertion below fails. The `ratio` sub-assertion pins that
+    /// this fixture's gap is well above 2, so the old design provably misses the
+    /// band low.
     #[tokio::test]
-    async fn narrow_rows_close_the_part_on_the_stored_target() {
-        const PER_INPUT: i64 = 500;
+    async fn stored_target_closes_parts_on_actual_encoded_object_bytes() {
+        const PER_INPUT: i64 = 2500;
         const INPUTS: i64 = 2;
-        const STORED_TARGET: u64 = 4 * 1024;
+        const STORED_TARGET: u64 = 16 * 1024;
         let total = (PER_INPUT * INPUTS) as u64;
 
         let store = Arc::new(MemoryStore::new());
         for j in 0..INPUTS {
             let recs: Vec<LogRecord> = (0..PER_INPUT)
-                .map(|i| narrow_record(i * INPUTS + j))
+                .map(|i| ratio_record(i * INPUTS + j))
                 .collect();
             seed(
                 store.as_ref(),
@@ -3803,29 +3990,35 @@ mod tests {
             .await;
         }
 
-        let stored = estimate_stored_record(&narrow_record(0));
-        // Every part also pays this fixture's single stream's STREAM_DIR entry
-        // once, at its first record, so the records-per-part arithmetic runs
-        // against what is left of the target.
-        let stream_charge = estimate_stored_stream(&narrow_record(0).stream_attrs);
+        // The fixture's encoded/decoded gap, measured not assumed: encode a
+        // sample exactly as the merge does and compare the payload proxy the old
+        // design closed on to the object bytes the new design closes on. A ratio
+        // above 2 is what puts the old design's parts (~STORED_TARGET / ratio)
+        // below the STORED_TARGET/2 band floor.
+        let sample: Vec<LogRecord> = (0..200).map(ratio_record).collect();
+        let proxy: u64 = sample.iter().map(estimate_stored_record).sum::<u64>()
+            + estimate_stored_stream(&ratio_record(0).stream_attrs);
+        let identity = compactor_identity(&bucket(), &CompactorConfig::default());
+        let mut w = RlogWriter::new(RlogConfig::default(), identity);
+        for r in &sample {
+            w.push(r.clone()).expect("push");
+        }
+        let object_len = w
+            .finish_compacted(1, vec![0u8; 32], 0)
+            .expect("encode")
+            .len() as u64;
+        let ratio = proxy as f64 / object_len as f64;
         assert!(
-            stream_charge < STORED_TARGET,
-            "fixture is unusable: its stream blob charges {stream_charge}B against a \
-             {STORED_TARGET}B target, leaving no room for records"
-        );
-        let expected_parts = expected_part_count(stored, STORED_TARGET - stream_charge, total);
-        assert!(
-            expected_parts >= 3,
-            "fixture must split several times, got {expected_parts}"
+            ratio > 2.0,
+            "fixture must have a real compression gap: payload proxy {proxy} vs object \
+             {object_len} is only {ratio:.2}x; the old proxy-close bug needs ratio > 2 to \
+             land parts below STORED_TARGET/2"
         );
 
         let tracker = MergeMemoryTracker::new();
         let config = CompactorConfig {
             max_l1_part_bytes: STORED_TARGET,
             merge_memory_tracker: Some(tracker.clone()),
-            // `l1_part_memory_target_bytes` is left at its shipped 256 MiB
-            // default: nothing this corpus does in heap comes close, so the
-            // memory split target can never be what fires.
             ..CompactorConfig::default()
         };
         let clock = FixedClock::new(sealed_now_ns());
@@ -3833,11 +4026,11 @@ mod tests {
             .await
             .expect("compact");
 
-        let (_rec, parts) = read_output(store.as_ref()).await;
-        assert_eq!(
-            parts.len() as u64,
-            expected_parts,
-            "part count is the stored arithmetic"
+        let (rec, parts) = read_output(store.as_ref()).await;
+        assert!(
+            parts.len() >= 4,
+            "fixture must split several times, got {}",
+            parts.len()
         );
         assert_eq!(
             tracker.memory_target_flushes(),
@@ -3845,9 +4038,53 @@ mod tests {
             "no part may close on the memory split target for this corpus"
         );
         assert_eq!(
-            tracker.stored_target_flushes(),
-            expected_parts - 1,
+            tracker.stored_target_flushes() as usize,
+            parts.len() - 1,
             "every closed part (all but the trailing one) closed on the stored target"
+        );
+
+        // The geometry band: every non-final part reached the target, and none
+        // ran more than one probe interval past it. The lower bound is the
+        // target itself, which the old proxy-close (object ~ STORED_TARGET /
+        // ratio) could not clear.
+        let last = parts.len() - 1;
+        for (i, p) in rec.parts.iter().enumerate() {
+            if i == last {
+                assert!(
+                    p.object_size > 0 && p.object_size <= STORED_TARGET + PROBE_MIN_STEP_BYTES,
+                    "trailing part of {} bytes out of band",
+                    p.object_size
+                );
+            } else {
+                assert!(
+                    p.object_size >= STORED_TARGET
+                        && p.object_size <= STORED_TARGET + PROBE_MIN_STEP_BYTES,
+                    "part {i} of {} bytes is outside [{STORED_TARGET}, {}] -- the stored \
+                     target must close on real object bytes, not {}x-smaller payload",
+                    p.object_size,
+                    STORED_TARGET + PROBE_MIN_STEP_BYTES,
+                    ratio as u64
+                );
+            }
+        }
+
+        // Conservation and decode-equality (issue #872 deliverable 5): moving
+        // part boundaries changes content hashes legitimately but never adds,
+        // drops, or reorders a record. The split run's decoded record sequence
+        // must equal a single-part run of the same inputs.
+        let mut split_rows: Vec<LogRecord> = Vec::new();
+        for p in &parts {
+            split_rows.extend(decode_all(p));
+        }
+        assert_eq!(
+            split_rows.len() as u64,
+            total,
+            "every record survives the split exactly once"
+        );
+        let baseline = ratio_fixture_single_part(PER_INPUT, INPUTS).await;
+        assert_eq!(
+            split_rows, baseline,
+            "the decoded record sequence must be identical whatever the split"
         );
     }
 
@@ -3912,28 +4149,29 @@ mod tests {
         }
     }
 
-    /// A part's STREAM_DIR is charged against the stored-size target once per
-    /// distinct stream, so a bucket of many streams with large resource blobs
-    /// splits on those blobs rather than running past the target on them.
+    /// A part's STREAM_DIR bytes must count toward the payload proxy that
+    /// schedules the stored-target probe, so a bucket of many streams with large
+    /// resource blobs splits on those blobs rather than making one giant object.
     ///
     /// `estimate_stored_record` excludes `stream_attrs`, correctly: the blob is
-    /// stored once per stream, not once per record. Nothing charged it per
-    /// stream either, so STREAM_DIR was invisible to the target: this fixture's
-    /// records are a few bytes each, so its estimate stayed near 4 KiB while its
-    /// single object held ~96 fat blobs.
+    /// stored once per stream, not once per record. If nothing charged it per
+    /// stream either, the proxy would stay near the tiny sum of this fixture's
+    /// few-byte records and never reach the target, so the exact-encode probe
+    /// would never be scheduled and the merge would run every stream's blob into
+    /// one object. [`estimate_stored_stream`] charging each distinct stream once
+    /// keeps the proxy tracking the object it schedules a probe for.
     ///
-    /// Both assertions are magnitudes proportional to the fixture, not floors:
-    /// the part count is the stream-charge arithmetic over `STREAMS` streams and
-    /// a `STORED_TARGET`-byte target, and each part's real object size stays
-    /// within twice the target.
+    /// The fat blobs are incompressible (pseudo-random), so the object cannot
+    /// compress far below its STREAM_DIR bytes: each non-final part therefore
+    /// closes AT the target (the probe measures real object bytes) and stays
+    /// under twice it.
     ///
-    /// Demonstrated red by under-charging, with the per-part charge model
-    /// below in place: adding `&& self.charged_streams.len() == 1` to the
-    /// charge in `PartBuilder::push` (one stream per part instead of every
-    /// distinct one) yields a single part of 269_641 bytes, 4.1x the
-    /// 65_536-byte target, failing the size assertion and then the count
-    /// assertion with `1 != 7`. A flat floor low enough to be safe would have
-    /// passed at both.
+    /// Demonstrated red by under-charging: gate the STREAM_DIR charge in
+    /// `PartBuilder::push` to the first stream only (`&& self.charged_streams
+    /// .len() == 1`). The proxy then stays a few KiB over the whole bucket, never
+    /// reaches the 64 KiB target, no probe is ever scheduled, and the merge emits
+    /// a single ~270 KiB object, failing the `object_size < 2 * STORED_TARGET`
+    /// assertion.
     #[tokio::test]
     async fn many_streams_charge_stream_dir_against_the_stored_target() {
         const STREAMS: u32 = 96;
@@ -3956,53 +4194,11 @@ mod tests {
             .await;
         }
 
-        // The split rule, walked: a stream's first record in a part pays the
-        // STREAM_DIR entry plus its own payload, later records in the SAME part
-        // pay their payload only, and the part closes as soon as the running
-        // total reaches the target. Every stream here has the same blob length
-        // and the same record shape, so the walk does not depend on which
-        // stream id sorts first.
-        //
-        // The charge is per part, not per merge: `PartBuilder::push` charges a
-        // stream once into the builder it is pushed into, and `PartSink::flush`
-        // starts the next record on a fresh builder with an empty
-        // `charged_streams`. So the walk clears its own charged set at every
-        // split. A stream whose records straddle a boundary is charged in both
-        // parts, because both objects carry its STREAM_DIR entry. Modelling one
-        // charge per stream over the whole walk undercounts the accumulator and
-        // can predict fewer parts than the merge produces. At this fixture's
-        // blob and record sizes every split lands on a stream's first record,
-        // so both models happen to reach the same seven parts; the reset is
-        // what keeps the prediction exact when either size moves.
         let charge = estimate_stored_stream(&fat_stream_record(0, 0).stream_attrs);
         let per_record = estimate_stored_record(&fat_stream_record(0, 0));
         assert!(
             charge > per_record * 100,
             "fixture must be STREAM_DIR-dominated: charge {charge} vs record {per_record}"
-        );
-        let mut expected_parts = 0u64;
-        let mut acc = 0u64;
-        let mut charged: BTreeSet<u32> = BTreeSet::new();
-        for s in 0..STREAMS {
-            for _ in 0..INPUTS {
-                acc += if charged.insert(s) {
-                    charge + per_record
-                } else {
-                    per_record
-                };
-                if acc >= STORED_TARGET {
-                    expected_parts += 1;
-                    acc = 0;
-                    charged.clear();
-                }
-            }
-        }
-        if acc > 0 {
-            expected_parts += 1;
-        }
-        assert!(
-            expected_parts >= 5,
-            "fixture must split several times, got {expected_parts}"
         );
 
         let tracker = MergeMemoryTracker::new();
@@ -4021,26 +4217,39 @@ mod tests {
             .expect("compact");
 
         let (rec, parts) = read_output(store.as_ref()).await;
+        assert!(
+            parts.len() >= 5,
+            "fixture must split several times, got {}",
+            parts.len()
+        );
         assert_eq!(
             tracker.memory_target_flushes(),
             0,
             "no part may close on the memory split target for this corpus"
         );
-        // The estimate is only worth having if it tracks the object it names.
-        // Each part's real stored size stays within twice the target; uncharged,
-        // one part carried every stream's blob.
-        for p in &rec.parts {
+        assert_eq!(
+            tracker.stored_target_flushes() as usize,
+            parts.len() - 1,
+            "every closed part (all but the trailing one) closed on the stored target"
+        );
+        // The probe measures the object it names: with the STREAM_DIR charge
+        // scheduling it, each non-final part reaches the target and none runs
+        // past twice it; uncharged, one part would carry every stream's blob.
+        let last = parts.len() - 1;
+        for (i, p) in rec.parts.iter().enumerate() {
             assert!(
                 p.object_size < 2 * STORED_TARGET,
-                "part of {} bytes exceeded twice the {STORED_TARGET}-byte stored target",
+                "part {i} of {} bytes exceeded twice the {STORED_TARGET}-byte stored target",
                 p.object_size
             );
+            if i != last {
+                assert!(
+                    p.object_size >= STORED_TARGET,
+                    "non-final part {i} of {} bytes did not reach the {STORED_TARGET}-byte target",
+                    p.object_size
+                );
+            }
         }
-        assert_eq!(
-            parts.len() as u64,
-            expected_parts,
-            "part count is the STREAM_DIR-charge arithmetic"
-        );
 
         // Records are conserved across the split.
         let mut l1: Vec<LogRecord> = Vec::new();
@@ -4203,8 +4412,13 @@ mod tests {
             // Hold every commit-record GET (".cmt" names commit records and
             // nothing else) so the in-flight count is observable.
             let gate = store.hold(Op::Get, Some(".cmt".to_string()), Occurrence::Always);
+            // Split on the memory target: wide records are far larger in heap
+            // than on the object, so this reliably produces several parts, and
+            // (unlike the stored target) needs no encoded-size probe. The point
+            // under test is byte-identity across concurrency, not which target
+            // fires.
             let config = CompactorConfig {
-                max_l1_part_bytes: 64 * 1024,
+                l1_part_memory_target_bytes: 64 * 1024,
                 input_read_concurrency: concurrency,
                 ..CompactorConfig::default()
             };
@@ -4625,8 +4839,11 @@ mod tests {
         }
         let config = CompactorConfig {
             // Small enough that the bucket splits into several parts, so the
-            // pin covers part boundaries and `part_index`, not one object.
-            max_l1_part_bytes: 4096,
+            // pin covers part boundaries and `part_index`, not one object. Split
+            // on the memory target: it is unaffected by the issue #872 stored-
+            // target change, so this pin stays reproducible independently of
+            // object-geometry knobs.
+            l1_part_memory_target_bytes: 32 * 1024,
             ..CompactorConfig::default()
         };
         let clock = FixedClock::new(sealed_now_ns());
@@ -4653,35 +4870,46 @@ mod tests {
         (hashes, rows)
     }
 
-    /// ADR-0979 verification item 2: the bounded merge's output parts are
-    /// byte-identical to what the pre-D1 cursor produced.
+    /// A pinned byte-stability guard: this exact fixture and config must keep
+    /// producing the same part `content_hash` vector, so an accidental change to
+    /// the merge, the writer pipeline, or the split logic shows up as a diff
+    /// here.
     ///
-    /// The expected hashes are PINNED, not recomputed. They were produced by
-    /// this exact fixture on commit 76c90a3 -- the last commit before the
-    /// columnar cursor swap, when `StreamCursor` still held one block's
-    /// eagerly decoded `Vec<LogRecord>` -- so this compares the new path
-    /// against the old path's real bytes rather than against itself. The old
-    /// path is deleted by the swap, which is why the constants exist at all.
-    ///
-    /// The fixture is built so the comparison cannot pass by accident:
-    /// [`differential_hash_inputs`] pins the two-way and three-way equal-ts
+    /// The pin covers part boundaries and `part_index`, not one object:
+    /// [`differential_hash_inputs`] fixes the two-way and three-way equal-ts
     /// tie-break order in the record bodies, [`differential_l0_cfg`] makes each
     /// stream span several blocks and several row groups per input with
-    /// stream-boundary blocks, and `max_l1_part_bytes` splits the bucket into
-    /// several parts.
+    /// stream-boundary blocks, and the run splits into several parts on the
+    /// memory split target.
+    ///
+    /// The vector was REGENERATED for issue #872: the original pin was taken
+    /// under `max_l1_part_bytes: 4096` on commit 76c90a3 (the last commit before
+    /// the ADR-0979 D1 columnar-cursor swap), but #872 changed the stored-size
+    /// target to close a part on its ACTUAL encoded bytes rather than the payload
+    /// proxy, which moves every stored-target boundary the original pin used, so
+    /// those hashes are unreproducible. This run instead splits on the #711
+    /// memory split target, which neither D1 nor #872 touches; the pre-D1
+    /// record-level equivalence the original pin guarded now rests on
+    /// [`streaming_merge_output_is_byte_identical_to_stable_sort_order`] and
+    /// [`admission_on_and_off_produce_identical_part_hashes`], and content
+    /// preservation across the moved #872 boundaries on
+    /// [`stored_target_closes_parts_on_actual_encoded_object_bytes`]'s
+    /// decode-equality check.
     #[tokio::test]
     async fn differential_part_hashes_match_the_pre_columnar_cursor() {
         /// Total records seeded across the three inputs: 4 streams x
         /// (30 + 1) + 4 x (30 + 1) + 4 x (40 + 1).
         const EXPECTED_ROWS: usize = 4 * 31 + 4 * 31 + 4 * 41;
-        /// Part `content_hash` values, in `part_index` order, as produced on
-        /// commit 76c90a3.
+        /// Part `content_hash` values, in `part_index` order, as produced by the
+        /// current merge under a 32 KiB memory split target (see the note above
+        /// on why they were regenerated for issue #872).
         const EXPECTED_PART_HASHES: &[&str] = &[
-            "ff8136ed3914f1e7735129ed727750abd700f035fac8546905ca24d256a9b012",
-            "6fae530b2b49e81d44e371a67237522730fa54a0ffc70955f79de924eaa9babe",
-            "e13ab6be5d9c740c3dead134402c47ac5165f00b8715b1c9adf5b3705adc51d7",
-            "5e8d796720a814bbc5cd8c760ce232f7e6405eed6d73c8cac3f0e24c7c24dfe9",
-            "088f8f8045e6b693ea944d8d9a0c4db46ab897625e3783653561c428a9485908",
+            "853fb59210a344a2e656f6e1a29aa2feeeab0ec486373f3d37fd8975f74cb7ac",
+            "dca4d7e8b9729de6c64f132fa1eb52028ab85de629d17e1f8b85d7b916c883a4",
+            "6669e7d418d5e42b1bcd46e664c9b00503e3cbdbf6ed35e9ddd49d493e386459",
+            "29d933b58b29a40ee80a1587ecf91021bdc747376131f86fcef8dfdca9b1679a",
+            "f6c414a7fc62039e3000817c8ab65e36060bd20cee30fab61d1cb2eb4f166dd1",
+            "5641cc650be9829ca9bfb88d203ca98872ddf4fd1149815d25ed8bb4ddd44e46",
         ];
 
         let (hashes, rows) = differential_hash_run().await;

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -917,13 +917,27 @@ impl PartSink<'_> {
                 // measures the bytes the knob is named for. `encode_clone`
                 // encodes a clone of the buffered records, so the builder can
                 // keep accumulating when the part is not yet full.
-                let (object, stats) = part.encode_clone(self.input_set_hash, self.part_index)?;
                 if let Some(t) = self.tracker {
+                    // The clone is a second live copy of the part's record heap,
+                    // so it belongs in the run's peak rather than being treated
+                    // as free; the object bytes join it below, once their size
+                    // is known.
+                    t.set_probe_bytes(part.estimate);
+                }
+                let probe = part.encode_clone(self.input_set_hash, self.part_index);
+                if let Some(t) = self.tracker {
+                    if let Ok((object, _)) = probe.as_ref() {
+                        t.set_probe_bytes(part.estimate.saturating_add(object.len() as u64));
+                    }
+                    // Cleared on the error path too, so a failed encode does not
+                    // leave the term charged for the rest of the run.
+                    t.set_probe_bytes(0);
                     // Counted whether or not it closes the part: this is the
                     // O(part) encode the stored target costs, and "no probe runs
                     // at the shipped defaults" is a claim a test asserts on.
                     t.note_probe_run();
                 }
+                let (object, stats) = probe?;
                 let encoded = object.len() as u64;
                 if encoded >= self.config.max_l1_part_bytes {
                     stored_close = Some((object, stats));
@@ -1011,14 +1025,15 @@ impl PartSink<'_> {
 /// The floor on how far apart two stored-target probes may sit on the payload
 /// proxy axis. A probe encodes the whole part (an O(part) cost), so the
 /// scheduler in [`PartBuilder::schedule_next_probe`] aims the next one near the
-/// target rather than running one per record; this floor keeps a momentarily
-/// flat encoded/proxy rate from scheduling the next probe in the past.
+/// target rather than running one per record; this floor keeps a deficit of a
+/// few bytes from turning the last stretch before a close into an encode per
+/// record.
 ///
 /// It is also the width of the stored target's overshoot band. The scheduler
-/// never aims a probe past the proxy value where the part would reach the target
-/// at the densest encoded-per-proxy rate it has already measured (and never
-/// assumes a rate below 1:1), so between two probes the encoded size can grow by
-/// at most the remaining deficit plus this floor plus the last record's proxy
+/// aims the next probe the remaining encoded deficit further along the proxy
+/// axis, or this floor if the deficit is smaller, so as long as encoded bytes
+/// grow at most 1:1 with the proxy over the closing interval the encoded size
+/// can pass the target by at most this floor plus the crossing record's proxy
 /// charge -- see [`PartBuilder::schedule_next_probe`] for the derivation and for
 /// what the band is conditional on.
 const PROBE_MIN_STEP_BYTES: u64 = 4096;
@@ -1061,20 +1076,6 @@ struct PartBuilder {
     /// past a probe that found the part still short of the target, so probing is
     /// a few encodes per part, not one per record.
     next_probe_stored: u64,
-    /// `stored_estimate` as of the last probe (0 before the first): the left edge
-    /// of the interval [`Self::schedule_next_probe`] measures the MARGINAL
-    /// encoded-per-proxy rate over. A cumulative rate (encoded/proxy since the
-    /// part opened) is the wrong estimator for a part whose compressibility
-    /// changes along the record sequence, which is the case that overshoots.
-    last_probe_stored: u64,
-    /// Encoded object bytes the last probe measured (0 before the first), the
-    /// other end of that interval.
-    last_probe_encoded: u64,
-    /// The densest encoded-per-proxy rate any probe interval of this part has
-    /// shown. The scheduler assumes the next interval runs at least this dense
-    /// (and never below 1:1), which is what bounds the overshoot; see
-    /// [`Self::schedule_next_probe`].
-    max_probe_rate: f64,
     /// The streams whose STREAM_DIR entry this part has already been charged for
     /// in `stored_estimate`. A set rather than a "did the stream change" check so
     /// the charge is once per distinct stream whatever order records arrive in;
@@ -1095,9 +1096,6 @@ impl PartBuilder {
             estimate: 0,
             stored_estimate: 0,
             next_probe_stored: 0,
-            last_probe_stored: 0,
-            last_probe_encoded: 0,
-            max_probe_rate: 1.0,
             charged_streams: BTreeSet::new(),
             min_stream: None,
             max_stream: None,
@@ -1190,59 +1188,55 @@ impl PartBuilder {
     /// short of the target, and bound how far past the target the part can then
     /// close.
     ///
-    /// The step is the proxy distance to the next probe. Two things set it:
+    /// The step is the proxy distance to the next probe, and it is the remaining
+    /// encoded deficit `target - encoded_now` spent along the PROXY axis, floored
+    /// at [`PROBE_MIN_STEP_BYTES`] so a part whose deficit is a handful of bytes
+    /// does not encode once per record.
     ///
-    /// - a CAP, which is what bounds the overshoot. The step never exceeds the
-    ///   deficit divided by [`Self::max_probe_rate`], the densest
-    ///   encoded-per-proxy rate any interval of this part has shown, held at 1:1
-    ///   or above. So if the records over the next interval encode at that rate,
-    ///   the part lands exactly on the target; they have to encode DENSER than
-    ///   every interval so far to go past it.
-    /// - the [`PROBE_MIN_STEP_BYTES`] floor, so a part whose deficit is a
-    ///   handful of bytes does not encode once per record.
+    /// Spending an encoded deficit as a proxy distance is the whole bound, and
+    /// the assumption it rests on is 1:1: over the interval that closes the
+    /// part, encoded bytes grow by at most as much as the uncompressed payload
+    /// proxy does. Under that assumption a probe that found `encoded_now <
+    /// target` cannot be followed by a close more than `step` of encoded growth
+    /// later, and the next probe fires at the first record on or after
+    /// `stored_estimate + step`, so the proxy -- and with it the encoded size --
+    /// advances by at most `step` plus that record's own charge. With
+    /// `step = deficit` that lands the close at `target` plus one record's
+    /// charge; with the floor binding (`deficit < PROBE_MIN_STEP_BYTES`) at
+    /// `target + PROBE_MIN_STEP_BYTES` plus one record's charge. So the enforced
+    /// band is
+    /// `[target, target + PROBE_MIN_STEP_BYTES + one record's proxy charge]`,
+    /// and the same arithmetic bounds a trailing part (its records simply run
+    /// out before the next probe).
     ///
-    /// The band that follows: a probe found `encoded_now < target`, the next one
-    /// fires at the first record on or after `stored_estimate + step`, so the
-    /// proxy advances by at most `step` plus that record's own charge, and the
-    /// encoded size by at most that interval's rate times that. While that rate
-    /// stays at or below [`Self::max_probe_rate`] the close lands in
-    /// `[target, target + PROBE_MIN_STEP_BYTES + one record's proxy charge]`, and
-    /// the same arithmetic bounds a trailing part (its records simply run out
-    /// before the next probe). It is conditional on that rate assumption, which
-    /// holds for the sections the proxy models -- the payload columns and
-    /// STREAM_DIR, where the proxy counts uncompressed bytes and the object
-    /// stores compressed ones -- and not on the ones it does not (POSTINGS,
-    /// SKIP_IDX, PAGE_DIR). It is not the "one record" tightness the memory
-    /// split target has, and the rate model inside the cap is an estimate, never
-    /// a guarantee: without the cap, a compressible prefix followed by an
-    /// incompressible suffix closes tens of times past the target.
+    /// The 1:1 assumption is the disclosed condition, not a proof: it holds for
+    /// the sections the proxy models -- the payload columns and STREAM_DIR, where
+    /// the proxy counts uncompressed bytes and the object stores compressed ones,
+    /// so encoded growth per proxy byte is at most 1 and usually far below it --
+    /// and not for the sections it does not model (POSTINGS, SKIP_IDX,
+    /// PAGE_DIR), which can grow faster than the payload they index and carry a
+    /// part past the band. It is also not the "one record" tightness the memory
+    /// split target has.
     ///
-    /// The cost of the cap is probes: a part converges on the target from below
-    /// in steps of the remaining deficit, so a stream whose payload compresses
-    /// `r`-fold takes on the order of `r` encodes per part rather than the two
-    /// or three an uncapped rate model would take. That cost is only paid when
-    /// an operator lowers `max_l1_part_bytes` below the memory split target; at
-    /// the shipped defaults no probe runs at all.
+    /// The cost is probes, and it is superlinear in compressibility rather than
+    /// the two or three encodes a per-part rate model would spend. A payload
+    /// that compresses `r`-fold turns a step of `deficit` proxy bytes into only
+    /// `deficit / r` encoded bytes, so each probe closes a `1 / r` fraction of
+    /// the deficit and the deficit decays GEOMETRICALLY by `(1 - 1 / r)` per
+    /// probe. Starting from the deficit at the first probe,
+    /// `d0 = target * (1 - 1 / r)` (the proxy reaches `target` when the object is
+    /// near `target / r`), reaching the floor takes
+    /// `ln(d0 / PROBE_MIN_STEP_BYTES) / ln(1 / (1 - 1 / r))` probes, which is
+    /// about `r * ln(d0 / PROBE_MIN_STEP_BYTES)`, and the tail below the floor
+    /// takes about `r` more (each floored step closes
+    /// `PROBE_MIN_STEP_BYTES / r`). So probes per part are about
+    /// `r * ln(d0 / PROBE_MIN_STEP_BYTES) + r`, and both stored-target geometry
+    /// tests pin the exact count their fixture produces against that formula.
+    /// The cost is only paid when an operator lowers `max_l1_part_bytes` below
+    /// the memory split target; at the shipped defaults no probe runs at all.
     fn schedule_next_probe(&mut self, encoded_now: u64, target: u64) {
         let deficit = target.saturating_sub(encoded_now);
-        // The rate over THIS interval, not since the part opened. Both ends are
-        // measured quantities: `d_proxy` is at least PROBE_MIN_STEP_BYTES after
-        // the first probe and at least `target` at it, so the `max(1)` guards a
-        // degenerate zero rather than being a live case.
-        let d_proxy = self
-            .stored_estimate
-            .saturating_sub(self.last_probe_stored)
-            .max(1);
-        let d_encoded = encoded_now.saturating_sub(self.last_probe_encoded);
-        let marginal = d_encoded as f64 / d_proxy as f64;
-        if marginal > self.max_probe_rate {
-            self.max_probe_rate = marginal;
-        }
-        // `max_probe_rate` starts at 1.0 and only grows, so `step <= deficit`.
-        let step = ((deficit as f64) / self.max_probe_rate).ceil() as u64;
-        let step = step.max(PROBE_MIN_STEP_BYTES);
-        self.last_probe_stored = self.stored_estimate;
-        self.last_probe_encoded = encoded_now;
+        let step = deficit.max(PROBE_MIN_STEP_BYTES);
         self.next_probe_stored = self.stored_estimate.saturating_add(step);
     }
 }
@@ -4027,15 +4021,42 @@ mod tests {
     /// the scheduler's guarantee rather than this fixture's luck. A part closes
     /// the moment a probe shows its object reaching `STORED_TARGET`. Probes sit
     /// at least [`PROBE_MIN_STEP_BYTES`] of payload proxy apart, and
-    /// [`PartBuilder::schedule_next_probe`] never aims one further ahead than the
-    /// remaining deficit at the densest encoded-per-proxy rate the part has
-    /// measured (never assumed below 1:1), so between two probes the encoded size
-    /// grows by at most that deficit plus the floor plus the charge of the record
-    /// that crosses. Every part therefore sits in `[STORED_TARGET, STORED_TARGET
-    /// + PROBE_MIN_STEP_BYTES + one record's proxy charge]`. The trailing part
-    /// loses only the lower bound (its records run out before the next probe
-    /// rather than a probe closing it); the same upper bound covers it by the
-    /// same arithmetic, so it is asserted, not excused.
+    /// [`PartBuilder::schedule_next_probe`] aims the next one exactly the
+    /// remaining encoded deficit further along the proxy axis, so while encoded
+    /// bytes grow at most 1:1 with the proxy the encoded size grows between two
+    /// probes by at most that deficit (or the floor, when it is larger) plus the
+    /// charge of the record that crosses. Every part therefore sits in
+    /// `[STORED_TARGET, STORED_TARGET + PROBE_MIN_STEP_BYTES + one record's proxy
+    /// charge]`. The trailing part loses only the lower bound (its records run
+    /// out before the next probe rather than a probe closing it); the same upper
+    /// bound covers it by the same arithmetic, so it is asserted, not excused.
+    ///
+    /// The probe count is pinned exactly, and the pin is checked against the
+    /// scheduler's geometric cost model rather than merely recorded. Spending an
+    /// encoded deficit as a PROXY distance closes only a `1 / r` fraction of it
+    /// on a payload that compresses `r`-fold, so the deficit decays by
+    /// `(1 - 1 / r)` per probe: from the deficit at the crossing probe,
+    /// `d0 = STORED_TARGET * (1 - 1 / r)`, the ladder takes
+    /// `ln(d0 / PROBE_MIN_STEP_BYTES) / ln(r / (r - 1))` probes to reach the
+    /// floor, about `r` more below it (each floored step closes
+    /// `PROBE_MIN_STEP_BYTES / r`), plus the crossing probe itself -- which is
+    /// `r * ln(d0 / PROBE_MIN_STEP_BYTES) + r` for large `r`.
+    ///
+    /// This fixture measures `r` = 7.08 (`ratio` below, printed by the run), so
+    /// `d0` = 14_069, the ladder is `ln(14069 / 4096) / ln(7.08 / 6.08)` = 8.1
+    /// probes, the floor tail is 7.1, and with the crossing probe that is 16.2
+    /// per part. 11 of the 12 parts close on the target (178 probes) and the
+    /// trailing part runs its own partial ladder without ever closing (its proxy
+    /// passes the target, its records run out), which accounts for the remaining
+    /// 13 of the 191 pinned below. The model treats `r` as constant along a part
+    /// and ignores that a floored step overshoots, so a few percent is the
+    /// expected agreement; a change that made probing linear in the deficit, or
+    /// per-record, would miss it by an order of magnitude. Demonstrated red by
+    /// the rate-model scheduler named in
+    /// [`stored_target_overshoot_is_bounded_when_compressibility_collapses`]
+    /// (an uncapped cumulative-rate step in place of
+    /// `let step = deficit.max(PROBE_MIN_STEP_BYTES);`), under which this fixture
+    /// runs 34 probes, not 191.
     ///
     /// Demonstrated red against the old proxy-as-close design: replace the probe
     /// block in `PartSink::push` with `over_stored = part.stored_estimate >=
@@ -4123,10 +4144,24 @@ mod tests {
         let band_top = STORED_TARGET + PROBE_MIN_STEP_BYTES + max_record_charge;
         println!(
             "[geom:rlog #872] target={STORED_TARGET}B parts={} probes={} band_top={band_top}B \
-             sizes={:?}",
+             ratio={ratio:.2} sizes={:?}",
             parts.len(),
             tracker.probes_run(),
             rec.parts.iter().map(|p| p.object_size).collect::<Vec<_>>()
+        );
+        // The probe cost, pinned exactly (the corpus is deterministic) and cross
+        // checked against the geometric model in the doc comment above:
+        // r = 7.08, d0 = STORED_TARGET * (1 - 1/r) = 14_069, ladder
+        // ln(14069/4096) / ln(7.08/6.08) = 8.1, floor tail r = 7.1, crossing
+        // probe 1, so 16.2 per part; 11 closing parts = 178, plus the trailing
+        // part's partial ladder = 191 pinned.
+        assert_eq!(
+            tracker.probes_run(),
+            191,
+            "the exact-encode probe count for this fixture is deterministic; the \
+             geometric model predicts about 16.2 probes per part for r={ratio:.2} \
+             over {} parts",
+            parts.len()
         );
         let last = parts.len() - 1;
         for (i, p) in rec.parts.iter().enumerate() {
@@ -4217,26 +4252,29 @@ mod tests {
     /// to be worth running; it puts no ceiling on the object that probe then
     /// measures. Fitted on a compressible prefix, the step it asks for is tens of
     /// times the remaining deficit, and an incompressible suffix inside that step
-    /// closes a part many times over the target. What bounds
-    /// it is the cap in [`PartBuilder::schedule_next_probe`]: the step never
-    /// exceeds the remaining deficit at the densest encoded-per-proxy rate the
-    /// part has measured, and never assumes a rate below 1:1, so the encoded size
-    /// cannot pass the target by more than [`PROBE_MIN_STEP_BYTES`] plus the
-    /// proxy charge of the record that crosses -- the same band the uniform
-    /// fixture asserts, now over a corpus that breaks the rate model.
+    /// closes a part many times over the target. What bounds it is that
+    /// [`PartBuilder::schedule_next_probe`] spends the remaining ENCODED deficit
+    /// as a PROXY distance and models no rate at all: the step assumes only that
+    /// encoded bytes grow at most 1:1 with the proxy over the closing interval,
+    /// so the encoded size cannot pass the target by more than
+    /// [`PROBE_MIN_STEP_BYTES`] plus the proxy charge of the record that crosses
+    /// -- the same band the uniform fixture asserts, now over a corpus on which
+    /// any fitted rate is wrong.
     ///
-    /// Demonstrated red against the uncapped scheduler this replaced: restore the
-    /// cumulative rate and the uncapped step in `schedule_next_probe` --
+    /// Demonstrated red against the uncapped rate-model scheduler this replaced:
+    /// substitute an uncapped cumulative-rate step in `schedule_next_probe` --
     /// `let rate = (encoded_now as f64 / self.stored_estimate.max(1) as f64)
-    /// .max(f64::MIN_POSITIVE); let step = ((deficit as f64) / rate).ceil() as
-    /// u64;` (dropping the `max_probe_rate` update, whose floor of 1.0 is the
-    /// cap) -- and this fixture emits 29 parts whose first object is 150_646
-    /// bytes, 9.2x the 16 KiB target, failing the band assertion below at part 0.
-    /// The remaining parts land between 16_853 and 18_893 bytes, inside the band,
-    /// which is why the assertion covers every part and not just the largest. The
-    /// uniformly compressible corpus of
-    /// [`stored_target_closes_parts_on_actual_encoded_object_bytes`] passes under
-    /// both schedulers, which is exactly why this fixture exists.
+    /// .max(f64::MIN_POSITIVE); let step = (((deficit as f64) / rate).ceil() as
+    /// u64).max(PROBE_MIN_STEP_BYTES);` in place of
+    /// `let step = deficit.max(PROBE_MIN_STEP_BYTES);` -- and the probe pin below
+    /// fails first at 85 against 124, then, with the pin relaxed to 85, this
+    /// fixture emits 29 parts whose first object is 150_646 bytes, 9.2x the
+    /// 16 KiB target, failing the band assertion at part 0. The remaining parts
+    /// land between 16_853 and 18_893 bytes, inside the band, which is why the
+    /// assertion covers every part and not just the largest. The uniformly
+    /// compressible corpus of
+    /// [`stored_target_closes_parts_on_actual_encoded_object_bytes`] passes the
+    /// band under both schedulers, which is exactly why this fixture exists.
     #[tokio::test]
     async fn stored_target_overshoot_is_bounded_when_compressibility_collapses() {
         const PER_INPUT: i64 = 2000;
@@ -4314,9 +4352,22 @@ mod tests {
             parts.len() - 1,
             "every closed part must have closed on the stored target"
         );
-        assert!(
-            tracker.probes_run() > 0,
-            "the fixture must actually exercise the probe scheduler"
+        // The probe cost, pinned exactly rather than as `> 0`: the corpus is
+        // deterministic, so the geometric model is checkable against it. Almost
+        // every part of this fixture lies past the collapse, where
+        // r = 1 / post_rate = 1.59, so d0 = STORED_TARGET * (1 - 1/r) = 6_072,
+        // the ladder to the floor is ln(6072/4096) / ln(1.59/0.59) = 0.4 probes,
+        // the floor tail is r = 1.6, and the crossing probe makes 3.0 per part:
+        // 40 closing parts = 120, plus the first part's longer ladder across the
+        // compressible prefix (r = 1/pre_rate = 46 there) = 124 pinned.
+        assert_eq!(
+            tracker.probes_run(),
+            124,
+            "the exact-encode probe count for this fixture is deterministic; the \
+             geometric model predicts about 3.0 probes per part for \
+             r={:.2} past the collapse, over {} parts",
+            1.0 / post_rate,
+            parts.len()
         );
 
         // The band, identical to the uniform fixture's because it is the
@@ -4366,6 +4417,125 @@ mod tests {
             split_rows.len() as u64,
             total,
             "every record survives the split exactly once"
+        );
+    }
+
+    /// ADR-0979 / issue #872: the exact-encode probe's residency is CHARGED to
+    /// the tracker, so a stored-target-bound run's peak is the real peak instead
+    /// of the writer buffer alone.
+    ///
+    /// [`PartBuilder::encode_clone`] clones the part's buffered records and
+    /// encodes the clone, so at the instant the probe returns the run holds the
+    /// writer's records, a second copy of them inside the writer the probe built,
+    /// and the encoded object those records produced. That is roughly
+    /// `2 * W + object bytes` where `W` is the part's record-heap estimate at the
+    /// probe, not the `W` a probe-free run reports, and
+    /// [`MergeMemoryTracker::peak_total_bytes`] has to cover it for a host to be
+    /// sized from it.
+    ///
+    /// Asserted proportionally against the tracker's own `peak_writer_bytes`,
+    /// which is `W` measured at the same close, so the claim needs no
+    /// hand-computed heap figure: the tracked peak must be at least 2x it (the
+    /// clone), and is expected under 3x it (the clone plus one object, an object
+    /// being a small fraction of the heap on this fixture -- the printed figures
+    /// give the exact multiple). The probe term alone is asserted to carry at
+    /// least the clone and at most the clone plus one band-width object.
+    ///
+    /// Demonstrated red by removing the charge: delete the two
+    /// `t.set_probe_bytes(part.estimate...)` calls in `PartSink::push` (keeping
+    /// the `t.set_probe_bytes(0)` and the counter), and `peak_probe_bytes()`
+    /// reads 0 -- failing the clone assertion below -- while `peak_total_bytes()`
+    /// falls from 486_654 to 252_714 against a `peak_writer_bytes()` of 217_189,
+    /// a 1.16x multiple that also misses the 2x-to-3x band.
+    #[tokio::test]
+    async fn probe_residency_is_charged_to_the_tracked_peak() {
+        const PER_INPUT: i64 = 1200;
+        const INPUTS: i64 = 2;
+        const STORED_TARGET: u64 = 16 * 1024;
+
+        let store = Arc::new(MemoryStore::new());
+        for j in 0..INPUTS {
+            let recs: Vec<LogRecord> = (0..PER_INPUT)
+                .map(|i| ratio_record(i * INPUTS + j))
+                .collect();
+            // Small L0 blocks so the decode-side terms `peak_total_bytes` pools
+            // in stay a fraction of one part's heap, and the multiple below is
+            // about the writer and the probe rather than about cursors. Blocking
+            // changes nothing about the merged record sequence, so the split
+            // points and the probe count are the same as with default blocking.
+            seed_l0(
+                store.as_ref(),
+                Uuid::from_u128(j as u128 + 1),
+                j as u64 + 1,
+                &recs,
+                RlogConfig {
+                    block_target_records: 40,
+                    group_target_blocks: 1,
+                    ..RlogConfig::default()
+                },
+                &[],
+            )
+            .await;
+        }
+
+        let tracker = MergeMemoryTracker::new();
+        let config = CompactorConfig {
+            max_l1_part_bytes: STORED_TARGET,
+            merge_memory_tracker: Some(tracker.clone()),
+            ..CompactorConfig::default()
+        };
+        let clock = FixedClock::new(sealed_now_ns());
+        compact_bucket(store.as_ref(), &clock, &config, &bucket())
+            .await
+            .expect("compact");
+
+        let (_rec, parts) = read_output(store.as_ref()).await;
+        assert!(
+            parts.len() >= 3,
+            "the fixture must close several parts on the stored target, got {}",
+            parts.len()
+        );
+        let peak_total = tracker.peak_total_bytes();
+        let peak_writer = tracker.peak_writer_bytes();
+        let peak_probe = tracker.peak_probe_bytes();
+        let multiple = peak_total as f64 / peak_writer.max(1) as f64;
+        println!(
+            "[memory:rlog #872] parts={} probes={} peak_writer={peak_writer}B \
+             peak_probe={peak_probe}B peak_total={peak_total}B multiple={multiple:.2}x",
+            parts.len(),
+            tracker.probes_run()
+        );
+        // Deterministic corpus, so the probe count is pinned here too: r = 7.08
+        // as in `stored_target_closes_parts_on_actual_encoded_object_bytes`
+        // (same `ratio_record` fixture), 16.2 probes per part by the geometric
+        // model, 5 closing parts = 81 plus the trailing part's partial ladder =
+        // 89. Under the rate-model scheduler that test names it runs 16.
+        assert_eq!(
+            tracker.probes_run(),
+            89,
+            "the probe count is deterministic for this corpus: 16.2 per part by \
+             the geometric model over the {} closing parts",
+            parts.len() - 1
+        );
+        assert!(
+            peak_writer > 0,
+            "the run must have buffered records for the charge to mean anything"
+        );
+        assert!(
+            peak_probe >= peak_writer,
+            "the probe term must carry at least the cloned record heap: \
+             peak_probe={peak_probe} peak_writer={peak_writer}"
+        );
+        assert!(
+            peak_probe <= peak_writer + 2 * STORED_TARGET,
+            "the probe term must be one clone plus one object, not more: \
+             peak_probe={peak_probe} peak_writer={peak_writer}"
+        );
+        assert!(
+            (2.0..3.0).contains(&multiple),
+            "a probing run's tracked peak must cover the probe's second copy of \
+             the part heap: peak_total={peak_total} is {multiple:.2}x \
+             peak_writer={peak_writer}, expected 2x to 3x"
         );
     }
 
@@ -4453,6 +4623,11 @@ mod tests {
     /// reaches the 64 KiB target, no probe is ever scheduled, and the merge emits
     /// a single ~270 KiB object, failing the `object_size < 2 * STORED_TARGET`
     /// assertion.
+    ///
+    /// The probe count is pinned exactly rather than left printed, and it is the
+    /// scheduler's figure, not the charge's: under the rate-model scheduler named
+    /// in [`stored_target_overshoot_is_bounded_when_compressibility_collapses`]
+    /// this fixture runs 8 probes, not 15.
     #[tokio::test]
     async fn many_streams_charge_stream_dir_against_the_stored_target() {
         const STREAMS: u32 = 96;
@@ -4481,6 +4656,17 @@ mod tests {
             charge > per_record * 100,
             "fixture must be STREAM_DIR-dominated: charge {charge} vs record {per_record}"
         );
+        // The fixture's proxy-to-object ratio, measured over one part's worth of
+        // distinct streams, for the probe-count arithmetic below. The pads are
+        // pseudo-random alphanumerics, so `r` sits just above 1.
+        let sample: Vec<LogRecord> = (0..20).map(|s| fat_stream_record(s, 0)).collect();
+        let sample_proxy: u64 = sample.iter().map(estimate_stored_record).sum::<u64>()
+            + sample
+                .iter()
+                .map(|r| estimate_stored_stream(&r.stream_attrs))
+                .sum::<u64>();
+        let (_, sample_object) = proxy_and_object_bytes(&sample);
+        let ratio = sample_proxy as f64 / sample_object as f64;
 
         let tracker = MergeMemoryTracker::new();
         let config = CompactorConfig {
@@ -4512,6 +4698,28 @@ mod tests {
             tracker.stored_target_flushes() as usize,
             parts.len() - 1,
             "every closed part (all but the trailing one) closed on the stored target"
+        );
+        // Probes pinned exactly, not left unasserted: the corpus is
+        // deterministic, and the figure agrees with the scheduler's geometric
+        // cost model (see `PartBuilder::schedule_next_probe`). r = 1.48 measured
+        // above, d0 = STORED_TARGET * (1 - 1/r) = 21_257, ladder
+        // ln(21257/4096) / ln(1.48/0.48) = 1.5, floor tail r = 1.5, crossing
+        // probe 1, so 3.9 per part; the 4 closing parts predict 15.8 against 15
+        // measured, and the trailing part never probes (its 14_400-byte object
+        // leaves the proxy short of the 64 KiB target).
+        println!(
+            "[geom:rlog #872] many-streams target={STORED_TARGET}B parts={} probes={} \
+             ratio={ratio:.2} sizes={:?}",
+            parts.len(),
+            tracker.probes_run(),
+            rec.parts.iter().map(|p| p.object_size).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            tracker.probes_run(),
+            15,
+            "the exact-encode probe count for this fixture is deterministic; the \
+             geometric model predicts 15.8 for r={ratio:.2} over the {} closing parts",
+            parts.len() - 1
         );
         // The probe measures the object it names: with the STREAM_DIR charge
         // scheduling it, each non-final part reaches the target and none runs

--- a/crates/ravel-maintain/tests/memory.rs
+++ b/crates/ravel-maintain/tests/memory.rs
@@ -223,7 +223,7 @@ async fn compaction_retains_no_part_bytes() {
     const RECORDS_PER_STREAM: usize = 4;
 
     let store = MemoryStore::new();
-    // A body long enough that a handful of records exceeds the tiny stored-size
+    // A body long enough that a handful of records exceeds the tiny memory split
     // target below, so the merge closes many parts rather than one.
     let body: String = "log-line-".repeat(24);
     for i in 0..INPUTS {
@@ -246,9 +246,14 @@ async fn compaction_retains_no_part_bytes() {
 
     let tracker = MergeMemoryTracker::new();
     let config = CompactorConfig {
-        // Small stored-size target so parts close often; this changes only where
-        // records split into parts, never their bytes.
-        max_l1_part_bytes: 2048,
+        // Small memory split target so parts close often; this changes only where
+        // records split into parts, never their bytes. The memory target is used
+        // rather than the stored-size target because D3 (retention released at
+        // PUT) holds on whichever target closes the part, and the memory target
+        // splits reliably regardless of how far the bodies compress (the stored
+        // target closes on real object bytes since issue #872, so a compressible
+        // fixture reaches it far more slowly).
+        l1_part_memory_target_bytes: 2048,
         merge_memory_tracker: Some(tracker.clone()),
         ..CompactorConfig::default()
     };
@@ -262,7 +267,7 @@ async fn compaction_retains_no_part_bytes() {
     let record = fetch_compaction_record(&store, &bucket).await;
     assert!(
         record.parts.len() >= 3,
-        "the small stored target must close at least three parts, got {}",
+        "the small memory split target must close at least three parts, got {}",
         record.parts.len()
     );
     // The parts really do carry bytes; the point is none of them stay resident.

--- a/crates/ravel-maintain/tests/memory.rs
+++ b/crates/ravel-maintain/tests/memory.rs
@@ -216,22 +216,33 @@ async fn peak_memory_on_rlog_input_bucket() {
 /// `<sum> != 0`. The flip is the exact behaviour D3 changes: retention at PUT
 /// vs release at PUT. The other phases are still asserted driven, so a merge
 /// that silently did nothing would fail here too.
-#[tokio::test]
-async fn compaction_retains_no_part_bytes() {
+///
+/// Run once per CLOSE PATH ([`ClosePath`]), because D3 releases at PUT whichever
+/// target closed the part and only one of the two paths reaches `finalize_part`
+/// per run: the memory split target closes on the decoded record heap, the
+/// stored-size target on an exact-encode probe's real object bytes (issue #872).
+/// Each variant asserts the flush counter of ITS target equals the number of
+/// closed parts, so a variant that silently closed on the other target fails
+/// instead of passing as coverage it does not have.
+async fn assert_compaction_retains_no_part_bytes(close_path: ClosePath) {
     const INPUTS: usize = 24;
     const STREAMS: u32 = 4;
     const RECORDS_PER_STREAM: usize = 4;
 
     let store = MemoryStore::new();
-    // A body long enough that a handful of records exceeds the tiny memory split
-    // target below, so the merge closes many parts rather than one.
-    let body: String = "log-line-".repeat(24);
     for i in 0..INPUTS {
         let mut records = Vec::new();
         for s in 0..STREAMS {
             for r in 0..RECORDS_PER_STREAM {
                 let ts = 1_000 + (i * RECORDS_PER_STREAM + r) as i64;
-                records.push(log_record(s, ts, &format!("{body}-{s}-{i}-{r}")));
+                // A body long enough that a handful of records exceeds the tiny
+                // memory split target, and INCOMPRESSIBLE so it also grows the
+                // real object bytes the stored-size target closes on: a repeated
+                // filler would zstd the whole bucket down to one object well
+                // under any workable stored target and the StoredTarget variant
+                // would never split.
+                let body = incompressible_body(((i * 100 + s as usize) * 100 + r) as u64, 216);
+                records.push(log_record(s, ts, &body));
             }
         }
         seed_rlog_input(
@@ -245,15 +256,17 @@ async fn compaction_retains_no_part_bytes() {
     }
 
     let tracker = MergeMemoryTracker::new();
+    // A small target on the axis under test, and the other left at its shipped
+    // 256 MiB default so it cannot fire. This changes only where records split
+    // into parts, never their bytes.
+    let defaults = CompactorConfig::default();
+    let (memory_target, stored_target) = match close_path {
+        ClosePath::MemoryTarget => (2048, defaults.max_l1_part_bytes),
+        ClosePath::StoredTarget => (defaults.l1_part_memory_target_bytes, 2048),
+    };
     let config = CompactorConfig {
-        // Small memory split target so parts close often; this changes only where
-        // records split into parts, never their bytes. The memory target is used
-        // rather than the stored-size target because D3 (retention released at
-        // PUT) holds on whichever target closes the part, and the memory target
-        // splits reliably regardless of how far the bodies compress (the stored
-        // target closes on real object bytes since issue #872, so a compressible
-        // fixture reaches it far more slowly).
-        l1_part_memory_target_bytes: 2048,
+        l1_part_memory_target_bytes: memory_target,
+        max_l1_part_bytes: stored_target,
         merge_memory_tracker: Some(tracker.clone()),
         ..CompactorConfig::default()
     };
@@ -267,8 +280,29 @@ async fn compaction_retains_no_part_bytes() {
     let record = fetch_compaction_record(&store, &bucket).await;
     assert!(
         record.parts.len() >= 3,
-        "the small memory split target must close at least three parts, got {}",
+        "the small {close_path:?} target must close at least three parts, got {}",
         record.parts.len()
+    );
+    // The parts closed on the path this variant is for, not on the other one,
+    // and the exact-encode probe count is the deterministic figure that path
+    // implies: zero on the memory path, one per probe the stored path scheduled.
+    let closed = (record.parts.len() - 1) as u64;
+    let (expected_flushes, expected_probes) = match close_path {
+        ClosePath::MemoryTarget => ((closed, 0), 0),
+        ClosePath::StoredTarget => ((0, closed), 28),
+    };
+    assert_eq!(
+        (
+            tracker.memory_target_flushes(),
+            tracker.stored_target_flushes()
+        ),
+        expected_flushes,
+        "the {close_path:?} variant's parts must all close on that target"
+    );
+    assert_eq!(
+        tracker.probes_run(),
+        expected_probes,
+        "the {close_path:?} variant's probe count is deterministic for this corpus"
     );
     // The parts really do carry bytes; the point is none of them stay resident.
     let part_bytes_sum: u64 = record.parts.iter().map(|p| p.object_size).sum();
@@ -305,16 +339,59 @@ async fn compaction_retains_no_part_bytes() {
         "the finish/publish term must have been driven"
     );
     println!(
-        "[memory:rlog:979] parts={} part_bytes_sum={part_bytes_sum} \
+        "[memory:rlog:979] close_path={close_path:?} parts={} \
+         part_bytes_sum={part_bytes_sum} \
          retained_part_encoded_bytes={} writer_heap_bytes={} \
-         cursor_bytes={} catalog_directory_decoded_bytes={} publish_record_encoded_bytes={}",
+         cursor_bytes={} catalog_directory_decoded_bytes={} publish_record_encoded_bytes={} \
+         probes={}",
         record.parts.len(),
         peaks.retained_part_encoded_bytes,
         peaks.writer_heap_bytes,
         peaks.cursor_bytes,
         peaks.catalog_directory_decoded_bytes,
         peaks.publish_record_encoded_bytes,
+        tracker.probes_run(),
     );
+}
+
+/// `n` bytes of deterministic pseudo-random alphanumerics, distinct per `seed`
+/// (an LCG, so the fixture is reproducible). Used for log bodies that must not
+/// compress across records.
+fn incompressible_body(seed: u64, n: usize) -> String {
+    const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+    let mut state = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut out = String::with_capacity(n);
+    for _ in 0..n {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        out.push(ALPHABET[(state >> 33) as usize % ALPHABET.len()] as char);
+    }
+    out
+}
+
+/// Which split target closes the parts in
+/// [`assert_compaction_retains_no_part_bytes`]. ADR-0979 D3 releases a part's
+/// bytes at PUT on both, and only the target that fires reaches that code, so
+/// both are exercised.
+#[derive(Copy, Clone, Debug)]
+enum ClosePath {
+    /// `l1_part_memory_target_bytes`: the part's decoded record-heap estimate
+    /// reaches the target.
+    MemoryTarget,
+    /// `max_l1_part_bytes`: an exact-encode probe shows the part's real object
+    /// bytes reaching the target (issue #872).
+    StoredTarget,
+}
+
+#[tokio::test]
+async fn compaction_retains_no_part_bytes() {
+    assert_compaction_retains_no_part_bytes(ClosePath::MemoryTarget).await;
+}
+
+#[tokio::test]
+async fn compaction_retains_no_part_bytes_on_stored_target_close() {
+    assert_compaction_retains_no_part_bytes(ClosePath::StoredTarget).await;
 }
 
 /// A tracker left installed across SERIAL runs reports each run's own peaks:

--- a/docs/adrs/0979-bounded-memory-rlog-compaction-merge.md
+++ b/docs/adrs/0979-bounded-memory-rlog-compaction-merge.md
@@ -306,7 +306,7 @@ cursor fan-out term).
 ### The memory bound, as an operator evaluates it
 
 ```text
-peak ≈ C_cat + min(D × (2·G + B_dec), merge_cursor_budget_bytes) + W
+peak ≈ C_cat + min(D × (2·G + B_dec), merge_cursor_budget_bytes) + W + P
 
 C_cat  = per-input catalog metadata ≈ 30 KB × input_objects        (~220 MB here)
 D      = max concurrent ts-overlap of one stream's input slices     (≤ objects carrying
@@ -336,10 +336,23 @@ B_dec  = one decoded columnar block                                  (~18-25 MB 
          `max column id + 1` comes from FIELD_DIR, pre-decode, like
          the other shape inputs.
 W      = in-progress part writer buffer ≤ ~1.3 × l1_part_memory_target_bytes  (~340 MB default)
+P      = exact-encode probe transient (issue #872)                   (0 at the shipped
+         Zero unless the stored-size target `max_l1_part_bytes`        defaults; ≈ W + object
+         binds: the RLOG merge measures a part by encoding a CLONE     bytes when the stored
+         of its buffered records, so while a probe runs the run        target binds)
+         holds a second copy of the part's record heap (≈ W) plus
+         the encoded object those records produce (≤ the stored
+         target plus the overshoot band). A stored-target-bound run
+         therefore peaks near 2·W + one part's object bytes, not W.
+         Charged to the tracker (`MergeMemoryTracker::set_probe_bytes`),
+         so `peak_total_bytes` reports it rather than omitting it.
 ```
 
 For `cb-20260831140539`: `0.22 + min(617 × 25 MB, 20 GiB) + 0.34 ≈ 16 GB`
-worst case, `≈ 2.8 GB` if intra-stream time order holds. Today's code:
+worst case, `≈ 2.8 GB` if intra-stream time order holds (`P` = 0 at the
+shipped defaults, where the memory target binds and no probe runs; an operator
+who lowers `max_l1_part_bytes` below it must size for `2 × 0.34` plus one
+part's object bytes instead). Today's code:
 `0.22 + 617 × 80 MB + 0.34 + retained parts ≈ 50+ GB`.
 
 ## Compatibility and convergence


### PR DESCRIPTION
Part sizing measured decoded bytes against max_l1_part_bytes, and RLOG
compression runs near 74x on log corpora, so stored parts came out a
fraction of the configured target (3,459 parts of ~3.3 MB on the
100M-row ClickBench tenant against a much larger target). The split
decision now runs on encoded bytes: the part builder buffers records,
schedules an exact-encode probe against the stored-size deficit, and
closes on the probe that reaches the target.

The probe step is max(deficit, PROBE_MIN_STEP_BYTES) under a stated
at-most-1:1 encoded-per-proxy assumption, giving an enforced overshoot
band of [target, target + PROBE_MIN_STEP_BYTES + one record's charge];
the unmodelled sections (POSTINGS, SKIP_IDX, PAGE_DIR) are named as the
disclosed condition. Probe cost follows the geometric form
r*ln(d0/PROBE_MIN_STEP_BYTES) + r and every fixture pins its exact
probe count with the derivation beside it. Probe residency (the record
clone plus the encoded object) is charged to the merge memory tracker,
and ADR-0979's operator peak formula gains the probe term in the same
change. At shipped defaults the two targets coincide and a pinned test
proves zero probes run, so the default path's cost is unchanged.

Byte identity across the change is pinned by a differential fixture
whose expected hashes were captured from pre-fix main (76c90a3), and
probe and close encodes are byte-identical by construction, so a rerun
of a crashed or raced run still converges on identical content keys.

Two adversarial review rounds (six findings total) shaped the final
form; all were resolved with tests demonstrated failing.

Fixes: #872
Refs: #979
Signed-off-by: Panagiotis Moustafellos <pmoust@nofire.ai>
