### PR TITLE
docs: state which fold passes reconcile a late rewrite record

### DIFF
--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -605,7 +605,18 @@ already-sealed hours:
   sweeper may physically delete a superseded compaction input) plus slack.
   Because the sweeper only deletes an input after that horizon, any record
   whose supersession could invalidate a snapshot entry is observed by a
-  reconcile pass before its inputs can disappear.
+  reconcile pass before its inputs can disappear, provided the record lands
+  inside this window. Compaction does: it targets hours near the watermark.
+  A selective-erasure rewrite record can land in any sealed hour, and this
+  window and the retention-frontier band below are the fold's only
+  reconciliation of a late record; no hook lets a rewrite pass force one
+  hour. A rewrite whose hour is older than this window and newer than the
+  retirement frontier is re-listed by neither pass, so its covering part
+  keeps naming the pre-rewrite inputs until the frontier band reaches that
+  hour, or until an operator rebuilds HEAD. Subject erasure stays correct
+  meanwhile (the query-time predicate outlives the inputs); the availability
+  cost once the sweeper deletes those inputs is stated in
+  docs/deletion-and-gc.md, "Selective subject erasure".
 - **Skipped when redundant.** The pass does not run on the first fold for a
   tenant (no previous watermark exists) or on a rebuilt fold (absent, corrupt,
   or unreadable-part HEAD): a rebuild already re-derives every hour from the
@@ -659,7 +670,10 @@ normally days) behind the watermark, so the fixed window alone would never
 observe it, and the snapshot would keep naming the retired bucket's segments
 forever. The retention-frontier reconcile below covers exactly that case.
 (This closes a latent correctness gap; see ADR-0063 Consequences and
-ADR-0020.)
+ADR-0020.) A rewrite record takes the same two routes and no third: inside
+the fixed window it is applied on the next fold, in an hour at or
+approaching the retirement frontier it is applied by the frontier band, and
+in between it waits for the frontier band to reach its hour.
 
 ## Retention-frontier reconcile (ADR-0020 delete blocker)
 

--- a/docs/deletion-and-gc.md
+++ b/docs/deletion-and-gc.md
@@ -325,7 +325,10 @@ every bound is measured.
 - **Physical removal reuses the existing sweep.** A rewrite's superseded
   inputs become inputs to `sweep_superseded`, deleted after
   `protection_horizon`, under the same `LegalHoldCheck` gate as every other
-  delete. The `.dreq` itself contains the subject
+  delete. That sweep carries no HEAD-reachability blocker: unlike retention,
+  it deletes an input on schedule even when a snapshot part the fold has not
+  reconciled still names it (see "Scope and interactions" below for what a
+  query then sees). The `.dreq` itself contains the subject
   identifier and is therefore not kept forever: a sweep rule deletes it once
   its `.done` exists, `now >= done.created_unix_ns + protection_horizon`, and
   the legal-hold check passes; the horizon wait guarantees the query-time
@@ -408,9 +411,17 @@ into them. An operator with erasure obligations must budget them deliberately.
     erasure by construction. This holds *only if* subject identifiers appear
     as label/attribute values and never inside metric names (a documented
     requirement; see docs/object-store-contract.md "Required bucket
-    configuration" point 5). Superseded catalog entries resolve to NotFound,
-    then SnapshotInvalidated, then re-resolve, and the next fold rebuilds over the
-    rewrite outputs.
+    configuration" point 5). A snapshot entry whose object a rewrite
+    superseded is refreshed only when the fold reconciles that hour, through
+    the fixed window or the retention-frontier band (docs/catalog-and-mvcc.md,
+    "Fold reconcile pass"). Until then a query over that hour resolves the
+    pre-rewrite inputs from the stale part, and the query-time predicate
+    removes the erased records after fetch. Once `sweep_superseded` has
+    deleted those inputs, the same query fails closed with
+    `SnapshotInvalidated` on every attempt, because a re-resolve reads the
+    same stale HEAD, until the fold reconciles the hour or an operator
+    rebuilds HEAD. That is an availability cost, never a served pre-rewrite
+    record: the `.dreq` outlives the inputs by construction.
   - **ADR-0028 analytics/derived datasets are a pure query-time stage, not a
     persisted store.** `ravel-analytics` carries no clock, IO, object-store,
     or catalog (docs/analytics.md): every analytic runs in memory over query

--- a/docs/deletion-and-gc.md
+++ b/docs/deletion-and-gc.md
@@ -414,7 +414,8 @@ into them. An operator with erasure obligations must budget them deliberately.
     configuration" point 5). A snapshot entry whose object a rewrite
     superseded is refreshed only when the fold reconciles that hour, through
     the fixed window or the retention-frontier band (docs/catalog-and-mvcc.md,
-    "Fold reconcile pass"). Until then a query over that hour resolves the
+    "Fold reconcile pass"), or when a HEAD rebuild re-derives every hour.
+    Until then a query over that hour resolves the
     pre-rewrite inputs from the stale part, and the query-time predicate
     removes the erased records after fetch. Once `sweep_superseded` has
     deleted those inputs, the same query fails closed with


### PR DESCRIPTION
Answers #1078 from the fleet research trace posted on the ticket. The catalog spec now says the fixed window and the retention-frontier band are the fold's only reconciliation of a late record, that compaction always lands inside the window while a selective-erasure rewrite can land in any sealed hour, and that a rewrite in a mid-retention hour waits for the frontier band or a HEAD rebuild. The deletion spec replaces the claim that the next fold rebuilds over the rewrite outputs with what a query sees: the pre-rewrite inputs filtered by the erasure predicate while they exist, then a fail-closed `SnapshotInvalidated` on every attempt once `sweep_superseded` has deleted them, because that sweep has no HEAD-reachability blocker and a re-resolve reads the same stale HEAD.

Subject erasure stays correct throughout; the availability defect is #1085.

Fixes: #1078