### PR TITLE
fix: make process_metrics.py import under Python 3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ test:
 # tests deliberately take no third-party dependency, and CI has no Python
 # environment beyond the interpreter. Run from scripts/ so the tests'
 # `from process_metrics import ...` resolves without a package layout.
+# Supported interpreter floor: Python 3.9 or newer (fleet executors run
+# 3.9.25). Keep the scripts import-clean on 3.9: `from __future__ import
+# annotations` plus typing.Optional[...] rather than the 3.10 `X | None` form.
 test-python:
 	cd scripts && python3 -m unittest discover -p 'test_*.py' -v
 

--- a/crates/ravel-cache/src/cache.rs
+++ b/crates/ravel-cache/src/cache.rs
@@ -259,8 +259,10 @@ impl<E> Drop for Cache<E> {
 
 impl Inner {
     /// Look up `key`, aging it out if it is past `max_entry_age_ns`. Records a
-    /// hit, or a miss (plus an expiry, when the miss is because the entry aged
-    /// out), matching the disk tier's `get`/expiry accounting.
+    /// hit on a live entry, or a miss otherwise. An over-age entry is dropped
+    /// and reported as an ordinary miss: unlike the disk tier, the RAM tier has
+    /// no max-age expiry counter, so an aged-out read moves the same `misses`
+    /// counter a cold miss does and nothing else.
     fn get(&self, key: &CacheKey) -> Option<Bytes> {
         let mut fifo = self.fifo.lock();
         let Some(entry) = fifo.get(key) else {

--- a/crates/ravel-maintain/src/codec.rs
+++ b/crates/ravel-maintain/src/codec.rs
@@ -45,10 +45,12 @@
 //! RSEG builder does not read it. The trait-wide claim is about not holding the
 //! bucket's inputs at once; it is not a ceiling on the output part.
 //!
-//! [`RsegCodec`] wraps the existing `read.rs`/`build.rs` RSEG logic: the
-//! verbatim page-copy merge for current-version inputs, plus ADR-0066 decision
-//! 5's decode-and-re-encode path for an input recorded below the current output
-//! version; [`crate::rlog::RlogCodec`] is the RLOG
+//! [`RsegCodec`] wraps the existing `read.rs`/`build.rs` RSEG logic: since the
+//! run-merged rewrite the verbatim page copy is taken only by a single-run
+//! series at the current output version; a multi-run series is decoded and
+//! re-encoded into one run regardless of version, and ADR-0066 decision 5's
+//! decode-and-re-encode path always runs for an input recorded below the current
+//! output version; [`crate::rlog::RlogCodec`] is the RLOG
 //! implementation; [`crate::rspan_codec::SpanCodec`] is the RSPAN
 //! implementation. [`crate::compact::compact_bucket`] dispatches on
 //! `bucket.signal` to whichever of the three it picked and runs the identical
@@ -117,12 +119,16 @@ pub trait SegmentCodec {
     }
 }
 
-/// The metrics codec: the RSEG half of the seam over `read.rs`/`build.rs`. For
-/// current-version inputs it is a behavior-preserving wrapper (the verbatim
-/// page-copy merge, unchanged). For an input recorded below the current output
-/// version it drives ADR-0066 decision 5's decode-and-re-encode rewrite: it
-/// marks that input's object key so [`crate::build::build_parts`] decodes and
-/// re-encodes its runs at the current version instead of copying them verbatim.
+/// The metrics codec: the RSEG half of the seam over `read.rs`/`build.rs`.
+/// Since the run-merged rewrite ([`crate::build`]) the verbatim page copy is
+/// per series, not per input: only a series that contributes exactly one run at
+/// the current output version is copied verbatim (byte-identical, no provenance
+/// column). A multi-run series is decoded and re-encoded into a single run
+/// regardless of its inputs' versions. For an input recorded below the current
+/// output version it drives ADR-0066 decision 5's decode-and-re-encode rewrite:
+/// it marks that input's object key (`migrate_keys`) so
+/// [`crate::build::build_parts`] always decodes and re-encodes that input's runs
+/// at the current version instead of copying them verbatim.
 pub struct RsegCodec;
 
 impl SegmentCodec for RsegCodec {

--- a/scripts/process_metrics.py
+++ b/scripts/process_metrics.py
@@ -6,9 +6,12 @@ before/after.
 Usage: python3 scripts/process_metrics.py [--repo OWNER/NAME] [--output PATH]
 """
 
+from __future__ import annotations
+
 import json
 import re
 import subprocess
+from typing import Optional
 
 DEFAULT_REPO = "NOFireAI/ravel"
 
@@ -70,7 +73,7 @@ def fetch_main_push_runs(repo: str) -> list[dict]:
 _CONFIRMED_FINDINGS_RE = re.compile(r"Confirmed findings:\s+\*\*(\d+)\*\*")
 
 
-def parse_confirmed_findings_count(report_text: str) -> int | None:
+def parse_confirmed_findings_count(report_text: str) -> Optional[int]:
     """Extract the prose 'Confirmed findings: **N**' summary line."""
     m = _CONFIRMED_FINDINGS_RE.search(report_text)
     return int(m.group(1)) if m else None


### PR DESCRIPTION
`scripts/process_metrics.py` used a PEP 604 union (`int | None`) in a
return annotation, which Python 3.9 evaluates at definition time and
rejects, so the script did not import on the fleet executors' interpreter.
Add `from __future__ import annotations` and spell the one union as
`Optional[int]`; the Makefile states the 3.9 floor next to the test target.

Also corrects two stale source comments from #1072: the RAM cache tier
reports an aged-out entry as an ordinary miss and has no expiry counter,
and the RSEG codec copies pages verbatim only for a single-run series at
the current output version since the run-merged rewrite. The third #1072
comment, in the server's metrics module, lands with the help-text task.

Fixes: #1071
Refs: #1072