### PR TITLE
feat(cli): add --max-flush-delay lever to load

### DIFF
--- a/services/ravel-cli/src/lib.rs
+++ b/services/ravel-cli/src/lib.rs
@@ -56,14 +56,28 @@ pub fn parse_max_flush_lifetime_ns(s: &str) -> Result<i64, String> {
 /// `1h5m`); the loader plumbs the result straight into
 /// `IngestConfig::max_flush_delay`, which is a `Duration`, so this returns one
 /// rather than an `i64` of nanoseconds. Zero is accepted, mirroring the
-/// `--max-flush-lifetime` flags: `0s` means the age trigger fires on the next
-/// flush tick for any non-empty buffer (its oldest point is always at least
-/// `0s` old), so every buffer flushes by age almost immediately regardless of
-/// `--target-bytes`. Negative values are unrepresentable in humantime, so the
-/// only rejections are an unparseable spelling and a value too large for
-/// `Duration`.
+/// `--max-flush-lifetime` flags: on the loader's path `0s` means the age
+/// trigger fires on the next flush tick for any non-empty buffer (its oldest
+/// point is always at least `0s` old), so every buffer flushes by age almost
+/// immediately regardless of `--target-bytes`. That holds because every loader
+/// write is Strict and therefore leaves a waiter on the buffer it merged into,
+/// which is what makes the shard compare the buffer's age against
+/// `max_flush_delay` rather than against the slower `max_flush_delay_idle`
+/// (`age_threshold_ns`, crates/ravel-ingest/src/log_shard.rs).
+///
+/// The `i64`-nanosecond ceiling is the same rejection the
+/// `--max-flush-lifetime` flags apply, and it is load-bearing here rather than
+/// merely tidy: the shard's age check casts `max_flush_delay.as_nanos() as
+/// i64`, so a `Duration` past 292 years wraps to a negative threshold that
+/// every buffer's age clears on the very next flush tick. The value furthest
+/// from "never age out" would otherwise parse as its exact opposite. Negative
+/// values are unrepresentable in humantime, so the only rejections are an
+/// unparseable spelling and a value too large for `i64` nanoseconds.
 pub fn parse_max_flush_delay(s: &str) -> Result<std::time::Duration, String> {
-    humantime::parse_duration(s).map_err(|e| format!("invalid --max-flush-delay '{s}': {e}"))
+    let dur = humantime::parse_duration(s)
+        .map_err(|e| format!("invalid --max-flush-delay '{s}': {e}"))?;
+    i64::try_from(dur.as_nanos()).map_err(|_| format!("--max-flush-delay '{s}' is too large"))?;
+    Ok(dur)
 }
 
 #[cfg(test)]
@@ -103,5 +117,32 @@ mod tests {
             err.contains("--max-flush-delay"),
             "the error names the flag: {err}"
         );
+    }
+
+    /// A duration past the `i64`-nanosecond ceiling is rejected, exactly as
+    /// [`parse_max_flush_lifetime_ns`] rejects it. The shard's age check casts
+    /// `max_flush_delay.as_nanos() as i64`, so an accepted 1000-year delay
+    /// would reach it as a negative threshold and age-flush every buffer on
+    /// every tick: the parse rejection is what keeps the largest expressible
+    /// value from behaving as the smallest.
+    ///
+    /// Prove-the-test: drop the `i64::try_from` line from
+    /// `parse_max_flush_delay` and this fails at `expect_err` with
+    /// `Ok(31557600000s)`.
+    #[test]
+    fn parse_max_flush_delay_rejects_a_value_past_the_i64_nanosecond_ceiling() {
+        // 1000 humantime years is 3.15e19 ns, past i64::MAX (9.22e18), and
+        // well inside what `Duration` itself can hold.
+        let err = parse_max_flush_delay("1000years").expect_err("1000 years is rejected");
+        assert!(
+            err.contains("--max-flush-delay") && err.contains("too large"),
+            "the error names the flag and the reason: {err}"
+        );
+        // The sibling flag rejects the same spelling for the same reason.
+        assert!(parse_max_flush_lifetime_ns("1000years").is_err());
+        // The largest value that still fits is accepted, so the guard rejects
+        // only what the cast would corrupt.
+        let ok = parse_max_flush_delay("292years").expect("292 years still fits in i64 ns");
+        assert!(i64::try_from(ok.as_nanos()).is_ok());
     }
 }

--- a/services/ravel-cli/src/lib.rs
+++ b/services/ravel-cli/src/lib.rs
@@ -70,14 +70,20 @@ pub fn parse_max_flush_lifetime_ns(s: &str) -> Result<i64, String> {
 /// merely tidy: the shard's age check casts `max_flush_delay.as_nanos() as
 /// i64`, so a `Duration` past 292 years wraps to a negative threshold that
 /// every buffer's age clears on the very next flush tick. The value furthest
-/// from "never age out" would otherwise parse as its exact opposite. Negative
-/// values are unrepresentable in humantime, so the only rejections are an
-/// unparseable spelling and a value too large for `i64` nanoseconds.
+/// from "never age out" would otherwise parse as its exact opposite. The
+/// ceiling leaves room for the strict-visibility reserve on top, so the
+/// derived budget stays strictly greater than the delay instead of saturating
+/// equal to it. Negative values are unrepresentable in humantime, so the only
+/// rejections are an unparseable spelling and a value too large for the
+/// `i64`-nanosecond budget arithmetic.
 pub fn parse_max_flush_delay(s: &str) -> Result<std::time::Duration, String> {
     let dur = humantime::parse_duration(s)
         .map_err(|e| format!("invalid --max-flush-delay '{s}': {e}"))?;
-    i64::try_from(dur.as_nanos()).map_err(|_| format!("--max-flush-delay '{s}' is too large"))?;
-    Ok(dur)
+    let ceiling = i64::MAX - ravel_ingest::STRICT_VISIBILITY_RESERVE_NS;
+    match i64::try_from(dur.as_nanos()) {
+        Ok(ns) if ns <= ceiling => Ok(dur),
+        _ => Err(format!("--max-flush-delay '{s}' is too large")),
+    }
 }
 
 #[cfg(test)]
@@ -144,5 +150,18 @@ mod tests {
         // only what the cast would corrupt.
         let ok = parse_max_flush_delay("292years").expect("292 years still fits in i64 ns");
         assert!(i64::try_from(ok.as_nanos()).is_ok());
+        // Boundary: the ceiling leaves room for the strict-visibility reserve,
+        // so the derived budget is strictly greater than any accepted delay
+        // rather than saturating equal to it at the edge.
+        let ceiling = i64::MAX - ravel_ingest::STRICT_VISIBILITY_RESERVE_NS;
+        let at = std::time::Duration::from_nanos(ceiling as u64);
+        assert!(
+            parse_max_flush_delay(&format!("{}ns", at.as_nanos())).is_ok(),
+            "the largest accepted delay sits exactly at i64::MAX minus the reserve"
+        );
+        assert!(
+            parse_max_flush_delay(&format!("{}ns", at.as_nanos() + 1)).is_err(),
+            "one nanosecond past the ceiling refuses"
+        );
     }
 }

--- a/services/ravel-cli/src/lib.rs
+++ b/services/ravel-cli/src/lib.rs
@@ -49,3 +49,59 @@ pub fn parse_max_flush_lifetime_ns(s: &str) -> Result<i64, String> {
         .map_err(|e| format!("invalid --max-flush-lifetime '{s}': {e}"))?;
     i64::try_from(dur.as_nanos()).map_err(|_| format!("--max-flush-lifetime '{s}' is too large"))
 }
+
+/// Parse a `load --max-flush-delay` value into a [`std::time::Duration`].
+///
+/// Same humantime grammar as [`parse_max_flush_lifetime_ns`] (`2s`, `10m`,
+/// `1h5m`); the loader plumbs the result straight into
+/// `IngestConfig::max_flush_delay`, which is a `Duration`, so this returns one
+/// rather than an `i64` of nanoseconds. Zero is accepted, mirroring the
+/// `--max-flush-lifetime` flags: `0s` means the age trigger fires on the next
+/// flush tick for any non-empty buffer (its oldest point is always at least
+/// `0s` old), so every buffer flushes by age almost immediately regardless of
+/// `--target-bytes`. Negative values are unrepresentable in humantime, so the
+/// only rejections are an unparseable spelling and a value too large for
+/// `Duration`.
+pub fn parse_max_flush_delay(s: &str) -> Result<std::time::Duration, String> {
+    humantime::parse_duration(s).map_err(|e| format!("invalid --max-flush-delay '{s}': {e}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// `--max-flush-delay` parses humantime and returns an exact `Duration`
+    /// (issue #801, deliverable 2's parse half).
+    #[test]
+    fn parse_max_flush_delay_reads_humantime_exactly() {
+        assert_eq!(
+            parse_max_flush_delay("10m").expect("10m"),
+            Duration::from_secs(600)
+        );
+        assert_eq!(
+            parse_max_flush_delay("2s").expect("2s"),
+            Duration::from_secs(2)
+        );
+        assert_eq!(
+            parse_max_flush_delay("1h5m").expect("1h5m"),
+            Duration::from_secs(3600 + 300)
+        );
+    }
+
+    /// Zero is accepted with a defined meaning, mirroring the sibling
+    /// `--max-flush-lifetime` flags rather than being refused (issue #801,
+    /// deliverable 4). Negative values are unrepresentable in humantime, so the
+    /// grammar cannot express one; a garbage spelling is a typed `Err`, never a
+    /// panic.
+    #[test]
+    fn parse_max_flush_delay_accepts_zero_and_rejects_garbage() {
+        assert_eq!(parse_max_flush_delay("0s").expect("0s"), Duration::ZERO);
+        let err = parse_max_flush_delay("later").expect_err("garbage is rejected");
+        assert!(
+            err.contains("--max-flush-delay"),
+            "the error names the flag: {err}"
+        );
+    }
+}

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -1641,10 +1641,12 @@ async fn drain_inflight(
 /// it is bounded: the remaining writes were submitted before the failing one and
 /// run concurrently, so this waits at most one [`write_ack_deadline`], which at
 /// a raised `--max-flush-delay` is that delay plus its margin rather than a flat
-/// minute. Reached from the clean-exhaustion drain the wait is short whatever
-/// the delay, because the tail buffers were already published by the `flush_all`
-/// that precedes that drain; only a mid-load failure can leave an outstanding
-/// write waiting on the age trigger here.
+/// minute. Reached from the clean-exhaustion drain the wait is usually short,
+/// because the tail buffers were already published by the `flush_all` that
+/// precedes that drain -- with one exception either path shares: a write whose
+/// task had not yet reached its channel send when the flush ran lands in a
+/// fresh buffer afterward and waits on the age trigger, which the scaled
+/// deadline outlasts by construction.
 ///
 /// A later write's own error is deliberately discarded apart from its recovered
 /// tokens: the returned error stays the first failure in submission order, which

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -35,7 +35,7 @@ use ravel_catalog::{AbsentPolicy, validate_or_adopt};
 use ravel_ingest::LogStageSnapshot;
 use ravel_ingest::{
     Clock, FlushTriggerMix, IngestConfig, LogIngestMetricsSnapshot, LogIngestRouter, LogWriteError,
-    LogWriteReceipt, SystemClock, WriteMode,
+    LogWriteReceipt, STRICT_VISIBILITY_RESERVE_NS, SystemClock, WriteMode,
 };
 use ravel_logseg::{
     Bitmap, ColumnarLogBatch, DynColumn, FieldType, StrColumnDict, stream_attrs_bytes,
@@ -110,7 +110,7 @@ pub const DEFAULT_DECODE_QUEUE_BATCHES: usize = 2;
 ///   object count unchanged at 8,424. A depth of 16 with the inner window left
 ///   at 1 aborted outright with `timed out waiting for shard ack`, because a
 ///   depth the inner window cannot absorb just queues batches behind the
-///   [`WRITE_ACK_DEADLINE`].
+///   [`write_ack_deadline`].
 /// - It bounds the memory cost at a stated multiple rather than at the shard
 ///   count, which is a provisioning decision an operator may set far above 4.
 ///   The loader holds at most `--pipeline-depth` built batches for their
@@ -130,7 +130,7 @@ pub const DEFAULT_PIPELINE_DEPTH: usize = 4;
 /// windows compose as `shards * min(pipeline_depth, max_inflight_flushes)`
 /// (ADR-0807): an inner window below the outer one re-serialises each shard's
 /// PUT round trips and makes batches queue behind a semaphore they will still
-/// have to clear before [`WRITE_ACK_DEADLINE`] elapses, and an inner window
+/// have to clear before [`write_ack_deadline`] elapses, and an inner window
 /// above the outer one is unreachable, since the loader never hands any shard
 /// more concurrent work than `--pipeline-depth` batches.
 ///
@@ -168,18 +168,52 @@ pub(crate) fn build_ingest_config(
     max_inflight_flushes: u32,
     max_flush_delay: Option<Duration>,
 ) -> IngestConfig {
+    let delay = max_flush_delay.unwrap_or_else(|| IngestConfig::default().max_flush_delay);
     IngestConfig {
         shard_count: shards,
         target_bytes,
         max_inflight_flushes,
-        max_flush_delay: max_flush_delay.unwrap_or_else(|| IngestConfig::default().max_flush_delay),
+        max_flush_delay: delay,
+        // ADR-0076 decision 4: follows the actually-configured
+        // `max_flush_delay`, not just its default, so the adaptive corridor
+        // never contradicts the configured cadence. Must EXCEED the delay by
+        // the same reserve `IngestConfig::default()` uses; setting it equal
+        // collapses the corridor to its floor. Same derivation as
+        // `services/ravel-server/src/lib.rs`'s router construction.
+        strict_visibility_budget_ns: i64::try_from(delay.as_nanos())
+            .unwrap_or(i64::MAX)
+            .saturating_add(STRICT_VISIBILITY_RESERVE_NS),
         ..IngestConfig::default()
     }
 }
 
-/// Ack deadline for each Strict write. Generous: a bulk load values completing
-/// over racing a slow store.
-const WRITE_ACK_DEADLINE: Duration = Duration::from_secs(60);
+/// Floor for a Strict write's ack deadline. Generous: a bulk load values
+/// completing over racing a slow store.
+const WRITE_ACK_DEADLINE_FLOOR: Duration = Duration::from_secs(60);
+
+/// Headroom added over `--max-flush-delay` by [`write_ack_deadline`]: the
+/// window the released flush still needs to encode and PUT its object once the
+/// age trigger has opened it.
+const WRITE_ACK_DEADLINE_MARGIN: Duration = Duration::from_secs(60);
+
+/// Ack deadline for each Strict write, scaled to the configured age trigger.
+///
+/// A write whose shard buffer never reaches `--target-bytes` is answered by the
+/// age trigger, so its ack can legitimately take `--max-flush-delay` plus the
+/// flush itself. A fixed 60s deadline therefore turns any raised delay into a
+/// `LogWriteError::AckTimeout` on the very batches the raised delay was meant
+/// to let accumulate, failing a whole load at its documented settings. Scaling
+/// keeps the deadline what it always was for an unset flag
+/// ([`WRITE_ACK_DEADLINE_FLOOR`] exactly) while leaving a raised delay one
+/// [`WRITE_ACK_DEADLINE_MARGIN`] of room past the trigger it configured.
+pub(crate) fn write_ack_deadline(max_flush_delay: Option<Duration>) -> Duration {
+    match max_flush_delay {
+        None => WRITE_ACK_DEADLINE_FLOOR,
+        Some(delay) => {
+            WRITE_ACK_DEADLINE_FLOOR.max(delay.saturating_add(WRITE_ACK_DEADLINE_MARGIN))
+        }
+    }
+}
 
 /// Source time unit for the mapped `ts` column, converted to nanoseconds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -1002,7 +1036,9 @@ type BuildStartHook = Arc<dyn Fn() + Send + Sync>;
 /// buffer flushes, beside `target_bytes` and the slice footprint: a buffer that
 /// does not reach `target_bytes` within this delay is released by the age
 /// trigger, so a large `target_bytes` is only reachable once this is raised past
-/// the time one target's worth accumulates. See [`build_ingest_config`].
+/// the time one target's worth accumulates. See [`build_ingest_config`]. It also
+/// scales every write's ack deadline ([`write_ack_deadline`]), so a buffer the
+/// age trigger releases late is still awaited rather than timed out.
 #[allow(clippy::too_many_arguments)]
 async fn load_instrumented(
     store: Arc<dyn ObjectStoreBackend>,
@@ -1124,10 +1160,12 @@ async fn load_instrumented(
     // from `ack_waiters` only after that flush's object and commit record are
     // published) but drops the other three: a shard's buffer now spans several
     // batches, so a batch's ack waits for whichever later batch pushes the
-    // buffer over the target, and a tail buffer that never reaches the target
-    // is released by the wall-clock age trigger instead. The loader's in-flight
-    // window must therefore be wide enough to hold the batches that accumulate
-    // into one flush, or every flush waits out `max_flush_delay`.
+    // buffer over the target, and mid-load a buffer that never reaches the
+    // target is released by the wall-clock age trigger instead (at the end of
+    // the input the `flush_all` below releases it, since no later batch is
+    // coming). The loader's in-flight window must therefore be wide enough to
+    // hold the batches that accumulate into one flush, or every flush waits out
+    // `max_flush_delay`.
     //
     // That age trigger (`max_flush_delay`, the `--max-flush-delay` lever) is the
     // THIRD binding constraint on object layout, beside `target_bytes` and one
@@ -1164,6 +1202,13 @@ async fn load_instrumented(
         Arc::clone(&store),
         clock,
     ));
+
+    // Every Strict write below waits this long for its ack, and the wait is
+    // whatever the age trigger the same flag configured takes to release the
+    // buffer (see `write_ack_deadline`): a buffer that misses `target_bytes`
+    // through slice variance mid-load is answered by the age trigger, so the
+    // deadline has to outlast it.
+    let ack_deadline = write_ack_deadline(max_flush_delay);
 
     // Parse the input's Parquet footer exactly once here (issue #773). The
     // shared metadata sizes the stride cursors, derives the reader schema, and
@@ -1303,7 +1348,7 @@ async fn load_instrumented(
                 let tenant = tenant_id.clone();
                 tokio::spawn(async move {
                     router
-                        .write(tenant, records, WriteMode::Strict, WRITE_ACK_DEADLINE)
+                        .write(tenant, records, WriteMode::Strict, ack_deadline)
                         .await
                 })
             }
@@ -1316,7 +1361,7 @@ async fn load_instrumented(
                 let tenant = tenant_id.clone();
                 tokio::spawn(async move {
                     router
-                        .write_columnar(tenant, *batch, WriteMode::Strict, WRITE_ACK_DEADLINE)
+                        .write_columnar(tenant, *batch, WriteMode::Strict, ack_deadline)
                         .await
                 })
             }
@@ -1388,10 +1433,26 @@ async fn load_instrumented(
         });
     }
 
-    // Clean exhaustion: reap the finished decoder task, then drain every write
-    // still in the window in the same oldest-first order before reporting
-    // success.
+    // Clean exhaustion: reap the finished decoder task first, so no further
+    // batch can be built.
     let _ = decode_handle.await;
+
+    // Publish the tail buffers BEFORE waiting on the writes that are still in
+    // the window. The input is exhausted, so no later batch will arrive to push
+    // a buffer that sits under `target_bytes` over it, and its writes' acks are
+    // then answered only by the age trigger -- which at a raised
+    // `--max-flush-delay` outlasts the ack deadline, failing the whole load at
+    // the end on exactly the settings the flag exists for. `FlushNow` travels
+    // each shard's own channel, so it merges behind the writes already queued
+    // there, publishes whatever they buffered, and answers their waiters; the
+    // drain below then resolves at PUT speed instead of on the age clock. A
+    // write whose task has not yet reached its channel send is the case
+    // `write_ack_deadline` covers: it is released by the age trigger and its
+    // ack is awaited long enough to arrive.
+    router.flush_all().await;
+
+    // Drain every write still in the window in the same oldest-first order
+    // before reporting success.
     drain_inflight(
         &mut inflight,
         &mut report,
@@ -1400,10 +1461,6 @@ async fn load_instrumented(
         shards,
     )
     .await?;
-
-    // Strict acks already guarantee durability; flush_all is a defensive
-    // no-op here (nothing is buffered after a Strict write returns).
-    router.flush_all().await;
 
     // Snapshot the router's cumulative counters before it drops: the caller
     // reads the dynamic-column figures to warn on overflow or near-cap pressure
@@ -1582,7 +1639,12 @@ async fn drain_inflight(
 /// there is nothing left that can commit, so the reported list is exactly what
 /// landed, at any `--pipeline-depth`. The cost is on the failure path only, and
 /// it is bounded: the remaining writes were submitted before the failing one and
-/// run concurrently, so this waits at most one [`WRITE_ACK_DEADLINE`].
+/// run concurrently, so this waits at most one [`write_ack_deadline`], which at
+/// a raised `--max-flush-delay` is that delay plus its margin rather than a flat
+/// minute. Reached from the clean-exhaustion drain the wait is short whatever
+/// the delay, because the tail buffers were already published by the `flush_all`
+/// that precedes that drain; only a mid-load failure can leave an outstanding
+/// write waiting on the age trigger here.
 ///
 /// A later write's own error is deliberately discarded apart from its recovered
 /// tokens: the returned error stays the first failure in submission order, which
@@ -5949,82 +6011,112 @@ type = "i64"
         );
     }
 
-    /// The `--max-flush-delay` lever is observable in the flush mix (issue #801,
-    /// deliverable 3): whether two sequential writes to one shard coalesce into
-    /// one object or split into two turns on the age trigger, holding the target
-    /// fixed. Geometry: one shard, two equal 4 KB-payload rows read one per
-    /// batch (`--batch-rows 1 --read-cursors 1`), so each write's estimated
-    /// per-shard slice is about 4.1 KB. `TARGET = 6000` sits above one slice and
-    /// below two, so a single write can never reach it on its own -- it is
-    /// released only by a later write merging in (size) or by aging out.
+    /// One side of the [`max_flush_delay_decides_whether_two_writes_coalesce`]
+    /// pair. Every argument of the load is fixed here, so the only thing the
+    /// two calls differ in is `max_flush_delay`.
     ///
-    /// - Raised delay (`Some(1h)`), both writes in flight (`--pipeline-depth
-    ///   2`), a `FixedClock` that never ages anything: whichever write the shard
-    ///   actor sees first buffers under `TARGET`, and the second merges into the
-    ///   same buffer, pushing it over `TARGET` and flushing both as ONE object by
-    ///   size. Order-independent, so no write is stranded. Mix: size 1, age 0.
-    /// - Default delay (`None` = 2s), serial writes (`--pipeline-depth 1`), an
-    ///   injected clock advanced past 2s: the loader awaits the first write's ack
-    ///   before submitting the second, so the two never share a buffer. With no
-    ///   later write to push either over `TARGET`, each is released only by the
-    ///   age trigger, which the advanced clock fires. TWO objects, both aged.
+    /// The injected clock advances 5s of load time every 20ms of real time and
+    /// stops once it has advanced `GATE_NS`; the decoder is gated on that same
+    /// point, blocking after the first batch is queued until the clock reaches
+    /// it. So batch 1's write sits alone in the shard buffer across the whole
+    /// advance, and batch 2's write arrives only once the clock has stopped
+    /// moving. Whether the first buffer survives that window is the delay's
+    /// decision and nothing else's.
+    async fn load_two_writes_across_one_clock_advance(
+        store: Arc<dyn ObjectStoreBackend>,
+        pq: &Path,
+        m: &Mapping,
+        max_flush_delay: Duration,
+    ) -> LoadReport {
+        // TARGET between one 4.1 KB slice and two, with margin on both sides,
+        // so one write never reaches it and two always do.
+        const TARGET: usize = 6_000;
+        const ADVANCE_STEP_NS: i64 = 5 * 1_000_000_000;
+        const GATE_NS: i64 = 100 * 1_000_000_000;
+
+        let clock = TestClock::new(NOW_NS);
+        let gate = Arc::clone(&clock);
+        let on_batch_queued: BuildStartHook = Arc::new(move || {
+            while gate.now_ns() < NOW_NS + GATE_NS {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        });
+
+        let load_fut = load_instrumented(
+            store,
+            pq,
+            "acme",
+            m,
+            1,       // one shard: both writes land in the same buffer
+            1,       // one row per batch
+            Some(1), // one read cursor: batches are strictly sequential
+            4,       // pipeline depth above the write count: no mid-loop ack wait
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
+            1, // one queued batch: the loader parks on `recv` between writes
+            TARGET,
+            Some(max_flush_delay),
+            NOW_NS,
+            Arc::clone(&clock) as Arc<dyn Clock>,
+            LoadPath::Columnar,
+            None,
+            Some(on_batch_queued),
+        );
+        tokio::pin!(load_fut);
+        loop {
+            tokio::select! {
+                report = &mut load_fut => break report.expect("the load completes"),
+                () = tokio::time::sleep(Duration::from_millis(20)) => {
+                    if clock.now_ns() < NOW_NS + GATE_NS {
+                        clock.advance_ns(ADVANCE_STEP_NS);
+                    }
+                }
+            }
+        }
+    }
+
+    /// The `--max-flush-delay` lever decides an object layout, not just a config
+    /// field (issue #801, deliverable 3). Both sides run
+    /// [`load_two_writes_across_one_clock_advance`]: same two rows, same
+    /// `--target-bytes`, same `--pipeline-depth`, same injected clock advanced
+    /// by the same pattern, only the delay flipped.
     ///
-    /// The demonstrated lever is the delay: same target, same rows, one object
-    /// versus two. The age total is 2 rather than 1 because equal slices make
-    /// the second write age out too instead of flushing itself by size; equal
-    /// slices are what make the raised-delay coalesce robust to the loader's
-    /// unordered spawn of the two writes. The default-delay side drives the clock
-    /// past the age trigger in an unbounded loop, so it pins the age/size layout
-    /// the trigger produces, not the exact delay value; that the plumbed value
-    /// reaches the config is pinned directly by
-    /// [`max_flush_delay_unset_keeps_the_default_age_trigger`] and
-    /// [`max_flush_delay_set_reaches_the_config_exactly`].
+    /// - `LONG` (1h) outlasts the 100s the clock ever advances, so nothing can
+    ///   age out. The second write merges into the first's buffer, pushes it
+    ///   past the target and flushes both as ONE object by size.
+    /// - `SHORT` (1s) is shorter than a single 5s advance step, so the first
+    ///   write's buffer ages out while the decoder is gated: one object by age.
+    ///   The second write then lands in a fresh buffer with the clock already
+    ///   stopped, so nothing can age it either, and the loader's end-of-input
+    ///   flush publishes it. TWO objects, exactly one of them aged.
     ///
-    /// Prove-the-test: hardcode `target_bytes: 1` into `build_ingest_config`
-    /// regardless of its argument and the raised-delay side no longer coalesces
-    /// -- each write flushes itself by size, so it writes two objects and the
-    /// object-count assertion fails at `left: 2, right: 1`. Dropping the `age`
-    /// count from `FlushMixCounts` (reporting size where age belongs) fails the
-    /// default-delay mix assertion instead, at `age: 0` where `age: 2` is
+    /// The counts come from the real router's issue #983 trigger mix, so each
+    /// side pins which trigger opened each object, not just how many there were.
+    ///
+    /// Prove-the-test, flipping only the delay: passing `SHORT` to the coalesced
+    /// side fails its object count at `left: 2, right: 1` (the first write ages
+    /// out during the gate instead of waiting for the second), and passing
+    /// `LONG` to the split side fails at `left: 1, right: 2`, with its mix at
+    /// `size: 1, age: 0, final: 0` where `size: 0, age: 1, final: 1` is
     /// required.
     #[tokio::test]
     async fn max_flush_delay_decides_whether_two_writes_coalesce() {
         use ravel_object_store::memory::MemoryStore;
 
-        // TARGET between one 4.1 KB slice and two, with margin on both sides, so
-        // one write never reaches it and two always do.
-        const TARGET: usize = 6_000;
+        const LONG: Duration = Duration::from_secs(3600);
+        const SHORT: Duration = Duration::from_secs(1);
+
         let (_dir, pq, _mapping_path, m) = fat_attr_sorted_by_shard_fixture(1, 2, 4000);
 
-        // Raised delay, both writes concurrent, a clock that never ages: the two
-        // writes merge into one buffer and flush together by size.
         let coalesced_store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
-        let coalesced = load_instrumented(
-            Arc::clone(&coalesced_store),
-            &pq,
-            "acme",
-            &m,
-            1,
-            1,
-            Some(1),
-            2,
-            DEFAULT_MAX_INFLIGHT_FLUSHES,
-            DEFAULT_DECODE_QUEUE_BATCHES,
-            TARGET,
-            Some(Duration::from_secs(3600)),
-            NOW_NS,
-            Arc::new(FixedClock(NOW_NS)),
-            LoadPath::Columnar,
-            None,
-            None,
-        )
-        .await
-        .expect("raised-delay load succeeds");
+        let coalesced =
+            load_two_writes_across_one_clock_advance(Arc::clone(&coalesced_store), &pq, &m, LONG)
+                .await;
 
         assert_eq!(
             coalesced.objects_written(),
             1,
-            "a raised delay lets the second write push the first over the target: one object"
+            "a delay longer than the advance keeps the first buffer alive for the second write: \
+             one object"
         );
         assert_eq!(
             coalesced.flush_mix_report().totals,
@@ -6033,59 +6125,29 @@ type = "i64"
                 age: 0,
                 final_drain: 0,
             },
-            "the single object is a size flush; nothing ages under a raised delay"
+            "the single object is a size flush; nothing ages under a delay longer than the advance"
         );
 
-        // Default 2s delay, serial writes, an injected clock advanced past 2s:
-        // each write is released only by aging out, into its own object.
         let split_store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
-        let clock = TestClock::new(NOW_NS);
-        let load_fut = load_instrumented(
-            Arc::clone(&split_store),
-            &pq,
-            "acme",
-            &m,
-            1,
-            1,
-            Some(1),
-            1,
-            DEFAULT_MAX_INFLIGHT_FLUSHES,
-            DEFAULT_DECODE_QUEUE_BATCHES,
-            TARGET,
-            None,
-            NOW_NS,
-            std::sync::Arc::clone(&clock) as Arc<dyn Clock>,
-            LoadPath::Columnar,
-            None,
-            None,
-        );
-        tokio::pin!(load_fut);
-        // Drive the injected clock past the 2s age trigger until the load
-        // completes. Each serial write is suspended waiting for its ack;
-        // advancing the clock fires the age tick that releases it. An advance on
-        // an empty buffer is a no-op, so over-advancing is harmless.
-        let split = loop {
-            tokio::select! {
-                report = &mut load_fut => break report.expect("default-delay load succeeds"),
-                () = tokio::time::sleep(Duration::from_millis(20)) => {
-                    clock.advance_ns(3 * 1_000_000_000);
-                }
-            }
-        };
+        let split =
+            load_two_writes_across_one_clock_advance(Arc::clone(&split_store), &pq, &m, SHORT)
+                .await;
 
         assert_eq!(
             split.objects_written(),
             2,
-            "at the default 2s delay with serial writes neither write coalesces: two objects"
+            "a delay shorter than the advance ages the first write out before the second arrives: \
+             two objects"
         );
         assert_eq!(
             split.flush_mix_report().totals,
             FlushMixCounts {
                 size: 0,
-                age: 2,
-                final_drain: 0,
+                age: 1,
+                final_drain: 1,
             },
-            "each serial write is released by the age trigger, one object apiece"
+            "the first object is the aged-out buffer, the second is the tail the end-of-input \
+             flush published"
         );
 
         // Same rows either way, only their object layout differs.
@@ -6095,6 +6157,148 @@ type = "i64"
             decoded_records(coalesced_store.as_ref()).await,
             decoded_records(split_store.as_ref()).await,
             "the same two rows, decoded, regardless of how many objects hold them"
+        );
+    }
+
+    /// A load whose last slice stays under `--target-bytes` completes under a
+    /// raised `--max-flush-delay`, with that tail published by the loader's
+    /// end-of-input flush (issue #801). This is the run-burner the flag shipped
+    /// with: the tail's Strict ack has nothing left to release it by size, so
+    /// when the force-flush ran only after the in-flight window was drained,
+    /// the ack waited on the age trigger, blew the deadline, and returned an
+    /// error from a load whose every object had already landed.
+    ///
+    /// Geometry: one shard, four 4 KB-payload rows read one per batch, so each
+    /// write's estimated per-shard slice is about 4.1 KB. `TARGET = 10_000`
+    /// sits above two slices and below three, so writes 1-3 flush as one object
+    /// by size and write 4 is left alone under the target. `--pipeline-depth 5`
+    /// is above the batch count, so the loader never waits on an ack mid-loop.
+    /// The clock is fixed, which makes the assertion sharp: the age trigger
+    /// cannot fire at all here, so the tail's object exists only because the
+    /// manual flush published it.
+    ///
+    /// Prove-the-test: move `router.flush_all()` back after `drain_inflight`
+    /// and the load never returns a report -- the tail ack is answered by
+    /// nothing, and after `write_ack_deadline` (10m + 1m here) it fails with
+    /// `LoadError::Flush` carrying `timed out waiting for shard ack`.
+    #[tokio::test]
+    async fn a_tail_below_target_is_published_by_the_end_of_input_flush() {
+        use ravel_object_store::memory::MemoryStore;
+
+        const TARGET: usize = 10_000;
+        let (_dir, pq, _mapping_path, m) = fat_attr_sorted_by_shard_fixture(1, 4, 4000);
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let report = load_instrumented(
+            Arc::clone(&store),
+            &pq,
+            "acme",
+            &m,
+            1,
+            1,
+            Some(1),
+            5, // pipeline depth above the batch count: no mid-loop ack wait
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
+            1,
+            TARGET,
+            Some(Duration::from_secs(600)),
+            NOW_NS,
+            Arc::new(FixedClock(NOW_NS)),
+            LoadPath::Columnar,
+            None,
+            None,
+        )
+        .await
+        .expect("a raised delay must not strand the tail buffer's ack");
+
+        assert_eq!(report.rows_processed, 4, "every row is durable");
+        assert_eq!(
+            report.objects_written(),
+            2,
+            "three slices reach the target as one object, the fourth is the tail"
+        );
+        assert_eq!(
+            report.flush_mix_report().totals,
+            FlushMixCounts {
+                size: 1,
+                age: 0,
+                final_drain: 1,
+            },
+            "the tail is published by the manual end-of-input flush, not by the age trigger"
+        );
+        assert_eq!(
+            decoded_records(store.as_ref()).await.len(),
+            4,
+            "the two objects hold all four rows"
+        );
+    }
+
+    /// The Strict ack deadline scales with the configured age trigger (issue
+    /// #801). A tail or under-target buffer is answered by the age trigger, so a
+    /// deadline that does not outlast the configured delay times out on exactly
+    /// the buffers the raised delay was set to let accumulate. An unset flag
+    /// keeps the deadline it always had, to the second.
+    ///
+    /// Prove-the-test: return `WRITE_ACK_DEADLINE_FLOOR` unconditionally from
+    /// `write_ack_deadline` and the 10m case fails at `left: 60s, right: 660s`.
+    #[test]
+    fn write_ack_deadline_scales_with_the_configured_flush_delay() {
+        assert_eq!(
+            write_ack_deadline(None),
+            Duration::from_secs(60),
+            "an unset --max-flush-delay leaves the deadline at exactly 60s"
+        );
+        assert_eq!(
+            write_ack_deadline(Some(Duration::from_secs(600))),
+            Duration::from_secs(660),
+            "--max-flush-delay 10m gives an 11m deadline: the delay plus one minute of margin"
+        );
+        assert_eq!(
+            write_ack_deadline(Some(Duration::ZERO)),
+            Duration::from_secs(60),
+            "a delay under the floor cannot shorten the deadline"
+        );
+        let long = Duration::from_secs(3600);
+        assert!(
+            write_ack_deadline(Some(long)) > long,
+            "the deadline always outlasts the age trigger it has to wait for"
+        );
+    }
+
+    /// `strict_visibility_budget_ns` follows the configured `max_flush_delay`
+    /// (ADR-0076 decision 4), exactly as ravel-server's own router construction
+    /// derives it. The field is metrics-only on this path, but the coupling is
+    /// documented on `IngestConfig` and a config that raises the delay while
+    /// leaving the budget at the 2s-based default contradicts it.
+    ///
+    /// Prove-the-test: drop the `strict_visibility_budget_ns` field from
+    /// `build_ingest_config` (falling through to `IngestConfig::default()`) and
+    /// the raised-delay case fails at `left: 2500000000, right: 600500000000`.
+    #[test]
+    fn strict_visibility_budget_follows_the_configured_flush_delay() {
+        let raised = build_ingest_config(
+            4,
+            DEFAULT_TARGET_BYTES,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
+            Some(Duration::from_secs(600)),
+        );
+        assert_eq!(
+            raised.strict_visibility_budget_ns,
+            600_000_000_000 + STRICT_VISIBILITY_RESERVE_NS,
+            "the budget is the configured delay plus the reserve, never the default's"
+        );
+        let delay_ns = i64::try_from(raised.max_flush_delay.as_nanos()).expect("delay fits i64");
+        assert!(
+            raised.strict_visibility_budget_ns > delay_ns,
+            "the budget must exceed the delay, not equal it: equal collapses the corridor"
+        );
+
+        let unset =
+            build_ingest_config(4, DEFAULT_TARGET_BYTES, DEFAULT_MAX_INFLIGHT_FLUSHES, None);
+        assert_eq!(
+            unset.strict_visibility_budget_ns,
+            IngestConfig::default().strict_visibility_budget_ns,
+            "an unset flag still builds a byte-for-byte default config"
         );
     }
 

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -148,6 +148,35 @@ pub const DEFAULT_PIPELINE_DEPTH: usize = 4;
 /// workload with a different memory owner.
 pub const DEFAULT_MAX_INFLIGHT_FLUSHES: u32 = DEFAULT_PIPELINE_DEPTH as u32;
 
+/// Build the router [`IngestConfig`] a load drives, given the three
+/// operator-facing flush levers.
+///
+/// `max_flush_delay` is `None` when `--max-flush-delay` is unset: the field is
+/// then left at its [`IngestConfig::default`] value, so an unset flag produces
+/// a byte-for-byte default config and changes nothing. `Some(d)` overrides only
+/// the router's age trigger, the third binding constraint on object layout
+/// beside `target_bytes` and a batch's per-shard slice footprint (issue #801):
+/// a shard buffer flushes when it reaches `target_bytes`, when its oldest point
+/// ages past `max_flush_delay`, or at the final drain. At the default 2s a
+/// buffer that fills slower than one target's worth every 2s is released by age
+/// before it ever reaches a large `target_bytes`, so a bulk load that wants
+/// target-sized objects must raise this delay past the time one target takes to
+/// fill.
+pub(crate) fn build_ingest_config(
+    shards: u32,
+    target_bytes: usize,
+    max_inflight_flushes: u32,
+    max_flush_delay: Option<Duration>,
+) -> IngestConfig {
+    IngestConfig {
+        shard_count: shards,
+        target_bytes,
+        max_inflight_flushes,
+        max_flush_delay: max_flush_delay.unwrap_or_else(|| IngestConfig::default().max_flush_delay),
+        ..IngestConfig::default()
+    }
+}
+
 /// Ack deadline for each Strict write. Generous: a bulk load values completing
 /// over racing a slow store.
 const WRITE_ACK_DEADLINE: Duration = Duration::from_secs(60);
@@ -421,6 +450,7 @@ pub async fn run(
     max_inflight_flushes: u32,
     decode_queue_batches: usize,
     target_bytes: usize,
+    max_flush_delay: Option<Duration>,
     now_ns: i64,
 ) -> anyhow::Result<()> {
     run_warning_to(
@@ -435,6 +465,7 @@ pub async fn run(
         max_inflight_flushes,
         decode_queue_batches,
         target_bytes,
+        max_flush_delay,
         now_ns,
         &mut std::io::stderr(),
     )
@@ -461,6 +492,7 @@ pub(crate) async fn run_warning_to(
     max_inflight_flushes: u32,
     decode_queue_batches: usize,
     target_bytes: usize,
+    max_flush_delay: Option<Duration>,
     now_ns: i64,
     warnings: &mut dyn std::io::Write,
 ) -> anyhow::Result<()> {
@@ -487,6 +519,7 @@ pub(crate) async fn run_warning_to(
         max_inflight_flushes,
         decode_queue_batches,
         target_bytes,
+        max_flush_delay,
         now_ns,
         Arc::new(SystemClock),
         LoadPath::Columnar,
@@ -925,6 +958,7 @@ pub async fn load(
         DEFAULT_MAX_INFLIGHT_FLUSHES,
         DEFAULT_DECODE_QUEUE_BATCHES,
         DEFAULT_TARGET_BYTES,
+        None,
         now_ns,
         clock,
         LoadPath::Columnar,
@@ -962,6 +996,13 @@ type BuildStartHook = Arc<dyn Fn() + Send + Sync>;
 /// tested once per write, so a value at or below one batch's per-shard slice
 /// changes nothing at all; [`target_bytes_no_effect_warning`] documents that
 /// arithmetic and is what reports the case to the operator.
+///
+/// `max_flush_delay` is the `--max-flush-delay` lever (`None` = the
+/// [`IngestConfig::default`] age trigger). It is the third constraint on when a
+/// buffer flushes, beside `target_bytes` and the slice footprint: a buffer that
+/// does not reach `target_bytes` within this delay is released by the age
+/// trigger, so a large `target_bytes` is only reachable once this is raised past
+/// the time one target's worth accumulates. See [`build_ingest_config`].
 #[allow(clippy::too_many_arguments)]
 async fn load_instrumented(
     store: Arc<dyn ObjectStoreBackend>,
@@ -975,6 +1016,7 @@ async fn load_instrumented(
     max_inflight_flushes: u32,
     decode_queue_batches: usize,
     target_bytes: usize,
+    max_flush_delay: Option<Duration>,
     now_ns: i64,
     clock: Arc<dyn Clock>,
     path: LoadPath,
@@ -1087,6 +1129,18 @@ async fn load_instrumented(
     // window must therefore be wide enough to hold the batches that accumulate
     // into one flush, or every flush waits out `max_flush_delay`.
     //
+    // That age trigger (`max_flush_delay`, the `--max-flush-delay` lever) is the
+    // THIRD binding constraint on object layout, beside `target_bytes` and one
+    // batch's per-shard slice footprint. At its 2s default a shard buffer that
+    // fills slower than one target's worth every 2s ages out before it reaches a
+    // large `target_bytes`, so the size trigger never fires and the target is
+    // unreachable as a lever no matter how the other two are set: the v4 load's
+    // ~11,871-row objects are about 2s of one shard's ingest rate. A bulk load
+    // that wants target-sized objects must therefore raise `--max-flush-delay`
+    // past the time one target takes to fill, in addition to widening the
+    // in-flight window. `None` here leaves the age trigger at its default, so an
+    // unset flag changes nothing.
+    //
     // "Larger" is measured against the shard's `est_bytes` footprint estimate,
     // not the encoded object, and tested once per write after a whole batch's
     // slice has merged: below one slice's footprint the target is unreachable
@@ -1106,12 +1160,7 @@ async fn load_instrumented(
     // (`Semaphore::new(config.max_inflight_flushes as usize)` in
     // crates/ravel-ingest/src/log_shard.rs); nothing downstream clamps it.
     let router = Arc::new(LogIngestRouter::new(
-        IngestConfig {
-            shard_count: shards,
-            target_bytes,
-            max_inflight_flushes,
-            ..IngestConfig::default()
-        },
+        build_ingest_config(shards, target_bytes, max_inflight_flushes, max_flush_delay),
         Arc::clone(&store),
         clock,
     ));
@@ -3738,6 +3787,59 @@ type = "i64"
         }
     }
 
+    /// A deterministic clock the test advances by hand, whose `sleep` the shard
+    /// actor's flush tick waits on (mirrors `ravel-ingest`'s own unit-test
+    /// `TestClock`, restated here because that clock is private to that crate's
+    /// test module). Advancing it past `max_flush_delay` is what drives an age
+    /// flush with no real-time sleep, so the age trigger can be exercised
+    /// through the loader deterministically.
+    struct TestClock {
+        now_ns: std::sync::atomic::AtomicI64,
+        wake_tx: tokio::sync::watch::Sender<()>,
+    }
+
+    impl TestClock {
+        fn new(start_ns: i64) -> std::sync::Arc<Self> {
+            let (wake_tx, _rx) = tokio::sync::watch::channel(());
+            std::sync::Arc::new(TestClock {
+                now_ns: std::sync::atomic::AtomicI64::new(start_ns),
+                wake_tx,
+            })
+        }
+
+        fn advance_ns(&self, delta_ns: i64) {
+            self.now_ns
+                .fetch_add(delta_ns, std::sync::atomic::Ordering::SeqCst);
+            let _ = self.wake_tx.send(());
+        }
+    }
+
+    impl Clock for TestClock {
+        fn now_ns(&self) -> i64 {
+            self.now_ns.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn sleep(
+            &self,
+            dur: Duration,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            let deadline = self
+                .now_ns()
+                .saturating_add(i64::try_from(dur.as_nanos()).unwrap_or(i64::MAX));
+            let mut rx = self.wake_tx.subscribe();
+            Box::pin(async move {
+                loop {
+                    if self.now_ns() >= deadline {
+                        return;
+                    }
+                    if rx.changed().await.is_err() {
+                        return;
+                    }
+                }
+            })
+        }
+    }
+
     /// Load a fixture of one record with `n_attrs` distinct i64 attribute
     /// columns (plus one resource attribute) through the real `load`, and return
     /// its report. `n_attrs` past the writer's 1000-column budget forces
@@ -3995,6 +4097,7 @@ type = "i64"
             DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             DEFAULT_TARGET_BYTES,
+            None,
             NOW_NS,
             &mut sink,
         )
@@ -4188,6 +4291,7 @@ type = "i64"
             DEFAULT_MAX_INFLIGHT_FLUSHES,
             0,
             DEFAULT_TARGET_BYTES,
+            None,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
             LoadPath::Columnar,
@@ -4235,6 +4339,7 @@ type = "i64"
             0,
             DEFAULT_DECODE_QUEUE_BATCHES,
             DEFAULT_TARGET_BYTES,
+            None,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
             LoadPath::Columnar,
@@ -4476,6 +4581,7 @@ type = "i64"
                     DEFAULT_MAX_INFLIGHT_FLUSHES,
                     depth,
                     DEFAULT_TARGET_BYTES,
+                    None,
                     NOW_NS,
                     Arc::new(FixedClock(NOW_NS)),
                     LoadPath::Columnar,
@@ -4660,6 +4766,7 @@ type = "i64"
             DEFAULT_MAX_INFLIGHT_FLUSHES,
             QUEUE_DEPTH,
             DEFAULT_TARGET_BYTES,
+            None,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
             LoadPath::Columnar,
@@ -4962,6 +5069,7 @@ type = "i64"
             DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             DEFAULT_TARGET_BYTES,
+            None,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
             LoadPath::Columnar,
@@ -5370,6 +5478,7 @@ type = "i64"
                     DEFAULT_MAX_INFLIGHT_FLUSHES,
                     DEFAULT_DECODE_QUEUE_BATCHES,
                     target_bytes,
+                    None,
                     NOW_NS,
                     // A real clock: above target 1 the tail of a load is
                     // released by the router's wall-clock age trigger, which a
@@ -5481,6 +5590,7 @@ type = "i64"
                     DEFAULT_MAX_INFLIGHT_FLUSHES,
                     DEFAULT_DECODE_QUEUE_BATCHES,
                     target_bytes,
+                    None,
                     NOW_NS,
                     // A real clock: above the size trigger the tail of a load is
                     // released by the router's wall-clock age trigger, which a
@@ -5597,6 +5707,7 @@ type = "i64"
                     DEFAULT_MAX_INFLIGHT_FLUSHES,
                     DEFAULT_DECODE_QUEUE_BATCHES,
                     target_bytes,
+                    None,
                     NOW_NS,
                     &mut sink,
                 )
@@ -5725,6 +5836,7 @@ type = "i64"
             DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             8 * 1024 * 1024,
+            None,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
             LoadPath::Columnar,
@@ -5775,6 +5887,7 @@ type = "i64"
             DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             0,
+            None,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
             LoadPath::Columnar,
@@ -5791,6 +5904,197 @@ type = "i64"
             err.to_string()
                 .contains("--target-bytes must be at least 1"),
             "the error names the lever: {err}"
+        );
+    }
+
+    /// `--max-flush-delay` unset (`None`) leaves the router's age trigger at
+    /// its `IngestConfig::default()` value, so an omitted flag builds a
+    /// byte-for-byte default config (issue #801, deliverable 1). The config
+    /// field is the thing that flows to the router, so it is what this asserts.
+    ///
+    /// Prove-the-test: change `build_ingest_config` to substitute any other
+    /// duration when `max_flush_delay` is `None` (e.g.
+    /// `Duration::from_secs(1)`) and this fails at
+    /// `left: 1s, right: 2s`.
+    #[test]
+    fn max_flush_delay_unset_keeps_the_default_age_trigger() {
+        let cfg = build_ingest_config(4, DEFAULT_TARGET_BYTES, DEFAULT_MAX_INFLIGHT_FLUSHES, None);
+        assert_eq!(
+            cfg.max_flush_delay,
+            IngestConfig::default().max_flush_delay,
+            "an unset --max-flush-delay must not change the router's age trigger"
+        );
+    }
+
+    /// `--max-flush-delay 10m` reaches `IngestConfig::max_flush_delay` as
+    /// exactly 600s (issue #801, deliverable 2). The humantime parse lives in
+    /// `parse_max_flush_delay`; this pins that a `Some(_)` overrides the field
+    /// exactly, with no scaling or rounding.
+    ///
+    /// Prove-the-test: change the `Some` arm of `build_ingest_config` to ignore
+    /// its argument (fall through to the default) and this fails at
+    /// `left: 2s, right: 600s`.
+    #[test]
+    fn max_flush_delay_set_reaches_the_config_exactly() {
+        let cfg = build_ingest_config(
+            4,
+            DEFAULT_TARGET_BYTES,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
+            Some(Duration::from_secs(600)),
+        );
+        assert_eq!(
+            cfg.max_flush_delay,
+            Duration::from_secs(600),
+            "--max-flush-delay 10m must arrive as exactly 600s"
+        );
+    }
+
+    /// The `--max-flush-delay` lever is observable in the flush mix (issue #801,
+    /// deliverable 3): whether two sequential writes to one shard coalesce into
+    /// one object or split into two turns on the age trigger, holding the target
+    /// fixed. Geometry: one shard, two equal 4 KB-payload rows read one per
+    /// batch (`--batch-rows 1 --read-cursors 1`), so each write's estimated
+    /// per-shard slice is about 4.1 KB. `TARGET = 6000` sits above one slice and
+    /// below two, so a single write can never reach it on its own -- it is
+    /// released only by a later write merging in (size) or by aging out.
+    ///
+    /// - Raised delay (`Some(1h)`), both writes in flight (`--pipeline-depth
+    ///   2`), a `FixedClock` that never ages anything: whichever write the shard
+    ///   actor sees first buffers under `TARGET`, and the second merges into the
+    ///   same buffer, pushing it over `TARGET` and flushing both as ONE object by
+    ///   size. Order-independent, so no write is stranded. Mix: size 1, age 0.
+    /// - Default delay (`None` = 2s), serial writes (`--pipeline-depth 1`), an
+    ///   injected clock advanced past 2s: the loader awaits the first write's ack
+    ///   before submitting the second, so the two never share a buffer. With no
+    ///   later write to push either over `TARGET`, each is released only by the
+    ///   age trigger, which the advanced clock fires. TWO objects, both aged.
+    ///
+    /// The demonstrated lever is the delay: same target, same rows, one object
+    /// versus two. The age total is 2 rather than 1 because equal slices make
+    /// the second write age out too instead of flushing itself by size; equal
+    /// slices are what make the raised-delay coalesce robust to the loader's
+    /// unordered spawn of the two writes. The default-delay side drives the clock
+    /// past the age trigger in an unbounded loop, so it pins the age/size layout
+    /// the trigger produces, not the exact delay value; that the plumbed value
+    /// reaches the config is pinned directly by
+    /// [`max_flush_delay_unset_keeps_the_default_age_trigger`] and
+    /// [`max_flush_delay_set_reaches_the_config_exactly`].
+    ///
+    /// Prove-the-test: hardcode `target_bytes: 1` into `build_ingest_config`
+    /// regardless of its argument and the raised-delay side no longer coalesces
+    /// -- each write flushes itself by size, so it writes two objects and the
+    /// object-count assertion fails at `left: 2, right: 1`. Dropping the `age`
+    /// count from `FlushMixCounts` (reporting size where age belongs) fails the
+    /// default-delay mix assertion instead, at `age: 0` where `age: 2` is
+    /// required.
+    #[tokio::test]
+    async fn max_flush_delay_decides_whether_two_writes_coalesce() {
+        use ravel_object_store::memory::MemoryStore;
+
+        // TARGET between one 4.1 KB slice and two, with margin on both sides, so
+        // one write never reaches it and two always do.
+        const TARGET: usize = 6_000;
+        let (_dir, pq, _mapping_path, m) = fat_attr_sorted_by_shard_fixture(1, 2, 4000);
+
+        // Raised delay, both writes concurrent, a clock that never ages: the two
+        // writes merge into one buffer and flush together by size.
+        let coalesced_store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let coalesced = load_instrumented(
+            Arc::clone(&coalesced_store),
+            &pq,
+            "acme",
+            &m,
+            1,
+            1,
+            Some(1),
+            2,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
+            DEFAULT_DECODE_QUEUE_BATCHES,
+            TARGET,
+            Some(Duration::from_secs(3600)),
+            NOW_NS,
+            Arc::new(FixedClock(NOW_NS)),
+            LoadPath::Columnar,
+            None,
+            None,
+        )
+        .await
+        .expect("raised-delay load succeeds");
+
+        assert_eq!(
+            coalesced.objects_written(),
+            1,
+            "a raised delay lets the second write push the first over the target: one object"
+        );
+        assert_eq!(
+            coalesced.flush_mix_report().totals,
+            FlushMixCounts {
+                size: 1,
+                age: 0,
+                final_drain: 0,
+            },
+            "the single object is a size flush; nothing ages under a raised delay"
+        );
+
+        // Default 2s delay, serial writes, an injected clock advanced past 2s:
+        // each write is released only by aging out, into its own object.
+        let split_store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let clock = TestClock::new(NOW_NS);
+        let load_fut = load_instrumented(
+            Arc::clone(&split_store),
+            &pq,
+            "acme",
+            &m,
+            1,
+            1,
+            Some(1),
+            1,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
+            DEFAULT_DECODE_QUEUE_BATCHES,
+            TARGET,
+            None,
+            NOW_NS,
+            std::sync::Arc::clone(&clock) as Arc<dyn Clock>,
+            LoadPath::Columnar,
+            None,
+            None,
+        );
+        tokio::pin!(load_fut);
+        // Drive the injected clock past the 2s age trigger until the load
+        // completes. Each serial write is suspended waiting for its ack;
+        // advancing the clock fires the age tick that releases it. An advance on
+        // an empty buffer is a no-op, so over-advancing is harmless.
+        let split = loop {
+            tokio::select! {
+                report = &mut load_fut => break report.expect("default-delay load succeeds"),
+                () = tokio::time::sleep(Duration::from_millis(20)) => {
+                    clock.advance_ns(3 * 1_000_000_000);
+                }
+            }
+        };
+
+        assert_eq!(
+            split.objects_written(),
+            2,
+            "at the default 2s delay with serial writes neither write coalesces: two objects"
+        );
+        assert_eq!(
+            split.flush_mix_report().totals,
+            FlushMixCounts {
+                size: 0,
+                age: 2,
+                final_drain: 0,
+            },
+            "each serial write is released by the age trigger, one object apiece"
+        );
+
+        // Same rows either way, only their object layout differs.
+        assert_eq!(coalesced.rows_processed, 2);
+        assert_eq!(split.rows_processed, 2);
+        assert_eq!(
+            decoded_records(coalesced_store.as_ref()).await,
+            decoded_records(split_store.as_ref()).await,
+            "the same two rows, decoded, regardless of how many objects hold them"
         );
     }
 
@@ -5920,6 +6224,7 @@ type = "i64"
             DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             DEFAULT_TARGET_BYTES,
+            None,
             NOW_NS,
             &mut sink,
         )
@@ -5949,6 +6254,7 @@ type = "i64"
             DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             DEFAULT_TARGET_BYTES,
+            None,
             NOW_NS,
             &mut sink,
         )
@@ -5992,6 +6298,7 @@ type = "i64"
             DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             DEFAULT_TARGET_BYTES,
+            None,
             NOW_NS,
             &mut sink,
         )
@@ -6876,6 +7183,7 @@ type = "i64"
             DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             DEFAULT_TARGET_BYTES,
+            None,
             now_ns,
             clock,
             LoadPath::Row,
@@ -7259,6 +7567,7 @@ type = "i64"
                 flushes,
                 DEFAULT_DECODE_QUEUE_BATCHES,
                 DEFAULT_TARGET_BYTES,
+                None,
                 NOW_NS,
                 Arc::new(FixedClock(NOW_NS)),
                 LoadPath::Columnar,
@@ -7392,6 +7701,7 @@ type = "i64"
                 flushes,
                 DEFAULT_DECODE_QUEUE_BATCHES,
                 DEFAULT_TARGET_BYTES,
+                None,
                 NOW_NS,
                 Arc::new(FixedClock(NOW_NS)),
                 LoadPath::Columnar,

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -1446,21 +1446,45 @@ async fn load_instrumented(
     // each shard's own channel, so it merges behind the writes already queued
     // there, publishes whatever they buffered, and answers their waiters; the
     // drain below then resolves at PUT speed instead of on the age clock. A
-    // write whose task has not yet reached its channel send is the case
-    // `write_ack_deadline` covers: it is released by the age trigger and its
-    // ack is awaited long enough to arrive.
+    // write whose task had not yet reached its channel send when this flush
+    // ran lands in a fresh buffer afterward; without help it would wait out
+    // the age trigger (up to the whole raised delay of silent tail stall,
+    // inside the scaled ack deadline but ugly), so a re-flush ticker below
+    // sweeps such stragglers every few seconds while the drain runs. Sends
+    // are FIFO per shard, so re-flushing never splits a dispatched write's
+    // records; at most a straggler gets its own object, exactly as
+    // `--target-bytes 1` would have laid it out.
     router.flush_all().await;
 
     // Drain every write still in the window in the same oldest-first order
-    // before reporting success.
-    drain_inflight(
-        &mut inflight,
-        &mut report,
-        &mut shards_seen,
-        &mut data_batches_flushed,
-        shards,
-    )
-    .await?;
+    // before reporting success, with the straggler re-flush ticker running
+    // alongside and stopped (and its task reaped) as soon as the drain ends.
+    let drain_result = {
+        let ticker_router = Arc::clone(&router);
+        let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let ticker = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut stop_rx => break,
+                    () = tokio::time::sleep(Duration::from_secs(2)) => {
+                        ticker_router.flush_all().await;
+                    }
+                }
+            }
+        });
+        let result = drain_inflight(
+            &mut inflight,
+            &mut report,
+            &mut shards_seen,
+            &mut data_batches_flushed,
+            shards,
+        )
+        .await;
+        let _ = stop_tx.send(());
+        let _ = ticker.await;
+        result
+    };
+    drain_result?;
 
     // Snapshot the router's cumulative counters before it drops: the caller
     // reads the dynamic-column figures to warn on overflow or near-cap pressure

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -1,5 +1,7 @@
 //! ravel-cli: inspect segments, decode commit records, list catalog entries.
 
+use std::time::Duration;
+
 use clap::{Parser, Subcommand};
 use ravel_cli::maintain::SignalArg;
 use ravel_cli::{
@@ -365,6 +367,39 @@ enum Command {
         /// waits out that timer. `0` is rejected.
         #[arg(long, value_name = "BYTES", default_value_t = ravel_cli::load::DEFAULT_TARGET_BYTES)]
         target_bytes: usize,
+        /// How long a shard buffer may age before the router flushes it,
+        /// regardless of `--target-bytes` (issue #801). A humantime duration
+        /// (`2s`, `10m`, `1h5m`). Unset leaves the router's default (2s), so an
+        /// omitted flag changes a load's object layout not at all.
+        ///
+        /// This is the THIRD binding constraint on object size, beside
+        /// `--target-bytes` and one batch's per-shard slice footprint. A shard
+        /// flushes on the first of: its buffer reaches `--target-bytes`, its
+        /// oldest buffered point ages past this delay, or the final drain at
+        /// load close. At the 2s default a buffer that fills slower than one
+        /// target's worth every 2s ages out before it ever reaches a large
+        /// `--target-bytes`, so the size trigger never fires and the target is
+        /// unreachable as a lever no matter how large it is set: the v4 load's
+        /// ~11,871-row objects are about 2s of one shard's ingest rate. To make
+        /// `--target-bytes` bind, raise this past the time one target's worth
+        /// takes to accumulate on a shard.
+        ///
+        /// The interaction is a triangle: `--target-bytes` binds only when the
+        /// buffer both SURVIVES long enough (this flag) and FILLS fast enough
+        /// (`--pipeline-depth` at least the number of batches that accumulate
+        /// into one flush, so a later batch is in flight to push the buffer over
+        /// the target before it ages out). Setting any one of the three without
+        /// the other two leaves the object layout at the `--target-bytes 1`
+        /// shape.
+        ///
+        /// The trade is ack latency, not durability: above the size trigger a
+        /// tail buffer's Strict ack can now wait up to this delay for the age
+        /// trigger to release it, since no later batch arrives to flush it by
+        /// size. An ack still means durable whenever it arrives. `0s` is
+        /// accepted and means the age trigger fires on the next flush tick for
+        /// any non-empty buffer.
+        #[arg(long, value_name = "DURATION", value_parser = ravel_cli::parse_max_flush_delay)]
+        max_flush_delay: Option<Duration>,
     },
 }
 
@@ -1526,6 +1561,7 @@ async fn main() -> anyhow::Result<()> {
             max_inflight_flushes,
             decode_queue_batches,
             target_bytes,
+            max_flush_delay,
         } => {
             let profile = ravel_cli::cli_profiling::ProfileSession::from_env("ravel-cli-load");
             let result = ravel_cli::load::run(
@@ -1540,6 +1576,7 @@ async fn main() -> anyhow::Result<()> {
                 max_inflight_flushes,
                 decode_queue_batches,
                 target_bytes,
+                max_flush_delay,
                 now_ns()?,
             )
             .await;
@@ -2472,6 +2509,50 @@ mod tests {
             max_inflight_flushes,
             ravel_cli::load::DEFAULT_MAX_INFLIGHT_FLUSHES,
             "--max-inflight-flushes must default to DEFAULT_MAX_INFLIGHT_FLUSHES"
+        );
+    }
+
+    /// `--max-flush-delay` is absent by default (so the loader keeps the
+    /// router's own age-trigger default) and, when given, parses humantime into
+    /// the `Option<Duration>` the load handler threads on (issue #801).
+    #[test]
+    fn max_flush_delay_flag_is_optional_and_parses_humantime() {
+        let base = [
+            "ravel",
+            "load",
+            "--parquet",
+            "hits.parquet",
+            "--tenant",
+            "acme",
+            "--mapping",
+            "hits.toml",
+        ];
+
+        let Command::Load {
+            max_flush_delay, ..
+        } = Cli::try_parse_from(base)
+            .expect("a load with no --max-flush-delay parses")
+            .command
+        else {
+            panic!("expected the load subcommand");
+        };
+        assert_eq!(
+            max_flush_delay, None,
+            "an omitted --max-flush-delay leaves the router default in place"
+        );
+
+        let Command::Load {
+            max_flush_delay, ..
+        } = Cli::try_parse_from(base.iter().copied().chain(["--max-flush-delay", "10m"]))
+            .expect("a load with --max-flush-delay 10m parses")
+            .command
+        else {
+            panic!("expected the load subcommand");
+        };
+        assert_eq!(
+            max_flush_delay,
+            Some(std::time::Duration::from_secs(600)),
+            "--max-flush-delay 10m reaches the field as 600s"
         );
     }
 

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -362,9 +362,10 @@ enum Command {
         /// that answers a batch's ack may be triggered by a LATER batch, so
         /// that ack now waits for one; a buffer that never reaches the target
         /// waits for the router's wall-clock age trigger instead
-        /// (`max_flush_delay`, 2s). Set `--pipeline-depth` to at least the
-        /// number of batches that accumulate into one flush, or every flush
-        /// waits out that timer. `0` is rejected.
+        /// (`--max-flush-delay`, 2s by default), or, at the end of the input,
+        /// for the loader's own force-flush. Set `--pipeline-depth` to at
+        /// least the number of batches that accumulate into one flush, or
+        /// every flush waits out that timer. `0` is rejected.
         #[arg(long, value_name = "BYTES", default_value_t = ravel_cli::load::DEFAULT_TARGET_BYTES)]
         target_bytes: usize,
         /// How long a shard buffer may age before the router flushes it,
@@ -392,12 +393,22 @@ enum Command {
         /// the other two leaves the object layout at the `--target-bytes 1`
         /// shape.
         ///
-        /// The trade is ack latency, not durability: above the size trigger a
-        /// tail buffer's Strict ack can now wait up to this delay for the age
-        /// trigger to release it, since no later batch arrives to flush it by
-        /// size. An ack still means durable whenever it arrives. `0s` is
-        /// accepted and means the age trigger fires on the next flush tick for
-        /// any non-empty buffer.
+        /// The trade is ack latency, not durability, and it lands mid-load
+        /// rather than at the tail. At the end of the input the loader force-
+        /// flushes every shard buffer (the load report's flush mix counts those
+        /// under `final`) before waiting on the last batches' acks, so a tail
+        /// buffer left under `--target-bytes` is published there and never
+        /// waits out this delay. Mid-load, a buffer that misses
+        /// `--target-bytes` because a batch's slices fell unevenly waits up to
+        /// this delay for the age trigger, and every write's ack deadline is
+        /// raised to this delay plus one minute so that wait completes instead
+        /// of failing the load. An ack still means durable whenever it arrives.
+        ///
+        /// `0s` is accepted and means the age trigger fires on the next flush
+        /// tick for any non-empty buffer on this path, where every write is
+        /// Strict and so leaves a waiter on the buffer it merged into (a
+        /// buffer with no waiter is judged idle and ages on the router's
+        /// slower idle timer instead).
         #[arg(long, value_name = "DURATION", value_parser = ravel_cli::parse_max_flush_delay)]
         max_flush_delay: Option<Duration>,
     },


### PR DESCRIPTION
The loader built IngestConfig with the 2 s age-trigger default and no
flag, so a shard buffer age-flushed after ~2 s of ingest regardless of
--target-bytes: the v4 load's 8,424 fragmented objects were ~2 s of
per-shard rate, and a large target was unreachable as a lever. The flag
plumbs the existing IngestConfig field, with the parse convention and
i64-nanosecond ceiling of its sibling duration flags, and re-derives
strict_visibility_budget_ns from the configured delay exactly as the
server's construction site does.

Raising the delay exposed a tail trap: the file's last batches sit below
target with no later batch coming, and their Strict acks died at the
flat 60 s deadline while waiting on an age trigger of minutes, failing
the whole multi-hour load at the end. The clean-exhaustion path now
force-flushes every buffer before draining the window (FlushNow travels
each shard's own FIFO channel, so it merges behind every dispatched
write and answers its waiters), and the ack deadline scales to the
configured delay plus a one-minute margin, so the one residual (a write
whose task had not yet reached its channel send when the flush ran) is
released by the age trigger inside its deadline.

A single-variable behavior pair on an advancing injected clock pins the
lever (same target, depth, writes, clock: long delay coalesces into one
object, short delay splits with exactly one age flush), and a tail-drain
test pins the end-of-input flush publishing a below-target tail with
zero age flushes.

Refs: #801
Signed-off-by: Panagiotis Moustafellos <pmoust@nofire.ai>
