### PR TITLE
docs: name the operator mechanism behind prefix-scoped Object Lock

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -425,6 +425,11 @@ expanded; other pages use them bare.
   `query`, and `maintain`, selected with `--mode`. Aliases: `tier`, `role`.
   Tier is the cache, and role belongs to a storage credential. The flag
   keeps its spelling.
+- **Object Lock**: the S3 feature that holds an object version under a
+  retention period, enabled per bucket and applied per object version either
+  as a bucket default retention or as a per-object retention; Ravel sets
+  neither, and [docs/object-store-contract.md](object-store-contract.md)
+  states which mechanism does.
 - **OTAP**: OpenTelemetry Arrow Protocol, the bidirectional gRPC protocol
   that carries telemetry as Arrow record batches. Feature-gated in Ravel; see
   [docs/otap-ingest.md](otap-ingest.md).
@@ -496,13 +501,11 @@ expanded; other pages use them bare.
 - **UDTF**: user-defined table function, a function that returns a table
   rather than a value. Ravel registers none, and the SQL surface's tables are
   the registered tables only.
-- **WORM**: write once read many, a bucket policy that forbids overwriting or
-  deleting an object version for a retention period. Ravel's bucket
-  protection contract asks for it, as Object Lock in compliance mode, on the
-  deployment records, the provisioning records, the commit records, and the
-  catalog HEAD history, paired with versioning so that a HEAD
-  compare-and-swap creates a new locked version rather than overwriting one.
-  The contract is in [docs/object-store-contract.md](object-store-contract.md).
+- **WORM**: write once read many, storage that forbids overwriting or
+  deleting an object version for a retention period; Ravel's bucket
+  protection contract asks for it on the protected prefixes, and
+  [docs/object-store-contract.md](object-store-contract.md) states the
+  mechanism that applies it.
 - **writer**: the identity a shard actor writes under, carried in commit and
   data object keys as a writer id and epoch. Commits are sequenced per
   writer and shard, and a restarted process takes a new epoch rather than

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -40,9 +40,35 @@ paired with versioning:
 Versioning is what makes the last of those work: a HEAD compare-and-swap
 creates a new locked version rather than overwriting one. None of those four
 prefix families holds an erasable subject value, deliberately, so locking them
-never collides with an erasure request. Scoped Object Lock on the protected
-prefixes is therefore not a disaster-recovery choice and carries no erasure
-cost; it is the baseline the commit and catalog layers already assume.
+never collides with an erasure request. The scoped posture is therefore not a
+disaster-recovery choice and carries no erasure cost; it is the baseline the
+commit and catalog layers already assume.
+
+Scoping the lock takes an operator-run mechanism, and it is a requirement of
+every level, not an optional extra. Object Lock is enabled per bucket, not per
+prefix, and Ravel never sets retention on an object. Objects under the
+protected prefixes carry **per-object retention** applied by a mechanism the
+operator runs outside Ravel. Check off all of these:
+
+- [ ] Object Lock enabled on the bucket, with **no bucket default retention**
+      (a default retention would lock the data objects too, which is level 2).
+- [ ] Versioning ON.
+- [ ] One of the two mechanisms below, applying per-object retention in
+      compliance mode, for the chosen retention period, to new objects under
+      `sys/`, the provisioning records, the commit records, and the catalog
+      HEAD history.
+
+| Mechanism | What it does | Coverage window |
+|---|---|---|
+| Event-driven function | A function subscribed to object-created events, filtered to the protected prefixes, calls the per-object retention API in compliance mode. | Each object is locked within seconds of its creation. |
+| Scheduled batch job | An S3 Batch Operations job, run on a schedule and driven by an S3 Inventory manifest filtered to the same prefixes, sets the same retention. | Up to the schedule interval plus the inventory delay. |
+
+Between an object's creation and the moment the mechanism acts on it, the
+object carries no retention and any credential that can delete can delete it.
+That window is the residual exposure of the scoped posture. Choose the
+mechanism whose window your compliance regime accepts. The AWS reference for
+both is
+[S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html).
 
 `--require-bucket-protection` gates startup on it. With the flag set, a bucket
 reporting Object Lock disabled, or a versioning misconfiguration, refuses to
@@ -53,14 +79,15 @@ until an operator turns it on. Enforcement itself stays at the bucket and IAM
 layer either way: nothing in a Ravel process can configure Object Lock.
 
 What the levels below add on top of that baseline is replication, and, at
-level 2, **bucket-default** retention across every prefix including the data
-objects. That last one is the choice with an erasure cost.
+level 2, a **bucket default retention** across every object including the data
+objects. That last one needs no mechanism, and it is the choice with an
+erasure cost.
 
 ## The three levels
 
 Each level states its erasure-bound consequence next to its protection. This
-disclosure is load-bearing, not a footnote: turning on versioning and
-bucket-wide Object Lock extends the physical erasure bound, and the tension
+disclosure is load-bearing, not a footnote: turning on versioning and a bucket
+default retention extends the physical erasure bound, and the tension
 between disaster recovery and the erasure guarantee is resolved by stating
 that cost, never by hiding it. Do not soften or omit it. The bounds the
 modifiers apply to are in
@@ -99,10 +126,11 @@ Replication to a replica bucket:
 replication lag plus `E_v_r` after the primary sweep, **provided
 `DeleteMarkerReplication` is enabled**. See the mandate below.
 
-### level 2, level 1 plus bucket-default Object Lock retention
+### level 2, level 1 plus a bucket default retention
 
-Bucket-default retention `D` across every prefix on the primary, the replica,
-or both. This is a strict superset of the scoped Object Lock the
+A bucket default retention `D` on the primary, the replica, or both. S3
+applies it to every object at write time, so this level needs no mechanism and
+has no coverage window. It is a strict superset of the scoped posture the
 bucket-protection contract asks for: it reaches the data objects too, which is
 where erasable subject values live. The physical erasure bound therefore
 becomes `max(bound, D)`; query-time exclusion stays immediate either way.
@@ -139,7 +167,7 @@ the same.
 Note the deliberate asymmetry this buys: version-id permanent deletes are
 **never** replicated at all, so a compromised primary credential cannot purge
 the replica through the replication channel. That is the property that lets
-the cross-account replica stand in for bucket-wide Object Lock at level 1.
+the cross-account replica stand in for a bucket default retention at level 1.
 
 ## `E_v` is one knob controlling two windows
 
@@ -179,9 +207,15 @@ aws s3api get-bucket-replication --bucket <primary>
 aws s3api get-bucket-versioning --bucket <replica>
 aws s3api get-bucket-lifecycle-configuration --bucket <replica>
 
-# Object Lock: compliance mode on the protected prefixes at every level,
-# and the bucket-default retention D that makes it level 2
+# Object Lock enabled on the bucket, and whether a bucket default
+# retention D is set (a default retention is level 2; the scoped posture
+# expects none here)
 aws s3api get-object-lock-configuration --bucket <primary>
+
+# The scoped posture, at every level: a recent object under a protected
+# prefix carries per-object retention in compliance mode. Repeat for one
+# object per protected prefix family.
+aws s3api get-object-retention --bucket <primary> --key <recent-protected-key>
 ```
 
 Confirm in the replication output that `DeleteMarkerReplication` is `Enabled`
@@ -252,9 +286,13 @@ verified operation.
    pays off here: processes mint fresh writer ids and epochs, no local state
    exists to reconcile, and the operator issues fresh per-mode storage
    credentials scoped to the restore bucket.
-6. **Re-protect.** Re-establish versioning, lifecycle rules, the protected
-   prefixes' Object Lock, and replication to a new replica before declaring
-   the incident closed. An unreplicated restored primary is level 0.
+6. **Re-protect.** Re-establish versioning, lifecycle rules, Object Lock on
+   the restore bucket, the mechanism that applies per-object retention to the
+   protected prefixes, and replication to a new replica before declaring the
+   incident closed. Objects restored before the mechanism is running stay
+   unlocked, so point it at the restore bucket and confirm one object per
+   protected prefix family carries retention. An unreplicated restored primary
+   is level 0.
 
 ## RPO and RTO: defined here, published only from a rehearsal
 
@@ -322,10 +360,10 @@ record: a real end-to-end run against MinIO is what fills a row.
 
 | Level | Controls | Erasure-bound consequence | RPO/RTO |
 |---|---|---|---|
-| **Every level** | Object Lock compliance mode on `sys/`, provisioning records, commit records and catalog HEAD history, paired with versioning; `--require-bucket-protection` to gate startup on it | None; those prefixes hold no erasable subject value | Not a recovery control |
+| **Every level** | Object Lock enabled on the bucket with no bucket default retention, versioning ON, and an operator-run mechanism applying per-object retention in compliance mode to `sys/`, provisioning records, commit records and catalog HEAD history; `--require-bucket-protection` to gate startup on it | None; those prefixes hold no erasable subject value | Not a recovery control |
 | **level 0** (default) | No replication | None; bounds as in consistency-model.md | None; bucket loss is total loss |
 | **level 1** (recommended) | Primary: versioning + `NoncurrentDays = E_v` + expired-delete-marker cleanup. Replica: different region/account/KMS key, replication v2 with `DeleteMarkerReplication`, RTC recommended, `NoncurrentDays = E_v_r` | Primary `+E_v`; replica residue is replication lag + `E_v_r` (requires `DeleteMarkerReplication`) | Defined here; **unmeasured** until a rehearsal record exists. RTC gives RPO a 15-minute ceiling; without RTC, unbounded |
-| **level 2** (optional) | level 1 plus bucket-default Object Lock retention `D` across every prefix | `max(bound, D)`; query-time exclusion still immediate | As level 1 |
+| **level 2** (optional) | level 1 plus a bucket default retention `D`, which S3 applies to every object including the data objects | `max(bound, D)`; query-time exclusion still immediate | As level 1 |
 
 `DeleteMarkerReplication` is mandatory for any erasure-obligated deployment;
 omitting it leaves erased bytes on the replica indefinitely and is

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -60,8 +60,8 @@ operator runs outside Ravel. Check off all of these:
 
 | Mechanism | What it does | Coverage window |
 |---|---|---|
-| Event-driven function | A function subscribed to object-created events, filtered to the protected prefixes, calls the per-object retention API in compliance mode. | Each object is locked within seconds of its creation. |
-| Scheduled batch job | An S3 Batch Operations job, run on a schedule and driven by an S3 Inventory manifest filtered to the same prefixes, sets the same retention. | Up to the schedule interval plus the inventory delay. |
+| Event-driven function | A function subscribed to object-created events, filtered to the protected prefixes, calls the per-object retention API in compliance mode. Events can be delayed or lost and objects written before the subscription raise none, so it needs durable retry with a dead-letter queue, a one-time backfill over existing versions, and a periodic reconciliation against an all-versions S3 Inventory. | Each object is locked within seconds of its creation; a missed event is covered at the next reconciliation. |
+| Scheduled batch job | An S3 Batch Operations job, run on a schedule and driven by an all-versions S3 Inventory manifest (`IncludedObjectVersions=All`) filtered to the same prefixes, sets the same retention on every listed version, current and noncurrent. | Up to the schedule interval plus the inventory delay plus the job's own execution and retry time. |
 
 Between an object's creation and the moment the mechanism acts on it, the
 object carries no retention and any credential that can delete can delete it.
@@ -70,13 +70,18 @@ mechanism whose window your compliance regime accepts. The AWS reference for
 both is
 [S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html).
 
-`--require-bucket-protection` gates startup on it. With the flag set, a bucket
-reporting Object Lock disabled, or a versioning misconfiguration, refuses to
-start; a backend that cannot disclose its state warns once and raises the
-`ravel_bucket_protection_unknown` gauge; a bucket reporting it enabled starts
-clean. The flag is off by default, so an existing deployment is unchanged
-until an operator turns it on. Enforcement itself stays at the bucket and IAM
-layer either way: nothing in a Ravel process can configure Object Lock.
+`--require-bucket-protection` gates startup on the bucket half of that
+posture only: Object Lock enabled and versioning on. With the flag set, a
+bucket reporting Object Lock disabled, or a versioning misconfiguration,
+refuses to start; a backend that cannot disclose its state warns once and
+raises the `ravel_bucket_protection_unknown` gauge; a bucket reporting it
+enabled starts clean. The flag cannot see whether the retention mechanism is
+running, whether every protected object version carries retention, or whether
+a bucket default retention is set; those are verified out of band with the
+commands under "Verification" below. The flag is off by default, so an
+existing deployment is unchanged until an operator turns it on. Enforcement
+itself stays at the bucket and IAM layer either way: nothing in a Ravel
+process can configure Object Lock.
 
 What the levels below add on top of that baseline is replication, and, at
 level 2, a **bucket default retention** across every object including the data
@@ -214,8 +219,12 @@ aws s3api get-object-lock-configuration --bucket <primary>
 
 # The scoped posture, at every level: a recent object under a protected
 # prefix carries per-object retention in compliance mode. Repeat for one
-# object per protected prefix family.
+# object per protected prefix family, and for one noncurrent version (a
+# superseded catalog HEAD is a good candidate): a mechanism fed by a
+# current-version-only inventory leaves noncurrent versions unlocked.
 aws s3api get-object-retention --bucket <primary> --key <recent-protected-key>
+aws s3api list-object-versions --bucket <primary> --prefix <protected-prefix> --max-keys 5
+aws s3api get-object-retention --bucket <primary> --key <protected-key> --version-id <noncurrent-version-id>
 ```
 
 Confirm in the replication output that `DeleteMarkerReplication` is `Enabled`
@@ -282,17 +291,22 @@ verified operation.
    and only for compaction.
 4. **Verify before serving.** `verify-custody` clean, `catalog verify` clean,
    and a canary query set over known-ingested data.
-5. **Resume.** Start Ravel against the restored bucket. Disposable compute
+5. **Re-protect before the first process starts.** The restore bucket must
+   meet the baseline before Ravel writes to it: versioning on, Object Lock
+   enabled with no default retention, and the retention mechanism pointed at
+   the restore bucket and backfilled over the restored objects. Objects
+   restored before the mechanism runs carry no retention, so run the backfill
+   and confirm one current and one noncurrent version per protected prefix
+   family carries retention, with the commands under "Verification". The
+   startup flag checks only the bucket half of this; the mechanism is verified
+   by hand.
+6. **Resume.** Start Ravel against the restored bucket. Disposable compute
    pays off here: processes mint fresh writer ids and epochs, no local state
    exists to reconcile, and the operator issues fresh per-mode storage
    credentials scoped to the restore bucket.
-6. **Re-protect.** Re-establish versioning, lifecycle rules, Object Lock on
-   the restore bucket, the mechanism that applies per-object retention to the
-   protected prefixes, and replication to a new replica before declaring the
-   incident closed. Objects restored before the mechanism is running stay
-   unlocked, so point it at the restore bucket and confirm one object per
-   protected prefix family carries retention. An unreplicated restored primary
-   is level 0.
+7. **Replicate and close out.** Re-establish the lifecycle rules and
+   replication to a new replica before declaring the incident closed. An
+   unreplicated restored primary is level 0.
 
 ## RPO and RTO: defined here, published only from a rehearsal
 
@@ -360,7 +374,7 @@ record: a real end-to-end run against MinIO is what fills a row.
 
 | Level | Controls | Erasure-bound consequence | RPO/RTO |
 |---|---|---|---|
-| **Every level** | Object Lock enabled on the bucket with no bucket default retention, versioning ON, and an operator-run mechanism applying per-object retention in compliance mode to `sys/`, provisioning records, commit records and catalog HEAD history; `--require-bucket-protection` to gate startup on it | None; those prefixes hold no erasable subject value | Not a recovery control |
+| **Every level** | Object Lock enabled on the bucket with no bucket default retention, versioning ON, and an operator-run mechanism applying per-object retention in compliance mode to `sys/`, provisioning records, commit records and catalog HEAD history; `--require-bucket-protection` gates startup on the bucket half (Object Lock enabled, versioning on), and the mechanism and the absence of a default retention are verified out of band | None; those prefixes hold no erasable subject value | Not a recovery control |
 | **level 0** (default) | No replication | None; bounds as in consistency-model.md | None; bucket loss is total loss |
 | **level 1** (recommended) | Primary: versioning + `NoncurrentDays = E_v` + expired-delete-marker cleanup. Replica: different region/account/KMS key, replication v2 with `DeleteMarkerReplication`, RTC recommended, `NoncurrentDays = E_v_r` | Primary `+E_v`; replica residue is replication lag + `E_v_r` (requires `DeleteMarkerReplication`) | Defined here; **unmeasured** until a rehearsal record exists. RTC gives RPO a 15-minute ceiling; without RTC, unbounded |
 | **level 2** (optional) | level 1 plus a bucket default retention `D`, which S3 applies to every object including the data objects | `max(bound, D)`; query-time exclusion still immediate | As level 1 |

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -45,10 +45,13 @@ disaster-recovery choice and carries no erasure cost; it is the baseline the
 commit and catalog layers already assume.
 
 Scoping the lock takes an operator-run mechanism, and it is a requirement of
-every level, not an optional extra. Object Lock is enabled per bucket, not per
-prefix, and Ravel never sets retention on an object. Objects under the
-protected prefixes carry **per-object retention** applied by a mechanism the
-operator runs outside Ravel. Check off all of these:
+levels 0 and 1, not an optional extra. Level 2 replaces it with a bucket
+default retention that reaches every object, so level 2 runs no mechanism and
+the "no bucket default retention" item below does not apply to it. Object
+Lock is enabled per bucket, not per prefix, and Ravel never sets retention on
+an object. Objects under the protected prefixes carry **per-object retention**
+applied by a mechanism the operator runs outside Ravel. Check off all of
+these:
 
 - [ ] Object Lock enabled on the bucket, with **no bucket default retention**
       (a default retention would lock the data objects too, which is level 2).
@@ -292,14 +295,16 @@ verified operation.
 4. **Verify before serving.** `verify-custody` clean, `catalog verify` clean,
    and a canary query set over known-ingested data.
 5. **Re-protect before the first process starts.** The restore bucket must
-   meet the baseline before Ravel writes to it: versioning on, Object Lock
-   enabled with no default retention, and the retention mechanism pointed at
-   the restore bucket and backfilled over the restored objects. Objects
-   restored before the mechanism runs carry no retention, so run the backfill
-   and confirm one current and one noncurrent version per protected prefix
-   family carries retention, with the commands under "Verification". The
-   startup flag checks only the bucket half of this; the mechanism is verified
-   by hand.
+   meet the baseline before Ravel writes to it: versioning on and Object Lock
+   enabled. At levels 0 and 1 that means no default retention and the
+   retention mechanism pointed at the restore bucket and backfilled over the
+   restored objects: objects restored before the mechanism runs carry no
+   retention, so run the backfill and confirm one current and one noncurrent
+   version per protected prefix family carries retention, with the commands
+   under "Verification". At level 2 it means the bucket default retention `D`
+   set on the restore bucket before the restore copy, so every restored
+   object is locked as it lands. The startup flag checks only the bucket half
+   of this; the mechanism, or the default retention, is verified by hand.
 6. **Resume.** Start Ravel against the restored bucket. Disposable compute
    pays off here: processes mint fresh writer ids and epochs, no local state
    exists to reconcile, and the operator issues fresh per-mode storage
@@ -374,7 +379,7 @@ record: a real end-to-end run against MinIO is what fills a row.
 
 | Level | Controls | Erasure-bound consequence | RPO/RTO |
 |---|---|---|---|
-| **Every level** | Object Lock enabled on the bucket with no bucket default retention, versioning ON, and an operator-run mechanism applying per-object retention in compliance mode to `sys/`, provisioning records, commit records and catalog HEAD history; `--require-bucket-protection` gates startup on the bucket half (Object Lock enabled, versioning on), and the mechanism and the absence of a default retention are verified out of band | None; those prefixes hold no erasable subject value | Not a recovery control |
+| **Every level** | Object Lock enabled on the bucket and versioning ON; at levels 0 and 1, no bucket default retention and an operator-run mechanism applying per-object retention in compliance mode to `sys/`, provisioning records, commit records and catalog HEAD history (level 2 replaces the mechanism with its bucket default retention); `--require-bucket-protection` gates startup on the bucket half (Object Lock enabled, versioning on), and the mechanism or the default retention is verified out of band | None; those prefixes hold no erasable subject value | Not a recovery control |
 | **level 0** (default) | No replication | None; bounds as in consistency-model.md | None; bucket loss is total loss |
 | **level 1** (recommended) | Primary: versioning + `NoncurrentDays = E_v` + expired-delete-marker cleanup. Replica: different region/account/KMS key, replication v2 with `DeleteMarkerReplication`, RTC recommended, `NoncurrentDays = E_v_r` | Primary `+E_v`; replica residue is replication lag + `E_v_r` (requires `DeleteMarkerReplication`) | Defined here; **unmeasured** until a rehearsal record exists. RTC gives RPO a 15-minute ceiling; without RTC, unbounded |
 | **level 2** (optional) | level 1 plus a bucket default retention `D`, which S3 applies to every object including the data objects | `max(bound, D)`; query-time exclusion still immediate | As level 1 |

--- a/docs/guides/operations/deployment.md
+++ b/docs/guides/operations/deployment.md
@@ -67,10 +67,12 @@ statement is
 [the object store contract](../../object-store-contract.md)'s required bucket
 configuration section; this is the operational summary.
 
-Object Lock in compliance mode on the control prefixes (`sys/*`, the
-provisioning records, commit records and the catalog HEAD history), plus the
-versioning and lifecycle-rule requirements that go with erasure obligations,
-are all bucket-layer settings.
+Object Lock enabled on the bucket, versioning, and the lifecycle rules that go
+with erasure obligations are bucket-layer settings. The compliance-mode
+retention on the control prefixes (`sys/*`, the provisioning records, commit
+records and the catalog HEAD history) is per-object retention that an
+operator-run mechanism applies, because Object Lock has no prefix scope of its
+own; the contract page describes the two shapes that mechanism can take.
 
 **One lifecycle rule is not optional for any bucket Ravel writes to.**
 Configure `AbortIncompleteMultipartUpload` with a cleanup period of seven days

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -618,8 +618,8 @@ adapter contract:
 
    | Mechanism | What it does | Coverage window |
    |---|---|---|
-   | Event-driven function | A function subscribed to object-created events, filtered to the protected prefixes, calls the per-object retention API in compliance mode with the chosen retention period. | Each object is locked within seconds of its creation. |
-   | Scheduled batch job | An S3 Batch Operations job, run on a schedule and driven by an S3 Inventory manifest filtered to the same prefixes, sets the same retention. | Up to the schedule interval plus the inventory delay. |
+   | Event-driven function | A function subscribed to object-created events, filtered to the protected prefixes, calls the per-object retention API in compliance mode with the chosen retention period. Notifications can be delayed or lost, and objects written before the subscription existed raise none, so the function needs durable retry with a dead-letter queue, a one-time backfill over every existing version under the prefixes, and a periodic reconciliation against an S3 Inventory of all versions that locks anything missed. | Each object is locked within seconds of its creation; a missed event is covered at the next reconciliation. |
+   | Scheduled batch job | An S3 Batch Operations job, run on a schedule and driven by an S3 Inventory manifest that lists all object versions (`IncludedObjectVersions=All`) filtered to the same prefixes, sets the same retention on every listed version, current and noncurrent. An entry with no version id is rejected before the job is submitted; a current-version-only manifest leaves noncurrent versions unlocked. | Up to the schedule interval plus the inventory delay plus the job's own execution and retry time. |
 
    Between an object's creation and the moment the mechanism acts on it,
    the object carries no retention, and any credential that can delete

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -600,6 +600,41 @@ adapter contract:
    *values*, never in *object keys or names*, precisely so Object Lock on
    these prefixes never conflicts with a legitimate erasure request.
 
+   **How the prefix scoping is achieved.** Object Lock has no prefix
+   scope of its own. It is enabled once per bucket, at bucket creation,
+   together with versioning. Retention then applies per object version,
+   in one of two ways: a **bucket default retention**, which reaches
+   every object written to the bucket, data objects included, or a
+   **per-object retention** set on an individual object version at write
+   time or afterwards. So "compliance mode on the protected prefixes"
+   means per-object retention on the objects under those prefixes, and
+   **no Ravel process ever sets it**. Every Ravel write path writes
+   plain objects and stays that way. The scoped posture is an
+   operator-run mechanism outside Ravel. Objects under the protected
+   prefixes carry per-object retention applied by that mechanism; the
+   bucket itself does not lock a prefix. Two shapes satisfy the
+   requirement. Both need Object Lock enabled on the bucket with **no
+   default retention**, and versioning ON:
+
+   | Mechanism | What it does | Coverage window |
+   |---|---|---|
+   | Event-driven function | A function subscribed to object-created events, filtered to the protected prefixes, calls the per-object retention API in compliance mode with the chosen retention period. | Each object is locked within seconds of its creation. |
+   | Scheduled batch job | An S3 Batch Operations job, run on a schedule and driven by an S3 Inventory manifest filtered to the same prefixes, sets the same retention. | Up to the schedule interval plus the inventory delay. |
+
+   Between an object's creation and the moment the mechanism acts on it,
+   the object carries no retention, and any credential that can delete
+   can delete it. That window is the residual exposure of the scoped
+   posture. Pick the mechanism whose window your compliance regime
+   accepts. The AWS reference for both is
+   [S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html).
+
+   The alternative posture is **whole-bucket**: set a bucket default
+   retention and run no mechanism at all. S3 then applies retention at
+   write time, so there is no window. The cost is that every data object
+   is locked for the retention period, which means selective subject
+   erasure and retention deletion cannot remove an object before that
+   period ends.
+
 Enforcement stays at the bucket/IAM layer (ADR-0042 decision 3): nothing
 in this crate can configure or verify Object Lock or lifecycle policy
 in-process, because `object_store` 0.14 exposes no such API and this crate


### PR DESCRIPTION
Three pages described "Object Lock in compliance mode on the protected prefixes" as a bucket-layer setting that leaves the data objects unlocked. S3 offers no prefix scope: Object Lock is enabled per bucket, and retention applies per object version either as a bucket default (which reaches the data objects too) or as per-object retention that something has to set. No Ravel process sets it.

The contract page now says so and names the operator-run mechanism that achieves the scoped posture, with the two shapes that satisfy it (an event-driven function on object-created events, or a scheduled S3 Batch Operations job over an inventory manifest), each with its coverage window, and states the residual exposure between an object's creation and the mechanism acting. The whole-bucket posture stays as the alternative with its erasure cost. The disaster-recovery guide carries the mechanism as a checklist requirement of every level, distinguishes bucket default retention from per-object retention throughout, and adds a per-object retention check to its verification commands, since the bucket-level query alone cannot show the prefixes are locked. The glossary entries for WORM and Object Lock no longer imply prefix-scoped locking, and the deployment guide's summary matches.

The level-0 description on the disaster-recovery page assumes an unversioned bucket, which contradicts the versioning the baseline requires; that is #1089.

Fixes: #1077