### PR TITLE
feat: compile jemalloc into the service binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4618,6 +4618,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "toml",
  "tower",
@@ -5086,6 +5088,8 @@ dependencies = [
  "snap",
  "tempfile",
  "thiserror",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "toml",
  "tonic",
@@ -6041,6 +6045,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,14 @@ reqwest = { version = "0.13", features = ["json"] }
 # hand-rolled JWT code.
 jsonwebtoken = { version = "10.4", default-features = false, features = ["use_pem", "aws_lc_rs"] }
 
+# Global allocator for the binary targets (issue #972). jemalloc via
+# tikv-jemallocator, which builds the allocator vendored into the binary: no
+# system library and no LD_PRELOAD, so the allocator cannot be forgotten or
+# vary by environment. Linked only by the two service binaries (and, in a
+# follow-up, ravel-bench) through a `cfg(not(target_env = "msvc"))` target
+# table; never by a library crate, whose test binaries install their own.
+tikv-jemallocator = "0.7"
+
 # telemetry protocol types
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic", "metrics", "logs", "trace"] }
 

--- a/services/ravel-cli/Cargo.toml
+++ b/services/ravel-cli/Cargo.toml
@@ -82,6 +82,20 @@ arrow = { workspace = true }
 # a new direct dependency of ravel-cli per CLAUDE.md.
 toml = "1"
 
+# Global allocator, compiled into this binary (issue #972). Kept off the msvc
+# target, which tikv-jemallocator does not support (its own documented cfg);
+# this repo builds on Linux and macOS. The `#[global_allocator]` lives in
+# src/main.rs, a binary root, never in a library crate.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
+# Honest runtime check that the binary is actually running under jemalloc: the
+# smoke test in main.rs reads jemalloc's own allocated-bytes stat. Pinned
+# directly (not via [workspace.dependencies]) matching this crate's convention
+# for deps the single authorized root line does not cover.
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
+
 [dev-dependencies]
 # Writing small Parquet fixtures in the loader tests uses the same parquet/arrow
 # reader deps declared above; ArrowWriter comes from the `parquet` dep.

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -16,6 +16,13 @@ use ravel_logseg::{RlogConfig, read_section};
 use ravel_proto::segment::v1::Footer;
 use ravel_types::{Signal, TenantId, TimeRange};
 
+// jemalloc is compiled into this binary so the allocator is part of the
+// binary's identity rather than an environment accident (#972); library crates
+// must never do this (their test binaries install their own global allocator).
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 // Decode caps for the whole-read RLOG sections, matching `RlogReader`'s own
 // limits (crates/ravel-logseg/src/reader.rs). The inspector reads STREAM_DIR,
 // FIELD_DIR, and SKIP_IDX; a decode past these caps is `Corrupted`.
@@ -2359,6 +2366,35 @@ mod tests {
     use super::rspan_status_mask_names;
     use super::{Cli, Command};
     use ravel_rspan::skip_index::{STATUS_BIT_ERROR, STATUS_BIT_OK, STATUS_BIT_UNSET};
+
+    /// This unit test binary is built from this binary root, so it links the
+    /// `#[global_allocator]` above; an integration test in `tests/` links the
+    /// library instead and would not. Read jemalloc's own allocated-bytes stat
+    /// and prove it accounts for a fresh large allocation: under glibc malloc
+    /// that allocation never touches jemalloc's arenas, so its counter does not
+    /// move and this assertion fails. That flip is what makes this a real
+    /// runtime check of the installed allocator, not a `cfg` echo.
+    #[cfg(not(target_env = "msvc"))]
+    #[test]
+    fn binary_runs_under_jemalloc() {
+        use tikv_jemalloc_ctl::{epoch, stats};
+
+        epoch::advance().expect("jemalloc epoch mallctl must succeed under jemalloc");
+        let before = stats::allocated::read().expect("jemalloc stats.allocated read must succeed");
+
+        let big: Vec<u8> = vec![7u8; 64 * 1024 * 1024];
+        std::hint::black_box(big.as_ptr());
+
+        epoch::advance().expect("jemalloc epoch mallctl must succeed under jemalloc");
+        let after = stats::allocated::read().expect("jemalloc stats.allocated read must succeed");
+
+        assert!(
+            after > before,
+            "jemalloc allocated bytes did not grow ({before} -> {after}) across a 64 MiB \
+             allocation: the process is not running under the jemalloc global allocator"
+        );
+        std::hint::black_box(big);
+    }
 
     /// The shipped write-concurrency defaults, read where an operator meets
     /// them: `ravel load` with neither window flag given (issue #800). The

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -168,6 +168,20 @@ ravel-sql = { path = "../../crates/ravel-sql", version = "0.11.0", optional = tr
 # the two never exchange types.
 arrow-flight = { workspace = true, optional = true }
 
+# Global allocator, compiled into this binary (issue #972). Kept off the msvc
+# target, which tikv-jemallocator does not support (its own documented cfg);
+# this repo builds on Linux and macOS. The `#[global_allocator]` lives in
+# src/main.rs, a binary root, never in a library crate.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
+# Honest runtime check that the binary is actually running under jemalloc: the
+# smoke test in main.rs reads jemalloc's own allocated-bytes stat. Pinned
+# directly (not via [workspace.dependencies]) matching this crate's convention
+# for deps the single authorized root line does not cover.
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
+
 [features]
 # OTAP (OpenTelemetry Arrow) metrics ingest on the gRPC listener: registers
 # `ArrowMetricsService` alongside the OTLP gRPC services. Off by default so the

--- a/services/ravel-server/src/main.rs
+++ b/services/ravel-server/src/main.rs
@@ -15,6 +15,13 @@ use ravel_server::{
 };
 use tracing_subscriber::EnvFilter;
 
+// jemalloc is compiled into this binary so the allocator is part of the
+// binary's identity rather than an environment accident (#972); library crates
+// must never do this (their test binaries install their own global allocator).
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 /// Wall-clock unix nanoseconds for stamping the `sys/tenancy` marker's
 /// informational `created_unix_ns` at bootstrap. This is the binary entry
 /// point, not library logic, so a direct clock read here does not violate the
@@ -546,8 +553,38 @@ async fn wait_for_shutdown_signal() {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+
+    /// This unit test binary is built from this binary root, so it links the
+    /// `#[global_allocator]` above; an integration test in `tests/` links the
+    /// library instead and would not. Read jemalloc's own allocated-bytes stat
+    /// and prove it accounts for a fresh large allocation: under glibc malloc
+    /// that allocation never touches jemalloc's arenas, so its counter does not
+    /// move and this assertion fails. That flip is what makes this a real
+    /// runtime check of the installed allocator, not a `cfg` echo.
+    #[cfg(not(target_env = "msvc"))]
+    #[test]
+    fn binary_runs_under_jemalloc() {
+        use tikv_jemalloc_ctl::{epoch, stats};
+
+        epoch::advance().expect("jemalloc epoch mallctl must succeed under jemalloc");
+        let before = stats::allocated::read().expect("jemalloc stats.allocated read must succeed");
+
+        let big: Vec<u8> = vec![7u8; 64 * 1024 * 1024];
+        std::hint::black_box(big.as_ptr());
+
+        epoch::advance().expect("jemalloc epoch mallctl must succeed under jemalloc");
+        let after = stats::allocated::read().expect("jemalloc stats.allocated read must succeed");
+
+        assert!(
+            after > before,
+            "jemalloc allocated bytes did not grow ({before} -> {after}) across a 64 MiB \
+             allocation: the process is not running under the jemalloc global allocator"
+        );
+        std::hint::black_box(big);
+    }
 
     /// the modes that build a query engine (and therefore spawn the alert
     /// evaluator) must not warn; the modes that do not, must warn when rules are


### PR DESCRIPTION
The allocator changes peak RSS by about 2x on this workload and was
selected by an LD_PRELOAD a human had to remember, so a measurement
could be wrong and unfalsifiable at once (#972, and it happened on #968
and #894). tikv-jemallocator builds the allocator vendored into the
binary: no system library, no environment variable, the allocator is
part of the binary's identity.

The #[global_allocator] static lives in the two binary roots only, never
a library crate: several library test binaries install their own global
allocator and a library-level one would conflict. A unit test in each
binary root proves the running allocator is really jemalloc by reading
jemalloc's own allocated-bytes stat across a 64 MiB allocation; under
glibc malloc the counter does not move and the test fails.

tikv-jemallocator and tikv-jemalloc-ctl (dev) are new external
dependencies, added deliberately per the user decision on #972. The
bench binaries and the runtime allocator provenance field follow
separately (the bench crate was held by another task). Peak-RSS figures
spanning this change are not comparable until the same-corpus A/B run
quantifies the break.

Refs: #972
Signed-off-by: Panagiotis Moustafellos <pmoust@nofire.ai>
