### PR TITLE
docs: state the per-bucket division of the default merge budget

### DIFF
--- a/docs/adrs/0979-bounded-memory-rlog-compaction-merge.md
+++ b/docs/adrs/0979-bounded-memory-rlog-compaction-merge.md
@@ -306,6 +306,13 @@ closed with the same typed refusal naming the divided figure, which is
 the deliberate, visible outcome; the operator lowers N or sets the
 budget explicitly.
 
+Until D5's `--merge-cursor-budget-bytes` flag exists there is no way to
+set the budget explicitly, so "carries the default" is currently exact.
+When that flag lands, explicitness travels as an `Option` from the flag
+into the walk rather than being inferred by comparing the resolved value
+against the default, so an operator who explicitly sets the default
+value is honored undivided too.
+
 ### D5. CLI exposure
 
 `maintain compact-tenant` and `compact-bucket` gain

--- a/docs/adrs/0979-bounded-memory-rlog-compaction-merge.md
+++ b/docs/adrs/0979-bounded-memory-rlog-compaction-merge.md
@@ -293,6 +293,19 @@ reference box completes the ClickBench worst case: 617 × ~25 MB ≈ 15.4 GiB
 < 20 GiB, leaving ~10 GB of the 30 GB box for the writer buffer, catalogs,
 and process overhead.
 
+The default is sized against the WHOLE box, so a concurrent bucket walk
+(`compact-tenant --bucket-concurrency N`, issue #1028) divides it per
+bucket: each bucket receives `DEFAULT / N` (integer floor) and the
+N-bucket envelope stays inside the box the default was sized for. The
+division applies only while the budget still carries the default. A
+budget the operator configured explicitly is a whole-box decision and is
+passed through per bucket undivided; dividing it would also make
+`MergeCursorBudgetExceeded`'s raise-to-`required_bytes` remediation wrong
+at N > 1. A merge that no longer fits its `DEFAULT / N` share fails
+closed with the same typed refusal naming the divided figure, which is
+the deliberate, visible outcome; the operator lowers N or sets the
+budget explicitly.
+
 ### D5. CLI exposure
 
 `maintain compact-tenant` and `compact-bucket` gain


### PR DESCRIPTION
ADR-0979 amendment matching PR #1042's budget-division rule: the box-sized 20 GiB default is divided per concurrent bucket; an explicitly configured budget is a whole-box decision and passes through undivided; the fail-closed refusal names the divided figure. Cut from the #1028 branch because the #872 chain held this file.

Merge after #1042.

Refs: #1028