### PR TITLE
fix(operator): order the sys/gc bootstrap under per-role credentials

### DIFF
--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -455,6 +455,22 @@ split in a kind cluster anyway, create the per-mode Secrets yourself the same
 way as above (`kubectl create secret generic ...`) before applying a
 `RavelCluster` that references them.
 
+Setting any per-mode `credentialsSecretRef` also changes the order the operator
+applies the three Deployments in. Every `ravel-server` mode creates the durable
+`sys/gc` object if it is absent and then validates itself against it, but under
+the per-role policies only Maintain and Admin can write it, so on a fresh bucket
+the operator applies the maintain Deployment first and the gateway and query
+Deployments only once maintain reports a ready replica. While it waits, the
+cluster carries `Available=False` with reason `WaitingForGcBootstrap` and
+`Degraded=False`, and the operator requeues: this is progress, not a failure,
+and it needs no manual bootstrap step. With `maintain.enabled: false` no pod can
+create the object at all, so the operator renders no gateway or query Deployment
+and reports `Degraded=True` with reason `GcBootstrapUnavailable`; either enable
+maintain, or create `sys/gc` yourself with `ravel-cli gc-config set` under the
+Admin credential. A `RavelCluster` with only the shared
+`spec.storage.s3.credentialsSecretRef` keeps the original order and never waits,
+because any pod holding that credential can create the object.
+
 ## Background
 
 The operator's design, its condition set and its reconcile model are

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -458,16 +458,20 @@ way as above (`kubectl create secret generic ...`) before applying a
 Setting any per-mode `credentialsSecretRef` also changes the order the operator
 applies the three Deployments in. Every `ravel-server` mode creates the durable
 `sys/gc` object if it is absent and then validates itself against it, but under
-the per-role policies only Maintain and Admin can write it, so on a fresh bucket
-the operator applies the maintain Deployment first and the gateway and query
-Deployments only once maintain reports a ready replica. While it waits, the
-cluster carries `Available=False` with reason `WaitingForGcBootstrap` and
-`Degraded=False`, and the operator requeues: this is progress, not a failure,
-and it needs no manual bootstrap step. With `maintain.enabled: false` no pod can
-create the object at all, so the operator renders no gateway or query Deployment
-and reports `Degraded=True` with reason `GcBootstrapUnavailable`; either enable
-maintain, or create `sys/gc` yourself with `ravel-cli gc-config set` under the
-Admin credential. A `RavelCluster` with only the shared
+the per-role policies only Maintain and Admin can write it. So on a fresh
+cluster the operator applies the maintain Deployment first and holds the gateway
+and query Deployments until maintain reports a ready replica. The hold applies
+only while neither request-serving Deployment exists yet: once either does, an
+existing cluster keeps reconciling both tiers through a maintain rollout or
+outage rather than stalling them. While it holds, the cluster carries
+`Available=False` with reason `WaitingForGcBootstrap` and `Degraded=False`, and
+the operator requeues: this is progress, not a failure, and it needs no manual
+bootstrap step. With `maintain.enabled: false` under per-role Secrets the
+operator still applies the gateway and query Deployments, but their pods restart
+until `sys/gc` exists, and the cluster reports `Degraded=True` with reason
+`GcBootstrapUnavailable` until one of them reports ready. That happens once you
+create `sys/gc` with `ravel-cli gc-config set` under the Admin credential (or
+enable `spec.maintain`). A `RavelCluster` with only the shared
 `spec.storage.s3.credentialsSecretRef` keeps the original order and never waits,
 because any pod holding that credential can create the object.
 

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -512,11 +512,13 @@ per-role storage credentials only the Maintain and Admin roles may create the
 object, so on a fresh bucket start the `maintain` process first, or create it
 with `ravel-cli gc-config set` under Admin; see
 [the first deployment](deployment.md#the-first-deployment-against-a-fresh-bucket).
-The Kubernetes operator applies the gateway and query Deployments before
-maintain and adds no ordering between them, so with per-role credential
-Secrets create `sys/gc` before applying the `RavelCluster`, or expect the
-gateway and query pods to restart until the first maintain pod has created
-it.
+With per-role credential Secrets the Kubernetes operator applies the maintain
+Deployment first on a fresh cluster and holds the gateway and query
+Deployments until maintain reports a ready replica, so no manual step is
+needed; with `maintain.enabled: false` it still applies both, their pods
+restart until `sys/gc` exists, and the cluster reports `Degraded=True` until
+you create the object under Admin. The Kubernetes guide describes the
+conditions the operator records while it waits.
 
 **What each mode validates:**
 
@@ -569,8 +571,9 @@ impossible for any mode to match, so it is rejected.
 The Kubernetes operator exposes no GC-horizon fields: it deploys every pod
 with the shipped defaults. On a fresh bucket with a shared credential the
 first pod bootstraps `sys/gc` from those defaults and every pod validates
-trivially; with per-role credential Secrets the maintain pod or an Admin
-step creates it first, as above. On a bucket whose stored protection horizon
+trivially; with per-role credential Secrets the operator applies the maintain
+Deployment first and its pod creates the object, as above. On a bucket whose
+stored protection horizon
 or grace differs from the shipped defaults (set with `gc-config set`), the
 operator's maintain pods refuse to start, because the must-match rule has no
 operator field to satisfy it; the other two stored values do not affect

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -1180,32 +1180,37 @@ async fn reconcile_inner(
     // Every `ravel-server` mode creates-if-absent and then validates `sys/gc`
     // at startup, but under per-role storage credentials only the maintain (and
     // Admin) role holds a write grant on it. So when the spec sets any
-    // per-Deployment `credentialsSecretRef`, maintain is applied first and the
-    // request-serving tiers are held until it reports a ready replica: applying
-    // them against a fresh bucket first would fail their create with an access
-    // error and crash-loop them until maintain got there. A single shared
+    // per-Deployment `credentialsSecretRef` with maintain enabled, maintain is
+    // applied first and the request-serving tiers are held until maintain
+    // reports a ready replica OR one of them already exists: applying them
+    // against a fresh bucket first would fail their create with an access error
+    // and crash-loop them until maintain got there, but once either exists a
+    // prior pass already got past the gate, so a serving cluster keeps
+    // reconciling both through a maintain rollout or outage. A single shared
     // credential keeps the original gateway-query-maintain order and reads
     // nothing extra, because any tier can create the object there.
     let plan = desired.gc_bootstrap;
     let maintain_name = child(instance, "maintain");
-    let maintain_ready_before = if plan.reads_maintain_ready() {
-        live_ready_replicas(&deployments, &maintain_name).await?
+    let (maintain_ready_before, request_serving_exists) = if plan.reads_live_state() {
+        let ready = live_ready_replicas(&deployments, &maintain_name).await?;
+        let exists = live_deployment_exists(&deployments, &child(instance, "gateway")).await?
+            || live_deployment_exists(&deployments, &child(instance, "query")).await?;
+        (ready, exists)
     } else {
-        None
+        (None, false)
     };
 
     let mut tiers = TierDeployments {
-        gateway: desired.gateway_deployment,
-        query: desired.query_deployment,
+        gateway: Some(desired.gateway_deployment),
+        query: Some(desired.query_deployment),
         maintain: desired.maintain_deployment,
         applied: BTreeMap::new(),
     };
-    // Maintain disabled: converge its Deployment away, whether that is because
-    // the spec turned the tier off or because the render withheld it.
+    // Maintain disabled: converge its Deployment away.
     if tiers.maintain.is_none() {
         delete_if_present(&deployments, &maintain_name).await?;
     }
-    for tier in plan.apply_sequence(maintain_ready_before) {
+    for tier in plan.apply_sequence(maintain_ready_before, request_serving_exists) {
         tiers
             .apply_tier(&deployments, namespace, instance, owner.as_ref(), tier)
             .await?;
@@ -1218,14 +1223,26 @@ async fn reconcile_inner(
         .applied(DeploymentTier::Maintain)
         .and_then(ready_replicas)
         .or(maintain_ready_before);
-    let waiting = plan.waiting_for_bootstrap(maintain_ready_before);
+    let gateway_ready = tiers
+        .applied(DeploymentTier::Gateway)
+        .and_then(ready_replicas);
+    let query_ready = tiers
+        .applied(DeploymentTier::Query)
+        .and_then(ready_replicas);
+    let waiting = plan.waiting_for_bootstrap(maintain_ready_before, request_serving_exists);
     let available_hold = match plan.gate {
-        GcBootstrapGate::Unavailable => {
-            // No rendered tier can create `sys/gc` at all, so this is a
-            // misconfiguration to surface, not a wait to sit through. It
-            // outranks a router render error for the pass's single `Degraded`
-            // entry: it stops the whole cluster from ever becoming ready,
-            // where a router error stops only ingest routing.
+        GcBootstrapGate::Unavailable
+            if gateway_ready.unwrap_or(0) <= 0 && query_ready.unwrap_or(0) <= 0 =>
+        {
+            // Maintain is disabled and the per-role credentials give neither
+            // request-serving tier a write grant on `sys/gc`, so their pods
+            // restart until `sys/gc` is created out of band. Surface that as a
+            // misconfiguration, but only while neither is serving: once either
+            // reports a ready replica the object exists and the cluster runs,
+            // so record no bootstrap condition at all. This outranks a router
+            // render error for the pass's single `Degraded` entry: it stops the
+            // whole cluster from becoming ready, where a router error stops only
+            // ingest routing.
             degraded = Some((
                 GC_BOOTSTRAP_UNAVAILABLE_REASON.to_string(),
                 GC_BOOTSTRAP_UNAVAILABLE_MESSAGE.to_string(),
@@ -1267,12 +1284,8 @@ async fn reconcile_inner(
         namespace,
         instance,
         obj.metadata.generation,
-        tiers
-            .applied(DeploymentTier::Gateway)
-            .and_then(ready_replicas),
-        tiers
-            .applied(DeploymentTier::Query)
-            .and_then(ready_replicas),
+        gateway_ready,
+        query_ready,
         maintain_ready,
         available_hold,
         extra_conditions,
@@ -1341,6 +1354,16 @@ async fn live_ready_replicas(api: &Api<Deployment>, name: &str) -> Result<Option
     match api.get(name).await {
         Ok(deployment) => Ok(ready_replicas(&deployment)),
         Err(err) if is_not_found(&err) => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Whether the live Deployment `name` exists on the cluster. A not-found is
+/// `false` (the fresh-cluster case); any other error propagates.
+async fn live_deployment_exists(api: &Api<Deployment>, name: &str) -> Result<bool, Error> {
+    match api.get(name).await {
+        Ok(_) => Ok(true),
+        Err(err) if is_not_found(&err) => Ok(false),
         Err(err) => Err(err.into()),
     }
 }
@@ -1911,6 +1934,22 @@ mod tests {
             Vec::new(),
         );
         let available = find(&ready.conditions, "Available");
+        assert_eq!(available.status, "True");
+        assert_eq!(available.reason, "MinimumReplicasAvailable");
+    }
+
+    /// Under the Unavailable gate the operator still applies the gateway and
+    /// query Deployments, so once `sys/gc` is created out of band and either
+    /// tier reports a ready replica the pass records NO bootstrap condition at
+    /// all: no `unavailable_reason` and no `Degraded` entry reach the status,
+    /// and the cluster is simply Available. This is the state the reworked
+    /// controller produces once its remedy (create `sys/gc` by hand) takes
+    /// effect, where the old plan withheld the tiers and nothing ever unblocked.
+    #[test]
+    fn gc_bootstrap_unavailable_clears_once_the_request_serving_tiers_report_ready() {
+        let running = build_status(Some(9), Some(1), Some(1), None, None, Vec::new());
+        assert_eq!(condition_types(&running.conditions), vec!["Available"]);
+        let available = find(&running.conditions, "Available");
         assert_eq!(available.status, "True");
         assert_eq!(available.reason, "MinimumReplicasAvailable");
     }

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -16,6 +16,7 @@ use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::{Secret, Service, ServiceAccount};
 use k8s_openapi::api::networking::v1::Ingress;
 use k8s_openapi::api::rbac::v1::{Role, RoleBinding};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::api::{DeleteParams, Patch, PatchParams};
 use kube::core::DynamicObject;
 use kube::{Api, Client, Resource, ResourceExt};
@@ -33,9 +34,11 @@ use crate::crd::{
     RavelClusterSpec, RavelClusterStatus, ShardOverridesSpec,
 };
 use crate::reconcile::{
-    DEPLOYMENT_KEY_SECRET_KEY, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY,
-    S3_SECRET_ACCESS_KEY_KEY, desired_objects, grpcroute_api_resource, httproute_api_resource,
-    possible_gateway_route_names, possible_ingest_ingress_names, possible_router_object_names,
+    DEPLOYMENT_KEY_SECRET_KEY, DeploymentTier, GC_BOOTSTRAP_UNAVAILABLE_MESSAGE,
+    GC_BOOTSTRAP_UNAVAILABLE_REASON, GcBootstrapGate, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY,
+    S3_SECRET_ACCESS_KEY_KEY, WAITING_FOR_GC_BOOTSTRAP_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_REASON,
+    desired_objects, grpcroute_api_resource, httproute_api_resource, possible_gateway_route_names,
+    possible_ingest_ingress_names, possible_router_object_names,
 };
 
 /// Server-side-apply field manager name.
@@ -56,6 +59,14 @@ const RESYNC: Duration = Duration::from_secs(300);
 
 /// Requeue interval after a failed reconcile.
 const RETRY: Duration = Duration::from_secs(30);
+
+/// Requeue interval while a pass is waiting on an ordering precondition rather
+/// than on anything having failed: today that is the `sys/gc` bootstrap under
+/// per-role storage credentials (see
+/// [`crate::reconcile::GcBootstrapPlan`]). Much shorter than [`RESYNC`] so a
+/// fresh cluster starts serving within seconds of the maintain tier becoming
+/// ready, and deliberately not [`RETRY`], which is the failure path.
+const BOOTSTRAP_POLL: Duration = Duration::from_secs(10);
 
 /// Reconcile errors.
 #[derive(Debug, thiserror::Error)]
@@ -1008,12 +1019,11 @@ async fn reconcile_inner(
     // every other tier's apply and sweep still runs this pass.
     let desired = desired_objects(&obj.spec, instance, namespace, &render_ctx)?;
 
-    // Gateway.
-    let mut gateway = desired.gateway_deployment;
-    gateway.metadata.namespace = Some(namespace.to_string());
-    gateway.metadata.owner_references = owner.clone();
-    let gateway_applied = apply(&deployments, &child(instance, "gateway"), &gateway).await?;
-
+    // Services and routing first, then the three Deployments in the order the
+    // `sys/gc` bootstrap plan dictates (see the block after the router sweep).
+    // A Service selecting pods that do not exist yet is inert, so applying it
+    // ahead of its Deployment costs nothing and keeps the ordering decision in
+    // one place.
     let mut gateway_svc = desired.gateway_service;
     gateway_svc.metadata.namespace = Some(namespace.to_string());
     gateway_svc.metadata.owner_references = owner.clone();
@@ -1102,16 +1112,13 @@ async fn reconcile_inner(
     // `desired_objects` already captured the error here rather than aborting the
     // whole reconcile, so all `router_*` fields are None and the apply blocks
     // below are no-ops; the sweep then removes any stale router objects.
-    if let Some(err) = desired.router_render_error {
-        let (reason, message) = degraded_reason(&Error::Render(err));
-        extra_conditions.push(condition(
-            "Degraded",
-            true,
-            obj.metadata.generation,
-            &reason,
-            &message,
-        ));
-    }
+    // Collected rather than pushed straight onto `extra_conditions`: a
+    // conditions array is keyed by type, so a pass may record at most one
+    // `Degraded` entry, and the `sys/gc` bootstrap check below can also produce
+    // one. Resolved once, after that check.
+    let mut degraded: Option<(String, String)> = desired
+        .router_render_error
+        .map(|err| degraded_reason(&Error::Render(err)));
     let mut desired_router_names: BTreeSet<String> = BTreeSet::new();
     if let Some(mut sa) = desired.router_service_account {
         let name = sa.name_any();
@@ -1162,52 +1169,180 @@ async fn reconcile_inner(
         delete_if_present(&role_bindings, &name).await?;
     }
 
-    // Query.
-    let mut query = desired.query_deployment;
-    query.metadata.namespace = Some(namespace.to_string());
-    query.metadata.owner_references = owner.clone();
-    let query_applied = apply(&deployments, &child(instance, "query"), &query).await?;
-
     let mut query_svc = desired.query_service;
     query_svc.metadata.namespace = Some(namespace.to_string());
     query_svc.metadata.owner_references = owner.clone();
     apply(&services, &child(instance, "query"), &query_svc).await?;
 
-    // Maintain: apply when enabled, delete when not.
+    // The three Deployments, in exactly the order `gc_bootstrap` names and no
+    // other.
+    //
+    // Every `ravel-server` mode creates-if-absent and then validates `sys/gc`
+    // at startup, but under per-role storage credentials only the maintain (and
+    // Admin) role holds a write grant on it. So when the spec sets any
+    // per-Deployment `credentialsSecretRef`, maintain is applied first and the
+    // request-serving tiers are held until it reports a ready replica: applying
+    // them against a fresh bucket first would fail their create with an access
+    // error and crash-loop them until maintain got there. A single shared
+    // credential keeps the original gateway-query-maintain order and reads
+    // nothing extra, because any tier can create the object there.
+    let plan = desired.gc_bootstrap;
     let maintain_name = child(instance, "maintain");
-    let maintain_ready = match desired.maintain_deployment {
-        Some(mut maintain) => {
-            maintain.metadata.namespace = Some(namespace.to_string());
-            maintain.metadata.owner_references = owner.clone();
-            let applied = apply(&deployments, &maintain_name, &maintain).await?;
-            ready_replicas(&applied)
-        }
-        None => {
-            // Ignore a not-found error: the Deployment may never have existed.
-            if let Err(err) = deployments
-                .delete(&maintain_name, &DeleteParams::default())
-                .await
-                && !is_not_found(&err)
-            {
-                return Err(err.into());
-            }
-            None
-        }
+    let maintain_ready_before = if plan.reads_maintain_ready() {
+        live_ready_replicas(&deployments, &maintain_name).await?
+    } else {
+        None
     };
+
+    let mut tiers = TierDeployments {
+        gateway: desired.gateway_deployment,
+        query: desired.query_deployment,
+        maintain: desired.maintain_deployment,
+        applied: BTreeMap::new(),
+    };
+    // Maintain disabled: converge its Deployment away, whether that is because
+    // the spec turned the tier off or because the render withheld it.
+    if tiers.maintain.is_none() {
+        delete_if_present(&deployments, &maintain_name).await?;
+    }
+    for tier in plan.apply_sequence(maintain_ready_before) {
+        tiers
+            .apply_tier(&deployments, namespace, instance, owner.as_ref(), tier)
+            .await?;
+    }
+
+    // Report the readiness the maintain apply just observed, but decide the
+    // `Available` condition from the count the ORDERING used: that is the one
+    // that describes what this pass actually applied.
+    let maintain_ready = tiers
+        .applied(DeploymentTier::Maintain)
+        .and_then(ready_replicas)
+        .or(maintain_ready_before);
+    let waiting = plan.waiting_for_bootstrap(maintain_ready_before);
+    let available_hold = match plan.gate {
+        GcBootstrapGate::Unavailable => {
+            // No rendered tier can create `sys/gc` at all, so this is a
+            // misconfiguration to surface, not a wait to sit through. It
+            // outranks a router render error for the pass's single `Degraded`
+            // entry: it stops the whole cluster from ever becoming ready,
+            // where a router error stops only ingest routing.
+            degraded = Some((
+                GC_BOOTSTRAP_UNAVAILABLE_REASON.to_string(),
+                GC_BOOTSTRAP_UNAVAILABLE_MESSAGE.to_string(),
+            ));
+            Some((
+                GC_BOOTSTRAP_UNAVAILABLE_REASON,
+                GC_BOOTSTRAP_UNAVAILABLE_MESSAGE,
+            ))
+        }
+        _ if waiting => Some((
+            WAITING_FOR_GC_BOOTSTRAP_REASON,
+            WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
+        )),
+        _ => None,
+    };
+    if let Some((reason, message)) = &degraded {
+        extra_conditions.push(condition(
+            "Degraded",
+            true,
+            obj.metadata.generation,
+            reason,
+            message,
+        ));
+    } else if waiting {
+        // Held back, not broken. An explicit `Degraded=False` says so, so
+        // `kubectl wait --for=condition=Degraded=false` succeeds while the
+        // bootstrap is still in flight and only `Available` reports the wait.
+        extra_conditions.push(condition(
+            "Degraded",
+            false,
+            obj.metadata.generation,
+            WAITING_FOR_GC_BOOTSTRAP_REASON,
+            WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
+        ));
+    }
 
     write_status(
         client,
         namespace,
         instance,
         obj.metadata.generation,
-        ready_replicas(&gateway_applied),
-        ready_replicas(&query_applied),
+        tiers
+            .applied(DeploymentTier::Gateway)
+            .and_then(ready_replicas),
+        tiers
+            .applied(DeploymentTier::Query)
+            .and_then(ready_replicas),
         maintain_ready,
+        available_hold,
         extra_conditions,
     )
     .await?;
 
+    if waiting {
+        return Ok(Action::requeue(BOOTSTRAP_POLL));
+    }
     Ok(Action::requeue(RESYNC))
+}
+
+/// The rendered Deployment for each tier and the applied result for each tier
+/// that this pass got to, so [`reconcile_inner`] applies them strictly in
+/// [`crate::reconcile::GcBootstrapPlan::apply_sequence`]'s order without three
+/// hand-written apply sites that could drift back into a fixed one.
+struct TierDeployments {
+    /// The rendered gateway Deployment, taken when applied.
+    gateway: Option<Deployment>,
+    /// The rendered query Deployment, taken when applied.
+    query: Option<Deployment>,
+    /// The rendered maintain Deployment, taken when applied.
+    maintain: Option<Deployment>,
+    /// The live object each applied tier came back as.
+    applied: BTreeMap<&'static str, Deployment>,
+}
+
+impl TierDeployments {
+    /// Apply one tier's Deployment, stamping namespace and owner references.
+    /// A tier the render withheld (or one already applied this pass) is a
+    /// no-op.
+    async fn apply_tier(
+        &mut self,
+        deployments: &Api<Deployment>,
+        namespace: &str,
+        instance: &str,
+        owner: Option<&Vec<OwnerReference>>,
+        tier: DeploymentTier,
+    ) -> Result<(), Error> {
+        let rendered = match tier {
+            DeploymentTier::Gateway => self.gateway.take(),
+            DeploymentTier::Query => self.query.take(),
+            DeploymentTier::Maintain => self.maintain.take(),
+        };
+        let Some(mut deployment) = rendered else {
+            return Ok(());
+        };
+        deployment.metadata.namespace = Some(namespace.to_string());
+        deployment.metadata.owner_references = owner.cloned();
+        let name = child(instance, tier.component());
+        let applied = apply(deployments, &name, &deployment).await?;
+        self.applied.insert(tier.component(), applied);
+        Ok(())
+    }
+
+    /// The live object a tier was applied as, or `None` when this pass did not
+    /// apply it.
+    fn applied(&self, tier: DeploymentTier) -> Option<&Deployment> {
+        self.applied.get(tier.component())
+    }
+}
+
+/// Ready replicas the live Deployment `name` reports, or `None` when it does not
+/// exist yet (the fresh-cluster case) or reports none.
+async fn live_ready_replicas(api: &Api<Deployment>, name: &str) -> Result<Option<i32>, Error> {
+    match api.get(name).await {
+        Ok(deployment) => Ok(ready_replicas(&deployment)),
+        Err(err) if is_not_found(&err) => Ok(None),
+        Err(err) => Err(err.into()),
+    }
 }
 
 /// Ready-replica count from a Deployment's status, if reported yet.
@@ -1288,11 +1423,17 @@ fn spec_conditions(spec: &RavelClusterSpec, observed_generation: Option<i64>) ->
 /// an `Available` condition derived from whether the gateway and query tiers
 /// report ready replicas, and whatever spec-derived conditions this pass
 /// computed. Pure, so the condition set is testable without a cluster.
+///
+/// `unavailable_reason` names a specific reason for `Available=False` when this
+/// pass knows one better than "not ready yet": today the `sys/gc` bootstrap
+/// hold and its unavailable case. It cannot make a ready cluster unavailable,
+/// only explain an unready one.
 fn build_status(
     observed_generation: Option<i64>,
     gateway_ready: Option<i32>,
     query_ready: Option<i32>,
     maintain_ready: Option<i32>,
+    unavailable_reason: Option<(&str, &str)>,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let available = gateway_ready.unwrap_or(0) > 0 && query_ready.unwrap_or(0) > 0;
@@ -1304,6 +1445,8 @@ fn build_status(
             "MinimumReplicasAvailable",
             "gateway and query tiers report ready replicas",
         )
+    } else if let Some((reason, message)) = unavailable_reason {
+        condition("Available", false, observed_generation, reason, message)
     } else {
         condition(
             "Available",
@@ -1359,6 +1502,7 @@ async fn write_status(
     gateway_ready: Option<i32>,
     query_ready: Option<i32>,
     maintain_ready: Option<i32>,
+    unavailable_reason: Option<(&str, &str)>,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_status(
@@ -1366,6 +1510,7 @@ async fn write_status(
         gateway_ready,
         query_ready,
         maintain_ready,
+        unavailable_reason,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -1605,7 +1750,7 @@ mod tests {
             vec!["IngestAffinityBackendDeprecated"]
         );
 
-        let ok = build_status(Some(7), Some(3), Some(2), Some(1), extra.clone());
+        let ok = build_status(Some(7), Some(3), Some(2), Some(1), None, extra.clone());
         assert_eq!(
             condition_types(&ok.conditions),
             vec!["Available", "IngestAffinityBackendDeprecated"]
@@ -1678,7 +1823,7 @@ mod tests {
                 "no spec-derived condition, got {:?}",
                 condition_types(&extra)
             );
-            let ok = build_status(Some(2), Some(1), Some(1), None, extra.clone());
+            let ok = build_status(Some(2), Some(1), Some(1), None, None, extra.clone());
             assert_eq!(condition_types(&ok.conditions), vec!["Available"]);
             let degraded = build_degraded_status(Some(2), "ReconcileError", "boom", extra);
             assert_eq!(
@@ -1686,6 +1831,88 @@ mod tests {
                 vec!["Degraded", "Available"]
             );
         }
+    }
+
+    /// The two `sys/gc` bootstrap states the ordering produces, at the status
+    /// layer: a wait that must NOT read as a failure, and a misconfiguration
+    /// that must. Pure, so no cluster is needed (see the module doc).
+    #[test]
+    fn gc_bootstrap_hold_names_the_wait_on_available_without_degrading() {
+        // Held: the request-serving tiers were not applied this pass, so they
+        // report no ready replicas, and `Available=False` names the wait
+        // instead of the generic not-ready-yet reason. `Degraded` is False,
+        // not True: the cluster is progressing, not broken.
+        let waiting = build_status(
+            Some(4),
+            None,
+            None,
+            Some(0),
+            Some((
+                WAITING_FOR_GC_BOOTSTRAP_REASON,
+                WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
+            )),
+            vec![condition(
+                "Degraded",
+                false,
+                Some(4),
+                WAITING_FOR_GC_BOOTSTRAP_REASON,
+                WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
+            )],
+        );
+        assert_eq!(
+            condition_types(&waiting.conditions),
+            vec!["Available", "Degraded"]
+        );
+        let available = find(&waiting.conditions, "Available");
+        assert_eq!(available.status, "False");
+        assert_eq!(available.reason, "WaitingForGcBootstrap");
+        assert!(
+            available.message.contains("sys/gc"),
+            "the message names what is being waited on: {}",
+            available.message
+        );
+        assert_eq!(find(&waiting.conditions, "Degraded").status, "False");
+
+        // Unavailable: nothing can create the object, so this one degrades.
+        let unavailable = build_status(
+            Some(4),
+            None,
+            None,
+            None,
+            Some((
+                GC_BOOTSTRAP_UNAVAILABLE_REASON,
+                GC_BOOTSTRAP_UNAVAILABLE_MESSAGE,
+            )),
+            vec![condition(
+                "Degraded",
+                true,
+                Some(4),
+                GC_BOOTSTRAP_UNAVAILABLE_REASON,
+                GC_BOOTSTRAP_UNAVAILABLE_MESSAGE,
+            )],
+        );
+        assert_eq!(
+            find(&unavailable.conditions, "Available").reason,
+            "GcBootstrapUnavailable"
+        );
+        assert_eq!(find(&unavailable.conditions, "Degraded").status, "True");
+
+        // A named reason can only explain an unready cluster, never make a
+        // ready one unavailable.
+        let ready = build_status(
+            Some(4),
+            Some(1),
+            Some(1),
+            Some(1),
+            Some((
+                WAITING_FOR_GC_BOOTSTRAP_REASON,
+                WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
+            )),
+            Vec::new(),
+        );
+        let available = find(&ready.conditions, "Available");
+        assert_eq!(available.status, "True");
+        assert_eq!(available.reason, "MinimumReplicasAvailable");
     }
 
     #[test]

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1554,6 +1554,163 @@ pub fn desired_gateway_routes(
     (Some(httproute), grpcroute)
 }
 
+/// A tier whose Deployment one reconcile pass applies.
+///
+/// The order these are applied in is a correctness concern rather than
+/// cosmetics; [`GcBootstrapPlan`] decides it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeploymentTier {
+    /// The request-serving ingest tier (`--mode gateway`).
+    Gateway,
+    /// The request-serving query tier (`--mode query`).
+    Query,
+    /// The maintenance tier (`--mode maintain`).
+    Maintain,
+}
+
+impl DeploymentTier {
+    /// The component suffix of this tier's child objects, which is also the
+    /// `--mode` value the tier runs.
+    pub fn component(self) -> &'static str {
+        match self {
+            Self::Gateway => "gateway",
+            Self::Query => "query",
+            Self::Maintain => "maintain",
+        }
+    }
+}
+
+/// Whether the cluster runs per-role storage credentials: at least one
+/// per-Deployment `credentialsSecretRef` override is set (ADR-0055 section 5).
+///
+/// With no override every tier shares one credential, so whichever tier reaches
+/// a fresh bucket first can create `sys/gc`. With any override in play the
+/// credentials are the per-role policies under `deploy/iam/`, where only
+/// Maintain and Admin carry `PutObject` on `sys/gc` while Gateway and Query hold
+/// `GetObject` only. One override is enough to put the cluster in that world:
+/// the overriding tier is the one whose grants narrowed.
+pub fn per_role_credentials(spec: &RavelClusterSpec) -> bool {
+    spec.gateway.credentials_secret_ref.is_some()
+        || spec.query.credentials_secret_ref.is_some()
+        || spec.maintain.credentials_secret_ref.is_some()
+}
+
+/// `Available=False` reason while the gateway and query Deployments are held
+/// back for the `sys/gc` bootstrap. A progress state, not a failure: the pass
+/// also writes `Degraded=False` under this same reason and requeues.
+pub const WAITING_FOR_GC_BOOTSTRAP_REASON: &str = "WaitingForGcBootstrap";
+
+/// Message paired with [`WAITING_FOR_GC_BOOTSTRAP_REASON`].
+pub const WAITING_FOR_GC_BOOTSTRAP_MESSAGE: &str = "waiting for the maintain Deployment to report a ready replica and create sys/gc; \
+     the gateway and query Deployments hold their per-role storage credentials, which \
+     carry no write grant on sys/gc, so they are applied only once it exists";
+
+/// `Degraded=True` reason when per-role storage credentials are in use and
+/// `maintain.enabled` is false, so no pod the operator would render can create
+/// `sys/gc`.
+pub const GC_BOOTSTRAP_UNAVAILABLE_REASON: &str = "GcBootstrapUnavailable";
+
+/// Message paired with [`GC_BOOTSTRAP_UNAVAILABLE_REASON`].
+pub const GC_BOOTSTRAP_UNAVAILABLE_MESSAGE: &str = "maintain.enabled is false and the per-role storage credentials give the gateway and \
+     query Deployments no write grant on sys/gc, so no pod can create it and every pod \
+     would crash-loop at startup; enable spec.maintain, or create sys/gc with \
+     \"ravel-cli gc-config set\" under the Admin credential";
+
+/// Which `sys/gc` bootstrap ordering regime a spec is in.
+///
+/// Every `ravel-server` mode creates-if-absent and then validates `sys/gc` at
+/// startup, so on a fresh bucket some process has to write it before any other
+/// can serve. Which processes are able to is a property of the credentials the
+/// spec hands them, which is what this enum reads off the spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GcBootstrapGate {
+    /// One shared credential across every tier, so any tier can create
+    /// `sys/gc`. No ordering constraint at all.
+    SharedCredential,
+    /// Per-role credentials with maintain enabled: only the maintain tier can
+    /// create `sys/gc`, so it is applied first and the request-serving tiers
+    /// wait for it to report a ready replica.
+    MaintainFirst,
+    /// Per-role credentials with maintain disabled: no tier the operator renders
+    /// can create `sys/gc`, so rendering the request-serving tiers would only
+    /// produce crash-looping pods.
+    Unavailable,
+}
+
+/// The Deployment apply ordering one reconcile pass follows, derived from the
+/// spec alone.
+///
+/// [`crate::controller`] applies exactly [`Self::apply_sequence`]'s contents, in
+/// that order and nothing else, so a test asserting on a sequence here is
+/// asserting on the operator's real apply order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GcBootstrapPlan {
+    /// The ordering regime.
+    pub gate: GcBootstrapGate,
+    /// Whether `spec.maintain.enabled` is set, i.e. whether the maintain
+    /// Deployment renders at all.
+    pub maintain_enabled: bool,
+}
+
+impl GcBootstrapPlan {
+    /// The exact sequence of Deployment applies for one pass, given the
+    /// ready-replica count the live maintain Deployment reports at the start of
+    /// it (`None` when that Deployment does not exist yet, which is the fresh
+    /// cluster case).
+    ///
+    /// Under [`GcBootstrapGate::SharedCredential`] this is the order the
+    /// operator has always used, and `maintain_ready` is ignored: any tier can
+    /// create `sys/gc` there, so waiting would only slow a fresh cluster down.
+    pub fn apply_sequence(&self, maintain_ready: Option<i32>) -> Vec<DeploymentTier> {
+        match self.gate {
+            GcBootstrapGate::SharedCredential => {
+                let mut sequence = vec![DeploymentTier::Gateway, DeploymentTier::Query];
+                if self.maintain_enabled {
+                    sequence.push(DeploymentTier::Maintain);
+                }
+                sequence
+            }
+            GcBootstrapGate::MaintainFirst => {
+                let mut sequence = vec![DeploymentTier::Maintain];
+                if maintain_ready.unwrap_or(0) > 0 {
+                    sequence.push(DeploymentTier::Gateway);
+                    sequence.push(DeploymentTier::Query);
+                }
+                sequence
+            }
+            GcBootstrapGate::Unavailable => Vec::new(),
+        }
+    }
+
+    /// Whether this pass holds the gateway and query Deployments back waiting
+    /// for maintain to create `sys/gc`. The pass records
+    /// [`WAITING_FOR_GC_BOOTSTRAP_REASON`] and requeues when true.
+    pub fn waiting_for_bootstrap(&self, maintain_ready: Option<i32>) -> bool {
+        matches!(self.gate, GcBootstrapGate::MaintainFirst) && maintain_ready.unwrap_or(0) <= 0
+    }
+
+    /// Whether the controller must read the live maintain Deployment's ready
+    /// replicas before it can order this pass. False under the shared
+    /// credential, so an unchanged single-credential cluster costs no extra
+    /// API call.
+    pub fn reads_maintain_ready(&self) -> bool {
+        matches!(self.gate, GcBootstrapGate::MaintainFirst)
+    }
+}
+
+/// The [`GcBootstrapPlan`] for a spec.
+pub fn gc_bootstrap_plan(spec: &RavelClusterSpec) -> GcBootstrapPlan {
+    let gate = match (per_role_credentials(spec), spec.maintain.enabled) {
+        (false, _) => GcBootstrapGate::SharedCredential,
+        (true, true) => GcBootstrapGate::MaintainFirst,
+        (true, false) => GcBootstrapGate::Unavailable,
+    };
+    GcBootstrapPlan {
+        gate,
+        maintain_enabled: spec.maintain.enabled,
+    }
+}
+
 /// Everything one `RavelCluster` reconcile applies, rendered in one place.
 ///
 /// [`crate::controller`] builds this and applies exactly its contents, so a
@@ -1561,8 +1718,10 @@ pub fn desired_gateway_routes(
 /// render path rather than on a helper that nothing calls.
 #[derive(Debug, Clone)]
 pub struct DesiredObjects {
-    /// The gateway Deployment.
-    pub gateway_deployment: Deployment,
+    /// The gateway Deployment, or `None` under
+    /// [`GcBootstrapGate::Unavailable`], where the tier's credentials cannot
+    /// create `sys/gc` and no other rendered tier will either.
+    pub gateway_deployment: Option<Deployment>,
     /// The gateway Service.
     pub gateway_service: Service,
     /// The ingest-affinity Ingress objects; empty when affinity is off.
@@ -1595,13 +1754,19 @@ pub struct DesiredObjects {
     /// abort the whole reconcile (ADR-0080 decision 3; crd.rs documents "renders
     /// no router objects" when misconfigured, i.e. everything else still runs).
     pub router_render_error: Option<RenderError>,
-    /// The query Deployment.
-    pub query_deployment: Deployment,
+    /// The query Deployment, or `None` under
+    /// [`GcBootstrapGate::Unavailable`] for the same reason as
+    /// [`Self::gateway_deployment`].
+    pub query_deployment: Option<Deployment>,
     /// The query Service.
     pub query_service: Service,
     /// The maintain Deployment, or `None` when `maintain.enabled` is false (the
     /// controller deletes it in that case).
     pub maintain_deployment: Option<Deployment>,
+    /// The order this pass applies the three Deployments in, and the condition
+    /// it records while an ordering constraint holds the request-serving tiers
+    /// back.
+    pub gc_bootstrap: GcBootstrapPlan,
 }
 
 /// Render every Kubernetes object a `RavelCluster` reconcile applies.
@@ -1648,8 +1813,21 @@ pub fn desired_objects(
     // router render error this pass. See `desired_gateway_routes` for why a static
     // spec check would strand the route at a deleted Service.
     let router_available = router_service.is_some();
+    // Under per-role storage credentials with maintain disabled, nothing the
+    // operator renders holds a write grant on `sys/gc`, and every mode
+    // creates-if-absent then validates it at startup. Rendering the
+    // request-serving tiers there produces two crash-looping Deployments and a
+    // cluster that never becomes ready, so render neither and let the
+    // controller record `GcBootstrapUnavailable` instead (the
+    // `RouterImageMissing` pattern: degrade visibly rather than ship a
+    // Deployment that cannot start). Withholding the render only stops the
+    // operator applying them; a Deployment already running against a bucket
+    // whose `sys/gc` exists is left alone rather than torn down.
+    let gc_bootstrap = gc_bootstrap_plan(spec);
+    let request_serving_renders = !matches!(gc_bootstrap.gate, GcBootstrapGate::Unavailable);
     Ok(DesiredObjects {
-        gateway_deployment: desired_gateway_deployment(spec, instance, ctx),
+        gateway_deployment: request_serving_renders
+            .then(|| desired_gateway_deployment(spec, instance, ctx)),
         gateway_service: desired_gateway_service(spec, instance),
         gateway_ingresses: desired_gateway_ingresses(spec, instance),
         gateway_routes: desired_gateway_routes(spec, instance, router_available),
@@ -1659,9 +1837,11 @@ pub fn desired_objects(
         router_role,
         router_role_binding,
         router_render_error,
-        query_deployment: desired_query_deployment(spec, instance, ctx),
+        query_deployment: request_serving_renders
+            .then(|| desired_query_deployment(spec, instance, ctx)),
         query_service: desired_query_service(spec, instance),
         maintain_deployment: desired_maintain_deployment(spec, instance, ctx),
+        gc_bootstrap,
     })
 }
 
@@ -2545,6 +2725,184 @@ mod tests {
         assert_ne!(checksum_of(&gb), checksum_of(&ga), "gateway must roll");
         assert_ne!(checksum_of(&qb), checksum_of(&qa), "query must roll");
         assert_ne!(checksum_of(&mb), checksum_of(&ma), "maintain must roll");
+    }
+
+    /// `base_spec` with a per-mode credential Secret on every tier: the
+    /// per-role storage credential model, where the gateway and query policies
+    /// hold `GetObject` on `sys/gc` and only maintain can create it.
+    fn per_role_spec() -> RavelClusterSpec {
+        let mut spec = base_spec();
+        spec.gateway.credentials_secret_ref = Some(LocalSecretRef {
+            name: "ravel-s3-gateway".to_string(),
+        });
+        spec.query.credentials_secret_ref = Some(LocalSecretRef {
+            name: "ravel-s3-query".to_string(),
+        });
+        spec.maintain.credentials_secret_ref = Some(LocalSecretRef {
+            name: "ravel-s3-maintain".to_string(),
+        });
+        spec
+    }
+
+    /// `base_spec` with a per-mode credential Secret on exactly one tier.
+    fn single_override_spec(tier: DeploymentTier) -> RavelClusterSpec {
+        let mut spec = base_spec();
+        let secret = Some(LocalSecretRef {
+            name: "ravel-s3-role".to_string(),
+        });
+        match tier {
+            DeploymentTier::Gateway => spec.gateway.credentials_secret_ref = secret,
+            DeploymentTier::Query => spec.query.credentials_secret_ref = secret,
+            DeploymentTier::Maintain => spec.maintain.credentials_secret_ref = secret,
+        }
+        spec
+    }
+
+    #[test]
+    fn per_role_credentials_apply_maintain_first_and_hold_the_request_serving_tiers() {
+        let spec = per_role_spec();
+        assert!(per_role_credentials(&spec));
+        let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
+        let plan = objects.gc_bootstrap;
+        assert_eq!(plan.gate, GcBootstrapGate::MaintainFirst);
+        assert!(
+            plan.reads_maintain_ready(),
+            "the pass must read maintain's live readiness to order itself"
+        );
+
+        // A fresh bucket: the maintain Deployment does not exist yet, so this
+        // pass applies maintain and nothing else. The exact sequence, not a
+        // containment check: applying gateway or query here is the bug.
+        assert_eq!(plan.apply_sequence(None), vec![DeploymentTier::Maintain]);
+        assert_eq!(plan.apply_sequence(Some(0)), vec![DeploymentTier::Maintain]);
+        assert!(plan.waiting_for_bootstrap(None));
+        assert!(plan.waiting_for_bootstrap(Some(0)));
+        assert_eq!(WAITING_FOR_GC_BOOTSTRAP_REASON, "WaitingForGcBootstrap");
+
+        // Once maintain reports a ready replica it has created `sys/gc`, so the
+        // pass applies maintain first and then both request-serving tiers.
+        assert_eq!(
+            plan.apply_sequence(Some(1)),
+            vec![
+                DeploymentTier::Maintain,
+                DeploymentTier::Gateway,
+                DeploymentTier::Query
+            ]
+        );
+        assert!(!plan.waiting_for_bootstrap(Some(1)));
+
+        // All three tiers still render; only the order they are applied in
+        // changed.
+        assert!(objects.gateway_deployment.is_some());
+        assert!(objects.query_deployment.is_some());
+        assert!(objects.maintain_deployment.is_some());
+
+        // One override is enough. Whichever tier narrowed its credential, the
+        // cluster is on the per-role policies and the same ordering holds.
+        for tier in [
+            DeploymentTier::Gateway,
+            DeploymentTier::Query,
+            DeploymentTier::Maintain,
+        ] {
+            let spec = single_override_spec(tier);
+            assert!(
+                per_role_credentials(&spec),
+                "a {} override alone is per-role credentials",
+                tier.component()
+            );
+            let plan = gc_bootstrap_plan(&spec);
+            assert_eq!(plan.gate, GcBootstrapGate::MaintainFirst);
+            assert_eq!(
+                plan.apply_sequence(None),
+                vec![DeploymentTier::Maintain],
+                "a {} override alone must still hold the request-serving tiers",
+                tier.component()
+            );
+        }
+    }
+
+    #[test]
+    fn per_role_credentials_with_maintain_disabled_render_no_request_serving_deployment() {
+        let mut spec = per_role_spec();
+        spec.maintain.enabled = false;
+        let objects =
+            desired_objects(&spec, "prod", "default", &ctx()).expect("render never aborts");
+        let plan = objects.gc_bootstrap;
+        assert_eq!(plan.gate, GcBootstrapGate::Unavailable);
+
+        // No pod could create `sys/gc`, so rendering the request-serving tiers
+        // would only produce two crash-looping Deployments.
+        assert!(
+            objects.gateway_deployment.is_none(),
+            "no gateway Deployment renders when nothing can create sys/gc"
+        );
+        assert!(
+            objects.query_deployment.is_none(),
+            "no query Deployment renders when nothing can create sys/gc"
+        );
+        assert!(objects.maintain_deployment.is_none());
+        for ready in [None, Some(0), Some(1)] {
+            assert_eq!(
+                plan.apply_sequence(ready),
+                Vec::<DeploymentTier>::new(),
+                "nothing is applied for maintain readiness {ready:?}"
+            );
+        }
+        assert!(
+            !plan.waiting_for_bootstrap(None),
+            "this is a misconfiguration to report, not a wait to sit through"
+        );
+
+        // The named reason and what its message must tell the operator to do.
+        assert_eq!(GC_BOOTSTRAP_UNAVAILABLE_REASON, "GcBootstrapUnavailable");
+        assert!(GC_BOOTSTRAP_UNAVAILABLE_MESSAGE.contains("spec.maintain"));
+        assert!(GC_BOOTSTRAP_UNAVAILABLE_MESSAGE.contains("ravel-cli gc-config set"));
+    }
+
+    #[test]
+    fn shared_credential_keeps_the_original_apply_order_with_no_wait() {
+        let spec = base_spec();
+        assert!(
+            !per_role_credentials(&spec),
+            "base_spec sets no per-Deployment override"
+        );
+        let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
+        let plan = objects.gc_bootstrap;
+        assert_eq!(plan.gate, GcBootstrapGate::SharedCredential);
+        assert!(
+            !plan.reads_maintain_ready(),
+            "a single-credential cluster must cost no extra API read"
+        );
+        // The order the operator has always used, independent of maintain
+        // readiness: any tier holding the shared credential can create sys/gc.
+        for ready in [None, Some(0), Some(1)] {
+            assert_eq!(
+                plan.apply_sequence(ready),
+                vec![
+                    DeploymentTier::Gateway,
+                    DeploymentTier::Query,
+                    DeploymentTier::Maintain
+                ],
+                "unchanged order for maintain readiness {ready:?}"
+            );
+            assert!(!plan.waiting_for_bootstrap(ready));
+        }
+        assert!(objects.gateway_deployment.is_some());
+        assert!(objects.query_deployment.is_some());
+
+        // Maintain off under one shared credential is unchanged too: the
+        // gateway or query pod creates sys/gc with the credential it holds.
+        let mut no_maintain = base_spec();
+        no_maintain.maintain.enabled = false;
+        let objects = desired_objects(&no_maintain, "prod", "default", &ctx()).expect("render");
+        assert_eq!(objects.gc_bootstrap.gate, GcBootstrapGate::SharedCredential);
+        assert_eq!(
+            objects.gc_bootstrap.apply_sequence(None),
+            vec![DeploymentTier::Gateway, DeploymentTier::Query]
+        );
+        assert!(objects.gateway_deployment.is_some());
+        assert!(objects.query_deployment.is_some());
+        assert!(objects.maintain_deployment.is_none());
     }
 
     /// An affinity block with everything at its default: what an operator gets
@@ -3721,12 +4079,18 @@ mod tests {
             assert!(objects.router_role_binding.is_none());
             // Every other tier still renders.
             assert_eq!(
-                objects.gateway_deployment.metadata.name.as_deref(),
+                objects
+                    .gateway_deployment
+                    .as_ref()
+                    .and_then(|d| d.metadata.name.as_deref()),
                 Some("prod-gateway"),
                 "gateway still renders when the router render fails"
             );
             assert_eq!(
-                objects.query_deployment.metadata.name.as_deref(),
+                objects
+                    .query_deployment
+                    .as_ref()
+                    .and_then(|d| d.metadata.name.as_deref()),
                 Some("prod-query"),
                 "query still renders when the router render fails"
             );

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1606,15 +1606,15 @@ pub const WAITING_FOR_GC_BOOTSTRAP_MESSAGE: &str = "waiting for the maintain Dep
      carry no write grant on sys/gc, so they are applied only once it exists";
 
 /// `Degraded=True` reason when per-role storage credentials are in use and
-/// `maintain.enabled` is false, so no pod the operator would render can create
-/// `sys/gc`.
+/// `maintain.enabled` is false, so no pod the operator renders holds a write
+/// grant on `sys/gc`.
 pub const GC_BOOTSTRAP_UNAVAILABLE_REASON: &str = "GcBootstrapUnavailable";
 
 /// Message paired with [`GC_BOOTSTRAP_UNAVAILABLE_REASON`].
 pub const GC_BOOTSTRAP_UNAVAILABLE_MESSAGE: &str = "maintain.enabled is false and the per-role storage credentials give the gateway and \
-     query Deployments no write grant on sys/gc, so no pod can create it and every pod \
-     would crash-loop at startup; enable spec.maintain, or create sys/gc with \
-     \"ravel-cli gc-config set\" under the Admin credential";
+     query Deployments no write grant on sys/gc, so their pods restart until sys/gc \
+     exists; enable spec.maintain, or create sys/gc with \"ravel-cli gc-config set\" \
+     under the Admin credential";
 
 /// Which `sys/gc` bootstrap ordering regime a spec is in.
 ///
@@ -1632,8 +1632,9 @@ pub enum GcBootstrapGate {
     /// wait for it to report a ready replica.
     MaintainFirst,
     /// Per-role credentials with maintain disabled: no tier the operator renders
-    /// can create `sys/gc`, so rendering the request-serving tiers would only
-    /// produce crash-looping pods.
+    /// holds a write grant on `sys/gc`. The request-serving tiers are still
+    /// applied, but their pods restart until `sys/gc` is created out of band,
+    /// so the pass degrades the cluster instead of waiting.
     Unavailable,
 }
 
@@ -1656,12 +1657,28 @@ impl GcBootstrapPlan {
     /// The exact sequence of Deployment applies for one pass, given the
     /// ready-replica count the live maintain Deployment reports at the start of
     /// it (`None` when that Deployment does not exist yet, which is the fresh
-    /// cluster case).
+    /// cluster case) and whether either request-serving Deployment already
+    /// exists on the cluster.
+    ///
+    /// Under [`GcBootstrapGate::MaintainFirst`] the hold on the request-serving
+    /// tiers is only meaningful before either of them exists: once one does,
+    /// its existence proves a prior pass already got past the bootstrap gate
+    /// (or an older operator applied it), so holding it back would stop a
+    /// serving cluster from reconciling through a maintain rollout or outage.
     ///
     /// Under [`GcBootstrapGate::SharedCredential`] this is the order the
-    /// operator has always used, and `maintain_ready` is ignored: any tier can
+    /// operator has always used, and both inputs are ignored: any tier can
     /// create `sys/gc` there, so waiting would only slow a fresh cluster down.
-    pub fn apply_sequence(&self, maintain_ready: Option<i32>) -> Vec<DeploymentTier> {
+    ///
+    /// Under [`GcBootstrapGate::Unavailable`] the request-serving tiers are
+    /// applied unconditionally: maintain is disabled there, so there is no
+    /// maintain Deployment to apply, and the controller degrades the cluster
+    /// until `sys/gc` is created out of band.
+    pub fn apply_sequence(
+        &self,
+        maintain_ready: Option<i32>,
+        request_serving_exists: bool,
+    ) -> Vec<DeploymentTier> {
         match self.gate {
             GcBootstrapGate::SharedCredential => {
                 let mut sequence = vec![DeploymentTier::Gateway, DeploymentTier::Query];
@@ -1672,28 +1689,39 @@ impl GcBootstrapPlan {
             }
             GcBootstrapGate::MaintainFirst => {
                 let mut sequence = vec![DeploymentTier::Maintain];
-                if maintain_ready.unwrap_or(0) > 0 {
+                if maintain_ready.unwrap_or(0) > 0 || request_serving_exists {
                     sequence.push(DeploymentTier::Gateway);
                     sequence.push(DeploymentTier::Query);
                 }
                 sequence
             }
-            GcBootstrapGate::Unavailable => Vec::new(),
+            GcBootstrapGate::Unavailable => {
+                vec![DeploymentTier::Gateway, DeploymentTier::Query]
+            }
         }
     }
 
     /// Whether this pass holds the gateway and query Deployments back waiting
     /// for maintain to create `sys/gc`. The pass records
-    /// [`WAITING_FOR_GC_BOOTSTRAP_REASON`] and requeues when true.
-    pub fn waiting_for_bootstrap(&self, maintain_ready: Option<i32>) -> bool {
-        matches!(self.gate, GcBootstrapGate::MaintainFirst) && maintain_ready.unwrap_or(0) <= 0
+    /// [`WAITING_FOR_GC_BOOTSTRAP_REASON`] and requeues when true. Only a fresh
+    /// [`GcBootstrapGate::MaintainFirst`] cluster with neither request-serving
+    /// Deployment yet and no ready maintain replica waits.
+    pub fn waiting_for_bootstrap(
+        &self,
+        maintain_ready: Option<i32>,
+        request_serving_exists: bool,
+    ) -> bool {
+        matches!(self.gate, GcBootstrapGate::MaintainFirst)
+            && !request_serving_exists
+            && maintain_ready.unwrap_or(0) <= 0
     }
 
-    /// Whether the controller must read the live maintain Deployment's ready
-    /// replicas before it can order this pass. False under the shared
+    /// Whether the controller must read live cluster state (the maintain
+    /// Deployment's ready replicas and whether a request-serving Deployment
+    /// exists) before it can order this pass. False under the shared
     /// credential, so an unchanged single-credential cluster costs no extra
     /// API call.
-    pub fn reads_maintain_ready(&self) -> bool {
+    pub fn reads_live_state(&self) -> bool {
         matches!(self.gate, GcBootstrapGate::MaintainFirst)
     }
 }
@@ -1718,10 +1746,8 @@ pub fn gc_bootstrap_plan(spec: &RavelClusterSpec) -> GcBootstrapPlan {
 /// render path rather than on a helper that nothing calls.
 #[derive(Debug, Clone)]
 pub struct DesiredObjects {
-    /// The gateway Deployment, or `None` under
-    /// [`GcBootstrapGate::Unavailable`], where the tier's credentials cannot
-    /// create `sys/gc` and no other rendered tier will either.
-    pub gateway_deployment: Option<Deployment>,
+    /// The gateway Deployment.
+    pub gateway_deployment: Deployment,
     /// The gateway Service.
     pub gateway_service: Service,
     /// The ingest-affinity Ingress objects; empty when affinity is off.
@@ -1754,10 +1780,8 @@ pub struct DesiredObjects {
     /// abort the whole reconcile (ADR-0080 decision 3; crd.rs documents "renders
     /// no router objects" when misconfigured, i.e. everything else still runs).
     pub router_render_error: Option<RenderError>,
-    /// The query Deployment, or `None` under
-    /// [`GcBootstrapGate::Unavailable`] for the same reason as
-    /// [`Self::gateway_deployment`].
-    pub query_deployment: Option<Deployment>,
+    /// The query Deployment.
+    pub query_deployment: Deployment,
     /// The query Service.
     pub query_service: Service,
     /// The maintain Deployment, or `None` when `maintain.enabled` is false (the
@@ -1813,21 +1837,15 @@ pub fn desired_objects(
     // router render error this pass. See `desired_gateway_routes` for why a static
     // spec check would strand the route at a deleted Service.
     let router_available = router_service.is_some();
-    // Under per-role storage credentials with maintain disabled, nothing the
-    // operator renders holds a write grant on `sys/gc`, and every mode
-    // creates-if-absent then validates it at startup. Rendering the
-    // request-serving tiers there produces two crash-looping Deployments and a
-    // cluster that never becomes ready, so render neither and let the
-    // controller record `GcBootstrapUnavailable` instead (the
-    // `RouterImageMissing` pattern: degrade visibly rather than ship a
-    // Deployment that cannot start). Withholding the render only stops the
-    // operator applying them; a Deployment already running against a bucket
-    // whose `sys/gc` exists is left alone rather than torn down.
+    // The gateway and query Deployments always render; the bootstrap plan only
+    // changes the order the controller applies the three tiers in and, under
+    // `GcBootstrapGate::Unavailable`, records a Degraded condition while their
+    // pods restart waiting on `sys/gc`. Rendering them even there is what lets
+    // the operator's own remedy (create `sys/gc` out of band) unblock the
+    // cluster: the Deployments exist, so they become ready once the object does.
     let gc_bootstrap = gc_bootstrap_plan(spec);
-    let request_serving_renders = !matches!(gc_bootstrap.gate, GcBootstrapGate::Unavailable);
     Ok(DesiredObjects {
-        gateway_deployment: request_serving_renders
-            .then(|| desired_gateway_deployment(spec, instance, ctx)),
+        gateway_deployment: desired_gateway_deployment(spec, instance, ctx),
         gateway_service: desired_gateway_service(spec, instance),
         gateway_ingresses: desired_gateway_ingresses(spec, instance),
         gateway_routes: desired_gateway_routes(spec, instance, router_available),
@@ -1837,8 +1855,7 @@ pub fn desired_objects(
         router_role,
         router_role_binding,
         router_render_error,
-        query_deployment: request_serving_renders
-            .then(|| desired_query_deployment(spec, instance, ctx)),
+        query_deployment: desired_query_deployment(spec, instance, ctx),
         query_service: desired_query_service(spec, instance),
         maintain_deployment: desired_maintain_deployment(spec, instance, ctx),
         gc_bootstrap,
@@ -2766,35 +2783,56 @@ mod tests {
         let plan = objects.gc_bootstrap;
         assert_eq!(plan.gate, GcBootstrapGate::MaintainFirst);
         assert!(
-            plan.reads_maintain_ready(),
-            "the pass must read maintain's live readiness to order itself"
+            plan.reads_live_state(),
+            "the pass must read live cluster state to order itself"
         );
 
-        // A fresh bucket: the maintain Deployment does not exist yet, so this
-        // pass applies maintain and nothing else. The exact sequence, not a
-        // containment check: applying gateway or query here is the bug.
-        assert_eq!(plan.apply_sequence(None), vec![DeploymentTier::Maintain]);
-        assert_eq!(plan.apply_sequence(Some(0)), vec![DeploymentTier::Maintain]);
-        assert!(plan.waiting_for_bootstrap(None));
-        assert!(plan.waiting_for_bootstrap(Some(0)));
+        let both = vec![
+            DeploymentTier::Maintain,
+            DeploymentTier::Gateway,
+            DeploymentTier::Query,
+        ];
+        // A fresh cluster: neither request-serving Deployment exists and
+        // maintain is not ready, so this pass applies maintain and nothing
+        // else. The exact sequence, not a containment check: applying gateway
+        // or query here is the bug.
+        assert_eq!(
+            plan.apply_sequence(None, false),
+            vec![DeploymentTier::Maintain]
+        );
+        assert_eq!(
+            plan.apply_sequence(Some(0), false),
+            vec![DeploymentTier::Maintain]
+        );
+        assert!(plan.waiting_for_bootstrap(None, false));
+        assert!(plan.waiting_for_bootstrap(Some(0), false));
         assert_eq!(WAITING_FOR_GC_BOOTSTRAP_REASON, "WaitingForGcBootstrap");
 
+        // An existing request-serving Deployment proves a prior pass got past
+        // the gate, so the hold lifts even while maintain reports nothing: a
+        // serving cluster keeps reconciling both tiers through a maintain
+        // rollout or outage.
+        assert_eq!(plan.apply_sequence(None, true), both);
+        assert_eq!(plan.apply_sequence(Some(0), true), both);
+        assert!(!plan.waiting_for_bootstrap(None, true));
+        assert!(!plan.waiting_for_bootstrap(Some(0), true));
+
         // Once maintain reports a ready replica it has created `sys/gc`, so the
-        // pass applies maintain first and then both request-serving tiers.
-        assert_eq!(
-            plan.apply_sequence(Some(1)),
-            vec![
-                DeploymentTier::Maintain,
-                DeploymentTier::Gateway,
-                DeploymentTier::Query
-            ]
-        );
-        assert!(!plan.waiting_for_bootstrap(Some(1)));
+        // pass applies maintain first and then both request-serving tiers even
+        // on a fresh cluster.
+        assert_eq!(plan.apply_sequence(Some(1), false), both);
+        assert!(!plan.waiting_for_bootstrap(Some(1), false));
 
         // All three tiers still render; only the order they are applied in
         // changed.
-        assert!(objects.gateway_deployment.is_some());
-        assert!(objects.query_deployment.is_some());
+        assert_eq!(
+            objects.gateway_deployment.metadata.name.as_deref(),
+            Some("prod-gateway")
+        );
+        assert_eq!(
+            objects.query_deployment.metadata.name.as_deref(),
+            Some("prod-query")
+        );
         assert!(objects.maintain_deployment.is_some());
 
         // One override is enough. Whichever tier narrowed its credential, the
@@ -2813,7 +2851,7 @@ mod tests {
             let plan = gc_bootstrap_plan(&spec);
             assert_eq!(plan.gate, GcBootstrapGate::MaintainFirst);
             assert_eq!(
-                plan.apply_sequence(None),
+                plan.apply_sequence(None, false),
                 vec![DeploymentTier::Maintain],
                 "a {} override alone must still hold the request-serving tiers",
                 tier.component()
@@ -2822,7 +2860,8 @@ mod tests {
     }
 
     #[test]
-    fn per_role_credentials_with_maintain_disabled_render_no_request_serving_deployment() {
+    fn per_role_credentials_with_maintain_disabled_still_render_and_apply_the_request_serving_tiers()
+     {
         let mut spec = per_role_spec();
         spec.maintain.enabled = false;
         let objects =
@@ -2830,27 +2869,40 @@ mod tests {
         let plan = objects.gc_bootstrap;
         assert_eq!(plan.gate, GcBootstrapGate::Unavailable);
 
-        // No pod could create `sys/gc`, so rendering the request-serving tiers
-        // would only produce two crash-looping Deployments.
-        assert!(
-            objects.gateway_deployment.is_none(),
-            "no gateway Deployment renders when nothing can create sys/gc"
+        // Both request-serving tiers render: the operator applies them so that
+        // creating `sys/gc` out of band (the remedy its message names) unblocks
+        // the cluster. There is no maintain Deployment to apply here.
+        assert_eq!(
+            objects.gateway_deployment.metadata.name.as_deref(),
+            Some("prod-gateway"),
+            "gateway still renders when maintain is disabled under per-role credentials"
         );
-        assert!(
-            objects.query_deployment.is_none(),
-            "no query Deployment renders when nothing can create sys/gc"
+        assert_eq!(
+            objects.query_deployment.metadata.name.as_deref(),
+            Some("prod-query"),
+            "query still renders when maintain is disabled under per-role credentials"
         );
         assert!(objects.maintain_deployment.is_none());
+
+        // The pass always applies gateway and query, regardless of the live
+        // state inputs, and never waits: this is a Degraded state to surface,
+        // not a wait to sit through.
         for ready in [None, Some(0), Some(1)] {
-            assert_eq!(
-                plan.apply_sequence(ready),
-                Vec::<DeploymentTier>::new(),
-                "nothing is applied for maintain readiness {ready:?}"
-            );
+            for exists in [false, true] {
+                assert_eq!(
+                    plan.apply_sequence(ready, exists),
+                    vec![DeploymentTier::Gateway, DeploymentTier::Query],
+                    "gateway and query always apply for readiness {ready:?} exists {exists}"
+                );
+                assert!(
+                    !plan.waiting_for_bootstrap(ready, exists),
+                    "unavailable is a misconfiguration to report, not a wait"
+                );
+            }
         }
         assert!(
-            !plan.waiting_for_bootstrap(None),
-            "this is a misconfiguration to report, not a wait to sit through"
+            !plan.reads_live_state(),
+            "only MaintainFirst reads live cluster state"
         );
 
         // The named reason and what its message must tell the operator to do.
@@ -2870,25 +2922,33 @@ mod tests {
         let plan = objects.gc_bootstrap;
         assert_eq!(plan.gate, GcBootstrapGate::SharedCredential);
         assert!(
-            !plan.reads_maintain_ready(),
+            !plan.reads_live_state(),
             "a single-credential cluster must cost no extra API read"
         );
-        // The order the operator has always used, independent of maintain
-        // readiness: any tier holding the shared credential can create sys/gc.
+        // The order the operator has always used, independent of both inputs:
+        // any tier holding the shared credential can create sys/gc.
         for ready in [None, Some(0), Some(1)] {
-            assert_eq!(
-                plan.apply_sequence(ready),
-                vec![
-                    DeploymentTier::Gateway,
-                    DeploymentTier::Query,
-                    DeploymentTier::Maintain
-                ],
-                "unchanged order for maintain readiness {ready:?}"
-            );
-            assert!(!plan.waiting_for_bootstrap(ready));
+            for exists in [false, true] {
+                assert_eq!(
+                    plan.apply_sequence(ready, exists),
+                    vec![
+                        DeploymentTier::Gateway,
+                        DeploymentTier::Query,
+                        DeploymentTier::Maintain
+                    ],
+                    "unchanged order for readiness {ready:?} exists {exists}"
+                );
+                assert!(!plan.waiting_for_bootstrap(ready, exists));
+            }
         }
-        assert!(objects.gateway_deployment.is_some());
-        assert!(objects.query_deployment.is_some());
+        assert_eq!(
+            objects.gateway_deployment.metadata.name.as_deref(),
+            Some("prod-gateway")
+        );
+        assert_eq!(
+            objects.query_deployment.metadata.name.as_deref(),
+            Some("prod-query")
+        );
 
         // Maintain off under one shared credential is unchanged too: the
         // gateway or query pod creates sys/gc with the credential it holds.
@@ -2897,11 +2957,17 @@ mod tests {
         let objects = desired_objects(&no_maintain, "prod", "default", &ctx()).expect("render");
         assert_eq!(objects.gc_bootstrap.gate, GcBootstrapGate::SharedCredential);
         assert_eq!(
-            objects.gc_bootstrap.apply_sequence(None),
+            objects.gc_bootstrap.apply_sequence(None, false),
             vec![DeploymentTier::Gateway, DeploymentTier::Query]
         );
-        assert!(objects.gateway_deployment.is_some());
-        assert!(objects.query_deployment.is_some());
+        assert_eq!(
+            objects.gateway_deployment.metadata.name.as_deref(),
+            Some("prod-gateway")
+        );
+        assert_eq!(
+            objects.query_deployment.metadata.name.as_deref(),
+            Some("prod-query")
+        );
         assert!(objects.maintain_deployment.is_none());
     }
 
@@ -4079,18 +4145,12 @@ mod tests {
             assert!(objects.router_role_binding.is_none());
             // Every other tier still renders.
             assert_eq!(
-                objects
-                    .gateway_deployment
-                    .as_ref()
-                    .and_then(|d| d.metadata.name.as_deref()),
+                objects.gateway_deployment.metadata.name.as_deref(),
                 Some("prod-gateway"),
                 "gateway still renders when the router render fails"
             );
             assert_eq!(
-                objects
-                    .query_deployment
-                    .as_ref()
-                    .and_then(|d| d.metadata.name.as_deref()),
+                objects.query_deployment.metadata.name.as_deref(),
                 Some("prod-query"),
                 "query still renders when the router render fails"
             );


### PR DESCRIPTION
Every ravel-server mode creates `sys/gc` if it is absent and then validates against it at startup, but under the per-role storage credentials only the Maintain and Admin roles hold a write grant on it. The operator applied the gateway and query Deployments before maintain with no ordering, so on a fresh bucket with per-role Secrets both request-serving tiers crash-looped until the first maintain pod had created the object, and with `maintain.enabled: false` nothing ever created it.

The reconcile pass now derives an apply order from the spec. With one shared credential nothing changes and no extra API call is made. With any per-mode `credentialsSecretRef` and maintain enabled, a fresh cluster applies maintain first and holds gateway and query until maintain reports a ready replica, recording `Available=False` with reason `WaitingForGcBootstrap` and `Degraded=False` and requeuing every 10 seconds; the hold applies only while neither request-serving Deployment exists yet, so a running cluster keeps reconciling both tiers through a maintain rollout or outage. With maintain disabled under per-role Secrets the operator still applies both tiers and records `Degraded=True` with reason `GcBootstrapUnavailable` until one of them reports ready, which happens once `sys/gc` is created out of band with the Admin credential. Tests pin the exact apply sequence for every gate and input, and the status shapes for the hold, the unavailable case, and its clearing.

The Kubernetes guide describes the ordering and conditions; the configuration guide no longer tells operators to create `sys/gc` by hand before applying the resource. The operator still renders no GC-horizon fields, so a bucket whose stored horizon or grace differs from the shipped defaults refuses its maintain pods; that is #1083.

Fixes: #1082