### PR TITLE
feat(maintain): recompute declared-column stamps in compaction

### DIFF
--- a/crates/ravel-maintain/src/build.rs
+++ b/crates/ravel-maintain/src/build.rs
@@ -1097,7 +1097,7 @@ fn flush_part(
         &hash16,
     )?;
 
-    let part = CompactionPart {
+    let mut part = CompactionPart {
         part_index,
         first_series_id: first_series_id.map(|s| s.0.to_vec()).unwrap_or_default(),
         last_series_id: last_series_id.map(|s| s.0.to_vec()).unwrap_or_default(),
@@ -1111,6 +1111,12 @@ fn flush_part(
         segment_format_version: OUTPUT_FORMAT_VERSION,
         declared_column_stats: Vec::new(),
     };
+    // Metrics never carry declared typed columns -- they are a logs concept
+    // (ADR-0873 decision 3), so this part has no eligible columns and stamps
+    // nothing. Routed through the same validated commit-side path the logs
+    // compactor uses, so "stamps nothing" is expressed the one way, not by a
+    // second hand-built empty field.
+    ravel_commit::declared_stats::stamp_compaction_part(&mut part, &[]);
     Ok(BuiltPart {
         key,
         bytes: Some(written.bytes),

--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -1134,7 +1134,7 @@ fn build_rewrite_part(
         &hash16,
     )?;
 
-    let part = CompactionPart {
+    let mut part = CompactionPart {
         part_index: 0,
         first_series_id: first_series_id.map(|s| s.0.to_vec()).unwrap_or_default(),
         last_series_id: last_series_id.map(|s| s.0.to_vec()).unwrap_or_default(),
@@ -1148,6 +1148,11 @@ fn build_rewrite_part(
         segment_format_version: OUTPUT_FORMAT_VERSION,
         declared_column_stats: Vec::new(),
     };
+    // Rewrite parts stamp nothing (the readers force rewrite-part stamps
+    // empty, and an unstamped part can never resurrect an erased row's
+    // extremum). Routed through the validated commit-side path like every
+    // other unstamped producer.
+    ravel_commit::declared_stats::stamp_compaction_part(&mut part, &[]);
     Ok(BuiltPart {
         key,
         // The erasure rewrite retains part bytes until its own publish path PUTs

--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -1254,6 +1254,11 @@ pub async fn build_rewrite_logs(
         &catalogs,
         input_set_hash,
         Vec::new(),
+        // declared: empty -- a rewrite drops rows, so a stamp computed over the
+        // pre-drop set would be stale for the survivors. Rewrite parts stay
+        // unstamped (ADR-0873 decision 3 staleness rule, the wave-3 fold also
+        // forces empty); this task stamps compaction parts only.
+        Vec::new(),
         true,
         // retain_bytes: true -- the erasure rewrite keeps each closed part's
         // bytes resident because `publish_rewrite_record` is what PUTs them,

--- a/crates/ravel-maintain/src/publish.rs
+++ b/crates/ravel-maintain/src/publish.rs
@@ -490,6 +490,52 @@ mod tests {
         assert!(list_all(&store, "").await.expect("list").is_empty());
     }
 
+    /// Wave-5b (ADR-0873 decision 3): stamping a part's declared columns does
+    /// not disturb the conservation gate. A part carrying a valid
+    /// declared-column stamp but a `sample_count` one record short of the input
+    /// sum still aborts with the typed error and writes nothing -- the gate sums
+    /// `part.sample_count`, which the stamp lives beside and never changes.
+    ///
+    /// Prove-the-test: comment out the `if !conservation.conserved(..)` guard in
+    /// `publish_record_with_conservation` and this rigged mismatch publishes, so
+    /// the `expect_err` fails.
+    #[tokio::test]
+    async fn conservation_gate_still_fires_with_stamped_parts() {
+        use ravel_types::declared_stats::{
+            DeclaredColumnStat, DeclaredStatType, DeclaredStatValue,
+        };
+
+        let store = MemoryStore::new();
+        let bucket = bucket(Signal::Logs);
+        let inputs = vec![input(1, 10, &bucket), input(2, 7, &bucket)];
+        let mut p = part(0, 16); // short by one record (input sum is 17)
+        let stamp = DeclaredColumnStat::new(
+            "http.status",
+            DeclaredStatType::I64,
+            Some(DeclaredStatValue::I64(200)),
+            Some(DeclaredStatValue::I64(500)),
+            0,
+        )
+        .expect("valid stamp");
+        ravel_commit::declared_stats::stamp_compaction_part(&mut p.part, &[stamp]);
+        assert!(
+            !p.part.declared_column_stats.is_empty(),
+            "the part must actually carry a stamp for this to test the interaction"
+        );
+
+        let err = publish(&store, &bucket, &inputs, &[p])
+            .await
+            .expect_err("a lossy merge must not publish, stamped or not");
+        assert!(
+            matches!(err, MaintainError::ConservationViolation { .. }),
+            "expected ConservationViolation, got {err:?}"
+        );
+        assert!(
+            list_all(&store, "").await.expect("list").is_empty(),
+            "aborted publish must write nothing"
+        );
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig { cases: 48, ..ProptestConfig::default() })]
 

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -212,6 +212,7 @@ use ravel_logseg::{
 };
 use ravel_object_store::{GetRange, ObjectStoreBackend};
 use ravel_proto::commit::v1::CompactionPart;
+use ravel_types::declared_stats::{DeclaredColumnStat, DeclaredStatType, DeclaredStatValue};
 
 use crate::bucket::Bucket;
 use crate::build::{BuiltPart, put_part};
@@ -347,6 +348,10 @@ impl SegmentCodec for RlogCodec {
         // `input_indexed_fields`). Every part of this compaction gets the same
         // list, so a field is indexed uniformly across the output.
         let indexed_fields = merged_indexed_fields(&catalogs);
+        // The declared eligible columns to recompute per-part stamps for, learned
+        // from the inputs' own stamps (ADR-0873 decision 3). Recomputed over
+        // output rows in the merge, never copied from an input.
+        let declared = declared_columns_from_inputs(inputs);
         // Compaction drops nothing, so every merged record is kept and the
         // counts the driver returns are the input count twice over; the
         // compaction-side conservation gate reads `part.sample_count`, not
@@ -358,6 +363,7 @@ impl SegmentCodec for RlogCodec {
             &catalogs,
             input_set_hash,
             indexed_fields,
+            declared,
             config.dry_run,
             // Compaction releases each part's bytes at PUT (ADR-0979 decision 3):
             // the retained-parts memory term goes to zero, and an `AlreadyExists`
@@ -700,7 +706,11 @@ pub(crate) struct MergeOutput {
 /// splits, or on the stream-identity invariant below.
 ///
 /// `indexed_fields` is the POSTINGS field list every part is written with, and
-/// `dry_run` decides whether each part is PUT as it closes: compaction PUTs
+/// `declared` is the eligible declared columns each output part recomputes
+/// min/max/null-count stamps for (ADR-0873 decision 3): the compactor passes
+/// the set recovered from its inputs, while the erasure rewrite passes an empty
+/// set so its parts stay unstamped (the wave-3 staleness rule). `dry_run`
+/// decides whether each part is PUT as it closes: compaction PUTs
 /// here, while the erasure rewrite defers every PUT to its own publish path,
 /// which writes parts only after its conservation gate passes.
 ///
@@ -719,6 +729,7 @@ pub(crate) async fn merge_catalogs(
     catalogs: &[RlogInputCatalog],
     input_set_hash: &[u8; 32],
     indexed_fields: Vec<String>,
+    declared: Vec<(String, DeclaredStatType)>,
     dry_run: bool,
     retain_bytes: bool,
     keep: &mut (dyn FnMut(&LogRecord) -> Result<bool> + Send),
@@ -763,6 +774,7 @@ pub(crate) async fn merge_catalogs(
         input_set_hash,
         identity,
         indexed_fields,
+        declared,
         tracker,
         dry_run,
         retain_bytes,
@@ -871,6 +883,10 @@ struct PartSink<'a> {
     input_set_hash: &'a [u8; 32],
     identity: ObjectIdentity,
     indexed_fields: Vec<String>,
+    /// The declared eligible columns each output part recomputes stamps for
+    /// (ADR-0873 decision 3). Empty on the erasure-rewrite route, whose parts
+    /// stay unstamped (the wave-3 staleness rule), and on metrics/spans buckets.
+    declared: Vec<(String, DeclaredStatType)>,
     tracker: Option<&'a MergeMemoryTracker>,
     /// Whether a closed part is encoded but not PUT. Not read from `config`:
     /// the erasure rewrite defers every part PUT to its own publish path (which
@@ -893,7 +909,11 @@ impl PartSink<'_> {
     /// closing it once a target is reached.
     async fn push(&mut self, r: LogRecord) -> Result<()> {
         if self.current.is_none() {
-            self.current = Some(PartBuilder::new(&self.identity, &self.indexed_fields));
+            self.current = Some(PartBuilder::new(
+                &self.identity,
+                &self.indexed_fields,
+                &self.declared,
+            ));
         }
         let mut over_memory = false;
         // Encoded object bytes from a stored-target probe that showed the part
@@ -971,11 +991,16 @@ impl PartSink<'_> {
     async fn flush(&mut self, pre_encoded: Option<(Vec<u8>, WriteStats)>) -> Result<()> {
         // The `if let` (rather than an `unwrap`/`expect`) keeps the critical
         // path free of a panic path; a `None` here is a no-op, not a lie.
-        if let Some(builder) = self.current.take() {
+        if let Some(mut builder) = self.current.take() {
             // Copy the Copy-typed stream bounds before the encode consumes the
             // builder.
             let first_stream_id = builder.min_stream;
             let last_stream_id = builder.max_stream;
+            // Take the part's declared-column fold out before the encode consumes
+            // the builder; it carries exactly the records this part holds
+            // (ADR-0873 decision 3), stamped against the closed part's own row
+            // count in `finalize_part`.
+            let declared_accum = std::mem::take(&mut builder.declared_accum);
             let (object, stats) = match pre_encoded {
                 Some(enc) => enc,
                 None => builder.into_encoded(self.input_set_hash, self.part_index)?,
@@ -991,6 +1016,7 @@ impl PartSink<'_> {
                 self.part_index,
                 self.dry_run,
                 self.retain_bytes,
+                &declared_accum,
             )
             .await?;
             // Only bytes actually retained past PUT count toward the
@@ -1020,6 +1046,210 @@ impl PartSink<'_> {
         }
         Ok(self.parts)
     }
+}
+
+/// The declared eligible columns to recompute stamps for on a compaction's
+/// output (ADR-0873 decision 3, L1 half), recovered from the input commit
+/// records.
+///
+/// The compactor recomputes extrema over the rows it writes and never copies an
+/// input's stamp -- inputs may predate a declaration, and a copied value could
+/// name a row a later input does not carry -- but it learns WHICH columns are
+/// declared from the stamps its inputs already carry (wave 5a stamped every L0
+/// flush). The result is the union over inputs, deduplicated by name (first
+/// eligible occurrence in canonical input order wins), read through the wave-2
+/// predicate so only a trustworthy declaration seeds the fold.
+///
+/// A column declared after every input was written carries no stamp on any
+/// input and is therefore not recomputed here; it converges once a stamped
+/// flush enters a later compaction (the reachability follow-up on #1022). A
+/// metrics or spans bucket carries no declared columns and yields an empty set.
+fn declared_columns_from_inputs(inputs: &[InputRecord]) -> Vec<(String, DeclaredStatType)> {
+    let mut seen: BTreeMap<String, DeclaredStatType> = BTreeMap::new();
+    for input in inputs {
+        for stat in ravel_commit::declared_stats::read_commit_record(&input.record).covered() {
+            seen.entry(stat.name().to_string())
+                .or_insert_with(|| stat.declared_type());
+        }
+    }
+    seen.into_iter().collect()
+}
+
+/// Running min/max and non-null row count for one declared column over the
+/// records pushed to the part. `min <= max` holds by construction (both start at
+/// the first value and only widen), so a stamp built from it never trips the
+/// reader's `min <= max` clause.
+#[derive(Clone, Copy)]
+struct Running<T> {
+    min: T,
+    max: T,
+    non_null: u64,
+}
+
+impl<T: Ord + Copy> Running<T> {
+    fn start(v: T) -> Self {
+        Running {
+            min: v,
+            max: v,
+            non_null: 1,
+        }
+    }
+
+    fn observe(&mut self, v: T) {
+        if v < self.min {
+            self.min = v;
+        }
+        if v > self.max {
+            self.max = v;
+        }
+        self.non_null += 1;
+    }
+}
+
+/// One declared column's running extrema over the records pushed to a part. Only
+/// the [`Running`] matching `ty` is ever populated: a declared I64 column counts
+/// an I64 value as non-null and reads a same-named BOOL value (or an absent one)
+/// as NULL, and vice versa -- the wave-5a `(name, value kind)` rule.
+struct ColumnAccum {
+    name: String,
+    ty: DeclaredStatType,
+    i64_run: Option<Running<i64>>,
+    bool_run: Option<Running<bool>>,
+    /// First-occurrence-wins within the record currently being folded: set once
+    /// this column has taken a value from that record, cleared before the next.
+    seen_this_record: bool,
+}
+
+/// The per-part fold of declared-column extrema for the compaction output
+/// (ADR-0873 decision 3, the L1 half of wave 5). It mirrors the ingest-side
+/// wave-5a accumulator (`ravel_ingest`'s `DeclaredStatAccum`): eligible I64/BOOL
+/// declared columns only, first-occurrence-wins per record, and a stamp whose
+/// `null_count` is derived as `sample_count - non_null` so the part's own reader
+/// ([`ravel_commit::declared_stats::read_compaction_part`]) never drops it.
+///
+/// Unlike the ingest side it is seeded with the declared column set up front
+/// (from [`declared_columns_from_inputs`]), so it tracks only the columns it
+/// will stamp rather than every eligible attribute the merge sees. It rides
+/// [`PartBuilder::push`], the same per-record path `estimate` and the stream
+/// bounds ride, so the exact-encode probe ([`PartBuilder::encode_clone`], which
+/// clones the buffered records without re-pushing) folds no record twice. Each
+/// part gets its own accumulator, opened when the part opens and consumed when
+/// it closes, so a record folds into exactly the part it is written into: at a
+/// mid-stream split the record that crosses the boundary is the one that opens
+/// the next [`PartBuilder`] and is folded only there.
+#[derive(Default)]
+struct DeclaredStatAccum {
+    cols: Vec<ColumnAccum>,
+}
+
+impl DeclaredStatAccum {
+    /// Build a fold over the declared eligible columns. The set already passed
+    /// [`DeclaredStatType::from_tag`] in [`declared_columns_from_inputs`], so
+    /// every column here is I64 or BOOL.
+    fn new(declared: &[(String, DeclaredStatType)]) -> Self {
+        let cols = declared
+            .iter()
+            .map(|(name, ty)| ColumnAccum {
+                name: name.clone(),
+                ty: *ty,
+                i64_run: None,
+                bool_run: None,
+                seen_this_record: false,
+            })
+            .collect();
+        DeclaredStatAccum { cols }
+    }
+
+    /// Fold one record's attributes. Each declared column takes at most one
+    /// non-null row from the record: the first attribute matching its name AND
+    /// its declared value kind wins, and a repeat (or a same-named value of the
+    /// other kind, or an absence) is a NULL for the declaration, so no column's
+    /// non-null count can exceed the part's row count and the derived
+    /// `null_count` can never go negative.
+    fn observe_record(&mut self, attrs: &[(String, AttrValue)]) {
+        if self.cols.is_empty() {
+            return;
+        }
+        for c in &mut self.cols {
+            c.seen_this_record = false;
+        }
+        for (name, value) in attrs {
+            for c in &mut self.cols {
+                if c.seen_this_record || c.name != *name {
+                    continue;
+                }
+                match (c.ty, value) {
+                    (DeclaredStatType::I64, AttrValue::I64(v)) => {
+                        match &mut c.i64_run {
+                            Some(r) => r.observe(*v),
+                            None => c.i64_run = Some(Running::start(*v)),
+                        }
+                        c.seen_this_record = true;
+                    }
+                    (DeclaredStatType::Bool, AttrValue::Bool(b)) => {
+                        match &mut c.bool_run {
+                            Some(r) => r.observe(*b),
+                            None => c.bool_run = Some(Running::start(*b)),
+                        }
+                        c.seen_this_record = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Build the part's stamps against its own `sample_count` (the part footer's
+    /// `record_count`). A declared column the part never saw a matching-typed
+    /// value for stamps absent extrema with `null_count == sample_count`; every
+    /// returned stat is valid by construction (`min <= max` from [`Running`],
+    /// `null_count = sample_count - non_null`), so `read_compaction_part` drops
+    /// none of them.
+    fn build_stamps(&self, sample_count: u64) -> Vec<DeclaredColumnStat> {
+        let mut out = Vec::new();
+        for c in &self.cols {
+            let observed = match c.ty {
+                DeclaredStatType::I64 => c.i64_run.map(|r| {
+                    (
+                        DeclaredStatValue::I64(r.min),
+                        DeclaredStatValue::I64(r.max),
+                        r.non_null,
+                    )
+                }),
+                DeclaredStatType::Bool => c.bool_run.map(|r| {
+                    (
+                        DeclaredStatValue::Bool(r.min),
+                        DeclaredStatValue::Bool(r.max),
+                        r.non_null,
+                    )
+                }),
+            };
+            if let Some(stat) = build_one(&c.name, c.ty, observed, sample_count) {
+                out.push(stat);
+            }
+        }
+        out
+    }
+}
+
+/// Build one declared-column stamp, or `None` when the accumulated non-null
+/// count exceeds `sample_count` (impossible under the per-record dedup above,
+/// but a `None` rather than a self-dropping stamp keeps decision 3's invariant
+/// true even if that ever changes) or the typed constructor refuses the triple.
+fn build_one(
+    name: &str,
+    ty: DeclaredStatType,
+    observed: Option<(DeclaredStatValue, DeclaredStatValue, u64)>,
+    sample_count: u64,
+) -> Option<DeclaredColumnStat> {
+    let (min, max, null_count) = match observed {
+        Some((min, max, non_null)) => {
+            let null_count = sample_count.checked_sub(non_null)?;
+            (Some(min), Some(max), null_count)
+        }
+        None => (None, None, sample_count),
+    };
+    DeclaredColumnStat::new(name, ty, min, max, null_count).ok()
 }
 
 /// The floor on how far apart two stored-target probes may sit on the payload
@@ -1085,10 +1315,18 @@ struct PartBuilder {
     min_stream: Option<LogStreamId>,
     max_stream: Option<LogStreamId>,
     count: usize,
+    /// The declared-column extrema fold for this part (ADR-0873 decision 3).
+    /// Fresh per part and folded once per pushed record, so a record folds into
+    /// exactly the part it is written into.
+    declared_accum: DeclaredStatAccum,
 }
 
 impl PartBuilder {
-    fn new(identity: &ObjectIdentity, indexed_fields: &[String]) -> Self {
+    fn new(
+        identity: &ObjectIdentity,
+        indexed_fields: &[String],
+        declared: &[(String, DeclaredStatType)],
+    ) -> Self {
         PartBuilder {
             identity: *identity,
             indexed_fields: indexed_fields.to_vec(),
@@ -1100,6 +1338,7 @@ impl PartBuilder {
             min_stream: None,
             max_stream: None,
             count: 0,
+            declared_accum: DeclaredStatAccum::new(declared),
         }
     }
 
@@ -1129,6 +1368,11 @@ impl PartBuilder {
             .stored_estimate
             .saturating_add(estimate_stored_record(&r));
         self.count += 1;
+        // Fold the declared-column extrema on the same per-record path the
+        // estimates ride (ADR-0873 decision 3). Done here, once per pushed
+        // record, so the exact-encode probe -- which clones `records` without
+        // re-pushing -- never double-counts a record.
+        self.declared_accum.observe_record(&r.attrs);
         self.records.push(r);
         if let Some(t) = tracker {
             t.set_writer_bytes(self.estimate);
@@ -2084,7 +2328,7 @@ async fn open_cursor<'a>(
 /// `last` may equal the next part's `first`; the bounds are adjacent, not
 /// strictly disjoint.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn finalize_part(
+async fn finalize_part(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,
     object: Vec<u8>,
@@ -2095,6 +2339,7 @@ pub(crate) async fn finalize_part(
     part_index: u32,
     dry_run: bool,
     retain_bytes: bool,
+    declared_accum: &DeclaredStatAccum,
 ) -> Result<BuiltPart> {
     if stats.postings_capped_fields > 0 {
         tracing::warn!(
@@ -2121,7 +2366,7 @@ pub(crate) async fn finalize_part(
         &hash16,
     )?;
 
-    let part = CompactionPart {
+    let mut part = CompactionPart {
         part_index,
         first_series_id: first_stream_id.map(|s| s.0.to_vec()).unwrap_or_default(),
         last_series_id: last_stream_id.map(|s| s.0.to_vec()).unwrap_or_default(),
@@ -2137,6 +2382,17 @@ pub(crate) async fn finalize_part(
         segment_format_version: OUTPUT_FORMAT_VERSION,
         declared_column_stats: Vec::new(),
     };
+    // Stamp the declared-column extrema recomputed over exactly this part's rows
+    // (ADR-0873 decision 3), through the validated commit-side path and against
+    // the part's own row count read back from the footer above, so
+    // `non_null + null_count == sample_count` by construction and the part's own
+    // reader never drops a stamp. An empty fold (metrics/spans, an unstamped
+    // input set, or the erasure-rewrite route) stamps nothing, which is the
+    // permanently legal state. This mutates only the record metadata: the object
+    // bytes and `content_hash` above are already fixed, so stamping cannot move a
+    // differential hash.
+    let stamps = declared_accum.build_stamps(part.sample_count);
+    ravel_commit::declared_stats::stamp_compaction_part(&mut part, &stamps);
     let mut built = BuiltPart {
         key,
         bytes: Some(object),

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -1143,9 +1143,10 @@ struct DeclaredStatAccum {
 }
 
 impl DeclaredStatAccum {
-    /// Build a fold over the declared eligible columns. The set already passed
-    /// [`DeclaredStatType::from_tag`] in [`declared_columns_from_inputs`], so
-    /// every column here is I64 or BOOL.
+    /// Build a fold over the declared eligible columns. The set comes from
+    /// [`declared_columns_from_inputs`], which reads each input's decoded
+    /// stamps through the commit-side reader whose type tags admit only I64
+    /// and BOOL, so every column here is one of the two.
     fn new(declared: &[(String, DeclaredStatType)]) -> Self {
         let cols = declared
             .iter()

--- a/crates/ravel-maintain/src/rspan_codec.rs
+++ b/crates/ravel-maintain/src/rspan_codec.rs
@@ -742,7 +742,7 @@ pub(crate) async fn finalize_part(
         &hash16,
     )?;
 
-    let part = CompactionPart {
+    let mut part = CompactionPart {
         part_index,
         first_series_id: ftr.min_trace_id.to_vec(),
         last_series_id: ftr.max_trace_id.to_vec(),
@@ -761,6 +761,11 @@ pub(crate) async fn finalize_part(
         segment_format_version: OUTPUT_FORMAT_VERSION,
         declared_column_stats: Vec::new(),
     };
+    // Spans never carry declared typed columns -- they are a logs concept
+    // (ADR-0873 decision 3), so this part has no eligible columns and stamps
+    // nothing. Routed through the same validated commit-side path the logs
+    // compactor uses, so "stamps nothing" is expressed the one way.
+    ravel_commit::declared_stats::stamp_compaction_part(&mut part, &[]);
     // RSPAN keeps its current retention behaviour (ADR-0979 decision 3 wraps the
     // bytes in `Some` mechanically; the bounded-memory fix for this codec is a
     // follow-up, #982), so `put_already_existed` stays false and the bytes are

--- a/crates/ravel-maintain/tests/rlog_declared_stamps.rs
+++ b/crates/ravel-maintain/tests/rlog_declared_stamps.rs
@@ -1,0 +1,789 @@
+//! ADR-0873 wave 5b: compaction recomputes declared-column min/max/null-count
+//! stamps over exactly the records that land in each output part (issue #1022).
+//!
+//! The L1 half of the wave-5 fold. Wave 5a stamps every L0 flush; here the
+//! compactor learns WHICH columns are declared from its inputs' own stamps and
+//! recomputes the extrema over the rows it writes into each part, never copying
+//! an input's stamp. These tests pin, over known I64/BOOL extrema:
+//!
+//! 1. each output part's stamps are the min/max/null-count of the records in
+//!    THAT part, across a multi-input bucket;
+//! 2. at a mid-stream split, the record that opens the next part is folded into
+//!    that next part, never the closing one (its extremum is constructed so a
+//!    misattribution flips a pinned value);
+//! 3. the stored L1 part object bytes are byte-identical whether or not the
+//!    parts are stamped -- the stamp lives in the compaction record's metadata,
+//!    never in the object (the #872 differential rests on that);
+//! 4. after compaction the wave-4 catalog reader answers MIN/MAX/COUNT of a
+//!    declared column from the resolved parts' stamps with zero GETs against any
+//!    L1 data object;
+//! 6. an erasure rewrite's parts stay unstamped even when the surviving records
+//!    carry eligible declared columns (the wave-3 staleness rule).
+//!
+//! (Test 5, the conservation gate under stamping, is a unit test beside the
+//! gate it exercises, in `publish.rs`.)
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use prost::Message;
+use ravel_commit::declared_stats::{read_compaction_part, stamp_commit_record};
+use ravel_commit::keys;
+use ravel_commit::record::{self, NewCommitRecord};
+use ravel_logseg::{LogRecord, RlogConfig, RlogWriter, writer::ObjectIdentity};
+use ravel_maintain::{
+    Bucket, CompactorConfig, ErasureRewriteOutcome, FixedClock, MaintainMemo, NoLeases,
+    PendingErasureRequest, compact_bucket, erasure_rewrite_bucket,
+};
+use ravel_object_store::fault::{FaultKind, FaultPlan, Op, Rule, ScriptedFault};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{GetRange, ObjectStoreBackend, PutOptions, list_all};
+use ravel_proto::commit::v1::{
+    CompactionPart, CompactionRecord, ErasurePredicateMatcher, ErasureRequest, RewriteRecord,
+};
+use ravel_types::declared_stats::{DeclaredColumnStat, DeclaredStatType, DeclaredStatValue};
+use ravel_types::logstream::{AttrValue, LogStreamId, log_stream_id};
+use ravel_types::{Signal, TenantHash, TenantId, TimeRange};
+use uuid::Uuid;
+
+const TENANT: &str = "acme";
+const SHARD: u32 = 7;
+const HOUR: u32 = 495_000;
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+const EPOCH: u64 = 10;
+
+/// The I64 declared column under test (ClickBench's `EventDate` shape).
+const STATUS: &str = "http.status";
+/// The BOOL declared column under test (ClickBench's `IsRefresh` shape).
+const CACHE: &str = "cache.hit";
+
+/// Each record's body is padded to this length. `estimate_record` (the memory
+/// split target's trigger) is then dominated by the body, so a part splits as a
+/// function of record COUNT, not of which declared values a record carries --
+/// the two tests that force a split can place a known number of records per part
+/// without depending on the exact per-record slot overhead.
+const BODY_LEN: usize = 20_000;
+
+/// Two records fit under this decoded-heap target and three do not: at
+/// `BODY_LEN` = 20_000 each record's estimate is ~20_400, so one is ~20_400
+/// (< 30_000) and two are ~40_800 (>= 30_000). `max_l1_part_bytes` stays at its
+/// 256 MiB default so only the memory split target ever fires here.
+const SPLIT_TARGET_BYTES: u64 = 30_000;
+
+const OUTPUT_FORMAT_VERSION: u32 = ravel_maintain::rlog::OUTPUT_FORMAT_VERSION;
+
+fn tenant_hash() -> TenantHash {
+    TenantId::new(TENANT).hash()
+}
+
+fn bucket() -> Bucket {
+    Bucket::new(tenant_hash(), Signal::Logs, SHARD, HOUR)
+}
+
+/// Past the seal margin for [`HOUR`] under default config.
+fn sealed_now_ns() -> i64 {
+    (i64::from(HOUR) + 1) * NS_PER_HOUR + 2 * NS_PER_HOUR
+}
+
+/// A `CompactorConfig` whose memory split target forces a part boundary every
+/// two records (see [`SPLIT_TARGET_BYTES`]).
+fn split_config() -> CompactorConfig {
+    CompactorConfig {
+        l1_part_memory_target_bytes: SPLIT_TARGET_BYTES,
+        ..Default::default()
+    }
+}
+
+/// A synthetic stream `n`'s id and canonical resource+scope blob, identical to
+/// the crate's own RLOG test helper: the id is the true hash of the blob.
+fn stream_ident(n: u32) -> (LogStreamId, Vec<u8>) {
+    let res = vec![(
+        "service.name".to_string(),
+        AttrValue::Str(format!("svc{n}")),
+    )];
+    let id = log_stream_id(&res, "scope", "1", &[]);
+    let blob = ravel_logseg::stream_attrs_bytes(&res, "scope", "1", &[]);
+    (id, blob)
+}
+
+/// A body of exactly [`BODY_LEN`] bytes, tagged with `ts` so distinct records
+/// stay distinct (logs never dedup, ADR-0032) while keeping a uniform length.
+fn body_of(ts: i64) -> String {
+    let mut b = format!("ts{ts}-");
+    if b.len() < BODY_LEN {
+        b.push_str(&"x".repeat(BODY_LEN - b.len()));
+    }
+    b
+}
+
+/// One record on stream `n` at `ts`, optionally carrying the I64 `STATUS` and
+/// BOOL `CACHE` declared columns. A `None` means the attribute is absent, which
+/// the fold reads as a NULL for that declaration.
+fn rec(
+    n: u32,
+    ts: i64,
+    status: Option<i64>,
+    cache: Option<bool>,
+    extra: &[(&str, &str)],
+) -> LogRecord {
+    let (stream_id, stream_attrs) = stream_ident(n);
+    let mut attrs: Vec<(String, AttrValue)> = Vec::new();
+    if let Some(v) = status {
+        attrs.push((STATUS.to_string(), AttrValue::I64(v)));
+    }
+    if let Some(b) = cache {
+        attrs.push((CACHE.to_string(), AttrValue::Bool(b)));
+    }
+    for (k, v) in extra {
+        attrs.push(((*k).to_string(), AttrValue::Str((*v).to_string())));
+    }
+    LogRecord {
+        stream_id,
+        stream_attrs,
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body_of(ts),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs,
+    }
+}
+
+fn attr_i64(r: &LogRecord, name: &str) -> Option<i64> {
+    r.attrs.iter().find_map(|(k, v)| match v {
+        AttrValue::I64(x) if k == name => Some(*x),
+        _ => None,
+    })
+}
+
+fn attr_bool(r: &LogRecord, name: &str) -> Option<bool> {
+    r.attrs.iter().find_map(|(k, v)| match v {
+        AttrValue::Bool(b) if k == name => Some(*b),
+        _ => None,
+    })
+}
+
+/// The exact declared-column stamps a wave-5a L0 writer would carry for
+/// `records`: `STATUS` as I64 and `CACHE` as BOOL, extrema over the non-null
+/// values (absent when there are none), and the exact NULL count. The compactor
+/// reads only the (name, type) pair from these to learn which columns are
+/// declared; it recomputes the extrema itself over the merged rows.
+fn l0_stamps(records: &[LogRecord]) -> Vec<DeclaredColumnStat> {
+    let iv: Vec<i64> = records.iter().filter_map(|r| attr_i64(r, STATUS)).collect();
+    let bv: Vec<bool> = records.iter().filter_map(|r| attr_bool(r, CACHE)).collect();
+    let i_null = records.len() as u64 - iv.len() as u64;
+    let b_null = records.len() as u64 - bv.len() as u64;
+    vec![
+        DeclaredColumnStat::new(
+            STATUS,
+            DeclaredStatType::I64,
+            iv.iter().min().map(|v| DeclaredStatValue::I64(*v)),
+            iv.iter().max().map(|v| DeclaredStatValue::I64(*v)),
+            i_null,
+        )
+        .expect("valid I64 L0 stamp"),
+        DeclaredColumnStat::new(
+            CACHE,
+            DeclaredStatType::Bool,
+            bv.iter().min().map(|v| DeclaredStatValue::Bool(*v)),
+            bv.iter().max().map(|v| DeclaredStatValue::Bool(*v)),
+            b_null,
+        )
+        .expect("valid BOOL L0 stamp"),
+    ]
+}
+
+/// Seed one L0 `.rlog` input (data object + commit record), as the ingest log
+/// shard would. When `stamp` is set the commit record carries the wave-5a
+/// declared-column stamps for `records`; otherwise it carries none (the
+/// pre-declaration corpus), which leaves the compaction output unstamped.
+async fn seed(
+    store: &dyn ObjectStoreBackend,
+    writer_id: Uuid,
+    seq: u64,
+    records: &[LogRecord],
+    stamp: bool,
+) {
+    let th = tenant_hash();
+    let identity = ObjectIdentity {
+        tenant_hash: th.0,
+        shard: SHARD,
+        writer_id: writer_id.into_bytes(),
+        writer_epoch: EPOCH,
+        writer_seq: seq,
+    };
+    let mut w = RlogWriter::new(RlogConfig::default(), identity);
+    for r in records {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = bytes::Bytes::from(w.finish().expect("finish L0"));
+    let content_hash: [u8; 32] = *blake3::hash(&bytes).as_bytes();
+    let data_key = keys::data_key(
+        &th,
+        Signal::Logs,
+        SHARD,
+        writer_id,
+        EPOCH,
+        seq,
+        &content_hash,
+    )
+    .expect("data key");
+    store
+        .put(&data_key, bytes.clone(), PutOptions::default())
+        .await
+        .expect("put data");
+
+    let mut ids = std::collections::BTreeSet::new();
+    let mut min_ts = i64::MAX;
+    let mut max_ts = i64::MIN;
+    for r in records {
+        ids.insert(r.stream_id);
+        min_ts = min_ts.min(r.ts_ns);
+        max_ts = max_ts.max(r.ts_ns);
+    }
+    let created = i64::from(HOUR) * NS_PER_HOUR + (seq as i64) * 1_000_000;
+    let mut crec = record::build(NewCommitRecord {
+        tenant_hash: th,
+        signal: Signal::Logs,
+        shard: SHARD,
+        writer_id,
+        writer_epoch: EPOCH,
+        writer_seq: seq,
+        object_size: bytes.len() as u64,
+        content_hash,
+        sample_count: records.len() as u64,
+        series_count: ids.len() as u64,
+        min_event_ts_ns: min_ts,
+        max_event_ts_ns: max_ts,
+        min_ingest_ts_ns: created,
+        max_ingest_ts_ns: created,
+        segment_format_version: OUTPUT_FORMAT_VERSION,
+        created_unix_ns: created,
+        ingest_hour_bucket: HOUR,
+    })
+    .expect("build commit record");
+    if stamp {
+        stamp_commit_record(&mut crec, &l0_stamps(records));
+    }
+    let commit_key = keys::commit_key_for_record(&crec).expect("commit key");
+    store
+        .put(&commit_key, record::encode(&crec), PutOptions::default())
+        .await
+        .expect("put commit");
+}
+
+/// Compact the seeded bucket and return the single compaction record, decoded.
+async fn compact_and_record(
+    store: &dyn ObjectStoreBackend,
+    config: &CompactorConfig,
+) -> CompactionRecord {
+    let clock = FixedClock::new(sealed_now_ns());
+    compact_bucket(store, &clock, config, &bucket())
+        .await
+        .expect("compact");
+    let prefix = keys::commit_shard_hour_prefix(&tenant_hash(), Signal::Logs, SHARD, HOUR).unwrap();
+    let record_key = list_all(store, &prefix)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|m| m.key)
+        .find(|k| {
+            matches!(
+                keys::partition_bucket_entry(k),
+                Ok(keys::BucketEntry::CompactionRecord(_))
+            )
+        })
+        .expect("compaction record key");
+    let bytes = store.get(&record_key, GetRange::Full).await.unwrap().data;
+    CompactionRecord::decode(bytes.as_ref()).unwrap()
+}
+
+/// The validated I64 stamp `(min, max, null_count)` a part carries for `name`,
+/// or a panic if the part is uncovered for it. Read through
+/// [`read_compaction_part`], the same wave-2/3 predicate the query side uses, so
+/// a stamp the reader would drop is never reported as coverage.
+fn part_i64(p: &CompactionPart, name: &str) -> (Option<i64>, Option<i64>, u64) {
+    let validated = read_compaction_part(p);
+    let stat = validated
+        .covered()
+        .iter()
+        .find(|s| s.name() == name)
+        .unwrap_or_else(|| panic!("part {} uncovered for {name}", p.part_index));
+    assert_eq!(stat.declared_type(), DeclaredStatType::I64);
+    let mn = match stat.min() {
+        Some(DeclaredStatValue::I64(x)) => Some(x),
+        None => None,
+        other => panic!("non-I64 min {other:?}"),
+    };
+    let mx = match stat.max() {
+        Some(DeclaredStatValue::I64(x)) => Some(x),
+        None => None,
+        other => panic!("non-I64 max {other:?}"),
+    };
+    (mn, mx, stat.null_count())
+}
+
+/// The validated BOOL stamp `(min, max, null_count)` a part carries for `name`.
+fn part_bool(p: &CompactionPart, name: &str) -> (Option<bool>, Option<bool>, u64) {
+    let validated = read_compaction_part(p);
+    let stat = validated
+        .covered()
+        .iter()
+        .find(|s| s.name() == name)
+        .unwrap_or_else(|| panic!("part {} uncovered for {name}", p.part_index));
+    assert_eq!(stat.declared_type(), DeclaredStatType::Bool);
+    let mn = match stat.min() {
+        Some(DeclaredStatValue::Bool(b)) => Some(b),
+        None => None,
+        other => panic!("non-BOOL min {other:?}"),
+    };
+    let mx = match stat.max() {
+        Some(DeclaredStatValue::Bool(b)) => Some(b),
+        None => None,
+        other => panic!("non-BOOL max {other:?}"),
+    };
+    (mn, mx, stat.null_count())
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: each output part's stamps are exactly its own records' extrema.
+// ---------------------------------------------------------------------------
+
+/// Two inputs merge into two output parts of two records each, and each part's
+/// I64/BOOL stamps are the exact min/max/null-count of the records THAT part
+/// holds -- never the whole bucket's, and never the other part's.
+///
+/// The four records span both extremes of each column and one NULL per column
+/// per part, so a fold that leaked a value across the part boundary (or summed
+/// the whole bucket) reports a different min, max, or null_count than the one
+/// asserted here. `non_null + null_count == sample_count` is checked on every
+/// part, the invariant `read_compaction_part` relies on.
+///
+/// Prove-the-test: delete the `self.declared_accum.observe_record(&r.attrs)`
+/// call in `PartBuilder::push` (crates/ravel-maintain/src/rlog.rs) and every
+/// part stamps all-NULL, so each `Some(..)` min/max assertion fails.
+#[tokio::test]
+async fn each_output_part_stamps_exactly_its_own_records() {
+    let store = MemoryStore::new();
+    // Merged (ts-ascending) order across the two inputs is A, B, C, D. The
+    // memory split target closes a part every two records, so part 0 = {A, B}
+    // and part 1 = {C, D}.
+    //   A ts1000 status=50  cache=false
+    //   B ts2000 status=10  cache=true    -> part0: status 10..50 null0, cache false..true null0
+    //   C ts3000 status=--  cache=true     (status NULL)
+    //   D ts4000 status=99  cache=--       (cache NULL) -> part1: status 99..99 null1, cache true..true null1
+    let input_1 = vec![
+        rec(0, 1000, Some(50), Some(false), &[]),
+        rec(0, 3000, None, Some(true), &[]),
+    ];
+    let input_2 = vec![
+        rec(0, 2000, Some(10), Some(true), &[]),
+        rec(0, 4000, Some(99), None, &[]),
+    ];
+    seed(&store, Uuid::from_u128(1), 1, &input_1, true).await;
+    seed(&store, Uuid::from_u128(2), 2, &input_2, true).await;
+
+    let record = compact_and_record(&store, &split_config()).await;
+    assert_eq!(record.parts.len(), 2, "two records per part -> two parts");
+
+    for p in &record.parts {
+        assert_eq!(p.sample_count, 2, "each part holds two records");
+        for stat in read_compaction_part(p).covered() {
+            let non_null = p.sample_count - stat.null_count();
+            assert!(
+                non_null <= p.sample_count,
+                "non_null + null_count must equal sample_count"
+            );
+        }
+    }
+
+    let p0 = &record.parts[0];
+    assert_eq!(
+        part_i64(p0, STATUS),
+        (Some(10), Some(50), 0),
+        "part0 status 10..50, no NULL"
+    );
+    assert_eq!(
+        part_bool(p0, CACHE),
+        (Some(false), Some(true), 0),
+        "part0 cache false..true, no NULL"
+    );
+
+    let p1 = &record.parts[1];
+    assert_eq!(
+        part_i64(p1, STATUS),
+        (Some(99), Some(99), 1),
+        "part1 status 99, one NULL (C)"
+    );
+    assert_eq!(
+        part_bool(p1, CACHE),
+        (Some(true), Some(true), 1),
+        "part1 cache true, one NULL (D)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: the record that opens the next part is folded into that part.
+// ---------------------------------------------------------------------------
+
+/// At a mid-stream split the boundary record belongs to the part it OPENS, not
+/// the part that just closed. Three records on one stream split after two, so
+/// R3 opens part 1. R1 and R2 both carry `status = 100` and R3 carries
+/// `status = 5`, so:
+///   - if R3 were (mis)folded into part 0, part 0's min would flip 100 -> 5;
+///   - part 1's stamp would then be all-NULL or empty.
+/// Asserting `part0.min == 100` excludes both a misattribution (`5`) and a
+/// dropped fold (`None`).
+///
+/// Prove-the-test: two independent flips fail it. (a) Delete the
+/// `observe_record` call in `PartBuilder::push` (rlog.rs) -> part 0's min is
+/// `None`, not `Some(100)`. (b) Raise this test's `l1_part_memory_target_bytes`
+/// so the split falls after three records instead of two: R3 then lands in part
+/// 0 and part 0's min flips to 5 -- the same misattribution the per-part
+/// accumulator prevents, demonstrated by moving the boundary.
+#[tokio::test]
+async fn boundary_record_folds_into_the_part_it_opens() {
+    let store = MemoryStore::new();
+    // input_1 = {R1, R3}, input_2 = {R2}; merged ts-ascending: R1, R2, R3.
+    let input_1 = vec![
+        rec(0, 1000, Some(100), None, &[]),
+        rec(0, 3000, Some(5), None, &[]),
+    ];
+    let input_2 = vec![rec(0, 2000, Some(100), None, &[])];
+    seed(&store, Uuid::from_u128(10), 1, &input_1, true).await;
+    seed(&store, Uuid::from_u128(11), 2, &input_2, true).await;
+
+    let record = compact_and_record(&store, &split_config()).await;
+    assert_eq!(
+        record.parts.len(),
+        2,
+        "split after two records -> {{R1,R2}} and {{R3}}"
+    );
+
+    let p0 = &record.parts[0];
+    assert_eq!(p0.sample_count, 2, "part0 holds R1 and R2");
+    assert_eq!(
+        part_i64(p0, STATUS),
+        (Some(100), Some(100), 0),
+        "part0 is R1,R2 only: min stays 100, NOT the boundary record's 5"
+    );
+
+    let p1 = &record.parts[1];
+    assert_eq!(
+        p1.sample_count, 1,
+        "part1 holds only the boundary record R3"
+    );
+    assert_eq!(
+        part_i64(p1, STATUS),
+        (Some(5), Some(5), 0),
+        "R3's 5 lands in the part it opens"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: stamping does not move the stored object bytes.
+// ---------------------------------------------------------------------------
+
+/// The declared-column stamp lives in the compaction record's part metadata,
+/// never in the L1 data object. Compacting the same records with the inputs
+/// stamped and unstamped yields byte-identical L1 part objects (identical
+/// content-addressed keys AND identical bytes), while only the stamped run's
+/// record carries non-empty `declared_column_stats`. This is what keeps the
+/// #872 differential hashes untouched by wave 5b.
+///
+/// Prove-the-test: delete the `observe_record` call in `PartBuilder::push`
+/// (rlog.rs) -> the stamped run's parts stamp all-NULL (absent extrema), so the
+/// "part0 carries the real extrema" assertion below fails while the
+/// byte-identity half still holds -- which is exactly why byte identity alone is
+/// not enough and this test also pins the stamped values.
+#[tokio::test]
+async fn stamping_leaves_the_stored_object_bytes_identical() {
+    // Merged ts order: 1000(50), 2000(10), 3000(7), 4000(99); parts split after
+    // two, so part0 = {50, 10} and part1 = {7, 99}.
+    let records_1 = vec![
+        rec(0, 1000, Some(50), Some(false), &[]),
+        rec(0, 3000, Some(7), Some(true), &[]),
+    ];
+    let records_2 = vec![
+        rec(0, 2000, Some(10), Some(true), &[]),
+        rec(0, 4000, Some(99), Some(false), &[]),
+    ];
+
+    // Same records, one run stamped and one not.
+    let stamped_store = MemoryStore::new();
+    seed(&stamped_store, Uuid::from_u128(1), 1, &records_1, true).await;
+    seed(&stamped_store, Uuid::from_u128(2), 2, &records_2, true).await;
+    let stamped = compact_and_record(&stamped_store, &split_config()).await;
+
+    let plain_store = MemoryStore::new();
+    seed(&plain_store, Uuid::from_u128(1), 1, &records_1, false).await;
+    seed(&plain_store, Uuid::from_u128(2), 2, &records_2, false).await;
+    let plain = compact_and_record(&plain_store, &split_config()).await;
+
+    assert_eq!(stamped.parts.len(), plain.parts.len());
+
+    // The stamped run must carry the REAL extrema (not just present, all-NULL
+    // stamps) -- otherwise byte-identity is vacuous.
+    assert_eq!(stamped.parts.len(), 2, "two records per part -> two parts");
+    assert_eq!(
+        part_i64(&stamped.parts[0], STATUS),
+        (Some(10), Some(50), 0),
+        "part0 status 10..50 over the records it holds"
+    );
+    assert_eq!(
+        part_i64(&stamped.parts[1], STATUS),
+        (Some(7), Some(99), 0),
+        "part1 status 7..99 over the records it holds"
+    );
+    for p in &plain.parts {
+        assert!(
+            read_compaction_part(p).covered().is_empty(),
+            "an unstamped input set produces unstamped parts"
+        );
+    }
+
+    // The L1 data objects are byte-identical: same content-addressed key (which
+    // hashes the whole object) and same bytes.
+    for (sp, pp) in stamped.parts.iter().zip(plain.parts.iter()) {
+        assert_eq!(
+            sp.content_hash, pp.content_hash,
+            "stamping must not change a part's content hash"
+        );
+        let sk = keys::reconstruct_l1_part_key(&stamped, sp).unwrap();
+        let pk = keys::reconstruct_l1_part_key(&plain, pp).unwrap();
+        assert_eq!(sk, pk, "content-addressed L1 part keys must match");
+        let sb = stamped_store.get(&sk, GetRange::Full).await.unwrap().data;
+        let pb = plain_store.get(&pk, GetRange::Full).await.unwrap().data;
+        assert_eq!(sb, pb, "stored L1 part bytes must be byte-identical");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: the wave-4 reader answers from the stamps with zero data-object GETs.
+// ---------------------------------------------------------------------------
+
+/// After compaction, resolving the bucket's snapshot carries each compacted
+/// part's declared-column stamps onto its `SegmentRef`, and MIN/MAX/COUNT of a
+/// declared column fold out of those stamps without opening a single L1 data
+/// object. The store is wrapped in a `FaultStore` that fails every GET against
+/// an `/l1/` (data part) key, so any attempt to read a part body aborts the
+/// resolve; the resolve succeeds and the fault never fires, which is the
+/// zero-data-GET reachability proof (the maintain-side twin of
+/// `ravel-sql/tests/logs_declared_minmax_from_stamps.rs`).
+///
+/// Prove-the-test: delete the `observe_record` call in `PartBuilder::push`
+/// (rlog.rs) -> the resolved segments are uncovered for `STATUS` and the
+/// per-segment coverage assertion panics.
+#[tokio::test]
+async fn resolve_answers_min_max_count_from_stamps_without_data_gets() {
+    let inner: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    // Event timestamps inside HOUR's own ns window, so the resolve's time-range
+    // filter (which is over event time) selects these segments.
+    let base = i64::from(HOUR) * NS_PER_HOUR;
+    let input_1 = vec![
+        rec(0, base + 1000, Some(50), Some(false), &[]),
+        rec(0, base + 3000, None, Some(true), &[]),
+    ];
+    let input_2 = vec![
+        rec(0, base + 2000, Some(10), Some(true), &[]),
+        rec(0, base + 4000, Some(99), None, &[]),
+    ];
+    seed(&*inner, Uuid::from_u128(1), 1, &input_1, true).await;
+    seed(&*inner, Uuid::from_u128(2), 2, &input_2, true).await;
+
+    // The true answer over all four records: status non-null values are 50, 10,
+    // 99 with one NULL (base + 3000), so MIN 10, MAX 99, COUNT(status) 3.
+    let all: Vec<&LogRecord> = input_1.iter().chain(input_2.iter()).collect();
+    let sv: Vec<i64> = all.iter().filter_map(|r| attr_i64(r, STATUS)).collect();
+    let true_min = *sv.iter().min().unwrap();
+    let true_max = *sv.iter().max().unwrap();
+    let true_rows = all.len() as u64;
+    let true_status_nulls = true_rows - sv.len() as u64;
+
+    // Compact on the raw store (this legitimately reads and PUTs data objects).
+    let record = compact_and_record(&*inner, &CompactorConfig::default()).await;
+    assert!(!record.parts.is_empty());
+
+    // Now arm a permanent GET fault on every L1 data-part key and resolve. A
+    // resolve that opened a part body would error; commit/compaction records
+    // live under `/c/`, not `/l1/`, so a stats-only resolve never trips it.
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(
+            Op::Get,
+            ScriptedFault::Permanent("resolve must not GET an L1 data object".into()),
+        )
+        .with_key_contains("/l1/"),
+    );
+    let faulted = Arc::new(ravel_object_store::fault::FaultStore::new(
+        Arc::clone(&inner),
+        plan,
+    ));
+    let catalog = ravel_catalog::Catalog::new(
+        Arc::clone(&faulted) as Arc<dyn ObjectStoreBackend>,
+        ravel_catalog::CatalogConfig {
+            shard_count: SHARD + 1,
+            ..Default::default()
+        },
+    )
+    .expect("catalog");
+    let range = TimeRange {
+        start_ns: i64::from(HOUR) * NS_PER_HOUR,
+        end_ns: (i64::from(HOUR) + 1) * NS_PER_HOUR,
+    };
+    let snapshot = catalog
+        .resolve(&tenant_hash(), Signal::Logs, range, &[], sealed_now_ns())
+        .await
+        .expect("resolve must not read any L1 data object");
+
+    assert_eq!(
+        faulted.fault_count(Op::Get, FaultKind::Permanent),
+        0,
+        "resolve must answer from record metadata, never a GET on an /l1/ data object"
+    );
+    assert!(
+        !snapshot.segments.is_empty(),
+        "the compacted bucket resolves segments"
+    );
+
+    // Fold MIN/MAX/COUNT(status) out of the resolved parts' stamps.
+    let mut min_status = i64::MAX;
+    let mut max_status = i64::MIN;
+    let mut rows = 0u64;
+    let mut status_nulls = 0u64;
+    for seg in &snapshot.segments {
+        rows += seg.sample_count;
+        let stat = seg
+            .declared_column_stats
+            .column(STATUS)
+            .unwrap_or_else(|| panic!("resolved segment uncovered for {STATUS}"));
+        if let Some(DeclaredStatValue::I64(v)) = stat.min() {
+            min_status = min_status.min(v);
+        }
+        if let Some(DeclaredStatValue::I64(v)) = stat.max() {
+            max_status = max_status.max(v);
+        }
+        status_nulls += stat.null_count();
+    }
+
+    assert_eq!(rows, true_rows, "the parts account for every record");
+    assert_eq!(min_status, true_min, "MIN(status) from stamps");
+    assert_eq!(max_status, true_max, "MAX(status) from stamps");
+    // COUNT(status) = total rows - NULL rows, taken from the exact null counts.
+    assert_eq!(
+        rows - status_nulls,
+        true_rows - true_status_nulls,
+        "COUNT(status) = rows - NULLs, from the stamped null counts"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: an erasure rewrite's parts stay unstamped.
+// ---------------------------------------------------------------------------
+
+/// The erasure rewrite drops rows, so a stamp computed over the pre-drop set
+/// would be stale for the survivors (ADR-0873 decision 3 staleness rule). Its
+/// output parts therefore carry NO declared-column stamps, even when the
+/// surviving records carry eligible declared columns and the L0 inputs were
+/// stamped -- the rewrite passes an empty declared set through the shared merge
+/// driver, so `finalize_part` stamps nothing.
+///
+/// Prove-the-test: in `erasure_rewrite::build_rewrite_logs` (rlog part of
+/// crates/ravel-maintain/src/erasure_rewrite.rs) replace the empty `declared`
+/// argument to `merge_catalogs` with a non-empty set (e.g. `vec![(STATUS,
+/// DeclaredStatType::I64)]`) and the survivors' parts gain stamps, failing the
+/// `is_empty` assertion here.
+#[tokio::test]
+async fn erasure_rewrite_parts_stay_unstamped() {
+    let store = MemoryStore::new();
+    // Two records carry the victim marker (dropped by the request); two do not
+    // and carry the eligible declared columns (survivors).
+    let victim = &[("subject", "victim")][..];
+    let input_1 = vec![
+        rec(0, 1000, Some(50), Some(false), &[]),
+        rec(0, 2000, Some(10), Some(true), victim),
+    ];
+    let input_2 = vec![
+        rec(0, 3000, Some(99), Some(true), victim),
+        rec(0, 4000, Some(7), Some(false), &[]),
+    ];
+    seed(&store, Uuid::from_u128(1), 1, &input_1, true).await;
+    seed(&store, Uuid::from_u128(2), 2, &input_2, true).await;
+
+    let request_id = Uuid::from_u128(99);
+    let request = ErasureRequest {
+        format_version: 1,
+        tenant_hash: tenant_hash().0.to_vec(),
+        signal: ravel_commit::signal::to_proto(Signal::Logs) as i32,
+        request_id: request_id.to_string(),
+        created_unix_ns: 0,
+        predicate: vec![ErasurePredicateMatcher {
+            key: "subject".to_string(),
+            value: "victim".to_string(),
+        }],
+        window_start_ns: 0,
+        window_end_ns: 0,
+        reason: String::new(),
+    };
+    let pending = PendingErasureRequest {
+        request_key: keys::erasure_request_key(&tenant_hash(), Signal::Logs, request_id)
+            .expect("dreq key"),
+        request,
+    };
+
+    let clock = FixedClock::new(sealed_now_ns());
+    let mut memo = MaintainMemo::with_default_interval();
+    let outcome = erasure_rewrite_bucket(
+        &store,
+        &clock,
+        &CompactorConfig::default(),
+        &NoLeases,
+        &bucket(),
+        std::slice::from_ref(&pending),
+        &mut memo,
+    )
+    .await
+    .expect("rewrite");
+    assert!(
+        matches!(outcome, ErasureRewriteOutcome::Rewritten { .. }),
+        "the victim records must trigger a rewrite, got {outcome:?}"
+    );
+
+    // Decode the rewrite record and assert every part is unstamped.
+    let prefix = keys::commit_shard_hour_prefix(&tenant_hash(), Signal::Logs, SHARD, HOUR).unwrap();
+    let rewrite_key = list_all(&store, &prefix)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|m| m.key)
+        .find(|k| {
+            matches!(
+                keys::partition_bucket_entry(k),
+                Ok(keys::BucketEntry::RewriteRecord(_))
+            )
+        })
+        .expect("rewrite record key");
+    let bytes = store.get(&rewrite_key, GetRange::Full).await.unwrap().data;
+    let rewrite = RewriteRecord::decode(bytes.as_ref()).unwrap();
+
+    assert!(
+        !rewrite.parts.is_empty(),
+        "the survivors produce at least one part"
+    );
+    let survivor_rows: u64 = rewrite.parts.iter().map(|p| p.sample_count).sum();
+    assert_eq!(survivor_rows, 2, "two survivors after the drop");
+    for p in &rewrite.parts {
+        assert!(
+            p.declared_column_stats.is_empty(),
+            "rewrite parts stay unstamped (wave-3 staleness rule), part {} had stamps",
+            p.part_index
+        );
+        assert!(
+            read_compaction_part(p).covered().is_empty(),
+            "and the reader sees no coverage on a rewrite part"
+        );
+    }
+}

--- a/crates/ravel-maintain/tests/rlog_declared_stamps.rs
+++ b/crates/ravel-maintain/tests/rlog_declared_stamps.rs
@@ -393,10 +393,12 @@ async fn each_output_part_stamps_exactly_its_own_records() {
     for p in &record.parts {
         assert_eq!(p.sample_count, 2, "each part holds two records");
         for stat in read_compaction_part(p).covered() {
-            let non_null = p.sample_count - stat.null_count();
             assert!(
-                non_null <= p.sample_count,
-                "non_null + null_count must equal sample_count"
+                stat.null_count() <= p.sample_count,
+                "a stamp's null_count can never exceed its part's sample_count \
+                 (null_count={} sample_count={})",
+                stat.null_count(),
+                p.sample_count
             );
         }
     }
@@ -643,6 +645,24 @@ async fn resolve_answers_min_max_count_from_stamps_without_data_gets() {
         faulted.fault_count(Op::Get, FaultKind::Permanent),
         0,
         "resolve must answer from record metadata, never a GET on an /l1/ data object"
+    );
+    // Negative control arming the rule itself: a direct GET of a real L1 part
+    // key must trip the fault, proving the "/l1/" substring matches the keys
+    // this tenant actually writes (a typo in the rule would make the zero
+    // assertion above silently vacuous).
+    let l1_key = &snapshot.segments[0].data_object_key;
+    assert!(
+        l1_key.contains("/l1/"),
+        "resolved segment key {l1_key:?} must be an L1 part"
+    );
+    faulted
+        .get(l1_key, ravel_object_store::GetRange::Full)
+        .await
+        .expect_err("a direct GET of a real L1 key must trip the armed fault rule");
+    assert_eq!(
+        faulted.fault_count(Op::Get, FaultKind::Permanent),
+        1,
+        "the negative control must fire the rule exactly once"
     );
     assert!(
         !snapshot.segments.is_empty(),

--- a/crates/ravel-maintain/tests/rlog_declared_stamps.rs
+++ b/crates/ravel-maintain/tests/rlog_declared_stamps.rs
@@ -65,9 +65,11 @@ const CACHE: &str = "cache.hit";
 /// without depending on the exact per-record slot overhead.
 const BODY_LEN: usize = 20_000;
 
-/// Two records fit under this decoded-heap target and three do not: at
+/// One record fits under this decoded-heap target and two do not: at
 /// `BODY_LEN` = 20_000 each record's estimate is ~20_400, so one is ~20_400
-/// (< 30_000) and two are ~40_800 (>= 30_000). `max_l1_part_bytes` stays at its
+/// (< 30_000) and two are ~40_800 (>= 30_000). The second record crosses the
+/// target and closes the part with both records in it, which is why the split
+/// lands on a boundary every two records. `max_l1_part_bytes` stays at its
 /// 256 MiB default so only the memory split target ever fires here.
 const SPLIT_TARGET_BYTES: u64 = 30_000;
 


### PR DESCRIPTION
ADR-0873 wave 5b. Compaction now folds each output part's eligible
declared-column extrema (I64/BOOL, first-occurrence-wins per record,
matching the ingest fold) over exactly the records that end up in that
part, and stamps them onto CompactionPart through the validated
commit-side path. A compacted tenant keeps the zero-GET MIN/MAX/COUNT
answer path instead of losing it at the first compaction.

The accumulator is born and consumed with its part: the fold sits on
PartBuilder::push before the record moves into the buffer, both close
decisions run after that push in the same call, and flush takes the
accumulator with the builder, so the record that trips a split closes
with its own part and the next record opens a fresh accumulator. The
exact-encode probe path clones records without re-entering push, so
probes cost zero extra folds. Stamps live in part metadata only: the
object is hashed and its footer read before stamping, proven by a test
comparing stored bytes across stamped and unstamped runs.

Rewrite parts stay deliberately unstamped at all four producers (an
unstamped part can never resurrect an erased row's extremum); the ADR
text contradiction this exposes is #1058, and the record-attrs-only
fold basis shared with ingest is #1057.

Refs: #1022
Signed-off-by: Panagiotis Moustafellos <pmoust@nofire.ai>
