### PR TITLE
docs(clickbench): fix the seven runbook findings from the review of #1063

### DIFF
--- a/docs/internal/clickbench-aws-runbook.md
+++ b/docs/internal/clickbench-aws-runbook.md
@@ -561,6 +561,24 @@ def byte_count(v, what):
         return None
     return v
 
+def finite_nonneg(v):
+    """An object-store count or byte field coerced to a finite, non-negative
+    number, or 0 when the report value is not one.
+
+    The class totals below sum these directly rather than gating the whole pass
+    on each field the way `byte_count` does, so an invalid value contributes 0
+    instead of aborting. The three traps `byte_count` documents apply here too:
+    `bool` is an `int` subclass and would add 1; `NaN` poisons every later
+    comparison so a band would read as MET; a negative would drag a total down
+    toward a passing figure. Each such value is worth 0."""
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
+        return 0
+    if v != v or v in (float("inf"), float("-inf")):      # NaN or +/-inf
+        return 0
+    if v < 0:
+        return 0
+    return v
+
 def scan_wire(acc, q):
     """Scan-phase WIRE bytes for statement `q`, or None with a recorded failure.
 
@@ -664,8 +682,8 @@ for q in CLASS_M:
     acc = cold(q)
     if acc is None:
         m_ok = False; continue
-    m_gets  += acc.get("object_store_get_requests") or 0
-    m_bytes += acc.get("object_store_bytes") or 0
+    m_gets  += finite_nonneg(acc.get("object_store_get_requests"))
+    m_bytes += finite_nonneg(acc.get("object_store_bytes"))
 if m_ok:
     print(f"class M total {m_gets} GETs, {m_bytes/1e9:.2f} GB")
     if m_gets > M_TOTAL_GETS_MAX:
@@ -679,7 +697,7 @@ for q in CLASS_S_EACH:
     acc = cold(q)
     if acc is None:
         continue
-    b = acc.get("object_store_bytes") or 0
+    b = finite_nonneg(acc.get("object_store_bytes"))
     print(f"class S {q} {b/1e9:.2f} GB ({100*b/CORPUS_BYTES:.1f}% of corpus)")
     if b > S_EACH_BYTES_MAX:
         fails.append(f"class S {q} {b/1e9:.2f} GB > {S_EACH_FRAC_MAX*100:.1f}% "
@@ -690,7 +708,7 @@ for q in CLASS_S_GRP:
     acc = cold(q)
     if acc is None:
         s_grp_ok = False; continue
-    s_grp_bytes += acc.get("object_store_bytes") or 0
+    s_grp_bytes += finite_nonneg(acc.get("object_store_bytes"))
 if s_grp_ok:
     print(f"class S q20..q24 group total {s_grp_bytes/1e9:.2f} GB")
     if s_grp_bytes > S_GROUP_BYTES_MAX:

--- a/docs/internal/clickbench-aws-runbook.md
+++ b/docs/internal/clickbench-aws-runbook.md
@@ -345,6 +345,9 @@ HEAD_SHA=$(cat /root/CLONE_SHA) && [ -n "$HEAD_SHA" ] \
   || { echo "no /root/CLONE_SHA: the bootstrap did not finish"; exit 1; }
 git checkout -q --detach "$HEAD_SHA" || { echo "cannot check out $HEAD_SHA"; exit 1; }
 [ "$(git rev-parse HEAD)" = "$HEAD_SHA" ] || { echo "HEAD is not $HEAD_SHA"; exit 1; }
+# A checkout can match HEAD_SHA and still carry edits; a binary built from
+# them would not be the commit its pinned name claims.
+[ -z "$(git status --porcelain)" ] || { echo "checkout is dirty; reset it before building"; exit 1; }
 
 export CARGO_TARGET_DIR=/root/target-fp
 RUSTFLAGS="-C force-frame-pointers=yes" \

--- a/docs/internal/clickbench-aws-runbook.md
+++ b/docs/internal/clickbench-aws-runbook.md
@@ -197,7 +197,9 @@ parallel with the build.
 # bootstrap.sh -- toolchain, checkout, release binaries, dataset.
 export HOME=/root
 set -uo pipefail
-rm -f /root/BOOT_DONE /root/BOOT_FAILED
+# Clear every marker a previous attempt could have left, and drop a partial
+# dataset, so a retry never reuses stale failure state.
+rm -f /root/BOOT_DONE /root/BOOT_FAILED /root/DATASET_FAILED /root/hits.parquet
 exec > /root/bootstrap.log 2>&1
 fail() { echo "FAILED: $1"; touch /root/BOOT_FAILED; exit 1; }
 trap '[ -f /root/BOOT_DONE ] || touch /root/BOOT_FAILED' EXIT
@@ -212,6 +214,12 @@ source /root/.cargo/env
 
 git clone https://github.com/NOFireAI/ravel.git /root/ravel || fail "git clone"
 cd /root/ravel || fail "no checkout"
+# Pin the exact commit the clone checked out. Both binaries here and the
+# re-build in step 8 build from this SHA, so a later push to main never lands
+# in the measured binaries. Recorded for step 8 to read.
+CLONE_SHA=$(git rev-parse HEAD) || fail "resolve clone commit"
+git checkout -q --detach "$CLONE_SHA" || fail "detach clone commit"
+echo "$CLONE_SHA" > /root/CLONE_SHA
 rustc --version || fail "toolchain resolve"   # resolves via rust-toolchain.toml
 
 # Download runs alongside the build; both must succeed.
@@ -328,9 +336,8 @@ different binaries at the same path turn a missing flag into a wrong default.
 
 ```sh
 cd /root/ravel
-git fetch origin main --quiet
-git checkout -q --detach origin/main
-HEAD_SHA=$(git rev-parse HEAD)
+HEAD_SHA=$(cat /root/CLONE_SHA)               # the commit the bootstrap clone built
+git checkout -q --detach "$HEAD_SHA"          # never a moving origin/main
 
 export CARGO_TARGET_DIR=/root/target-fp
 RUSTFLAGS="-C force-frame-pointers=yes" \

--- a/docs/internal/clickbench-aws-runbook.md
+++ b/docs/internal/clickbench-aws-runbook.md
@@ -111,11 +111,11 @@ aws iam create-role --role-name ravel-clickbench-box \
 
 ACCT=$(aws sts get-caller-identity --query Account --output text)
 
-# The SecureStrings are encrypted under the account's default SSM KMS key
-# unless you created them with a customer-managed key. Set KMS_KEY_ID to that
-# key's id (the default key's id is what `aws kms describe-key --key-id
-# alias/aws/ssm --query KeyMetadata.KeyId --output text` prints).
-KMS_KEY_ID=<ssm-kms-key-id>
+# Step 3 wrote the SecureStrings without --key-id, so they are encrypted under
+# the account's default SSM key, which is the key this policy must name. If you
+# passed --key-id to put-parameter instead, set KMS_KEY_ID to that key's id.
+KMS_KEY_ID=$(aws kms describe-key --key-id alias/aws/ssm \
+  --query KeyMetadata.KeyId --output text)
 
 cat > /tmp/ssm-read.json <<EOF
 {
@@ -198,8 +198,10 @@ parallel with the build.
 export HOME=/root
 set -uo pipefail
 # Clear every marker a previous attempt could have left, and drop a partial
-# dataset, so a retry never reuses stale failure state.
-rm -f /root/BOOT_DONE /root/BOOT_FAILED /root/DATASET_FAILED /root/hits.parquet
+# dataset and checkout, so a retry never reuses stale failure state and the
+# clone below never fails on a non-empty destination.
+rm -f /root/BOOT_DONE /root/BOOT_FAILED /root/DATASET_FAILED /root/CLONE_SHA /root/hits.parquet
+rm -rf /root/ravel
 exec > /root/bootstrap.log 2>&1
 fail() { echo "FAILED: $1"; touch /root/BOOT_FAILED; exit 1; }
 trap '[ -f /root/BOOT_DONE ] || touch /root/BOOT_FAILED' EXIT
@@ -335,9 +337,14 @@ Build with frame pointers so a profile taken from the same binary resolves, and
 different binaries at the same path turn a missing flag into a wrong default.
 
 ```sh
-cd /root/ravel
-HEAD_SHA=$(cat /root/CLONE_SHA)               # the commit the bootstrap clone built
-git checkout -q --detach "$HEAD_SHA"          # never a moving origin/main
+cd /root/ravel || exit 1
+# The commit the bootstrap clone built, never a moving origin/main. Stop if the
+# record is missing or the checkout does not land on it: a build from whatever
+# is checked out would carry an unknown SHA under a pinned name.
+HEAD_SHA=$(cat /root/CLONE_SHA) && [ -n "$HEAD_SHA" ] \
+  || { echo "no /root/CLONE_SHA: the bootstrap did not finish"; exit 1; }
+git checkout -q --detach "$HEAD_SHA" || { echo "cannot check out $HEAD_SHA"; exit 1; }
+[ "$(git rev-parse HEAD)" = "$HEAD_SHA" ] || { echo "HEAD is not $HEAD_SHA"; exit 1; }
 
 export CARGO_TARGET_DIR=/root/target-fp
 RUSTFLAGS="-C force-frame-pointers=yes" \
@@ -561,22 +568,25 @@ def byte_count(v, what):
         return None
     return v
 
-def finite_nonneg(v):
-    """An object-store count or byte field coerced to a finite, non-negative
-    number, or 0 when the report value is not one.
+def finite_nonneg(v, what):
+    """An object-store count or byte field from the report, or None with a
+    recorded failure.
 
-    The class totals below sum these directly rather than gating the whole pass
-    on each field the way `byte_count` does, so an invalid value contributes 0
-    instead of aborting. The three traps `byte_count` documents apply here too:
-    `bool` is an `int` subclass and would add 1; `NaN` poisons every later
-    comparison so a band would read as MET; a negative would drag a total down
-    toward a passing figure. Each such value is worth 0."""
+    The class totals below sum these, so the same three traps `byte_count`
+    documents apply: `bool` is an `int` subclass and would add 1; `NaN` poisons
+    every later comparison so a band would read as MET; a negative would drag a
+    total down toward a passing figure. An invalid field is a failed pass, not
+    a zero: a total computed over fewer fields than the class has statements
+    would pass a band it never measured."""
     if isinstance(v, bool) or not isinstance(v, (int, float)):
-        return 0
+        fails.append(f"{what}: expected a finite non-negative number, got {v!r}")
+        return None
     if v != v or v in (float("inf"), float("-inf")):      # NaN or +/-inf
-        return 0
+        fails.append(f"{what}: value is not finite ({v!r})")
+        return None
     if v < 0:
-        return 0
+        fails.append(f"{what}: value is negative ({v!r})")
+        return None
     return v
 
 def scan_wire(acc, q):
@@ -682,8 +692,12 @@ for q in CLASS_M:
     acc = cold(q)
     if acc is None:
         m_ok = False; continue
-    m_gets  += finite_nonneg(acc.get("object_store_get_requests"))
-    m_bytes += finite_nonneg(acc.get("object_store_bytes"))
+    g = finite_nonneg(acc.get("object_store_get_requests"), f"class M {q} object_store_get_requests")
+    b = finite_nonneg(acc.get("object_store_bytes"), f"class M {q} object_store_bytes")
+    if g is None or b is None:
+        m_ok = False; continue
+    m_gets  += g
+    m_bytes += b
 if m_ok:
     print(f"class M total {m_gets} GETs, {m_bytes/1e9:.2f} GB")
     if m_gets > M_TOTAL_GETS_MAX:
@@ -697,7 +711,9 @@ for q in CLASS_S_EACH:
     acc = cold(q)
     if acc is None:
         continue
-    b = finite_nonneg(acc.get("object_store_bytes"))
+    b = finite_nonneg(acc.get("object_store_bytes"), f"class S {q} object_store_bytes")
+    if b is None:
+        continue
     print(f"class S {q} {b/1e9:.2f} GB ({100*b/CORPUS_BYTES:.1f}% of corpus)")
     if b > S_EACH_BYTES_MAX:
         fails.append(f"class S {q} {b/1e9:.2f} GB > {S_EACH_FRAC_MAX*100:.1f}% "
@@ -708,7 +724,10 @@ for q in CLASS_S_GRP:
     acc = cold(q)
     if acc is None:
         s_grp_ok = False; continue
-    s_grp_bytes += finite_nonneg(acc.get("object_store_bytes"))
+    b = finite_nonneg(acc.get("object_store_bytes"), f"class S {q} object_store_bytes")
+    if b is None:
+        s_grp_ok = False; continue
+    s_grp_bytes += b
 if s_grp_ok:
     print(f"class S q20..q24 group total {s_grp_bytes/1e9:.2f} GB")
     if s_grp_bytes > S_GROUP_BYTES_MAX:

--- a/docs/internal/clickbench-aws-runbook.md
+++ b/docs/internal/clickbench-aws-runbook.md
@@ -817,10 +817,13 @@ aws ec2 terminate-instances --instance-ids <id>   # discards everything
 
 Removing the rest:
 
+Read the bucket name out of SSM into `B` **before** deleting anything: the
+parameter is deleted last, so the recursive object removal and the bucket
+delete both have a name to use.
+
 ```sh
-aws ssm delete-parameter --name /ravel-clickbench/access-key
-aws ssm delete-parameter --name /ravel-clickbench/secret-key
-aws ssm delete-parameter --name /ravel-clickbench/bucket
+B=$(aws ssm get-parameter --name /ravel-clickbench/bucket \
+  --query Parameter.Value --output text)
 
 aws iam remove-role-from-instance-profile \
   --instance-profile-name ravel-clickbench-box --role-name ravel-clickbench-box
@@ -834,8 +837,12 @@ aws iam list-access-keys --user-name ravel-clickbench \
   | xargs -n1 -I{} aws iam delete-access-key --user-name ravel-clickbench --access-key-id {}
 aws iam delete-user --user-name ravel-clickbench
 
-aws s3 rm "s3://$BUCKET" --recursive
-aws s3api delete-bucket --bucket "$BUCKET"
+aws s3 rm "s3://$B" --recursive
+aws s3api delete-bucket --bucket "$B"
+
+aws ssm delete-parameter --name /ravel-clickbench/access-key
+aws ssm delete-parameter --name /ravel-clickbench/secret-key
+aws ssm delete-parameter --name /ravel-clickbench/bucket
 ```
 
 An idle instance bills at its full on-demand rate. Stop it when a run finishes.

--- a/docs/internal/clickbench-aws-runbook.md
+++ b/docs/internal/clickbench-aws-runbook.md
@@ -110,6 +110,13 @@ aws iam create-role --role-name ravel-clickbench-box \
   --assume-role-policy-document file:///tmp/trust.json
 
 ACCT=$(aws sts get-caller-identity --query Account --output text)
+
+# The SecureStrings are encrypted under the account's default SSM KMS key
+# unless you created them with a customer-managed key. Set KMS_KEY_ID to that
+# key's id (the default key's id is what `aws kms describe-key --key-id
+# alias/aws/ssm --query KeyMetadata.KeyId --output text` prints).
+KMS_KEY_ID=<ssm-kms-key-id>
+
 cat > /tmp/ssm-read.json <<EOF
 {
   "Version": "2012-10-17",
@@ -122,8 +129,17 @@ cat > /tmp/ssm-read.json <<EOF
     {
       "Effect": "Allow",
       "Action": "kms:Decrypt",
-      "Resource": "*",
-      "Condition": {"StringEquals": {"kms:ViaService": "ssm.$AWS_REGION.amazonaws.com"}}
+      "Resource": "arn:aws:kms:$AWS_REGION:$ACCT:key/$KMS_KEY_ID",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "ssm.$AWS_REGION.amazonaws.com",
+          "kms:EncryptionContext:PARAMETER_ARN": [
+            "arn:aws:ssm:$AWS_REGION:$ACCT:parameter/ravel-clickbench/access-key",
+            "arn:aws:ssm:$AWS_REGION:$ACCT:parameter/ravel-clickbench/secret-key",
+            "arn:aws:ssm:$AWS_REGION:$ACCT:parameter/ravel-clickbench/bucket"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/internal/clickbench.md
+++ b/docs/internal/clickbench.md
@@ -659,7 +659,11 @@ two tables are comparable: a folded ClickBench tenant sits far above the 1024
 default sealed-segment ceiling (step 5), so the server must raise it or every
 statement fails with `8424 exceeds max 1024`; and the cache must exceed the
 ~12 GB corpus (`25769803776` is 24 GiB) or every run is cold and there is no
-hot column to compare.
+hot column to compare. Both settings live on the server only. The bench's
+`--cache-bytes` and `--sql-max-segments` configure the in-process fetcher and
+engine, which the Flight lane never builds, so neither flag reaches the
+server; leave them off the bench command, or the report header claims a
+client-side cache that took part in nothing.
 
 The flags that must mirror the bench's, or the two tables are not comparable:
 
@@ -690,8 +694,7 @@ cargo run -p ravel-bench --features sql-latency,flight-lane --bin sql_latency_be
   --tenant clickbench --store s3 --flight 127.0.0.1:4317 \
   --corpus benchmarks/clickbench/hits.corpus.json \
   --runs 3 --compaction pre --window-hours 200000 \
-  --fetch-concurrency 8 --sql-max-query-bytes 1073741824 \
-  --cache-bytes 25769803776
+  --fetch-concurrency 8 --sql-max-query-bytes 1073741824
 ```
 
 - `--flight <host:port>` is the server's `--listen-grpc` address. It needs the

--- a/docs/internal/clickbench.md
+++ b/docs/internal/clickbench.md
@@ -650,9 +650,16 @@ cargo run -p ravel-server --features flight-sql --bin ravel-server -- \
   --fetch-concurrency 8 \
   --sql-max-query-bytes 1073741824 \
   --sql-tenant-max-bytes 2147483648 \
-  --max-segments 1024 \
-  --cache-max-bytes 268435456
+  --max-segments 1000000 \
+  --cache-max-bytes 25769803776
 ```
+
+`--max-segments` and `--cache-max-bytes` here match the in-process pass, so the
+two tables are comparable: a folded ClickBench tenant sits far above the 1024
+default sealed-segment ceiling (step 5), so the server must raise it or every
+statement fails with `8424 exceeds max 1024`; and the cache must exceed the
+~12 GB corpus (`25769803776` is 24 GiB) or every run is cold and there is no
+hot column to compare.
 
 The flags that must mirror the bench's, or the two tables are not comparable:
 
@@ -683,7 +690,8 @@ cargo run -p ravel-bench --features sql-latency,flight-lane --bin sql_latency_be
   --tenant clickbench --store s3 --flight 127.0.0.1:4317 \
   --corpus benchmarks/clickbench/hits.corpus.json \
   --runs 3 --compaction pre --window-hours 200000 \
-  --fetch-concurrency 8 --sql-max-query-bytes 1073741824
+  --fetch-concurrency 8 --sql-max-query-bytes 1073741824 \
+  --cache-bytes 25769803776
 ```
 
 - `--flight <host:port>` is the server's `--listen-grpc` address. It needs the

--- a/docs/internal/clickbench.md
+++ b/docs/internal/clickbench.md
@@ -364,9 +364,17 @@ cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
   --corpus benchmarks/clickbench/hits.corpus.json \
   --runs 3 \
   --compaction pre \
-  --window-hours 200000
+  --window-hours 200000 \
+  --sql-max-segments 1000000 \
+  --cache-bytes 25769803776
 ```
 
+- `--sql-max-segments 1000000` lifts the engine's sealed-segment ceiling from
+  its default of 1024; a folded ClickBench tenant sits far above that and
+  every statement would otherwise fail with `8424 exceeds max 1024`.
+- `--cache-bytes 25769803776` (24 GiB) exceeds the ~12 GB corpus, so the second
+  and third runs have a hot column to report. Leave it off for a cold-only
+  pass.
 - `--tenant clickbench` measures the loaded tenant (not an in-process generated
   dataset). It resolves the tenant's real durable declaration and **skips** any
   statement whose required declared column is absent or the wrong type, rather
@@ -654,12 +662,14 @@ cargo run -p ravel-server --features flight-sql --bin ravel-server -- \
   --cache-max-bytes 25769803776
 ```
 
-`--max-segments` and `--cache-max-bytes` here match the in-process pass, so the
-two tables are comparable: a folded ClickBench tenant sits far above the 1024
-default sealed-segment ceiling (step 5), so the server must raise it or every
-statement fails with `8424 exceeds max 1024`; and the cache must exceed the
-~12 GB corpus (`25769803776` is 24 GiB) or every run is cold and there is no
-hot column to compare. Both settings live on the server only. The bench's
+`--max-segments 1000000` and `--cache-max-bytes 25769803776` match the
+`--sql-max-segments` and `--cache-bytes` values the in-process command in
+step 5 passes, so the two tables are comparable: a folded ClickBench tenant
+sits far above the 1024 default sealed-segment ceiling, so the server must
+raise it or every statement fails with `8424 exceeds max 1024`; and the cache
+must exceed the ~12 GB corpus (`25769803776` is 24 GiB) or every run is cold
+and there is no hot column to compare. Both settings live on the server only
+in this lane. The bench's
 `--cache-bytes` and `--sql-max-segments` configure the in-process fetcher and
 engine, which the Flight lane never builds, so neither flag reaches the
 server; leave them off the bench command, or the report header claims a

--- a/docs/internal/clickbench.md
+++ b/docs/internal/clickbench.md
@@ -338,9 +338,9 @@ This writes ~104 declared columns (every `[[attribute]]` and
   it against an epoch-day integer, not a `DATE` literal. The corpus flags those
   statements `modified` with the conversion stated (see the gap/modification
   notes below). `#432` tracks the date/time ergonomic gap.
-- **No column is skipped for `f64`.** `ColType::F64` attributes cannot be
-  declared (`DeclaredType` has no F64 variant; ADR-0101 / `#431`), so a float
-  column would be skipped here with a stderr warning and stay queryable only
+- **`f64` columns are skipped, and `hits` has none.** `ColType::F64` attributes
+  cannot be declared (`DeclaredType` has no F64 variant; ADR-0101 / `#431`), so a
+  float column would be skipped here with a stderr warning and stay queryable only
   through `attrs['<key>']`. The `hits` schema has **zero** float columns (77
   integer/date/time, 28 text), so this affects nothing here.
 


### PR DESCRIPTION
Fixes the findings the review of the documentation PR raised on the two
internal ClickBench pages. The teardown reads the bucket name from SSM
before it deletes the parameters. The instance role's `kms:Decrypt` is
scoped to the SSM key and to the three parameter ARNs through the
encryption context. The bootstrap clears every retry marker and the partial
dataset, records the commit it cloned, and the profiling rebuild reads that
commit instead of a moving `origin/main`. The report totals coerce every
object-store count and byte field to a finite non-negative number before
the arithmetic. The Flight server is started with the same sealed-segment
ceiling and cache budget as the in-process pass, since the 1024 default
fails every statement on a folded tenant, and the text says why. The f64
heading now states what the body already did: float columns are skipped,
and `hits` has none.

One correction on top of the fleet result: the client-side `--cache-bytes`
it added to the Flight bench command was removed. Under `--flight` the
bench builds no in-process fetcher, so the flag reaches nothing and only
makes the report header claim a client cache that does not exist.

Fixes: #1080