### PR TITLE
feat(maintain): add the compaction read ledger

### DIFF
--- a/crates/ravel-maintain/src/build.rs
+++ b/crates/ravel-maintain/src/build.rs
@@ -79,6 +79,7 @@ use crate::bucket::Bucket;
 use crate::config::CompactorConfig;
 use crate::error::{MaintainError, Result};
 use crate::read::{InputCatalog, InputRecord, RunPlan, SeriesPlan};
+use crate::request_ledger::{RequestLedger, RequestPhase, note_get, note_put};
 
 /// Maximum concurrent page GETs in flight across a whole `build_parts` call.
 /// A single global cap (one shared [`Semaphore`]) driving
@@ -182,6 +183,7 @@ pub async fn build_parts(
     }
     let ingest_bounds = merged_ingest_bounds(inputs);
     let input_set_hash16 = hex::encode(&input_set_hash[..8]);
+    let ledger = config.request_ledger.as_ref();
 
     // Every input's exemplars, grouped by the series they name, in canonical
     // input order then each object's own stored order (ADR-0047 decision 3).
@@ -314,7 +316,7 @@ pub async fn build_parts(
             continue;
         }
         let window = &builds[window_start..=i];
-        let regions = fetch_batch_pages(store, &semaphore, window).await?;
+        let regions = fetch_batch_pages(store, &semaphore, window, ledger).await?;
         for build in window {
             let series_v7 = materialize_series(build, &regions, migrate_keys, limits)?;
             pending_estimate.push_series(&series_v7);
@@ -336,7 +338,7 @@ pub async fn build_parts(
                     std::mem::take(&mut pending_exemplars),
                 )?;
                 if !config.dry_run {
-                    put_part(store, &part).await?;
+                    put_part_with_ledger(store, &part, ledger).await?;
                 }
                 parts.push(part);
                 part_index += 1;
@@ -360,7 +362,7 @@ pub async fn build_parts(
             pending_exemplars,
         )?;
         if !config.dry_run {
-            put_part(store, &part).await?;
+            put_part_with_ledger(store, &part, ledger).await?;
         }
         parts.push(part);
     }
@@ -414,6 +416,7 @@ async fn fetch_batch_pages<'a, 'f>(
     store: &'f dyn ObjectStoreBackend,
     semaphore: &'f Semaphore,
     builds: &[SeriesBuild<'a>],
+    ledger: Option<&'f RequestLedger>,
 ) -> Result<BatchRegions<'a>>
 where
     'a: 'f,
@@ -451,7 +454,8 @@ where
     let futures: Vec<GetFuture<'a, 'f>> = gets
         .into_iter()
         .map(|(key, start, end)| {
-            Box::pin(fetch_one_range(store, semaphore, key, start, end)) as GetFuture<'a, 'f>
+            Box::pin(fetch_one_range(store, semaphore, key, start, end, ledger))
+                as GetFuture<'a, 'f>
         })
         .collect();
     let fetched: Vec<(&'a str, u64, Bytes)> = stream_iter(futures)
@@ -475,13 +479,15 @@ async fn fetch_one_range<'a>(
     key: &'a str,
     start: u64,
     end: u64,
+    ledger: Option<&RequestLedger>,
 ) -> Result<(&'a str, u64, Bytes)> {
     let _permit = semaphore
         .acquire()
         .await
         .map_err(|_| MaintainError::Invariant("page-fetch semaphore closed".into()))?;
-    let got = store.get(key, GetRange::Range(start, end)).await?;
-    Ok((key, start, got.data))
+    let got = store.get(key, GetRange::Range(start, end)).await;
+    note_get(ledger, RequestPhase::BlockRead, &got);
+    Ok((key, start, got?.data))
 }
 
 /// Decode, merge, and re-encode one series into a single run-merged
@@ -1135,6 +1141,19 @@ fn flush_part(
 /// time, before any release, so a `None` here is an internal invariant breach
 /// rather than a store fault.
 pub async fn put_part(store: &dyn ObjectStoreBackend, part: &BuiltPart) -> Result<PartPut> {
+    put_part_with_ledger(store, part, None).await
+}
+
+/// [`put_part`], counting the PUT attempt into `ledger`'s
+/// [`RequestPhase::PartPut`] with the encoded object bytes it offered (ADR-0996
+/// task 996-8). Recorded before the outcome is inspected, so a converging
+/// rerun's `AlreadyExists` still counts as the attempt it was: the request was
+/// issued and the body was sent either way.
+pub async fn put_part_with_ledger(
+    store: &dyn ObjectStoreBackend,
+    part: &BuiltPart,
+    ledger: Option<&RequestLedger>,
+) -> Result<PartPut> {
     use ravel_object_store::{PutOptions, StoreError, UploadChecksum};
     let bytes = part.bytes.as_ref().ok_or_else(|| {
         MaintainError::Invariant(format!(
@@ -1143,14 +1162,15 @@ pub async fn put_part(store: &dyn ObjectStoreBackend, part: &BuiltPart) -> Resul
         ))
     })?;
     let checksum = UploadChecksum::Crc32c(crc32c::crc32c(bytes));
-    match store
+    let result = store
         .put(
             &part.key,
             bytes.clone(),
             PutOptions::create_if_absent().with_checksum(checksum),
         )
-        .await
-    {
+        .await;
+    note_put(ledger, RequestPhase::PartPut, bytes.len() as u64);
+    match result {
         Ok(_) => Ok(PartPut::Created),
         Err(StoreError::AlreadyExists) => Ok(PartPut::AlreadyExisted),
         Err(e) => Err(MaintainError::Store(e)),

--- a/crates/ravel-maintain/src/compact.rs
+++ b/crates/ravel-maintain/src/compact.rs
@@ -58,17 +58,18 @@ pub async fn compact_bucket(
     // primitive it later dispatches to therefore must not reset (ADR-0996 task
     // 996-8). The scope is closed on every exit path, including the gates that
     // return before any rewrite runs.
-    if let Some(l) = config.request_ledger.as_ref() {
+    let scope = config.request_ledger.as_ref().map(|l| {
         l.reset_for_run();
-    }
+        l.run_scope_guard()
+    });
     let outcome = compact_bucket_scoped(store, clock, config, bucket).await;
     // As the opener, this driver emits the run's report on EVERY outcome: the
     // gates that return before any rewrite (NotSealed, AlreadyCompacted,
     // Tombstoned, BelowMinInputs) still paid their LIST and report it
-    // (ADR-0996 task 996-8).
+    // (ADR-0996 task 996-8). The guard closes the scope even on cancellation.
     crate::rewrite::emit_request_report(config, bucket, outcome.is_ok());
-    if let Some(l) = config.request_ledger.as_ref() {
-        l.end_run();
+    if let Some(scope) = scope {
+        scope.close();
     }
     outcome
 }

--- a/crates/ravel-maintain/src/compact.rs
+++ b/crates/ravel-maintain/src/compact.rs
@@ -62,6 +62,11 @@ pub async fn compact_bucket(
         l.reset_for_run();
     }
     let outcome = compact_bucket_scoped(store, clock, config, bucket).await;
+    // As the opener, this driver emits the run's report on EVERY outcome: the
+    // gates that return before any rewrite (NotSealed, AlreadyCompacted,
+    // Tombstoned, BelowMinInputs) still paid their LIST and report it
+    // (ADR-0996 task 996-8).
+    crate::rewrite::emit_request_report(config, bucket, outcome.is_ok());
     if let Some(l) = config.request_ledger.as_ref() {
         l.end_run();
     }

--- a/crates/ravel-maintain/src/compact.rs
+++ b/crates/ravel-maintain/src/compact.rs
@@ -14,7 +14,7 @@ use crate::config::CompactorConfig;
 use crate::error::{MaintainError, Result};
 use crate::publish::{PublishOutcome, conserve_exact};
 use crate::read;
-use crate::read::list_bucket;
+use crate::read::list_bucket_with_ledger;
 use crate::rewrite::rewrite_and_publish;
 use crate::rlog::RlogCodec;
 use crate::rspan_codec::SpanCodec;
@@ -52,12 +52,36 @@ pub async fn compact_bucket(
     config: &CompactorConfig,
     bucket: &Bucket,
 ) -> Result<CompactionOutcome> {
+    // This is the run's outermost driver, so it opens the request ledger's
+    // scope here, BEFORE the bucket LIST below: that LIST is the run's first
+    // store request and belongs in the run's own report, and the rewrite
+    // primitive it later dispatches to therefore must not reset (ADR-0996 task
+    // 996-8). The scope is closed on every exit path, including the gates that
+    // return before any rewrite runs.
+    if let Some(l) = config.request_ledger.as_ref() {
+        l.reset_for_run();
+    }
+    let outcome = compact_bucket_scoped(store, clock, config, bucket).await;
+    if let Some(l) = config.request_ledger.as_ref() {
+        l.end_run();
+    }
+    outcome
+}
+
+/// [`compact_bucket`]'s body, with the request ledger's run scope already
+/// opened and guaranteed to be closed by its caller.
+async fn compact_bucket_scoped(
+    store: &dyn ObjectStoreBackend,
+    clock: &dyn Clock,
+    config: &CompactorConfig,
+    bucket: &Bucket,
+) -> Result<CompactionOutcome> {
     let start_ns = clock.now_ns();
     if !bucket.is_sealed(start_ns, config) {
         return Ok(CompactionOutcome::NotSealed);
     }
 
-    let listing = list_bucket(store, bucket).await?;
+    let listing = list_bucket_with_ledger(store, bucket, config.request_ledger.as_ref()).await?;
     if listing.tombstone_key.is_some() {
         return Ok(CompactionOutcome::Tombstoned);
     }

--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -13,6 +13,8 @@ use std::time::Duration;
 use ravel_types::{TenantHash, TenantId};
 use uuid::Uuid;
 
+use crate::request_ledger::RequestLedger;
+
 /// A test-injectable accounting hook for the RLOG and RSPAN compaction
 /// merges' peak resident memory (RLOG and RSPAN, ADR-0065 decision 4).
 ///
@@ -1012,6 +1014,16 @@ pub struct CompactorConfig {
     /// `..CompactorConfig::default()` call sites are unaffected. Default
     /// `None`.
     pub merge_memory_tracker: Option<MergeMemoryTracker>,
+    /// Optional test-injectable ledger of the run's store requests and wire
+    /// bytes, split by the phase that issued them (ADR-0996 task 996-8).
+    /// `None` in production (every hook is skipped); a test or an operator
+    /// build installs one and reads [`RequestLedger::report`] after the run.
+    /// Counters only: no fetch decision, coalescing choice, or budget anywhere
+    /// in this crate reads a ledger figure (see [`crate::request_ledger`]).
+    /// Carried in the config like every other merge knob, so
+    /// `..CompactorConfig::default()` call sites are unaffected. Default
+    /// `None`.
+    pub request_ledger: Option<RequestLedger>,
     /// Slow safety-net re-verify cadence for the interior zone (ADR-0065
     /// decision 3, config `maintain_interior_reverify`). A terminal interior
     /// bucket is re-evaluated no later than this after its last verification,
@@ -1046,6 +1058,7 @@ impl Default for CompactorConfig {
             audit_retention_window_ns: DEFAULT_AUDIT_RETENTION_NS,
             dry_run: false,
             merge_memory_tracker: None,
+            request_ledger: None,
             interior_reverify_ns: DEFAULT_INTERIOR_REVERIFY_NS,
         }
     }

--- a/crates/ravel-maintain/src/lib.rs
+++ b/crates/ravel-maintain/src/lib.rs
@@ -53,6 +53,7 @@ pub mod provision_audit;
 pub mod publish;
 pub mod query_audit;
 pub mod read;
+pub mod request_ledger;
 pub mod retention;
 pub mod rewrite;
 pub mod rlog;
@@ -102,6 +103,7 @@ pub use publish::{
 };
 pub use query_audit::{QUERY_AUDIT_SHARD, QueryStatus, query_audit_event, write_query_audit};
 pub use ravel_fleet::worker_set::{WorkerSet, owner, owns, run_bounded, unit_key};
+pub use request_ledger::{PhaseRequests, RequestLedger, RequestPhase, RunRequestReport};
 pub use retention::{
     RetentionOutcome, SnapshotBlock, SnapshotReachability, maintain_bucket,
     maintain_bucket_with_reach, retention_sweep_bucket, retention_sweep_bucket_with_reach,

--- a/crates/ravel-maintain/src/publish.rs
+++ b/crates/ravel-maintain/src/publish.rs
@@ -16,6 +16,7 @@ use crate::clock::Clock;
 use crate::config::CompactorConfig;
 use crate::error::{MaintainError, Result};
 use crate::read::InputRecord;
+use crate::request_ledger::{RequestLedger, RequestPhase, note_get, note_metadata, note_put};
 
 /// What publishing did.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -206,7 +207,14 @@ pub async fn publish_record_with_conservation(
         return Ok(PublishOutcome::Published);
     }
 
-    match store.put(&record_key, payload.into(), opts).await {
+    let ledger = config.request_ledger.as_ref();
+    // Publish phase (ADR-0996 task 996-8): the record PUT is recorded before its
+    // outcome is inspected, so the `AlreadyExists` convergence arm below counts
+    // the request it spent exactly like the winning arm.
+    let payload_len = payload.len() as u64;
+    let put = store.put(&record_key, payload.into(), opts).await;
+    note_put(ledger, RequestPhase::Publish, payload_len);
+    match put {
         Ok(_) => {
             // The tombstone race is closed by verification, not retention
             // (ADR-0979 decision 3): a part that answered `AlreadyExists` at PUT
@@ -215,12 +223,12 @@ pub async fn publish_record_with_conservation(
             // parts now that the record is durable; a missing one fails loud with
             // a re-runnable typed error rather than leaving the record pointing
             // at a part the bounded compactor can no longer repair.
-            verify_already_existed_parts(store, parts).await?;
+            verify_already_existed_parts(store, parts, ledger).await?;
             tracing::info!(key = %record_key, parts = parts.len(), "compaction record published");
             Ok(PublishOutcome::Published)
         }
         Err(StoreError::AlreadyExists) => {
-            resolve_already_exists(store, &record_key, input_set_hash, parts).await
+            resolve_already_exists(store, &record_key, input_set_hash, parts, ledger).await
         }
         Err(e) => Err(MaintainError::Store(e)),
     }
@@ -239,9 +247,12 @@ pub async fn publish_record_with_conservation(
 async fn verify_already_existed_parts(
     store: &dyn ObjectStoreBackend,
     parts: &[BuiltPart],
+    ledger: Option<&RequestLedger>,
 ) -> Result<()> {
     for part in parts.iter().filter(|p| p.put_already_existed) {
-        match store.head(&part.key).await {
+        let head = store.head(&part.key).await;
+        note_metadata(ledger, RequestPhase::Publish);
+        match head {
             Ok(_) => {}
             Err(StoreError::NotFound) => {
                 return Err(MaintainError::AlreadyExistsPartVanished {
@@ -280,8 +291,11 @@ async fn resolve_already_exists(
     record_key: &str,
     our_hash: &[u8; 32],
     our_parts: &[BuiltPart],
+    ledger: Option<&RequestLedger>,
 ) -> Result<PublishOutcome> {
-    let existing = store.get(record_key, GetRange::Full).await?;
+    let existing = store.get(record_key, GetRange::Full).await;
+    note_get(ledger, RequestPhase::Publish, &existing);
+    let existing = existing?;
     let winner = CompactionRecord::decode(existing.data.as_ref())
         .map_err(|e| MaintainError::Invariant(format!("winner record decode failed: {e}")))?;
     // The winner's key must reconstruct to the key we fetched it at.
@@ -299,7 +313,9 @@ async fn resolve_already_exists(
     let mut repaired = 0usize;
     for part in &winner.parts {
         let part_key = keys::reconstruct_l1_part_key(&winner, part)?;
-        match store.head(&part_key).await {
+        let head = store.head(&part_key).await;
+        note_metadata(ledger, RequestPhase::Publish);
+        match head {
             Ok(_) => {}
             Err(StoreError::NotFound) => {
                 // Re-PUT only a part whose bytes we still hold. A bounded
@@ -309,7 +325,11 @@ async fn resolve_already_exists(
                 // scratch rebuilds and re-PUTs the byte-identical part.
                 match our_parts.iter().find(|p| p.key == part_key) {
                     Some(ours) if ours.bytes.is_some() => {
-                        crate::build::put_part(store, ours).await?;
+                        // A repair re-PUT is a part PUT: it is attributed to
+                        // `PartPut` by what the request writes, beside every
+                        // other L1 part write, not to the phase that noticed
+                        // the hole.
+                        crate::build::put_part_with_ledger(store, ours, ledger).await?;
                         repaired += 1;
                     }
                     // Cannot repair (bytes released at PUT, or a part this run

--- a/crates/ravel-maintain/src/read.rs
+++ b/crates/ravel-maintain/src/read.rs
@@ -22,7 +22,7 @@ use futures::stream::{StreamExt, TryStreamExt, iter as stream_iter};
 use ravel_commit::erasure::compute_compaction_input_set_hash;
 use ravel_commit::keys::{self, BucketEntry};
 use ravel_commit::record;
-use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError, list_all};
+use ravel_object_store::{GetRange, ObjectMeta, ObjectStoreBackend, StoreError};
 use ravel_proto::commit::v1::{CommitRecord, CompactionInputIdentity};
 use ravel_segment::{
     ExemplarInput, FooterLocation, FooterOutcome, ReaderLimits, ValueKind, decode_catalog_v4,
@@ -33,6 +33,7 @@ use ravel_types::{LabelSet, SeriesId, Signal};
 use crate::bucket::Bucket;
 use crate::config::CompactorConfig;
 use crate::error::{MaintainError, Result};
+use crate::request_ledger::{RequestLedger, RequestPhase, note_get, note_metadata};
 
 /// Persistent section-kind numbers (docs/segment-format.md); not re-exported
 /// by `ravel_segment`, named here as the format contract, same as ravel-bench.
@@ -66,13 +67,26 @@ pub struct BucketListing {
 /// A key matching no known shape is [`MaintainError::UnknownBucketEntry`]
 /// (fail loud on layout drift), never skipped.
 pub async fn list_bucket(store: &dyn ObjectStoreBackend, bucket: &Bucket) -> Result<BucketListing> {
+    list_bucket_with_ledger(store, bucket, None).await
+}
+
+/// [`list_bucket`], counting each listing page into `ledger`'s
+/// [`RequestPhase::List`] (ADR-0996 task 996-8). The listing drain is the same
+/// one [`ravel_object_store::list_all`] performs; it is spelled out here only so
+/// the per-page request count is recorded where the page is fetched, rather than
+/// inferred afterwards from a total.
+pub async fn list_bucket_with_ledger(
+    store: &dyn ObjectStoreBackend,
+    bucket: &Bucket,
+    ledger: Option<&RequestLedger>,
+) -> Result<BucketListing> {
     let prefix = keys::commit_shard_hour_prefix(
         &bucket.tenant_hash,
         bucket.signal,
         bucket.shard,
         bucket.ingest_hour_bucket,
     )?;
-    let metas = list_all(store, &prefix).await?;
+    let metas = list_all_counted(store, &prefix, ledger).await?;
     let mut listing = BucketListing::default();
     for meta in metas {
         match keys::partition_bucket_entry(&meta.key) {
@@ -91,6 +105,37 @@ pub async fn list_bucket(store: &dyn ObjectStoreBackend, bucket: &Bucket) -> Res
     listing.compaction_record_keys.sort();
     listing.rewrite_record_keys.sort();
     Ok(listing)
+}
+
+/// Drain every page of a listing, deduplicating by key per the cross-page
+/// guarantee, recording one [`RequestPhase::List`] request per page. Byte for
+/// byte the behaviour of [`ravel_object_store::list_all`]; only the counting
+/// hook is added, and a listing response body is not visible at the store seam,
+/// so no byte figure moves.
+async fn list_all_counted(
+    store: &dyn ObjectStoreBackend,
+    prefix: &str,
+    ledger: Option<&RequestLedger>,
+) -> Result<Vec<ObjectMeta>> {
+    let mut out: Vec<ObjectMeta> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut page_token = None;
+    loop {
+        // Recorded before the error check: a failed page was still spent.
+        let page = store.list(prefix, page_token).await;
+        note_metadata(ledger, RequestPhase::List);
+        let page = page?;
+        for meta in page.objects {
+            if seen.insert(meta.key.clone()) {
+                out.push(meta);
+            }
+        }
+        match page.next {
+            Some(next) => page_token = Some(next),
+            None => break,
+        }
+    }
+    Ok(out)
 }
 
 /// One decoded L0 input: its commit record plus the key it was listed at.
@@ -118,6 +163,19 @@ pub async fn load_inputs(
     commit_keys: &[String],
     concurrency: usize,
 ) -> Result<Vec<InputRecord>> {
+    load_inputs_with_ledger(store, bucket, commit_keys, concurrency, None).await
+}
+
+/// [`load_inputs`], counting each commit-record GET into `ledger`'s
+/// [`RequestPhase::RecordRead`] with the response bytes it returned (ADR-0996
+/// task 996-8).
+pub async fn load_inputs_with_ledger(
+    store: &dyn ObjectStoreBackend,
+    bucket: &Bucket,
+    commit_keys: &[String],
+    concurrency: usize,
+    ledger: Option<&RequestLedger>,
+) -> Result<Vec<InputRecord>> {
     // Box each GET future with an explicit `+ Send` bound before handing it to
     // `buffer_unordered`, the same workaround `crate::build::fetch_batch_pages`
     // documents: a bare `async` block borrowing the `&dyn ObjectStoreBackend`
@@ -126,7 +184,7 @@ pub async fn load_inputs(
     type InputFuture<'f> = Pin<Box<dyn Future<Output = Result<InputRecord>> + Send + 'f>>;
     let futures: Vec<InputFuture<'_>> = commit_keys
         .iter()
-        .map(|key| Box::pin(load_one_input(store, bucket, key)) as InputFuture<'_>)
+        .map(|key| Box::pin(load_one_input(store, bucket, key, ledger)) as InputFuture<'_>)
         .collect();
     let mut inputs: Vec<InputRecord> = stream_iter(futures)
         .buffer_unordered(concurrency.max(1))
@@ -154,8 +212,11 @@ async fn load_one_input(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,
     key: &str,
+    ledger: Option<&RequestLedger>,
 ) -> Result<InputRecord> {
-    let got = store.get(key, GetRange::Full).await?;
+    let got = store.get(key, GetRange::Full).await;
+    note_get(ledger, RequestPhase::RecordRead, &got);
+    let got = got?;
     let record = record::decode(&got.data)?;
     // The record's key must reconstruct to the key we listed it at.
     verify_commit_key(&record, key)?;
@@ -335,18 +396,23 @@ pub async fn load_catalog_from_object(
     writer_seq: u64,
 ) -> Result<InputCatalog> {
     let limits = ReaderLimits::default();
+    let ledger = config.request_ledger.as_ref();
 
     // Locate the footer from a suffix probe.
     let probe = store
         .get(&object_key, GetRange::Suffix(config.footer_probe_bytes))
-        .await?;
+        .await;
+    note_get(ledger, RequestPhase::CatalogRead, &probe);
+    let probe = probe?;
     let total = probe.total_size;
     let loc = match open_from_suffix(&probe.data, total, limits)? {
         FooterOutcome::Ready(loc) => loc,
         FooterOutcome::NeedRange { offset, len } => {
             let tail = store
                 .get(&object_key, GetRange::Range(offset, offset + len))
-                .await?;
+                .await;
+            note_get(ledger, RequestPhase::CatalogRead, &tail);
+            let tail = tail?;
             match open_from_suffix(&tail.data, total, limits)? {
                 FooterOutcome::Ready(loc) => loc,
                 FooterOutcome::NeedRange { .. } => {
@@ -366,12 +432,13 @@ pub async fn load_catalog_from_object(
         // routine input shape, not a rare one; the whole-object GET is the
         // stated cost of the sparse catalog decode, not evidence of a corner
         // case.
-        let whole = store.get(&object_key, GetRange::Full).await?;
-        decode_catalog_v5(footer, &whole.data, limits)?
+        let whole = store.get(&object_key, GetRange::Full).await;
+        note_get(ledger, RequestPhase::CatalogRead, &whole);
+        decode_catalog_v5(footer, &whole?.data, limits)?
     } else {
-        let dict = get_section(store, &object_key, footer, LABEL_DICT).await?;
-        let ids = get_section(store, &object_key, footer, SERIES_IDS).await?;
-        let meta = get_section(store, &object_key, footer, SERIES_META).await?;
+        let dict = get_section(store, &object_key, footer, LABEL_DICT, ledger).await?;
+        let ids = get_section(store, &object_key, footer, SERIES_IDS, ledger).await?;
+        let meta = get_section(store, &object_key, footer, SERIES_META, ledger).await?;
         decode_catalog_v4(footer, &dict, &ids, &meta, limits)?
     };
 
@@ -418,7 +485,8 @@ pub async fn load_catalog_from_object(
         ));
     }
 
-    let exemplars = load_input_exemplars(store, &object_key, footer, limits, &series).await?;
+    let exemplars =
+        load_input_exemplars(store, &object_key, footer, limits, &series, ledger).await?;
 
     Ok(InputCatalog {
         object_key,
@@ -480,6 +548,7 @@ async fn load_input_exemplars(
     footer: &ravel_segment::Footer,
     limits: ReaderLimits,
     series: &[SeriesPlan],
+    ledger: Option<&RequestLedger>,
 ) -> Result<Vec<ExemplarInput>> {
     if !footer.sections.iter().any(|s| s.kind == EXEMPLARS) {
         return Ok(Vec::new());
@@ -492,8 +561,8 @@ async fn load_input_exemplars(
             footer.series_count
         )));
     }
-    let dict = get_section(store, object_key, footer, LABEL_DICT).await?;
-    let section = get_section(store, object_key, footer, EXEMPLARS).await?;
+    let dict = get_section(store, object_key, footer, LABEL_DICT, ledger).await?;
+    let section = get_section(store, object_key, footer, EXEMPLARS, ledger).await?;
     let records = decode_exemplars_section(footer, &dict, &section, limits)?;
 
     let mut out = Vec::with_capacity(records.len());
@@ -523,6 +592,7 @@ async fn get_section(
     key: &str,
     footer: &ravel_segment::Footer,
     kind: u32,
+    ledger: Option<&RequestLedger>,
 ) -> Result<bytes::Bytes> {
     let section = footer
         .sections
@@ -536,8 +606,9 @@ async fn get_section(
             key,
             GetRange::Range(section.offset, section.offset + section.len),
         )
-        .await?;
-    Ok(got.data)
+        .await;
+    note_get(ledger, RequestPhase::CatalogRead, &got);
+    Ok(got?.data)
 }
 
 #[cfg(test)]

--- a/crates/ravel-maintain/src/request_ledger.rs
+++ b/crates/ravel-maintain/src/request_ledger.rs
@@ -1,0 +1,439 @@
+//! The compaction read ledger (ADR-0996 task 996-8): a per-run count of the
+//! store requests a compaction run issues, and the wire bytes they move, split
+//! by the phase that issued them.
+//!
+//! # Observation only
+//!
+//! Nothing in this crate ever reads a ledger figure back to make a decision.
+//! No fetch is routed, no range is coalesced, no budget is consulted, and no
+//! branch anywhere tests a request count or a byte count recorded here. The
+//! only condition any call site evaluates is whether a ledger is installed at
+//! all ([`CompactorConfig::request_ledger`] being `Some`), exactly as the
+//! [`MergeMemoryTracker`] hooks do. ADR-0996 defers every compaction
+//! fetch-policy question behind epic #979; this task is counters only.
+//!
+//! [`CompactorConfig::request_ledger`]: crate::config::CompactorConfig::request_ledger
+//! [`MergeMemoryTracker`]: crate::config::MergeMemoryTracker
+//!
+//! # Attribution is by call site, never inferred
+//!
+//! Every increment happens at the store call the run already owns, naming its
+//! phase there. Nothing is derived afterwards from a pooled total, and no
+//! instrumented-store wrapper does the counting in production: a decorator sees
+//! `get`/`put`/`head`/`list` and cannot say which phase issued one, which is the
+//! whole point of a per-phase split (the repo's measurement rule: a slowdown has
+//! to be attributable in one query, not one afternoon). Tests do wrap the store,
+//! but only as an ORACLE for the totals this ledger claims.
+//!
+//! # Byte kinds
+//!
+//! Each phase reports a request count plus two byte figures that are DIFFERENT
+//! KINDS and are never summed with each other:
+//!
+//! - [`PhaseRequests::wire_bytes_received`]: response payload bytes as
+//!   transferred, i.e. the stored (still compressed) form a GET hands back,
+//!   including the gap bytes a coalesced range carries.
+//! - [`PhaseRequests::wire_bytes_sent`]: request payload bytes as offered to a
+//!   PUT, counted whether the store accepted the write or answered
+//!   `AlreadyExists`.
+//!
+//! Neither is a decoded-heap figure: [`crate::config::MergePhasePeaks`] owns
+//! decoded residency, and folding the two together would produce a number of no
+//! kind at all. LIST and HEAD report requests only; their response bodies are
+//! not visible at the [`ObjectStoreBackend`] seam, so both byte fields stay zero
+//! for a phase that only issues those.
+//!
+//! [`ObjectStoreBackend`]: ravel_object_store::ObjectStoreBackend
+//!
+//! # Requests are calls, not billed attempts
+//!
+//! A figure here counts logical store calls the compaction path made. ADR-0996
+//! decision 3's headline BILLING figure is `StoreMetrics.attempts`, which only
+//! the S3 adapter's counting connector can fill in; that seam is below this one
+//! and is not duplicated here (the ADR's rejected alternative 4). On a backend
+//! with an attempts source, `calls <= attempts`, and the difference is retry
+//! overhead this ledger does not see.
+//!
+//! # Run scope
+//!
+//! One ledger per concurrent run, like the memory tracker. The run's outermost
+//! driver opens the scope with [`RequestLedger::reset_for_run`] before its first
+//! store call (the bucket LIST happens before the rewrite primitive is entered,
+//! so the rewrite cannot be the resetting point), and
+//! [`RequestLedger::reset_for_run_unless_open`] lets a directly driven
+//! [`crate::rewrite::rewrite_and_publish`] still get a scope of its own without
+//! wiping the LIST an enclosing driver already counted.
+//!
+//! The instrumented paths are the shared compaction pipeline: the bucket
+//! listing, input commit-record reads, per-input catalog reads, the merge's
+//! block reads, part PUTs, and the publish protocol. The erasure rewrite
+//! (`crate::erasure_rewrite`) reuses several of those helpers, so a ledger
+//! installed while it runs collects the shared parts of its traffic and not its
+//! own listing or publish; install one per compaction run.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+/// The phase a store request is attributed to. Attribution is by the call site
+/// that issued the request, never by operation kind: a HEAD in the publish
+/// protocol and a HEAD anywhere else are different phases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RequestPhase {
+    /// The bucket listing that discovers the input set (`crate::read::list_bucket`).
+    /// One request per listing PAGE, so a paginated drain counts every page.
+    List,
+    /// The L0 commit-record GETs that decode the input set
+    /// (`crate::read::load_inputs`).
+    RecordRead,
+    /// Per-input catalog reads: the footer suffix probe and any follow-up tail
+    /// range, the directory/catalog sections fetched by range, the whole-object
+    /// GET the RSEG sparse-catalog decode needs, and the optional
+    /// exemplar/postings sections.
+    CatalogRead,
+    /// Page and block reads during the merge: the RSEG coalesced page-range
+    /// GETs and the RLOG/RSPAN cursor pipeline's per-block ranged GETs.
+    BlockRead,
+    /// L1 part PUT attempts, including one that answers `AlreadyExists` (a
+    /// converging rerun still spent the request), and the convergence-repair
+    /// re-PUT of a winner's missing part.
+    PartPut,
+    /// The publish protocol: the compaction record's `CreateIfAbsent` PUT, the
+    /// post-publish HEAD verification of `AlreadyExists` parts, and, on the
+    /// converging path, the winner-record GET and its per-part HEADs.
+    Publish,
+}
+
+impl RequestPhase {
+    /// Every phase, in report order.
+    pub const ALL: [RequestPhase; 6] = [
+        RequestPhase::List,
+        RequestPhase::RecordRead,
+        RequestPhase::CatalogRead,
+        RequestPhase::BlockRead,
+        RequestPhase::PartPut,
+        RequestPhase::Publish,
+    ];
+
+    /// Stable snake_case name, used as the tracing field prefix.
+    pub fn name(self) -> &'static str {
+        match self {
+            RequestPhase::List => "list",
+            RequestPhase::RecordRead => "record_read",
+            RequestPhase::CatalogRead => "catalog_read",
+            RequestPhase::BlockRead => "block_read",
+            RequestPhase::PartPut => "part_put",
+            RequestPhase::Publish => "publish",
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            RequestPhase::List => 0,
+            RequestPhase::RecordRead => 1,
+            RequestPhase::CatalogRead => 2,
+            RequestPhase::BlockRead => 3,
+            RequestPhase::PartPut => 4,
+            RequestPhase::Publish => 5,
+        }
+    }
+}
+
+/// One phase's figures. The two byte fields are different kinds and are never
+/// summed with each other, nor with any decoded-heap figure
+/// ([`crate::config::MergePhasePeaks`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PhaseRequests {
+    /// Store calls this phase issued. A ranged GET is one request, a listing
+    /// page is one request, and a PUT that answered `AlreadyExists` is one
+    /// request: what is counted is what was spent, not what succeeded.
+    pub requests: u64,
+    /// Response payload bytes as transferred, summed over this phase's GETs:
+    /// the stored (compressed) form the store handed back, including the gap
+    /// bytes a coalesced range carries. Zero for a phase that only issues LIST
+    /// or HEAD, whose response bodies this seam cannot see. Never a decoded
+    /// figure.
+    pub wire_bytes_received: u64,
+    /// Request payload bytes as offered, summed over this phase's PUTs,
+    /// counted whether the store accepted the write or answered
+    /// `AlreadyExists`. Encoded object bytes, the same kind a part's
+    /// `object_size` records.
+    pub wire_bytes_sent: u64,
+}
+
+/// One compaction run's request/byte figures split by phase (ADR-0996
+/// decision 3's per-phase attribution rule). Read from a [`RequestLedger`] via
+/// [`RequestLedger::report`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RunRequestReport {
+    /// Bucket listing ([`RequestPhase::List`]): requests only.
+    pub list: PhaseRequests,
+    /// Input commit-record reads ([`RequestPhase::RecordRead`]).
+    pub record_read: PhaseRequests,
+    /// Per-input catalog reads ([`RequestPhase::CatalogRead`]).
+    pub catalog_read: PhaseRequests,
+    /// Merge page/block reads ([`RequestPhase::BlockRead`]).
+    pub block_read: PhaseRequests,
+    /// L1 part PUT attempts ([`RequestPhase::PartPut`]).
+    pub part_put: PhaseRequests,
+    /// The publish protocol ([`RequestPhase::Publish`]).
+    pub publish: PhaseRequests,
+}
+
+impl RunRequestReport {
+    /// One phase's figures.
+    pub fn phase(&self, phase: RequestPhase) -> PhaseRequests {
+        match phase {
+            RequestPhase::List => self.list,
+            RequestPhase::RecordRead => self.record_read,
+            RequestPhase::CatalogRead => self.catalog_read,
+            RequestPhase::BlockRead => self.block_read,
+            RequestPhase::PartPut => self.part_put,
+            RequestPhase::Publish => self.publish,
+        }
+    }
+
+    /// Total store calls across every phase. Requests are one kind, so this sum
+    /// is meaningful where a byte sum across phases would not be.
+    pub fn total_requests(&self) -> u64 {
+        RequestPhase::ALL
+            .iter()
+            .fold(0u64, |acc, p| acc.saturating_add(self.phase(*p).requests))
+    }
+
+    /// Total response payload bytes received across every phase. One kind
+    /// (bytes as transferred, GET responses only), so the sum is well defined.
+    pub fn total_wire_bytes_received(&self) -> u64 {
+        RequestPhase::ALL.iter().fold(0u64, |acc, p| {
+            acc.saturating_add(self.phase(*p).wire_bytes_received)
+        })
+    }
+
+    /// Total request payload bytes sent across every phase. One kind (bytes as
+    /// offered, PUT bodies only); deliberately NOT added to
+    /// [`Self::total_wire_bytes_received`].
+    pub fn total_wire_bytes_sent(&self) -> u64 {
+        RequestPhase::ALL.iter().fold(0u64, |acc, p| {
+            acc.saturating_add(self.phase(*p).wire_bytes_sent)
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct PhaseCounters {
+    requests: AtomicU64,
+    wire_bytes_received: AtomicU64,
+    wire_bytes_sent: AtomicU64,
+}
+
+#[derive(Debug, Default)]
+struct RequestLedgerInner {
+    phases: [PhaseCounters; RequestPhase::ALL.len()],
+    /// Whether a run's scope is currently open. Read only by
+    /// [`RequestLedger::reset_for_run_unless_open`] to decide whether an
+    /// enclosing driver already opened one; it never reaches any store or
+    /// fetch decision.
+    run_open: AtomicBool,
+}
+
+/// A test-injectable, cheap-atomics ledger of a compaction run's store requests
+/// and wire bytes, split by phase. See the [module docs](self): observation
+/// only, attributed at the call site, one ledger per concurrent run.
+///
+/// Production never installs one ([`crate::config::CompactorConfig::request_ledger`]
+/// is `None`), so every hook compiles to a single `Option` check. Installing one
+/// is the one-line change that surfaces [`Self::report`] to an operator through
+/// the `tracing::info!` event [`crate::rewrite::rewrite_and_publish`] emits.
+#[derive(Clone, Debug, Default)]
+pub struct RequestLedger {
+    inner: Arc<RequestLedgerInner>,
+}
+
+impl RequestLedger {
+    /// A fresh ledger with every counter at zero and no run open.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Account one GET issued by `phase`, with the response payload length it
+    /// returned (bytes as transferred).
+    pub fn record_get(&self, phase: RequestPhase, wire_bytes_received: u64) {
+        let counters = &self.inner.phases[phase.index()];
+        counters.requests.fetch_add(1, Ordering::Relaxed);
+        counters
+            .wire_bytes_received
+            .fetch_add(wire_bytes_received, Ordering::Relaxed);
+    }
+
+    /// Account one PUT issued by `phase`, with the request payload length it
+    /// offered (bytes as transferred). Called whether the PUT was accepted or
+    /// answered `AlreadyExists`: both spent the request and both sent the body.
+    pub fn record_put(&self, phase: RequestPhase, wire_bytes_sent: u64) {
+        let counters = &self.inner.phases[phase.index()];
+        counters.requests.fetch_add(1, Ordering::Relaxed);
+        counters
+            .wire_bytes_sent
+            .fetch_add(wire_bytes_sent, Ordering::Relaxed);
+    }
+
+    /// Account one metadata request issued by `phase`: a HEAD, or one page of a
+    /// LIST drain. Neither payload is visible at the store seam, so only the
+    /// request count moves.
+    pub fn record_metadata(&self, phase: RequestPhase) {
+        self.inner.phases[phase.index()]
+            .requests
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Open a run's scope: clear every phase counter and mark a run in
+    /// progress. Called by the run's outermost driver
+    /// ([`crate::compact::compact_bucket`],
+    /// [`crate::rewrite::migrate_bucket_format`]) BEFORE its first store call,
+    /// so the bucket LIST that opens a run lands in that run's report instead
+    /// of being wiped by the rewrite primitive it precedes.
+    ///
+    /// Wrong to call mid-run. CONCURRENT runs sharing one ledger still produce
+    /// combined figures, and that contract is the installer's to keep, exactly
+    /// as for [`crate::config::MergeMemoryTracker::reset_for_run`].
+    pub fn reset_for_run(&self) {
+        for counters in &self.inner.phases {
+            counters.requests.store(0, Ordering::Relaxed);
+            counters.wire_bytes_received.store(0, Ordering::Relaxed);
+            counters.wire_bytes_sent.store(0, Ordering::Relaxed);
+        }
+        self.inner.run_open.store(true, Ordering::Relaxed);
+    }
+
+    /// Open a run's scope only if no enclosing driver already opened one. This
+    /// is what [`crate::rewrite::rewrite_and_publish`] calls: driven under
+    /// `compact_bucket` it must keep that run's already-counted LIST and
+    /// record reads, and driven directly it must still start from zero.
+    pub fn reset_for_run_unless_open(&self) {
+        if !self.inner.run_open.load(Ordering::Relaxed) {
+            self.reset_for_run();
+        }
+    }
+
+    /// Close the run's scope. The counters are left intact (a caller reads the
+    /// report after the run returns, including after an error); only the next
+    /// [`Self::reset_for_run_unless_open`] is affected.
+    pub fn end_run(&self) {
+        self.inner.run_open.store(false, Ordering::Relaxed);
+    }
+
+    /// Whether a run's scope is currently open.
+    pub fn run_is_open(&self) -> bool {
+        self.inner.run_open.load(Ordering::Relaxed)
+    }
+
+    /// The full per-phase split. See [`RunRequestReport`]; do not sum the two
+    /// byte kinds.
+    pub fn report(&self) -> RunRequestReport {
+        let read = |phase: RequestPhase| {
+            let counters = &self.inner.phases[phase.index()];
+            PhaseRequests {
+                requests: counters.requests.load(Ordering::Relaxed),
+                wire_bytes_received: counters.wire_bytes_received.load(Ordering::Relaxed),
+                wire_bytes_sent: counters.wire_bytes_sent.load(Ordering::Relaxed),
+            }
+        };
+        RunRequestReport {
+            list: read(RequestPhase::List),
+            record_read: read(RequestPhase::RecordRead),
+            catalog_read: read(RequestPhase::CatalogRead),
+            block_read: read(RequestPhase::BlockRead),
+            part_put: read(RequestPhase::PartPut),
+            publish: read(RequestPhase::Publish),
+        }
+    }
+}
+
+/// Record one GET into `ledger` if one is installed, whether or not it
+/// succeeded: a failed GET still spent the request, and carried no payload
+/// back. Takes the result by reference so a call site keeps its `?`.
+pub(crate) fn note_get(
+    ledger: Option<&RequestLedger>,
+    phase: RequestPhase,
+    result: &std::result::Result<ravel_object_store::GetOutcome, ravel_object_store::StoreError>,
+) {
+    if let Some(l) = ledger {
+        l.record_get(phase, result.as_ref().map_or(0, |g| g.data.len() as u64));
+    }
+}
+
+/// Record one PUT of `payload_len` bytes into `ledger` if one is installed.
+/// Called on every outcome: a rejected write (`AlreadyExists`, a failed
+/// precondition) still sent the body.
+pub(crate) fn note_put(ledger: Option<&RequestLedger>, phase: RequestPhase, payload_len: u64) {
+    if let Some(l) = ledger {
+        l.record_put(phase, payload_len);
+    }
+}
+
+/// Record one HEAD, or one listing page, into `ledger` if one is installed.
+pub(crate) fn note_metadata(ledger: Option<&RequestLedger>, phase: RequestPhase) {
+    if let Some(l) = ledger {
+        l.record_metadata(phase);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase_indices_are_dense_and_in_report_order() {
+        for (expected, phase) in RequestPhase::ALL.iter().enumerate() {
+            assert_eq!(phase.index(), expected, "{} index moved", phase.name());
+        }
+    }
+
+    /// Totals sum within a kind and never across kinds: a report carrying both
+    /// received and sent bytes reports each separately, and the request total is
+    /// the sum of the per-phase counts.
+    #[test]
+    fn totals_stay_within_one_byte_kind() {
+        let ledger = RequestLedger::new();
+        ledger.reset_for_run();
+        ledger.record_metadata(RequestPhase::List);
+        ledger.record_get(RequestPhase::RecordRead, 100);
+        ledger.record_get(RequestPhase::CatalogRead, 250);
+        ledger.record_put(RequestPhase::PartPut, 4_000);
+        ledger.record_put(RequestPhase::Publish, 70);
+        ledger.record_metadata(RequestPhase::Publish);
+
+        let report = ledger.report();
+        assert_eq!(report.total_requests(), 6);
+        assert_eq!(report.total_wire_bytes_received(), 350);
+        assert_eq!(report.total_wire_bytes_sent(), 4_070);
+        assert_eq!(report.list.requests, 1);
+        assert_eq!(report.list.wire_bytes_received, 0);
+        assert_eq!(report.list.wire_bytes_sent, 0);
+        assert_eq!(report.publish.requests, 2);
+        assert_eq!(report.publish.wire_bytes_sent, 70);
+    }
+
+    /// `reset_for_run` clears; `reset_for_run_unless_open` does not clear a
+    /// scope an enclosing driver already opened, and does clear once it closed.
+    #[test]
+    fn run_scope_protects_an_enclosing_drivers_figures() {
+        let ledger = RequestLedger::new();
+        ledger.reset_for_run();
+        ledger.record_metadata(RequestPhase::List);
+        ledger.reset_for_run_unless_open();
+        assert_eq!(
+            ledger.report().list.requests,
+            1,
+            "a nested reset must not wipe the driver's LIST"
+        );
+
+        ledger.end_run();
+        ledger.reset_for_run_unless_open();
+        assert_eq!(
+            ledger.report().list.requests,
+            0,
+            "once the scope closed, the next entry starts from zero"
+        );
+        assert!(ledger.run_is_open());
+    }
+}

--- a/crates/ravel-maintain/src/request_ledger.rs
+++ b/crates/ravel-maintain/src/request_ledger.rs
@@ -307,10 +307,16 @@ impl RequestLedger {
     /// is what [`crate::rewrite::rewrite_and_publish`] calls: driven under
     /// `compact_bucket` it must keep that run's already-counted LIST and
     /// record reads, and driven directly it must still start from zero.
-    pub fn reset_for_run_unless_open(&self) {
+    /// Returns whether THIS call opened the scope: the opener is the frame
+    /// that must emit the run's report exactly once, so a rewrite dispatched by
+    /// an outer driver (which opened first) stays silent and the outer driver
+    /// reports.
+    pub fn reset_for_run_unless_open(&self) -> bool {
         if !self.inner.run_open.load(Ordering::Relaxed) {
             self.reset_for_run();
+            return true;
         }
+        false
     }
 
     /// Close the run's scope. The counters are left intact (a caller reads the

--- a/crates/ravel-maintain/src/request_ledger.rs
+++ b/crates/ravel-maintain/src/request_ledger.rs
@@ -310,13 +310,38 @@ impl RequestLedger {
     /// Returns whether THIS call opened the scope: the opener is the frame
     /// that must emit the run's report exactly once, so a rewrite dispatched by
     /// an outer driver (which opened first) stays silent and the outer driver
-    /// reports.
+    /// reports. The open is a compare-exchange, so of two racing direct
+    /// callers exactly one becomes the opener and only that one clears the
+    /// counters -- though sharing one ledger across CONCURRENT runs remains a
+    /// misuse (the counters are one pool; see the module doc's one-ledger-per-
+    /// run contract), the flag itself cannot elect two openers.
     pub fn reset_for_run_unless_open(&self) -> bool {
-        if !self.inner.run_open.load(Ordering::Relaxed) {
-            self.reset_for_run();
+        if self
+            .inner
+            .run_open
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            for counters in &self.inner.phases {
+                counters.requests.store(0, Ordering::Relaxed);
+                counters.wire_bytes_received.store(0, Ordering::Relaxed);
+                counters.wire_bytes_sent.store(0, Ordering::Relaxed);
+            }
             return true;
         }
         false
+    }
+
+    /// RAII closer for a run scope: closes the scope on drop unless disarmed,
+    /// so a driver future cancelled mid-run cannot leave a stale open scope
+    /// that would silence the next direct rewrite's report. The normal path
+    /// emits its report first, then calls [`RunScopeGuard::close`], which
+    /// disarms the drop path.
+    pub fn run_scope_guard(&self) -> RunScopeGuard<'_> {
+        RunScopeGuard {
+            ledger: self,
+            armed: true,
+        }
     }
 
     /// Close the run's scope. The counters are left intact (a caller reads the
@@ -349,6 +374,31 @@ impl RequestLedger {
             block_read: read(RequestPhase::BlockRead),
             part_put: read(RequestPhase::PartPut),
             publish: read(RequestPhase::Publish),
+        }
+    }
+}
+
+/// RAII closer for a run scope (see [`RequestLedger::run_scope_guard`]).
+/// Dropping it while armed closes the scope, so a cancelled driver future
+/// cannot leave a stale open flag behind; the normal path emits its report
+/// and then calls [`Self::close`].
+pub struct RunScopeGuard<'a> {
+    ledger: &'a RequestLedger,
+    armed: bool,
+}
+
+impl RunScopeGuard<'_> {
+    /// Close the scope on the normal path, disarming the drop closer.
+    pub fn close(mut self) {
+        self.armed = false;
+        self.ledger.end_run();
+    }
+}
+
+impl Drop for RunScopeGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.ledger.end_run();
         }
     }
 }

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -248,7 +248,7 @@ async fn rewrite_and_publish_scoped<C: SegmentCodec>(
             total_requests = r.total_requests(),
             total_wire_bytes_received = r.total_wire_bytes_received(),
             total_wire_bytes_sent = r.total_wire_bytes_sent(),
-            "compaction store requests by phase (received and sent bytes are              different kinds; do not sum them together)"
+            "compaction store requests by phase (received and sent bytes are different kinds; do not sum them together)"
         );
     }
 

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -109,10 +109,12 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
     // path, including an error, so a later directly-driven rewrite still starts
     // from zero. Closing leaves the counters readable: a caller inspecting an
     // aborted run's figures reads them after this returns.
-    let opened = config
+    // The guard closes the scope even if this future is cancelled mid-run, so
+    // a stale open flag cannot silence a later direct rewrite's report.
+    let scope = config
         .request_ledger
         .as_ref()
-        .is_some_and(|l| l.reset_for_run_unless_open());
+        .and_then(|l| l.reset_for_run_unless_open().then(|| l.run_scope_guard()));
     let outcome = rewrite_and_publish_scoped::<C>(
         store,
         clock,
@@ -127,11 +129,9 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
     // (ADR-0996 task 996-8): a directly-driven rewrite reports here; a rewrite
     // dispatched by `compact_bucket` or `migrate_bucket_format` stays silent
     // and the outer driver reports every outcome, gate refusals included.
-    if opened {
+    if let Some(scope) = scope {
         emit_request_report(config, bucket, outcome.is_ok());
-        if let Some(l) = config.request_ledger.as_ref() {
-            l.end_run();
-        }
+        scope.close();
     }
     outcome
 }
@@ -331,13 +331,14 @@ pub async fn migrate_bucket_format(
     // (NotSealed, UpToDate, listing errors) still paid their LIST and report
     // it. The rewrite primitive it dispatches to sees the open scope and stays
     // silent (ADR-0996 task 996-8).
-    if let Some(l) = config.request_ledger.as_ref() {
+    let scope = config.request_ledger.as_ref().map(|l| {
         l.reset_for_run();
-    }
+        l.run_scope_guard()
+    });
     let outcome = migrate_bucket_format_scoped(store, clock, config, bucket, target_version).await;
     emit_request_report(config, bucket, outcome.is_ok());
-    if let Some(l) = config.request_ledger.as_ref() {
-        l.end_run();
+    if let Some(scope) = scope {
+        scope.close();
     }
     outcome
 }

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -122,6 +122,41 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
         start_ns,
     )
     .await;
+    // ADR-0996 task 996-8: the run's store requests and wire bytes, split by
+    // the phase that issued them, emitted on EVERY outcome. A failed run's
+    // request costs are exactly what an operator wants to see (a conservation
+    // abort still paid for its whole read side), so the report sits here in
+    // the wrapper rather than on the success path. Counters only -- nothing in
+    // this crate reads a figure back to route a fetch. Requests are logical
+    // store calls, not billed attempts (that seam is the S3 adapter's,
+    // ADR-0996 decision 3). Received and sent bytes are different kinds and
+    // are never summed with each other or with the decoded-heap peaks. Only
+    // fires when a ledger is installed (never in production today).
+    if let Some(l) = config.request_ledger.as_ref() {
+        let r = l.report();
+        tracing::info!(
+            signal = ?bucket.signal,
+            shard = bucket.shard,
+            ingest_hour_bucket = bucket.ingest_hour_bucket,
+            outcome = if outcome.is_ok() { "ok" } else { "err" },
+            list_requests = r.list.requests,
+            record_read_requests = r.record_read.requests,
+            record_read_wire_bytes_received = r.record_read.wire_bytes_received,
+            catalog_read_requests = r.catalog_read.requests,
+            catalog_read_wire_bytes_received = r.catalog_read.wire_bytes_received,
+            block_read_requests = r.block_read.requests,
+            block_read_wire_bytes_received = r.block_read.wire_bytes_received,
+            part_put_requests = r.part_put.requests,
+            part_put_wire_bytes_sent = r.part_put.wire_bytes_sent,
+            publish_requests = r.publish.requests,
+            publish_wire_bytes_received = r.publish.wire_bytes_received,
+            publish_wire_bytes_sent = r.publish.wire_bytes_sent,
+            total_requests = r.total_requests(),
+            total_wire_bytes_received = r.total_wire_bytes_received(),
+            total_wire_bytes_sent = r.total_wire_bytes_sent(),
+            "compaction store requests by phase (received and sent bytes are different kinds; do not sum them together)"
+        );
+    }
     if let Some(l) = config.request_ledger.as_ref() {
         l.end_run();
     }
@@ -215,40 +250,6 @@ async fn rewrite_and_publish_scoped<C: SegmentCodec>(
             publish_record_encoded_bytes = peaks.publish_record_encoded_bytes,
             probe_bytes = peaks.probe_bytes,
             "compaction peak memory by phase (byte kinds differ per term; do not sum)"
-        );
-    }
-
-    // ADR-0996 task 996-8: the run's store requests and wire bytes, split by the
-    // phase that issued them. Counters only -- nothing in this crate reads a
-    // figure back to route a fetch. Requests are logical store calls, not billed
-    // attempts (that seam is the S3 adapter's, ADR-0996 decision 3). Received
-    // and sent bytes are different kinds and are never summed with each other or
-    // with the decoded-heap peaks above. Only fires when a ledger is installed
-    // (never in production today); installing one is the same one-line service
-    // change the memory tracker needs.
-    if let Some(l) = config.request_ledger.as_ref() {
-        let r = l.report();
-        tracing::info!(
-            signal = ?bucket.signal,
-            shard = bucket.shard,
-            ingest_hour_bucket = bucket.ingest_hour_bucket,
-            parts = parts.len(),
-            list_requests = r.list.requests,
-            record_read_requests = r.record_read.requests,
-            record_read_wire_bytes_received = r.record_read.wire_bytes_received,
-            catalog_read_requests = r.catalog_read.requests,
-            catalog_read_wire_bytes_received = r.catalog_read.wire_bytes_received,
-            block_read_requests = r.block_read.requests,
-            block_read_wire_bytes_received = r.block_read.wire_bytes_received,
-            part_put_requests = r.part_put.requests,
-            part_put_wire_bytes_sent = r.part_put.wire_bytes_sent,
-            publish_requests = r.publish.requests,
-            publish_wire_bytes_received = r.publish.wire_bytes_received,
-            publish_wire_bytes_sent = r.publish.wire_bytes_sent,
-            total_requests = r.total_requests(),
-            total_wire_bytes_received = r.total_wire_bytes_received(),
-            total_wire_bytes_sent = r.total_wire_bytes_sent(),
-            "compaction store requests by phase (received and sent bytes are different kinds; do not sum them together)"
         );
     }
 

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -66,7 +66,7 @@ use crate::error::{MaintainError, Result};
 use crate::publish::{
     ConservationPredicate, PublishOutcome, conserve_exact, publish_record_with_conservation,
 };
-use crate::read::{input_set_hash, list_bucket, load_inputs};
+use crate::read::{input_set_hash, list_bucket_with_ledger, load_inputs_with_ledger};
 use crate::rlog::RlogCodec;
 use crate::rspan_codec::SpanCodec;
 
@@ -102,6 +102,44 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
     conservation: impl ConservationPredicate,
     start_ns: i64,
 ) -> Result<RewriteOutcome> {
+    // Request-ledger scope (ADR-0996 task 996-8). A run driven by
+    // `compact_bucket` or `migrate_bucket_format` already opened its scope
+    // before the bucket LIST, and those figures belong to this run's report; a
+    // rewrite driven directly opens its own. The scope closes on EVERY exit
+    // path, including an error, so a later directly-driven rewrite still starts
+    // from zero. Closing leaves the counters readable: a caller inspecting an
+    // aborted run's figures reads them after this returns.
+    if let Some(l) = config.request_ledger.as_ref() {
+        l.reset_for_run_unless_open();
+    }
+    let outcome = rewrite_and_publish_scoped::<C>(
+        store,
+        clock,
+        config,
+        bucket,
+        commit_keys,
+        conservation,
+        start_ns,
+    )
+    .await;
+    if let Some(l) = config.request_ledger.as_ref() {
+        l.end_run();
+    }
+    outcome
+}
+
+/// [`rewrite_and_publish`]'s body, with the request ledger's run scope already
+/// opened and guaranteed to be closed by its caller.
+#[allow(clippy::too_many_arguments)]
+async fn rewrite_and_publish_scoped<C: SegmentCodec>(
+    store: &dyn ObjectStoreBackend,
+    clock: &dyn Clock,
+    config: &CompactorConfig,
+    bucket: &Bucket,
+    commit_keys: &[String],
+    conservation: impl ConservationPredicate,
+    start_ns: i64,
+) -> Result<RewriteOutcome> {
     // A new run's accounting starts from zero: a tracker left installed in a
     // long-lived config would otherwise carry the previous bucket's peaks
     // into this bucket's emission (serial reuse; concurrent sharing is the
@@ -109,7 +147,14 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
     if let Some(t) = config.merge_memory_tracker.as_ref() {
         t.reset_for_run();
     }
-    let inputs = load_inputs(store, bucket, commit_keys, config.input_read_concurrency).await?;
+    let inputs = load_inputs_with_ledger(
+        store,
+        bucket,
+        commit_keys,
+        config.input_read_concurrency,
+        config.request_ledger.as_ref(),
+    )
+    .await?;
     C::validate_rewrite_inputs(&inputs)?;
     let hash = input_set_hash(&inputs);
 
@@ -173,6 +218,40 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
         );
     }
 
+    // ADR-0996 task 996-8: the run's store requests and wire bytes, split by the
+    // phase that issued them. Counters only -- nothing in this crate reads a
+    // figure back to route a fetch. Requests are logical store calls, not billed
+    // attempts (that seam is the S3 adapter's, ADR-0996 decision 3). Received
+    // and sent bytes are different kinds and are never summed with each other or
+    // with the decoded-heap peaks above. Only fires when a ledger is installed
+    // (never in production today); installing one is the same one-line service
+    // change the memory tracker needs.
+    if let Some(l) = config.request_ledger.as_ref() {
+        let r = l.report();
+        tracing::info!(
+            signal = ?bucket.signal,
+            shard = bucket.shard,
+            ingest_hour_bucket = bucket.ingest_hour_bucket,
+            parts = parts.len(),
+            list_requests = r.list.requests,
+            record_read_requests = r.record_read.requests,
+            record_read_wire_bytes_received = r.record_read.wire_bytes_received,
+            catalog_read_requests = r.catalog_read.requests,
+            catalog_read_wire_bytes_received = r.catalog_read.wire_bytes_received,
+            block_read_requests = r.block_read.requests,
+            block_read_wire_bytes_received = r.block_read.wire_bytes_received,
+            part_put_requests = r.part_put.requests,
+            part_put_wire_bytes_sent = r.part_put.wire_bytes_sent,
+            publish_requests = r.publish.requests,
+            publish_wire_bytes_received = r.publish.wire_bytes_received,
+            publish_wire_bytes_sent = r.publish.wire_bytes_sent,
+            total_requests = r.total_requests(),
+            total_wire_bytes_received = r.total_wire_bytes_received(),
+            total_wire_bytes_sent = r.total_wire_bytes_sent(),
+            "compaction store requests by phase (received and sent bytes are              different kinds; do not sum them together)"
+        );
+    }
+
     Ok(RewriteOutcome {
         parts: parts.len(),
         publish,
@@ -233,12 +312,34 @@ pub async fn migrate_bucket_format(
     bucket: &Bucket,
     target_version: u32,
 ) -> Result<MigrateOutcome> {
+    // This is the run's outermost driver, so it opens the request ledger's
+    // scope before the bucket LIST below; the rewrite primitive it dispatches to
+    // keeps that scope and closes it (ADR-0996 task 996-8).
+    if let Some(l) = config.request_ledger.as_ref() {
+        l.reset_for_run();
+    }
+    let outcome = migrate_bucket_format_scoped(store, clock, config, bucket, target_version).await;
+    if let Some(l) = config.request_ledger.as_ref() {
+        l.end_run();
+    }
+    outcome
+}
+
+/// [`migrate_bucket_format`]'s body, with the request ledger's run scope
+/// already opened and guaranteed to be closed by its caller.
+async fn migrate_bucket_format_scoped(
+    store: &dyn ObjectStoreBackend,
+    clock: &dyn Clock,
+    config: &CompactorConfig,
+    bucket: &Bucket,
+    target_version: u32,
+) -> Result<MigrateOutcome> {
     let start_ns = clock.now_ns();
     if !bucket.is_sealed(start_ns, config) {
         return Ok(MigrateOutcome::NotSealed);
     }
 
-    let listing = list_bucket(store, bucket).await?;
+    let listing = list_bucket_with_ledger(store, bucket, config.request_ledger.as_ref()).await?;
     if listing.tombstone_key.is_some() {
         return Ok(MigrateOutcome::Tombstoned);
     }
@@ -254,11 +355,12 @@ pub async fn migrate_bucket_format(
     // version without reading it). `load_inputs` verifies each record's key and
     // bucket, so the eligibility read rides on the same decode the rewrite
     // needs anyway.
-    let inputs = load_inputs(
+    let inputs = load_inputs_with_ledger(
         store,
         bucket,
         &listing.commit_keys,
         config.input_read_concurrency,
+        config.request_ledger.as_ref(),
     )
     .await?;
     let needs_migration = inputs
@@ -366,7 +468,7 @@ mod tests {
 
     use super::*;
     use crate::publish::conserve_exact;
-    use crate::read::{input_set_hash, load_inputs};
+    use crate::read::{input_set_hash, list_bucket, load_inputs};
     use crate::{CompactorConfig, FixedClock};
 
     const TENANT: &str = "acme";

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -109,9 +109,10 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
     // path, including an error, so a later directly-driven rewrite still starts
     // from zero. Closing leaves the counters readable: a caller inspecting an
     // aborted run's figures reads them after this returns.
-    if let Some(l) = config.request_ledger.as_ref() {
-        l.reset_for_run_unless_open();
-    }
+    let opened = config
+        .request_ledger
+        .as_ref()
+        .is_some_and(|l| l.reset_for_run_unless_open());
     let outcome = rewrite_and_publish_scoped::<C>(
         store,
         clock,
@@ -122,23 +123,38 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
         start_ns,
     )
     .await;
-    // ADR-0996 task 996-8: the run's store requests and wire bytes, split by
-    // the phase that issued them, emitted on EVERY outcome. A failed run's
-    // request costs are exactly what an operator wants to see (a conservation
-    // abort still paid for its whole read side), so the report sits here in
-    // the wrapper rather than on the success path. Counters only -- nothing in
-    // this crate reads a figure back to route a fetch. Requests are logical
-    // store calls, not billed attempts (that seam is the S3 adapter's,
-    // ADR-0996 decision 3). Received and sent bytes are different kinds and
-    // are never summed with each other or with the decoded-heap peaks. Only
-    // fires when a ledger is installed (never in production today).
+    // The frame that OPENED the scope emits the run's report, exactly once
+    // (ADR-0996 task 996-8): a directly-driven rewrite reports here; a rewrite
+    // dispatched by `compact_bucket` or `migrate_bucket_format` stays silent
+    // and the outer driver reports every outcome, gate refusals included.
+    if opened {
+        emit_request_report(config, bucket, outcome.is_ok());
+        if let Some(l) = config.request_ledger.as_ref() {
+            l.end_run();
+        }
+    }
+    outcome
+}
+
+/// Emit the run's per-phase request report on the outcome the run actually
+/// had (ADR-0996 task 996-8). A failed run's request costs are exactly what
+/// an operator wants to see (a conservation abort still paid for its whole
+/// read side, and a gate refusal still paid its LIST), so every outermost
+/// driver calls this on success and error alike, before closing the scope.
+/// Counters only -- nothing in this crate reads a figure back to route a
+/// fetch. Requests are logical store calls, not billed attempts (that seam is
+/// the S3 adapter's, ADR-0996 decision 3). Received and sent bytes are
+/// different kinds and are never summed with each other or with the
+/// decoded-heap peaks. Only fires when a ledger is installed (never in
+/// production today).
+pub(crate) fn emit_request_report(config: &CompactorConfig, bucket: &Bucket, ok: bool) {
     if let Some(l) = config.request_ledger.as_ref() {
         let r = l.report();
         tracing::info!(
             signal = ?bucket.signal,
             shard = bucket.shard,
             ingest_hour_bucket = bucket.ingest_hour_bucket,
-            outcome = if outcome.is_ok() { "ok" } else { "err" },
+            outcome = if ok { "ok" } else { "err" },
             list_requests = r.list.requests,
             record_read_requests = r.record_read.requests,
             record_read_wire_bytes_received = r.record_read.wire_bytes_received,
@@ -157,10 +173,6 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
             "compaction store requests by phase (received and sent bytes are different kinds; do not sum them together)"
         );
     }
-    if let Some(l) = config.request_ledger.as_ref() {
-        l.end_run();
-    }
-    outcome
 }
 
 /// [`rewrite_and_publish`]'s body, with the request ledger's run scope already
@@ -313,13 +325,17 @@ pub async fn migrate_bucket_format(
     bucket: &Bucket,
     target_version: u32,
 ) -> Result<MigrateOutcome> {
-    // This is the run's outermost driver, so it opens the request ledger's
-    // scope before the bucket LIST below; the rewrite primitive it dispatches to
-    // keeps that scope and closes it (ADR-0996 task 996-8).
+    // This is the run's outermost driver: it opens the request ledger's scope
+    // before the bucket LIST below and, as the opener, emits the run's report
+    // on EVERY outcome -- the gates that return before any rewrite dispatches
+    // (NotSealed, UpToDate, listing errors) still paid their LIST and report
+    // it. The rewrite primitive it dispatches to sees the open scope and stays
+    // silent (ADR-0996 task 996-8).
     if let Some(l) = config.request_ledger.as_ref() {
         l.reset_for_run();
     }
     let outcome = migrate_bucket_format_scoped(store, clock, config, bucket, target_version).await;
+    emit_request_report(config, bucket, outcome.is_ok());
     if let Some(l) = config.request_ledger.as_ref() {
         l.end_run();
     }

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -215,11 +215,12 @@ use ravel_proto::commit::v1::CompactionPart;
 use ravel_types::declared_stats::{DeclaredColumnStat, DeclaredStatType, DeclaredStatValue};
 
 use crate::bucket::Bucket;
-use crate::build::{BuiltPart, put_part};
+use crate::build::{BuiltPart, put_part_with_ledger};
 use crate::codec::SegmentCodec;
 use crate::config::{AdmissionMode, CompactorConfig, MergeMemoryTracker};
 use crate::error::{MaintainError, MergeCursorBudgetSite, Result};
 use crate::read::InputRecord;
+use crate::request_ledger::{RequestLedger, RequestPhase, note_get};
 
 /// The RLOG output trailer version every L1 part carries (currently 3:
 /// ADR-0032 introduced v2, ADR-0095 moved it to v3). Recorded in each part's
@@ -396,20 +397,25 @@ pub(crate) async fn load_catalog_from_object(
     recover_indexed_fields: bool,
 ) -> Result<RlogInputCatalog> {
     let cfg = RlogConfig::default();
+    let ledger = config.request_ledger.as_ref();
 
     // Locate the footer and section directory from a suffix probe: one
     // ranged GET, growing to a second only if the probe missed the footer
     // (the RLOG analogue of the RSEG read path).
     let probe = store
         .get(&object_key, GetRange::Suffix(config.footer_probe_bytes))
-        .await?;
+        .await;
+    note_get(ledger, RequestPhase::CatalogRead, &probe);
+    let probe = probe?;
     let total = probe.total_size;
     let ftr = match footer::open_from_suffix(&probe.data, total)? {
         SuffixOutcome::Ready(f) => f,
         SuffixOutcome::NeedRange { offset, len } => {
             let tail = store
                 .get(&object_key, GetRange::Range(offset, offset + len))
-                .await?;
+                .await;
+            note_get(ledger, RequestPhase::CatalogRead, &tail);
+            let tail = tail?;
             match footer::open_from_suffix(&tail.data, total)? {
                 SuffixOutcome::Ready(f) => f,
                 SuffixOutcome::NeedRange { .. } => {
@@ -425,16 +431,19 @@ pub(crate) async fn load_catalog_from_object(
     // BLOCKS and BLOOM are never fetched here; the merge streams blocks by
     // range one stream at a time. FIELD_DIR is decoded (and validated) even
     // though the merge rebuilds it, so a corrupt input fails loud here.
-    let stream_dir_raw = fetch_section(store, &object_key, &ftr, kind::STREAM_DIR, &cfg).await?;
-    let field_dir_raw = fetch_section(store, &object_key, &ftr, kind::FIELD_DIR, &cfg).await?;
-    let skip_idx_raw = fetch_section(store, &object_key, &ftr, kind::SKIP_IDX, &cfg).await?;
+    let stream_dir_raw =
+        fetch_section(store, &object_key, &ftr, kind::STREAM_DIR, &cfg, ledger).await?;
+    let field_dir_raw =
+        fetch_section(store, &object_key, &ftr, kind::FIELD_DIR, &cfg, ledger).await?;
+    let skip_idx_raw =
+        fetch_section(store, &object_key, &ftr, kind::SKIP_IDX, &cfg, ledger).await?;
 
     // Which fields this input had indexed. Recovered here, while the
     // object's footer and FIELD_DIR bytes are already at hand, and reduced
     // immediately to a name list: the POSTINGS bytes themselves are dropped
     // before this function returns and never take part in the merge.
     let indexed_fields = if recover_indexed_fields {
-        input_indexed_fields(store, &object_key, &ftr, &field_dir_raw, &cfg).await?
+        input_indexed_fields(store, &object_key, &ftr, &field_dir_raw, &cfg, ledger).await?
     } else {
         Vec::new()
     };
@@ -451,7 +460,8 @@ pub(crate) async fn load_catalog_from_object(
             format_version: OUTPUT_FORMAT_VERSION,
         });
     };
-    let page_dir_raw = fetch_section(store, &object_key, &ftr, kind::PAGE_DIR, &cfg).await?;
+    let page_dir_raw =
+        fetch_section(store, &object_key, &ftr, kind::PAGE_DIR, &cfg, ledger).await?;
     // The per-block shape and string-payload figures the bounded merge reserves
     // a cursor's decode against (ADR-0979 decision 4). Decoded here, once, from
     // directory bytes already fetched: these are the same decodes the range
@@ -1017,6 +1027,7 @@ impl PartSink<'_> {
                 self.dry_run,
                 self.retain_bytes,
                 &declared_accum,
+                self.config.request_ledger.as_ref(),
             )
             .await?;
             // Only bytes actually retained past PUT count toward the
@@ -1681,6 +1692,7 @@ impl<'a> StreamCursor<'a> {
         &mut self,
         store: &dyn ObjectStoreBackend,
         tracker: Option<&MergeMemoryTracker>,
+        ledger: Option<&RequestLedger>,
         mut budget: Option<&mut CursorBudget<'_>>,
     ) -> Result<()> {
         loop {
@@ -1700,7 +1712,7 @@ impl<'a> StreamCursor<'a> {
                 continue;
             }
             // The current loc is fully decoded: fetch the next one.
-            match self.next_raw_block(store, tracker).await? {
+            match self.next_raw_block(store, tracker, ledger).await? {
                 Some((loc, data)) => {
                     self.group_raw_bytes = data.len() as u64;
                     self.decoded_in_group = 0;
@@ -1811,6 +1823,7 @@ impl<'a> StreamCursor<'a> {
         &mut self,
         store: &dyn ObjectStoreBackend,
         tracker: Option<&MergeMemoryTracker>,
+        ledger: Option<&RequestLedger>,
     ) -> Result<Option<(StreamBlockLoc, bytes::Bytes)>> {
         if let Some((loc, data)) = self.prefetched.take() {
             return Ok(Some((loc, data)));
@@ -1821,8 +1834,8 @@ impl<'a> StreamCursor<'a> {
         let data = match self.take_next_loc() {
             Some(ahead) => {
                 let (a, b) = futures::try_join!(
-                    fetch_block(store, self.object_key, &loc),
-                    fetch_block(store, self.object_key, &ahead)
+                    fetch_block(store, self.object_key, &loc, ledger),
+                    fetch_block(store, self.object_key, &ahead, ledger)
                 )?;
                 if let Some(t) = tracker {
                     t.block_fetched(b.len() as u64);
@@ -1830,7 +1843,7 @@ impl<'a> StreamCursor<'a> {
                 self.prefetched = Some((ahead, b));
                 a
             }
-            None => fetch_block(store, self.object_key, &loc).await?,
+            None => fetch_block(store, self.object_key, &loc, ledger).await?,
         };
         if let Some(t) = tracker {
             t.block_fetched(data.len() as u64);
@@ -1853,11 +1866,13 @@ async fn fetch_block(
     store: &dyn ObjectStoreBackend,
     object_key: &str,
     loc: &StreamBlockLoc,
+    ledger: Option<&RequestLedger>,
 ) -> Result<bytes::Bytes> {
     let got = store
         .get(object_key, GetRange::Range(loc.start(), loc.end()))
-        .await?;
-    Ok(got.data)
+        .await;
+    note_get(ledger, RequestPhase::BlockRead, &got);
+    Ok(got?.data)
 }
 
 /// One input queued for overlap-gated admission (ADR-0979 decision 2): its
@@ -2062,6 +2077,9 @@ async fn merge_stream_into_parts(
     let concurrency = sink.config.input_read_concurrency.max(1);
     let budget = sink.config.merge_cursor_budget_bytes;
     let mode = sink.config.merge_admission;
+    // Copied out of the sink before its `&mut` borrows begin: `config` is a
+    // shared reference field, so the ledger handle outlives them.
+    let ledger = sink.config.request_ledger.as_ref();
 
     // The admission queue: one entry per input carrying the stream, ordered by
     // (lower_bound, input_index) so opens follow the frontier and ties keep
@@ -2165,6 +2183,7 @@ async fn merge_stream_into_parts(
                         p.input_index,
                         stream_id,
                         tracker,
+                        ledger,
                     )) as CursorFuture<'_, '_>
                 })
                 .collect();
@@ -2245,7 +2264,7 @@ async fn merge_stream_into_parts(
             inputs_carrying_stream: pending.len(),
         };
         open[bi]
-            .refill(store, tracker, Some(&mut cursor_budget))
+            .refill(store, tracker, ledger, Some(&mut cursor_budget))
             .await?;
         // A drained cursor releases its residency (refill already dropped its
         // last block) and its charge, so both the open-cursor high-water and the
@@ -2295,6 +2314,7 @@ async fn open_cursor<'a>(
     input_index: usize,
     stream_id: &LogStreamId,
     tracker: Option<&MergeMemoryTracker>,
+    ledger: Option<&RequestLedger>,
 ) -> Result<Option<StreamCursor<'a>>> {
     let Some(mut cursor) = StreamCursor::open(catalog, input_index, stream_id)? else {
         return Ok(None);
@@ -2302,7 +2322,7 @@ async fn open_cursor<'a>(
     // No budget: the caller reserved this cursor's ceiling before calling, and
     // that reservation is the maximum over every block the cursor can decode,
     // so this first refill is covered whichever blocks it decodes.
-    cursor.refill(store, tracker, None).await?;
+    cursor.refill(store, tracker, ledger, None).await?;
     Ok(cursor.peek_ts().is_some().then_some(cursor))
 }
 
@@ -2341,6 +2361,7 @@ async fn finalize_part(
     dry_run: bool,
     retain_bytes: bool,
     declared_accum: &DeclaredStatAccum,
+    ledger: Option<&RequestLedger>,
 ) -> Result<BuiltPart> {
     if stats.postings_capped_fields > 0 {
         tracing::warn!(
@@ -2401,7 +2422,7 @@ async fn finalize_part(
         put_already_existed: false,
     };
     if !dry_run {
-        match put_part(store, &built).await? {
+        match put_part_with_ledger(store, &built, ledger).await? {
             crate::build::PartPut::Created => {}
             crate::build::PartPut::AlreadyExisted => built.put_already_existed = true,
         }
@@ -2685,6 +2706,7 @@ async fn input_indexed_fields(
     ftr: &footer::LogFooter,
     field_dir_raw: &[u8],
     cfg: &RlogConfig,
+    ledger: Option<&RequestLedger>,
 ) -> Result<Vec<String>> {
     // POSTINGS is optional (ADR-0049 decision 5): no section means the input
     // indexed nothing, so there is nothing to carry forward.
@@ -2696,8 +2718,9 @@ async fn input_indexed_fields(
             object_key,
             GetRange::Range(desc.offset, desc.offset + desc.len),
         )
-        .await?;
-    let raw = decode_section(got.data.as_ref(), desc, cfg)?;
+        .await;
+    note_get(ledger, RequestPhase::CatalogRead, &got);
+    let raw = decode_section(got?.data.as_ref(), desc, cfg)?;
     let section = PostingsSection::parse(&raw)?;
     let field_dir = FieldDir::decode(field_dir_raw, MAX_FIELD_DIR_ENTRIES)?;
     let mut names: BTreeSet<String> = BTreeSet::new();
@@ -2737,6 +2760,7 @@ async fn fetch_section(
     ftr: &footer::LogFooter,
     k: u32,
     cfg: &RlogConfig,
+    ledger: Option<&RequestLedger>,
 ) -> Result<Vec<u8>> {
     let desc = ftr.section(k).ok_or_else(|| {
         MaintainError::Invariant(format!("input .rlog object missing section kind {k}"))
@@ -2746,8 +2770,9 @@ async fn fetch_section(
             object_key,
             GetRange::Range(desc.offset, desc.offset + desc.len),
         )
-        .await?;
-    Ok(decode_section(got.data.as_ref(), desc, cfg)?)
+        .await;
+    note_get(ledger, RequestPhase::CatalogRead, &got);
+    Ok(decode_section(got?.data.as_ref(), desc, cfg)?)
 }
 
 #[cfg(test)]
@@ -6305,7 +6330,7 @@ mod tests {
     ) -> u64 {
         let catalog = stream_catalog(store, writer_id, seq, bytes).await;
         let (stream_id, _) = stream_ident(0);
-        let cursor = open_cursor(store, &catalog, 0, &stream_id, None)
+        let cursor = open_cursor(store, &catalog, 0, &stream_id, None, None)
             .await
             .expect("open cursor")
             .expect("input carries stream 0");
@@ -6348,7 +6373,11 @@ mod tests {
         let mut out: Vec<(usize, u64)> = Vec::new();
         loop {
             let Some(block) = cursor.pending_block_index() else {
-                match cursor.next_raw_block(store, None).await.expect("fetch") {
+                match cursor
+                    .next_raw_block(store, None, None)
+                    .await
+                    .expect("fetch")
+                {
                     Some((loc, data)) => {
                         cursor.group_raw_bytes = data.len() as u64;
                         cursor.decoded_in_group = 0;
@@ -6547,7 +6576,7 @@ mod tests {
         let reservation = cursor_reservation_bytes(&catalog, &stream_id)
             .expect("reservation")
             .expect("input carries stream 0");
-        let mut cursor = open_cursor(&store, &catalog, 0, &stream_id, None)
+        let mut cursor = open_cursor(&store, &catalog, 0, &stream_id, None, None)
             .await
             .expect("open cursor")
             .expect("input carries stream 0");
@@ -6955,7 +6984,7 @@ mod tests {
         // Open the cursor and reconcile it exactly as the merge does after an
         // admission: the charge is now the SMALL first block's residency.
         let tracker = MergeMemoryTracker::new();
-        let mut cursor = open_cursor(&store, &catalog, 0, &stream_id, Some(&tracker))
+        let mut cursor = open_cursor(&store, &catalog, 0, &stream_id, Some(&tracker), None)
             .await
             .expect("open cursor")
             .expect("input carries stream 0");
@@ -7000,7 +7029,7 @@ mod tests {
             inputs_carrying_stream: 1,
         };
         let err = cursor
-            .refill(&store, Some(&tracker), Some(&mut budget))
+            .refill(&store, Some(&tracker), None, Some(&mut budget))
             .await
             .expect_err("a budget below the grown figure must refuse the decode");
         match err {
@@ -7064,7 +7093,7 @@ mod tests {
         // decodes block 1, and the charge at that moment IS the grown figure --
         // the ceiling, held until the caller reconciles it back down.
         let tracker = MergeMemoryTracker::new();
-        let mut cursor = open_cursor(&store, &catalog, 0, &stream_id, Some(&tracker))
+        let mut cursor = open_cursor(&store, &catalog, 0, &stream_id, Some(&tracker), None)
             .await
             .expect("open cursor")
             .expect("input carries stream 0");
@@ -7083,7 +7112,7 @@ mod tests {
             inputs_carrying_stream: 1,
         };
         cursor
-            .refill(&store, Some(&tracker), Some(&mut budget))
+            .refill(&store, Some(&tracker), None, Some(&mut budget))
             .await
             .expect("a budget at the grown figure admits the decode");
         assert_eq!(
@@ -7109,7 +7138,7 @@ mod tests {
         while cursor.peek_ts().is_some() {
             got.push(cursor.next_record().expect("record").expect("a row").ts_ns);
             cursor
-                .refill(&store, Some(&tracker), Some(&mut budget))
+                .refill(&store, Some(&tracker), None, Some(&mut budget))
                 .await
                 .expect("refill");
         }
@@ -7172,11 +7201,11 @@ mod tests {
         let r_b = cursor_reservation_bytes(&cat_b, &stream_id)
             .expect("reservation")
             .expect("B carries stream 0");
-        let cursor_a = open_cursor(&probe, &cat_a, 0, &stream_id, None)
+        let cursor_a = open_cursor(&probe, &cat_a, 0, &stream_id, None, None)
             .await
             .expect("open A")
             .expect("A carries stream 0");
-        let cursor_b = open_cursor(&probe, &cat_b, 1, &stream_id, None)
+        let cursor_b = open_cursor(&probe, &cat_b, 1, &stream_id, None, None)
             .await
             .expect("open B")
             .expect("B carries stream 0");

--- a/crates/ravel-maintain/src/rspan_codec.rs
+++ b/crates/ravel-maintain/src/rspan_codec.rs
@@ -136,11 +136,12 @@ use ravel_rspan::{
 };
 
 use crate::bucket::Bucket;
-use crate::build::{BuiltPart, put_part};
+use crate::build::{BuiltPart, put_part_with_ledger};
 use crate::codec::SegmentCodec;
 use crate::config::{CompactorConfig, MergeMemoryTracker};
 use crate::error::{MaintainError, Result};
 use crate::read::InputRecord;
+use crate::request_ledger::{RequestLedger, RequestPhase, note_get};
 
 /// The RSPAN output trailer version every L1 part carries. Recorded in each
 /// part's `CompactionPart.segment_format_version`, the span analogue of RSEG's
@@ -229,16 +230,21 @@ pub(crate) async fn load_catalog_from_object(
     // growing to a second only if the probe missed the whole footer (the
     // RSPAN analogue of the RSEG/RLOG read path). This fails loud here on a
     // missing or corrupt input, before the merge fetches any block bytes.
+    let ledger = config.request_ledger.as_ref();
     let probe = store
         .get(&object_key, GetRange::Suffix(config.footer_probe_bytes))
-        .await?;
+        .await;
+    note_get(ledger, RequestPhase::CatalogRead, &probe);
+    let probe = probe?;
     let total = probe.total_size;
     let ftr = match footer::open_from_suffix(&probe.data, total)? {
         SuffixOutcome::Ready(f) => f,
         SuffixOutcome::NeedRange { offset, len } => {
             let tail = store
                 .get(&object_key, GetRange::Range(offset, offset + len))
-                .await?;
+                .await;
+            note_get(ledger, RequestPhase::CatalogRead, &tail);
+            let tail = tail?;
             match footer::open_from_suffix(&tail.data, total)? {
                 SuffixOutcome::Ready(f) => f,
                 SuffixOutcome::NeedRange { .. } => {
@@ -259,7 +265,9 @@ pub(crate) async fn load_catalog_from_object(
             &object_key,
             GetRange::Range(skip_desc.offset, skip_desc.offset + skip_desc.len),
         )
-        .await?;
+        .await;
+    note_get(ledger, RequestPhase::CatalogRead, &skip_section);
+    let skip_section = skip_section?;
     let skip_idx_raw = footer::decode_section(
         skip_section.data.as_ref(),
         skip_desc,
@@ -375,6 +383,7 @@ pub(crate) async fn merge(
     dry_run: bool,
     keep: &mut (dyn FnMut(&SpanRecord) -> Result<bool> + Send),
 ) -> Result<SpanMergeOutput> {
+    let ledger = config.request_ledger.as_ref();
     // No whole-object fetch: the per-input ranged readers are already in the
     // catalogs. Blocks are fetched by range one at a time in the flat k-way
     // merge below, so raw resident bytes stay bounded to one block per input,
@@ -394,7 +403,7 @@ pub(crate) async fn merge(
         .iter()
         .enumerate()
         .map(|(idx, catalog)| {
-            Box::pin(open_cursor(store, catalog, idx, tracker)) as CursorFuture<'_, '_>
+            Box::pin(open_cursor(store, catalog, idx, tracker, ledger)) as CursorFuture<'_, '_>
         })
         .collect();
     let mut cursors: Vec<BlockCursor> = stream_iter(opens)
@@ -445,7 +454,7 @@ pub(crate) async fn merge(
                     part.estimate >= config.l1_part_memory_target_bytes && !part.is_empty();
                 if over_cap && let Some(builder) = current.take() {
                     let built = builder
-                        .finish(store, bucket, input_set_hash, part_index, dry_run)
+                        .finish(store, bucket, input_set_hash, part_index, dry_run, ledger)
                         .await?;
                     parts.push(built);
                     part_index += 1;
@@ -462,14 +471,14 @@ pub(crate) async fn merge(
             let part = current.get_or_insert_with(|| PartBuilder::new(&identity));
             part.push(rec, tracker);
         }
-        cursors[bi].refill(store, tracker).await?;
+        cursors[bi].refill(store, tracker, ledger).await?;
     }
 
     if let Some(part) = current
         && !part.is_empty()
     {
         let built = part
-            .finish(store, bucket, input_set_hash, part_index, dry_run)
+            .finish(store, bucket, input_set_hash, part_index, dry_run, ledger)
             .await?;
         parts.push(built);
         if let Some(t) = tracker {
@@ -494,9 +503,10 @@ async fn open_cursor<'a>(
     catalog: &'a SpanInputCatalog,
     input_index: usize,
     tracker: Option<&MergeMemoryTracker>,
+    ledger: Option<&RequestLedger>,
 ) -> Result<BlockCursor<'a>> {
     let mut cursor = BlockCursor::open(catalog, input_index);
-    cursor.refill(store, tracker).await?;
+    cursor.refill(store, tracker, ledger).await?;
     Ok(cursor)
 }
 
@@ -557,6 +567,7 @@ impl PartBuilder {
         input_set_hash: &[u8; 32],
         part_index: u32,
         dry_run: bool,
+        ledger: Option<&RequestLedger>,
     ) -> Result<BuiltPart> {
         finalize_part(
             store,
@@ -566,6 +577,7 @@ impl PartBuilder {
             part_index,
             self.trace_count,
             dry_run,
+            ledger,
         )
         .await
     }
@@ -650,6 +662,7 @@ impl<'a> BlockCursor<'a> {
         &mut self,
         store: &dyn ObjectStoreBackend,
         tracker: Option<&MergeMemoryTracker>,
+        ledger: Option<&RequestLedger>,
     ) -> Result<()> {
         if let Some(rec) = self.block.next() {
             self.head = Some(rec);
@@ -661,7 +674,9 @@ impl<'a> BlockCursor<'a> {
             self.next_block += 1;
             let got = store
                 .get(self.object_key, GetRange::Range(loc.start(), loc.end()))
-                .await?;
+                .await;
+            note_get(ledger, RequestPhase::BlockRead, &got);
+            let got = got?;
             let raw_len = got.data.len() as u64;
             if let Some(t) = tracker {
                 t.block_fetched(raw_len);
@@ -711,6 +726,7 @@ impl<'a> BlockCursor<'a> {
 /// `level = 1`, the `input_set_hash`, and `part_index`), then PUT it
 /// `CreateIfAbsent`. The part's summary stats are read back from the produced
 /// object's own footer, so they describe exactly what was written.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn finalize_part(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,
@@ -719,6 +735,7 @@ pub(crate) async fn finalize_part(
     part_index: u32,
     trace_count: u64,
     dry_run: bool,
+    ledger: Option<&RequestLedger>,
 ) -> Result<BuiltPart> {
     let object = writer.finish_compacted(1, input_set_hash.to_vec(), part_index)?;
     let object = bytes::Bytes::from(object);
@@ -777,7 +794,7 @@ pub(crate) async fn finalize_part(
         put_already_existed: false,
     };
     if !dry_run {
-        put_part(store, &built).await?;
+        put_part_with_ledger(store, &built, ledger).await?;
     }
     Ok(built)
 }

--- a/crates/ravel-maintain/tests/compaction_request_ledger.rs
+++ b/crates/ravel-maintain/tests/compaction_request_ledger.rs
@@ -8,9 +8,11 @@
 //! and the sum over phases equals the wrapper's grand total exactly -- no
 //! request uncounted, none counted twice.
 //!
-//! Every figure asserted here is exact, not a floor: a test that only checked
-//! `> 0` would pass on a ledger that double-counts, which is the failure this
-//! seam exists to make impossible.
+//! Every request count asserted here is exact; ranged-read byte figures use
+//! per-object proportional bands (backed by the oracle's exact grand-total
+//! reconciliation), never flat floors. A suite that only checked `> 0` would
+//! pass on a ledger that double-counts, which is the failure this seam
+//! exists to make impossible.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 mod common;

--- a/crates/ravel-maintain/tests/compaction_request_ledger.rs
+++ b/crates/ravel-maintain/tests/compaction_request_ledger.rs
@@ -1,0 +1,557 @@
+//! The compaction read ledger (ADR-0996 task 996-8): per-run store requests and
+//! wire bytes, split by the phase that issued them.
+//!
+//! The headline test uses an [`InstrumentedStore`] as an ORACLE. It is the only
+//! independent account of what a run actually spent, and it knows nothing about
+//! phases, so two properties are checkable at once: each phase's count is what
+//! that phase's call sites issued (pinned as exact integers for this fixture),
+//! and the sum over phases equals the wrapper's grand total exactly -- no
+//! request uncounted, none counted twice.
+//!
+//! Every figure asserted here is exact, not a floor: a test that only checked
+//! `> 0` would pass on a ledger that double-counts, which is the failure this
+//! seam exists to make impossible.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod common;
+
+use common::*;
+use ravel_maintain::request_ledger::RunRequestReport;
+use ravel_maintain::{
+    CompactionOutcome, CompactorConfig, FixedClock, MaintainError, PublishOutcome, RequestLedger,
+    RlogCodec, compact_bucket, conserve_exact, read, rewrite_and_publish,
+};
+use ravel_object_store::instrument::{InstrumentedStore, StoreMetricsSnapshot};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{GetRange, ObjectStoreBackend, list_all};
+use uuid::Uuid;
+
+/// A config with a ledger installed and nothing else changed from the shipped
+/// defaults, so the figures pinned below are the default geometry's.
+fn config_with(ledger: &RequestLedger) -> CompactorConfig {
+    CompactorConfig {
+        request_ledger: Some(ledger.clone()),
+        ..CompactorConfig::default()
+    }
+}
+
+/// Every store call the wrapper saw, as one figure: GET + PUT + HEAD + LIST.
+/// This is what the ledger's `total_requests()` must equal.
+fn oracle_requests(before: &StoreMetricsSnapshot, after: &StoreMetricsSnapshot) -> u64 {
+    (after.get.calls - before.get.calls)
+        + (after.put.calls - before.put.calls)
+        + (after.head.calls - before.head.calls)
+        + (after.list_calls() - before.list_calls())
+}
+
+/// Assert the ledger's totals reconcile against the wrapper's, per byte kind.
+/// `wire_bytes_received` is checked against the wrapper's GET bytes (the only
+/// op whose returned payload it counts) and `wire_bytes_sent` against its PUT
+/// bytes; the two are never added together.
+fn assert_reconciles(
+    report: &RunRequestReport,
+    before: &StoreMetricsSnapshot,
+    after: &StoreMetricsSnapshot,
+) {
+    assert_eq!(
+        report.total_requests(),
+        oracle_requests(before, after),
+        "every store call must be attributed to exactly one phase"
+    );
+    assert_eq!(
+        report.total_wire_bytes_received(),
+        after.get.bytes - before.get.bytes,
+        "received bytes must equal the wrapper's GET payload total"
+    );
+    assert_eq!(
+        report.total_wire_bytes_sent(),
+        after.put.bytes - before.put.bytes,
+        "sent bytes must equal the wrapper's PUT payload total"
+    );
+}
+
+/// The byte size of every object under `prefix`, summed.
+async fn bytes_under(store: &dyn ObjectStoreBackend, prefix: &str) -> u64 {
+    list_all(store, prefix)
+        .await
+        .expect("list")
+        .iter()
+        .map(|m| m.size)
+        .sum()
+}
+
+/// Headline: a real RLOG compaction over the two-input logs fixture, with the
+/// instrumented wrapper as the oracle. Each phase's request count is pinned
+/// exactly and the phases reconcile to the wrapper's grand total.
+///
+/// Where each expected integer comes from (two L0 `.rlog` inputs, one part):
+///
+/// - `list` 1: one listing page over the bucket's commit prefix (2 keys, well
+///   under `MemoryStore`'s default page size).
+/// - `record_read` 2: one whole-object GET per input commit record.
+/// - `catalog_read` 10: per input, the footer suffix probe plus the four
+///   whole-read directory sections the RLOG merge needs (STREAM_DIR, FIELD_DIR,
+///   SKIP_IDX, PAGE_DIR). No tail range (a 64 KiB probe covers these small
+///   objects' footers) and no POSTINGS GET (the fixture indexes no fields, so
+///   the section is absent).
+/// - `block_read` 4: one ranged block GET per (stream, input) cursor. The
+///   fixture's streams are stream 0 in both inputs, stream 1 in the first and
+///   stream 2 in the second, i.e. four cursors, each over a single block.
+/// - `part_put` 1: the single L1 part's `CreateIfAbsent` PUT.
+/// - `publish` 1: the compaction record's PUT. No post-publish HEAD: no part
+///   answered `AlreadyExists` on a first run.
+///
+/// Flip proofs, each run against this test:
+///
+/// - dropping the `note_get` at `rlog.rs`'s `fetch_block`: `block_read` reads
+///   0 against the expected 4.
+/// - attributing the commit-record GET to `CatalogRead` instead of
+///   `RecordRead` in `read.rs`'s `load_one_input`: `record_read` reads 0
+///   against the expected 2, so the pinned split, not just the total, is what
+///   holds attribution in place.
+/// - making `rewrite_and_publish` reset unconditionally instead of
+///   `reset_for_run_unless_open`: `list` reads 0 against the expected 1,
+///   because the rewrite would wipe the LIST its driver had already counted.
+///
+/// The reconciliation assertion is proved non-vacuous separately, in
+/// `the_rseg_and_rspan_paths_report_under_the_same_phases`.
+#[tokio::test]
+async fn per_phase_counts_match_the_instrumented_oracle_exactly() {
+    let store = InstrumentedStore::new(MemoryStore::new());
+    let bucket = seed_rlog_two_inputs(&store).await;
+    let metrics = store.metrics();
+    let before = metrics.snapshot();
+
+    let ledger = RequestLedger::new();
+    let clock = FixedClock::new(sealed_now_ns());
+    let outcome = compact_bucket(&store, &clock, &config_with(&ledger), &bucket)
+        .await
+        .expect("compact");
+    assert_eq!(
+        outcome,
+        CompactionOutcome::Compacted {
+            parts: 1,
+            publish: PublishOutcome::Published,
+        }
+    );
+    let after = metrics.snapshot();
+    let report = ledger.report();
+
+    assert_eq!(report.list.requests, 1, "one listing page");
+    assert_eq!(report.record_read.requests, 2, "one GET per commit record");
+    assert_eq!(
+        report.catalog_read.requests, 10,
+        "probe + STREAM_DIR + FIELD_DIR + SKIP_IDX + PAGE_DIR, per input"
+    );
+    assert_eq!(
+        report.block_read.requests, 4,
+        "one block GET per (stream, input) cursor"
+    );
+    assert_eq!(report.part_put.requests, 1, "one L1 part PUT");
+    assert_eq!(report.publish.requests, 1, "the compaction record PUT");
+    assert_eq!(report.total_requests(), 19);
+
+    assert_reconciles(&report, &before, &after);
+
+    // LIST reports requests only: its response body is not visible at the store
+    // seam, so neither byte figure may move for that phase.
+    assert_eq!(report.list.wire_bytes_received, 0);
+    assert_eq!(report.list.wire_bytes_sent, 0);
+    // Read phases move no bytes upward and write phases move none downward, so
+    // the two kinds stay separable per phase.
+    assert_eq!(report.record_read.wire_bytes_sent, 0);
+    assert_eq!(report.catalog_read.wire_bytes_sent, 0);
+    assert_eq!(report.block_read.wire_bytes_sent, 0);
+    assert_eq!(report.part_put.wire_bytes_received, 0);
+}
+
+/// Wire bytes are proportional to the fixture's ACTUAL object sizes, per
+/// object, not to a flat floor:
+///
+/// - `record_read` received bytes equal the summed size of the two commit
+///   record objects, exactly (each is read whole, once).
+/// - `part_put` sent bytes equal the L1 part object's own size, exactly.
+/// - `publish` sent bytes equal the compaction record object's own size,
+///   exactly.
+/// - the ranged read phases are banded against the inputs' OWN sizes, per
+///   object: the catalog phase must cover at least every input's footer probe
+///   (`min(footer_probe_bytes, that object's size)`, which on this fixture's
+///   small objects is the whole object) and at most one further object's worth
+///   of directory sections; the block phase must be positive and cannot exceed
+///   the inputs' bytes, since every block is fetched by range exactly once.
+///
+/// Flip proof (run): charging `read.rs`'s `load_one_input` a constant 1 byte
+/// instead of the response payload length reports 2 received bytes against the
+/// fixture's real 582, so the byte figures track the objects rather than the
+/// request count.
+#[tokio::test]
+async fn wire_bytes_track_the_fixtures_real_object_sizes() {
+    let store = MemoryStore::new();
+    let bucket = seed_rlog_two_inputs(&store).await;
+
+    let commit_prefix = ravel_commit::keys::commit_shard_hour_prefix(
+        &bucket.tenant_hash,
+        bucket.signal,
+        bucket.shard,
+        bucket.ingest_hour_bucket,
+    )
+    .expect("prefix");
+    let commit_record_bytes = bytes_under(&store, &commit_prefix).await;
+    // The inputs' own object sizes, read per object from their commit records
+    // rather than from a flat assumption about the fixture.
+    let listing = read::list_bucket(&store, &bucket).await.expect("list");
+    let input_object_bytes: u64 = read::load_inputs(&store, &bucket, &listing.commit_keys, 1)
+        .await
+        .expect("inputs")
+        .iter()
+        .map(|i| i.record.object_size)
+        .sum();
+
+    let ledger = RequestLedger::new();
+    let clock = FixedClock::new(sealed_now_ns());
+    compact_bucket(&store, &clock, &config_with(&ledger), &bucket)
+        .await
+        .expect("compact");
+    let report = ledger.report();
+
+    assert_eq!(
+        report.record_read.wire_bytes_received, commit_record_bytes,
+        "each input commit record is read whole, exactly once"
+    );
+
+    let record = fetch_compaction_record(&store, &bucket).await;
+    let part_bytes: u64 = record.parts.iter().map(|p| p.object_size).sum();
+    assert_eq!(
+        report.part_put.wire_bytes_sent, part_bytes,
+        "the part PUT offered exactly the part object's bytes"
+    );
+
+    let record_key =
+        ravel_commit::keys::compaction_record_key_for(&record).expect("compaction record key");
+    let published = store
+        .get(&record_key, GetRange::Full)
+        .await
+        .expect("get record")
+        .data
+        .len() as u64;
+    assert_eq!(
+        report.publish.wire_bytes_sent, published,
+        "the record PUT offered exactly the record object's bytes"
+    );
+
+    // Per-object band, not a flat floor: each input's probe window is capped by
+    // that object's own size.
+    let probe_floor: u64 = read::load_inputs(&store, &bucket, &listing.commit_keys, 1)
+        .await
+        .expect("inputs")
+        .iter()
+        .map(|i| {
+            i.record
+                .object_size
+                .min(CompactorConfig::default().footer_probe_bytes)
+        })
+        .sum();
+    let catalog = report.catalog_read.wire_bytes_received;
+    assert!(
+        catalog >= probe_floor,
+        "the catalog phase covers every input's footer probe: {catalog} < {probe_floor}"
+    );
+    assert!(
+        catalog <= probe_floor + input_object_bytes,
+        "the directory sections add at most one further object's worth: \
+         {catalog} > {probe_floor} + {input_object_bytes}"
+    );
+    let blocks = report.block_read.wire_bytes_received;
+    assert!(blocks > 0, "the merge read its inputs' blocks");
+    assert!(
+        blocks <= input_object_bytes,
+        "every block is fetched by range exactly once: {blocks} > {input_object_bytes}"
+    );
+}
+
+/// One LIST request per listing PAGE, not per listing. Driving the same
+/// compaction over a store paginating at one key per page turns the fixture's
+/// single `list` request into three (a page per commit record, then the
+/// terminating empty page), and every other phase is unchanged.
+///
+/// Flip proof (run): moving the `note_metadata` in `read.rs`'s
+/// `list_all_counted` out of the loop to after it reports 1 here against the
+/// expected 3.
+#[tokio::test]
+async fn list_counts_every_page_of_a_paginated_drain() {
+    let store = InstrumentedStore::new(MemoryStore::with_page_size(1));
+    let bucket = seed_rlog_two_inputs(&store).await;
+    let metrics = store.metrics();
+    let before = metrics.snapshot();
+
+    let ledger = RequestLedger::new();
+    let clock = FixedClock::new(sealed_now_ns());
+    compact_bucket(&store, &clock, &config_with(&ledger), &bucket)
+        .await
+        .expect("compact");
+    let after = metrics.snapshot();
+    let report = ledger.report();
+
+    assert_eq!(
+        report.list.requests, 3,
+        "two single-key pages plus the terminating page"
+    );
+    assert_eq!(report.record_read.requests, 2);
+    assert_eq!(report.catalog_read.requests, 10);
+    assert_eq!(report.block_read.requests, 4);
+    assert_reconciles(&report, &before, &after);
+}
+
+/// A converging rerun still counts its part PUT: the `CreateIfAbsent` answered
+/// `AlreadyExists`, but the request was issued and the body was sent, so it is
+/// an attempt like any other. The rerun's publish phase is the record PUT that
+/// lost, the winner-record GET, and one HEAD per referenced part.
+///
+/// Flip proof (run): moving `put_part_with_ledger`'s `note_put` onto the `Ok`
+/// arm of the outcome match reports `part_put.requests == 0` here against the
+/// expected 1.
+#[tokio::test]
+async fn an_already_exists_part_put_still_counts_as_an_attempt() {
+    let store = InstrumentedStore::new(MemoryStore::new());
+    let bucket = seed_rlog_two_inputs(&store).await;
+    let listing = read::list_bucket(&store, &bucket).await.expect("list");
+    let clock = FixedClock::new(sealed_now_ns());
+    let ledger = RequestLedger::new();
+    let config = config_with(&ledger);
+
+    let first = rewrite_and_publish::<RlogCodec>(
+        &store,
+        &clock,
+        &config,
+        &bucket,
+        &listing.commit_keys,
+        conserve_exact(),
+        sealed_now_ns(),
+    )
+    .await
+    .expect("first run");
+    assert_eq!(first.publish, PublishOutcome::Published);
+    assert_eq!(first.parts, 1);
+    assert_eq!(
+        ledger.report().part_put.requests,
+        1,
+        "the first run created the part"
+    );
+
+    // Re-run from scratch, as a crashed run would: identical content-addressed
+    // parts, so every part PUT answers AlreadyExists and the record PUT loses.
+    let metrics = store.metrics();
+    let before = metrics.snapshot();
+    let second = rewrite_and_publish::<RlogCodec>(
+        &store,
+        &clock,
+        &config,
+        &bucket,
+        &listing.commit_keys,
+        conserve_exact(),
+        sealed_now_ns(),
+    )
+    .await
+    .expect("second run");
+    assert_eq!(
+        second.publish,
+        PublishOutcome::Converged { parts_repaired: 0 }
+    );
+    let after = metrics.snapshot();
+    let report = ledger.report();
+
+    assert_eq!(
+        report.part_put.requests, 1,
+        "the AlreadyExists part PUT is still an attempt"
+    );
+    assert!(
+        report.part_put.wire_bytes_sent > 0,
+        "the rejected PUT still sent the part's body"
+    );
+    assert_eq!(
+        report.publish.requests, 3,
+        "the losing record PUT, the winner-record GET, and one part HEAD"
+    );
+    assert_eq!(
+        report.list.requests, 0,
+        "this run was driven straight into the rewrite; it listed nothing"
+    );
+    assert_reconciles(&report, &before, &after);
+}
+
+/// A publish that aborts on the conservation gate reports the phases that ran
+/// and ZERO publish-phase requests: the gate fires before the record PUT, so no
+/// publish request was ever issued, and the ledger must not imply one was.
+///
+/// Flip proof (run): accounting the record PUT before the conservation gate
+/// rather than at the call reports `publish.requests == 1` here against the
+/// expected 0.
+#[tokio::test]
+async fn a_conservation_abort_reports_zero_publish_requests() {
+    let store = InstrumentedStore::new(MemoryStore::new());
+    let bucket = seed_rlog_two_inputs(&store).await;
+    let listing = read::list_bucket(&store, &bucket).await.expect("list");
+    let metrics = store.metrics();
+    let before = metrics.snapshot();
+
+    let ledger = RequestLedger::new();
+    let clock = FixedClock::new(sealed_now_ns());
+    let err = rewrite_and_publish::<RlogCodec>(
+        &store,
+        &clock,
+        &config_with(&ledger),
+        &bucket,
+        &listing.commit_keys,
+        // Demand one dropped record where the merge drops none.
+        |input: u64, output: u64| input == output + 1,
+        sealed_now_ns(),
+    )
+    .await
+    .expect_err("a rejected count must abort");
+    assert!(
+        matches!(err, MaintainError::ConservationViolation { .. }),
+        "expected ConservationViolation, got {err:?}"
+    );
+    let after = metrics.snapshot();
+    let report = ledger.report();
+
+    assert_eq!(
+        report.publish.requests, 0,
+        "the gate fires before the record PUT; nothing was published"
+    );
+    assert_eq!(report.publish.wire_bytes_sent, 0);
+    assert_eq!(report.publish.wire_bytes_received, 0);
+    // The phases that did run are reported in full, including the part PUTs the
+    // aborted run already spent.
+    assert_eq!(report.record_read.requests, 2);
+    assert_eq!(report.catalog_read.requests, 10);
+    assert_eq!(report.block_read.requests, 4);
+    assert_eq!(report.part_put.requests, 1);
+    assert_reconciles(&report, &before, &after);
+}
+
+/// Run scoping: a second run reports only its own figures. The rerun here is
+/// gated `AlreadyCompacted` after its LIST, so its report is exactly one
+/// listing request and nothing else -- none of the first run's 19 requests
+/// survive into it.
+///
+/// Flip proofs, both run against this test:
+///
+/// - making `RequestLedger::reset_for_run` clear nothing: the second run's
+///   `list` reads 2 against the expected 1, the accumulation this scoping
+///   exists to prevent.
+/// - removing `compact_bucket`'s `reset_for_run` entirely: the FIRST run's
+///   `list` reads 0 against the expected 1, because `rewrite_and_publish`
+///   then finds no open scope and resets over the LIST its driver counted.
+#[tokio::test]
+async fn a_second_run_reports_only_its_own_figures() {
+    let store = MemoryStore::new();
+    let bucket = seed_rlog_two_inputs(&store).await;
+    let ledger = RequestLedger::new();
+    let config = config_with(&ledger);
+    let clock = FixedClock::new(sealed_now_ns());
+
+    compact_bucket(&store, &clock, &config, &bucket)
+        .await
+        .expect("first compaction");
+    let first = ledger.report();
+    assert_eq!(
+        first.list.requests, 1,
+        "the driver's LIST survives the rewrite"
+    );
+    assert_eq!(first.total_requests(), 19);
+
+    let outcome = compact_bucket(&store, &clock, &config, &bucket)
+        .await
+        .expect("second compaction");
+    assert_eq!(outcome, CompactionOutcome::AlreadyCompacted);
+    let second = ledger.report();
+
+    assert_eq!(second.list.requests, 1, "its own listing page");
+    assert_eq!(
+        second.total_requests(),
+        1,
+        "an already-compacted bucket spends one LIST and nothing else"
+    );
+    assert_eq!(second.record_read, Default::default());
+    assert_eq!(second.catalog_read, Default::default());
+    assert_eq!(second.block_read, Default::default());
+    assert_eq!(second.part_put, Default::default());
+    assert_eq!(second.publish, Default::default());
+}
+
+/// The RSEG (metrics) and RSPAN (spans) paths report under the same phases: a
+/// compaction of either signal attributes every request it makes and reconciles
+/// against the oracle, so the ledger is not RLOG-only.
+///
+/// This is also where the reconciliation assertion is shown non-vacuous. Flip
+/// proof (run): dropping the `note_get` on RSPAN's SKIP_IDX section fetch
+/// leaves every per-phase assertion here passing (the footer probe still puts
+/// `catalog_read` above zero) and fails only the reconciliation, 9 attributed
+/// against the wrapper's 11 -- exactly the "a request went uncounted" case a
+/// per-phase floor cannot see.
+#[tokio::test]
+async fn the_rseg_and_rspan_paths_report_under_the_same_phases() {
+    for signal in ["metrics", "spans"] {
+        let store = InstrumentedStore::new(MemoryStore::new());
+        let bucket = if signal == "metrics" {
+            seed_input(
+                &store,
+                &InputSpec::new(
+                    Uuid::from_u128(1),
+                    10,
+                    1,
+                    vec![raw_series("m", &[], &[(10, 1.0)])],
+                ),
+            )
+            .await;
+            seed_input(
+                &store,
+                &InputSpec::new(
+                    Uuid::from_u128(2),
+                    10,
+                    2,
+                    vec![raw_series("m", &[], &[(20, 2.0)])],
+                ),
+            )
+            .await;
+            common::bucket()
+        } else {
+            seed_rspan_two_inputs(&store).await
+        };
+        let metrics = store.metrics();
+        let before = metrics.snapshot();
+
+        let ledger = RequestLedger::new();
+        let clock = FixedClock::new(sealed_now_ns());
+        let outcome = compact_bucket(&store, &clock, &config_with(&ledger), &bucket)
+            .await
+            .expect("compact");
+        assert!(
+            matches!(outcome, CompactionOutcome::Compacted { .. }),
+            "{signal} fixture must compact, got {outcome:?}"
+        );
+        let after = metrics.snapshot();
+        let report = ledger.report();
+
+        assert_eq!(report.list.requests, 1, "{signal}: one listing page");
+        assert_eq!(
+            report.record_read.requests, 2,
+            "{signal}: two commit records"
+        );
+        assert!(
+            report.catalog_read.requests > 0,
+            "{signal}: catalog reads attributed"
+        );
+        assert!(
+            report.block_read.requests > 0,
+            "{signal}: page/block reads attributed"
+        );
+        assert!(
+            report.part_put.requests > 0,
+            "{signal}: part PUTs attributed"
+        );
+        assert_eq!(report.publish.requests, 1, "{signal}: the record PUT");
+        assert_reconciles(&report, &before, &after);
+    }
+}


### PR DESCRIPTION
ADR-0996 task 996-8. Every store request a compaction run issues is now
counted at its own call site under the phase that issued it: list,
record_read, catalog_read, block_read, part_put, publish. Requests and
wire bytes as transferred, received and sent kept as separate kinds that
are never summed; LIST and HEAD carry request counts only. The report
reaches the operator on the same tracing line pattern as the phase
memory peaks, and reset_for_run scopes each run to its own figures.

Counters are observed, never consulted: no fetch decision, policy, or
budget reads a ledger value, and the ledger stays out of the memory
tracker's decoded-residency domain. An AlreadyExists part PUT counts as
the attempt it billed; the publish phase counts the record PUT, winner
GET, and post-publish HEAD verifications; a conservation abort reports
the phases that ran with zero publish requests.

The test suite reconciles the ledger against an instrumented-store
oracle exactly (per-phase pinned integers summing to the oracle's grand
total, no request uncounted or double-counted), with ranged-read byte
figures banded per object.

Refs: #996
Signed-off-by: Panagiotis Moustafellos <pmoust@nofire.ai>
