### PR TITLE
fix(sql): reconcile .cstat row accounting before granting exact stats

### DIFF
--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -810,21 +810,29 @@ fn stamp_coverage(
 /// `None` when that carrier grants nothing: no object, no entry for this
 /// segment, no entry for the column, more than one entry under the column's
 /// name (`unique_column_stat` refuses to pick), an entry whose extrema
-/// presence disagrees with its `non_null_count` in either direction (#970), or
-/// a value of the wrong kind.
+/// presence disagrees with its `non_null_count` in either direction (#970), an
+/// entry whose row accounting (`non_null_count + null_count`) does not
+/// reconcile against the joined [`SegmentRef::sample_count`] (#1023), or a
+/// value of the wrong kind.
 ///
-/// Two of those refusals are DEFECTS rather than absences, and each reports one
-/// drop observation under [`StatCarrier::Cstat`] (ADR-0873 decision 2's metric,
-/// whose stamp-carrier labels are fed by the carrier reads in `ravel-commit`):
-/// a duplicated column name, and a presence/row-accounting contradiction. The
-/// other refusals are not counted, and the distinction is the point of the
-/// metric: an absent object, an absent segment entry, and an absent column
-/// entry are the ordinary uncovered state of every tenant whose fold never
-/// built that column, while a value of a kind the tenant's current declared
-/// type does not match is a legal consequence of re-declaring a column, not a
-/// writer bug.
+/// Three of those refusals are DEFECTS rather than absences, and each reports
+/// one drop observation under [`StatCarrier::Cstat`] (ADR-0873 decision 2's
+/// metric, whose stamp-carrier labels are fed by the carrier reads in
+/// `ravel-commit`): a duplicated column name, a presence contradiction, and a
+/// row-accounting disagreement with the joined `sample_count`. The other
+/// refusals are not counted, and the distinction is the point of the metric: an
+/// absent object, an absent segment entry, and an absent column entry are the
+/// ordinary uncovered state of every tenant whose fold never built that column,
+/// while a value of a kind the tenant's current declared type does not match is
+/// a legal consequence of re-declaring a column, not a writer bug.
+///
+/// The reconciliation is a fail-closed gate on the WHOLE entry, extrema
+/// included: a stale or miscounted entry describes rows this immutable object
+/// does not have (or omits rows it does), so no figure it carries -- not just
+/// its null count -- may be granted `Precision::Exact`.
 fn cstat_coverage(
     declared: &DeclaredColumn,
+    seg: &SegmentRef,
     seg_stats: Option<&ravel_proto::catalog::v1::ColumnStatsSegment>,
 ) -> Option<SegmentCoverage> {
     let seg_stats = seg_stats?;
@@ -850,6 +858,17 @@ fn cstat_coverage(
     // public fields and can be populated by a carrier that never decoded an
     // object, so the check has to bind here, where coverage is granted.
     if validate_min_max_presence(stat).is_err() {
+        observe_declared_stat_drops(StatCarrier::Cstat, 1);
+        return None;
+    }
+    // Reconcile the entry's row accounting against the immutable segment it is
+    // joined to before granting any figure (ADR-0873 decision 2, clause 4's
+    // `.cstat` arm): `non_null_count + null_count` must equal the joined
+    // `SegmentRef::sample_count`. A checked add is used so an overflowing sum is
+    // itself a disagreement rather than a wrap, and either shape refuses the
+    // whole entry -- extrema included -- and is counted as a drop.
+    let accounted = stat.non_null_count.checked_add(stat.null_count);
+    if accounted != Some(seg.sample_count) {
         observe_declared_stat_drops(StatCarrier::Cstat, 1);
         return None;
     }
@@ -1489,13 +1508,14 @@ impl LogsScanExec {
     /// already pinned both to the same value, so one proof covers both);
     /// today the proving carrier is the stamp: a stamp's
     /// `null_count` passed clauses 4 and 5 against the carrying record's own
-    /// row count before the type existed, while a `.cstat` entry's row
-    /// accounting is not reconciled against the joined
-    /// `SegmentRef::sample_count` anywhere on this path (ADR-0873 decision 2
-    /// requires it of that carrier; the tree does not yet do it). An
-    /// unreconciled `null_count` reported as `Precision::Exact` would answer
-    /// `COUNT(col)` from a figure nothing checked, so it stays `Absent` and
-    /// only the extrema are claimed.
+    /// row count before the type existed. A `.cstat` entry's row accounting is
+    /// now reconciled against the joined `SegmentRef::sample_count` in
+    /// [`cstat_coverage`] (ADR-0873 decision 2, clause 4's arm), but that
+    /// reconciliation is a fail-closed gate on what the entry may grant --
+    /// extrema included -- not a promotion of its `null_count` to a proven
+    /// figure: the entry still reports `null_count_proven = false`, so a
+    /// `.cstat`-only column still answers `COUNT(col)` as `Absent` rather than
+    /// from a count no carrier proved. Only the extrema are claimed.
     ///
     /// Resolving every column in one segment walk instead of one full walk per
     /// column keeps `partition_statistics` cost at
@@ -1544,7 +1564,7 @@ impl LogsScanExec {
                 let declared = &self.declared[k];
                 let coverage = match (
                     stamp_coverage(declared, stamps),
-                    cstat_coverage(declared, seg_stats),
+                    cstat_coverage(declared, seg, seg_stats),
                 ) {
                     // Covered by neither: the ordinary uncovered state,
                     // never an error, and the column falls back to a scan.

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -680,7 +680,9 @@ fn record_carrier_conflict(
 /// [`stamp_coverage`]'s parameter type ([`DeclaredColumnStats`], constructable
 /// non-empty only from a `ValidatedDeclaredStats`) rather than a convention its
 /// caller is trusted to have followed; false for a `.cstat` entry, whose row
-/// accounting this path does not reconcile.
+/// accounting [`cstat_coverage`] reconciles against the segment's
+/// `sample_count` before any grant but whose NULL count is deliberately not
+/// promoted to proven here.
 #[derive(Clone)]
 struct SegmentCoverage {
     min: Option<ScalarValue>,
@@ -701,9 +703,10 @@ impl SegmentCoverage {
 /// The exact statistics one declared column's carriers prove over every
 /// segment a scan touches, from [`LogsScanExec::declared_min_max_all`].
 ///
-/// `null_count` is `None` when at least one covering carrier's NULL count was
-/// not reconciled against the segment's row count; the extrema are still
-/// exact in that case (see the method's docs).
+/// `null_count` is `None` when at least one covering carrier's NULL count is
+/// not proven (a `.cstat` entry is reconciled against the segment's row count
+/// before any grant, but its NULL count is deliberately not promoted to
+/// proven); the extrema are still exact in that case (see the method's docs).
 #[derive(Clone)]
 pub(crate) struct DeclaredExactStats {
     pub(crate) min: ScalarValue,
@@ -2244,7 +2247,7 @@ impl ExecutionPlan for LogsScanExec {
                     col.min_value = Precision::Exact(exact.min);
                     col.max_value = Precision::Exact(exact.max);
                     // An unproven NULL count leaves `null_count` `Absent`
-                    // rather than reporting an unreconciled figure as exact;
+                    // rather than reporting an unproven figure as exact;
                     // the extrema stay exact either way.
                     if let Some(nulls) = exact.null_count
                         && let Ok(nulls) = usize::try_from(nulls)

--- a/crates/ravel-sql/tests/declared_stat_carrier_conflicts.rs
+++ b/crates/ravel-sql/tests/declared_stat_carrier_conflicts.rs
@@ -264,8 +264,8 @@ fn one_carrier_alone_is_not_a_conflict() {
     assert_eq!(
         col.null_count,
         Precision::Absent,
-        "a .cstat NULL count is not reconciled against the joined sample_count \
-         on this path, so it is never reported as exact"
+        "a .cstat NULL count is reconciled against the joined sample_count but \
+         deliberately not promoted to proven, so it is never reported as exact"
     );
     assert_eq!(delta, 0);
 }

--- a/crates/ravel-sql/tests/declared_stat_cstat_drops.rs
+++ b/crates/ravel-sql/tests/declared_stat_cstat_drops.rs
@@ -254,3 +254,101 @@ fn absence_and_validity_leave_the_cstat_label_untouched() {
     assert_eq!(col.min_value, Precision::Absent);
     assert_eq!((mine, others), (0, 0), "nor is an entryless segment");
 }
+
+/// A raw `ColumnStat`: unlike [`cstat`], it does not force
+/// `non_null_count + null_count == SAMPLE_COUNT`, so the reconciliation half of
+/// #1023 can be exercised with a deliberately unbalanced entry.
+fn raw_stat(
+    non_null_count: u64,
+    null_count: u64,
+    min: Option<i64>,
+    max: Option<i64>,
+) -> ColumnStat {
+    ColumnStat {
+        name: COL.to_string(),
+        declared_type: 2, // ravel.sys.v1.TypedAttrColumnType::I64
+        non_null_count,
+        null_count,
+        min: min.map(i64_value),
+        max: max.map(i64_value),
+        dictionary_present: false,
+        dictionary: Vec::new(),
+        sum: None,
+    }
+}
+
+/// #1023 reconciliation: an entry whose row accounting disagrees with the
+/// joined `SegmentRef::sample_count` grants NOTHING for the column -- the
+/// extrema included, not only the unproven null count -- and is counted once
+/// under `cstat`. Here `non_null_count(2) + null_count(1) = 3`, but the segment
+/// carries `SAMPLE_COUNT = 4` rows, so the entry describes an object that does
+/// not exist. Its extrema are internally consistent (non-null rows, both
+/// present), so `validate_min_max_presence` passes and only the sample_count
+/// reconciliation refuses it.
+///
+/// Prove-the-test: delete the `accounted != Some(seg.sample_count)` refusal
+/// block in `cstat_coverage` (crates/ravel-sql/src/logs_scan.rs). Both extrema
+/// then reach `Precision::Exact(200)`/`Exact(500)` from an unreconciled entry
+/// and the delta reads 0, which is the exact state #1023 item 3 was filed
+/// about; the `Absent` and `mine == 1` assertions both fail.
+#[test]
+fn a_row_accounting_mismatch_grants_nothing_and_is_counted() {
+    let (col, mine, others) = resolve(seg_ref(7), vec![raw_stat(2, 1, Some(200), Some(500))]);
+    assert_eq!(
+        col.min_value,
+        Precision::Absent,
+        "an unreconciled entry grants no MIN"
+    );
+    assert_eq!(
+        col.max_value,
+        Precision::Absent,
+        "nor a MAX: the whole entry is refused, not only its null count"
+    );
+    assert_eq!(mine, 1, "one unreconciled entry, counted once");
+    assert_eq!(others, 0, "and under the cstat label only");
+}
+
+/// #1023 reconciliation, the checkpoint's stale-all-NULL case: an entry claiming
+/// all-NULL (both extrema absent, `non_null_count == 0`) whose row accounting
+/// cannot be all-null, because `0 + null_count(0)` does not reach the segment's
+/// `SAMPLE_COUNT = 4` rows. Such an entry is internally consistent by the
+/// presence rule (`validate_min_max_presence` accepts absent extrema with zero
+/// non-null rows), so before reconciliation it was accepted as covering the
+/// segment while contributing nothing: the column's MIN/MAX then read as an
+/// exact NULL over a segment that actually holds four rows.
+///
+/// Prove-the-test: delete the same `accounted != Some(seg.sample_count)` block.
+/// The entry is then accepted, the single-segment column reports
+/// `Precision::Exact(Int64(None))` (an exact NULL) with the delta at 0, and the
+/// `Absent`/`mine == 1` assertions fail -- the silent nothing-contribution the
+/// wave-4 checkpoint named.
+#[test]
+fn a_stale_all_null_entry_grants_nothing_and_is_counted() {
+    let (col, mine, others) = resolve(seg_ref(8), vec![raw_stat(0, 0, None, None)]);
+    assert_eq!(
+        col.min_value,
+        Precision::Absent,
+        "a stale all-NULL entry that cannot be all-null is refused, not accepted \
+         as an exact NULL"
+    );
+    assert_eq!(col.max_value, Precision::Absent);
+    assert_eq!(mine, 1, "one stale entry, counted once");
+    assert_eq!(others, 0, "and under the cstat label only");
+}
+
+/// A reconciled, consistent entry keeps today's behavior exactly: the
+/// [`cstat`] helper balances `non_null_count + null_count` to `SAMPLE_COUNT`, so
+/// the reconciliation is a no-op and the entry answers with `Exact` extrema and
+/// no drop, identical to `absence_and_validity_leave_the_cstat_label_untouched`
+/// above. Pinned separately so a reconciliation that rejected a VALID entry
+/// (an off-by-one, a wrong comparand) would fail here rather than pass silently.
+#[test]
+fn a_reconciled_entry_keeps_todays_behavior() {
+    let (col, mine, others) = resolve(seg_ref(9), vec![cstat(COL, 200, 500, 1)]);
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Int64(Some(200))),
+        "3 non-null + 1 null == 4 == sample_count, so the entry still answers"
+    );
+    assert_eq!((mine, others), (0, 0), "a reconciled entry is not a defect");
+}

--- a/crates/ravel-sql/tests/logs_declared_minmax_from_stamps.rs
+++ b/crates/ravel-sql/tests/logs_declared_minmax_from_stamps.rs
@@ -918,9 +918,9 @@ async fn one_carrier_each_still_covers_the_whole_snapshot() {
     assert_eq!(out.gets, 0);
 
     // The NULL count, by contrast, stays `Absent`: segment B's figure comes
-    // from a `.cstat` entry, whose row accounting nothing on this path
-    // reconciles against the joined `sample_count`. The extrema are exact
-    // regardless.
+    // from a `.cstat` entry, which is reconciled against the joined
+    // `sample_count` before any grant but whose NULL count is deliberately
+    // not promoted to proven. The extrema are exact regardless.
     let col_stats = scan_stats(snapshot, Some(stats));
     let col = declared_col_stats(&col_stats);
     assert_eq!(

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -1542,6 +1542,54 @@ async fn all_null_column_carrying_extrema_declines_and_scans() {
     );
 }
 
+/// #1023 reconciliation, end to end: an entry whose row accounting disagrees
+/// with the joined `SegmentRef::sample_count` must decline and fall back to a
+/// scan, reading objects. Segment A's real object holds six rows, but its entry
+/// claims `non_null_count(3) + null_count(1) = 4`; the extrema are internally
+/// consistent (both present, non-null rows) and sit OUTSIDE the real corpus
+/// range (-1 and 999), so a pre-fix answer that trusts them cannot coincide with
+/// the correct one. The plan keeps its `LogsScanExec`, the answer is the true
+/// scanned `(200, 500)`, and the scan reads objects (`gets() > 0`).
+///
+/// Prove-the-test: delete the `accounted != Some(seg.sample_count)` refusal
+/// block in `cstat_coverage` (crates/ravel-sql/src/logs_scan.rs). The entry is
+/// then accepted, the plan loses its `LogsScanExec` for a `MetadataOnlyExec`,
+/// the answer becomes `(-1, 999)`, and `gets()` drops to 0; all three
+/// assertions fail.
+#[tokio::test]
+async fn a_row_accounting_mismatch_declines_and_scans() {
+    let corpus = RealCorpus::build().await;
+    let bad_stats = loaded_stats(vec![
+        (
+            &corpus.a,
+            // 3 + 1 = 4, but segment A holds six rows: unreconciled.
+            stats_segment(
+                &corpus.a,
+                vec![flat_i64_stat("status", 3, 1, Some(-1), Some(999))],
+            ),
+        ),
+        (
+            &corpus.b,
+            stats_segment(&corpus.b, vec![stat_from_rows(SEG_B_ROWS)]),
+        ),
+    ]);
+
+    let (shown, answer) = min_max_over(&corpus, bad_stats).await;
+    assert!(
+        shown.contains("LogsScanExec") && !shown.contains("MetadataOnlyExec"),
+        "an unreconciled row count must decline and fall back to a scan; plan was:\n{shown}"
+    );
+    assert_eq!(
+        answer,
+        (Some(200), Some(500)),
+        "the scan answers the true MIN/MAX, not the fabricated out-of-range extrema"
+    );
+    assert!(
+        corpus.store.gets() > 0,
+        "a declined statement must read objects"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // q03/q04: SUM(<declared integer column> + k), and q30: AVG(<declared integer
 // column>) -- answered from the exact per-object integer sum (#861). Every


### PR DESCRIPTION
ADR-0873's clause 4 requires a .cstat entry whose row accounting
diverges from the joined segment to be dropped before any exact grant.
cstat_coverage now compares the entry's non_null_count + null_count
(checked_add, fail-closed on overflow or absence) against the segment's
own sample_count before extracting any value; a mismatch drops the whole
entry, records one declared_stat_drops_observed(Cstat) observation, and
the column falls back to the scan with Precision::Absent. The reconcile
precedes every grant on the path and there is no early return around it.

The entry's NULL count is deliberately not promoted to proven: this
change is behavior-preserving for balanced entries, and a pinned test
keeps the reconciled happy path answering exactly with zero drops. A
divergent carrier built over real RLOG objects proves the fallback
answer itself is the scan's correct result, not merely that the grant
was dropped.

The checkpoint review found three sibling grant sites (not-equal count,
group counts, column sum) that still answer from an unreconciled entry;
that pre-existing gap is #1037, out of scope here.

Refs: #1023
Refs: #873
Signed-off-by: Panagiotis Moustafellos <pmoust@nofire.ai>
