### PR TITLE
fix(maintain): hold a superseded input while a HEAD-named part still resolves it

### DIFF
--- a/crates/ravel-maintain/src/lib.rs
+++ b/crates/ravel-maintain/src/lib.rs
@@ -52,6 +52,7 @@ pub mod migrate;
 pub mod provision_audit;
 pub mod publish;
 pub mod query_audit;
+pub mod reachability;
 pub mod read;
 pub mod request_ledger;
 pub mod retention;
@@ -121,8 +122,8 @@ pub use scrub::{
 };
 pub use sweep::{
     CatalogSweepOutcome, ErasureRequestSweepOutcome, IdemSweepOutcome, LeaseCheck, NoLeases,
-    OrphanSweepOutcome, SweepReport, sweep_erasure_requests, sweep_idempotency_markers,
-    sweep_orphans, sweep_shard, sweep_shard_zoned, sweep_superseded,
+    OrphanSweepOutcome, SupersededSweepOutcome, SweepReport, sweep_erasure_requests,
+    sweep_idempotency_markers, sweep_orphans, sweep_shard, sweep_shard_zoned, sweep_superseded,
     sweep_unreferenced_catalog_objects, sweep_unreferenced_parts,
 };
 

--- a/crates/ravel-maintain/src/lib.rs
+++ b/crates/ravel-maintain/src/lib.rs
@@ -121,10 +121,12 @@ pub use scrub::{
     advance_cursor, per_tick_byte_budget, scrub_one_object,
 };
 pub use sweep::{
-    CatalogSweepOutcome, ErasureRequestSweepOutcome, IdemSweepOutcome, LeaseCheck, NoLeases,
-    OrphanSweepOutcome, SupersededSweepOutcome, SweepReport, sweep_erasure_requests,
-    sweep_idempotency_markers, sweep_orphans, sweep_shard, sweep_shard_zoned, sweep_superseded,
-    sweep_unreferenced_catalog_objects, sweep_unreferenced_parts,
+    CatalogSweepOutcome, ErasureRequestSweepOutcome, HeldBucket, IdemSweepOutcome, LeaseCheck,
+    NoLeases, OrphanSweepOutcome, SupersededHolds, SupersededSweepOutcome, SweepReport,
+    sweep_erasure_requests, sweep_erasure_requests_with_holds, sweep_idempotency_markers,
+    sweep_orphans, sweep_shard, sweep_shard_with_holds, sweep_shard_zoned,
+    sweep_shard_zoned_with_holds, sweep_superseded, sweep_unreferenced_catalog_objects,
+    sweep_unreferenced_parts,
 };
 
 #[cfg(test)]

--- a/crates/ravel-maintain/src/reachability.rs
+++ b/crates/ravel-maintain/src/reachability.rs
@@ -26,7 +26,7 @@
 //! `(tenant, signal)` never pays a HEAD GET per candidate (ADR-0076 request
 //! cost).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use ravel_catalog::{DecodedPart, PartLimits, decode_head, decode_part};
@@ -76,7 +76,7 @@ pub(crate) enum SnapshotGate {
 /// `writer_epoch` carries the `part_index` (crates/ravel-catalog's
 /// `build_l1_snapshot_entry`). [`snapshot_object`] is the one place that
 /// convention is read here.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum SnapshotObject {
     /// A raw L0 flush: the `(writer_id, epoch, seq)` identity its commit
     /// record and its data object share.
@@ -184,7 +184,7 @@ impl SnapshotReachability {
         store: &dyn ObjectStoreBackend,
         bucket: &Bucket,
     ) -> Result<SnapshotGate> {
-        let covering = match self
+        let (covering, skipped) = match self
             .covering_parts(
                 store,
                 &bucket.tenant_hash,
@@ -195,7 +195,7 @@ impl SnapshotReachability {
         {
             Covering::Clear => return Ok(SnapshotGate::Clear),
             Covering::Blocked(reason) => return Ok(SnapshotGate::Blocked(reason)),
-            Covering::Parts(parts) => parts,
+            Covering::Parts { covering, skipped } => (covering, skipped),
         };
 
         for part_ref in &covering {
@@ -216,7 +216,7 @@ impl SnapshotReachability {
                 }
             }
         }
-        Ok(SnapshotGate::Clear)
+        self.clear_or_block_on_skipped(store, &skipped).await
     }
 
     /// Whether the live HEAD snapshot still names any of `objects`, all of
@@ -229,6 +229,11 @@ impl SnapshotReachability {
     /// Same three answers, same cache, same fail-closed direction. An empty
     /// `objects` is [`SnapshotGate::Clear`] without reading anything, so a pass
     /// with no delete candidate issues no HEAD GET at all.
+    ///
+    /// `objects` is indexed into a set once per call, so the cost is one hash
+    /// lookup per snapshot entry rather than a scan of every candidate: a group
+    /// holding a long supersession chain gates in time linear in the covering
+    /// parts' entry count, not in its product with the group's size.
     pub(crate) async fn object_gate(
         &mut self,
         store: &dyn ObjectStoreBackend,
@@ -240,13 +245,14 @@ impl SnapshotReachability {
         if objects.is_empty() {
             return Ok(SnapshotGate::Clear);
         }
-        let covering = match self
+        let wanted: HashSet<SnapshotObject> = objects.iter().copied().collect();
+        let (covering, skipped) = match self
             .covering_parts(store, tenant, signal, ingest_hour_bucket)
             .await?
         {
             Covering::Clear => return Ok(SnapshotGate::Clear),
             Covering::Blocked(reason) => return Ok(SnapshotGate::Blocked(reason)),
-            Covering::Parts(parts) => parts,
+            Covering::Parts { covering, skipped } => (covering, skipped),
         };
 
         for part_ref in &covering {
@@ -259,18 +265,46 @@ impl SnapshotReachability {
                     // fail-closed answer an unreadable part gets.
                     return Ok(SnapshotGate::Blocked(SnapshotBlock::Unreadable));
                 };
-                if objects.contains(&named) {
+                if wanted.contains(&named) {
                     return Ok(SnapshotGate::Blocked(SnapshotBlock::Named));
                 }
+            }
+        }
+        self.clear_or_block_on_skipped(store, &skipped).await
+    }
+
+    /// The last step of both gates, reached only when every covering part came
+    /// back clear and the gate is about to permit a delete: prove that the
+    /// parts the hour-range filter skipped really were outside the hour.
+    ///
+    /// [`Self::covering_parts`] reads each part's range from the HEAD-level
+    /// reference, not from the part itself. A reference whose declared range is
+    /// narrower than the part it names would silently exclude a part that does
+    /// hold entries for the gated hour, so a skip is only sound once
+    /// [`Self::ensure_part`] has confirmed the two agree; it returns `None`
+    /// when they do not, and that is the fail-closed answer here too.
+    ///
+    /// Done last, and only on the clearing path, so the ordinary held pass
+    /// still reads nothing beyond HEAD and the covering parts: a delete this
+    /// pass would not have performed anyway never pays for the proof.
+    async fn clear_or_block_on_skipped(
+        &mut self,
+        store: &dyn ObjectStoreBackend,
+        skipped: &[SnapshotPartRef],
+    ) -> Result<SnapshotGate> {
+        for part_ref in skipped {
+            if self.ensure_part(store, part_ref).await?.is_none() {
+                return Ok(SnapshotGate::Blocked(SnapshotBlock::Unreadable));
             }
         }
         Ok(SnapshotGate::Clear)
     }
 
-    /// Load HEAD once for the pass and return the part refs whose hour range
-    /// covers `ingest_hour_bucket`, or the terminal answer when HEAD is absent
-    /// or unreadable. The refs are owned clones so the borrow of `self.head` is
-    /// released before the callers' part loads borrow `self` mutably.
+    /// Load HEAD once for the pass and split its part refs into the ones whose
+    /// declared hour range covers `ingest_hour_bucket` and the ones it does
+    /// not, or return the terminal answer when HEAD is absent or unreadable.
+    /// The refs are owned clones so the borrow of `self.head` is released
+    /// before the callers' part loads borrow `self` mutably.
     async fn covering_parts(
         &mut self,
         store: &dyn ObjectStoreBackend,
@@ -282,16 +316,12 @@ impl SnapshotReachability {
             HeadStatus::Absent => Ok(Covering::Clear),
             HeadStatus::Unreadable => Ok(Covering::Blocked(SnapshotBlock::Unreadable)),
             HeadStatus::Present => match &self.head {
-                Some(HeadLoad::Present(head)) => Ok(Covering::Parts(
-                    head.parts
-                        .iter()
-                        .filter(|p| {
-                            p.min_hour <= ingest_hour_bucket
-                                && ingest_hour_bucket <= p.watermark_hour
-                        })
-                        .cloned()
-                        .collect(),
-                )),
+                Some(HeadLoad::Present(head)) => {
+                    let (covering, skipped) = head.parts.iter().cloned().partition(|p| {
+                        p.min_hour <= ingest_hour_bucket && ingest_hour_bucket <= p.watermark_hour
+                    });
+                    Ok(Covering::Parts { covering, skipped })
+                }
                 // Unreachable after `ensure_head` returned `Present`; block
                 // fail-closed rather than panic (no unwrap/expect on a
                 // production path).
@@ -340,10 +370,19 @@ impl SnapshotReachability {
         })
     }
 
-    /// Load, verify (blake3 against the HEAD ref), and decode one snapshot part
-    /// once per pass, caching the result. `Ok(None)` is the fail-closed
-    /// "present but unreadable" case (a missing HEAD-named part, a hash
+    /// Load, verify (blake3 against the HEAD ref, and the ref's hour range
+    /// against the decoded header's), and decode one snapshot part once per
+    /// pass, caching the result. `Ok(None)` is the fail-closed "present but
+    /// unreadable" case (a missing HEAD-named part, a hash mismatch, a bounds
     /// mismatch, or a decode failure); a transient store fault propagates.
+    ///
+    /// The bounds check is what makes [`Self::covering_parts`]' range filter
+    /// safe to trust. That filter skips every part whose
+    /// `[min_hour, watermark_hour]` excludes the hour being gated, reading
+    /// those bounds from the HEAD-level reference; a reference whose range is
+    /// narrower than the part it names would then let the gate skip a part
+    /// that does name the candidate, and clear a delete the snapshot still
+    /// reaches.
     async fn ensure_part(
         &mut self,
         store: &dyn ObjectStoreBackend,
@@ -366,6 +405,21 @@ impl SnapshotReachability {
                         max_snapshot_part_bytes: ravel_catalog::DEFAULT_MAX_SNAPSHOT_PART_BYTES,
                     };
                     match decode_part(data.as_ref(), &limits) {
+                        Ok(part)
+                            if part.header.min_hour != part_ref.min_hour
+                                || part.header.watermark_hour != part_ref.watermark_hour =>
+                        {
+                            tracing::warn!(
+                                key = %part_ref.key,
+                                ref_min_hour = part_ref.min_hour,
+                                ref_watermark_hour = part_ref.watermark_hour,
+                                header_min_hour = part.header.min_hour,
+                                header_watermark_hour = part.header.watermark_hour,
+                                "maintain sweep: snapshot part reference range disagrees with the \
+                                 part header; blocking deletes fail-closed"
+                            );
+                            None
+                        }
                         Ok(part) => Some(Arc::new(part)),
                         Err(err) => {
                             tracing::warn!(
@@ -404,8 +458,14 @@ enum Covering {
     Clear,
     /// HEAD itself decided the answer (unreadable).
     Blocked(SnapshotBlock),
-    /// The HEAD-named parts whose hour range covers the requested hour.
-    Parts(Vec<SnapshotPartRef>),
+    /// The HEAD-named parts split by the declared hour range: `covering` is
+    /// read for entries naming the candidate, `skipped` only has its declared
+    /// range checked against the part header, and only when the gate is
+    /// otherwise about to clear.
+    Parts {
+        covering: Vec<SnapshotPartRef>,
+        skipped: Vec<SnapshotPartRef>,
+    },
 }
 
 /// Lightweight status returned by [`SnapshotReachability::ensure_head`], so the
@@ -421,8 +481,8 @@ enum HeadStatus {
 /// `t/<tenant_hash_hex>/catalog/<signal>/HEAD` -- the mutable head pointer for
 /// one `(tenant, signal)` (docs/catalog-and-mvcc.md key layout, a frozen
 /// contract). No public builder is exported from ravel-catalog, so it is
-/// constructed here from the same pieces, matching `sweep.rs`'s
-/// `catalog_head_key` precedent.
-fn catalog_head_key(tenant: &TenantHash, signal: Signal) -> String {
+/// constructed here from the same pieces. This is the crate's only copy; the
+/// catalog-object sweep in [`crate::sweep`] uses it too.
+pub(crate) fn catalog_head_key(tenant: &TenantHash, signal: Signal) -> String {
     format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
 }

--- a/crates/ravel-maintain/src/reachability.rs
+++ b/crates/ravel-maintain/src/reachability.rs
@@ -1,0 +1,428 @@
+//! The HEAD-reachability delete blocker (ADR-0020), shared by every physical
+//! delete that can race a fold.
+//!
+//! A snapshot the live `(tenant, signal)` HEAD names is what a resolver reads;
+//! the protection horizon bounds a *pinned in-flight reader*, but it does not
+//! on its own prove the *current* HEAD has stopped naming an object. Both the
+//! retention sweep (whole tombstoned buckets) and the superseded-input sweep
+//! (a compaction or rewrite record's inputs) therefore ask the same question
+//! before deleting: does the live HEAD snapshot still reach this object?
+//!
+//! The three answers are fixed and identical for both callers:
+//!
+//! - **HEAD absent**: no snapshot names anything, so nothing is blocked
+//!   (ADR-0020: the catalog index is a pure optimization; a missing HEAD
+//!   degrades to listing).
+//! - **HEAD, or a covering snapshot part, present but unreadable**: blocked
+//!   fail-closed. Non-reachability cannot be proven from data that cannot be
+//!   read, and a wrongly-permitted delete is unrecoverable while a delayed one
+//!   is not.
+//! - **A decoded snapshot entry names the object**: blocked. The ordinary
+//!   lagging-fold case.
+//!
+//! [`SnapshotReachability`] is the per-pass cache that keeps this affordable:
+//! HEAD is read at most once per pass and each covering part at most once, so
+//! a pass that gates many buckets or many superseded inputs of one
+//! `(tenant, signal)` never pays a HEAD GET per candidate (ADR-0076 request
+//! cost).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ravel_catalog::{DecodedPart, PartLimits, decode_head, decode_part};
+use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
+use ravel_proto::catalog::v1::{SnapshotEntry, SnapshotHead, SnapshotPartRef};
+use ravel_types::{Signal, TenantHash};
+
+use crate::bucket::Bucket;
+use crate::error::{MaintainError, Result};
+
+/// Why a physical delete was blocked by HEAD reachability (ADR-0020
+/// delete-blocker). Both variants delete nothing; they are distinguished so
+/// each is separately observable in the maintain counters (a persistent
+/// [`SnapshotBlock::Unreadable`] is an operator signal that HEAD or a part
+/// cannot be read, not the ordinary lagging-fold case).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotBlock {
+    /// A decoded snapshot entry names an object the delete would remove: the
+    /// bucket it sits in (retention) or the object itself (superseded inputs).
+    /// The ordinary case: the fold has not yet reconciled the hour.
+    Named,
+    /// HEAD, or a snapshot part covering the relevant hour, was present but
+    /// could not be read (undecodable, checksum/hash mismatch, unsupported
+    /// version, an entry whose identity fields do not fit the shape a fold
+    /// writes, or a HEAD-named part that is missing). Blocked fail-closed:
+    /// non-reachability cannot be proven from data that cannot be read, and a
+    /// wrongly-permitted delete is unrecoverable while a delayed one is not.
+    Unreadable,
+}
+
+/// The result of gating one delete candidate on HEAD reachability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnapshotGate {
+    /// No snapshot entry names the candidate: the delete may proceed.
+    Clear,
+    /// The delete is blocked; the reason distinguishes the counters.
+    Blocked(SnapshotBlock),
+}
+
+/// The identity of one physical object exactly as a snapshot entry carries it,
+/// so "does the live HEAD still name this object" is decided without
+/// reconstructing key strings on either side.
+///
+/// The frozen `SnapshotEntry` has no dedicated level-1 identity field, so the
+/// fold overloads the writer slots for a compaction or rewrite output part:
+/// `writer_id` carries the parent record's 32-byte `input_set_hash` and
+/// `writer_epoch` carries the `part_index` (crates/ravel-catalog's
+/// `build_l1_snapshot_entry`). [`snapshot_object`] is the one place that
+/// convention is read here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnapshotObject {
+    /// A raw L0 flush: the `(writer_id, epoch, seq)` identity its commit
+    /// record and its data object share.
+    L0 {
+        shard: u32,
+        ingest_hour_bucket: u32,
+        writer_id: [u8; 16],
+        writer_epoch: u64,
+        writer_seq: u64,
+    },
+    /// A compaction or rewrite output part: its parent record's input-set hash
+    /// plus its own part index.
+    L1 {
+        shard: u32,
+        ingest_hour_bucket: u32,
+        input_set_hash: [u8; 32],
+        part_index: u32,
+    },
+}
+
+/// Read one decoded snapshot entry's object identity, or `None` if its
+/// identity fields do not fit the shape a fold writes (a 16-byte `writer_id`
+/// at level 0, a 32-byte `input_set_hash` and a `u32`-ranged `part_index`
+/// above it). `None` is a fail-closed signal, never "does not match": an entry
+/// whose identity cannot be read cannot be proven not to name the candidate.
+fn snapshot_object(entry: &SnapshotEntry) -> Option<SnapshotObject> {
+    if entry.level == 0 {
+        let writer_id: [u8; 16] = entry.writer_id.as_slice().try_into().ok()?;
+        Some(SnapshotObject::L0 {
+            shard: entry.shard,
+            ingest_hour_bucket: entry.ingest_hour_bucket,
+            writer_id,
+            writer_epoch: entry.writer_epoch,
+            writer_seq: entry.writer_seq,
+        })
+    } else {
+        let input_set_hash: [u8; 32] = entry.writer_id.as_slice().try_into().ok()?;
+        let part_index = u32::try_from(entry.writer_epoch).ok()?;
+        Some(SnapshotObject::L1 {
+            shard: entry.shard,
+            ingest_hour_bucket: entry.ingest_hour_bucket,
+            input_set_hash,
+            part_index,
+        })
+    }
+}
+
+/// Per-sweep-pass cache of the catalog HEAD and the snapshot parts it names,
+/// so a pass that gates many candidates of one `(tenant, signal)` reads HEAD at
+/// most once and each covering part at most once, rather than once per
+/// candidate (a per-candidate HEAD GET would be an S3-request-cost regression
+/// against the live cost-reduction epic, ADR-0076). A retention pass creates
+/// one per [`crate::scan::scan_and_maintain_with_memo`] call and threads it
+/// through [`crate::retention::maintain_bucket_with_reach`]; the
+/// superseded-input sweep creates one per pass. The public entry points
+/// ([`crate::retention::maintain_bucket`],
+/// [`crate::retention::retention_sweep_bucket`],
+/// [`crate::sweep::sweep_superseded`]) create a fresh one per call.
+///
+/// The cache is read-once-per-pass, not a durable cache. For retention it is
+/// safe precisely because a retention tombstone is irreversible (ADR-0019
+/// decision 2), so a bucket the fold has already dropped from HEAD is never
+/// re-added. For superseded inputs it is safe because a fold never starts
+/// naming an input a published compaction or rewrite record already
+/// superseded. In both directions a HEAD read that DOES name the candidate
+/// only ever delays a delete by one pass, the fail-safe direction.
+#[derive(Default)]
+pub struct SnapshotReachability {
+    head: Option<HeadLoad>,
+    /// Decoded snapshot parts by object key. `None` = present but unreadable
+    /// (fail-closed); `Some` = decoded and usable.
+    parts: HashMap<String, Option<Arc<DecodedPart>>>,
+}
+
+/// The catalog HEAD as read once for a sweep pass.
+enum HeadLoad {
+    /// HEAD is absent: no snapshot names anything, so nothing is blocked
+    /// (ADR-0020: the index is a pure optimization; a missing HEAD degrades to
+    /// listing).
+    Absent,
+    /// HEAD is present but undecodable (or a newer format this build cannot
+    /// read): fail-closed, every candidate is blocked.
+    Unreadable,
+    /// HEAD is present and decoded. Boxed so this large variant does not
+    /// inflate every `HeadLoad` (`clippy::large_enum_variant`): `SnapshotHead`
+    /// grew past 300 bytes when ADR-0850 added `column_stats`, while the other
+    /// variants are unit-sized.
+    Present(Box<SnapshotHead>),
+}
+
+impl SnapshotReachability {
+    /// A fresh, empty cache for one sweep pass.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the live HEAD snapshot still reaches an object inside `bucket`
+    /// (ADR-0020 delete-blocker). HEAD and each covering part are loaded at
+    /// most once per pass and cached. HEAD absent -> [`SnapshotGate::Clear`];
+    /// HEAD or any covering part unreadable -> fail-closed
+    /// [`SnapshotBlock::Unreadable`]; a decoded entry naming this bucket's
+    /// shard+hour -> [`SnapshotBlock::Named`].
+    pub(crate) async fn bucket_gate(
+        &mut self,
+        store: &dyn ObjectStoreBackend,
+        bucket: &Bucket,
+    ) -> Result<SnapshotGate> {
+        let covering = match self
+            .covering_parts(
+                store,
+                &bucket.tenant_hash,
+                bucket.signal,
+                bucket.ingest_hour_bucket,
+            )
+            .await?
+        {
+            Covering::Clear => return Ok(SnapshotGate::Clear),
+            Covering::Blocked(reason) => return Ok(SnapshotGate::Blocked(reason)),
+            Covering::Parts(parts) => parts,
+        };
+
+        for part_ref in &covering {
+            match self.ensure_part(store, part_ref).await? {
+                // A covering part could not be read: cannot prove
+                // non-reachability, fail closed.
+                None => return Ok(SnapshotGate::Blocked(SnapshotBlock::Unreadable)),
+                Some(part) => {
+                    // An object is physically inside this bucket iff its entry's
+                    // shard and ingest hour match the bucket. Any such entry
+                    // means the snapshot still names an object the sweep would
+                    // delete.
+                    if part.entries.iter().any(|e| {
+                        e.shard == bucket.shard && e.ingest_hour_bucket == bucket.ingest_hour_bucket
+                    }) {
+                        return Ok(SnapshotGate::Blocked(SnapshotBlock::Named));
+                    }
+                }
+            }
+        }
+        Ok(SnapshotGate::Clear)
+    }
+
+    /// Whether the live HEAD snapshot still names any of `objects`, all of
+    /// which sit in `ingest_hour_bucket`. The object-granular counterpart of
+    /// [`Self::bucket_gate`]: the superseded-input sweep deletes individual
+    /// objects out of a bucket whose other objects (the compaction or rewrite
+    /// outputs that superseded them) the snapshot legitimately still names, so
+    /// a bucket-granular question would block it forever.
+    ///
+    /// Same three answers, same cache, same fail-closed direction. An empty
+    /// `objects` is [`SnapshotGate::Clear`] without reading anything, so a pass
+    /// with no delete candidate issues no HEAD GET at all.
+    pub(crate) async fn object_gate(
+        &mut self,
+        store: &dyn ObjectStoreBackend,
+        tenant: &TenantHash,
+        signal: Signal,
+        ingest_hour_bucket: u32,
+        objects: &[SnapshotObject],
+    ) -> Result<SnapshotGate> {
+        if objects.is_empty() {
+            return Ok(SnapshotGate::Clear);
+        }
+        let covering = match self
+            .covering_parts(store, tenant, signal, ingest_hour_bucket)
+            .await?
+        {
+            Covering::Clear => return Ok(SnapshotGate::Clear),
+            Covering::Blocked(reason) => return Ok(SnapshotGate::Blocked(reason)),
+            Covering::Parts(parts) => parts,
+        };
+
+        for part_ref in &covering {
+            let Some(part) = self.ensure_part(store, part_ref).await? else {
+                return Ok(SnapshotGate::Blocked(SnapshotBlock::Unreadable));
+            };
+            for entry in &part.entries {
+                let Some(named) = snapshot_object(entry) else {
+                    // An entry whose identity fields cannot be read: the same
+                    // fail-closed answer an unreadable part gets.
+                    return Ok(SnapshotGate::Blocked(SnapshotBlock::Unreadable));
+                };
+                if objects.contains(&named) {
+                    return Ok(SnapshotGate::Blocked(SnapshotBlock::Named));
+                }
+            }
+        }
+        Ok(SnapshotGate::Clear)
+    }
+
+    /// Load HEAD once for the pass and return the part refs whose hour range
+    /// covers `ingest_hour_bucket`, or the terminal answer when HEAD is absent
+    /// or unreadable. The refs are owned clones so the borrow of `self.head` is
+    /// released before the callers' part loads borrow `self` mutably.
+    async fn covering_parts(
+        &mut self,
+        store: &dyn ObjectStoreBackend,
+        tenant: &TenantHash,
+        signal: Signal,
+        ingest_hour_bucket: u32,
+    ) -> Result<Covering> {
+        match self.ensure_head(store, tenant, signal).await? {
+            HeadStatus::Absent => Ok(Covering::Clear),
+            HeadStatus::Unreadable => Ok(Covering::Blocked(SnapshotBlock::Unreadable)),
+            HeadStatus::Present => match &self.head {
+                Some(HeadLoad::Present(head)) => Ok(Covering::Parts(
+                    head.parts
+                        .iter()
+                        .filter(|p| {
+                            p.min_hour <= ingest_hour_bucket
+                                && ingest_hour_bucket <= p.watermark_hour
+                        })
+                        .cloned()
+                        .collect(),
+                )),
+                // Unreachable after `ensure_head` returned `Present`; block
+                // fail-closed rather than panic (no unwrap/expect on a
+                // production path).
+                _ => Ok(Covering::Blocked(SnapshotBlock::Unreadable)),
+            },
+        }
+    }
+
+    /// Load HEAD once for the pass, caching the result. Returns a lightweight
+    /// status; the decoded HEAD itself stays in `self.head` for the covering
+    /// part-ref extraction in [`Self::covering_parts`].
+    async fn ensure_head(
+        &mut self,
+        store: &dyn ObjectStoreBackend,
+        tenant: &TenantHash,
+        signal: Signal,
+    ) -> Result<HeadStatus> {
+        if self.head.is_none() {
+            let head_key = catalog_head_key(tenant, signal);
+            let load = match store.get(&head_key, GetRange::Full).await {
+                Ok(got) => match decode_head(got.data.as_ref()) {
+                    Ok(head) => HeadLoad::Present(Box::new(head)),
+                    Err(err) => {
+                        // Present but undecodable/newer: fail-closed. Cannot
+                        // prove non-reachability from a HEAD we cannot read.
+                        tracing::warn!(
+                            error = %err,
+                            key = %head_key,
+                            "maintain sweep: catalog HEAD failed to decode; blocking deletes \
+                             fail-closed this pass rather than proving non-reachability from an \
+                             unreadable HEAD"
+                        );
+                        HeadLoad::Unreadable
+                    }
+                },
+                Err(StoreError::NotFound) => HeadLoad::Absent,
+                Err(err) => return Err(MaintainError::Store(err)),
+            };
+            self.head = Some(load);
+        }
+        Ok(match &self.head {
+            Some(HeadLoad::Absent) => HeadStatus::Absent,
+            Some(HeadLoad::Unreadable) => HeadStatus::Unreadable,
+            Some(HeadLoad::Present(_)) => HeadStatus::Present,
+            None => HeadStatus::Unreadable,
+        })
+    }
+
+    /// Load, verify (blake3 against the HEAD ref), and decode one snapshot part
+    /// once per pass, caching the result. `Ok(None)` is the fail-closed
+    /// "present but unreadable" case (a missing HEAD-named part, a hash
+    /// mismatch, or a decode failure); a transient store fault propagates.
+    async fn ensure_part(
+        &mut self,
+        store: &dyn ObjectStoreBackend,
+        part_ref: &SnapshotPartRef,
+    ) -> Result<Option<Arc<DecodedPart>>> {
+        if let Some(cached) = self.parts.get(&part_ref.key) {
+            return Ok(cached.clone());
+        }
+        let load: Option<Arc<DecodedPart>> = match store.get(&part_ref.key, GetRange::Full).await {
+            Ok(got) => {
+                let data = got.data;
+                if blake3::hash(&data).as_bytes().as_slice() != part_ref.blake3.as_slice() {
+                    tracing::warn!(
+                        key = %part_ref.key,
+                        "maintain sweep: snapshot part hash mismatch; blocking deletes fail-closed"
+                    );
+                    None
+                } else {
+                    let limits = PartLimits {
+                        max_snapshot_part_bytes: ravel_catalog::DEFAULT_MAX_SNAPSHOT_PART_BYTES,
+                    };
+                    match decode_part(data.as_ref(), &limits) {
+                        Ok(part) => Some(Arc::new(part)),
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err,
+                                key = %part_ref.key,
+                                "maintain sweep: snapshot part failed to decode; blocking deletes \
+                                 fail-closed"
+                            );
+                            None
+                        }
+                    }
+                }
+            }
+            // HEAD names a part that is not present. Anomalous (a HEAD-named
+            // part is only deleted after HEAD stops naming it plus the
+            // horizon): cannot read its entries, so fail closed.
+            Err(StoreError::NotFound) => {
+                tracing::warn!(
+                    key = %part_ref.key,
+                    "maintain sweep: HEAD-named snapshot part is missing; blocking deletes \
+                     fail-closed"
+                );
+                None
+            }
+            Err(err) => return Err(MaintainError::Store(err)),
+        };
+        self.parts.insert(part_ref.key.clone(), load.clone());
+        Ok(load)
+    }
+}
+
+/// What [`SnapshotReachability::covering_parts`] resolved for one hour: either
+/// a terminal gate answer that needs no part reads, or the parts to inspect.
+enum Covering {
+    /// HEAD is absent: nothing is blocked.
+    Clear,
+    /// HEAD itself decided the answer (unreadable).
+    Blocked(SnapshotBlock),
+    /// The HEAD-named parts whose hour range covers the requested hour.
+    Parts(Vec<SnapshotPartRef>),
+}
+
+/// Lightweight status returned by [`SnapshotReachability::ensure_head`], so the
+/// decoded HEAD can stay owned in the cache while the caller decides how to
+/// proceed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeadStatus {
+    Absent,
+    Unreadable,
+    Present,
+}
+
+/// `t/<tenant_hash_hex>/catalog/<signal>/HEAD` -- the mutable head pointer for
+/// one `(tenant, signal)` (docs/catalog-and-mvcc.md key layout, a frozen
+/// contract). No public builder is exported from ravel-catalog, so it is
+/// constructed here from the same pieces, matching `sweep.rs`'s
+/// `catalog_head_key` precedent.
+fn catalog_head_key(tenant: &TenantHash, signal: Signal) -> String {
+    format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
+}

--- a/crates/ravel-maintain/src/retention.rs
+++ b/crates/ravel-maintain/src/retention.rs
@@ -33,27 +33,28 @@
 //! declines when it lists a tombstone, but ADR-0019 calls that "an efficiency
 //! measure only": its absence would only waste work, never corrupt data.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use prost::Message;
-use ravel_catalog::{DecodedPart, PartLimits, decode_head, decode_part};
 use ravel_commit::keys;
 use ravel_commit::record;
 use ravel_object_store::{
     GetRange, ObjectStoreBackend, PutOptions, StoreError, UploadChecksum, list_all,
 };
-use ravel_proto::catalog::v1::{SnapshotHead, SnapshotPartRef};
 use ravel_proto::commit::v1::{CommitRecord, CompactionRecord, RetentionTombstone};
-use ravel_types::{Signal, TenantHash};
 
 use crate::bucket::Bucket;
 use crate::clock::Clock;
 use crate::compact::{CompactionOutcome, compact_bucket};
 use crate::config::{CompactorConfig, RetentionConfig};
 use crate::error::{MaintainError, Result};
+use crate::reachability::SnapshotGate;
 use crate::read::{BucketListing, list_bucket, verify_commit_key};
 use crate::sweep::LeaseCheck;
+
+/// The HEAD-reachability delete blocker, shared with the superseded-input
+/// sweep (see [`crate::reachability`]). Re-exported at this path because
+/// retention was its first caller and the maintain crate's public surface
+/// names it here.
+pub use crate::reachability::{SnapshotBlock, SnapshotReachability};
 
 /// The outcome of one retention pass over a bucket.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,258 +85,6 @@ pub enum RetentionOutcome {
     /// retention-frontier reconcile, crates/ravel-catalog). The [`SnapshotBlock`]
     /// says why the block fired.
     BlockedBySnapshot(SnapshotBlock),
-}
-
-/// Why the physical sweep was blocked by HEAD reachability (ADR-0020
-/// delete-blocker). Both variants leave the tombstone in place and delete
-/// nothing; they are distinguished so each is separately observable in the
-/// maintain counters (a persistent [`SnapshotBlock::Unreadable`] is an
-/// operator signal that HEAD or a part cannot be read, not the ordinary
-/// lagging-fold case).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SnapshotBlock {
-    /// A decoded snapshot entry names an object physically inside this bucket
-    /// (same shard and ingest hour). The ordinary case: the fold has not yet
-    /// dropped the tombstoned bucket from the snapshot.
-    Named,
-    /// HEAD, or a snapshot part covering this bucket's hour, was present but
-    /// could not be read (undecodable, checksum/hash mismatch, unsupported
-    /// version, or a HEAD-named part that is missing). Blocked fail-closed:
-    /// non-reachability cannot be proven from data that cannot be read, and a
-    /// wrongly-permitted delete is unrecoverable while a delayed one is not
-    /// (deliverable 3).
-    Unreadable,
-}
-
-/// Per-sweep-pass cache of the catalog HEAD and the snapshot parts it names,
-/// so a retention pass that walks many buckets of one `(tenant, signal)` reads
-/// HEAD at most once and each covering part at most once, rather than once per
-/// bucket (a per-bucket HEAD GET would be an S3-request-cost regression against
-/// the live cost-reduction epic, ADR-0076). Created once per
-/// [`crate::scan::scan_and_maintain_with_memo`] call and threaded through
-/// [`maintain_bucket_with_reach`] into [`physical_sweep`]; the public
-/// [`maintain_bucket`] / [`retention_sweep_bucket`] entry points create a fresh
-/// one per call.
-///
-/// The cache is read-once-per-pass, not a durable cache: it is safe precisely
-/// because a retention tombstone is irreversible (ADR-0019 decision 2), so a
-/// bucket the fold has already dropped from HEAD is never re-added, and a HEAD
-/// read at the start of a pass that does NOT name a bucket cannot later start
-/// naming it. A HEAD read that DOES name a bucket only ever delays a delete by
-/// one pass, the fail-safe direction.
-#[derive(Default)]
-pub struct SnapshotReachability {
-    head: Option<HeadLoad>,
-    /// Decoded snapshot parts by object key. `None` = present but unreadable
-    /// (fail-closed); `Some` = decoded and usable.
-    parts: HashMap<String, Option<Arc<DecodedPart>>>,
-}
-
-/// The catalog HEAD as read once for a sweep pass.
-enum HeadLoad {
-    /// HEAD is absent: no snapshot names anything, so no bucket is blocked
-    /// (ADR-0020: the index is a pure optimization; a missing HEAD degrades to
-    /// listing).
-    Absent,
-    /// HEAD is present but undecodable (or a newer format this build cannot
-    /// read): fail-closed, every bucket is blocked.
-    Unreadable,
-    /// HEAD is present and decoded. Boxed so this large variant does not
-    /// inflate every `HeadLoad` (`clippy::large_enum_variant`): `SnapshotHead`
-    /// grew past 300 bytes when ADR-0850 added `column_stats`, while the other
-    /// variants are unit-sized.
-    Present(Box<SnapshotHead>),
-}
-
-/// The result of gating one bucket on HEAD reachability.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SnapshotGate {
-    /// No snapshot entry names an object in this bucket: the sweep may proceed.
-    Clear,
-    /// The sweep is blocked; the reason distinguishes the counters.
-    Blocked(SnapshotBlock),
-}
-
-impl SnapshotReachability {
-    /// A fresh, empty cache for one sweep pass.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Whether the live HEAD snapshot still reaches an object inside `bucket`
-    /// (ADR-0020 delete-blocker). HEAD and each covering part are loaded at
-    /// most once per pass and cached. HEAD absent -> [`SnapshotGate::Clear`];
-    /// HEAD or any covering part unreadable -> fail-closed
-    /// [`SnapshotBlock::Unreadable`]; a decoded entry naming this bucket's
-    /// shard+hour -> [`SnapshotBlock::Named`].
-    async fn bucket_gate(
-        &mut self,
-        store: &dyn ObjectStoreBackend,
-        bucket: &Bucket,
-    ) -> Result<SnapshotGate> {
-        // Load HEAD once, then take the covering part refs out (owned clones)
-        // so the borrow of `self.head` is released before the part loads below
-        // borrow `self` mutably.
-        let covering: Vec<SnapshotPartRef> = match self
-            .ensure_head(store, &bucket.tenant_hash, bucket.signal)
-            .await?
-        {
-            HeadStatus::Absent => return Ok(SnapshotGate::Clear),
-            HeadStatus::Unreadable => {
-                return Ok(SnapshotGate::Blocked(SnapshotBlock::Unreadable));
-            }
-            HeadStatus::Present => match &self.head {
-                Some(HeadLoad::Present(head)) => head
-                    .parts
-                    .iter()
-                    .filter(|p| {
-                        p.min_hour <= bucket.ingest_hour_bucket
-                            && bucket.ingest_hour_bucket <= p.watermark_hour
-                    })
-                    .cloned()
-                    .collect(),
-                // Unreachable after `ensure_head` returned `Present`; block
-                // fail-closed rather than panic (no unwrap/expect on a
-                // production path).
-                _ => return Ok(SnapshotGate::Blocked(SnapshotBlock::Unreadable)),
-            },
-        };
-
-        for part_ref in &covering {
-            match self.ensure_part(store, part_ref).await? {
-                // A covering part could not be read: cannot prove
-                // non-reachability, fail closed (deliverable 3).
-                None => return Ok(SnapshotGate::Blocked(SnapshotBlock::Unreadable)),
-                Some(part) => {
-                    // An object is physically inside this bucket iff its entry's
-                    // shard and ingest hour match the bucket. Any such entry
-                    // means the snapshot still names an object the sweep would
-                    // delete.
-                    if part.entries.iter().any(|e| {
-                        e.shard == bucket.shard && e.ingest_hour_bucket == bucket.ingest_hour_bucket
-                    }) {
-                        return Ok(SnapshotGate::Blocked(SnapshotBlock::Named));
-                    }
-                }
-            }
-        }
-        Ok(SnapshotGate::Clear)
-    }
-
-    /// Load HEAD once for the pass, caching the result. Returns a lightweight
-    /// status; the decoded HEAD itself stays in `self.head` for the covering
-    /// part-ref extraction in [`Self::bucket_gate`].
-    async fn ensure_head(
-        &mut self,
-        store: &dyn ObjectStoreBackend,
-        tenant: &TenantHash,
-        signal: Signal,
-    ) -> Result<HeadStatus> {
-        if self.head.is_none() {
-            let head_key = catalog_head_key(tenant, signal);
-            let load = match store.get(&head_key, GetRange::Full).await {
-                Ok(got) => match decode_head(got.data.as_ref()) {
-                    Ok(head) => HeadLoad::Present(Box::new(head)),
-                    Err(err) => {
-                        // Present but undecodable/newer: fail-closed. Cannot
-                        // prove non-reachability from a HEAD we cannot read.
-                        tracing::warn!(
-                            error = %err,
-                            key = %head_key,
-                            "retention sweep: catalog HEAD failed to decode; blocking deletes \
-                             fail-closed this pass rather than proving non-reachability from an \
-                             unreadable HEAD"
-                        );
-                        HeadLoad::Unreadable
-                    }
-                },
-                Err(StoreError::NotFound) => HeadLoad::Absent,
-                Err(err) => return Err(MaintainError::Store(err)),
-            };
-            self.head = Some(load);
-        }
-        Ok(match &self.head {
-            Some(HeadLoad::Absent) => HeadStatus::Absent,
-            Some(HeadLoad::Unreadable) => HeadStatus::Unreadable,
-            Some(HeadLoad::Present(_)) => HeadStatus::Present,
-            None => HeadStatus::Unreadable,
-        })
-    }
-
-    /// Load, verify (blake3 against the HEAD ref), and decode one snapshot part
-    /// once per pass, caching the result. `Ok(None)` is the fail-closed
-    /// "present but unreadable" case (a missing HEAD-named part, a hash
-    /// mismatch, or a decode failure); a transient store fault propagates.
-    async fn ensure_part(
-        &mut self,
-        store: &dyn ObjectStoreBackend,
-        part_ref: &SnapshotPartRef,
-    ) -> Result<Option<Arc<DecodedPart>>> {
-        if let Some(cached) = self.parts.get(&part_ref.key) {
-            return Ok(cached.clone());
-        }
-        let load: Option<Arc<DecodedPart>> = match store.get(&part_ref.key, GetRange::Full).await {
-            Ok(got) => {
-                let data = got.data;
-                if blake3::hash(&data).as_bytes().as_slice() != part_ref.blake3.as_slice() {
-                    tracing::warn!(
-                        key = %part_ref.key,
-                        "retention sweep: snapshot part hash mismatch; blocking deletes fail-closed"
-                    );
-                    None
-                } else {
-                    let limits = PartLimits {
-                        max_snapshot_part_bytes: ravel_catalog::DEFAULT_MAX_SNAPSHOT_PART_BYTES,
-                    };
-                    match decode_part(data.as_ref(), &limits) {
-                        Ok(part) => Some(Arc::new(part)),
-                        Err(err) => {
-                            tracing::warn!(
-                                error = %err,
-                                key = %part_ref.key,
-                                "retention sweep: snapshot part failed to decode; blocking deletes \
-                                 fail-closed"
-                            );
-                            None
-                        }
-                    }
-                }
-            }
-            // HEAD names a part that is not present. Anomalous (a HEAD-named
-            // part is only deleted after HEAD stops naming it plus the
-            // horizon): cannot read its entries, so fail closed.
-            Err(StoreError::NotFound) => {
-                tracing::warn!(
-                    key = %part_ref.key,
-                    "retention sweep: HEAD-named snapshot part is missing; blocking deletes \
-                     fail-closed"
-                );
-                None
-            }
-            Err(err) => return Err(MaintainError::Store(err)),
-        };
-        self.parts.insert(part_ref.key.clone(), load.clone());
-        Ok(load)
-    }
-}
-
-/// Lightweight status returned by [`SnapshotReachability::ensure_head`], so the
-/// decoded HEAD can stay owned in the cache while the caller decides how to
-/// proceed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HeadStatus {
-    Absent,
-    Unreadable,
-    Present,
-}
-
-/// `t/<tenant_hash_hex>/catalog/<signal>/HEAD` -- the mutable head pointer for
-/// one `(tenant, signal)` (docs/catalog-and-mvcc.md key layout, a frozen
-/// contract). No public builder is exported from ravel-catalog, so it is
-/// constructed here from the same pieces, matching `sweep.rs`'s
-/// `catalog_head_key` precedent.
-fn catalog_head_key(tenant: &TenantHash, signal: Signal) -> String {
-    format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
 }
 
 /// Run one retention pass over a single sealed bucket (ADR-0019):

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -543,18 +543,32 @@ async fn sweep_superseded_impl(
 ) -> Result<SupersededSweepOutcome> {
     let now = clock.now_ns();
     let entries = list_commit_entries_scoped(store, tenant, signal, shard, hours).await?;
+    // Every rewrite record in scope, read once for the pass, plus the set of
+    // record keys those rewrites supersede. A record another present rewrite
+    // supersedes is not processed from its own listing entry: it belongs to
+    // that rewrite's chain group, which is gated and deleted as one unit. Doing
+    // both would let the gate clear a predecessor from its own entry (where the
+    // group holds only that predecessor's outputs) while the same predecessor's
+    // raw inputs are held from another entry, which is exactly how a record
+    // could vanish ahead of the inputs it superseded.
+    let rewrites = load_rewrite_records(store, &entries).await?;
+    let superseded_by_present: HashSet<&str> = rewrites
+        .values()
+        .map(|r| r.superseded_record_key.as_str())
+        .filter(|k| !k.is_empty())
+        .collect();
 
     let mut outcome = SupersededSweepOutcome::default();
     for (key, entry) in &entries {
+        if superseded_by_present.contains(key.as_str()) {
+            continue;
+        }
         // Both a compaction record and a selective-erasure rewrite record
         // (ADR-0064 decision 3 point 6) render their superseded inputs
         // collectable by this one rule; a raw commit record or tombstone names
-        // no superseded input. The two record types are fetched NotFound-
-        // tolerantly: a rewrite whose `superseded_record_key` names a
-        // predecessor record deletes that predecessor here, and that same
-        // predecessor may also appear as its own entry in this listing, so its
-        // fetch can legitimately miss once a superseding generation processed
-        // earlier in this pass already removed it.
+        // no superseded input. A compaction record is fetched NotFound-
+        // tolerantly, and a rewrite absent from `rewrites` is skipped the same
+        // way: a crash-interrupted prior pass can leave a listed key gone.
         let groups = match entry {
             BucketEntry::CompactionRecord(_) => {
                 let Some(record) = get_compaction_record_opt(store, key).await? else {
@@ -571,7 +585,7 @@ async fn sweep_superseded_impl(
                 gather_l0_inputs(store, tenant, signal, shard, &record).await?
             }
             BucketEntry::RewriteRecord(_) => {
-                let Some(record) = get_rewrite_record_opt(store, key).await? else {
+                let Some(record) = rewrites.get(key) else {
                     continue;
                 };
                 // Horizon gate anchored on the rewrite's own durable
@@ -588,14 +602,21 @@ async fn sweep_superseded_impl(
                 if !record.inputs.is_empty() {
                     // RawL0 rewrite: the same L0 commit records + data objects
                     // a compaction over the same inputs would supersede.
-                    gather_l0_inputs(store, tenant, signal, shard, &record).await?
+                    gather_l0_inputs(store, tenant, signal, shard, record).await?
                 } else {
-                    // Predecessor rewrite: the whole prior compaction/rewrite
-                    // record this one superseded, plus every L1 part it named
-                    // (the pre-rewrite parts holding the un-erased subject).
-                    // Rule 3 cannot collect those parts while the predecessor
-                    // record still references them, so this rule removes both.
-                    gather_superseded_predecessor(store, &record.superseded_record_key).await?
+                    // Predecessor rewrite: the whole supersession chain behind
+                    // it, down to the raw L0 inputs the oldest generation
+                    // superseded. Rule 3 cannot collect a superseded
+                    // generation's parts while its record still references
+                    // them, so this rule removes records and parts together.
+                    gather_superseded_chain(
+                        store,
+                        tenant,
+                        signal,
+                        shard,
+                        &record.superseded_record_key,
+                    )
+                    .await?
                 }
             }
             BucketEntry::CommitRecord(_) | BucketEntry::Tombstone(_) => continue,
@@ -606,7 +627,9 @@ async fn sweep_superseded_impl(
         // surviving compaction or rewrite outputs the snapshot legitimately
         // still names. A group is indivisible: a predecessor record must
         // outlive every part it names, or rule 3 would collect those parts on
-        // the next pass and undo the hold.
+        // the next pass and undo the hold; and a whole supersession chain is
+        // one group so a HEAD that still names the oldest generation's raw
+        // inputs holds every record above them too.
         let mut cleared: Vec<&SupersededGroup> = Vec::with_capacity(groups.len());
         for group in &groups {
             match reach
@@ -629,11 +652,20 @@ async fn sweep_superseded_impl(
             }
         }
 
-        // Every cleared group's records first, then every cleared group's data
-        // objects (docs/consistency-model.md): a crash between the two phases
-        // leaves record-less data (orphan GC) or an unreferenced part (rule 3),
-        // never a record pointing at a deleted object. The gate runs entirely
-        // ahead of both phases so a held group never splits that order.
+        // Every cleared group's superseded-input records first, then every
+        // cleared group's data objects (docs/consistency-model.md): a crash
+        // between the two phases leaves record-less data (orphan GC) or an
+        // unreferenced part (rule 3), never a record pointing at a deleted
+        // object. The gate runs entirely ahead of every phase so a held group
+        // never splits that order.
+        //
+        // The chain's own records go last of all, oldest generation first, so
+        // a rewrite record outlives every input it superseded: a crash inside
+        // this rule leaves the record still naming inputs that are already
+        // gone (harmless, and the next pass finishes the job), never a
+        // surviving input with the record that erased a subject out of it
+        // deleted, which would leave the erasure request's filter with nothing
+        // durable to discover it by.
         for group in &cleared {
             for k in &group.record_keys {
                 if lease.is_protected(k) {
@@ -656,8 +688,37 @@ async fn sweep_superseded_impl(
                 outcome.data_deleted += 1;
             }
         }
+        for group in &cleared {
+            for k in &group.chain_record_keys {
+                if lease.is_protected(k) {
+                    continue;
+                }
+                if !config.dry_run {
+                    store.delete(k).await?;
+                }
+                outcome.records_deleted += 1;
+            }
+        }
     }
     Ok(outcome)
+}
+
+/// GET every rewrite record among `entries`, keyed by its commit key, tolerant
+/// of a key that vanished between the pass's LIST and now.
+async fn load_rewrite_records(
+    store: &dyn ObjectStoreBackend,
+    entries: &[(String, BucketEntry)],
+) -> Result<HashMap<String, RewriteRecord>> {
+    let mut out: HashMap<String, RewriteRecord> = HashMap::new();
+    for (key, entry) in entries {
+        if !matches!(entry, BucketEntry::RewriteRecord(_)) {
+            continue;
+        }
+        if let Some(record) = get_rewrite_record_opt(store, key).await? {
+            out.insert(key.clone(), record);
+        }
+    }
+    Ok(out)
 }
 
 /// One indivisible deletion unit for rule 2: the records to delete first, the
@@ -666,9 +727,11 @@ async fn sweep_superseded_impl(
 /// once.
 ///
 /// A raw-L0 input is its own group (one commit record plus one data object),
-/// so a still-named input holds only itself. A superseded predecessor record
-/// and every L1 part it names form one group, because deleting the record
-/// without the parts would expose the parts to rule 3.
+/// so a still-named input holds only itself. A whole supersession chain is one
+/// group: every superseded generation's record and parts plus the raw L0 inputs
+/// the oldest generation superseded, because deleting a record without the
+/// objects below it would expose them to rule 3 or leave them resolvable with
+/// nothing durable naming them as erased.
 struct SupersededGroup {
     /// The ingest hour every object in the group sits in: the parent record's
     /// own bucket, which is also the hour whose covering snapshot parts the
@@ -676,13 +739,16 @@ struct SupersededGroup {
     ingest_hour_bucket: u32,
     record_keys: Vec<String>,
     data_keys: Vec<String>,
+    /// The supersession chain's own compaction/rewrite records, oldest
+    /// generation first, deleted after every object they superseded.
+    chain_record_keys: Vec<String>,
     objects: Vec<SnapshotObject>,
 }
 
 impl SupersededGroup {
     /// Objects this group would delete, for the held counters.
     fn object_count(&self) -> usize {
-        self.record_keys.len() + self.data_keys.len()
+        self.record_keys.len() + self.data_keys.len() + self.chain_record_keys.len()
     }
 }
 
@@ -729,6 +795,7 @@ async fn gather_l0_inputs(
                     ingest_hour_bucket: rec.ingest_hour_bucket,
                     record_keys: vec![commit_key],
                     data_keys: vec![data_key],
+                    chain_record_keys: Vec::new(),
                     objects: vec![SnapshotObject::L0 {
                         shard: rec.shard,
                         ingest_hour_bucket: rec.ingest_hour_bucket,
@@ -816,84 +883,226 @@ impl SupersededInputs for RewriteRecord {
     }
 }
 
+/// One generation on a supersession chain: the compaction or rewrite record a
+/// newer rewrite superseded (ADR-0064 amendment: `superseded_record_key` names
+/// either an `l1.<hash>.cmt` compaction record or an `rw.<hash>.cmt` rewrite
+/// record, recursive supersession included).
+enum ChainLink {
+    Compaction(CompactionRecord),
+    Rewrite(RewriteRecord),
+}
+
+impl ChainLink {
+    fn ingest_hour_bucket(&self) -> u32 {
+        match self {
+            ChainLink::Compaction(r) => r.ingest_hour_bucket,
+            ChainLink::Rewrite(r) => r.ingest_hour_bucket,
+        }
+    }
+
+    /// Whether this generation superseded raw L0 inputs (the end of the
+    /// chain), rather than another compaction/rewrite record.
+    fn names_raw_l0_inputs(&self) -> bool {
+        match self {
+            ChainLink::Compaction(_) => true,
+            ChainLink::Rewrite(r) => !r.inputs.is_empty(),
+        }
+    }
+
+    /// The record this generation itself superseded, or `None` at the end of
+    /// the chain.
+    fn superseded_record_key(&self) -> Option<&str> {
+        match self {
+            ChainLink::Compaction(_) => None,
+            ChainLink::Rewrite(r) if r.superseded_record_key.is_empty() => None,
+            ChainLink::Rewrite(r) => Some(&r.superseded_record_key),
+        }
+    }
+
+    /// The erasure request ids this generation applied (empty for a compaction
+    /// record, which applies none).
+    fn applied_request_ids(&self) -> Vec<&str> {
+        match self {
+            ChainLink::Compaction(_) => Vec::new(),
+            ChainLink::Rewrite(r) => r.drops.iter().map(|d| d.request_id.as_str()).collect(),
+        }
+    }
+
+    /// This generation's output L1 part keys and their snapshot identities.
+    fn part_targets(&self) -> Result<Vec<(String, SnapshotObject)>> {
+        match self {
+            ChainLink::Compaction(record) => {
+                let input_set_hash = input_set_hash_array(&record.input_set_hash)?;
+                record
+                    .parts
+                    .iter()
+                    .map(|part| {
+                        Ok((
+                            keys::reconstruct_l1_part_key(record, part)?,
+                            SnapshotObject::L1 {
+                                shard: record.shard,
+                                ingest_hour_bucket: record.ingest_hour_bucket,
+                                input_set_hash,
+                                part_index: part.part_index,
+                            },
+                        ))
+                    })
+                    .collect()
+            }
+            ChainLink::Rewrite(record) => {
+                let input_set_hash = input_set_hash_array(&record.input_set_hash)?;
+                record
+                    .parts
+                    .iter()
+                    .map(|part| {
+                        Ok((
+                            keys::reconstruct_rewrite_part_key(record, part)?,
+                            SnapshotObject::L1 {
+                                shard: record.shard,
+                                ingest_hour_bucket: record.ingest_hour_bucket,
+                                input_set_hash,
+                                part_index: part.part_index,
+                            },
+                        ))
+                    })
+                    .collect()
+            }
+        }
+    }
+
+    /// The raw-L0 input groups this generation superseded, one per input still
+    /// present in the store. Empty unless [`Self::names_raw_l0_inputs`].
+    async fn raw_l0_input_groups(
+        &self,
+        store: &dyn ObjectStoreBackend,
+        tenant: &TenantHash,
+        signal: Signal,
+        shard: u32,
+    ) -> Result<Vec<SupersededGroup>> {
+        match self {
+            ChainLink::Compaction(r) => gather_l0_inputs(store, tenant, signal, shard, r).await,
+            ChainLink::Rewrite(r) if !r.inputs.is_empty() => {
+                gather_l0_inputs(store, tenant, signal, shard, r).await
+            }
+            ChainLink::Rewrite(_) => Ok(Vec::new()),
+        }
+    }
+}
+
+/// GET, decode, and key-verify the compaction or rewrite record at `key`.
+/// `Ok(None)` means the chain is truncated there: the record was swept by a
+/// crash-interrupted prior pass, or by an older sweep that did not yet hold a
+/// predecessor for its inputs.
+async fn load_chain_link(store: &dyn ObjectStoreBackend, key: &str) -> Result<Option<ChainLink>> {
+    match keys::partition_bucket_entry(key) {
+        Ok(BucketEntry::CompactionRecord(_)) => Ok(get_compaction_record_opt(store, key)
+            .await?
+            .map(ChainLink::Compaction)),
+        Ok(BucketEntry::RewriteRecord(_)) => Ok(get_rewrite_record_opt(store, key)
+            .await?
+            .map(ChainLink::Rewrite)),
+        Ok(BucketEntry::CommitRecord(_) | BucketEntry::Tombstone(_)) => {
+            Err(MaintainError::Invariant(format!(
+                "rewrite superseded_record_key {key} names a non-compaction, non-rewrite entry"
+            )))
+        }
+        Err(KeyError::UnknownBucketEntryShape(k)) => Err(MaintainError::UnknownBucketEntry(k)),
+        Err(e) => Err(MaintainError::Key(e)),
+    }
+}
+
 /// Gather the deletion targets for a rewrite record that superseded a whole
-/// prior compaction/rewrite record (ADR-0064 amendment: `superseded_record_key`
-/// names either an `l1.<hash>.cmt` compaction record or an `rw.<hash>.cmt`
-/// rewrite record, recursive supersession included). Returns one group holding
-/// the predecessor record (deleted first, records-before-data) and every L1
-/// part it named, plus each part's level-1 snapshot identity.
+/// prior compaction/rewrite record: the entire supersession chain behind
+/// `predecessor_key`, walked back generation by generation to the raw L0 inputs
+/// the oldest generation superseded. Returns at most one group holding, in
+/// deletion order, those inputs' commit records, their data objects together
+/// with every generation's L1 parts, and last the generations' own records
+/// oldest first.
 ///
-/// One group, not one per part: deleting the record while a still-named part
-/// is held would leave that part unreferenced, and rule 3 would then collect
-/// it on the next pass, undoing the hold.
+/// One group, not one per generation or per part, for two reasons. Deleting a
+/// record while a still-named part of its own is held would leave that part
+/// unreferenced and rule 3 would collect it on the next pass, undoing the hold.
+/// And gating a generation on its own outputs alone is not enough: a HEAD that
+/// has not been re-folded since the rewrite still names the raw L0 inputs at
+/// the end of the chain, not any generation's parts, so a per-generation gate
+/// clears while the inputs stay resolvable. The whole chain shares one gate, so
+/// a HEAD naming anything in it holds all of it.
 ///
-/// A predecessor already gone (swept by an earlier iteration of this same pass
-/// when the predecessor also appeared as its own entry, or by a crash-
-/// interrupted prior pass) yields no group: any of its parts that survive
-/// become unreferenced under the live rewrite record and are collected by rule
-/// 3.
-async fn gather_superseded_predecessor(
+/// A chain truncated by an absent record yields whatever it reached before the
+/// gap; an absent `predecessor_key` yields no group at all, and any surviving
+/// parts below it are unreferenced under the live record and collected by
+/// rule 3.
+async fn gather_superseded_chain(
     store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    signal: Signal,
+    shard: u32,
     predecessor_key: &str,
 ) -> Result<Vec<SupersededGroup>> {
-    let got = match store.get(predecessor_key, GetRange::Full).await {
-        Ok(got) => got,
-        Err(StoreError::NotFound) => return Ok(Vec::new()),
-        Err(e) => return Err(MaintainError::Store(e)),
-    };
-    let mut data_keys: Vec<String> = Vec::new();
+    let mut chain_record_keys: Vec<String> = Vec::new();
+    let mut chain_part_keys: Vec<String> = Vec::new();
+    let mut input_record_keys: Vec<String> = Vec::new();
+    let mut input_data_keys: Vec<String> = Vec::new();
     let mut objects: Vec<SnapshotObject> = Vec::new();
-    let ingest_hour_bucket;
-    match keys::partition_bucket_entry(predecessor_key) {
-        Ok(BucketEntry::CompactionRecord(_)) => {
-            let record = CompactionRecord::decode(got.data.as_ref()).map_err(|e| {
-                MaintainError::Invariant(format!("superseded compaction record decode failed: {e}"))
-            })?;
-            keys::verify_compaction_record_key(&record, predecessor_key)?;
-            ingest_hour_bucket = record.ingest_hour_bucket;
-            let input_set_hash = input_set_hash_array(&record.input_set_hash)?;
-            for part in &record.parts {
-                data_keys.push(keys::reconstruct_l1_part_key(&record, part)?);
-                objects.push(SnapshotObject::L1 {
-                    shard: record.shard,
-                    ingest_hour_bucket: record.ingest_hour_bucket,
-                    input_set_hash,
-                    part_index: part.part_index,
-                });
-            }
-        }
-        Ok(BucketEntry::RewriteRecord(_)) => {
-            let record = ravel_commit::erasure::decode_rewrite(got.data.as_ref()).map_err(|e| {
-                MaintainError::Invariant(format!("superseded rewrite record decode failed: {e}"))
-            })?;
-            keys::verify_rewrite_record_key(&record, predecessor_key)?;
-            ingest_hour_bucket = record.ingest_hour_bucket;
-            let input_set_hash = input_set_hash_array(&record.input_set_hash)?;
-            for part in &record.parts {
-                data_keys.push(keys::reconstruct_rewrite_part_key(&record, part)?);
-                objects.push(SnapshotObject::L1 {
-                    shard: record.shard,
-                    ingest_hour_bucket: record.ingest_hour_bucket,
-                    input_set_hash,
-                    part_index: part.part_index,
-                });
-            }
-        }
-        Ok(BucketEntry::CommitRecord(_) | BucketEntry::Tombstone(_)) => {
+    let mut ingest_hour_bucket: Option<u32> = None;
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut cursor = Some(predecessor_key.to_string());
+
+    while let Some(key) = cursor {
+        if !seen.insert(key.clone()) {
             return Err(MaintainError::Invariant(format!(
-                "rewrite superseded_record_key {predecessor_key} names a non-compaction, \
-                 non-rewrite entry"
+                "supersession chain from {predecessor_key} revisits {key}"
             )));
         }
-        Err(KeyError::UnknownBucketEntryShape(k)) => {
-            return Err(MaintainError::UnknownBucketEntry(k));
+        let Some(link) = load_chain_link(store, &key).await? else {
+            break;
+        };
+        // The gate reads one hour's covering snapshot parts, so a chain that
+        // spanned two ingest hours could not be gated as one unit. A rewrite
+        // record's decode already verifies that its `superseded_record_key`
+        // sits in its own bucket, so this is a redundant local check on a
+        // durable invariant rather than a new rule.
+        match ingest_hour_bucket {
+            None => ingest_hour_bucket = Some(link.ingest_hour_bucket()),
+            Some(hour) if hour == link.ingest_hour_bucket() => {}
+            Some(hour) => {
+                return Err(MaintainError::Invariant(format!(
+                    "supersession chain from {predecessor_key} spans ingest hours {hour} and {}",
+                    link.ingest_hour_bucket()
+                )));
+            }
         }
-        Err(e) => return Err(MaintainError::Key(e)),
+        for (part_key, object) in link.part_targets()? {
+            chain_part_keys.push(part_key);
+            objects.push(object);
+        }
+        chain_record_keys.push(key);
+        if link.names_raw_l0_inputs() {
+            for group in link
+                .raw_l0_input_groups(store, tenant, signal, shard)
+                .await?
+            {
+                input_record_keys.extend(group.record_keys);
+                input_data_keys.extend(group.data_keys);
+                objects.extend(group.objects);
+            }
+            break;
+        }
+        cursor = link.superseded_record_key().map(str::to_string);
     }
+
+    let Some(ingest_hour_bucket) = ingest_hour_bucket else {
+        return Ok(Vec::new());
+    };
+    // Oldest generation first: a record is deleted only after every object the
+    // generations below it superseded, and after the generation it superseded.
+    chain_record_keys.reverse();
+    input_data_keys.extend(chain_part_keys);
     Ok(vec![SupersededGroup {
         ingest_hour_bucket,
-        record_keys: vec![predecessor_key.to_string()],
-        data_keys,
+        record_keys: input_record_keys,
+        data_keys: input_data_keys,
+        chain_record_keys,
         objects,
     }])
 }
@@ -1548,20 +1757,24 @@ pub struct ErasureRequestSweepOutcome {
 ///   because after the horizon no resolvable snapshot can still reference a
 ///   pre-rewrite input (ADR-0064 §3.5 race window, closed durably). Deleting
 ///   the `.dreq` a nanosecond early would reopen exactly that window.
-/// - no input a rewrite applying this request superseded is still physically
-///   present. The horizon on its own does not imply that: rule 2 holds an
-///   input the live HEAD snapshot still names, and a legal hold over the
-///   shard's data prefixes (which does not cover `del/`) holds it too. In both
-///   cases a snapshot can still resolve the pre-rewrite input, so retiring the
-///   filter would serve the erased subject again. The check reads the
-///   `.done`'s own `bucket_drops` for the buckets this request touched, so it
-///   costs one LIST per touched bucket and runs only for a `.dreq` that has
-///   already cleared its horizon; in the ordinary case rule 2 collected the
-///   inputs long before, so the first such pass finds nothing and removes the
-///   request. An input whose commit record is already gone but whose data
-///   object survives (the window between rule 2's two delete phases) is not
-///   counted: it is a record-less orphan awaiting rule 1, discovered from no
-///   durable record.
+/// - no input superseded by a rewrite anywhere on a supersession chain that
+///   applied this request is still physically present. The horizon on its own
+///   does not imply that: rule 2 holds an input the live HEAD snapshot still
+///   names, and a legal hold over the shard's data prefixes (which does not
+///   cover `del/`) holds it too. In both cases a snapshot can still resolve the
+///   pre-rewrite input, so retiring the filter would serve the erased subject
+///   again. The check reads the `.done`'s own `bucket_drops` for the buckets
+///   this request touched and walks each bucket's chains back through
+///   `superseded_record_key`, so it costs one LIST per touched bucket plus one
+///   GET per record on the chain, and runs only for a `.dreq` that has already
+///   cleared its horizon; in the ordinary case rule 2 collected the inputs long
+///   before, so the first such pass finds nothing and removes the request. It
+///   does not require the record that applied the request to still exist: see
+///   [`superseded_inputs_outstanding`] for the truncated-chain fallback. An
+///   input whose commit record and data object are both gone but whose chain is
+///   intact is not counted, and neither is a record-less L0 data object in a
+///   bucket whose chain is intact: that is a record-less orphan awaiting rule
+///   1, discovered from no durable record.
 /// - the [`LeaseCheck`] passes: a legal hold over the `del/` keyspace pins the
 ///   request exactly as it pins any other object.
 ///
@@ -1615,6 +1828,9 @@ pub async fn sweep_erasure_requests(
     let mut deleted = 0usize;
     let mut kept = 0usize;
     let mut held_by_superseded_inputs = 0usize;
+    // Every bucket's commit listing, its rewrite records, and its chain walks,
+    // read once for the pass: several requests routinely share one bucket.
+    let mut scans: HashMap<(u32, u32), BucketScan> = HashMap::new();
     for (request_id, dreq_key) in &dreq_keys {
         let Some(completion) = completions.get(request_id) else {
             // No `.done`: the erasure is not verified complete, so the request
@@ -1640,8 +1856,15 @@ pub async fn sweep_erasure_requests(
         // superseded may still be in the store (held by rule 2's HEAD gate, or
         // by a legal hold over the data prefixes that does not cover `del/`).
         // A snapshot can still resolve such an input, so the filter stays.
-        if superseded_inputs_outstanding(store, tenant, signal, completion, &request_id.to_string())
-            .await?
+        if superseded_inputs_outstanding(
+            store,
+            tenant,
+            signal,
+            completion,
+            &request_id.to_string(),
+            &mut scans,
+        )
+        .await?
         {
             tracing::warn!(
                 tenant_hash = %tenant.to_hex(),
@@ -1668,22 +1891,99 @@ pub async fn sweep_erasure_requests(
     })
 }
 
-/// Whether any input superseded by a rewrite that applied `request_id` is still
-/// physically present, across every bucket the request's `.done` records a drop
-/// for in `signal`.
+/// What one supersession chain, walked from a live record back to the raw L0
+/// inputs at its end, says about the requests applied along it.
+#[derive(Debug, Default, Clone)]
+struct ChainWalk {
+    /// Every erasure request id any generation on the chain applied.
+    request_ids: HashSet<String>,
+    /// A generation on the chain names a `superseded_record_key` whose record
+    /// is gone, so the walk could not reach the raw L0 inputs. The requests
+    /// that generation applied are no longer discoverable from any record.
+    truncated: bool,
+    /// Something a generation on this chain superseded is still physically
+    /// present: a deeper generation's own record and parts, or a raw L0 input.
+    inputs_outstanding: bool,
+}
+
+/// One (shard, ingest hour) bucket's commit listing, read once per sweep pass
+/// and shared by every request whose `.done` records a drop for that bucket.
+struct BucketScan {
+    entries: Vec<(String, BucketEntry)>,
+    rewrites: HashMap<String, RewriteRecord>,
+    /// The bucket's compaction/rewrite records no present rewrite supersedes:
+    /// the heads of its supersession chains.
+    live_heads: Vec<String>,
+    /// Chain walks by live head, filled on first use.
+    walks: HashMap<String, ChainWalk>,
+    /// The truncated-chain residue answer, computed at most once.
+    residue: Option<bool>,
+}
+
+impl BucketScan {
+    async fn load(
+        store: &dyn ObjectStoreBackend,
+        tenant: &TenantHash,
+        signal: Signal,
+        shard: u32,
+        hour: u32,
+    ) -> Result<Self> {
+        let entries =
+            list_commit_entries_scoped(store, tenant, signal, shard, Some(&[hour])).await?;
+        let rewrites = load_rewrite_records(store, &entries).await?;
+        let live_heads: Vec<String> = {
+            let superseded: HashSet<&str> = rewrites
+                .values()
+                .map(|r| r.superseded_record_key.as_str())
+                .filter(|k| !k.is_empty())
+                .collect();
+            entries
+                .iter()
+                .filter(|(key, entry)| {
+                    matches!(
+                        entry,
+                        BucketEntry::CompactionRecord(_) | BucketEntry::RewriteRecord(_)
+                    ) && !superseded.contains(key.as_str())
+                })
+                .map(|(key, _)| key.clone())
+                .collect()
+        };
+        Ok(Self {
+            entries,
+            rewrites,
+            live_heads,
+            walks: HashMap::new(),
+            residue: None,
+        })
+    }
+}
+
+/// Whether any input superseded by a rewrite on a supersession chain that
+/// applied `request_id` is still physically present, across every bucket the
+/// request's `.done` records a drop for in `signal`.
 ///
 /// Anchored on durable records only: the `.done`'s `bucket_drops` name the
-/// buckets, each bucket's own listing names its rewrite records, and each
-/// rewrite record names the inputs it superseded. A superseded input that is
-/// still present yields a group from the same gather helpers rule 2 uses, so
-/// the two rules agree on what "superseded input" means by construction rather
-/// than by restatement.
+/// buckets, each bucket's own listing names the heads of its supersession
+/// chains, and each chain is walked back through `superseded_record_key` to
+/// the raw L0 inputs at its end. Every generation past the head is itself an
+/// input the generation above it superseded, so a chain deeper than one
+/// generation holds the request whatever the raw inputs' state.
+///
+/// This walk does not assume rule 2 deletes a chain in any particular order,
+/// and it deliberately does not assume the record that applied `request_id` is
+/// still there. A chain truncated by a missing record leaves that request
+/// undiscoverable from any record, so the guard falls back to a residue check
+/// on the bucket ([`truncated_chain_residue`]) and holds the `.dreq` while
+/// anything the missing generation could have superseded survives. That is what
+/// makes the guard independent of deletion ordering: the filter outlives the
+/// data even if a record it depended on was already swept.
 async fn superseded_inputs_outstanding(
     store: &dyn ObjectStoreBackend,
     tenant: &TenantHash,
     signal: Signal,
     completion: &ErasureCompletion,
     request_id: &str,
+    scans: &mut HashMap<(u32, u32), BucketScan>,
 ) -> Result<bool> {
     for drop in &completion.bucket_drops {
         // A `.done` is per (tenant, signal); a drop for another signal cannot
@@ -1692,29 +1992,183 @@ async fn superseded_inputs_outstanding(
         if ravel_commit::signal::from_proto(drop.signal) != Ok(signal) {
             continue;
         }
-        let prefix =
-            keys::commit_shard_hour_prefix(tenant, signal, drop.shard, drop.ingest_hour_bucket)?;
-        for meta in list_all(store, &prefix).await? {
-            if !matches!(
-                keys::partition_bucket_entry(&meta.key),
-                Ok(BucketEntry::RewriteRecord(_))
-            ) {
-                continue;
-            }
-            let Some(record) = get_rewrite_record_opt(store, &meta.key).await? else {
-                continue;
+        let cache_key = (drop.shard, drop.ingest_hour_bucket);
+        if let std::collections::hash_map::Entry::Vacant(e) = scans.entry(cache_key) {
+            let scan = BucketScan::load(store, tenant, signal, drop.shard, drop.ingest_hour_bucket)
+                .await?;
+            e.insert(scan);
+        }
+
+        let heads = match scans.get(&cache_key) {
+            Some(scan) => scan.live_heads.clone(),
+            None => continue,
+        };
+        for head in &heads {
+            let fresh = match scans.get(&cache_key) {
+                Some(scan) if scan.walks.contains_key(head) => None,
+                Some(scan) => Some(
+                    walk_supersession_chain(
+                        store,
+                        tenant,
+                        signal,
+                        drop.shard,
+                        head,
+                        &scan.rewrites,
+                    )
+                    .await?,
+                ),
+                None => None,
             };
-            if !record.drops.iter().any(|d| d.request_id == request_id) {
-                continue;
+            if let (Some(walk), Some(scan)) = (fresh, scans.get_mut(&cache_key)) {
+                scan.walks.insert(head.clone(), walk);
             }
-            let groups = if !record.inputs.is_empty() {
-                gather_l0_inputs(store, tenant, signal, drop.shard, &record).await?
-            } else {
-                gather_superseded_predecessor(store, &record.superseded_record_key).await?
+        }
+
+        // The residue check costs one `l1/` LIST and one GET per compaction
+        // record, so it runs only when a chain in this bucket is truncated, and
+        // only once per bucket per pass.
+        let needs_residue = scans.get(&cache_key).is_some_and(|scan| {
+            scan.residue.is_none() && scan.walks.values().any(|walk| walk.truncated)
+        });
+        if needs_residue {
+            let residue = match scans.get(&cache_key) {
+                Some(scan) => {
+                    truncated_chain_residue(
+                        store,
+                        tenant,
+                        signal,
+                        drop.shard,
+                        drop.ingest_hour_bucket,
+                        scan,
+                    )
+                    .await?
+                }
+                None => false,
             };
-            if groups.iter().any(|g| g.object_count() > 0) {
+            if let Some(scan) = scans.get_mut(&cache_key) {
+                scan.residue = Some(residue);
+            }
+        }
+
+        let Some(scan) = scans.get(&cache_key) else {
+            continue;
+        };
+        let residue = scan.residue.unwrap_or(false);
+        for walk in scan.walks.values() {
+            if walk.request_ids.contains(request_id) {
+                if walk.inputs_outstanding || (walk.truncated && residue) {
+                    return Ok(true);
+                }
+            } else if walk.truncated && (walk.inputs_outstanding || residue) {
+                // The request is not named anywhere on this chain, but the
+                // chain is cut: the generation that applied it may be the one
+                // that is missing. Hold while any of its possible inputs
+                // survive.
                 return Ok(true);
             }
+        }
+    }
+    Ok(false)
+}
+
+/// Walk one supersession chain from `head_key` back to the raw L0 inputs at its
+/// end, collecting every erasure request applied along it and whether anything
+/// any generation superseded is still present.
+async fn walk_supersession_chain(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    signal: Signal,
+    shard: u32,
+    head_key: &str,
+    rewrites: &HashMap<String, RewriteRecord>,
+) -> Result<ChainWalk> {
+    let mut walk = ChainWalk::default();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut cursor = Some(head_key.to_string());
+    let mut generation = 0usize;
+
+    while let Some(key) = cursor {
+        if !seen.insert(key.clone()) {
+            return Err(MaintainError::Invariant(format!(
+                "supersession chain from {head_key} revisits {key}"
+            )));
+        }
+        // Every rewrite generation sits in the same bucket as the head, so it
+        // was already read for this pass; only a compaction record at the end
+        // of the chain needs its own GET.
+        let link = match rewrites.get(&key) {
+            Some(record) => Some(ChainLink::Rewrite(record.clone())),
+            None => load_chain_link(store, &key).await?,
+        };
+        let Some(link) = link else {
+            walk.truncated = true;
+            break;
+        };
+        for id in link.applied_request_ids() {
+            walk.request_ids.insert(id.to_string());
+        }
+        // Every generation past the head is an input the generation above it
+        // superseded: its parts still hold the subject that generation erased.
+        if generation > 0 {
+            walk.inputs_outstanding = true;
+        }
+        if link.names_raw_l0_inputs() {
+            if !link
+                .raw_l0_input_groups(store, tenant, signal, shard)
+                .await?
+                .is_empty()
+            {
+                walk.inputs_outstanding = true;
+            }
+            break;
+        }
+        cursor = link.superseded_record_key().map(str::to_string);
+        generation += 1;
+    }
+    Ok(walk)
+}
+
+/// Whether a bucket whose supersession chain is truncated still holds anything
+/// the missing generation could have superseded: a raw L0 commit record (a
+/// pre-rewrite input rule 2 has not collected), or an `l1/` part no surviving
+/// record in the bucket references (a superseded generation's output whose own
+/// record is gone). Either one can still be reached by a snapshot, so the
+/// query-time exclusion filter must stay.
+///
+/// Both conditions clear once rules 2 and 3 have finished the bucket, so the
+/// hold this produces terminates rather than pinning the `.dreq` forever.
+async fn truncated_chain_residue(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    signal: Signal,
+    shard: u32,
+    hour: u32,
+    scan: &BucketScan,
+) -> Result<bool> {
+    let mut referenced: HashSet<String> = HashSet::new();
+    for (key, entry) in &scan.entries {
+        match entry {
+            BucketEntry::CommitRecord(_) => return Ok(true),
+            BucketEntry::CompactionRecord(_) => {
+                if let Some(record) = get_compaction_record_opt(store, key).await? {
+                    for part in &record.parts {
+                        referenced.insert(keys::reconstruct_l1_part_key(&record, part)?);
+                    }
+                }
+            }
+            BucketEntry::RewriteRecord(_) => {
+                if let Some(record) = scan.rewrites.get(key) {
+                    for part in &record.parts {
+                        referenced.insert(keys::reconstruct_rewrite_part_key(record, part)?);
+                    }
+                }
+            }
+            BucketEntry::Tombstone(_) => {}
+        }
+    }
+    for meta in list_l1_scoped(store, tenant, signal, shard, Some(&[hour])).await? {
+        if !referenced.contains(&meta.key) {
+            return Ok(true);
         }
     }
     Ok(false)

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -613,10 +613,10 @@ impl SupersededSweepOutcome {
 /// This is the whole input to the erasure-request guard. Rule 6 asks no
 /// question of its own about supersession chains: rule 2 already walked them,
 /// already gated them, and already knows which requests the objects it held
-/// predate. A completion record's `bucket_drops` is used only to narrow which
-/// buckets rule 2 is asked about, never to decide a hold, because the field is
-/// optional on the wire and a completion written without it must still be
-/// safe.
+/// predate. A completion record's `bucket_drops` plays no part in it at all,
+/// neither to decide a hold nor to narrow which buckets are observed: the
+/// field is optional on the wire, and a list that is present but partial is
+/// indistinguishable from a complete one.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SupersededHolds {
     /// [`SupersededSweepOutcome::held_request_ids`], unioned across shards.
@@ -674,14 +674,35 @@ pub async fn sweep_superseded(
 /// computes the gate and the holds.
 ///
 /// [`SweepMode::GateOnly`] is what makes the erasure-request guard reachable
-/// from a caller that has no rule-2 outcome to hand: the pass reads exactly
-/// what a deleting pass reads and reports exactly the same holds, and its
-/// `records_deleted` / `data_deleted` are always zero. It is not `dry_run`,
-/// which reports what it would have deleted.
+/// from a caller that has no rule-2 outcome to hand. It is not `dry_run`,
+/// which reports what a deleting pass would have removed: `records_deleted`
+/// and `data_deleted` are always zero here, and the only outputs a caller
+/// reads are [`SupersededSweepOutcome::held_request_ids`] and
+/// [`SupersededSweepOutcome::held_truncated_buckets`].
+///
+/// An observing pass gathers strictly more than a deleting one. The two
+/// filters that decide whether a chain is *collectable yet*, the protection
+/// horizon and the skip of a record another present rewrite supersedes, say
+/// nothing about whether a HEAD-named part still resolves that chain's inputs,
+/// which is the only question the erasure filter's hold turns on. So both
+/// filters apply to deletion alone, and every chain in scope is gathered and
+/// gated for the holds. A chain the gate clears contributes nothing either
+/// way; a chain the gate blocks contributes the same request ids and buckets
+/// whatever its age.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SweepMode {
     Delete,
     GateOnly,
+}
+
+impl SweepMode {
+    /// Whether this pass may skip a chain the horizon, or a present successor,
+    /// keeps from being deleted this pass. Only a deleting pass may: an
+    /// observing pass has to see every chain, because a young chain's inputs
+    /// are more resolvable than an aged one's, not less.
+    fn gathers_only_deletable(self) -> bool {
+        matches!(self, SweepMode::Delete)
+    }
 }
 
 /// Shared implementation behind [`sweep_superseded`] (whole-shard, `hours:
@@ -704,15 +725,18 @@ async fn sweep_superseded_impl(
     mode: SweepMode,
 ) -> Result<SupersededSweepOutcome> {
     let now = clock.now_ns();
+    // Both skips below narrow what this pass may DELETE. An observing pass
+    // (`SweepMode::GateOnly`) applies neither: see [`SweepMode`].
+    let deleting = mode.gathers_only_deletable();
     let entries = list_commit_entries_scoped(store, tenant, signal, shard, hours).await?;
     // Every rewrite record in scope, read once for the pass, plus the set of
-    // record keys those rewrites supersede. A record another present rewrite
-    // supersedes is not processed from its own listing entry: it belongs to
-    // that rewrite's chain group, which is gated and deleted as one unit. Doing
-    // both would let the gate clear a predecessor from its own entry (where the
-    // group holds only that predecessor's outputs) while the same predecessor's
-    // raw inputs are held from another entry, which is exactly how a record
-    // could vanish ahead of the inputs it superseded.
+    // record keys those rewrites supersede. In a deleting pass a record another
+    // present rewrite supersedes is not processed from its own listing entry:
+    // it belongs to that rewrite's chain group, which is gated and deleted as
+    // one unit. Doing both would let the gate clear a predecessor from its own
+    // entry (where the group holds only that predecessor's outputs) while the
+    // same predecessor's raw inputs are held from another entry, which is
+    // exactly how a record could vanish ahead of the inputs it superseded.
     let rewrites = load_rewrite_records(store, &entries).await?;
     let superseded_by_present: HashSet<&str> = rewrites
         .values()
@@ -729,7 +753,12 @@ async fn sweep_superseded_impl(
     let mut groups: Vec<SupersededGroup> = Vec::new();
     let mut by_identity: HashMap<String, usize> = HashMap::new();
     for (key, entry) in &entries {
-        if superseded_by_present.contains(key.as_str()) {
+        // An observing pass gathers this entry too. The successor's own gather
+        // covers the same chain only when the successor superseded a whole
+        // record; a successor that superseded raw L0 inputs directly never
+        // walks back past them, so skipping the predecessor here would drop
+        // its chain from the holds entirely.
+        if deleting && superseded_by_present.contains(key.as_str()) {
             continue;
         }
         // Both a compaction record and a selective-erasure rewrite record
@@ -750,11 +779,14 @@ async fn sweep_superseded_impl(
                 let Some(record) = get_compaction_record_opt(store, key).await? else {
                     continue;
                 };
-                // Horizon gate anchored on the durable created_unix_ns.
-                if now
-                    < record
-                        .created_unix_ns
-                        .saturating_add(config.protection_horizon_ns)
+                // Horizon gate anchored on the durable created_unix_ns. It
+                // bounds when the inputs may be DELETED; an observing pass
+                // gathers them whatever the record's age.
+                if deleting
+                    && now
+                        < record
+                            .created_unix_ns
+                            .saturating_add(config.protection_horizon_ns)
                 {
                     continue;
                 }
@@ -770,11 +802,16 @@ async fn sweep_superseded_impl(
                 // Horizon gate anchored on the rewrite's own durable
                 // created_unix_ns: that is the instant it superseded its
                 // inputs, so a query pinned before it is drained by the
-                // protection horizon exactly as for a compaction record.
-                if now
-                    < record
-                        .created_unix_ns
-                        .saturating_add(config.protection_horizon_ns)
+                // protection horizon exactly as for a compaction record. An
+                // observing pass skips the gate: a rewrite still inside its
+                // horizon is the case where a stale HEAD is MOST likely to
+                // resolve the chain's inputs, so the erasure filter's hold has
+                // to see it.
+                if deleting
+                    && now
+                        < record
+                            .created_unix_ns
+                            .saturating_add(config.protection_horizon_ns)
                 {
                     continue;
                 }
@@ -886,7 +923,15 @@ async fn sweep_superseded_impl(
         }
     }
 
-    if mode == SweepMode::GateOnly {
+    if !deleting {
+        // Nothing is deleted, and nothing in the outcome says which of these
+        // groups a deleting pass could have collected: an observing pass
+        // answers one question, "does a HEAD-named part still resolve this
+        // chain", and a young chain answers it exactly as an aged one does.
+        // The two object counters can exceed the number of distinct objects
+        // here, because a predecessor is gathered both from its own entry and
+        // from its successor's chain walk; only the held request ids and
+        // buckets are consumed.
         return Ok(outcome);
     }
 
@@ -2051,16 +2096,20 @@ pub struct ErasureRequestSweepOutcome {
 ///   and `truncated_buckets` when a held group's chain could not be walked to
 ///   the end, in which case the requests the missing generation applied are
 ///   named by no surviving record and the bucket stands in for them. This
-///   costs no LIST and no GET of its own beyond rule 2's own pass.
+///   costs no LIST and no GET of its own beyond rule 2's own pass. The holds
+///   cover every supersession chain in the signal, not only the ones old
+///   enough to delete: an object's age says nothing about whether a snapshot
+///   still resolves it, and a chain still inside its own protection horizon is
+///   the likeliest one a stale HEAD names.
 /// - the [`LeaseCheck`] passes: a legal hold over the `del/` keyspace pins the
 ///   request exactly as it pins any other object.
 ///
-/// A completion's `bucket_drops` is a narrowing hint only, never the basis of a
-/// hold: the field is optional on the wire, has been written empty by a
-/// production writer, and a `.dreq` whose completion carries no drops is held
-/// by any truncated bucket in the signal rather than exempted. Where it is
-/// present it narrows which buckets rule 2 is asked about, and which truncated
-/// buckets can hold a given request.
+/// A completion's `bucket_drops` is informational only. No part of this rule
+/// reads it: not the hold decision, and not the scope of the observation the
+/// six-argument entry runs. The field is optional on the wire, is written
+/// empty by the production writer, and a writer that does populate it is not
+/// obliged to enumerate every bucket it touched, so a present list can be
+/// partial. Any truncated bucket in the signal therefore holds any candidate.
 ///
 /// A completion whose `completed_unix_ns` is zero is treated fail-safe as "not
 /// yet a valid horizon anchor" and its `.dreq` is kept: a zero anchor would
@@ -2083,7 +2132,7 @@ pub struct ErasureRequestSweepOutcome {
 ///
 /// This is the production entry (`ravel-server`'s maintenance tick), and it is
 /// what makes the guard reachable there: it runs rule 2 in
-/// [`SweepMode::GateOnly`] over the buckets that matter and decides from the
+/// [`SweepMode::GateOnly`] over every shard of the signal and decides from the
 /// holds that pass reports, instead of from a completion field a production
 /// writer may leave empty. The observation costs one rule-2-shaped pass and
 /// nothing more; a caller that already swept the signal's shards this tick
@@ -2169,7 +2218,7 @@ async fn sweep_erasure_requests_inner(
     // Split the requests into the ones this pass could delete and the ones a
     // cheaper condition already keeps, before any hold is observed: an
     // ordinary pass has no candidate and does no further work.
-    let mut candidates: Vec<(&Uuid, &String, &ErasureCompletion)> = Vec::new();
+    let mut candidates: Vec<(&Uuid, &String)> = Vec::new();
     let mut kept = 0usize;
     for (request_id, dreq_key) in &dreq_keys {
         let Some(completion) = completions.get(request_id) else {
@@ -2192,7 +2241,7 @@ async fn sweep_erasure_requests_inner(
             kept += 1;
             continue;
         }
-        candidates.push((request_id, dreq_key, completion));
+        candidates.push((request_id, dreq_key));
     }
 
     if candidates.is_empty() {
@@ -2207,44 +2256,29 @@ async fn sweep_erasure_requests_inner(
     let holds = match holds {
         Some(holds) => holds,
         None => {
-            let narrow = narrowing_buckets(&candidates, signal);
-            observed = observe_superseded_holds(
-                store,
-                clock,
-                config,
-                lease,
-                tenant,
-                signal,
-                narrow.as_deref(),
-            )
-            .await?;
+            observed =
+                observe_superseded_holds(store, clock, config, lease, tenant, signal).await?;
             &observed
         }
     };
 
     let mut deleted = 0usize;
     let mut held_by_superseded_inputs = 0usize;
-    for (request_id, dreq_key, completion) in candidates {
+    for (request_id, dreq_key) in candidates {
         // The horizon has elapsed, but rule 2 may have held an object one of
         // this request's rewrites superseded: an input the live HEAD still
         // names, one under an unreadable snapshot part, or a chain a legal
         // hold over the data prefixes touches. A snapshot can still resolve
         // such an object, so the filter stays.
+        // A held chain rule 2 could not walk to the end names requests no
+        // surviving record does, so any such bucket stands in for them. The
+        // completion's own `bucket_drops` are not consulted: the field is
+        // optional on the wire, a production writer leaves it empty, and
+        // nothing forces a writer that does fill it to enumerate every bucket
+        // it touched. Narrowing on a list that may be partial would release a
+        // filter over a bucket the request did touch.
         let request_id_s = request_id.to_string();
-        let held = if holds.request_ids.contains(&request_id_s) {
-            true
-        } else {
-            // A held chain rule 2 could not walk to the end names requests no
-            // surviving record does, so the bucket stands in for them. The
-            // completion's own drops narrow which buckets can hold this
-            // request; a completion that carries none (the production shape
-            // today) is narrowed by nothing and any truncated bucket holds it.
-            let drops = completion_buckets(completion, signal);
-            match &drops {
-                Some(buckets) => buckets.iter().any(|b| holds.truncated_buckets.contains(b)),
-                None => !holds.truncated_buckets.is_empty(),
-            }
-        };
+        let held = holds.request_ids.contains(&request_id_s) || !holds.truncated_buckets.is_empty();
         if held {
             tracing::warn!(
                 tenant_hash = %tenant.to_hex(),
@@ -2273,57 +2307,19 @@ async fn sweep_erasure_requests_inner(
     })
 }
 
-/// The buckets one completion records a drop for in `signal`, or `None` when it
-/// records none.
+/// Observe what rule 2 holds, without deleting anything, for a rule-6 caller
+/// that has no [`SupersededHolds`] of its own.
 ///
-/// `None` is not "no buckets": it is "this completion says nothing about which
-/// buckets it touched", which is what a completion written without
-/// `bucket_drops` says. The two are treated oppositely, since a completion that
-/// names its buckets can be exempted by a truncated bucket it does not name,
-/// and one that names none cannot.
-fn completion_buckets(completion: &ErasureCompletion, signal: Signal) -> Option<Vec<HeldBucket>> {
-    let buckets: Vec<HeldBucket> = completion
-        .bucket_drops
-        .iter()
-        // A `.done` is per (tenant, signal); a drop for another signal cannot
-        // appear, but the sweep never widens its own scope on a field it did
-        // not write.
-        .filter(|drop| ravel_commit::signal::from_proto(drop.signal) == Ok(signal))
-        .map(|drop| HeldBucket {
-            shard: drop.shard,
-            ingest_hour_bucket: drop.ingest_hour_bucket,
-        })
-        .collect();
-    (!buckets.is_empty()).then_some(buckets)
-}
-
-/// The `(shard, hour)` buckets a self-observing rule-6 pass can restrict its
-/// rule-2 observation to, or `None` to observe the whole signal.
+/// The observation always covers the whole signal: the commit keyspace is
+/// listed once to enumerate its shards, and every shard is observed across
+/// every hour. It is never narrowed by a candidate completion's `bucket_drops`.
+/// That field is optional on the wire and nothing makes a writer that fills it
+/// enumerate every bucket it touched, so a partial list would silently exclude
+/// the bucket whose chain holds the request. Shard enumeration is one LIST for
+/// the pass, and a shard with no commit key holds nothing, so the whole-signal
+/// scope costs listing, never correctness.
 ///
-/// Narrowing is sound only when every candidate names its own buckets: one
-/// candidate whose completion carries no `bucket_drops` could have touched any
-/// bucket in the signal, so the observation must cover all of them. This is the
-/// only use `bucket_drops` has left, and dropping it entirely would cost
-/// request count, never safety.
-fn narrowing_buckets(
-    candidates: &[(&Uuid, &String, &ErasureCompletion)],
-    signal: Signal,
-) -> Option<Vec<HeldBucket>> {
-    let mut out: BTreeSet<HeldBucket> = BTreeSet::new();
-    for (_, _, completion) in candidates {
-        out.extend(completion_buckets(completion, signal)?);
-    }
-    Some(out.into_iter().collect())
-}
-
-/// Observe what rule 2 would hold, without deleting anything, for a rule-6
-/// caller that has no [`SupersededHolds`] of its own.
-///
-/// `narrow` restricts the observation to a set of `(shard, hour)` buckets; when
-/// it is `None` the signal's whole commit keyspace is listed once to enumerate
-/// its shards, and every shard is observed across every hour. Either way the
-/// pass reads what a deleting rule-2 pass over the same scope reads, and it
-/// runs only when there is a `.dreq` past its horizon to decide about.
+/// The pass runs only when there is a `.dreq` past its horizon to decide about.
 async fn observe_superseded_holds(
     store: &dyn ObjectStoreBackend,
     clock: &dyn Clock,
@@ -2331,35 +2327,13 @@ async fn observe_superseded_holds(
     lease: &dyn LeaseCheck,
     tenant: &TenantHash,
     signal: Signal,
-    narrow: Option<&[HeldBucket]>,
 ) -> Result<SupersededHolds> {
     // One pass, one reachability cache: HEAD is read at most once no matter how
     // many shards are observed.
     let mut reach = SnapshotReachability::new();
     let mut holds = SupersededHolds::default();
 
-    let scoped: Vec<(u32, Option<Vec<u32>>)> = match narrow {
-        Some(buckets) => {
-            let mut by_shard: HashMap<u32, BTreeSet<u32>> = HashMap::new();
-            for bucket in buckets {
-                by_shard
-                    .entry(bucket.shard)
-                    .or_default()
-                    .insert(bucket.ingest_hour_bucket);
-            }
-            by_shard
-                .into_iter()
-                .map(|(shard, hours)| (shard, Some(hours.into_iter().collect())))
-                .collect()
-        }
-        None => signal_shards(store, tenant, signal)
-            .await?
-            .into_iter()
-            .map(|shard| (shard, None))
-            .collect(),
-    };
-
-    for (shard, hours) in scoped {
+    for shard in signal_shards(store, tenant, signal).await? {
         let outcome = sweep_superseded_impl(
             &mut reach,
             store,
@@ -2369,7 +2343,7 @@ async fn observe_superseded_holds(
             tenant,
             signal,
             shard,
-            hours.as_deref(),
+            None,
             SweepMode::GateOnly,
         )
         .await?;

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -1051,10 +1051,14 @@ impl SupersededGroup {
     }
 
     /// Fold in a second gather of the same group (a sibling live rewrite over
-    /// the same predecessor). Only the two facts a duplicate can add are
-    /// taken: the sibling's own applied requests, and a truncation either
-    /// gather saw. The keys and objects are identical by construction, since
-    /// both walks start from the same record.
+    /// the same predecessor, or, in an observing pass, a predecessor gathered
+    /// from its own entry and again through a successor's walk). Only the two
+    /// facts a duplicate can add are taken: the sibling's own applied requests,
+    /// and a truncation either gather saw. The two gathers may differ in the
+    /// parts they collected when they started from different links, and that
+    /// difference is not merged: the first gather's keys and objects stand,
+    /// which is all a deleting pass acts on, and the observation consumes only
+    /// the request ids and the truncation flag.
     fn absorb_duplicate(&mut self, other: SupersededGroup) {
         self.request_ids.extend(other.request_ids);
         self.truncated |= other.truncated;
@@ -1395,7 +1399,7 @@ async fn gather_superseded_chain(
         }
         for id in link.applied_request_ids() {
             if !id.is_empty() {
-                request_ids.insert(id.to_string());
+                request_ids.insert(canonical_request_id(id));
             }
         }
         for (part_key, object) in link.part_targets()? {
@@ -2537,9 +2541,40 @@ fn format_shard(shard: u32) -> Result<String> {
     Ok(format!("{shard:04}"))
 }
 
+/// The form a request id takes in the hold set and in the `.dreq` check: the
+/// hyphenated UUID text, which is what a parsed `.dreq` key renders. A rewrite
+/// record carries the id as the string its writer supplied, and a UUID has
+/// more than one accepted text form, so both sides are normalised through the
+/// parser before they are compared. A string that is not a UUID is kept as
+/// written: normalising it would only make an unrelated pair compare equal.
+fn canonical_request_id(id: &str) -> String {
+    match Uuid::parse_str(id) {
+        Ok(uuid) => uuid.hyphenated().to_string(),
+        Err(_) => id.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    /// A drop that names its request in the simple UUID form still matches
+    /// the hyphenated form a `.dreq` key renders; a non-UUID id is kept as
+    /// written. Without the normalisation the first assertion fails: the two
+    /// strings differ and the hold set would miss the request.
+    #[test]
+    fn request_ids_compare_in_the_hyphenated_form() {
+        let hyphenated = "6f1c9a2e-0d3b-4b5a-9e7f-1c2d3e4f5a6b";
+        let simple = "6f1c9a2e0d3b4b5a9e7f1c2d3e4f5a6b";
+        assert_eq!(super::canonical_request_id(simple), hyphenated);
+        assert_eq!(super::canonical_request_id(hyphenated), hyphenated);
+        assert_eq!(
+            super::canonical_request_id(&simple.to_uppercase()),
+            hyphenated,
+            "case is normalised too"
+        );
+        assert_eq!(super::canonical_request_id("not-a-uuid"), "not-a-uuid");
+    }
 
     use bytes::Bytes;
     use ravel_ingest::{IdempotencyReceipt, LookupOutcome, marker_key, read_marker, write_marker};

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -102,7 +102,7 @@
 //! (L0 keys carry no ingest-hour component); see [`sweep_shard_zoned`]'s doc
 //! for that deviation.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use prost::Message;
 use ravel_commit::keys::{self, BucketEntry, KeyError, parse_ingest_hour_string};
@@ -117,7 +117,9 @@ use uuid::Uuid;
 use crate::clock::Clock;
 use crate::config::{CompactorConfig, NS_PER_HOUR};
 use crate::error::{MaintainError, Result};
-use crate::reachability::{SnapshotBlock, SnapshotGate, SnapshotObject, SnapshotReachability};
+use crate::reachability::{
+    SnapshotBlock, SnapshotGate, SnapshotObject, SnapshotReachability, catalog_head_key,
+};
 use crate::read::verify_commit_key;
 
 use ravel_ingest::{IDEM_MARKER_FORWARD_SKEW_TOLERANCE_HOURS, MARKER_SUFFIX};
@@ -198,8 +200,29 @@ pub async fn sweep_shard(
     signal: Signal,
     shard: u32,
 ) -> Result<SweepReport> {
+    let (report, _holds) =
+        sweep_shard_with_holds(store, clock, config, lease, tenant, signal, shard).await?;
+    Ok(report)
+}
+
+/// [`sweep_shard`], also returning what rule 2 held this pass in the form
+/// [`sweep_erasure_requests_with_holds`] consumes. A caller that sweeps several
+/// shards of one signal per tick unions these with [`SupersededHolds::absorb`]
+/// and passes the union to that function, so rule 6 decides from what rule 2
+/// actually held instead of walking the chains a second time.
+pub async fn sweep_shard_with_holds(
+    store: &dyn ObjectStoreBackend,
+    clock: &dyn Clock,
+    config: &CompactorConfig,
+    lease: &dyn LeaseCheck,
+    tenant: &TenantHash,
+    signal: Signal,
+    shard: u32,
+) -> Result<(SweepReport, SupersededHolds)> {
     let superseded = sweep_superseded(store, clock, config, lease, tenant, signal, shard).await?;
     log_superseded_holds(tenant, signal, shard, &superseded);
+    let mut superseded_holds = SupersededHolds::default();
+    superseded_holds.absorb(&superseded);
     let unreferenced_parts_deleted =
         sweep_unreferenced_parts(store, clock, config, lease, tenant, signal, shard).await?;
     let (orphans_deleted, orphan_breaker_tripped, orphans_withheld, orphan_breaker_overridden) =
@@ -210,16 +233,19 @@ pub async fn sweep_shard(
             }
             Err(e) => return Err(e),
         };
-    Ok(SweepReport {
-        orphans_deleted,
-        superseded_records_deleted: superseded.records_deleted,
-        superseded_data_deleted: superseded.data_deleted,
-        unreferenced_parts_deleted,
-        orphan_breaker_tripped,
-        orphans_withheld,
-        orphan_breaker_overridden,
-        full_pass: true,
-    })
+    Ok((
+        SweepReport {
+            orphans_deleted,
+            superseded_records_deleted: superseded.records_deleted,
+            superseded_data_deleted: superseded.data_deleted,
+            unreferenced_parts_deleted,
+            orphan_breaker_tripped,
+            orphans_withheld,
+            orphan_breaker_overridden,
+            full_pass: true,
+        },
+        superseded_holds,
+    ))
 }
 
 /// Zone-scoped sweep pass (ADR-0065 decision 3): rules 2 and 3 list only the
@@ -251,6 +277,25 @@ pub async fn sweep_shard_zoned(
     shard: u32,
     hours: &[u32],
 ) -> Result<SweepReport> {
+    let (report, _holds) =
+        sweep_shard_zoned_with_holds(store, clock, config, lease, tenant, signal, shard, hours)
+            .await?;
+    Ok(report)
+}
+
+/// [`sweep_shard_zoned`], also returning what rule 2 held this pass, exactly as
+/// [`sweep_shard_with_holds`] does for the full pass.
+#[allow(clippy::too_many_arguments)]
+pub async fn sweep_shard_zoned_with_holds(
+    store: &dyn ObjectStoreBackend,
+    clock: &dyn Clock,
+    config: &CompactorConfig,
+    lease: &dyn LeaseCheck,
+    tenant: &TenantHash,
+    signal: Signal,
+    shard: u32,
+    hours: &[u32],
+) -> Result<(SweepReport, SupersededHolds)> {
     let mut reach = SnapshotReachability::new();
     let superseded = sweep_superseded_impl(
         &mut reach,
@@ -262,9 +307,12 @@ pub async fn sweep_shard_zoned(
         signal,
         shard,
         Some(hours),
+        SweepMode::Delete,
     )
     .await?;
     log_superseded_holds(tenant, signal, shard, &superseded);
+    let mut superseded_holds = SupersededHolds::default();
+    superseded_holds.absorb(&superseded);
     let unreferenced_parts_deleted = sweep_unreferenced_parts_impl(
         store,
         clock,
@@ -284,21 +332,24 @@ pub async fn sweep_shard_zoned(
             }
             Err(e) => return Err(e),
         };
-    Ok(SweepReport {
-        orphans_deleted,
-        superseded_records_deleted: superseded.records_deleted,
-        superseded_data_deleted: superseded.data_deleted,
-        unreferenced_parts_deleted,
-        orphan_breaker_tripped,
-        orphans_withheld,
-        orphan_breaker_overridden,
-        full_pass: false,
-    })
+    Ok((
+        SweepReport {
+            orphans_deleted,
+            superseded_records_deleted: superseded.records_deleted,
+            superseded_data_deleted: superseded.data_deleted,
+            unreferenced_parts_deleted,
+            orphan_breaker_tripped,
+            orphans_withheld,
+            orphan_breaker_overridden,
+            full_pass: false,
+        },
+        superseded_holds,
+    ))
 }
 
 /// Surface a superseded-input hold to an operator running the combined
-/// [`sweep_shard`] / [`sweep_shard_zoned`] pass. [`SweepReport`] itself is
-/// unchanged: the structured counters live on [`SupersededSweepOutcome`], which
+/// [`sweep_shard`] / [`sweep_shard_zoned`] pass. [`SweepReport`] carries no
+/// hold counter: the structured counters live on [`SupersededSweepOutcome`], which
 /// [`sweep_superseded`] returns directly, and this log line is what a caller
 /// that only has the combined report sees. Silent on a pass that held nothing,
 /// which is every ordinary pass.
@@ -308,7 +359,7 @@ fn log_superseded_holds(
     shard: u32,
     outcome: &SupersededSweepOutcome,
 ) {
-    if outcome.held() == 0 {
+    if outcome.held() == 0 && outcome.chain_groups_held_by_legal_hold == 0 {
         return;
     }
     tracing::warn!(
@@ -317,9 +368,12 @@ fn log_superseded_holds(
         shard,
         held_by_snapshot = outcome.held_by_snapshot,
         held_by_unreadable_head = outcome.held_by_unreadable_head,
+        chain_groups_held_by_legal_hold = outcome.chain_groups_held_by_legal_hold,
+        held_requests = outcome.held_request_ids.len(),
+        held_truncated_buckets = outcome.held_truncated_buckets.len(),
         "superseded-input sweep: held inputs the live catalog HEAD snapshot still names \
-         (or could not be read); they are collected once the fold reconciles their hour or \
-         HEAD is rebuilt"
+         (or could not be read, or a legal hold protects); they are collected once the fold \
+         reconciles their hour, HEAD is rebuilt, or the hold is released"
     );
 }
 
@@ -468,6 +522,17 @@ async fn referenced_l0_identities(
 
 // --- Rule 2: superseded-input sweep (ADR-0018) -----------------------------
 
+/// One `(shard, ingest hour)` bucket in which a sweep pass held part of a
+/// supersession chain it could not walk to the end (a generation's record was
+/// already gone). The requests the missing generation applied are not
+/// discoverable from any surviving record, so the erasure-request sweep holds
+/// every `.dreq` that could name such a bucket.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HeldBucket {
+    pub shard: u32,
+    pub ingest_hour_bucket: u32,
+}
+
 /// What one superseded-input sweep pass did.
 ///
 /// The two `held_*` counters are the object-granular counterpart of
@@ -475,7 +540,14 @@ async fn referenced_l0_identities(
 /// count plus the blocked reason, so an operator watching inputs pile up can
 /// tell the ordinary lagging-fold case ([`SnapshotBlock::Named`]) from an
 /// unreadable HEAD or snapshot part ([`SnapshotBlock::Unreadable`]).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+///
+/// `held_request_ids` and `held_truncated_buckets` are what the
+/// erasure-request sweep consumes: this pass is the only component that
+/// already knows, per chain group, both which erasure requests the group's
+/// generations applied and whether the group was held. Publishing that here
+/// is what lets rule 6 decide without a walk of its own, and without depending
+/// on a completion record's optional per-bucket drop list.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SupersededSweepOutcome {
     /// Superseded commit, compaction, and rewrite records deleted (or, under
     /// `dry_run`, that would have been).
@@ -495,12 +567,78 @@ pub struct SupersededSweepOutcome {
     /// lagging-fold case. Counter seam for
     /// `ravel_maintain_superseded_inputs_held_total{reason="unreadable_head"}`.
     pub held_by_unreadable_head: usize,
+    /// Chain groups skipped whole this pass because the [`LeaseCheck`] protects
+    /// at least one key in them. The unit is the group, not the object: a
+    /// group is one indivisible deletion unit, so a hold over any single key in
+    /// it stops all of it. Counter seam for
+    /// `ravel_maintain_superseded_groups_held_by_legal_hold_total`.
+    pub chain_groups_held_by_legal_hold: usize,
+    /// Every erasure request id applied anywhere on a chain group this pass
+    /// held, for any of the three reasons above. While a request is in this
+    /// set an object that predates its rewrite is still in the store, so its
+    /// `.dreq` (and with it the query-time exclusion filter) must survive.
+    pub held_request_ids: BTreeSet<String>,
+    /// The buckets in which this pass held a group whose supersession chain it
+    /// could not walk to the end. The requests the missing generation applied
+    /// are not in `held_request_ids`, because no surviving record names them,
+    /// so rule 6 falls back to the bucket.
+    pub held_truncated_buckets: BTreeSet<HeldBucket>,
 }
 
 impl SupersededSweepOutcome {
     /// Objects held this pass for any reason.
     pub fn held(&self) -> usize {
         self.held_by_snapshot + self.held_by_unreadable_head
+    }
+
+    /// Record what a held group means for rule 6: every request the group's
+    /// objects predate must keep its `.dreq`, and a group whose chain could
+    /// not be walked to the end names requests no surviving record does, so
+    /// its bucket is reported instead.
+    fn note_hold(&mut self, group: &SupersededGroup, shard: u32) {
+        self.held_request_ids
+            .extend(group.request_ids.iter().cloned());
+        if group.truncated {
+            self.held_truncated_buckets.insert(HeldBucket {
+                shard,
+                ingest_hour_bucket: group.ingest_hour_bucket,
+            });
+        }
+    }
+}
+
+/// What a superseded-input sweep held, in the form rule 6 consumes: the union
+/// over however many shards the caller swept.
+///
+/// This is the whole input to the erasure-request guard. Rule 6 asks no
+/// question of its own about supersession chains: rule 2 already walked them,
+/// already gated them, and already knows which requests the objects it held
+/// predate. A completion record's `bucket_drops` is used only to narrow which
+/// buckets rule 2 is asked about, never to decide a hold, because the field is
+/// optional on the wire and a completion written without it must still be
+/// safe.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SupersededHolds {
+    /// [`SupersededSweepOutcome::held_request_ids`], unioned across shards.
+    pub request_ids: BTreeSet<String>,
+    /// [`SupersededSweepOutcome::held_truncated_buckets`], unioned across
+    /// shards.
+    pub truncated_buckets: BTreeSet<HeldBucket>,
+}
+
+impl SupersededHolds {
+    /// Fold one shard's outcome into the union.
+    pub fn absorb(&mut self, outcome: &SupersededSweepOutcome) {
+        self.request_ids
+            .extend(outcome.held_request_ids.iter().cloned());
+        self.truncated_buckets
+            .extend(outcome.held_truncated_buckets.iter().copied());
+    }
+
+    /// `true` when nothing was held: every `.dreq` past its horizon is
+    /// collectable, which is the ordinary steady state.
+    pub fn is_empty(&self) -> bool {
+        self.request_ids.is_empty() && self.truncated_buckets.is_empty()
     }
 }
 
@@ -518,9 +656,32 @@ pub async fn sweep_superseded(
 ) -> Result<SupersededSweepOutcome> {
     let mut reach = SnapshotReachability::new();
     sweep_superseded_impl(
-        &mut reach, store, clock, config, lease, tenant, signal, shard, None,
+        &mut reach,
+        store,
+        clock,
+        config,
+        lease,
+        tenant,
+        signal,
+        shard,
+        None,
+        SweepMode::Delete,
     )
     .await
+}
+
+/// Whether a [`sweep_superseded_impl`] pass deletes what it cleared, or only
+/// computes the gate and the holds.
+///
+/// [`SweepMode::GateOnly`] is what makes the erasure-request guard reachable
+/// from a caller that has no rule-2 outcome to hand: the pass reads exactly
+/// what a deleting pass reads and reports exactly the same holds, and its
+/// `records_deleted` / `data_deleted` are always zero. It is not `dry_run`,
+/// which reports what it would have deleted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SweepMode {
+    Delete,
+    GateOnly,
 }
 
 /// Shared implementation behind [`sweep_superseded`] (whole-shard, `hours:
@@ -540,6 +701,7 @@ async fn sweep_superseded_impl(
     signal: Signal,
     shard: u32,
     hours: Option<&[u32]>,
+    mode: SweepMode,
 ) -> Result<SupersededSweepOutcome> {
     let now = clock.now_ns();
     let entries = list_commit_entries_scoped(store, tenant, signal, shard, hours).await?;
@@ -558,7 +720,14 @@ async fn sweep_superseded_impl(
         .filter(|k| !k.is_empty())
         .collect();
 
-    let mut outcome = SupersededSweepOutcome::default();
+    // Phase A: gather every group this pass could delete, deduplicated by
+    // chain identity across the whole pass. Two live rewrites naming the same
+    // `superseded_record_key` gather the identical chain, so without the
+    // dedup every key in it is gated twice and counted twice, and
+    // `records_deleted` / `data_deleted` exceed the number of distinct objects
+    // the pass removed.
+    let mut groups: Vec<SupersededGroup> = Vec::new();
+    let mut by_identity: HashMap<String, usize> = HashMap::new();
     for (key, entry) in &entries {
         if superseded_by_present.contains(key.as_str()) {
             continue;
@@ -569,7 +738,14 @@ async fn sweep_superseded_impl(
         // no superseded input. A compaction record is fetched NotFound-
         // tolerantly, and a rewrite absent from `rewrites` is skipped the same
         // way: a crash-interrupted prior pass can leave a listed key gone.
-        let groups = match entry {
+        //
+        // `applied` is the live record's own drops. Everything in the groups it
+        // gathers predates them: a group's L1 parts are the pre-image this
+        // record erased a subject out of, and its raw L0 inputs are the
+        // pre-image below that. So a hold on the group is a hold on those
+        // requests' `.dreq`s, on top of whatever the generations inside the
+        // group applied themselves.
+        let (gathered, applied) = match entry {
             BucketEntry::CompactionRecord(_) => {
                 let Some(record) = get_compaction_record_opt(store, key).await? else {
                     continue;
@@ -582,7 +758,10 @@ async fn sweep_superseded_impl(
                 {
                     continue;
                 }
-                gather_l0_inputs(store, tenant, signal, shard, &record).await?
+                (
+                    gather_l0_inputs(store, tenant, signal, shard, &record).await?,
+                    Vec::new(),
+                )
             }
             BucketEntry::RewriteRecord(_) => {
                 let Some(record) = rewrites.get(key) else {
@@ -599,105 +778,153 @@ async fn sweep_superseded_impl(
                 {
                     continue;
                 }
+                let applied: Vec<String> = record
+                    .drops
+                    .iter()
+                    .map(|d| d.request_id.clone())
+                    .filter(|id| !id.is_empty())
+                    .collect();
                 if !record.inputs.is_empty() {
                     // RawL0 rewrite: the same L0 commit records + data objects
                     // a compaction over the same inputs would supersede.
-                    gather_l0_inputs(store, tenant, signal, shard, record).await?
+                    (
+                        gather_l0_inputs(store, tenant, signal, shard, record).await?,
+                        applied,
+                    )
                 } else {
                     // Predecessor rewrite: the whole supersession chain behind
                     // it, down to the raw L0 inputs the oldest generation
                     // superseded. Rule 3 cannot collect a superseded
                     // generation's parts while its record still references
                     // them, so this rule removes records and parts together.
-                    gather_superseded_chain(
-                        store,
-                        tenant,
-                        signal,
-                        shard,
-                        &record.superseded_record_key,
+                    (
+                        gather_superseded_chain(
+                            store,
+                            tenant,
+                            signal,
+                            shard,
+                            &record.superseded_record_key,
+                        )
+                        .await?,
+                        applied,
                     )
-                    .await?
                 }
             }
             BucketEntry::CommitRecord(_) | BucketEntry::Tombstone(_) => continue,
         };
 
-        // HEAD-reachability gate (ADR-0020 delete blocker), object-granular
-        // because this rule deletes individual objects out of a bucket whose
-        // surviving compaction or rewrite outputs the snapshot legitimately
-        // still names. A group is indivisible: a predecessor record must
-        // outlive every part it names, or rule 3 would collect those parts on
-        // the next pass and undo the hold; and a whole supersession chain is
-        // one group so a HEAD that still names the oldest generation's raw
-        // inputs holds every record above them too.
-        let mut cleared: Vec<&SupersededGroup> = Vec::with_capacity(groups.len());
-        for group in &groups {
-            match reach
-                .object_gate(
-                    store,
-                    tenant,
-                    signal,
-                    group.ingest_hour_bucket,
-                    &group.objects,
-                )
-                .await?
-            {
-                SnapshotGate::Clear => cleared.push(group),
-                SnapshotGate::Blocked(SnapshotBlock::Named) => {
-                    outcome.held_by_snapshot += group.object_count();
-                }
-                SnapshotGate::Blocked(SnapshotBlock::Unreadable) => {
-                    outcome.held_by_unreadable_head += group.object_count();
+        for mut group in gathered {
+            group.request_ids.extend(applied.iter().cloned());
+            match by_identity.get(&group.identity) {
+                Some(&index) => groups[index].absorb_duplicate(group),
+                None => {
+                    by_identity.insert(group.identity.clone(), groups.len());
+                    groups.push(group);
                 }
             }
         }
+    }
 
-        // Every cleared group's superseded-input records first, then every
-        // cleared group's data objects (docs/consistency-model.md): a crash
-        // between the two phases leaves record-less data (orphan GC) or an
-        // unreferenced part (rule 3), never a record pointing at a deleted
-        // object. The gate runs entirely ahead of every phase so a held group
-        // never splits that order.
-        //
-        // The chain's own records go last of all, oldest generation first, so
-        // a rewrite record outlives every input it superseded: a crash inside
-        // this rule leaves the record still naming inputs that are already
-        // gone (harmless, and the next pass finishes the job), never a
-        // surviving input with the record that erased a subject out of it
-        // deleted, which would leave the erasure request's filter with nothing
-        // durable to discover it by.
-        for group in &cleared {
-            for k in &group.record_keys {
-                if lease.is_protected(k) {
-                    continue;
-                }
-                if !config.dry_run {
-                    store.delete(k).await?;
-                }
-                outcome.records_deleted += 1;
+    // Phase B: gate every group, once. Nothing is deleted before every group
+    // has an answer, so a held group never splits a delete phase.
+    //
+    // The lease/legal-hold check is per group, not per key: a group is one
+    // indivisible deletion unit, and its phase order exists so a record always
+    // outlives the objects it superseded. Skipping only the protected keys
+    // inside the phases breaks that order, and a prefix-scoped legal hold
+    // covering the data keys but not the commit prefix is exactly the shape
+    // that does it -- the records that erased a subject go while the bytes
+    // holding it stay.
+    //
+    // The HEAD-reachability gate (ADR-0020 delete blocker) is object-granular
+    // because this rule deletes individual objects out of a bucket whose
+    // surviving compaction or rewrite outputs the snapshot legitimately still
+    // names. A group is indivisible there too: a predecessor record must
+    // outlive every part it names, or rule 3 would collect those parts on the
+    // next pass and undo the hold; and a whole supersession chain is one group
+    // so a HEAD that still names the oldest generation's raw inputs holds
+    // every record above them too.
+    let mut outcome = SupersededSweepOutcome::default();
+    let mut cleared: Vec<&SupersededGroup> = Vec::with_capacity(groups.len());
+    for group in &groups {
+        if let Some(protected) = group.protected_key(lease) {
+            tracing::warn!(
+                tenant_hash = %tenant.to_hex(),
+                signal = signal.key_prefix(),
+                shard,
+                ingest_hour_bucket = group.ingest_hour_bucket,
+                protected_key = %protected,
+                group_objects = group.object_count(),
+                "superseded-input sweep: a lease or legal hold protects a key in a supersession \
+                 chain, so the whole chain is skipped this pass; deleting the unprotected part of \
+                 it would break the order that keeps a record alive until the objects it \
+                 superseded are gone"
+            );
+            outcome.chain_groups_held_by_legal_hold += 1;
+            outcome.note_hold(group, shard);
+            continue;
+        }
+        match reach
+            .object_gate(
+                store,
+                tenant,
+                signal,
+                group.ingest_hour_bucket,
+                &group.objects,
+            )
+            .await?
+        {
+            SnapshotGate::Clear => cleared.push(group),
+            SnapshotGate::Blocked(SnapshotBlock::Named) => {
+                outcome.held_by_snapshot += group.object_count();
+                outcome.note_hold(group, shard);
+            }
+            SnapshotGate::Blocked(SnapshotBlock::Unreadable) => {
+                outcome.held_by_unreadable_head += group.object_count();
+                outcome.note_hold(group, shard);
             }
         }
-        for group in &cleared {
-            for k in &group.data_keys {
-                if lease.is_protected(k) {
-                    continue;
-                }
-                if !config.dry_run {
-                    store.delete(k).await?;
-                }
-                outcome.data_deleted += 1;
+    }
+
+    if mode == SweepMode::GateOnly {
+        return Ok(outcome);
+    }
+
+    // Phase C: every cleared group's superseded-input records first, then every
+    // cleared group's data objects (docs/consistency-model.md): a crash
+    // between the two phases leaves record-less data (orphan GC) or an
+    // unreferenced part (rule 3), never a record pointing at a deleted
+    // object.
+    //
+    // The chains' own records go last of all, oldest generation first, so a
+    // rewrite record outlives every input it superseded: a crash inside this
+    // rule leaves the record still naming inputs that are already gone
+    // (harmless, and the next pass finishes the job), never a surviving input
+    // with the record that erased a subject out of it deleted, which would
+    // leave the erasure request's filter with nothing durable to discover it
+    // by.
+    for group in &cleared {
+        for k in &group.record_keys {
+            if !config.dry_run {
+                store.delete(k).await?;
             }
+            outcome.records_deleted += 1;
         }
-        for group in &cleared {
-            for k in &group.chain_record_keys {
-                if lease.is_protected(k) {
-                    continue;
-                }
-                if !config.dry_run {
-                    store.delete(k).await?;
-                }
-                outcome.records_deleted += 1;
+    }
+    for group in &cleared {
+        for k in &group.data_keys {
+            if !config.dry_run {
+                store.delete(k).await?;
             }
+            outcome.data_deleted += 1;
+        }
+    }
+    for group in &cleared {
+        for k in &group.chain_record_keys {
+            if !config.dry_run {
+                store.delete(k).await?;
+            }
+            outcome.records_deleted += 1;
         }
     }
     Ok(outcome)
@@ -743,12 +970,49 @@ struct SupersededGroup {
     /// generation first, deleted after every object they superseded.
     chain_record_keys: Vec<String>,
     objects: Vec<SnapshotObject>,
+    /// Every erasure request id the objects in this group predate: the drops of
+    /// the live record that superseded the group, plus the drops of every
+    /// generation inside it. A hold on the group is a hold on each of these
+    /// requests' `.dreq`s.
+    request_ids: BTreeSet<String>,
+    /// The chain walk stopped at a generation whose record was already gone,
+    /// so whatever requests that generation applied are named by no surviving
+    /// record and cannot appear in `request_ids`.
+    truncated: bool,
+    /// Dedup key: the oldest record this group deletes, which is the one thing
+    /// two live rewrites over the same predecessor gather identically.
+    identity: String,
 }
 
 impl SupersededGroup {
     /// Objects this group would delete, for the held counters.
     fn object_count(&self) -> usize {
         self.record_keys.len() + self.data_keys.len() + self.chain_record_keys.len()
+    }
+
+    /// Every key this group deletes, in delete order.
+    fn keys(&self) -> impl Iterator<Item = &String> {
+        self.record_keys
+            .iter()
+            .chain(self.data_keys.iter())
+            .chain(self.chain_record_keys.iter())
+    }
+
+    /// The first key in this group the `lease` protects, if any.
+    fn protected_key(&self, lease: &dyn LeaseCheck) -> Option<&str> {
+        self.keys()
+            .find(|k| lease.is_protected(k))
+            .map(String::as_str)
+    }
+
+    /// Fold in a second gather of the same group (a sibling live rewrite over
+    /// the same predecessor). Only the two facts a duplicate can add are
+    /// taken: the sibling's own applied requests, and a truncation either
+    /// gather saw. The keys and objects are identical by construction, since
+    /// both walks start from the same record.
+    fn absorb_duplicate(&mut self, other: SupersededGroup) {
+        self.request_ids.extend(other.request_ids);
+        self.truncated |= other.truncated;
     }
 }
 
@@ -793,6 +1057,7 @@ async fn gather_l0_inputs(
                 })?;
                 groups.push(SupersededGroup {
                     ingest_hour_bucket: rec.ingest_hour_bucket,
+                    identity: commit_key.clone(),
                     record_keys: vec![commit_key],
                     data_keys: vec![data_key],
                     chain_record_keys: Vec::new(),
@@ -803,6 +1068,8 @@ async fn gather_l0_inputs(
                         writer_epoch: rec.writer_epoch,
                         writer_seq: rec.writer_seq,
                     }],
+                    request_ids: BTreeSet::new(),
+                    truncated: false,
                 });
             }
             Err(StoreError::NotFound) => {}
@@ -1029,9 +1296,15 @@ async fn load_chain_link(store: &dyn ObjectStoreBackend, key: &str) -> Result<Op
 /// a HEAD naming anything in it holds all of it.
 ///
 /// A chain truncated by an absent record yields whatever it reached before the
-/// gap; an absent `predecessor_key` yields no group at all, and any surviving
-/// parts below it are unreferenced under the live record and collected by
-/// rule 3.
+/// gap, flagged [`SupersededGroup::truncated`] so a hold on it can be reported
+/// per bucket rather than per request; an absent `predecessor_key` yields no
+/// group at all, and any surviving parts below it are unreferenced under the
+/// live record and collected by rule 3.
+///
+/// The group also carries every erasure request the generations it covers
+/// applied. Those requests' `.dreq`s cannot be retired while the group is
+/// held, because the objects in it are the pre-image the requests erased a
+/// subject out of.
 async fn gather_superseded_chain(
     store: &dyn ObjectStoreBackend,
     tenant: &TenantHash,
@@ -1045,6 +1318,8 @@ async fn gather_superseded_chain(
     let mut input_data_keys: Vec<String> = Vec::new();
     let mut objects: Vec<SnapshotObject> = Vec::new();
     let mut ingest_hour_bucket: Option<u32> = None;
+    let mut request_ids: BTreeSet<String> = BTreeSet::new();
+    let mut truncated = false;
     let mut seen: HashSet<String> = HashSet::new();
     let mut cursor = Some(predecessor_key.to_string());
 
@@ -1055,6 +1330,7 @@ async fn gather_superseded_chain(
             )));
         }
         let Some(link) = load_chain_link(store, &key).await? else {
+            truncated = true;
             break;
         };
         // The gate reads one hour's covering snapshot parts, so a chain that
@@ -1070,6 +1346,11 @@ async fn gather_superseded_chain(
                     "supersession chain from {predecessor_key} spans ingest hours {hour} and {}",
                     link.ingest_hour_bucket()
                 )));
+            }
+        }
+        for id in link.applied_request_ids() {
+            if !id.is_empty() {
+                request_ids.insert(id.to_string());
             }
         }
         for (part_key, object) in link.part_targets()? {
@@ -1098,12 +1379,21 @@ async fn gather_superseded_chain(
     // generations below it superseded, and after the generation it superseded.
     chain_record_keys.reverse();
     input_data_keys.extend(chain_part_keys);
+    // The oldest generation's record is the group's identity: it is what every
+    // live rewrite over this same predecessor walks down to.
+    let identity = chain_record_keys
+        .first()
+        .cloned()
+        .unwrap_or_else(|| predecessor_key.to_string());
     Ok(vec![SupersededGroup {
         ingest_hour_bucket,
         record_keys: input_record_keys,
         data_keys: input_data_keys,
         chain_record_keys,
         objects,
+        request_ids,
+        truncated,
+        identity,
     }])
 }
 
@@ -1691,14 +1981,6 @@ async fn read_head_reference(
     }
 }
 
-/// `t/<tenant_hash_hex>/catalog/<signal>/HEAD` -- the mutable head pointer for
-/// one `(tenant, signal)` (docs/catalog-and-mvcc.md key layout). No public
-/// builder is exported from ravel-catalog, so it is constructed here from the
-/// same pieces, matching `idem_prefix`'s local-reconstruction precedent.
-fn catalog_head_key(tenant: &TenantHash, signal: Signal) -> String {
-    format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
-}
-
 /// `t/<tenant_hash_hex>/catalog/<signal>/snap/` -- the prefix covering every
 /// snapshot part for one `(tenant, signal)`, across every watermark.
 fn catalog_snap_prefix(tenant: &TenantHash, signal: Signal) -> String {
@@ -1757,26 +2039,28 @@ pub struct ErasureRequestSweepOutcome {
 ///   because after the horizon no resolvable snapshot can still reference a
 ///   pre-rewrite input (ADR-0064 §3.5 race window, closed durably). Deleting
 ///   the `.dreq` a nanosecond early would reopen exactly that window.
-/// - no input superseded by a rewrite anywhere on a supersession chain that
-///   applied this request is still physically present. The horizon on its own
-///   does not imply that: rule 2 holds an input the live HEAD snapshot still
-///   names, and a legal hold over the shard's data prefixes (which does not
-///   cover `del/`) holds it too. In both cases a snapshot can still resolve the
-///   pre-rewrite input, so retiring the filter would serve the erased subject
-///   again. The check reads the `.done`'s own `bucket_drops` for the buckets
-///   this request touched and walks each bucket's chains back through
-///   `superseded_record_key`, so it costs one LIST per touched bucket plus one
-///   GET per record on the chain, and runs only for a `.dreq` that has already
-///   cleared its horizon; in the ordinary case rule 2 collected the inputs long
-///   before, so the first such pass finds nothing and removes the request. It
-///   does not require the record that applied the request to still exist: see
-///   [`superseded_inputs_outstanding`] for the truncated-chain fallback. An
-///   input whose commit record and data object are both gone but whose chain is
-///   intact is not counted, and neither is a record-less L0 data object in a
-///   bucket whose chain is intact: that is a record-less orphan awaiting rule
-///   1, discovered from no durable record.
+/// - rule 2 did not hold anything this request's rewrites superseded. The
+///   horizon on its own does not imply that: rule 2 holds an input the live
+///   HEAD snapshot still names, an input under a snapshot part it cannot read,
+///   and a whole chain any legal hold over the shard's data prefixes touches
+///   (such a hold does not cover `del/`, so it does not pin the `.dreq`
+///   itself). In every one of those cases a snapshot can still resolve the
+///   pre-rewrite object, so retiring the filter would serve the erased subject
+///   again. The decision is read straight off [`SupersededHolds`], which rule
+///   2 fills while it gates: `request_ids` when a held group names the request,
+///   and `truncated_buckets` when a held group's chain could not be walked to
+///   the end, in which case the requests the missing generation applied are
+///   named by no surviving record and the bucket stands in for them. This
+///   costs no LIST and no GET of its own beyond rule 2's own pass.
 /// - the [`LeaseCheck`] passes: a legal hold over the `del/` keyspace pins the
 ///   request exactly as it pins any other object.
+///
+/// A completion's `bucket_drops` is a narrowing hint only, never the basis of a
+/// hold: the field is optional on the wire, has been written empty by a
+/// production writer, and a `.dreq` whose completion carries no drops is held
+/// by any truncated bucket in the signal rather than exempted. Where it is
+/// present it narrows which buckets rule 2 is asked about, and which truncated
+/// buckets can hold a given request.
 ///
 /// A completion whose `completed_unix_ns` is zero is treated fail-safe as "not
 /// yet a valid horizon anchor" and its `.dreq` is kept: a zero anchor would
@@ -1794,6 +2078,23 @@ pub struct ErasureRequestSweepOutcome {
 /// `del/` that is neither a `.dreq` nor a `.done` is layout drift and fails
 /// the pass loud, matching the resolver's and the rewrite pass's fail-loud
 /// discipline for this keyspace.
+/// Run rule 6 for a caller that has no rule-2 outcome to hand, observing the
+/// holds itself.
+///
+/// This is the production entry (`ravel-server`'s maintenance tick), and it is
+/// what makes the guard reachable there: it runs rule 2 in
+/// [`SweepMode::GateOnly`] over the buckets that matter and decides from the
+/// holds that pass reports, instead of from a completion field a production
+/// writer may leave empty. The observation costs one rule-2-shaped pass and
+/// nothing more; a caller that already swept the signal's shards this tick
+/// should sweep with [`sweep_shard_with_holds`], union the holds it returns,
+/// and call [`sweep_erasure_requests_with_holds`] instead, which costs nothing
+/// at all.
+///
+/// The observation runs only when there is a `.dreq` past its horizon to
+/// decide about. An ordinary pass, where every request is either incomplete or
+/// still inside its horizon, reads nothing but the `del/` listing and the
+/// completions.
 pub async fn sweep_erasure_requests(
     store: &dyn ObjectStoreBackend,
     clock: &dyn Clock,
@@ -1801,6 +2102,46 @@ pub async fn sweep_erasure_requests(
     lease: &dyn LeaseCheck,
     tenant: &TenantHash,
     signal: Signal,
+) -> Result<ErasureRequestSweepOutcome> {
+    sweep_erasure_requests_inner(store, clock, config, lease, tenant, signal, None).await
+}
+
+/// Run rule 6 against the holds a caller's own rule-2 passes already reported
+/// (`holds`), adding no request of its own.
+///
+/// This is the shape the per-tick maintenance loop wants: sweep the signal's
+/// shards with [`sweep_shard_with_holds`], union each returned
+/// [`SupersededHolds`], and pass the union here. Rule 2 walked every
+/// supersession chain in those shards while it gated them, so rule 6 needs no
+/// walk of its own.
+///
+/// `holds` must cover every shard of `signal` the caller swept, and the caller
+/// must have swept them with the same `config` horizon. A `holds` that omits a
+/// shard rule 2 held in is the one unsafe input to this function: it would let
+/// a `.dreq` retire while a pre-rewrite object in that shard is still
+/// resolvable. [`sweep_erasure_requests`] exists for callers that cannot make
+/// that guarantee.
+pub async fn sweep_erasure_requests_with_holds(
+    store: &dyn ObjectStoreBackend,
+    clock: &dyn Clock,
+    config: &CompactorConfig,
+    lease: &dyn LeaseCheck,
+    tenant: &TenantHash,
+    signal: Signal,
+    holds: &SupersededHolds,
+) -> Result<ErasureRequestSweepOutcome> {
+    sweep_erasure_requests_inner(store, clock, config, lease, tenant, signal, Some(holds)).await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn sweep_erasure_requests_inner(
+    store: &dyn ObjectStoreBackend,
+    clock: &dyn Clock,
+    config: &CompactorConfig,
+    lease: &dyn LeaseCheck,
+    tenant: &TenantHash,
+    signal: Signal,
+    holds: Option<&SupersededHolds>,
 ) -> Result<ErasureRequestSweepOutcome> {
     let now = clock.now_ns();
     let prefix = keys::del_prefix(tenant, signal);
@@ -1825,12 +2166,11 @@ pub async fn sweep_erasure_requests(
         }
     }
 
-    let mut deleted = 0usize;
+    // Split the requests into the ones this pass could delete and the ones a
+    // cheaper condition already keeps, before any hold is observed: an
+    // ordinary pass has no candidate and does no further work.
+    let mut candidates: Vec<(&Uuid, &String, &ErasureCompletion)> = Vec::new();
     let mut kept = 0usize;
-    let mut held_by_superseded_inputs = 0usize;
-    // Every bucket's commit listing, its rewrite records, and its chain walks,
-    // read once for the pass: several requests routinely share one bucket.
-    let mut scans: HashMap<(u32, u32), BucketScan> = HashMap::new();
     for (request_id, dreq_key) in &dreq_keys {
         let Some(completion) = completions.get(request_id) else {
             // No `.done`: the erasure is not verified complete, so the request
@@ -1852,27 +2192,69 @@ pub async fn sweep_erasure_requests(
             kept += 1;
             continue;
         }
-        // The horizon has elapsed, but an input one of this request's rewrites
-        // superseded may still be in the store (held by rule 2's HEAD gate, or
-        // by a legal hold over the data prefixes that does not cover `del/`).
-        // A snapshot can still resolve such an input, so the filter stays.
-        if superseded_inputs_outstanding(
-            store,
-            tenant,
-            signal,
-            completion,
-            &request_id.to_string(),
-            &mut scans,
-        )
-        .await?
-        {
+        candidates.push((request_id, dreq_key, completion));
+    }
+
+    if candidates.is_empty() {
+        return Ok(ErasureRequestSweepOutcome {
+            deleted: 0,
+            kept,
+            held_by_superseded_inputs: 0,
+        });
+    }
+
+    let observed;
+    let holds = match holds {
+        Some(holds) => holds,
+        None => {
+            let narrow = narrowing_buckets(&candidates, signal);
+            observed = observe_superseded_holds(
+                store,
+                clock,
+                config,
+                lease,
+                tenant,
+                signal,
+                narrow.as_deref(),
+            )
+            .await?;
+            &observed
+        }
+    };
+
+    let mut deleted = 0usize;
+    let mut held_by_superseded_inputs = 0usize;
+    for (request_id, dreq_key, completion) in candidates {
+        // The horizon has elapsed, but rule 2 may have held an object one of
+        // this request's rewrites superseded: an input the live HEAD still
+        // names, one under an unreadable snapshot part, or a chain a legal
+        // hold over the data prefixes touches. A snapshot can still resolve
+        // such an object, so the filter stays.
+        let request_id_s = request_id.to_string();
+        let held = if holds.request_ids.contains(&request_id_s) {
+            true
+        } else {
+            // A held chain rule 2 could not walk to the end names requests no
+            // surviving record does, so the bucket stands in for them. The
+            // completion's own drops narrow which buckets can hold this
+            // request; a completion that carries none (the production shape
+            // today) is narrowed by nothing and any truncated bucket holds it.
+            let drops = completion_buckets(completion, signal);
+            match &drops {
+                Some(buckets) => buckets.iter().any(|b| holds.truncated_buckets.contains(b)),
+                None => !holds.truncated_buckets.is_empty(),
+            }
+        };
+        if held {
             tracing::warn!(
                 tenant_hash = %tenant.to_hex(),
                 signal = signal.key_prefix(),
                 request_id = %request_id,
-                "erasure-request sweep: holding a .dreq past its horizon because an input its \
-                 rewrite superseded is still in the store; the query-time exclusion filter must \
-                 outlive it"
+                held_requests = holds.request_ids.len(),
+                held_truncated_buckets = holds.truncated_buckets.len(),
+                "erasure-request sweep: holding a .dreq past its horizon because the \
+                 superseded-input sweep held an object its rewrite superseded; the query-time \
+                 exclusion filter must outlive it"
             );
             kept += 1;
             held_by_superseded_inputs += 1;
@@ -1891,287 +2273,145 @@ pub async fn sweep_erasure_requests(
     })
 }
 
-/// What one supersession chain, walked from a live record back to the raw L0
-/// inputs at its end, says about the requests applied along it.
-#[derive(Debug, Default, Clone)]
-struct ChainWalk {
-    /// Every erasure request id any generation on the chain applied.
-    request_ids: HashSet<String>,
-    /// A generation on the chain names a `superseded_record_key` whose record
-    /// is gone, so the walk could not reach the raw L0 inputs. The requests
-    /// that generation applied are no longer discoverable from any record.
-    truncated: bool,
-    /// Something a generation on this chain superseded is still physically
-    /// present: a deeper generation's own record and parts, or a raw L0 input.
-    inputs_outstanding: bool,
-}
-
-/// One (shard, ingest hour) bucket's commit listing, read once per sweep pass
-/// and shared by every request whose `.done` records a drop for that bucket.
-struct BucketScan {
-    entries: Vec<(String, BucketEntry)>,
-    rewrites: HashMap<String, RewriteRecord>,
-    /// The bucket's compaction/rewrite records no present rewrite supersedes:
-    /// the heads of its supersession chains.
-    live_heads: Vec<String>,
-    /// Chain walks by live head, filled on first use.
-    walks: HashMap<String, ChainWalk>,
-    /// The truncated-chain residue answer, computed at most once.
-    residue: Option<bool>,
-}
-
-impl BucketScan {
-    async fn load(
-        store: &dyn ObjectStoreBackend,
-        tenant: &TenantHash,
-        signal: Signal,
-        shard: u32,
-        hour: u32,
-    ) -> Result<Self> {
-        let entries =
-            list_commit_entries_scoped(store, tenant, signal, shard, Some(&[hour])).await?;
-        let rewrites = load_rewrite_records(store, &entries).await?;
-        let live_heads: Vec<String> = {
-            let superseded: HashSet<&str> = rewrites
-                .values()
-                .map(|r| r.superseded_record_key.as_str())
-                .filter(|k| !k.is_empty())
-                .collect();
-            entries
-                .iter()
-                .filter(|(key, entry)| {
-                    matches!(
-                        entry,
-                        BucketEntry::CompactionRecord(_) | BucketEntry::RewriteRecord(_)
-                    ) && !superseded.contains(key.as_str())
-                })
-                .map(|(key, _)| key.clone())
-                .collect()
-        };
-        Ok(Self {
-            entries,
-            rewrites,
-            live_heads,
-            walks: HashMap::new(),
-            residue: None,
-        })
-    }
-}
-
-/// Whether any input superseded by a rewrite on a supersession chain that
-/// applied `request_id` is still physically present, across every bucket the
-/// request's `.done` records a drop for in `signal`.
+/// The buckets one completion records a drop for in `signal`, or `None` when it
+/// records none.
 ///
-/// Anchored on durable records only: the `.done`'s `bucket_drops` name the
-/// buckets, each bucket's own listing names the heads of its supersession
-/// chains, and each chain is walked back through `superseded_record_key` to
-/// the raw L0 inputs at its end. Every generation past the head is itself an
-/// input the generation above it superseded, so a chain deeper than one
-/// generation holds the request whatever the raw inputs' state.
-///
-/// This walk does not assume rule 2 deletes a chain in any particular order,
-/// and it deliberately does not assume the record that applied `request_id` is
-/// still there. A chain truncated by a missing record leaves that request
-/// undiscoverable from any record, so the guard falls back to a residue check
-/// on the bucket ([`truncated_chain_residue`]) and holds the `.dreq` while
-/// anything the missing generation could have superseded survives. That is what
-/// makes the guard independent of deletion ordering: the filter outlives the
-/// data even if a record it depended on was already swept.
-async fn superseded_inputs_outstanding(
-    store: &dyn ObjectStoreBackend,
-    tenant: &TenantHash,
-    signal: Signal,
-    completion: &ErasureCompletion,
-    request_id: &str,
-    scans: &mut HashMap<(u32, u32), BucketScan>,
-) -> Result<bool> {
-    for drop in &completion.bucket_drops {
+/// `None` is not "no buckets": it is "this completion says nothing about which
+/// buckets it touched", which is what a completion written without
+/// `bucket_drops` says. The two are treated oppositely, since a completion that
+/// names its buckets can be exempted by a truncated bucket it does not name,
+/// and one that names none cannot.
+fn completion_buckets(completion: &ErasureCompletion, signal: Signal) -> Option<Vec<HeldBucket>> {
+    let buckets: Vec<HeldBucket> = completion
+        .bucket_drops
+        .iter()
         // A `.done` is per (tenant, signal); a drop for another signal cannot
         // appear, but the sweep never widens its own scope on a field it did
         // not write.
-        if ravel_commit::signal::from_proto(drop.signal) != Ok(signal) {
-            continue;
-        }
-        let cache_key = (drop.shard, drop.ingest_hour_bucket);
-        if let std::collections::hash_map::Entry::Vacant(e) = scans.entry(cache_key) {
-            let scan = BucketScan::load(store, tenant, signal, drop.shard, drop.ingest_hour_bucket)
-                .await?;
-            e.insert(scan);
-        }
-
-        let heads = match scans.get(&cache_key) {
-            Some(scan) => scan.live_heads.clone(),
-            None => continue,
-        };
-        for head in &heads {
-            let fresh = match scans.get(&cache_key) {
-                Some(scan) if scan.walks.contains_key(head) => None,
-                Some(scan) => Some(
-                    walk_supersession_chain(
-                        store,
-                        tenant,
-                        signal,
-                        drop.shard,
-                        head,
-                        &scan.rewrites,
-                    )
-                    .await?,
-                ),
-                None => None,
-            };
-            if let (Some(walk), Some(scan)) = (fresh, scans.get_mut(&cache_key)) {
-                scan.walks.insert(head.clone(), walk);
-            }
-        }
-
-        // The residue check costs one `l1/` LIST and one GET per compaction
-        // record, so it runs only when a chain in this bucket is truncated, and
-        // only once per bucket per pass.
-        let needs_residue = scans.get(&cache_key).is_some_and(|scan| {
-            scan.residue.is_none() && scan.walks.values().any(|walk| walk.truncated)
-        });
-        if needs_residue {
-            let residue = match scans.get(&cache_key) {
-                Some(scan) => {
-                    truncated_chain_residue(
-                        store,
-                        tenant,
-                        signal,
-                        drop.shard,
-                        drop.ingest_hour_bucket,
-                        scan,
-                    )
-                    .await?
-                }
-                None => false,
-            };
-            if let Some(scan) = scans.get_mut(&cache_key) {
-                scan.residue = Some(residue);
-            }
-        }
-
-        let Some(scan) = scans.get(&cache_key) else {
-            continue;
-        };
-        let residue = scan.residue.unwrap_or(false);
-        for walk in scan.walks.values() {
-            if walk.request_ids.contains(request_id) {
-                if walk.inputs_outstanding || (walk.truncated && residue) {
-                    return Ok(true);
-                }
-            } else if walk.truncated && (walk.inputs_outstanding || residue) {
-                // The request is not named anywhere on this chain, but the
-                // chain is cut: the generation that applied it may be the one
-                // that is missing. Hold while any of its possible inputs
-                // survive.
-                return Ok(true);
-            }
-        }
-    }
-    Ok(false)
+        .filter(|drop| ravel_commit::signal::from_proto(drop.signal) == Ok(signal))
+        .map(|drop| HeldBucket {
+            shard: drop.shard,
+            ingest_hour_bucket: drop.ingest_hour_bucket,
+        })
+        .collect();
+    (!buckets.is_empty()).then_some(buckets)
 }
 
-/// Walk one supersession chain from `head_key` back to the raw L0 inputs at its
-/// end, collecting every erasure request applied along it and whether anything
-/// any generation superseded is still present.
-async fn walk_supersession_chain(
-    store: &dyn ObjectStoreBackend,
-    tenant: &TenantHash,
-    signal: Signal,
-    shard: u32,
-    head_key: &str,
-    rewrites: &HashMap<String, RewriteRecord>,
-) -> Result<ChainWalk> {
-    let mut walk = ChainWalk::default();
-    let mut seen: HashSet<String> = HashSet::new();
-    let mut cursor = Some(head_key.to_string());
-    let mut generation = 0usize;
-
-    while let Some(key) = cursor {
-        if !seen.insert(key.clone()) {
-            return Err(MaintainError::Invariant(format!(
-                "supersession chain from {head_key} revisits {key}"
-            )));
-        }
-        // Every rewrite generation sits in the same bucket as the head, so it
-        // was already read for this pass; only a compaction record at the end
-        // of the chain needs its own GET.
-        let link = match rewrites.get(&key) {
-            Some(record) => Some(ChainLink::Rewrite(record.clone())),
-            None => load_chain_link(store, &key).await?,
-        };
-        let Some(link) = link else {
-            walk.truncated = true;
-            break;
-        };
-        for id in link.applied_request_ids() {
-            walk.request_ids.insert(id.to_string());
-        }
-        // Every generation past the head is an input the generation above it
-        // superseded: its parts still hold the subject that generation erased.
-        if generation > 0 {
-            walk.inputs_outstanding = true;
-        }
-        if link.names_raw_l0_inputs() {
-            if !link
-                .raw_l0_input_groups(store, tenant, signal, shard)
-                .await?
-                .is_empty()
-            {
-                walk.inputs_outstanding = true;
-            }
-            break;
-        }
-        cursor = link.superseded_record_key().map(str::to_string);
-        generation += 1;
-    }
-    Ok(walk)
-}
-
-/// Whether a bucket whose supersession chain is truncated still holds anything
-/// the missing generation could have superseded: a raw L0 commit record (a
-/// pre-rewrite input rule 2 has not collected), or an `l1/` part no surviving
-/// record in the bucket references (a superseded generation's output whose own
-/// record is gone). Either one can still be reached by a snapshot, so the
-/// query-time exclusion filter must stay.
+/// The `(shard, hour)` buckets a self-observing rule-6 pass can restrict its
+/// rule-2 observation to, or `None` to observe the whole signal.
 ///
-/// Both conditions clear once rules 2 and 3 have finished the bucket, so the
-/// hold this produces terminates rather than pinning the `.dreq` forever.
-async fn truncated_chain_residue(
+/// Narrowing is sound only when every candidate names its own buckets: one
+/// candidate whose completion carries no `bucket_drops` could have touched any
+/// bucket in the signal, so the observation must cover all of them. This is the
+/// only use `bucket_drops` has left, and dropping it entirely would cost
+/// request count, never safety.
+fn narrowing_buckets(
+    candidates: &[(&Uuid, &String, &ErasureCompletion)],
+    signal: Signal,
+) -> Option<Vec<HeldBucket>> {
+    let mut out: BTreeSet<HeldBucket> = BTreeSet::new();
+    for (_, _, completion) in candidates {
+        out.extend(completion_buckets(completion, signal)?);
+    }
+    Some(out.into_iter().collect())
+}
+
+/// Observe what rule 2 would hold, without deleting anything, for a rule-6
+/// caller that has no [`SupersededHolds`] of its own.
+///
+/// `narrow` restricts the observation to a set of `(shard, hour)` buckets; when
+/// it is `None` the signal's whole commit keyspace is listed once to enumerate
+/// its shards, and every shard is observed across every hour. Either way the
+/// pass reads what a deleting rule-2 pass over the same scope reads, and it
+/// runs only when there is a `.dreq` past its horizon to decide about.
+async fn observe_superseded_holds(
+    store: &dyn ObjectStoreBackend,
+    clock: &dyn Clock,
+    config: &CompactorConfig,
+    lease: &dyn LeaseCheck,
+    tenant: &TenantHash,
+    signal: Signal,
+    narrow: Option<&[HeldBucket]>,
+) -> Result<SupersededHolds> {
+    // One pass, one reachability cache: HEAD is read at most once no matter how
+    // many shards are observed.
+    let mut reach = SnapshotReachability::new();
+    let mut holds = SupersededHolds::default();
+
+    let scoped: Vec<(u32, Option<Vec<u32>>)> = match narrow {
+        Some(buckets) => {
+            let mut by_shard: HashMap<u32, BTreeSet<u32>> = HashMap::new();
+            for bucket in buckets {
+                by_shard
+                    .entry(bucket.shard)
+                    .or_default()
+                    .insert(bucket.ingest_hour_bucket);
+            }
+            by_shard
+                .into_iter()
+                .map(|(shard, hours)| (shard, Some(hours.into_iter().collect())))
+                .collect()
+        }
+        None => signal_shards(store, tenant, signal)
+            .await?
+            .into_iter()
+            .map(|shard| (shard, None))
+            .collect(),
+    };
+
+    for (shard, hours) in scoped {
+        let outcome = sweep_superseded_impl(
+            &mut reach,
+            store,
+            clock,
+            config,
+            lease,
+            tenant,
+            signal,
+            shard,
+            hours.as_deref(),
+            SweepMode::GateOnly,
+        )
+        .await?;
+        holds.absorb(&outcome);
+    }
+    Ok(holds)
+}
+
+/// Every shard with at least one commit-prefix key for one `(tenant, signal)`,
+/// from one LIST of `t/<tenant_hash_hex>/<signal>/c/`.
+///
+/// A shard with no commit key holds no supersession chain and so can hold
+/// nothing, which is why key presence is the right enumeration and no shard
+/// count needs to be configured or guessed.
+async fn signal_shards(
     store: &dyn ObjectStoreBackend,
     tenant: &TenantHash,
     signal: Signal,
-    shard: u32,
-    hour: u32,
-    scan: &BucketScan,
-) -> Result<bool> {
-    let mut referenced: HashSet<String> = HashSet::new();
-    for (key, entry) in &scan.entries {
-        match entry {
-            BucketEntry::CommitRecord(_) => return Ok(true),
-            BucketEntry::CompactionRecord(_) => {
-                if let Some(record) = get_compaction_record_opt(store, key).await? {
-                    for part in &record.parts {
-                        referenced.insert(keys::reconstruct_l1_part_key(&record, part)?);
-                    }
-                }
+) -> Result<Vec<u32>> {
+    let prefix = format!("t/{}/{}/c/", tenant.to_hex(), signal.key_prefix());
+    let mut shards: BTreeSet<u32> = BTreeSet::new();
+    for meta in list_all(store, &prefix).await? {
+        match keys::partition_bucket_entry(&meta.key) {
+            Ok(BucketEntry::CommitRecord(pk)) => {
+                shards.insert(pk.shard);
             }
-            BucketEntry::RewriteRecord(_) => {
-                if let Some(record) = scan.rewrites.get(key) {
-                    for part in &record.parts {
-                        referenced.insert(keys::reconstruct_rewrite_part_key(record, part)?);
-                    }
-                }
+            Ok(BucketEntry::CompactionRecord(pk)) => {
+                shards.insert(pk.shard);
             }
-            BucketEntry::Tombstone(_) => {}
+            Ok(BucketEntry::RewriteRecord(pk)) => {
+                shards.insert(pk.shard);
+            }
+            Ok(BucketEntry::Tombstone(pk)) => {
+                shards.insert(pk.shard);
+            }
+            Err(KeyError::UnknownBucketEntryShape(k)) => {
+                return Err(MaintainError::UnknownBucketEntry(k));
+            }
+            Err(e) => return Err(MaintainError::Key(e)),
         }
     }
-    for meta in list_l1_scoped(store, tenant, signal, shard, Some(&[hour])).await? {
-        if !referenced.contains(&meta.key) {
-            return Ok(true);
-        }
-    }
-    Ok(false)
+    Ok(shards.into_iter().collect())
 }
 
 // --- shared helpers --------------------------------------------------------

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -17,9 +17,17 @@
 //!    out-of-band commit-record loss, not routine cleanup.
 //! 2. **Superseded-input sweep** (ADR-0018): the L0 commit records and data
 //!    objects a compaction record names in its input list, once
-//!    `now >= record.created_unix_ns + protection_horizon`. Records are
+//!    `now >= record.created_unix_ns + protection_horizon` AND the live catalog
+//!    HEAD snapshot no longer names the input (the ADR-0020 delete blocker,
+//!    the same gate retention uses, [`crate::reachability`]). Records are
 //!    deleted before data objects, so a crash mid-sweep never leaves a commit
-//!    record pointing at a deleted data object visible to a resolver.
+//!    record pointing at a deleted data object visible to a resolver. The
+//!    horizon alone is not enough: a selective-erasure rewrite record can land
+//!    in any sealed hour, including one the fold's fixed reconcile window and
+//!    retention-frontier band both miss, and the snapshot part covering that
+//!    hour then keeps naming the pre-rewrite inputs. Deleting them on schedule
+//!    would fail every query over that hour closed until the fold caught up, so
+//!    a still-named input is held for a later pass instead.
 //! 3. **Unreferenced-part cleanup**: an `l1/` object referenced by no
 //!    compaction record in its bucket, once the object is older than `grace +
 //!    max_compaction_lifetime` and one of two branch conditions holds:
@@ -100,13 +108,16 @@ use prost::Message;
 use ravel_commit::keys::{self, BucketEntry, KeyError, parse_ingest_hour_string};
 use ravel_commit::record;
 use ravel_object_store::{GetRange, ObjectMeta, ObjectStoreBackend, StoreError, list_all};
-use ravel_proto::commit::v1::{CompactionInputIdentity, CompactionRecord, RewriteRecord};
+use ravel_proto::commit::v1::{
+    CompactionInputIdentity, CompactionRecord, ErasureCompletion, RewriteRecord,
+};
 use ravel_types::{Signal, TenantHash};
 use uuid::Uuid;
 
 use crate::clock::Clock;
 use crate::config::{CompactorConfig, NS_PER_HOUR};
 use crate::error::{MaintainError, Result};
+use crate::reachability::{SnapshotBlock, SnapshotGate, SnapshotObject, SnapshotReachability};
 use crate::read::verify_commit_key;
 
 use ravel_ingest::{IDEM_MARKER_FORWARD_SKEW_TOLERANCE_HOURS, MARKER_SUFFIX};
@@ -187,8 +198,8 @@ pub async fn sweep_shard(
     signal: Signal,
     shard: u32,
 ) -> Result<SweepReport> {
-    let (superseded_records_deleted, superseded_data_deleted) =
-        sweep_superseded(store, clock, config, lease, tenant, signal, shard).await?;
+    let superseded = sweep_superseded(store, clock, config, lease, tenant, signal, shard).await?;
+    log_superseded_holds(tenant, signal, shard, &superseded);
     let unreferenced_parts_deleted =
         sweep_unreferenced_parts(store, clock, config, lease, tenant, signal, shard).await?;
     let (orphans_deleted, orphan_breaker_tripped, orphans_withheld, orphan_breaker_overridden) =
@@ -201,8 +212,8 @@ pub async fn sweep_shard(
         };
     Ok(SweepReport {
         orphans_deleted,
-        superseded_records_deleted,
-        superseded_data_deleted,
+        superseded_records_deleted: superseded.records_deleted,
+        superseded_data_deleted: superseded.data_deleted,
         unreferenced_parts_deleted,
         orphan_breaker_tripped,
         orphans_withheld,
@@ -240,7 +251,9 @@ pub async fn sweep_shard_zoned(
     shard: u32,
     hours: &[u32],
 ) -> Result<SweepReport> {
-    let (superseded_records_deleted, superseded_data_deleted) = sweep_superseded_impl(
+    let mut reach = SnapshotReachability::new();
+    let superseded = sweep_superseded_impl(
+        &mut reach,
         store,
         clock,
         config,
@@ -251,6 +264,7 @@ pub async fn sweep_shard_zoned(
         Some(hours),
     )
     .await?;
+    log_superseded_holds(tenant, signal, shard, &superseded);
     let unreferenced_parts_deleted = sweep_unreferenced_parts_impl(
         store,
         clock,
@@ -272,14 +286,41 @@ pub async fn sweep_shard_zoned(
         };
     Ok(SweepReport {
         orphans_deleted,
-        superseded_records_deleted,
-        superseded_data_deleted,
+        superseded_records_deleted: superseded.records_deleted,
+        superseded_data_deleted: superseded.data_deleted,
         unreferenced_parts_deleted,
         orphan_breaker_tripped,
         orphans_withheld,
         orphan_breaker_overridden,
         full_pass: false,
     })
+}
+
+/// Surface a superseded-input hold to an operator running the combined
+/// [`sweep_shard`] / [`sweep_shard_zoned`] pass. [`SweepReport`] itself is
+/// unchanged: the structured counters live on [`SupersededSweepOutcome`], which
+/// [`sweep_superseded`] returns directly, and this log line is what a caller
+/// that only has the combined report sees. Silent on a pass that held nothing,
+/// which is every ordinary pass.
+fn log_superseded_holds(
+    tenant: &TenantHash,
+    signal: Signal,
+    shard: u32,
+    outcome: &SupersededSweepOutcome,
+) {
+    if outcome.held() == 0 {
+        return;
+    }
+    tracing::warn!(
+        tenant_hash = %tenant.to_hex(),
+        signal = signal.key_prefix(),
+        shard,
+        held_by_snapshot = outcome.held_by_snapshot,
+        held_by_unreadable_head = outcome.held_by_unreadable_head,
+        "superseded-input sweep: held inputs the live catalog HEAD snapshot still names \
+         (or could not be read); they are collected once the fold reconciles their hour or \
+         HEAD is rebuilt"
+    );
 }
 
 // --- Rule 1: orphan GC (ADR-0010 §11) --------------------------------------
@@ -427,9 +468,45 @@ async fn referenced_l0_identities(
 
 // --- Rule 2: superseded-input sweep (ADR-0018) -----------------------------
 
+/// What one superseded-input sweep pass did.
+///
+/// The two `held_*` counters are the object-granular counterpart of
+/// retention's [`crate::retention::RetentionOutcome::BlockedBySnapshot`]: a
+/// count plus the blocked reason, so an operator watching inputs pile up can
+/// tell the ordinary lagging-fold case ([`SnapshotBlock::Named`]) from an
+/// unreadable HEAD or snapshot part ([`SnapshotBlock::Unreadable`]).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SupersededSweepOutcome {
+    /// Superseded commit, compaction, and rewrite records deleted (or, under
+    /// `dry_run`, that would have been).
+    pub records_deleted: usize,
+    /// Superseded data objects and L1 parts deleted (or, under `dry_run`, that
+    /// would have been).
+    pub data_deleted: usize,
+    /// Objects (records plus data) held this pass because the live catalog HEAD
+    /// snapshot still names them: a query over that hour would fail closed if
+    /// they were deleted now. Counter seam for
+    /// `ravel_maintain_superseded_inputs_held_total{reason="named"}`.
+    pub held_by_snapshot: usize,
+    /// Objects held this pass because HEAD, or a snapshot part covering the
+    /// record's hour, was present but could not be read: fail-closed, since
+    /// non-reachability cannot be proven from data that cannot be read. A
+    /// persistent nonzero value here is an operator signal, not the ordinary
+    /// lagging-fold case. Counter seam for
+    /// `ravel_maintain_superseded_inputs_held_total{reason="unreadable_head"}`.
+    pub held_by_unreadable_head: usize,
+}
+
+impl SupersededSweepOutcome {
+    /// Objects held this pass for any reason.
+    pub fn held(&self) -> usize {
+        self.held_by_snapshot + self.held_by_unreadable_head
+    }
+}
+
 /// Delete the L0 commit records and data objects named in each horizon-passed
-/// compaction record's input list, records before data objects. Returns
-/// `(records_deleted, data_deleted)`.
+/// compaction record's input list, records before data objects, skipping any
+/// the live catalog HEAD snapshot still names (the ADR-0020 delete blocker).
 pub async fn sweep_superseded(
     store: &dyn ObjectStoreBackend,
     clock: &dyn Clock,
@@ -438,14 +515,23 @@ pub async fn sweep_superseded(
     tenant: &TenantHash,
     signal: Signal,
     shard: u32,
-) -> Result<(usize, usize)> {
-    sweep_superseded_impl(store, clock, config, lease, tenant, signal, shard, None).await
+) -> Result<SupersededSweepOutcome> {
+    let mut reach = SnapshotReachability::new();
+    sweep_superseded_impl(
+        &mut reach, store, clock, config, lease, tenant, signal, shard, None,
+    )
+    .await
 }
 
 /// Shared implementation behind [`sweep_superseded`] (whole-shard, `hours:
 /// None`) and [`sweep_shard_zoned`] (hour-scoped, `hours: Some(_)`).
+///
+/// `reach` is the pass's [`SnapshotReachability`] cache: HEAD is read at most
+/// once for the pass and each covering snapshot part at most once, never once
+/// per input, and a pass with no horizon-passed record reads neither.
 #[allow(clippy::too_many_arguments)]
 async fn sweep_superseded_impl(
+    reach: &mut SnapshotReachability,
     store: &dyn ObjectStoreBackend,
     clock: &dyn Clock,
     config: &CompactorConfig,
@@ -454,12 +540,11 @@ async fn sweep_superseded_impl(
     signal: Signal,
     shard: u32,
     hours: Option<&[u32]>,
-) -> Result<(usize, usize)> {
+) -> Result<SupersededSweepOutcome> {
     let now = clock.now_ns();
     let entries = list_commit_entries_scoped(store, tenant, signal, shard, hours).await?;
 
-    let mut records_deleted = 0usize;
-    let mut data_deleted = 0usize;
+    let mut outcome = SupersededSweepOutcome::default();
     for (key, entry) in &entries {
         // Both a compaction record and a selective-erasure rewrite record
         // (ADR-0064 decision 3 point 6) render their superseded inputs
@@ -470,7 +555,7 @@ async fn sweep_superseded_impl(
         // predecessor may also appear as its own entry in this listing, so its
         // fetch can legitimately miss once a superseding generation processed
         // earlier in this pass already removed it.
-        let (record_keys, data_keys) = match entry {
+        let groups = match entry {
             BucketEntry::CompactionRecord(_) => {
                 let Some(record) = get_compaction_record_opt(store, key).await? else {
                     continue;
@@ -516,39 +601,103 @@ async fn sweep_superseded_impl(
             BucketEntry::CommitRecord(_) | BucketEntry::Tombstone(_) => continue,
         };
 
-        // Records first, then data objects (docs/consistency-model.md):
-        // a crash between the two phases leaves record-less data (orphan GC) or
-        // an unreferenced part (rule 3), never a record pointing at a deleted
-        // object.
-        for k in &record_keys {
-            if lease.is_protected(k) {
-                continue;
+        // HEAD-reachability gate (ADR-0020 delete blocker), object-granular
+        // because this rule deletes individual objects out of a bucket whose
+        // surviving compaction or rewrite outputs the snapshot legitimately
+        // still names. A group is indivisible: a predecessor record must
+        // outlive every part it names, or rule 3 would collect those parts on
+        // the next pass and undo the hold.
+        let mut cleared: Vec<&SupersededGroup> = Vec::with_capacity(groups.len());
+        for group in &groups {
+            match reach
+                .object_gate(
+                    store,
+                    tenant,
+                    signal,
+                    group.ingest_hour_bucket,
+                    &group.objects,
+                )
+                .await?
+            {
+                SnapshotGate::Clear => cleared.push(group),
+                SnapshotGate::Blocked(SnapshotBlock::Named) => {
+                    outcome.held_by_snapshot += group.object_count();
+                }
+                SnapshotGate::Blocked(SnapshotBlock::Unreadable) => {
+                    outcome.held_by_unreadable_head += group.object_count();
+                }
             }
-            if !config.dry_run {
-                store.delete(k).await?;
-            }
-            records_deleted += 1;
         }
-        for k in &data_keys {
-            if lease.is_protected(k) {
-                continue;
+
+        // Every cleared group's records first, then every cleared group's data
+        // objects (docs/consistency-model.md): a crash between the two phases
+        // leaves record-less data (orphan GC) or an unreferenced part (rule 3),
+        // never a record pointing at a deleted object. The gate runs entirely
+        // ahead of both phases so a held group never splits that order.
+        for group in &cleared {
+            for k in &group.record_keys {
+                if lease.is_protected(k) {
+                    continue;
+                }
+                if !config.dry_run {
+                    store.delete(k).await?;
+                }
+                outcome.records_deleted += 1;
             }
-            if !config.dry_run {
-                store.delete(k).await?;
+        }
+        for group in &cleared {
+            for k in &group.data_keys {
+                if lease.is_protected(k) {
+                    continue;
+                }
+                if !config.dry_run {
+                    store.delete(k).await?;
+                }
+                outcome.data_deleted += 1;
             }
-            data_deleted += 1;
         }
     }
-    Ok((records_deleted, data_deleted))
+    Ok(outcome)
 }
 
-/// Gather `(commit record key, data object key)` pairs for every input a
-/// compaction or rewrite record names in its `inputs` list. Shared by rule 2's
-/// compaction and rewrite-RawL0 arms (ADR-0018, ADR-0064 decision 3 point 6):
-/// both name the same raw-L0 input shape. The data key needs each input
-/// record's content hash, so each input record is read before it is deleted; an
-/// input already gone (a crash-interrupted prior pass) is skipped and its data
-/// object, if any, is collected by orphan GC (row 8).
+/// One indivisible deletion unit for rule 2: the records to delete first, the
+/// data objects to delete after them, and the snapshot identities those
+/// objects carry so the HEAD-reachability gate can decide the whole unit at
+/// once.
+///
+/// A raw-L0 input is its own group (one commit record plus one data object),
+/// so a still-named input holds only itself. A superseded predecessor record
+/// and every L1 part it names form one group, because deleting the record
+/// without the parts would expose the parts to rule 3.
+struct SupersededGroup {
+    /// The ingest hour every object in the group sits in: the parent record's
+    /// own bucket, which is also the hour whose covering snapshot parts the
+    /// gate must read.
+    ingest_hour_bucket: u32,
+    record_keys: Vec<String>,
+    data_keys: Vec<String>,
+    objects: Vec<SnapshotObject>,
+}
+
+impl SupersededGroup {
+    /// Objects this group would delete, for the held counters.
+    fn object_count(&self) -> usize {
+        self.record_keys.len() + self.data_keys.len()
+    }
+}
+
+/// Gather one [`SupersededGroup`] per input a compaction or rewrite record
+/// names in its `inputs` list: the input's commit record, its data object, and
+/// the level-0 snapshot identity both share. Shared by rule 2's compaction and
+/// rewrite-RawL0 arms (ADR-0018, ADR-0064 decision 3 point 6): both name the
+/// same raw-L0 input shape. The data key needs each input record's content
+/// hash, so each input record is read before it is deleted; an input already
+/// gone (a crash-interrupted prior pass) yields no group and its data object,
+/// if any, is collected by orphan GC (row 8).
+///
+/// One group per input, not one for the whole record: an input the live HEAD
+/// no longer names is still collectable in a pass where a sibling input is
+/// held.
 async fn gather_l0_inputs(
     store: &dyn ObjectStoreBackend,
     tenant: &TenantHash,
@@ -560,9 +709,8 @@ async fn gather_l0_inputs(
     // and unspawnable from the server's maintain loop. A concrete `&R` over the
     // two `Sync` proto record types is `Send`.
     record: &impl SupersededInputs,
-) -> Result<(Vec<String>, Vec<String>)> {
-    let mut record_keys: Vec<String> = Vec::new();
-    let mut data_keys: Vec<String> = Vec::new();
+) -> Result<Vec<SupersededGroup>> {
+    let mut groups: Vec<SupersededGroup> = Vec::new();
     for commit_key in superseded_input_commit_keys(tenant, signal, shard, record)? {
         match store.get(&commit_key, GetRange::Full).await {
             Ok(got) => {
@@ -574,14 +722,27 @@ async fn gather_l0_inputs(
                 // read::load_inputs).
                 verify_commit_key(&rec, &commit_key)?;
                 let data_key = keys::reconstruct_data_key(&rec)?;
-                record_keys.push(commit_key);
-                data_keys.push(data_key);
+                let writer_id = Uuid::parse_str(&rec.writer_id).map_err(|_| {
+                    MaintainError::Key(KeyError::InvalidWriterId(rec.writer_id.clone()))
+                })?;
+                groups.push(SupersededGroup {
+                    ingest_hour_bucket: rec.ingest_hour_bucket,
+                    record_keys: vec![commit_key],
+                    data_keys: vec![data_key],
+                    objects: vec![SnapshotObject::L0 {
+                        shard: rec.shard,
+                        ingest_hour_bucket: rec.ingest_hour_bucket,
+                        writer_id: writer_id.into_bytes(),
+                        writer_epoch: rec.writer_epoch,
+                        writer_seq: rec.writer_seq,
+                    }],
+                });
             }
             Err(StoreError::NotFound) => {}
             Err(e) => return Err(MaintainError::Store(e)),
         }
     }
-    Ok((record_keys, data_keys))
+    Ok(groups)
 }
 
 /// Reconstruct the commit key of every raw-L0 input a compaction or rewrite
@@ -658,33 +819,47 @@ impl SupersededInputs for RewriteRecord {
 /// Gather the deletion targets for a rewrite record that superseded a whole
 /// prior compaction/rewrite record (ADR-0064 amendment: `superseded_record_key`
 /// names either an `l1.<hash>.cmt` compaction record or an `rw.<hash>.cmt`
-/// rewrite record, recursive supersession included). Returns
-/// `([predecessor record key], [predecessor part keys...])`: the record is
-/// deleted first (records-before-data), then every L1 part it named.
+/// rewrite record, recursive supersession included). Returns one group holding
+/// the predecessor record (deleted first, records-before-data) and every L1
+/// part it named, plus each part's level-1 snapshot identity.
+///
+/// One group, not one per part: deleting the record while a still-named part
+/// is held would leave that part unreferenced, and rule 3 would then collect
+/// it on the next pass, undoing the hold.
 ///
 /// A predecessor already gone (swept by an earlier iteration of this same pass
 /// when the predecessor also appeared as its own entry, or by a crash-
-/// interrupted prior pass) yields empty lists: any of its parts that survive
+/// interrupted prior pass) yields no group: any of its parts that survive
 /// become unreferenced under the live rewrite record and are collected by rule
 /// 3.
 async fn gather_superseded_predecessor(
     store: &dyn ObjectStoreBackend,
     predecessor_key: &str,
-) -> Result<(Vec<String>, Vec<String>)> {
+) -> Result<Vec<SupersededGroup>> {
     let got = match store.get(predecessor_key, GetRange::Full).await {
         Ok(got) => got,
-        Err(StoreError::NotFound) => return Ok((Vec::new(), Vec::new())),
+        Err(StoreError::NotFound) => return Ok(Vec::new()),
         Err(e) => return Err(MaintainError::Store(e)),
     };
     let mut data_keys: Vec<String> = Vec::new();
+    let mut objects: Vec<SnapshotObject> = Vec::new();
+    let ingest_hour_bucket;
     match keys::partition_bucket_entry(predecessor_key) {
         Ok(BucketEntry::CompactionRecord(_)) => {
             let record = CompactionRecord::decode(got.data.as_ref()).map_err(|e| {
                 MaintainError::Invariant(format!("superseded compaction record decode failed: {e}"))
             })?;
             keys::verify_compaction_record_key(&record, predecessor_key)?;
+            ingest_hour_bucket = record.ingest_hour_bucket;
+            let input_set_hash = input_set_hash_array(&record.input_set_hash)?;
             for part in &record.parts {
                 data_keys.push(keys::reconstruct_l1_part_key(&record, part)?);
+                objects.push(SnapshotObject::L1 {
+                    shard: record.shard,
+                    ingest_hour_bucket: record.ingest_hour_bucket,
+                    input_set_hash,
+                    part_index: part.part_index,
+                });
             }
         }
         Ok(BucketEntry::RewriteRecord(_)) => {
@@ -692,8 +867,16 @@ async fn gather_superseded_predecessor(
                 MaintainError::Invariant(format!("superseded rewrite record decode failed: {e}"))
             })?;
             keys::verify_rewrite_record_key(&record, predecessor_key)?;
+            ingest_hour_bucket = record.ingest_hour_bucket;
+            let input_set_hash = input_set_hash_array(&record.input_set_hash)?;
             for part in &record.parts {
                 data_keys.push(keys::reconstruct_rewrite_part_key(&record, part)?);
+                objects.push(SnapshotObject::L1 {
+                    shard: record.shard,
+                    ingest_hour_bucket: record.ingest_hour_bucket,
+                    input_set_hash,
+                    part_index: part.part_index,
+                });
             }
         }
         Ok(BucketEntry::CommitRecord(_) | BucketEntry::Tombstone(_)) => {
@@ -707,7 +890,24 @@ async fn gather_superseded_predecessor(
         }
         Err(e) => return Err(MaintainError::Key(e)),
     }
-    Ok((vec![predecessor_key.to_string()], data_keys))
+    Ok(vec![SupersededGroup {
+        ingest_hour_bucket,
+        record_keys: vec![predecessor_key.to_string()],
+        data_keys,
+        objects,
+    }])
+}
+
+/// A record's `input_set_hash` as the 32-byte array a level-1 snapshot entry
+/// carries in its `writer_id` slot. A wrong length is the same fatal invariant
+/// breach `reconstruct_l1_part_key` reports for it.
+fn input_set_hash_array(bytes: &[u8]) -> Result<[u8; 32]> {
+    bytes.try_into().map_err(|_| {
+        MaintainError::Invariant(format!(
+            "superseded record input_set_hash is {} bytes, expected 32",
+            bytes.len()
+        ))
+    })
 }
 
 /// [`get_compaction_record`] tolerant of a NotFound (Ok(None)): the record was
@@ -1314,9 +1514,18 @@ pub struct ErasureRequestSweepOutcome {
     /// `.dreq` objects deleted (or, under `dry_run`, that would have been).
     pub deleted: usize,
     /// `.dreq` objects left in place: no `.done` yet (erasure not complete),
-    /// still inside the post-completion protection horizon, or lease/legal-hold
-    /// protected.
+    /// still inside the post-completion protection horizon, lease/legal-hold
+    /// protected, or held because an input one of its rewrites superseded is
+    /// still in the store (`held_by_superseded_inputs` below counts that
+    /// subset).
     pub kept: usize,
+    /// The subset of `kept` held past their horizon because an input a rewrite
+    /// applying that request superseded is still physically present. Retiring
+    /// the query-time exclusion filter while such an input exists would let a
+    /// snapshot that still resolves it serve the erased subject again, so the
+    /// `.dreq` outlives every input its own rewrites superseded. Counter seam
+    /// for `ravel_maintain_dreq_held_by_superseded_inputs_total`.
+    pub held_by_superseded_inputs: usize,
 }
 
 /// Delete every erasure request `t/<tenant_hash>/<signal>/del/<request_id>.dreq`
@@ -1339,6 +1548,20 @@ pub struct ErasureRequestSweepOutcome {
 ///   because after the horizon no resolvable snapshot can still reference a
 ///   pre-rewrite input (ADR-0064 §3.5 race window, closed durably). Deleting
 ///   the `.dreq` a nanosecond early would reopen exactly that window.
+/// - no input a rewrite applying this request superseded is still physically
+///   present. The horizon on its own does not imply that: rule 2 holds an
+///   input the live HEAD snapshot still names, and a legal hold over the
+///   shard's data prefixes (which does not cover `del/`) holds it too. In both
+///   cases a snapshot can still resolve the pre-rewrite input, so retiring the
+///   filter would serve the erased subject again. The check reads the
+///   `.done`'s own `bucket_drops` for the buckets this request touched, so it
+///   costs one LIST per touched bucket and runs only for a `.dreq` that has
+///   already cleared its horizon; in the ordinary case rule 2 collected the
+///   inputs long before, so the first such pass finds nothing and removes the
+///   request. An input whose commit record is already gone but whose data
+///   object survives (the window between rule 2's two delete phases) is not
+///   counted: it is a record-less orphan awaiting rule 1, discovered from no
+///   durable record.
 /// - the [`LeaseCheck`] passes: a legal hold over the `del/` keyspace pins the
 ///   request exactly as it pins any other object.
 ///
@@ -1370,10 +1593,10 @@ pub async fn sweep_erasure_requests(
     let prefix = keys::del_prefix(tenant, signal);
     let objects = list_all(store, &prefix).await?;
 
-    // One LIST, split into pending requests and their completion timestamps.
-    // Both suffixes share the `del/` prefix, so this needs no second listing.
+    // One LIST, split into pending requests and their completions. Both
+    // suffixes share the `del/` prefix, so this needs no second listing.
     let mut dreq_keys: Vec<(Uuid, String)> = Vec::new();
-    let mut done_completed_ns: HashMap<Uuid, i64> = HashMap::new();
+    let mut completions: HashMap<Uuid, ErasureCompletion> = HashMap::new();
     for meta in &objects {
         if let Ok(parsed) = keys::parse_erasure_request_key(&meta.key) {
             dreq_keys.push((parsed.request_id, meta.key.clone()));
@@ -1383,7 +1606,7 @@ pub async fn sweep_erasure_requests(
                 MaintainError::Invariant(format!("erasure completion decode failed: {e}"))
             })?;
             keys::verify_erasure_completion_key(&completion, &meta.key)?;
-            done_completed_ns.insert(parsed.request_id, completion.completed_unix_ns);
+            completions.insert(parsed.request_id, completion);
         } else {
             return Err(MaintainError::UnknownBucketEntry(meta.key.clone()));
         }
@@ -1391,13 +1614,15 @@ pub async fn sweep_erasure_requests(
 
     let mut deleted = 0usize;
     let mut kept = 0usize;
+    let mut held_by_superseded_inputs = 0usize;
     for (request_id, dreq_key) in &dreq_keys {
-        let Some(&completed_ns) = done_completed_ns.get(request_id) else {
+        let Some(completion) = completions.get(request_id) else {
             // No `.done`: the erasure is not verified complete, so the request
             // (and its query-time exclusion filter) must stay live.
             kept += 1;
             continue;
         };
+        let completed_ns = completion.completed_unix_ns;
         // Fail-safe: a zero completion timestamp is not a valid horizon anchor.
         if completed_ns == 0 {
             kept += 1;
@@ -1411,13 +1636,88 @@ pub async fn sweep_erasure_requests(
             kept += 1;
             continue;
         }
+        // The horizon has elapsed, but an input one of this request's rewrites
+        // superseded may still be in the store (held by rule 2's HEAD gate, or
+        // by a legal hold over the data prefixes that does not cover `del/`).
+        // A snapshot can still resolve such an input, so the filter stays.
+        if superseded_inputs_outstanding(store, tenant, signal, completion, &request_id.to_string())
+            .await?
+        {
+            tracing::warn!(
+                tenant_hash = %tenant.to_hex(),
+                signal = signal.key_prefix(),
+                request_id = %request_id,
+                "erasure-request sweep: holding a .dreq past its horizon because an input its \
+                 rewrite superseded is still in the store; the query-time exclusion filter must \
+                 outlive it"
+            );
+            kept += 1;
+            held_by_superseded_inputs += 1;
+            continue;
+        }
         if !config.dry_run {
             store.delete(dreq_key).await?;
         }
         deleted += 1;
     }
 
-    Ok(ErasureRequestSweepOutcome { deleted, kept })
+    Ok(ErasureRequestSweepOutcome {
+        deleted,
+        kept,
+        held_by_superseded_inputs,
+    })
+}
+
+/// Whether any input superseded by a rewrite that applied `request_id` is still
+/// physically present, across every bucket the request's `.done` records a drop
+/// for in `signal`.
+///
+/// Anchored on durable records only: the `.done`'s `bucket_drops` name the
+/// buckets, each bucket's own listing names its rewrite records, and each
+/// rewrite record names the inputs it superseded. A superseded input that is
+/// still present yields a group from the same gather helpers rule 2 uses, so
+/// the two rules agree on what "superseded input" means by construction rather
+/// than by restatement.
+async fn superseded_inputs_outstanding(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    signal: Signal,
+    completion: &ErasureCompletion,
+    request_id: &str,
+) -> Result<bool> {
+    for drop in &completion.bucket_drops {
+        // A `.done` is per (tenant, signal); a drop for another signal cannot
+        // appear, but the sweep never widens its own scope on a field it did
+        // not write.
+        if ravel_commit::signal::from_proto(drop.signal) != Ok(signal) {
+            continue;
+        }
+        let prefix =
+            keys::commit_shard_hour_prefix(tenant, signal, drop.shard, drop.ingest_hour_bucket)?;
+        for meta in list_all(store, &prefix).await? {
+            if !matches!(
+                keys::partition_bucket_entry(&meta.key),
+                Ok(BucketEntry::RewriteRecord(_))
+            ) {
+                continue;
+            }
+            let Some(record) = get_rewrite_record_opt(store, &meta.key).await? else {
+                continue;
+            };
+            if !record.drops.iter().any(|d| d.request_id == request_id) {
+                continue;
+            }
+            let groups = if !record.inputs.is_empty() {
+                gather_l0_inputs(store, tenant, signal, drop.shard, &record).await?
+            } else {
+                gather_superseded_predecessor(store, &record.superseded_record_key).await?
+            };
+            if groups.iter().any(|g| g.object_count() > 0) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }
 
 // --- shared helpers --------------------------------------------------------

--- a/crates/ravel-maintain/tests/erasure_sweep.rs
+++ b/crates/ravel-maintain/tests/erasure_sweep.rs
@@ -265,9 +265,9 @@ async fn rewrite_raw_l0_inputs_swept_only_after_horizon() {
 /// inputs. Proven against a no-hold control that does delete them, and by
 /// asserting the hold was actually consulted.
 ///
-/// Flip-line proof: dropping the `lease.is_protected(k)` guard in
-/// `sweep_superseded_impl`'s delete loop makes the held inputs vanish, failing
-/// the `l0_data_count == 2` assertion.
+/// Flip-line proof: dropping the `group.protected_key(lease)` skip that
+/// `sweep_superseded_impl` applies to a whole chain group before gating it
+/// makes the held inputs vanish, failing the `l0_data_count == 2` assertion.
 #[tokio::test]
 async fn rewrite_superseded_inputs_survive_under_legal_hold() {
     let created = sealed_now_ns();
@@ -334,8 +334,8 @@ async fn rewrite_superseded_inputs_survive_under_legal_hold() {
 /// horizon, while the rewrite's own output parts survive.
 ///
 /// Flip-line proof: replacing the `superseded_record_key` arm's
-/// `gather_superseded_predecessor` call with `(Vec::new(), Vec::new())` leaves
-/// the predecessor compaction record and its L1 parts in place, failing the
+/// `gather_superseded_chain` call with `Ok(Vec::new())` leaves the predecessor
+/// compaction record and its L1 parts in place, failing the
 /// `!present(comp_key)` / `!present(comp_part)` assertions after the horizon.
 #[tokio::test]
 async fn rewrite_predecessor_record_and_parts_swept_after_horizon() {

--- a/crates/ravel-maintain/tests/erasure_sweep.rs
+++ b/crates/ravel-maintain/tests/erasure_sweep.rs
@@ -23,9 +23,9 @@ use ravel_commit::keys::{self, BucketEntry};
 use ravel_commit::{erasure, signal};
 use ravel_maintain::{
     Bucket, CompactionOutcome, CompactorConfig, ErasureRewriteOutcome, FixedClock, LeaseCheck,
-    LegalHoldCheck, MaintainMemo, NoLeases, PendingErasureRequest, compact_bucket,
-    erasure_rewrite_bucket, shard_hold_scopes, sweep_erasure_requests, sweep_superseded,
-    write_hold_set,
+    LegalHoldCheck, MaintainMemo, NoLeases, PendingErasureRequest, SupersededSweepOutcome,
+    compact_bucket, erasure_rewrite_bucket, shard_hold_scopes, sweep_erasure_requests,
+    sweep_superseded, write_hold_set,
 };
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions, list_all};
@@ -125,6 +125,15 @@ async fn sweep(
     clock: &FixedClock,
     lease: &dyn LeaseCheck,
 ) -> (usize, usize) {
+    let out = sweep_full(store, clock, lease).await;
+    (out.records_deleted, out.data_deleted)
+}
+
+async fn sweep_full(
+    store: &dyn ObjectStoreBackend,
+    clock: &FixedClock,
+    lease: &dyn LeaseCheck,
+) -> SupersededSweepOutcome {
     let b = bucket();
     sweep_superseded(
         store,

--- a/crates/ravel-maintain/tests/superseded_head_gate.rs
+++ b/crates/ravel-maintain/tests/superseded_head_gate.rs
@@ -25,9 +25,9 @@ use common::*;
 use ravel_commit::keys::{self, BucketEntry};
 use ravel_commit::{erasure, signal};
 use ravel_maintain::{
-    Bucket, CompactorConfig, ErasureRewriteOutcome, FixedClock, MaintainMemo, NoLeases,
-    PendingErasureRequest, SupersededSweepOutcome, erasure_rewrite_bucket, sweep_erasure_requests,
-    sweep_superseded,
+    Bucket, CompactorConfig, ErasureRequestSweepOutcome, ErasureRewriteOutcome, FixedClock,
+    MaintainMemo, NoLeases, PendingErasureRequest, SupersededSweepOutcome, erasure_rewrite_bucket,
+    sweep_erasure_requests, sweep_superseded,
 };
 use ravel_object_store::fault::{
     FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
@@ -58,6 +58,12 @@ fn old_bucket() -> Bucket {
 
 fn request_id() -> Uuid {
     Uuid::from_u128(REQUEST_SEED)
+}
+
+/// The `n`th distinct erasure request id; `request_id_n(0)` is
+/// [`request_id`]. Each one becomes its own rewrite generation.
+fn request_id_n(n: u128) -> Uuid {
+    Uuid::from_u128(REQUEST_SEED + n)
 }
 
 fn head_key() -> String {
@@ -123,23 +129,33 @@ async fn seed_two_hours(store: &dyn ObjectStoreBackend) -> [String; 2] {
 
 /// A windowless erasure request matching every series named `victim`.
 fn pending_request() -> PendingErasureRequest {
+    pending_request_for(request_id(), "victim")
+}
+
+/// A windowless erasure request under `id` matching every series named
+/// `series`.
+fn pending_request_for(id: Uuid, series: &str) -> PendingErasureRequest {
     PendingErasureRequest {
-        request_key: keys::erasure_request_key(&tenant_hash(), Signal::Metrics, request_id())
+        request_key: keys::erasure_request_key(&tenant_hash(), Signal::Metrics, id)
             .expect("dreq key"),
-        request: erasure_request(),
+        request: erasure_request_for(id, series),
     }
 }
 
 fn erasure_request() -> ErasureRequest {
+    erasure_request_for(request_id(), "victim")
+}
+
+fn erasure_request_for(id: Uuid, series: &str) -> ErasureRequest {
     ErasureRequest {
         format_version: 1,
         tenant_hash: tenant_hash().0.to_vec(),
         signal: signal::to_proto(Signal::Metrics) as i32,
-        request_id: request_id().to_string(),
+        request_id: id.to_string(),
         created_unix_ns: 0,
         predicate: vec![ErasurePredicateMatcher {
             key: "__name__".to_string(),
-            value: "victim".to_string(),
+            value: series.to_string(),
         }],
         window_start_ns: 0,
         window_end_ns: 0,
@@ -150,6 +166,18 @@ fn erasure_request() -> ErasureRequest {
 /// Publish a rewrite record into [`OLD_HOUR`], superseding both of its raw-L0
 /// inputs.
 async fn run_rewrite(store: &dyn ObjectStoreBackend, clock: &FixedClock) {
+    run_rewrite_with(store, clock, &[pending_request()]).await
+}
+
+/// Publish one rewrite generation into [`OLD_HOUR`] applying `pending`. The
+/// first call supersedes the bucket's raw L0 inputs; each later call with a
+/// request id no live generation has applied yet supersedes the generation
+/// before it, which is how these fixtures grow a supersession chain.
+async fn run_rewrite_with(
+    store: &dyn ObjectStoreBackend,
+    clock: &FixedClock,
+    pending: &[PendingErasureRequest],
+) {
     let mut memo = MaintainMemo::with_default_interval();
     let outcome = erasure_rewrite_bucket(
         store,
@@ -157,7 +185,7 @@ async fn run_rewrite(store: &dyn ObjectStoreBackend, clock: &FixedClock) {
         &cfg(),
         &NoLeases,
         &old_bucket(),
-        &[pending_request()],
+        pending,
         &mut memo,
     )
     .await
@@ -313,6 +341,117 @@ async fn rewrite_record_key(store: &dyn ObjectStoreBackend) -> String {
         }
     }
     panic!("no rewrite record in the old bucket");
+}
+
+/// The old bucket's rewrite record keys ordered oldest generation first: the
+/// one that superseded the raw L0 inputs, then each record that superseded the
+/// one before it. Reconstructed from the `superseded_record_key` pointers, so
+/// it never restates the sweep's own walk.
+async fn rewrite_chain(store: &dyn ObjectStoreBackend) -> Vec<String> {
+    let b = old_bucket();
+    let prefix =
+        keys::commit_shard_hour_prefix(&b.tenant_hash, b.signal, b.shard, b.ingest_hour_bucket)
+            .unwrap();
+    let mut records = Vec::new();
+    for meta in list_all(store, &prefix).await.unwrap() {
+        if matches!(
+            keys::partition_bucket_entry(&meta.key),
+            Ok(BucketEntry::RewriteRecord(_))
+        ) {
+            let bytes = get_full(store, &meta.key).await;
+            let record = erasure::decode_rewrite(&bytes).expect("rewrite record decodes");
+            records.push((meta.key, record));
+        }
+    }
+    let mut current = records
+        .iter()
+        .find(|(_, r)| !r.inputs.is_empty())
+        .expect("one generation supersedes the raw L0 inputs")
+        .0
+        .clone();
+    let mut chain = Vec::new();
+    loop {
+        chain.push(current.clone());
+        match records
+            .iter()
+            .find(|(_, r)| r.superseded_record_key == current)
+        {
+            Some((key, _)) => current = key.clone(),
+            None => return chain,
+        }
+    }
+}
+
+/// The L1 part keys the rewrite record at `key` names.
+async fn rewrite_part_keys(store: &dyn ObjectStoreBackend, key: &str) -> BTreeSet<String> {
+    let bytes = get_full(store, key).await;
+    let record = erasure::decode_rewrite(&bytes).expect("rewrite record decodes");
+    record
+        .parts
+        .iter()
+        .map(|part| keys::reconstruct_rewrite_part_key(&record, part).expect("part key"))
+        .collect()
+}
+
+/// Seed a `.dreq` for `id` over `series` and its `.done` completion, anchored
+/// at `completed` and naming [`OLD_HOUR`] as the one bucket it touched.
+async fn seed_dreq_and_done_for(
+    store: &dyn ObjectStoreBackend,
+    id: Uuid,
+    series: &str,
+    completed: i64,
+) -> (String, String) {
+    let dreq_key = keys::erasure_request_key(&tenant_hash(), Signal::Metrics, id).unwrap();
+    store
+        .put(
+            &dreq_key,
+            erasure::encode_request(&erasure_request_for(id, series)),
+            PutOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    let completion = ErasureCompletion {
+        format_version: 1,
+        tenant_hash: tenant_hash().0.to_vec(),
+        signal: signal::to_proto(Signal::Metrics) as i32,
+        request_id: id.to_string(),
+        predicate_hash: vec![0x11; 32],
+        bucket_drops: vec![ErasureBucketDrop {
+            signal: signal::to_proto(Signal::Metrics) as i32,
+            shard: SHARD,
+            ingest_hour_bucket: OLD_HOUR,
+            dropped_count: 2,
+        }],
+        requested_unix_ns: 0,
+        completed_unix_ns: completed,
+        deferral_cause: 0,
+    };
+    let done_key = keys::erasure_completion_key(&tenant_hash(), Signal::Metrics, id).unwrap();
+    store
+        .put(
+            &done_key,
+            erasure::encode_completion(&completion),
+            PutOptions::default(),
+        )
+        .await
+        .unwrap();
+    (dreq_key, done_key)
+}
+
+async fn sweep_dreq(
+    store: &dyn ObjectStoreBackend,
+    clock: &FixedClock,
+) -> ravel_maintain::Result<ErasureRequestSweepOutcome> {
+    sweep_erasure_requests(
+        store,
+        clock,
+        &cfg(),
+        &NoLeases,
+        &tenant_hash(),
+        Signal::Metrics,
+    )
+    .await
 }
 
 fn past_horizon(created: i64) -> i64 {
@@ -750,4 +889,417 @@ async fn dreq_outlives_every_superseded_input_its_rewrite_left_resolvable() {
         mem.head(&done_key).await.is_ok(),
         ".done is permanent audit evidence, never swept"
     );
+}
+
+// --- (f) the erasure-invariant hole: supersession chains --------------------
+//
+// A rewrite record can itself be superseded by a later rewrite applying a
+// different request. Gating the later generation on its predecessor's OUTPUT
+// parts alone clears while a stale HEAD names the raw inputs at the end of the
+// chain, so the predecessor's record disappears and the request it applied is
+// no longer discoverable from any record. The `.dreq` guard then retires the
+// query-time exclusion filter while the raw inputs it erased the subject out of
+// are still present and HEAD-resolvable. Two rules close it: a rewrite record
+// outlives every input it superseded, and a `.dreq` outlives every input any
+// rewrite in its supersession chain superseded.
+
+/// The pieces of a supersession-chain fixture the assertions need.
+struct ChainFixture {
+    commit_keys: [String; 2],
+    input_data_keys: BTreeSet<String>,
+    /// Rewrite record keys, oldest generation first.
+    chain: Vec<String>,
+}
+
+/// Seed `generations` rewrite generations over [`OLD_HOUR`]'s two raw L0
+/// inputs. The oldest applies [`request_id`] over `victim` (the only request
+/// that erases anything here); each later one applies a fresh request id over a
+/// series name no input carries, so it republishes its predecessor's surviving
+/// rows and grows the chain without changing what is erased.
+///
+/// `reconcile` is the second fold's reconcile window: `None` leaves the hour
+/// unreconciled, so HEAD still names the raw inputs.
+async fn seed_chain(
+    mem: &Arc<MemoryStore>,
+    clock: &FixedClock,
+    created: i64,
+    generations: u128,
+    reconcile: Option<u32>,
+) -> ChainFixture {
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+    fold_head(mem, created, 1, None).await;
+    run_rewrite_with(mem.as_ref(), clock, &[pending_request()]).await;
+    for n in 1..generations {
+        run_rewrite_with(
+            mem.as_ref(),
+            clock,
+            &[pending_request_for(request_id_n(n), &format!("absent{n}"))],
+        )
+        .await;
+    }
+    fold_head(mem, created + 3 * NS_PER_HOUR, 2, reconcile).await;
+    let chain = rewrite_chain(mem.as_ref()).await;
+    assert_eq!(
+        u128::try_from(chain.len()).unwrap(),
+        generations,
+        "one rewrite generation per applied request"
+    );
+    ChainFixture {
+        commit_keys,
+        input_data_keys,
+        chain,
+    }
+}
+
+/// The reviewer's scenario. R1 applies X and supersedes the two raw L0 inputs
+/// carrying `victim`; R2 applies Y and supersedes R1; HEAD is never re-folded
+/// within reach of the hour, so it still names the raw inputs.
+///
+/// Past the horizon the sweep must delete nothing: the chain is one group, and
+/// a HEAD naming anything in it holds all of it, R1's own record included. The
+/// `.dreq` guard must then find X by walking the chain from R2 back through R1,
+/// and hold the filter.
+///
+/// Also pins the guard's request shape on this fixture: two LISTs (`del/` and
+/// the bucket's commit prefix) and five GETs (the `.done`, R1's and R2's
+/// records, and the two input commit records) for the whole pass, with the
+/// chain walk reusing the records the pass already read.
+///
+/// Flip-line proof: in `sweep_superseded_impl`, drop the
+/// `superseded_by_present.contains(key)` skip and gate each generation from its
+/// own entry again (equivalently, replace `gather_superseded_chain` with a
+/// gather of the predecessor's own record and parts). R1's record is then
+/// deleted while its raw inputs are held, the `records_deleted == 0` assertion
+/// fails, and the `.dreq` assertions fail with it.
+#[tokio::test]
+async fn superseded_predecessor_and_its_dreq_outlive_head_named_raw_inputs() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let fixture = seed_chain(&mem, &clock, created, 2, None).await;
+    let r1 = fixture.chain[0].clone();
+    let r2 = fixture.chain[1].clone();
+    let r1_parts = rewrite_part_keys(mem.as_ref(), &r1).await;
+    assert_eq!(r1_parts.len(), 1, "R1 published exactly one part");
+
+    assert_eq!(
+        head_named_data_keys(mem.as_ref(), OLD_HOUR).await,
+        fixture.input_data_keys,
+        "the stale snapshot still names exactly the two pre-rewrite inputs"
+    );
+
+    let (dreq_x, _) = seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created).await;
+
+    clock.set(past_horizon(created));
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(
+        out.records_deleted, 0,
+        "no record deleted: R1 is part of the held chain group, not its own gate"
+    );
+    assert_eq!(out.data_deleted, 0, "no data object deleted");
+    assert_eq!(
+        out.held_by_snapshot, 6,
+        "one group of six: two input commit records, two input data objects, R1's single \
+         part, and R1's own record"
+    );
+    assert_eq!(out.held_by_unreadable_head, 0);
+
+    // Exact surviving key sets.
+    assert_eq!(
+        present_keys(mem.as_ref(), &fixture.input_data_keys).await,
+        fixture.input_data_keys,
+        "both victim inputs still present"
+    );
+    let mut records: BTreeSet<String> = fixture.commit_keys.iter().cloned().collect();
+    records.insert(r1.clone());
+    records.insert(r2.clone());
+    assert_eq!(
+        present_keys(mem.as_ref(), &records).await,
+        records,
+        "R1's record survives with the inputs it superseded, and so does R2"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &r1_parts).await,
+        r1_parts,
+        "R1's parts survive with its record"
+    );
+
+    // The guard's request shape is asserted, not printed: the sixth GET and the
+    // third LIST of the pass both fault, so the pass succeeding proves the
+    // counts.
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Get, ScriptedFault::Timeout).with_occurrence(Occurrence::Nth(6)))
+        .with_rule(Rule::new(Op::List, ScriptedFault::Timeout).with_occurrence(Occurrence::Nth(3)));
+    let store = FaultStore::new(mem.clone(), plan);
+    let dreq = sweep_dreq(&store, &clock)
+        .await
+        .expect("the chain walk reads each record once, so no sixth GET and no third LIST");
+    assert_eq!(
+        dreq.deleted, 0,
+        ".dreq_X outlives the inputs R1 erased the subject out of"
+    );
+    assert_eq!(dreq.kept, 1);
+    assert_eq!(
+        dreq.held_by_superseded_inputs, 1,
+        "held for the stated reason: X is found by walking R2 -> R1, whose inputs are present"
+    );
+    assert_eq!(
+        store.fault_count(Op::Get, FaultKind::Timeout),
+        0,
+        "exactly five GETs: the .done, R1's and R2's records, and the two input commit records"
+    );
+    assert_eq!(
+        store.fault_count(Op::List, FaultKind::Timeout),
+        0,
+        "exactly two LISTs: the del/ prefix and the touched bucket's commit prefix"
+    );
+    assert!(
+        mem.head(&dreq_x).await.is_ok(),
+        ".dreq_X physically present"
+    );
+}
+
+/// The same chain, once the fold has reconciled the hour: the gate clears and
+/// the whole chain is collected in the one order the invariant allows. The
+/// superseded inputs go first and R1's record goes last, proven by faulting
+/// exactly R1's record delete and observing what is already gone at that
+/// instant. A second, clean pass finishes R1, and only then does the `.dreq`
+/// sweep retire the filter.
+///
+/// Flip-line proof: move the `chain_record_keys` delete loop in
+/// `sweep_superseded_impl` ahead of the `data_keys` loop. R1's record is then
+/// deleted before the inputs it superseded, and the "already gone at the fault"
+/// assertions fail.
+#[tokio::test]
+async fn reconciled_chain_deletes_the_superseded_inputs_before_the_record_that_erased_them() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let fixture = seed_chain(&mem, &clock, created, 2, Some(200)).await;
+    let r1 = fixture.chain[0].clone();
+    let r2 = fixture.chain[1].clone();
+    let r1_parts = rewrite_part_keys(mem.as_ref(), &r1).await;
+    let r2_parts = rewrite_part_keys(mem.as_ref(), &r2).await;
+
+    let named = head_named_data_keys(mem.as_ref(), OLD_HOUR).await;
+    assert_eq!(
+        named, r2_parts,
+        "the reconciled snapshot names exactly the live generation's parts"
+    );
+
+    let (dreq_x, done_x) =
+        seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created).await;
+
+    // Step 1: fault exactly R1's record delete. Everything the invariant
+    // requires to be gone before it must already be gone.
+    clock.set(past_horizon(created));
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout).with_key_contains(r1.clone()));
+    let store = FaultStore::new(mem.clone(), plan);
+    let err = sweep(&store, &clock).await;
+    assert!(
+        err.is_err(),
+        "the faulted delete of R1's record surfaces as a pass error"
+    );
+    assert_eq!(
+        store.fault_count(Op::Delete, FaultKind::Timeout),
+        1,
+        "exactly one delete was aimed at R1's record"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &fixture.input_data_keys).await,
+        BTreeSet::new(),
+        "every input R1 superseded is already gone when its record's delete is issued"
+    );
+    for key in &fixture.commit_keys {
+        assert!(
+            mem.head(key).await.is_err(),
+            "the superseded input's commit record went before R1's record too"
+        );
+    }
+    assert_eq!(
+        present_keys(mem.as_ref(), &r1_parts).await,
+        BTreeSet::new(),
+        "R1's own parts went before R1's record"
+    );
+    assert!(
+        mem.head(&r1).await.is_ok(),
+        "R1's record is still there: its delete is the one that faulted"
+    );
+    assert!(
+        mem.head(&dreq_x).await.is_ok(),
+        "the filter is still live while R1's record is"
+    );
+
+    // Step 2: a clean pass finishes the job. The group's inputs are already
+    // gone, so it is R1's record and the parts it names, re-issued idempotently.
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(out.records_deleted, 1, "R1's record, and nothing else");
+    assert_eq!(
+        out.data_deleted, 1,
+        "R1's single part, deleted again now that the pass reaches past the fault"
+    );
+    assert_eq!((out.held_by_snapshot, out.held_by_unreadable_head), (0, 0));
+    assert!(mem.head(&r1).await.is_err(), "R1's record is gone");
+    assert!(mem.head(&r2).await.is_ok(), "the live generation survives");
+    assert_eq!(
+        present_keys(mem.as_ref(), &r2_parts).await,
+        r2_parts,
+        "the live generation's parts survive"
+    );
+
+    // Step 3: only with every superseded input gone does the filter retire.
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(dreq.deleted, 1, ".dreq_X is removed once, and only now");
+    assert_eq!(dreq.kept, 0);
+    assert_eq!(dreq.held_by_superseded_inputs, 0);
+    assert!(mem.head(&dreq_x).await.is_err(), ".dreq_X physically gone");
+    assert!(
+        mem.head(&done_x).await.is_ok(),
+        ".done is permanent audit evidence, never swept"
+    );
+}
+
+/// Three generations: R1 applies X, R2 applies Y and supersedes R1, R3 applies
+/// Z and supersedes R2. Only R1's raw inputs are HEAD-named, and that holds
+/// every record in the chain and every one of the three `.dreq` objects: each
+/// superseded generation's parts still carry whatever the generation above it
+/// erased, so the same rule covers Y and Z without a special case.
+///
+/// Flip-line proof: stop the walk in `gather_superseded_chain` after one
+/// generation (`break` instead of following `superseded_record_key`). R1 and its
+/// inputs then fall outside the group R3's entry gates, the chain is collected
+/// from the top down, and the `records_deleted == 0` and
+/// `held_by_superseded_inputs == 3` assertions both fail.
+#[tokio::test]
+async fn three_deep_chain_holds_every_generation_and_every_request() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let fixture = seed_chain(&mem, &clock, created, 3, None).await;
+    let r1_parts = rewrite_part_keys(mem.as_ref(), &fixture.chain[0]).await;
+    let r2_parts = rewrite_part_keys(mem.as_ref(), &fixture.chain[1]).await;
+    assert_eq!(r1_parts.len(), 1);
+    assert_eq!(r2_parts.len(), 1);
+
+    assert_eq!(
+        head_named_data_keys(mem.as_ref(), OLD_HOUR).await,
+        fixture.input_data_keys,
+        "only R1's raw inputs are HEAD-named"
+    );
+
+    let mut dreqs = BTreeSet::new();
+    for n in 0..3u128 {
+        let series = if n == 0 {
+            "victim".to_string()
+        } else {
+            format!("absent{n}")
+        };
+        let (dreq, _) =
+            seed_dreq_and_done_for(mem.as_ref(), request_id_n(n), &series, created).await;
+        dreqs.insert(dreq);
+    }
+    assert_eq!(dreqs.len(), 3, "three distinct requests");
+
+    clock.set(past_horizon(created));
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(
+        (out.records_deleted, out.data_deleted),
+        (0, 0),
+        "no record in the chain is deleted while R1's inputs are present"
+    );
+    assert_eq!(
+        out.held_by_snapshot, 8,
+        "one group of eight: two input commit records, two input data objects, R1's and R2's \
+         one part each, and R1's and R2's own records"
+    );
+    assert_eq!(out.held_by_unreadable_head, 0);
+
+    let mut survivors: BTreeSet<String> = fixture.chain.iter().cloned().collect();
+    survivors.extend(fixture.commit_keys.iter().cloned());
+    survivors.extend(fixture.input_data_keys.iter().cloned());
+    survivors.extend(r1_parts.iter().cloned());
+    survivors.extend(r2_parts.iter().cloned());
+    assert_eq!(
+        present_keys(mem.as_ref(), &survivors).await,
+        survivors,
+        "every generation, its parts, and the raw inputs all survive"
+    );
+
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(dreq.deleted, 0, "no filter retires");
+    assert_eq!(dreq.kept, 3);
+    assert_eq!(
+        dreq.held_by_superseded_inputs, 3,
+        "X because R1's raw inputs are present, Y and Z because a generation each superseded \
+         is still present"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &dreqs).await,
+        dreqs,
+        "all three .dreq objects physically present"
+    );
+}
+
+/// The guard on its own, with deliverable 1's ordering removed by hand: R1's
+/// record is deleted directly, as an older sweep would have left it, while its
+/// raw inputs stay. The chain from R2 is then cut at a missing record, so X is
+/// named nowhere, and the guard must still hold `.dreq_X` rather than infer
+/// from "no record mentions X" that nothing is outstanding.
+///
+/// The hold terminates: once every object the missing generation could have
+/// superseded is gone, the same guard retires the filter on the next pass.
+///
+/// Flip-line proof: delete the `walk.truncated` arm of the decision in
+/// `superseded_inputs_outstanding` (keep only the
+/// `walk.request_ids.contains(request_id)` branch). The cut chain then reports
+/// nothing outstanding and the `deleted == 0` assertion fails.
+#[tokio::test]
+async fn dreq_guard_holds_when_the_record_that_applied_the_request_is_already_gone() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let fixture = seed_chain(&mem, &clock, created, 2, None).await;
+    let r1 = fixture.chain[0].clone();
+    let r1_parts = rewrite_part_keys(mem.as_ref(), &r1).await;
+    let (dreq_x, _) = seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created).await;
+
+    // An older sweep's leftover: the record that applied X is gone, the inputs
+    // it superseded are not.
+    mem.delete(&r1).await.expect("delete R1's record");
+    assert_eq!(
+        present_keys(mem.as_ref(), &fixture.input_data_keys).await,
+        fixture.input_data_keys,
+        "the inputs R1 superseded are still present"
+    );
+
+    clock.set(past_horizon(created));
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(
+        dreq.deleted, 0,
+        "the chain from R2 is cut at the missing record and the bucket still holds raw inputs, \
+         so the filter stays even though no record names X"
+    );
+    assert_eq!(dreq.kept, 1);
+    assert_eq!(dreq.held_by_superseded_inputs, 1);
+    assert!(
+        mem.head(&dreq_x).await.is_ok(),
+        ".dreq_X physically present"
+    );
+
+    // Remove everything the missing generation could have superseded.
+    for key in fixture
+        .commit_keys
+        .iter()
+        .chain(fixture.input_data_keys.iter())
+        .chain(r1_parts.iter())
+    {
+        mem.delete(key).await.expect("delete a residual object");
+    }
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(dreq.deleted, 1, "the hold terminates on the next pass");
+    assert_eq!(dreq.kept, 0);
+    assert_eq!(dreq.held_by_superseded_inputs, 0);
+    assert!(mem.head(&dreq_x).await.is_err(), ".dreq_X physically gone");
 }

--- a/crates/ravel-maintain/tests/superseded_head_gate.rs
+++ b/crates/ravel-maintain/tests/superseded_head_gate.rs
@@ -26,8 +26,9 @@ use ravel_commit::keys::{self, BucketEntry};
 use ravel_commit::{erasure, signal};
 use ravel_maintain::{
     Bucket, CompactorConfig, ErasureRequestSweepOutcome, ErasureRewriteOutcome, FixedClock,
-    MaintainMemo, NoLeases, PendingErasureRequest, SupersededSweepOutcome, erasure_rewrite_bucket,
-    sweep_erasure_requests, sweep_superseded,
+    LeaseCheck, LegalHoldCheck, MaintainMemo, NoLeases, PendingErasureRequest,
+    SupersededSweepOutcome, erasure_rewrite_bucket, shard_hold_scopes, sweep_erasure_requests,
+    sweep_superseded, write_hold_set,
 };
 use ravel_object_store::fault::{
     FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
@@ -35,7 +36,7 @@ use ravel_object_store::fault::{
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions, list_all};
 use ravel_proto::commit::v1::{
-    ErasureBucketDrop, ErasureCompletion, ErasurePredicateMatcher, ErasureRequest,
+    ErasureBucketDrop, ErasureCompletion, ErasurePredicateMatcher, ErasureRequest, RewriteDrop,
 };
 use ravel_types::Signal;
 use uuid::Uuid;
@@ -140,10 +141,6 @@ fn pending_request_for(id: Uuid, series: &str) -> PendingErasureRequest {
             .expect("dreq key"),
         request: erasure_request_for(id, series),
     }
-}
-
-fn erasure_request() -> ErasureRequest {
-    erasure_request_for(request_id(), "victim")
 }
 
 fn erasure_request_for(id: Uuid, series: &str) -> ErasureRequest {
@@ -294,6 +291,13 @@ async fn present_keys(
     out
 }
 
+/// The data-object key the commit record at `key` names.
+async fn data_key_of(store: &dyn ObjectStoreBackend, key: &str) -> String {
+    let bytes = get_full(store, key).await;
+    let record = ravel_commit::record::decode(&bytes).expect("commit record decodes");
+    keys::reconstruct_data_key(&record).expect("data key")
+}
+
 /// The old hour's superseded input data keys, read off the commit records the
 /// fixture seeded (so the expected set never restates the sweep's arithmetic).
 async fn seeded_input_data_keys(
@@ -302,9 +306,7 @@ async fn seeded_input_data_keys(
 ) -> BTreeSet<String> {
     let mut out = BTreeSet::new();
     for key in commit_keys {
-        let bytes = get_full(store, key).await;
-        let record = ravel_commit::record::decode(&bytes).expect("commit record decodes");
-        out.insert(keys::reconstruct_data_key(&record).expect("data key"));
+        out.insert(data_key_of(store, key).await);
     }
     out
 }
@@ -393,13 +395,43 @@ async fn rewrite_part_keys(store: &dyn ObjectStoreBackend, key: &str) -> BTreeSe
         .collect()
 }
 
+/// Whether a seeded `.done` carries per-bucket dropped counts.
+///
+/// [`Drops::Absent`] is the production shape: the server's completion writer
+/// publishes `bucket_drops` empty, so no rule may depend on it being
+/// populated. [`Drops::Present`] is the optional narrowing hint a completion
+/// may carry. Every test that seeds the hint has a production-shape twin
+/// asserting the same holds, so a rule that only works on the hint cannot
+/// pass this suite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Drops {
+    Present,
+    Absent,
+}
+
+impl Drops {
+    fn bucket_drops(self) -> Vec<ErasureBucketDrop> {
+        match self {
+            Drops::Present => vec![ErasureBucketDrop {
+                signal: signal::to_proto(Signal::Metrics) as i32,
+                shard: SHARD,
+                ingest_hour_bucket: OLD_HOUR,
+                dropped_count: 2,
+            }],
+            Drops::Absent => Vec::new(),
+        }
+    }
+}
+
 /// Seed a `.dreq` for `id` over `series` and its `.done` completion, anchored
-/// at `completed` and naming [`OLD_HOUR`] as the one bucket it touched.
+/// at `completed`, with `drops` deciding whether the completion names
+/// [`OLD_HOUR`] as a bucket it touched.
 async fn seed_dreq_and_done_for(
     store: &dyn ObjectStoreBackend,
     id: Uuid,
     series: &str,
     completed: i64,
+    drops: Drops,
 ) -> (String, String) {
     let dreq_key = keys::erasure_request_key(&tenant_hash(), Signal::Metrics, id).unwrap();
     store
@@ -417,12 +449,7 @@ async fn seed_dreq_and_done_for(
         signal: signal::to_proto(Signal::Metrics) as i32,
         request_id: id.to_string(),
         predicate_hash: vec![0x11; 32],
-        bucket_drops: vec![ErasureBucketDrop {
-            signal: signal::to_proto(Signal::Metrics) as i32,
-            shard: SHARD,
-            ingest_hour_bucket: OLD_HOUR,
-            dropped_count: 2,
-        }],
+        bucket_drops: drops.bucket_drops(),
         requested_unix_ns: 0,
         completed_unix_ns: completed,
         deferral_cause: 0,
@@ -706,47 +733,13 @@ async fn absent_head_clears_the_gate_and_the_pass_deletes_as_before() {
 // --- (e) the two horizons, cross-checked ------------------------------------
 
 /// Seed the request object and its completion record. `completed` anchors the
-/// `.dreq` removal horizon; `bucket_drops` names the one bucket this request's
-/// rewrite touched.
-async fn seed_dreq_and_done(store: &dyn ObjectStoreBackend, completed: i64) -> (String, String) {
-    let dreq_key =
-        keys::erasure_request_key(&tenant_hash(), Signal::Metrics, request_id()).unwrap();
-    store
-        .put(
-            &dreq_key,
-            erasure::encode_request(&erasure_request()),
-            PutOptions::default(),
-        )
-        .await
-        .unwrap();
-
-    let completion = ErasureCompletion {
-        format_version: 1,
-        tenant_hash: tenant_hash().0.to_vec(),
-        signal: signal::to_proto(Signal::Metrics) as i32,
-        request_id: request_id().to_string(),
-        predicate_hash: vec![0x11; 32],
-        bucket_drops: vec![ErasureBucketDrop {
-            signal: signal::to_proto(Signal::Metrics) as i32,
-            shard: SHARD,
-            ingest_hour_bucket: OLD_HOUR,
-            dropped_count: 2,
-        }],
-        requested_unix_ns: 0,
-        completed_unix_ns: completed,
-        deferral_cause: 0,
-    };
-    let done_key =
-        keys::erasure_completion_key(&tenant_hash(), Signal::Metrics, request_id()).unwrap();
-    store
-        .put(
-            &done_key,
-            erasure::encode_completion(&completion),
-            PutOptions::default(),
-        )
-        .await
-        .unwrap();
-    (dreq_key, done_key)
+/// `.dreq` removal horizon.
+async fn seed_dreq_and_done(
+    store: &dyn ObjectStoreBackend,
+    completed: i64,
+    drops: Drops,
+) -> (String, String) {
+    seed_dreq_and_done_for(store, request_id(), "victim", completed, drops).await
 }
 
 /// The two horizons are tied only by both being `protection_horizon_ns`; the
@@ -757,16 +750,29 @@ async fn seed_dreq_and_done(store: &dyn ObjectStoreBackend, completed: i64) -> (
 /// after every single sweep call that the `.dreq` is still present whenever any
 /// superseded input is.
 ///
-/// Flip-line proof, two lines, one per direction. Remove the
-/// `superseded_inputs_outstanding` guard in `sweep_erasure_requests` and the
-/// `.dreq` disappears at its horizon while the held inputs are still resolvable
-/// from the stale snapshot, failing the ordering assertion at step 3. Replace
-/// the `reach.object_gate(...)` match in `sweep_superseded_impl` with
-/// `SnapshotGate::Clear` and the inputs are deleted at step 3 while the
-/// snapshot still names them, failing the "inputs still present" assertion
-/// there.
+/// Flip-line proof, two lines, one per direction. Drop the
+/// `holds.request_ids.contains(...)` arm of the `held` decision in
+/// `sweep_erasure_requests_inner` and the `.dreq` disappears at its horizon
+/// while the held inputs are still resolvable from the stale snapshot, failing
+/// the ordering assertion at step 3. Replace the `reach.object_gate(...)` match
+/// in `sweep_superseded_impl` with `SnapshotGate::Clear` and the inputs are
+/// deleted at step 3 while the snapshot still names them, failing the "inputs
+/// still present" assertion there.
 #[tokio::test]
 async fn dreq_outlives_every_superseded_input_its_rewrite_left_resolvable() {
+    dreq_outlives_every_superseded_input_case(Drops::Present).await;
+}
+
+/// The production-shape twin: the same holds must come out of a completion
+/// that names no buckets at all, because that is the only shape the server
+/// writes. On the pre-fix code the step-3 `dreq.deleted == 0` assertion fails
+/// with `deleted: 1`.
+#[tokio::test]
+async fn dreq_outlives_every_superseded_input_its_rewrite_left_resolvable_in_production_shape() {
+    dreq_outlives_every_superseded_input_case(Drops::Absent).await;
+}
+
+async fn dreq_outlives_every_superseded_input_case(drops: Drops) {
     let mem = Arc::new(MemoryStore::new());
     let created = sealed_now_ns();
     let clock = FixedClock::new(created);
@@ -780,7 +786,7 @@ async fn dreq_outlives_every_superseded_input_its_rewrite_left_resolvable() {
 
     // The completion lands at the same instant the rewrite did, so the two
     // horizons coincide exactly: this is the tightest ordering the pair admits.
-    let (dreq_key, done_key) = seed_dreq_and_done(mem.as_ref(), created).await;
+    let (dreq_key, done_key) = seed_dreq_and_done(mem.as_ref(), created, drops).await;
 
     // After every sweep call: if any superseded input is still in the store,
     // the request that excludes it must still be there too.
@@ -961,10 +967,9 @@ async fn seed_chain(
 /// `.dreq` guard must then find X by walking the chain from R2 back through R1,
 /// and hold the filter.
 ///
-/// Also pins the guard's request shape on this fixture: two LISTs (`del/` and
-/// the bucket's commit prefix) and five GETs (the `.done`, R1's and R2's
-/// records, and the two input commit records) for the whole pass, with the
-/// chain walk reusing the records the pass already read.
+/// Also pins the guard's request shape on this fixture, which is rule 2's own
+/// shape plus the `del/` LIST and the `.done` GET: the guard performs no
+/// listing or fetching of its own beyond observing that sweep.
 ///
 /// Flip-line proof: in `sweep_superseded_impl`, drop the
 /// `superseded_by_present.contains(key)` skip and gate each generation from its
@@ -974,6 +979,18 @@ async fn seed_chain(
 /// fails, and the `.dreq` assertions fail with it.
 #[tokio::test]
 async fn superseded_predecessor_and_its_dreq_outlive_head_named_raw_inputs() {
+    superseded_predecessor_outlives_raw_inputs_case(Drops::Present).await;
+}
+
+/// The production-shape twin: a completion naming no buckets holds the same
+/// way, at the cost of one extra LIST to discover the signal's shards and a
+/// shard-wide commit LIST in place of the one-hour one.
+#[tokio::test]
+async fn superseded_predecessor_and_its_dreq_outlive_head_named_raw_inputs_in_production_shape() {
+    superseded_predecessor_outlives_raw_inputs_case(Drops::Absent).await;
+}
+
+async fn superseded_predecessor_outlives_raw_inputs_case(drops: Drops) {
     let mem = Arc::new(MemoryStore::new());
     let created = sealed_now_ns();
     let clock = FixedClock::new(created);
@@ -989,7 +1006,8 @@ async fn superseded_predecessor_and_its_dreq_outlive_head_named_raw_inputs() {
         "the stale snapshot still names exactly the two pre-rewrite inputs"
     );
 
-    let (dreq_x, _) = seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created).await;
+    let (dreq_x, _) =
+        seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created, drops).await;
 
     clock.set(past_horizon(created));
     let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
@@ -1025,16 +1043,34 @@ async fn superseded_predecessor_and_its_dreq_outlive_head_named_raw_inputs() {
         "R1's parts survive with its record"
     );
 
-    // The guard's request shape is asserted, not printed: the sixth GET and the
-    // third LIST of the pass both fault, so the pass succeeding proves the
-    // counts.
+    // The guard's request shape is asserted, not printed: the first GET and the
+    // first LIST past the expected count both fault, so the pass succeeding
+    // proves the counts.
+    //
+    // Eight GETs either way: the `.done`, R1's and R2's records read once for
+    // the pass, R1 again as the chain link the walk follows, the two input
+    // commit records, the catalog HEAD, and the one covering snapshot part.
+    // The LISTs are the only difference between the two completion shapes. A
+    // completion naming the bucket it touched narrows the observation to that
+    // one (shard, hour): the `del/` prefix and that bucket's commit prefix. A
+    // production-shape completion names none, so the observation covers the
+    // signal's shards: one LIST to discover them, plus the shard's whole
+    // commit prefix in place of the single hour's.
+    let (gets, lists) = match drops {
+        Drops::Present => (8, 2),
+        Drops::Absent => (8, 3),
+    };
     let plan = FaultPlan::empty()
-        .with_rule(Rule::new(Op::Get, ScriptedFault::Timeout).with_occurrence(Occurrence::Nth(6)))
-        .with_rule(Rule::new(Op::List, ScriptedFault::Timeout).with_occurrence(Occurrence::Nth(3)));
+        .with_rule(
+            Rule::new(Op::Get, ScriptedFault::Timeout).with_occurrence(Occurrence::Nth(gets + 1)),
+        )
+        .with_rule(
+            Rule::new(Op::List, ScriptedFault::Timeout).with_occurrence(Occurrence::Nth(lists + 1)),
+        );
     let store = FaultStore::new(mem.clone(), plan);
     let dreq = sweep_dreq(&store, &clock)
         .await
-        .expect("the chain walk reads each record once, so no sixth GET and no third LIST");
+        .expect("the observed sweep reads each record once, so no GET or LIST past the count");
     assert_eq!(
         dreq.deleted, 0,
         ".dreq_X outlives the inputs R1 erased the subject out of"
@@ -1047,12 +1083,12 @@ async fn superseded_predecessor_and_its_dreq_outlive_head_named_raw_inputs() {
     assert_eq!(
         store.fault_count(Op::Get, FaultKind::Timeout),
         0,
-        "exactly five GETs: the .done, R1's and R2's records, and the two input commit records"
+        "exactly {gets} GETs for the whole pass"
     );
     assert_eq!(
         store.fault_count(Op::List, FaultKind::Timeout),
         0,
-        "exactly two LISTs: the del/ prefix and the touched bucket's commit prefix"
+        "exactly {lists} LISTs for the whole pass"
     );
     assert!(
         mem.head(&dreq_x).await.is_ok(),
@@ -1073,6 +1109,17 @@ async fn superseded_predecessor_and_its_dreq_outlive_head_named_raw_inputs() {
 /// assertions fail.
 #[tokio::test]
 async fn reconciled_chain_deletes_the_superseded_inputs_before_the_record_that_erased_them() {
+    reconciled_chain_delete_order_case(Drops::Present).await;
+}
+
+/// The production-shape twin: the delete order and the filter's retirement do
+/// not depend on the completion naming its buckets.
+#[tokio::test]
+async fn reconciled_chain_deletes_the_superseded_inputs_first_in_production_shape() {
+    reconciled_chain_delete_order_case(Drops::Absent).await;
+}
+
+async fn reconciled_chain_delete_order_case(drops: Drops) {
     let mem = Arc::new(MemoryStore::new());
     let created = sealed_now_ns();
     let clock = FixedClock::new(created);
@@ -1089,7 +1136,7 @@ async fn reconciled_chain_deletes_the_superseded_inputs_before_the_record_that_e
     );
 
     let (dreq_x, done_x) =
-        seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created).await;
+        seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created, drops).await;
 
     // Step 1: fault exactly R1's record delete. Everything the invariant
     // requires to be gone before it must already be gone.
@@ -1174,6 +1221,18 @@ async fn reconciled_chain_deletes_the_superseded_inputs_before_the_record_that_e
 /// `held_by_superseded_inputs == 3` assertions both fail.
 #[tokio::test]
 async fn three_deep_chain_holds_every_generation_and_every_request() {
+    three_deep_chain_holds_case(Drops::Present).await;
+}
+
+/// The production-shape twin: all three filters are held by the request ids
+/// the held chain group carries, which is what the sweep observes rather than
+/// anything the completions declare.
+#[tokio::test]
+async fn three_deep_chain_holds_every_generation_and_every_request_in_production_shape() {
+    three_deep_chain_holds_case(Drops::Absent).await;
+}
+
+async fn three_deep_chain_holds_case(drops: Drops) {
     let mem = Arc::new(MemoryStore::new());
     let created = sealed_now_ns();
     let clock = FixedClock::new(created);
@@ -1197,7 +1256,7 @@ async fn three_deep_chain_holds_every_generation_and_every_request() {
             format!("absent{n}")
         };
         let (dreq, _) =
-            seed_dreq_and_done_for(mem.as_ref(), request_id_n(n), &series, created).await;
+            seed_dreq_and_done_for(mem.as_ref(), request_id_n(n), &series, created, drops).await;
         dreqs.insert(dreq);
     }
     assert_eq!(dreqs.len(), 3, "three distinct requests");
@@ -1242,64 +1301,812 @@ async fn three_deep_chain_holds_every_generation_and_every_request() {
     );
 }
 
-/// The guard on its own, with deliverable 1's ordering removed by hand: R1's
-/// record is deleted directly, as an older sweep would have left it, while its
-/// raw inputs stay. The chain from R2 is then cut at a missing record, so X is
-/// named nowhere, and the guard must still hold `.dreq_X` rather than infer
-/// from "no record mentions X" that nothing is outstanding.
+/// A request no surviving record names, held on the bucket whose cut chain the
+/// sweep held. R1 applies X, R2 applies Y and supersedes R1, R3 applies Z and
+/// supersedes R2. A pass whose last delete fails leaves the chain cut at R1's
+/// missing record, so nothing durable names X any more; the next pass, run
+/// against an unreadable catalog HEAD, holds what the crash left of that chain
+/// and reports the bucket, and the guard holds all three filters: Y and Z by
+/// the request ids the held group still carries, X by that bucket.
 ///
-/// The hold terminates: once every object the missing generation could have
-/// superseded is gone, the same guard retires the filter on the next pass.
+/// The crash state is the one the delete order actually produces.
+/// `chain_record_keys` is ordered oldest generation first, so faulting R2's
+/// record delete leaves R1's record gone with every object below it already
+/// deleted by the two earlier phases: this is a reachable state, not a
+/// hand-built one.
 ///
-/// Flip-line proof: delete the `walk.truncated` arm of the decision in
-/// `superseded_inputs_outstanding` (keep only the
-/// `walk.request_ids.contains(request_id)` branch). The cut chain then reports
-/// nothing outstanding and the `deleted == 0` assertion fails.
+/// The hold terminates, and for a reason this test walks all the way out: the
+/// only thing holding it is a group of objects the sweep itself is trying to
+/// delete. As soon as the gate clears, that group goes, the chain from R3
+/// reaches nothing at all, no group is gathered, and the same guard retires
+/// all three filters on the next pass.
+///
+/// Flip-line proof, one per half. Drop the truncated-bucket arm of the `held`
+/// decision in `sweep_erasure_requests_inner` (keep only
+/// `holds.request_ids.contains(...)`): X is named by no record, so its filter
+/// is deleted at step 3 and the `deleted == 0` assertion fails. For the
+/// termination half, make `gather_superseded_chain` return a group for a chain
+/// that reached nothing (replace the `let Some(ingest_hour_bucket) = ... else
+/// return Ok(Vec::new())` guard with the predecessor's own bucket): the empty
+/// group is then held by the unreadable HEAD forever and the step-5
+/// `deleted == 3` assertion fails.
 #[tokio::test]
 async fn dreq_guard_holds_when_the_record_that_applied_the_request_is_already_gone() {
+    cut_chain_holds_the_bucket_case(Drops::Present).await;
+}
+
+/// The production-shape twin: with no buckets named at all, the completion
+/// takes the legacy branch of the bucket fallback and is held by the same
+/// cut-chain observation.
+#[tokio::test]
+async fn dreq_guard_holds_when_no_record_names_the_request_in_production_shape() {
+    cut_chain_holds_the_bucket_case(Drops::Absent).await;
+}
+
+async fn cut_chain_holds_the_bucket_case(drops: Drops) {
     let mem = Arc::new(MemoryStore::new());
     let created = sealed_now_ns();
     let clock = FixedClock::new(created);
-    let fixture = seed_chain(&mem, &clock, created, 2, None).await;
+    // A reconciled hour, so the gate clears and the chain is collectable.
+    let fixture = seed_chain(&mem, &clock, created, 3, Some(200)).await;
     let r1 = fixture.chain[0].clone();
-    let r1_parts = rewrite_part_keys(mem.as_ref(), &r1).await;
-    let (dreq_x, _) = seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created).await;
+    let r2 = fixture.chain[1].clone();
+    let r3 = fixture.chain[2].clone();
+    let r2_parts = rewrite_part_keys(mem.as_ref(), &r2).await;
+    let r3_parts = rewrite_part_keys(mem.as_ref(), &r3).await;
+    assert_eq!(r2_parts.len(), 1, "R2 published exactly one part");
 
-    // An older sweep's leftover: the record that applied X is gone, the inputs
-    // it superseded are not.
-    mem.delete(&r1).await.expect("delete R1's record");
+    let mut dreqs = BTreeSet::new();
+    for n in 0..3u128 {
+        let series = if n == 0 {
+            "victim".to_string()
+        } else {
+            format!("absent{n}")
+        };
+        let (dreq, _) =
+            seed_dreq_and_done_for(mem.as_ref(), request_id_n(n), &series, created, drops).await;
+        dreqs.insert(dreq);
+    }
+
+    // Step 1: a pass that dies on the last delete of the chain.
+    clock.set(past_horizon(created));
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout).with_key_contains(r2.clone()));
+    let store = FaultStore::new(mem.clone(), plan);
+    assert!(
+        sweep(&store, &clock).await.is_err(),
+        "the faulted delete of R2's record surfaces as a pass error"
+    );
+    assert_eq!(
+        store.fault_count(Op::Delete, FaultKind::Timeout),
+        1,
+        "exactly one delete was aimed at R2's record"
+    );
+    assert!(
+        mem.head(&r1).await.is_err(),
+        "R1's record went first: chain records are deleted oldest generation first"
+    );
+    assert!(
+        mem.head(&r2).await.is_ok(),
+        "R2's record is the delete that faulted"
+    );
     assert_eq!(
         present_keys(mem.as_ref(), &fixture.input_data_keys).await,
-        fixture.input_data_keys,
-        "the inputs R1 superseded are still present"
+        BTreeSet::new(),
+        "every raw input the chain superseded went in the earlier phases"
     );
-
-    clock.set(past_horizon(created));
-    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
     assert_eq!(
-        dreq.deleted, 0,
-        "the chain from R2 is cut at the missing record and the bucket still holds raw inputs, \
-         so the filter stays even though no record names X"
-    );
-    assert_eq!(dreq.kept, 1);
-    assert_eq!(dreq.held_by_superseded_inputs, 1);
-    assert!(
-        mem.head(&dreq_x).await.is_ok(),
-        ".dreq_X physically present"
+        present_keys(mem.as_ref(), &r2_parts).await,
+        BTreeSet::new(),
+        "so did every superseded generation's parts"
     );
 
-    // Remove everything the missing generation could have superseded.
-    for key in fixture
-        .commit_keys
-        .iter()
-        .chain(fixture.input_data_keys.iter())
-        .chain(r1_parts.iter())
-    {
-        mem.delete(key).await.expect("delete a residual object");
-    }
+    // Step 2: the next pass gathers the chain from R3, finds it cut at R1's
+    // missing record, and cannot prove non-reachability against an unreadable
+    // HEAD. What it holds is exactly what the crash left: R2's record and the
+    // part key that record still names.
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Get, ScriptedFault::CorruptRange).with_key_contains(head_key()))
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout));
+    let store = FaultStore::new(mem.clone(), plan);
+    let out = sweep(&store, &clock)
+        .await
+        .expect("an unreadable HEAD holds, it does not error the pass");
+    assert_eq!((out.records_deleted, out.data_deleted), (0, 0));
+    assert_eq!(
+        out.held_by_unreadable_head, 2,
+        "the cut chain's residue: R2's record and the one part key it names"
+    );
+    assert_eq!(out.held_by_snapshot, 0);
+    assert_eq!(out.chain_groups_held_by_legal_hold, 0);
+
+    // Step 3: X is named by no surviving record, so it is held by the bucket
+    // the cut chain was held in. Y and Z are held by the request ids that
+    // group still carries. No delete is issued at all: one would fault.
+    let dreq = sweep_erasure_requests(
+        &store,
+        &clock,
+        &cfg(),
+        &NoLeases,
+        &tenant_hash(),
+        Signal::Metrics,
+    )
+    .await
+    .expect("dreq sweep");
+    assert_eq!(dreq.deleted, 0, "no filter retires while the chain is cut");
+    assert_eq!(dreq.kept, 3);
+    assert_eq!(dreq.held_by_superseded_inputs, 3);
+    assert_eq!(
+        present_keys(mem.as_ref(), &dreqs).await,
+        dreqs,
+        "all three .dreq objects physically present"
+    );
+
+    // Step 4: the same pass with a readable HEAD. The reconciled snapshot
+    // names R3's parts and nothing else, so the residue clears and goes.
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(
+        out.records_deleted, 1,
+        "R2's record: the delete the crash lost"
+    );
+    assert_eq!(
+        out.data_deleted, 1,
+        "the part key R2's record names, re-issued idempotently"
+    );
+    assert_eq!((out.held_by_snapshot, out.held_by_unreadable_head), (0, 0));
+    assert!(mem.head(&r2).await.is_err(), "R2's record is gone");
+    assert!(mem.head(&r3).await.is_ok(), "the live generation survives");
+    assert_eq!(
+        present_keys(mem.as_ref(), &r3_parts).await,
+        r3_parts,
+        "and so do its parts"
+    );
+
+    // Step 5: with the residue gone the chain from R3 reaches nothing, so no
+    // group is gathered, nothing is held, and every filter retires.
     let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
-    assert_eq!(dreq.deleted, 1, "the hold terminates on the next pass");
+    assert_eq!(dreq.deleted, 3, "the hold terminates on the next pass");
     assert_eq!(dreq.kept, 0);
     assert_eq!(dreq.held_by_superseded_inputs, 0);
-    assert!(mem.head(&dreq_x).await.is_err(), ".dreq_X physically gone");
+    assert_eq!(
+        present_keys(mem.as_ref(), &dreqs).await,
+        BTreeSet::new(),
+        "all three .dreq objects physically gone"
+    );
+}
+
+// --- (g) the whole ordering, end to end, across a crash and a fold ----------
+
+/// Two requests over two generations, in production completion shape. R1
+/// applies X over `victim` and supersedes the two raw L0 inputs; R2 applies Y
+/// over `keep` and supersedes R1, so R1's output part is the pre-image Y erased
+/// from exactly as the raw inputs are the pre-image X erased from.
+///
+/// After every sweep call this asserts the ordering both horizons exist for: no
+/// pre-rewrite object is resolvable without the filter that excludes what it
+/// still holds. The raw inputs carry both subjects, so while either input is
+/// present both filters must be; R1's part carries Y's subject, so while that
+/// part is present `.dreq_Y` must be.
+///
+/// The crash comes after the reconciling fold, and it can only come there:
+/// while the hour is unreconciled the gate holds the whole chain group and the
+/// pass issues no delete at all, so there is nothing to crash on until the fold
+/// clears it.
+///
+/// Flip-line proof: replace the `held` decision in
+/// `sweep_erasure_requests_inner` with `false`. Both filters are then deleted
+/// at step 2 while the stale snapshot still names the inputs, and the ordering
+/// assertion at that step fails on `.dreq_X`.
+#[tokio::test]
+async fn neither_filter_retires_while_any_pre_rewrite_object_survives() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+
+    // Step 1: two generations, X then Y, in an hour the fold's reconcile
+    // window never reaches.
+    fold_head(&mem, created, 1, None).await;
+    run_rewrite_with(mem.as_ref(), &clock, &[pending_request()]).await;
+    run_rewrite_with(
+        mem.as_ref(),
+        &clock,
+        &[pending_request_for(request_id_n(1), "keep")],
+    )
+    .await;
+    fold_head(&mem, created + 3 * NS_PER_HOUR, 2, None).await;
+    let chain = rewrite_chain(mem.as_ref()).await;
+    assert_eq!(chain.len(), 2, "R1 superseded by R2");
+    let r1 = chain[0].clone();
+    let r2 = chain[1].clone();
+    let r1_parts = rewrite_part_keys(mem.as_ref(), &r1).await;
+    assert_eq!(r1_parts.len(), 1, "R1 published exactly one part");
+    assert_eq!(
+        head_named_data_keys(mem.as_ref(), OLD_HOUR).await,
+        input_data_keys,
+        "the stale snapshot still names exactly the two pre-rewrite inputs"
+    );
+
+    let (dreq_x, done_x) =
+        seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created, Drops::Absent).await;
+    let (dreq_y, done_y) = seed_dreq_and_done_for(
+        mem.as_ref(),
+        request_id_n(1),
+        "keep",
+        created,
+        Drops::Absent,
+    )
+    .await;
+
+    async fn assert_ordering(
+        store: &dyn ObjectStoreBackend,
+        dreq_x: &str,
+        dreq_y: &str,
+        inputs: &BTreeSet<String>,
+        r1_parts: &BTreeSet<String>,
+        step: &str,
+    ) {
+        let inputs_left = present_keys(store, inputs).await.len();
+        if inputs_left > 0 {
+            assert!(
+                store.head(dreq_x).await.is_ok(),
+                "{step}: {inputs_left} raw input(s) still resolvable, so .dreq_X must still be \
+                 excluding X's subject"
+            );
+            assert!(
+                store.head(dreq_y).await.is_ok(),
+                "{step}: {inputs_left} raw input(s) still resolvable, and they carry Y's subject \
+                 too, so .dreq_Y must still be excluding it"
+            );
+        }
+        if !present_keys(store, r1_parts).await.is_empty() {
+            assert!(
+                store.head(dreq_y).await.is_ok(),
+                "{step}: R1's part is the pre-image Y erased from, so .dreq_Y must outlive it"
+            );
+        }
+    }
+
+    // Step 2: past both horizons with the hour still unreconciled. The chain is
+    // one group of six and the stale snapshot names two of them, so all six are
+    // held and both filters are held with them.
+    clock.set(past_horizon(created));
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!((out.records_deleted, out.data_deleted), (0, 0));
+    assert_eq!(
+        out.held_by_snapshot, 6,
+        "two input commit records, two input data objects, R1's part, R1's own record"
+    );
+    assert_eq!(out.chain_groups_held_by_legal_hold, 0);
+    assert_ordering(
+        mem.as_ref(),
+        &dreq_x,
+        &dreq_y,
+        &input_data_keys,
+        &r1_parts,
+        "unreconciled",
+    )
+    .await;
+
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(dreq.deleted, 0, "unreconciled: neither filter retires");
+    assert_eq!(dreq.kept, 2);
+    assert_eq!(dreq.held_by_superseded_inputs, 2);
+    assert_ordering(
+        mem.as_ref(),
+        &dreq_x,
+        &dreq_y,
+        &input_data_keys,
+        &r1_parts,
+        "unreconciled, after the dreq sweep",
+    )
+    .await;
+
+    // Step 3: the fold reconciles the hour, and the very next pass dies on R1's
+    // record delete. Everything the ordering requires to go before it is gone
+    // at that instant, and both filters are still live.
+    fold_head(&mem, past_horizon(created) + 3 * NS_PER_HOUR, 3, Some(200)).await;
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout).with_key_contains(r1.clone()));
+    let store = FaultStore::new(mem.clone(), plan);
+    assert!(
+        sweep(&store, &clock).await.is_err(),
+        "the faulted delete of R1's record surfaces as a pass error"
+    );
+    assert_eq!(store.fault_count(Op::Delete, FaultKind::Timeout), 1);
+    assert_eq!(
+        present_keys(mem.as_ref(), &input_data_keys).await,
+        BTreeSet::new(),
+        "both raw inputs went before R1's record"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &r1_parts).await,
+        BTreeSet::new(),
+        "and so did R1's part, the pre-image Y erased from"
+    );
+    assert!(mem.head(&r1).await.is_ok(), "R1's record is what faulted");
+    assert_ordering(
+        mem.as_ref(),
+        &dreq_x,
+        &dreq_y,
+        &input_data_keys,
+        &r1_parts,
+        "after the crash",
+    )
+    .await;
+
+    // Step 4: with no pre-rewrite object left there is nothing for either
+    // filter to exclude, and both retire on the same pass.
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(dreq.deleted, 2, "both filters retire, once each");
+    assert_eq!(dreq.kept, 0);
+    assert_eq!(dreq.held_by_superseded_inputs, 0);
+    for key in [&dreq_x, &dreq_y] {
+        assert!(mem.head(key).await.is_err(), "the .dreq is physically gone");
+    }
+    for key in [&done_x, &done_y] {
+        assert!(
+            mem.head(key).await.is_ok(),
+            ".done is permanent audit evidence, never swept"
+        );
+    }
+
+    // Step 5: a clean pass finishes the delete the crash lost.
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(out.records_deleted, 1, "R1's record, and nothing else");
+    assert_eq!(
+        out.data_deleted, 1,
+        "R1's single part, re-issued idempotently"
+    );
+    assert!(mem.head(&r1).await.is_err(), "R1's record is gone");
+    assert!(mem.head(&r2).await.is_ok(), "the live generation survives");
+}
+
+// --- (h) termination: a late flush into a swept hour pins nothing -----------
+
+/// Two generations swept clean, then one late L0 flush lands in the same sealed
+/// hour. The stray object is an input of no record that has passed its horizon,
+/// so it forms no group, holds nothing, and the filters retire on the very next
+/// pass. The flush itself survives: rule 2 collects superseded inputs, and
+/// nothing supersedes this one.
+///
+/// This is the termination argument's hard case. A rule that held a filter
+/// whenever a swept bucket still listed raw L0 commit records would pin both
+/// filters here forever, because ingest can drop a late segment into a sealed
+/// hour at any time.
+///
+/// Flip-line proof: reintroduce a bucket-residue rule of the shape this pass
+/// removed, holding whenever the chain from a live record is cut and the bucket
+/// still lists any raw L0 commit record. R2's chain is cut (its predecessor is
+/// gone) and the late flush is such a record, so both filters are pinned and
+/// the `deleted == 2` assertion fails with `deleted: 0`.
+#[tokio::test]
+async fn a_late_l0_flush_into_a_swept_hour_never_pins_a_filter() {
+    late_flush_pins_nothing_case(Drops::Present).await;
+}
+
+/// The production-shape twin: the same termination, out of completions that
+/// name no bucket for the residue rule to have narrowed to in the first place.
+#[tokio::test]
+async fn a_late_l0_flush_into_a_swept_hour_never_pins_a_filter_in_production_shape() {
+    late_flush_pins_nothing_case(Drops::Absent).await;
+}
+
+async fn late_flush_pins_nothing_case(drops: Drops) {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let fixture = seed_chain(&mem, &clock, created, 2, Some(200)).await;
+    let r1 = fixture.chain[0].clone();
+    let r2 = fixture.chain[1].clone();
+
+    let mut dreqs = BTreeSet::new();
+    for (n, series) in [(0u128, "victim"), (1, "absent1")] {
+        let (dreq, _) =
+            seed_dreq_and_done_for(mem.as_ref(), request_id_n(n), series, created, drops).await;
+        dreqs.insert(dreq);
+    }
+
+    // Two generations collected: the raw inputs, their commit records, and R1.
+    clock.set(past_horizon(created));
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!((out.records_deleted, out.data_deleted), (3, 3));
+    assert_eq!((out.held_by_snapshot, out.held_by_unreadable_head), (0, 0));
+    assert!(mem.head(&r1).await.is_err(), "R1's record is gone");
+
+    // One late segment for the sealed hour, published after the sweep passed
+    // over it. This is ordinary ingest, not a fixture contrivance: the hour is
+    // sealed against compaction, not against a straggling writer.
+    let old_ns = i64::from(OLD_HOUR) * NS_PER_HOUR;
+    let late_commit = seed_input(
+        mem.as_ref(),
+        &InputSpec::new_at(
+            OLD_HOUR,
+            Uuid::from_u128(0xC1),
+            1,
+            1,
+            vec![raw_series("late", &[("k", "z")], &[(old_ns + 9_000, 7.0)])],
+        ),
+    )
+    .await;
+    let late_data = data_key_of(mem.as_ref(), &late_commit).await;
+
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(
+        (out.records_deleted, out.data_deleted),
+        (0, 0),
+        "no live record names the late flush as an input, so it is in no group"
+    );
+    assert_eq!((out.held_by_snapshot, out.held_by_unreadable_head), (0, 0));
+    assert_eq!(out.chain_groups_held_by_legal_hold, 0);
+
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(
+        dreq.deleted, 2,
+        "the late flush pins nothing: both filters retire"
+    );
+    assert_eq!(dreq.kept, 0);
+    assert_eq!(dreq.held_by_superseded_inputs, 0);
+    assert_eq!(present_keys(mem.as_ref(), &dreqs).await, BTreeSet::new());
+
+    assert!(
+        mem.head(&late_commit).await.is_ok(),
+        "the stray commit record survives: rule 2 deletes superseded inputs, and nothing \
+         supersedes this one"
+    );
+    assert!(mem.head(&late_data).await.is_ok(), "and so does its data");
+    assert!(mem.head(&r2).await.is_ok(), "the live generation survives");
+}
+
+// --- (i) a prefix-scoped legal hold covers the group, not the key -----------
+
+/// A legal hold over the L0 data prefix alone protects the two input data
+/// objects and nothing else in the chain group: not the commit records that
+/// resolve them, not the L1 part, not the rewrite record. Per-key filtering
+/// inside each delete phase would therefore delete everything the hold does not
+/// name and leave held bytes no record resolves. The group is the deletion
+/// unit, so a hold on any one of its keys skips all of it, and the pass says so
+/// in its own counter.
+///
+/// The control pass at the end proves the fixture was collectable: the same
+/// clock, the same store, no hold, everything goes.
+///
+/// Flip-line proof: restore the per-key `lease.is_protected(k)` test inside the
+/// three delete loops in `sweep_superseded_impl` in place of the group-level
+/// `protected_key` skip. The two input commit records and R1's record are then
+/// deleted while the held data objects stay, so both the `present == all`
+/// assertion and `chain_groups_held_by_legal_hold == 1` fail.
+#[tokio::test]
+async fn a_hold_on_the_data_prefix_alone_skips_the_whole_chain_group() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let fixture = seed_chain(&mem, &clock, created, 2, Some(200)).await;
+    let r1 = fixture.chain[0].clone();
+    let r1_parts = rewrite_part_keys(mem.as_ref(), &r1).await;
+    let (dreq_x, _) =
+        seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created, Drops::Absent).await;
+
+    let b = old_bucket();
+    let scopes = shard_hold_scopes(&b.tenant_hash, b.signal, b.shard).expect("hold scopes");
+    write_hold_set(
+        mem.as_ref(),
+        &b.tenant_hash,
+        Uuid::from_u128(0x4001),
+        created,
+        &scopes[0],
+        "litigation hold",
+    )
+    .await
+    .expect("hold set");
+    let lease = LegalHoldCheck::refresh(mem.as_ref(), &b.tenant_hash)
+        .await
+        .expect("hold snapshot");
+    assert!(!lease.is_empty(), "the hold is active");
+
+    // The hold's exact reach: the data objects, and nothing else the group
+    // holds. This is the shape the group-level rule exists for.
+    let mut unprotected: BTreeSet<String> = fixture.commit_keys.iter().cloned().collect();
+    unprotected.insert(r1.clone());
+    unprotected.extend(r1_parts.iter().cloned());
+    unprotected.insert(dreq_x.clone());
+    for key in &fixture.input_data_keys {
+        assert!(lease.is_protected(key), "the hold covers the input data");
+    }
+    for key in &unprotected {
+        assert!(
+            !lease.is_protected(key),
+            "the hold does not reach {key}: holding one prefix protects one prefix"
+        );
+    }
+
+    clock.set(past_horizon(created));
+    let out = sweep_superseded(
+        mem.as_ref(),
+        &clock,
+        &cfg(),
+        &lease,
+        &b.tenant_hash,
+        b.signal,
+        b.shard,
+    )
+    .await
+    .expect("superseded sweep");
+    assert_eq!(
+        (out.records_deleted, out.data_deleted),
+        (0, 0),
+        "one held key skips the whole group, so no phase deletes anything"
+    );
+    assert_eq!(
+        out.chain_groups_held_by_legal_hold, 1,
+        "exactly one group skipped, and reported as skipped for the hold"
+    );
+    assert_eq!((out.held_by_snapshot, out.held_by_unreadable_head), (0, 0));
+
+    let mut all = unprotected.clone();
+    all.extend(fixture.input_data_keys.iter().cloned());
+    assert_eq!(
+        present_keys(mem.as_ref(), &all).await,
+        all,
+        "every key in the group survives, held and unheld alike"
+    );
+
+    let dreq = sweep_erasure_requests(
+        mem.as_ref(),
+        &clock,
+        &cfg(),
+        &lease,
+        &tenant_hash(),
+        Signal::Metrics,
+    )
+    .await
+    .expect("dreq sweep");
+    assert_eq!(dreq.deleted, 0, "the filter is held with the group");
+    assert_eq!(dreq.kept, 1);
+    assert_eq!(dreq.held_by_superseded_inputs, 1);
+
+    // Control: the same fixture, the same instant, no hold.
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(
+        (out.records_deleted, out.data_deleted),
+        (3, 3),
+        "the group was collectable all along; the hold is the only thing that stopped it"
+    );
+    assert_eq!(out.chain_groups_held_by_legal_hold, 0);
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(dreq.deleted, 1);
+    assert_eq!(dreq.held_by_superseded_inputs, 0);
+}
+
+// --- (j) two live rewrites over one predecessor -----------------------------
+
+/// Publish a second live rewrite record over the same predecessor `sibling`
+/// names, applying `request_id` instead of whatever `sibling` applied. This is
+/// the racing-worker shape: two passes read the same live bucket and each
+/// applies a different pending request to the same predecessor. Both records
+/// survive `CreateIfAbsent`, because the input-set hash covers the applied
+/// request ids, so the two land at different keys and each gathers the same
+/// chain behind them.
+async fn publish_sibling_rewrite(
+    store: &dyn ObjectStoreBackend,
+    sibling: &str,
+    request_id: Uuid,
+) -> String {
+    let bytes = get_full(store, sibling).await;
+    let mut record = erasure::decode_rewrite(&bytes).expect("rewrite record decodes");
+    record.drops = vec![RewriteDrop {
+        request_id: request_id.to_string(),
+        dropped_count: 1,
+    }];
+    // This sibling dropped every surviving row, so it publishes no parts at all
+    // (a permitted shape) and names no object of its own.
+    record.parts = Vec::new();
+    let hash = erasure::compute_rewrite_input_set_hash(
+        &record.inputs,
+        Some(record.superseded_record_key.as_str()),
+        &[request_id.to_string()],
+    );
+    record.input_set_hash = hash.to_vec();
+    let key = keys::rewrite_record_key_for(&record).expect("sibling rewrite key");
+    assert_ne!(
+        key, sibling,
+        "the applied request ids are part of the key, so the sibling lands at its own"
+    );
+    store
+        .put(
+            &key,
+            erasure::encode_rewrite(&record),
+            PutOptions::default(),
+        )
+        .await
+        .expect("publish the sibling");
+    key
+}
+
+/// Two live rewrite records naming the same `superseded_record_key` gather the
+/// identical chain group. The pass must count and delete each object once: the
+/// reported figures are the distinct key counts, not the per-entry sums.
+///
+/// The figures are read off a dry-run pass first. That is where a duplicate
+/// group is visible at all: a real pass deletes the shared predecessor's record
+/// in the first entry's turn, so the second entry's walk finds the chain gone
+/// and gathers nothing, and the double count hides behind its own delete. The
+/// dry run deletes nothing, so the second gather still sees the whole chain and
+/// reports it a second time.
+///
+/// Flip-line proof: drop the `by_identity` dedup in `sweep_superseded_impl`'s
+/// gather phase (push every gathered group unconditionally). Each object is then
+/// counted twice in the dry-run figures, so `records_deleted` comes back 6
+/// against the 3 distinct records and the assertion fails.
+#[tokio::test]
+async fn two_live_rewrites_over_one_predecessor_count_each_object_once() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let fixture = seed_chain(&mem, &clock, created, 2, Some(200)).await;
+    let r1 = fixture.chain[0].clone();
+    let r2 = fixture.chain[1].clone();
+    let r1_parts = rewrite_part_keys(mem.as_ref(), &r1).await;
+    let sibling = publish_sibling_rewrite(mem.as_ref(), &r2, request_id_n(9)).await;
+
+    // The distinct objects the one shared group holds.
+    let mut records: BTreeSet<String> = fixture.commit_keys.iter().cloned().collect();
+    records.insert(r1.clone());
+    let mut data = fixture.input_data_keys.clone();
+    data.extend(r1_parts.iter().cloned());
+    assert_eq!(records.len(), 3, "two input commit records and R1's own");
+    assert_eq!(data.len(), 3, "two input data objects and R1's single part");
+
+    clock.set(past_horizon(created));
+    let b = old_bucket();
+    let dry = CompactorConfig {
+        dry_run: true,
+        ..cfg()
+    };
+    let out = sweep_superseded(
+        mem.as_ref(),
+        &clock,
+        &dry,
+        &NoLeases,
+        &b.tenant_hash,
+        b.signal,
+        b.shard,
+    )
+    .await
+    .expect("dry-run superseded sweep");
+    assert_eq!(
+        out.records_deleted,
+        records.len(),
+        "the dry run reports each record once, though two live entries gathered it"
+    );
+    assert_eq!(
+        out.data_deleted,
+        data.len(),
+        "and each data object once: the figures are distinct keys, not per-entry sums"
+    );
+    let mut all = records.clone();
+    all.extend(data.iter().cloned());
+    assert_eq!(
+        present_keys(mem.as_ref(), &all).await,
+        all,
+        "the dry run deleted nothing"
+    );
+
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(
+        out.records_deleted,
+        records.len(),
+        "each record deleted and counted exactly once, though two live entries gathered it"
+    );
+    assert_eq!(
+        out.data_deleted,
+        data.len(),
+        "each data object deleted and counted exactly once"
+    );
+    assert_eq!((out.held_by_snapshot, out.held_by_unreadable_head), (0, 0));
+    assert_eq!(out.chain_groups_held_by_legal_hold, 0);
+
+    assert_eq!(present_keys(mem.as_ref(), &records).await, BTreeSet::new());
+    assert_eq!(present_keys(mem.as_ref(), &data).await, BTreeSet::new());
+    assert!(mem.head(&r2).await.is_ok(), "both live records survive");
+    assert!(mem.head(&sibling).await.is_ok());
+}
+
+// --- (k) a part reference that disagrees with the part it names -------------
+
+/// The hour-range filter that decides which snapshot parts a gate must read
+/// takes its bounds from the HEAD-level reference. A reference whose declared
+/// range excludes the hour being gated makes the gate skip that part, so a
+/// reference narrower than the part it names would clear a delete the snapshot
+/// still reaches. The gate proves the skip instead: it opens each skipped part
+/// on the clearing path and blocks fail-closed when the two disagree.
+///
+/// The fixture keeps the part bytes untouched, so its blake3 still matches and
+/// only the mirrored bounds are wrong. A single-part HEAD leaves `min_hour`
+/// unconstrained, so this is a HEAD the catalog itself accepts.
+///
+/// Flip-line proof: delete the bounds arm of the `decode_part` match in
+/// `SnapshotReachability::ensure_part` (or drop the
+/// `clear_or_block_on_skipped` call at the end of `object_gate`). The part is
+/// then skipped unproven, the gate clears, all four objects the snapshot still
+/// names are deleted, the `Op::Delete` fault fires, and the `.expect` on the
+/// sweep panics.
+#[tokio::test]
+async fn a_part_reference_that_excludes_its_own_entries_blocks_fail_closed() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+
+    fold_head(&mem, created, 1, None).await;
+    run_rewrite(mem.as_ref(), &clock).await;
+    fold_head(&mem, created + 3 * NS_PER_HOUR, 2, None).await;
+    assert_eq!(
+        head_named_data_keys(mem.as_ref(), OLD_HOUR).await,
+        input_data_keys,
+        "the part names exactly the two pre-rewrite inputs"
+    );
+
+    let head_bytes = get_full(mem.as_ref(), &head_key()).await;
+    let mut head = ravel_catalog::decode_head(head_bytes.as_ref()).expect("HEAD decodes");
+    assert_eq!(head.parts.len(), 1, "single-part HEAD on this fixture");
+    assert!(
+        head.parts[0].min_hour <= OLD_HOUR && OLD_HOUR <= head.parts[0].watermark_hour,
+        "the reference covers the rewritten hour before the edit"
+    );
+    head.parts[0].min_hour = OLD_HOUR + 1;
+    let encoded = ravel_catalog::encode_head(&head).expect("the narrowed HEAD is still valid");
+    mem.put(
+        &head_key(),
+        bytes::Bytes::from(encoded),
+        PutOptions::default(),
+    )
+    .await
+    .expect("republish HEAD");
+
+    // Any delete faults the pass, so "zero deletes" is proven by the pass
+    // succeeding. The third catalog GET faults too: HEAD once and the part
+    // once, with the second group reusing the first group's verdict.
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout))
+        .with_rule(
+            Rule::new(Op::Get, ScriptedFault::Timeout)
+                .with_key_contains("/catalog/")
+                .with_occurrence(Occurrence::Nth(3)),
+        );
+    let store = FaultStore::new(mem.clone(), plan);
+
+    clock.set(past_horizon(created));
+    let out = sweep(&store, &clock)
+        .await
+        .expect("a bounds mismatch holds, it does not error the pass");
+    assert_eq!((out.records_deleted, out.data_deleted), (0, 0));
+    assert_eq!(
+        out.held_by_unreadable_head, 4,
+        "all four objects held under the Unreadable reason: the skip could not be proven sound"
+    );
+    assert_eq!(
+        out.held_by_snapshot, 0,
+        "not the Named reason: the gate never got to read the entries"
+    );
+    assert_eq!(
+        store.fault_count(Op::Delete, FaultKind::Timeout),
+        0,
+        "the sweep issued exactly zero deletes"
+    );
+    assert_eq!(
+        store.fault_count(Op::Get, FaultKind::Timeout),
+        0,
+        "exactly two catalog GETs per pass: one HEAD, one part"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &input_data_keys).await,
+        input_data_keys,
+        "both inputs the skipped part names survive"
+    );
+    for key in &commit_keys {
+        assert!(mem.head(key).await.is_ok(), "and both their commit records");
+    }
 }

--- a/crates/ravel-maintain/tests/superseded_head_gate.rs
+++ b/crates/ravel-maintain/tests/superseded_head_gate.rs
@@ -1,0 +1,753 @@
+//! The superseded-input sweep's HEAD-reachability gate (ADR-0020 delete
+//! blocker, applied to rule 2).
+//!
+//! A selective-erasure rewrite record can land in any sealed hour, including
+//! one the fold's fixed reconcile window and its retention-frontier band both
+//! miss. The snapshot part covering that hour then keeps naming the
+//! pre-rewrite inputs. Deleting those inputs on the protection horizon alone
+//! makes every query over that hour fail closed until the fold catches up, so
+//! the sweep asks the same question retention asks before deleting: does the
+//! live catalog HEAD still name this object?
+//!
+//! Every fixture here uses a rewrite in an hour 100 hours behind the fold
+//! watermark, well outside the default 26-hour reconcile window and with no
+//! retirement frontier configured, so the second fold provably does not
+//! refresh it. Each test names the line whose flip breaks it, per the repo's
+//! prove-the-test discipline.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod common;
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use common::*;
+use ravel_commit::keys::{self, BucketEntry};
+use ravel_commit::{erasure, signal};
+use ravel_maintain::{
+    Bucket, CompactorConfig, ErasureRewriteOutcome, FixedClock, MaintainMemo, NoLeases,
+    PendingErasureRequest, SupersededSweepOutcome, erasure_rewrite_bucket, sweep_erasure_requests,
+    sweep_superseded,
+};
+use ravel_object_store::fault::{
+    FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions, list_all};
+use ravel_proto::commit::v1::{
+    ErasureBucketDrop, ErasureCompletion, ErasurePredicateMatcher, ErasureRequest,
+};
+use ravel_types::Signal;
+use uuid::Uuid;
+
+/// The rewritten hour: 100 hours behind the hour the fold watermark lands on,
+/// so it is outside the default `fold_reconcile_window_hours` (26).
+const OLD_HOUR: u32 = HOUR - 100;
+/// A recent hour that keeps the fold watermark far ahead of [`OLD_HOUR`].
+const RECENT_HOUR: u32 = HOUR;
+
+const REQUEST_SEED: u128 = 0x0E45;
+
+fn cfg() -> CompactorConfig {
+    CompactorConfig::default()
+}
+
+fn old_bucket() -> Bucket {
+    bucket_at(OLD_HOUR)
+}
+
+fn request_id() -> Uuid {
+    Uuid::from_u128(REQUEST_SEED)
+}
+
+fn head_key() -> String {
+    format!(
+        "t/{}/catalog/{}/HEAD",
+        tenant_hash().to_hex(),
+        Signal::Metrics.key_prefix()
+    )
+}
+
+/// Two L0 inputs in [`OLD_HOUR`] (both carrying the erasure subject) and one in
+/// [`RECENT_HOUR`] that holds the fold watermark far ahead of them. Returns the
+/// old hour's two commit keys, in seed order.
+async fn seed_two_hours(store: &dyn ObjectStoreBackend) -> [String; 2] {
+    let old_ns = i64::from(OLD_HOUR) * NS_PER_HOUR;
+    let first = seed_input(
+        store,
+        &InputSpec::new_at(
+            OLD_HOUR,
+            Uuid::from_u128(0xA1),
+            1,
+            1,
+            vec![
+                raw_series("keep", &[("k", "a")], &[(old_ns + 1_000, 1.0)]),
+                raw_series("victim", &[("k", "b")], &[(old_ns + 2_000, 5.0)]),
+            ],
+        ),
+    )
+    .await;
+    let second = seed_input(
+        store,
+        &InputSpec::new_at(
+            OLD_HOUR,
+            Uuid::from_u128(0xA2),
+            1,
+            2,
+            vec![raw_series(
+                "victim",
+                &[("k", "b")],
+                &[(old_ns + 3_000, 3.0)],
+            )],
+        ),
+    )
+    .await;
+    let recent_ns = i64::from(RECENT_HOUR) * NS_PER_HOUR;
+    seed_input(
+        store,
+        &InputSpec::new_at(
+            RECENT_HOUR,
+            Uuid::from_u128(0xB1),
+            1,
+            1,
+            vec![raw_series(
+                "keep",
+                &[("k", "c")],
+                &[(recent_ns + 1_000, 2.0)],
+            )],
+        ),
+    )
+    .await;
+    [first, second]
+}
+
+/// A windowless erasure request matching every series named `victim`.
+fn pending_request() -> PendingErasureRequest {
+    PendingErasureRequest {
+        request_key: keys::erasure_request_key(&tenant_hash(), Signal::Metrics, request_id())
+            .expect("dreq key"),
+        request: erasure_request(),
+    }
+}
+
+fn erasure_request() -> ErasureRequest {
+    ErasureRequest {
+        format_version: 1,
+        tenant_hash: tenant_hash().0.to_vec(),
+        signal: signal::to_proto(Signal::Metrics) as i32,
+        request_id: request_id().to_string(),
+        created_unix_ns: 0,
+        predicate: vec![ErasurePredicateMatcher {
+            key: "__name__".to_string(),
+            value: "victim".to_string(),
+        }],
+        window_start_ns: 0,
+        window_end_ns: 0,
+        reason: String::new(),
+    }
+}
+
+/// Publish a rewrite record into [`OLD_HOUR`], superseding both of its raw-L0
+/// inputs.
+async fn run_rewrite(store: &dyn ObjectStoreBackend, clock: &FixedClock) {
+    let mut memo = MaintainMemo::with_default_interval();
+    let outcome = erasure_rewrite_bucket(
+        store,
+        clock,
+        &cfg(),
+        &NoLeases,
+        &old_bucket(),
+        &[pending_request()],
+        &mut memo,
+    )
+    .await
+    .expect("rewrite");
+    assert!(
+        matches!(outcome, ErasureRewriteOutcome::Rewritten { .. }),
+        "the rewrite must publish a record, got {outcome:?}"
+    );
+}
+
+/// Fold a HEAD for the metrics signal at `now_ns`. `reconcile_window_hours`
+/// widens the fold's fixed reconcile window; the default (26) leaves
+/// [`OLD_HOUR`] unreconciled forever, which is the defect this suite pins.
+async fn fold_head(
+    store: &Arc<MemoryStore>,
+    now_ns: i64,
+    folder: u128,
+    reconcile_window_hours: Option<u32>,
+) {
+    let dyn_store: Arc<dyn ObjectStoreBackend> = store.clone();
+    let mut config = ravel_catalog::CatalogConfig {
+        shard_count: SHARD + 1,
+        ..Default::default()
+    };
+    if let Some(hours) = reconcile_window_hours {
+        config.fold_reconcile_window_hours = hours;
+    }
+    let catalog = ravel_catalog::Catalog::new(dyn_store, config).expect("catalog");
+    catalog
+        .fold(
+            &tenant_hash(),
+            Signal::Metrics,
+            Uuid::from_u128(folder),
+            now_ns,
+            &[],
+            None,
+        )
+        .await
+        .expect("fold publishes a HEAD");
+}
+
+/// Every data-object key the current HEAD names for `hour`, reconstructed from
+/// the snapshot entries independently of the sweep's own mapping: a level-0
+/// entry carries a 16-byte `writer_id`, a level-1 entry carries its parent
+/// record's 32-byte `input_set_hash` there and the `part_index` in
+/// `writer_epoch`.
+async fn head_named_data_keys(store: &dyn ObjectStoreBackend, hour: u32) -> BTreeSet<String> {
+    let got = get_full(store, &head_key()).await;
+    let head = ravel_catalog::decode_head(got.as_ref()).expect("HEAD decodes");
+    let limits = ravel_catalog::PartLimits {
+        max_snapshot_part_bytes: ravel_catalog::DEFAULT_MAX_SNAPSHOT_PART_BYTES,
+    };
+    let mut out = BTreeSet::new();
+    for part_ref in &head.parts {
+        let bytes = get_full(store, &part_ref.key).await;
+        let part = ravel_catalog::decode_part(bytes.as_ref(), &limits).expect("part decodes");
+        for entry in &part.entries {
+            if entry.ingest_hour_bucket != hour {
+                continue;
+            }
+            let content_hash: [u8; 32] = entry.content_hash.as_slice().try_into().unwrap();
+            let key = if entry.level == 0 {
+                let writer_id: [u8; 16] = entry.writer_id.as_slice().try_into().unwrap();
+                keys::data_key(
+                    &tenant_hash(),
+                    Signal::Metrics,
+                    entry.shard,
+                    Uuid::from_bytes(writer_id),
+                    entry.writer_epoch,
+                    entry.writer_seq,
+                    &content_hash,
+                )
+                .unwrap()
+            } else {
+                let input_set_hash: [u8; 32] = entry.writer_id.as_slice().try_into().unwrap();
+                keys::l1_part_key(
+                    &tenant_hash(),
+                    Signal::Metrics,
+                    entry.shard,
+                    entry.ingest_hour_bucket,
+                    &hex::encode(&input_set_hash[..8]),
+                    u32::try_from(entry.writer_epoch).unwrap(),
+                    &hex::encode(&content_hash[..8]),
+                )
+                .unwrap()
+            };
+            out.insert(key);
+        }
+    }
+    out
+}
+
+/// The L0 data-object keys physically present for `bucket`'s shard, restricted
+/// to the ones `expected` names (L0 keys carry no hour component, so the other
+/// hour's object is filtered out by membership, never by prefix).
+async fn present_keys(
+    store: &dyn ObjectStoreBackend,
+    candidates: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for key in candidates {
+        if store.head(key).await.is_ok() {
+            out.insert(key.clone());
+        }
+    }
+    out
+}
+
+/// The old hour's superseded input data keys, read off the commit records the
+/// fixture seeded (so the expected set never restates the sweep's arithmetic).
+async fn seeded_input_data_keys(
+    store: &dyn ObjectStoreBackend,
+    commit_keys: &[String; 2],
+) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for key in commit_keys {
+        let bytes = get_full(store, key).await;
+        let record = ravel_commit::record::decode(&bytes).expect("commit record decodes");
+        out.insert(keys::reconstruct_data_key(&record).expect("data key"));
+    }
+    out
+}
+
+async fn sweep(
+    store: &dyn ObjectStoreBackend,
+    clock: &FixedClock,
+) -> ravel_maintain::Result<SupersededSweepOutcome> {
+    let b = old_bucket();
+    sweep_superseded(
+        store,
+        clock,
+        &cfg(),
+        &NoLeases,
+        &b.tenant_hash,
+        b.signal,
+        b.shard,
+    )
+    .await
+}
+
+/// The rewrite record's own key in the old bucket.
+async fn rewrite_record_key(store: &dyn ObjectStoreBackend) -> String {
+    let b = old_bucket();
+    let prefix =
+        keys::commit_shard_hour_prefix(&b.tenant_hash, b.signal, b.shard, b.ingest_hour_bucket)
+            .unwrap();
+    for meta in list_all(store, &prefix).await.unwrap() {
+        if matches!(
+            keys::partition_bucket_entry(&meta.key),
+            Ok(BucketEntry::RewriteRecord(_))
+        ) {
+            return meta.key;
+        }
+    }
+    panic!("no rewrite record in the old bucket");
+}
+
+fn past_horizon(created: i64) -> i64 {
+    created + cfg().protection_horizon_ns + 1
+}
+
+// --- (a) the defect: a HEAD-named input is never deleted --------------------
+
+/// A rewrite in an hour the fold's reconcile window never reaches leaves the
+/// published snapshot naming the pre-rewrite inputs. Past the protection
+/// horizon the sweep must delete none of them: the exact delete count is zero,
+/// and the exact set of surviving input keys is the set the HEAD-named part
+/// still references.
+///
+/// Also pins the gate's request shape: two catalog GETs for the whole pass
+/// (one HEAD, one covering part), regardless of how many input groups it gates.
+///
+/// Flip-line proof: replace the `reach.object_gate(...)` match in
+/// `sweep_superseded_impl` with `SnapshotGate::Clear` (or delete the match):
+/// the pass then deletes the four inputs, the `Op::Delete` fault rule below
+/// fires, and the `.expect` on the sweep panics.
+#[tokio::test]
+async fn head_named_superseded_inputs_are_held_not_deleted() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+
+    // 1. Fold: the snapshot names the old hour's two L0 inputs.
+    fold_head(&mem, created, 1, None).await;
+    // 2. Rewrite the old hour, superseding both inputs.
+    run_rewrite(mem.as_ref(), &clock).await;
+    // 3. Fold again three hours later. The watermark advances, but the old
+    //    hour is 100 hours behind it and no retirement frontier is configured,
+    //    so neither the fixed window nor the frontier band re-lists it: HEAD
+    //    still names the pre-rewrite inputs.
+    fold_head(&mem, created + 3 * NS_PER_HOUR, 2, None).await;
+
+    let named = head_named_data_keys(mem.as_ref(), OLD_HOUR).await;
+    assert_eq!(
+        named, input_data_keys,
+        "the stale snapshot still names exactly the two pre-rewrite inputs"
+    );
+    let head_bytes = get_full(mem.as_ref(), &head_key()).await;
+    let head = ravel_catalog::decode_head(head_bytes.as_ref()).expect("HEAD decodes");
+    assert_eq!(head.parts.len(), 1, "single-part HEAD on this fixture");
+
+    // Any delete at all faults the pass, so "zero deletes" is proven by the
+    // pass succeeding, not only by the returned counters. The third catalog
+    // GET faults too: the gate reads HEAD once and the one covering part once
+    // per pass, never per input.
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout))
+        .with_rule(
+            Rule::new(Op::Get, ScriptedFault::Timeout)
+                .with_key_contains("/catalog/")
+                .with_occurrence(Occurrence::Nth(3)),
+        );
+    let store = FaultStore::new(mem.clone(), plan);
+
+    clock.set(past_horizon(created));
+    let outcome = sweep(&store, &clock)
+        .await
+        .expect("the gate holds every input, so no delete and no third catalog GET happen");
+
+    assert_eq!(outcome.records_deleted, 0, "no record deleted");
+    assert_eq!(outcome.data_deleted, 0, "no data object deleted");
+    assert_eq!(
+        outcome.held_by_snapshot, 4,
+        "two commit records and two data objects held, reported as Named"
+    );
+    assert_eq!(outcome.held_by_unreadable_head, 0);
+    assert_eq!(
+        store.fault_count(Op::Delete, FaultKind::Timeout),
+        0,
+        "the sweep issued exactly zero deletes"
+    );
+    assert_eq!(
+        store.fault_count(Op::Get, FaultKind::Timeout),
+        0,
+        "exactly two catalog GETs per pass: one HEAD, one covering part"
+    );
+
+    // The exact surviving set: every key the HEAD-named part references, and
+    // both commit records that resolve them.
+    assert_eq!(
+        present_keys(mem.as_ref(), &input_data_keys).await,
+        named,
+        "the objects left in the store are exactly the ones HEAD names"
+    );
+    for key in &commit_keys {
+        assert!(
+            mem.head(key).await.is_ok(),
+            "the commit record resolving a held input survives with it"
+        );
+    }
+}
+
+// --- (b) the gate delays, never prevents ------------------------------------
+
+/// Once the fold has reconciled the hour, the snapshot names the rewrite's
+/// output part instead of the pre-rewrite inputs, and the very next sweep
+/// deletes exactly those inputs: two records, two data objects, nothing held.
+///
+/// Flip-line proof: make `SnapshotReachability::object_gate` return
+/// `SnapshotGate::Blocked(SnapshotBlock::Named)` unconditionally (or drop the
+/// `objects.contains(&named)` test so every entry blocks): the inputs are then
+/// held forever and the `records_deleted == 2` assertion fails.
+#[tokio::test]
+async fn reconciled_hour_lets_the_sweep_delete_exactly_the_superseded_inputs() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+
+    fold_head(&mem, created, 1, None).await;
+    run_rewrite(mem.as_ref(), &clock).await;
+    // A reconcile window wide enough to reach 100 hours back: the fold now
+    // observes the late rewrite record and republishes the hour.
+    fold_head(&mem, created + 3 * NS_PER_HOUR, 2, Some(200)).await;
+
+    let named = head_named_data_keys(mem.as_ref(), OLD_HOUR).await;
+    assert!(
+        named.is_disjoint(&input_data_keys),
+        "the reconciled snapshot names none of the pre-rewrite inputs"
+    );
+    assert_eq!(
+        named.len(),
+        1,
+        "it names exactly the rewrite's single output part"
+    );
+
+    clock.set(past_horizon(created));
+    let outcome = sweep(mem.as_ref(), &clock).await.expect("sweep");
+    assert_eq!(outcome.records_deleted, 2, "both input commit records gone");
+    assert_eq!(outcome.data_deleted, 2, "both input data objects gone");
+    assert_eq!(outcome.held_by_snapshot, 0);
+    assert_eq!(outcome.held_by_unreadable_head, 0);
+
+    assert_eq!(
+        present_keys(mem.as_ref(), &input_data_keys).await,
+        BTreeSet::new(),
+        "exactly the superseded input data objects were deleted"
+    );
+    for key in &commit_keys {
+        assert!(
+            mem.head(key).await.is_err(),
+            "the superseded input's commit record is gone too"
+        );
+    }
+    for key in &named {
+        assert!(
+            mem.head(key).await.is_ok(),
+            "the live rewrite output part survives"
+        );
+    }
+}
+
+// --- (c) unreadable HEAD blocks the whole pass fail-closed ------------------
+
+/// A HEAD that is present but unreadable blocks every group in the pass:
+/// non-reachability cannot be proven from data that cannot be read. Nothing is
+/// deleted and the hold is reported under the `Unreadable` reason, not the
+/// ordinary `Named` one.
+///
+/// Flip-line proof: map the `decode_head` error in
+/// `SnapshotReachability::ensure_head` to `HeadLoad::Absent` instead of
+/// `HeadLoad::Unreadable`: the gate then clears, the four inputs are deleted,
+/// the `Op::Delete` fault fires, and the `.expect` on the sweep panics.
+#[tokio::test]
+async fn unreadable_head_blocks_the_whole_pass_fail_closed() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+
+    fold_head(&mem, created, 1, None).await;
+    run_rewrite(mem.as_ref(), &clock).await;
+
+    // Every byte of the HEAD object is flipped on read: present, undecodable.
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Get, ScriptedFault::CorruptRange).with_key_contains(head_key()))
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout));
+    let store = FaultStore::new(mem.clone(), plan);
+
+    clock.set(past_horizon(created));
+    let outcome = sweep(&store, &clock)
+        .await
+        .expect("an unreadable HEAD holds, it does not error the pass");
+
+    assert_eq!(
+        store.fault_count(Op::Get, FaultKind::CorruptRange),
+        1,
+        "exactly one HEAD GET per pass, and it was corrupted"
+    );
+    assert_eq!(outcome.records_deleted, 0);
+    assert_eq!(outcome.data_deleted, 0);
+    assert_eq!(
+        outcome.held_by_unreadable_head, 4,
+        "all four objects held under the Unreadable reason"
+    );
+    assert_eq!(outcome.held_by_snapshot, 0);
+    assert_eq!(
+        store.fault_count(Op::Delete, FaultKind::Timeout),
+        0,
+        "the sweep issued exactly zero deletes"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &input_data_keys).await.len(),
+        2,
+        "both input data objects survive"
+    );
+}
+
+// --- (d) absent HEAD clears the gate ---------------------------------------
+
+/// With no HEAD at all there is no snapshot naming anything, so the gate
+/// clears and the sweep deletes on the horizon exactly as it always did
+/// (ADR-0020: the catalog index is a pure optimization).
+///
+/// Flip-line proof: map `StoreError::NotFound` in
+/// `SnapshotReachability::ensure_head` to `HeadLoad::Unreadable` instead of
+/// `HeadLoad::Absent`: nothing is deleted and the `records_deleted == 2`
+/// assertion fails.
+#[tokio::test]
+async fn absent_head_clears_the_gate_and_the_pass_deletes_as_before() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+
+    // Deliberately no fold: HEAD is absent.
+    run_rewrite(mem.as_ref(), &clock).await;
+    assert!(mem.head(&head_key()).await.is_err(), "no HEAD was folded");
+
+    clock.set(past_horizon(created));
+    let outcome = sweep(mem.as_ref(), &clock).await.expect("sweep");
+    assert_eq!(outcome.records_deleted, 2);
+    assert_eq!(outcome.data_deleted, 2);
+    assert_eq!(outcome.held_by_snapshot, 0);
+    assert_eq!(outcome.held_by_unreadable_head, 0);
+    assert_eq!(
+        present_keys(mem.as_ref(), &input_data_keys).await,
+        BTreeSet::new()
+    );
+}
+
+// --- (e) the two horizons, cross-checked ------------------------------------
+
+/// Seed the request object and its completion record. `completed` anchors the
+/// `.dreq` removal horizon; `bucket_drops` names the one bucket this request's
+/// rewrite touched.
+async fn seed_dreq_and_done(store: &dyn ObjectStoreBackend, completed: i64) -> (String, String) {
+    let dreq_key =
+        keys::erasure_request_key(&tenant_hash(), Signal::Metrics, request_id()).unwrap();
+    store
+        .put(
+            &dreq_key,
+            erasure::encode_request(&erasure_request()),
+            PutOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    let completion = ErasureCompletion {
+        format_version: 1,
+        tenant_hash: tenant_hash().0.to_vec(),
+        signal: signal::to_proto(Signal::Metrics) as i32,
+        request_id: request_id().to_string(),
+        predicate_hash: vec![0x11; 32],
+        bucket_drops: vec![ErasureBucketDrop {
+            signal: signal::to_proto(Signal::Metrics) as i32,
+            shard: SHARD,
+            ingest_hour_bucket: OLD_HOUR,
+            dropped_count: 2,
+        }],
+        requested_unix_ns: 0,
+        completed_unix_ns: completed,
+        deferral_cause: 0,
+    };
+    let done_key =
+        keys::erasure_completion_key(&tenant_hash(), Signal::Metrics, request_id()).unwrap();
+    store
+        .put(
+            &done_key,
+            erasure::encode_completion(&completion),
+            PutOptions::default(),
+        )
+        .await
+        .unwrap();
+    (dreq_key, done_key)
+}
+
+/// The two horizons are tied only by both being `protection_horizon_ns`; the
+/// invariant they exist to provide is an ordering: the query-time exclusion
+/// filter must outlive every pre-rewrite input a snapshot can still resolve.
+/// This drives both sweeps in the maintenance tick's own order (superseded
+/// inputs first, then `.dreq` removal) across a clock advance, and asserts
+/// after every single sweep call that the `.dreq` is still present whenever any
+/// superseded input is.
+///
+/// Flip-line proof, two lines, one per direction. Remove the
+/// `superseded_inputs_outstanding` guard in `sweep_erasure_requests` and the
+/// `.dreq` disappears at its horizon while the held inputs are still resolvable
+/// from the stale snapshot, failing the ordering assertion at step 3. Replace
+/// the `reach.object_gate(...)` match in `sweep_superseded_impl` with
+/// `SnapshotGate::Clear` and the inputs are deleted at step 3 while the
+/// snapshot still names them, failing the "inputs still present" assertion
+/// there.
+#[tokio::test]
+async fn dreq_outlives_every_superseded_input_its_rewrite_left_resolvable() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+
+    fold_head(&mem, created, 1, None).await;
+    run_rewrite(mem.as_ref(), &clock).await;
+    fold_head(&mem, created + 3 * NS_PER_HOUR, 2, None).await;
+    let rw_key = rewrite_record_key(mem.as_ref()).await;
+
+    // The completion lands at the same instant the rewrite did, so the two
+    // horizons coincide exactly: this is the tightest ordering the pair admits.
+    let (dreq_key, done_key) = seed_dreq_and_done(mem.as_ref(), created).await;
+
+    // After every sweep call: if any superseded input is still in the store,
+    // the request that excludes it must still be there too.
+    async fn assert_ordering(
+        store: &dyn ObjectStoreBackend,
+        dreq_key: &str,
+        inputs: &BTreeSet<String>,
+        step: &str,
+    ) {
+        let remaining = present_keys(store, inputs).await.len();
+        if remaining > 0 {
+            assert!(
+                store.head(dreq_key).await.is_ok(),
+                "{step}: {remaining} superseded input(s) still resolvable, so the .dreq must \
+                 still be excluding them"
+            );
+        }
+    }
+
+    let horizon = created + cfg().protection_horizon_ns;
+    for (step, now) in [("pre-horizon", created), ("one ns early", horizon - 1)] {
+        clock.set(now);
+        let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+        assert_eq!(
+            (out.records_deleted, out.data_deleted),
+            (0, 0),
+            "{step}: nothing collectable yet"
+        );
+        assert_ordering(mem.as_ref(), &dreq_key, &input_data_keys, step).await;
+
+        let dreq = sweep_erasure_requests(
+            mem.as_ref(),
+            &clock,
+            &cfg(),
+            &NoLeases,
+            &tenant_hash(),
+            Signal::Metrics,
+        )
+        .await
+        .expect("dreq sweep");
+        assert_eq!(dreq.deleted, 0, "{step}: the .dreq horizon has not elapsed");
+        assert_ordering(mem.as_ref(), &dreq_key, &input_data_keys, step).await;
+    }
+
+    // Step 3: both horizons have elapsed, but the stale snapshot still names
+    // the inputs. The sweep holds them, and the .dreq is held with them.
+    clock.set(horizon);
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(out.held_by_snapshot, 4, "at the horizon: all four held");
+    assert_eq!((out.records_deleted, out.data_deleted), (0, 0));
+    assert_eq!(
+        present_keys(mem.as_ref(), &input_data_keys).await.len(),
+        2,
+        "the inputs the stale snapshot names are still present"
+    );
+    assert_ordering(mem.as_ref(), &dreq_key, &input_data_keys, "at the horizon").await;
+
+    let dreq = sweep_erasure_requests(
+        mem.as_ref(),
+        &clock,
+        &cfg(),
+        &NoLeases,
+        &tenant_hash(),
+        Signal::Metrics,
+    )
+    .await
+    .expect("dreq sweep");
+    assert_eq!(dreq.deleted, 0, "the .dreq outlives the held inputs");
+    assert_eq!(dreq.kept, 1);
+    assert_eq!(
+        dreq.held_by_superseded_inputs, 1,
+        "held for the stated reason, not merely by the horizon"
+    );
+    assert_ordering(mem.as_ref(), &dreq_key, &input_data_keys, "at the horizon").await;
+    assert!(
+        mem.head(&rw_key).await.is_ok(),
+        "the rewrite record that supersedes them is untouched"
+    );
+
+    // Step 4: the fold reconciles the hour. The gate clears, the inputs go,
+    // and only then does the .dreq become removable.
+    fold_head(&mem, horizon + 3 * NS_PER_HOUR, 3, Some(200)).await;
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!((out.records_deleted, out.data_deleted), (2, 2));
+    assert_eq!(
+        present_keys(mem.as_ref(), &input_data_keys).await,
+        BTreeSet::new(),
+        "every superseded input is physically gone"
+    );
+    assert_ordering(mem.as_ref(), &dreq_key, &input_data_keys, "after reconcile").await;
+
+    let dreq = sweep_erasure_requests(
+        mem.as_ref(),
+        &clock,
+        &cfg(),
+        &NoLeases,
+        &tenant_hash(),
+        Signal::Metrics,
+    )
+    .await
+    .expect("dreq sweep");
+    assert_eq!(dreq.deleted, 1, "the .dreq is removed once, and only now");
+    assert_eq!(dreq.held_by_superseded_inputs, 0);
+    assert!(mem.head(&dreq_key).await.is_err(), ".dreq physically gone");
+    assert!(
+        mem.head(&done_key).await.is_ok(),
+        ".done is permanent audit evidence, never swept"
+    );
+}

--- a/crates/ravel-maintain/tests/superseded_head_gate.rs
+++ b/crates/ravel-maintain/tests/superseded_head_gate.rs
@@ -57,6 +57,10 @@ fn old_bucket() -> Bucket {
     bucket_at(OLD_HOUR)
 }
 
+fn recent_bucket() -> Bucket {
+    bucket_at(RECENT_HOUR)
+}
+
 fn request_id() -> Uuid {
     Uuid::from_u128(REQUEST_SEED)
 }
@@ -175,18 +179,21 @@ async fn run_rewrite_with(
     clock: &FixedClock,
     pending: &[PendingErasureRequest],
 ) {
+    run_rewrite_in(store, clock, &old_bucket(), pending).await
+}
+
+/// [`run_rewrite_with`] against an arbitrary bucket of the same shard.
+async fn run_rewrite_in(
+    store: &dyn ObjectStoreBackend,
+    clock: &FixedClock,
+    bucket: &Bucket,
+    pending: &[PendingErasureRequest],
+) {
     let mut memo = MaintainMemo::with_default_interval();
-    let outcome = erasure_rewrite_bucket(
-        store,
-        clock,
-        &cfg(),
-        &NoLeases,
-        &old_bucket(),
-        pending,
-        &mut memo,
-    )
-    .await
-    .expect("rewrite");
+    let outcome =
+        erasure_rewrite_bucket(store, clock, &cfg(), &NoLeases, bucket, pending, &mut memo)
+            .await
+            .expect("rewrite");
     assert!(
         matches!(outcome, ErasureRewriteOutcome::Rewritten { .. }),
         "the rewrite must publish a record, got {outcome:?}"
@@ -330,7 +337,11 @@ async fn sweep(
 
 /// The rewrite record's own key in the old bucket.
 async fn rewrite_record_key(store: &dyn ObjectStoreBackend) -> String {
-    let b = old_bucket();
+    rewrite_record_key_in(store, &old_bucket()).await
+}
+
+/// [`rewrite_record_key`] for an arbitrary bucket.
+async fn rewrite_record_key_in(store: &dyn ObjectStoreBackend, b: &Bucket) -> String {
     let prefix =
         keys::commit_shard_hour_prefix(&b.tenant_hash, b.signal, b.shard, b.ingest_hour_bucket)
             .unwrap();
@@ -342,7 +353,7 @@ async fn rewrite_record_key(store: &dyn ObjectStoreBackend) -> String {
             return meta.key;
         }
     }
-    panic!("no rewrite record in the old bucket");
+    panic!("no rewrite record in bucket {}", b.ingest_hour_bucket);
 }
 
 /// The old bucket's rewrite record keys ordered oldest generation first: the
@@ -395,6 +406,15 @@ async fn rewrite_part_keys(store: &dyn ObjectStoreBackend, key: &str) -> BTreeSe
         .collect()
 }
 
+/// The `created_unix_ns` the rewrite record at `key` durably carries, which is
+/// the instant its own protection horizon is anchored on.
+async fn rewrite_created_ns(store: &dyn ObjectStoreBackend, key: &str) -> i64 {
+    let bytes = get_full(store, key).await;
+    erasure::decode_rewrite(&bytes)
+        .expect("rewrite record decodes")
+        .created_unix_ns
+}
+
 /// Whether a seeded `.done` carries per-bucket dropped counts.
 ///
 /// [`Drops::Absent`] is the production shape: the server's completion writer
@@ -433,6 +453,18 @@ async fn seed_dreq_and_done_for(
     completed: i64,
     drops: Drops,
 ) -> (String, String) {
+    seed_dreq_and_done_with_drops(store, id, series, completed, drops.bucket_drops()).await
+}
+
+/// [`seed_dreq_and_done_for`] with the completion's `bucket_drops` written out
+/// in full, for the shapes [`Drops`] does not cover.
+async fn seed_dreq_and_done_with_drops(
+    store: &dyn ObjectStoreBackend,
+    id: Uuid,
+    series: &str,
+    completed: i64,
+    bucket_drops: Vec<ErasureBucketDrop>,
+) -> (String, String) {
     let dreq_key = keys::erasure_request_key(&tenant_hash(), Signal::Metrics, id).unwrap();
     store
         .put(
@@ -449,7 +481,7 @@ async fn seed_dreq_and_done_for(
         signal: signal::to_proto(Signal::Metrics) as i32,
         request_id: id.to_string(),
         predicate_hash: vec![0x11; 32],
-        bucket_drops: drops.bucket_drops(),
+        bucket_drops,
         requested_unix_ns: 0,
         completed_unix_ns: completed,
         deferral_cause: 0,
@@ -983,8 +1015,8 @@ async fn superseded_predecessor_and_its_dreq_outlive_head_named_raw_inputs() {
 }
 
 /// The production-shape twin: a completion naming no buckets holds the same
-/// way, at the cost of one extra LIST to discover the signal's shards and a
-/// shard-wide commit LIST in place of the one-hour one.
+/// way, and by the same request shape, because the observation never reads the
+/// field.
 #[tokio::test]
 async fn superseded_predecessor_and_its_dreq_outlive_head_named_raw_inputs_in_production_shape() {
     superseded_predecessor_outlives_raw_inputs_case(Drops::Absent).await;
@@ -1045,21 +1077,19 @@ async fn superseded_predecessor_outlives_raw_inputs_case(drops: Drops) {
 
     // The guard's request shape is asserted, not printed: the first GET and the
     // first LIST past the expected count both fault, so the pass succeeding
-    // proves the counts.
+    // proves the counts. Both completion shapes cost the same, because the
+    // observation reads neither the field nor anything derived from it.
     //
-    // Eight GETs either way: the `.done`, R1's and R2's records read once for
-    // the pass, R1 again as the chain link the walk follows, the two input
-    // commit records, the catalog HEAD, and the one covering snapshot part.
-    // The LISTs are the only difference between the two completion shapes. A
-    // completion naming the bucket it touched narrows the observation to that
-    // one (shard, hour): the `del/` prefix and that bucket's commit prefix. A
-    // production-shape completion names none, so the observation covers the
-    // signal's shards: one LIST to discover them, plus the shard's whole
-    // commit prefix in place of the single hour's.
-    let (gets, lists) = match drops {
-        Drops::Present => (8, 2),
-        Drops::Absent => (8, 3),
-    };
+    // Three LISTs: the `del/` prefix, the commit keyspace once to enumerate the
+    // signal's shards, and that shard's whole commit prefix.
+    //
+    // Ten GETs: the `.done`; R1's and R2's records read once for the pass; the
+    // two input commit records from R1's own entry; R1 again as the chain link
+    // R2's walk follows, and the two input commit records again from that walk;
+    // the catalog HEAD; and the one covering snapshot part. The observing pass
+    // gathers R1 both ways on purpose (its own entry and its successor's chain),
+    // which is what makes a predecessor visible whatever its successor's age.
+    let (gets, lists) = (10, 3);
     let plan = FaultPlan::empty()
         .with_rule(
             Rule::new(Op::Get, ScriptedFault::Timeout).with_occurrence(Occurrence::Nth(gets + 1)),
@@ -2109,4 +2139,513 @@ async fn a_part_reference_that_excludes_its_own_entries_blocks_fail_closed() {
     for key in &commit_keys {
         assert!(mem.head(key).await.is_ok(), "and both their commit records");
     }
+}
+
+// --- (l) observing the holds is never gated on age --------------------------
+//
+// Two filters decide whether a chain is collectable YET: the protection
+// horizon, and the skip of a record another present rewrite supersedes. Neither
+// says anything about whether a stale snapshot still resolves that chain's
+// inputs, which is the only question the erasure filter's hold turns on. Apply
+// them while merely OBSERVING and a whole chain disappears from rule 6: the
+// predecessor is skipped because its successor supersedes it, the successor is
+// skipped because it is still inside its own horizon, and the pass reports no
+// hold while both raw inputs are present and HEAD-named. The same applies to
+// the scope of the observation: narrowing it by a completion's `bucket_drops`
+// trusts a non-empty list to be complete, and nothing on the wire makes it so.
+
+/// A two-generation chain whose generations were published at different
+/// instants: R1 applies [`request_id`] over `victim` at `created`, R2 applies
+/// `request_id_n(1)` over a series no input carries at `second`. That stagger
+/// is what lets R2 sit inside its own protection horizon while R1 is past its.
+async fn seed_staggered_chain(
+    mem: &Arc<MemoryStore>,
+    clock: &FixedClock,
+    created: i64,
+    second: i64,
+    reconcile: Option<u32>,
+) -> ChainFixture {
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+    fold_head(mem, created, 1, None).await;
+    clock.set(created);
+    run_rewrite_with(mem.as_ref(), clock, &[pending_request()]).await;
+    clock.set(second);
+    run_rewrite_with(
+        mem.as_ref(),
+        clock,
+        &[pending_request_for(request_id_n(1), "absent1")],
+    )
+    .await;
+    fold_head(mem, created + 3 * NS_PER_HOUR, 2, reconcile).await;
+    let chain = rewrite_chain(mem.as_ref()).await;
+    assert_eq!(chain.len(), 2, "one rewrite generation per applied request");
+    assert_eq!(
+        rewrite_created_ns(mem.as_ref(), &chain[0]).await,
+        created,
+        "R1's horizon is anchored on the first instant"
+    );
+    assert_eq!(
+        rewrite_created_ns(mem.as_ref(), &chain[1]).await,
+        second,
+        "R2's horizon is anchored on the second instant"
+    );
+    ChainFixture {
+        commit_keys,
+        input_data_keys,
+        chain,
+    }
+}
+
+/// The reviewer's scenario. R1 applies X over the two raw L0 inputs at t0. One
+/// nanosecond short of a full protection horizon later, R2 applies Y and
+/// supersedes R1. The hour is never reconciled, so HEAD still names R1's raw
+/// inputs. At X's completion horizon the `.dreq` sweep must hold `.dreq_X`: R2
+/// is younger than a horizon, which is a reason not to DELETE its chain, never
+/// a reason to stop looking at it.
+///
+/// Flip-line proof, either direction. In `sweep_superseded_impl`, drop the
+/// `deleting &&` from the `superseded_by_present.contains(key)` skip, or drop
+/// it from the rewrite arm's `created_unix_ns + protection_horizon_ns` gate.
+/// Either one leaves the observing pass with no group at all:
+/// `held_by_superseded_inputs == 1` fails with `0` and `deleted == 0` fails
+/// with `1`, while both of R1's inputs are still HEAD-named.
+#[tokio::test]
+async fn a_young_successor_does_not_hide_the_chain_it_supersedes() {
+    young_successor_hides_nothing_case(Drops::Present).await;
+}
+
+/// The production-shape twin: a completion naming no bucket holds the same way.
+#[tokio::test]
+async fn a_young_successor_does_not_hide_the_chain_in_production_shape() {
+    young_successor_hides_nothing_case(Drops::Absent).await;
+}
+
+async fn young_successor_hides_nothing_case(drops: Drops) {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let horizon = cfg().protection_horizon_ns;
+    let r2_created = created + horizon - 1;
+    let fixture = seed_staggered_chain(&mem, &clock, created, r2_created, None).await;
+
+    assert_eq!(
+        head_named_data_keys(mem.as_ref(), OLD_HOUR).await,
+        fixture.input_data_keys,
+        "the stale snapshot still names exactly the two pre-rewrite inputs"
+    );
+
+    let (dreq_x, _) =
+        seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created, drops).await;
+    let (dreq_y, _) =
+        seed_dreq_and_done_for(mem.as_ref(), request_id_n(1), "absent1", r2_created, drops).await;
+
+    clock.set(past_horizon(created));
+    assert!(
+        past_horizon(created) < r2_created.saturating_add(horizon),
+        "R2 is still inside its own protection horizon at X's completion horizon"
+    );
+
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(
+        dreq.deleted, 0,
+        "no filter retires while R1's raw inputs are HEAD-resolvable"
+    );
+    assert_eq!(
+        dreq.held_by_superseded_inputs, 1,
+        "X is held: the observation walked R2 -> R1 regardless of R2's age"
+    );
+    assert_eq!(
+        dreq.kept, 2,
+        ".dreq_X held by the chain, .dreq_Y kept by its own horizon"
+    );
+
+    assert_eq!(
+        present_keys(mem.as_ref(), &fixture.input_data_keys).await,
+        fixture.input_data_keys,
+        "both victim inputs are still present"
+    );
+    assert_eq!(
+        head_named_data_keys(mem.as_ref(), OLD_HOUR).await,
+        fixture.input_data_keys,
+        "and are still exactly what the snapshot names"
+    );
+    let mut records: BTreeSet<String> = fixture.commit_keys.iter().cloned().collect();
+    records.insert(fixture.chain[0].clone());
+    records.insert(fixture.chain[1].clone());
+    assert_eq!(
+        present_keys(mem.as_ref(), &records).await,
+        records,
+        "both input commit records and both generations survive"
+    );
+    let filters = BTreeSet::from([dreq_x, dreq_y]);
+    assert_eq!(
+        present_keys(mem.as_ref(), &filters).await,
+        filters,
+        "both filters are physically present"
+    );
+}
+
+/// The boundary partner of the case above: R2 lands exactly one full protection
+/// horizon after R1, so R1 is past its horizon by one nanosecond at the sweep
+/// clock and R2 has exactly its own horizon still to run. The holds are
+/// identical, and rule 2 in deleting mode deletes nothing: R1 is skipped as a
+/// record a present rewrite supersedes, R2 by its own horizon. That pair of
+/// exact zeroes is how an observing pass tells "young, not deletable" from
+/// "held": the deleting pass reports no hold and no delete, while the observing
+/// pass the `.dreq` sweep runs reports the hold.
+///
+/// Flip-line proof: the same two lines as the case above, with the same two
+/// failures. The `records_deleted`/`held_by_snapshot` zeroes below pin the other
+/// direction: dropping either filter from the DELETING path would collect or
+/// hold a chain this pass must leave entirely alone.
+#[tokio::test]
+async fn a_successor_exactly_at_its_horizon_holds_the_same_and_deletes_nothing() {
+    successor_at_its_horizon_case(Drops::Present).await;
+}
+
+/// The production-shape twin.
+#[tokio::test]
+async fn a_successor_exactly_at_its_horizon_holds_the_same_in_production_shape() {
+    successor_at_its_horizon_case(Drops::Absent).await;
+}
+
+async fn successor_at_its_horizon_case(drops: Drops) {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let horizon = cfg().protection_horizon_ns;
+    let r2_created = created + horizon;
+    let fixture = seed_staggered_chain(&mem, &clock, created, r2_created, None).await;
+
+    let (dreq_x, _) =
+        seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created, drops).await;
+    let (dreq_y, _) =
+        seed_dreq_and_done_for(mem.as_ref(), request_id_n(1), "absent1", r2_created, drops).await;
+
+    clock.set(past_horizon(created));
+
+    // Rule 2 in deleting mode, in the maintenance tick's own order.
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(
+        (out.records_deleted, out.data_deleted),
+        (0, 0),
+        "nothing is collectable: R2 has its whole horizon still to run"
+    );
+    assert_eq!(
+        (out.held_by_snapshot, out.held_by_unreadable_head),
+        (0, 0),
+        "and nothing is even gathered, so the deleting pass reports no hold either"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &fixture.input_data_keys).await,
+        fixture.input_data_keys,
+        "both victim inputs are untouched"
+    );
+
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(dreq.deleted, 0, "the filter is held, not retired");
+    assert_eq!(
+        dreq.held_by_superseded_inputs, 1,
+        "the observing pass sees the chain the deleting pass could not touch"
+    );
+    assert_eq!(dreq.kept, 2);
+    let filters = BTreeSet::from([dreq_x, dreq_y]);
+    assert_eq!(
+        present_keys(mem.as_ref(), &filters).await,
+        filters,
+        "both filters are physically present"
+    );
+}
+
+/// Termination for the staggered chain: the hold lasts exactly until the fold
+/// reconciles the hour and the chain's own horizons elapse, and not one pass
+/// longer. The inputs go before the record that erased the subject out of them,
+/// proven by faulting exactly R1's record delete, and only then do both filters
+/// retire.
+///
+/// Flip-line proof: the same two lines as the two cases above fail the first
+/// step's `held_by_superseded_inputs == 1` with `0`, and the release step then
+/// fails too, with `deleted == 1` instead of `2`, because `.dreq_X` was already
+/// gone. Moving the `chain_record_keys` delete loop in `sweep_superseded_impl`
+/// ahead of the `data_keys` loop fails the "already gone at the fault"
+/// assertions.
+#[tokio::test]
+async fn the_staggered_chain_releases_both_filters_once_the_fold_reconciles() {
+    staggered_chain_release_case(Drops::Present).await;
+}
+
+/// The production-shape twin.
+#[tokio::test]
+async fn the_staggered_chain_releases_both_filters_in_production_shape() {
+    staggered_chain_release_case(Drops::Absent).await;
+}
+
+async fn staggered_chain_release_case(drops: Drops) {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let horizon = cfg().protection_horizon_ns;
+    let r2_created = created + horizon - 1;
+    let fixture = seed_staggered_chain(&mem, &clock, created, r2_created, None).await;
+    let r1 = fixture.chain[0].clone();
+    let r2 = fixture.chain[1].clone();
+    let r1_parts = rewrite_part_keys(mem.as_ref(), &r1).await;
+    let r2_parts = rewrite_part_keys(mem.as_ref(), &r2).await;
+
+    let (dreq_x, done_x) =
+        seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created, drops).await;
+    let (dreq_y, done_y) =
+        seed_dreq_and_done_for(mem.as_ref(), request_id_n(1), "absent1", r2_created, drops).await;
+
+    // Step 1: at X's horizon the stale snapshot still names R1's inputs, so the
+    // filter is held.
+    clock.set(past_horizon(created));
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(
+        dreq.deleted, 0,
+        "no filter retires while R1's raw inputs are HEAD-resolvable"
+    );
+    assert_eq!(dreq.held_by_superseded_inputs, 1);
+
+    // Step 2: the fold reconciles the hour, and the clock reaches past R2's own
+    // horizon, which is the last thing the chain was waiting on.
+    fold_head(&mem, r2_created + 3 * NS_PER_HOUR, 3, Some(200)).await;
+    assert_eq!(
+        head_named_data_keys(mem.as_ref(), OLD_HOUR).await,
+        r2_parts,
+        "the reconciled snapshot names exactly the live generation's parts"
+    );
+    clock.set(past_horizon(r2_created));
+
+    // Step 3: fault exactly R1's record delete. Everything the invariant
+    // requires to be gone before it must already be gone.
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout).with_key_contains(r1.clone()));
+    let store = FaultStore::new(mem.clone(), plan);
+    assert!(
+        sweep(&store, &clock).await.is_err(),
+        "the faulted delete of R1's record surfaces as a pass error"
+    );
+    assert_eq!(
+        store.fault_count(Op::Delete, FaultKind::Timeout),
+        1,
+        "exactly one delete was aimed at R1's record"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &fixture.input_data_keys).await,
+        BTreeSet::new(),
+        "every input R1 superseded is already gone when its record's delete is issued"
+    );
+    let commit_records: BTreeSet<String> = fixture.commit_keys.iter().cloned().collect();
+    assert_eq!(
+        present_keys(mem.as_ref(), &commit_records).await,
+        BTreeSet::new(),
+        "and so are their commit records"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &r1_parts).await,
+        BTreeSet::new(),
+        "R1's own parts went before R1's record too"
+    );
+    assert!(
+        mem.head(&r1).await.is_ok(),
+        "R1's record is still there: its delete is the one that faulted"
+    );
+    let filters = BTreeSet::from([dreq_x.clone(), dreq_y.clone()]);
+    assert_eq!(
+        present_keys(mem.as_ref(), &filters).await,
+        filters,
+        "both filters are live while R1's record is"
+    );
+
+    // Step 4: a clean pass finishes the job, R1's record last.
+    let out = sweep(mem.as_ref(), &clock).await.expect("superseded sweep");
+    assert_eq!(out.records_deleted, 1, "R1's record, and nothing else");
+    assert_eq!(
+        out.data_deleted, 1,
+        "R1's single part, re-issued idempotently"
+    );
+    assert_eq!((out.held_by_snapshot, out.held_by_unreadable_head), (0, 0));
+    assert!(mem.head(&r1).await.is_err(), "R1's record is gone");
+    assert!(mem.head(&r2).await.is_ok(), "the live generation survives");
+    assert_eq!(
+        present_keys(mem.as_ref(), &r2_parts).await,
+        r2_parts,
+        "with its parts"
+    );
+
+    // Step 5: with nothing left resolvable, both filters retire in one pass.
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(dreq.deleted, 2, ".dreq_X and .dreq_Y, each removed once");
+    assert_eq!(dreq.kept, 0);
+    assert_eq!(dreq.held_by_superseded_inputs, 0);
+    assert_eq!(
+        present_keys(mem.as_ref(), &filters).await,
+        BTreeSet::new(),
+        "both filters are physically gone"
+    );
+    let completions = BTreeSet::from([done_x, done_y]);
+    assert_eq!(
+        present_keys(mem.as_ref(), &completions).await,
+        completions,
+        "both .done records are permanent audit evidence, never swept"
+    );
+}
+
+/// A completion that names one of the two buckets its request touched. The
+/// bucket it omits is the one whose inputs are still HEAD-named, so narrowing
+/// the observation by that list would release the filter over data the request
+/// erased a subject out of. `bucket_drops` is informational only: the hold is
+/// decided over every chain in the signal.
+///
+/// The two touched buckets are real, not asserted: X was applied in
+/// [`OLD_HOUR`] and in [`RECENT_HOUR`], and the second fold reconciles only the
+/// recent one, which is the bucket the completion names.
+///
+/// Flip-line proof: restore the narrowing in `observe_superseded_holds` by
+/// passing the completion's buckets as the `hours` argument for their shard.
+/// The observation then covers [`RECENT_HOUR`] alone, where the gate clears,
+/// `held_by_superseded_inputs == 1` fails with `0`, and `deleted == 0` fails
+/// with `1`.
+#[tokio::test]
+async fn a_partial_bucket_list_does_not_narrow_the_observation() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let old_input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+
+    // A second victim-carrying input in the recent hour, so the same request
+    // has something to erase in both buckets.
+    let recent_ns = i64::from(RECENT_HOUR) * NS_PER_HOUR;
+    seed_input(
+        mem.as_ref(),
+        &InputSpec::new_at(
+            RECENT_HOUR,
+            Uuid::from_u128(0xB2),
+            1,
+            2,
+            vec![raw_series(
+                "victim",
+                &[("k", "d")],
+                &[(recent_ns + 2_000, 7.0)],
+            )],
+        ),
+    )
+    .await;
+
+    fold_head(&mem, created, 1, None).await;
+    run_rewrite_with(mem.as_ref(), &clock, &[pending_request()]).await;
+    run_rewrite_in(mem.as_ref(), &clock, &recent_bucket(), &[pending_request()]).await;
+    // The default reconcile window reaches the recent hour and not the old one.
+    fold_head(&mem, created + 3 * NS_PER_HOUR, 2, None).await;
+
+    let recent_rw = rewrite_record_key_in(mem.as_ref(), &recent_bucket()).await;
+    let recent_parts = rewrite_part_keys(mem.as_ref(), &recent_rw).await;
+    assert_eq!(
+        head_named_data_keys(mem.as_ref(), RECENT_HOUR).await,
+        recent_parts,
+        "the fold reconciled the bucket the completion names, so the gate clears there"
+    );
+    assert_eq!(
+        head_named_data_keys(mem.as_ref(), OLD_HOUR).await,
+        old_input_data_keys,
+        "and left the omitted bucket naming its pre-rewrite inputs"
+    );
+
+    // The completion names the reconciled bucket only. Both counts are what the
+    // rewrites actually dropped, so the list is partial, not wrong.
+    let (dreq_x, _) = seed_dreq_and_done_with_drops(
+        mem.as_ref(),
+        request_id(),
+        "victim",
+        created,
+        vec![ErasureBucketDrop {
+            signal: signal::to_proto(Signal::Metrics) as i32,
+            shard: SHARD,
+            ingest_hour_bucket: RECENT_HOUR,
+            dropped_count: 1,
+        }],
+    )
+    .await;
+
+    clock.set(past_horizon(created));
+    let dreq = sweep_dreq(mem.as_ref(), &clock).await.expect("dreq sweep");
+    assert_eq!(
+        dreq.deleted, 0,
+        "the omitted bucket still holds the request's own pre-rewrite inputs"
+    );
+    assert_eq!(
+        dreq.held_by_superseded_inputs, 1,
+        "held by the chain in the bucket the completion does not name"
+    );
+    assert_eq!(dreq.kept, 1);
+    assert_eq!(
+        present_keys(mem.as_ref(), &old_input_data_keys).await,
+        old_input_data_keys,
+        "both victim inputs in the omitted bucket are still present"
+    );
+    assert!(
+        mem.head(&dreq_x).await.is_ok(),
+        ".dreq_X physically present"
+    );
+}
+
+/// The observing pass is an observation and nothing else: over a chain no
+/// deleting pass could touch yet, it issues zero deletes and reads the catalog
+/// exactly twice, HEAD once and the one covering part once, however many groups
+/// it gates.
+///
+/// Flip-line proof: return `SweepMode::Delete` from the `mode` argument
+/// `observe_superseded_holds` passes. The pass then reaches its delete phases
+/// (the gate blocks here, so the visible failure is the request shape and the
+/// hold, not a delete); replacing the `object_gate` match with
+/// `SnapshotGate::Clear` on top of that fires the `Op::Delete` rule and the
+/// `.expect` panics. Dropping the shared `SnapshotReachability` (a fresh one per
+/// shard, or per group) fires the third-catalog-GET rule instead.
+#[tokio::test]
+async fn the_observing_pass_deletes_nothing_and_reads_the_catalog_twice() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let horizon = cfg().protection_horizon_ns;
+    let r2_created = created + horizon - 1;
+    let fixture = seed_staggered_chain(&mem, &clock, created, r2_created, None).await;
+
+    seed_dreq_and_done_for(mem.as_ref(), request_id(), "victim", created, Drops::Absent).await;
+
+    // Any delete faults the pass, so "zero deletes" is proven by the pass
+    // succeeding. The third catalog GET faults too: HEAD once and the covering
+    // part once, with every later group reusing the first group's verdict.
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout))
+        .with_rule(
+            Rule::new(Op::Get, ScriptedFault::Timeout)
+                .with_key_contains("/catalog/")
+                .with_occurrence(Occurrence::Nth(3)),
+        );
+    let store = FaultStore::new(mem.clone(), plan);
+
+    clock.set(past_horizon(created));
+    let dreq = sweep_dreq(&store, &clock)
+        .await
+        .expect("an observing pass deletes nothing and re-reads no catalog object");
+    assert_eq!(dreq.deleted, 0);
+    assert_eq!(dreq.held_by_superseded_inputs, 1);
+    assert_eq!(
+        store.fault_count(Op::Delete, FaultKind::Timeout),
+        0,
+        "the observing pass issued exactly zero deletes"
+    );
+    assert_eq!(
+        store.fault_count(Op::Get, FaultKind::Timeout),
+        0,
+        "exactly two catalog GETs for the whole pass: one HEAD, one part"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &fixture.input_data_keys).await,
+        fixture.input_data_keys,
+        "and nothing it observed was removed"
+    );
 }

--- a/crates/ravel-maintain/tests/sweep_crash_matrix.rs
+++ b/crates/ravel-maintain/tests/sweep_crash_matrix.rs
@@ -513,7 +513,11 @@ async fn no_delete_before_horizon_boundary_stepped() {
         )
         .await
         .expect("sweep");
-        assert_eq!(before, (0, 0), "nothing before the horizon");
+        assert_eq!(
+            (before.records_deleted, before.data_deleted),
+            (0, 0),
+            "nothing before the horizon"
+        );
         assert_eq!(l0_commit_count(&store, &bucket).await, 2);
 
         // One ns before the boundary: still nothing.
@@ -529,7 +533,11 @@ async fn no_delete_before_horizon_boundary_stepped() {
         )
         .await
         .expect("sweep");
-        assert_eq!(edge, (0, 0), "nothing one ns before the horizon");
+        assert_eq!(
+            (edge.records_deleted, edge.data_deleted),
+            (0, 0),
+            "nothing one ns before the horizon"
+        );
         assert_eq!(l0_commit_count(&store, &bucket).await, 2);
 
         // Exactly at the boundary: the inputs are swept.
@@ -545,7 +553,10 @@ async fn no_delete_before_horizon_boundary_stepped() {
         )
         .await
         .expect("sweep");
-        assert_eq!(at.0, 2, "both input records deleted at the horizon");
+        assert_eq!(
+            at.records_deleted, 2,
+            "both input records deleted at the horizon"
+        );
         assert_eq!(l0_commit_count(&store, &bucket).await, 0);
         assert_l1_intact(&store, &bucket).await;
     }

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -615,8 +615,10 @@ already-sealed hours:
   retirement frontier is re-listed by neither pass, so its covering part
   keeps naming the pre-rewrite inputs until the frontier band reaches that
   hour, or until an operator rebuilds HEAD. Subject erasure stays correct
-  meanwhile (the query-time predicate outlives the inputs); the availability
-  cost once the sweeper deletes those inputs is stated in
+  meanwhile (the query-time predicate outlives the inputs), and the sweeper
+  does not delete an input the covering part still names: it holds it until
+  one of those two events, so a query over the hour keeps resolving normally.
+  What that hold costs, and what it guarantees, is stated in
   docs/deletion-and-gc.md, "Selective subject erasure".
 - **Skipped when redundant.** The pass does not run on the first fold for a
   tenant (no previous watermark exists) or on a rebuilt fold (absent, corrupt,

--- a/docs/deletion-and-gc.md
+++ b/docs/deletion-and-gc.md
@@ -154,6 +154,15 @@ covering that hour then keeps naming the pre-rewrite inputs. An input the live
 HEAD still names is held for a later pass instead of deleted, and the pass
 reports how many objects it held under each of the two reasons below.
 
+A rewrite record can itself be superseded by a later rewrite applying a
+different erasure request, so the objects one delete unit covers are a whole
+supersession chain, not a single record's own outputs. The gate is asked over
+the entire chain at once, down to the raw inputs the oldest generation
+superseded: a HEAD naming anything in the chain holds all of it. Asking per
+generation would clear on a stale HEAD, which names the raw inputs rather than
+any generation's outputs, and would delete a record while the inputs it erased
+a subject out of were still resolvable.
+
 HEAD read failures are explicit. An **absent** HEAD is NOT a block: with no
 snapshot naming anything, the sweep proceeds (ADR-0020: the catalog index is a
 pure optimization; a missing HEAD degrades to listing). A HEAD, or a covering
@@ -250,6 +259,15 @@ window would still call a Hit.
   held or deleted together: dropping the record while a still-named part is
   held would leave that part unreferenced, and the unreferenced-part rule
   would then collect it and undo the hold.
+- **A rewrite record outlives every input it superseded.** A whole
+  supersession chain, from the live record back to the raw inputs its oldest
+  generation superseded, is one indivisible delete unit: the HEAD gate decides
+  it all at once, and within a pass the superseded inputs and each
+  generation's parts are deleted before the records that superseded them,
+  oldest generation first. A record is the only durable statement that a
+  subject was erased out of a particular set of inputs, so a record that
+  disappeared while one of those inputs remained would leave that input
+  present with nothing naming it as erased.
 - A held input costs storage until the fold reconciles its hour or an
   operator rebuilds HEAD; nothing else about the hour changes, and every
   query over it keeps resolving normally. That is the deliberate trade
@@ -366,8 +384,9 @@ every bound is measured.
   meanwhile). The `.dreq` itself contains the subject
   identifier and is therefore not kept forever: a sweep rule deletes it once
   its `.done` exists, `now >= done.completed_unix_ns + protection_horizon`, no
-  input a rewrite applying that request superseded is still in the store, and
-  the legal-hold check passes. The horizon and the outstanding-input check
+  input any rewrite in that request's supersession chain superseded is still
+  in the store, and the legal-hold check passes. The horizon and the
+  outstanding-input check
   together are what guarantee the query-time filter only disappears after no
   resolvable snapshot can still include a pre-rewrite input: the horizon
   covers the ordinary case, and the check covers the two cases that outlive
@@ -378,6 +397,25 @@ every bound is measured.
   predicate, per-bucket dropped counts, and timestamps, no subject
   identifier, and is permanent, deny-delete audit evidence for every role
   (ADR-0055 amendment).
+
+- **An erasure request's `.dreq` outlives every input any rewrite in its
+  supersession chain superseded.** The outstanding-input check does not look
+  only for the record that applied this request. It walks each touched
+  bucket's supersession chain from the live record back to the raw inputs at
+  its end, collecting the requests every generation applied, and holds the
+  `.dreq` when anything any generation on that chain superseded is still
+  present. A superseded generation's own parts count: they still carry
+  whatever the generation above them erased. If the walk hits a
+  generation whose record is already gone, the request that generation applied
+  is no longer named anywhere, so the check falls back to asking whether the
+  bucket still holds anything that generation could have superseded (a raw
+  input's commit record, or a part no surviving record references) and holds
+  the `.dreq` while it does. That fallback is what makes the check independent
+  of delete ordering: the filter outlives the data even on a store where an
+  older sweep already removed a record it would otherwise have needed. Both
+  conditions clear once the superseded-input and unreferenced-part rules have
+  finished the bucket, so the hold ends rather than pinning the request
+  forever.
 
 ### Modifiers to the bound
 
@@ -462,10 +500,14 @@ into them. An operator with erasure obligations must budget them deliberately.
     query-time predicate removes the erased records after fetch, exactly as it
     did before the horizon elapsed; the request stays live for as long as any
     held input does, so the filter never retires under a snapshot that can
-    still resolve one. The cost is the held storage, not a failed query, and
-    it ends when the fold reconciles the hour or an operator rebuilds HEAD:
-    the next sweep deletes the inputs, and the request becomes removable
-    behind them.
+    still resolve one. That holds however many rewrite generations the hour has
+    accumulated: each rewrite record stays in place behind the inputs it
+    superseded, and each request's filter stays live behind the whole chain,
+    not just behind the one generation that applied it. The cost is the held
+    storage, not a failed query, and it ends when the fold reconciles the hour
+    or an operator rebuilds HEAD: the next sweep deletes the inputs, then the
+    records that superseded them, and the requests become removable behind
+    both.
   - **ADR-0028 analytics/derived datasets are a pure query-time stage, not a
     persisted store.** `ravel-analytics` carries no clock, IO, object-store,
     or catalog (docs/analytics.md): every analytic runs in memory over query

--- a/docs/deletion-and-gc.md
+++ b/docs/deletion-and-gc.md
@@ -412,14 +412,35 @@ every bound is measured.
   pass, for either reason the gate holds them, and the buckets in which it
   held the inputs of a chain it could not walk back to a raw input. The
   erasure rule holds a `.dreq` past its horizon when its request id is in the
-  first set, and also when the second set is non-empty and the request's
-  completion either names one of those buckets or names no buckets at all. No
-  part of the rule depends on the completion record enumerating buckets: a
-  completion that lists them narrows the second condition to buckets the
-  request could have touched, and a completion that lists none is treated as
-  covering every bucket where a chain was cut. The rule issues no store
-  requests of its own beyond the sweep's; it reads a verdict the sweep
-  produced while doing its own work.
+  first set, or when the second set is non-empty at all.
+
+  **The hold is computed over every supersession chain a HEAD-named part
+  still resolves, whether or not the chain is old enough to delete.** Two
+  filters decide whether a chain is collectable *yet*: the protection horizon
+  on the live record's own `created_unix_ns`, and the rule that a record
+  another present rewrite supersedes is processed only as part of that
+  rewrite's chain group. Both bound deletion only. Neither says anything about
+  whether a snapshot still resolves the chain's inputs, which is the only
+  question this hold turns on, and a chain still inside its own horizon is the
+  likeliest one a stale HEAD names. So the observation gathers and gates every
+  chain in the signal and applies neither filter. A chain that is merely young
+  contributes exactly the request ids and buckets it will contribute after its
+  horizon; that a pass could not have deleted it is not recorded and not
+  consulted.
+
+  **A completion record's bucket list is informational only.** No part of this
+  rule reads `bucket_drops`: not the hold decision, and not the scope of the
+  observation. The field is optional on the wire, is written empty by the
+  production completion writer, and a writer that does populate it is not
+  obliged to enumerate every bucket it touched, so a present list can be
+  partial. Narrowing either the decision or the observation by such a list
+  would release the filter over a bucket the request did touch. The
+  observation is therefore always whole-signal: one listing of the commit
+  keyspace enumerates the signal's shards, and every shard is observed across
+  every hour. A shard with no commit key holds nothing, so that scope costs
+  listing, never correctness. The rule issues no GET of its own beyond the
+  sweep's and the completions it must read anyway; it reads a verdict that
+  sweep produced while doing its own work.
 
 - **An erasure request's `.dreq` outlives every input any rewrite in its
   supersession chain superseded.** The hold does not look only for the record
@@ -430,8 +451,9 @@ every bound is measured.
   they still carry whatever the generation above them erased. When the walk
   cannot reach a raw input because a generation's record is already gone, the
   requests that generation applied are no longer named anywhere; the sweep
-  reports that bucket as one where a chain was cut, and every request whose
-  completion is consistent with that bucket is held with it. A chain group
+  reports that bucket as one where a chain was cut, and any candidate `.dreq`
+  is held while such a bucket exists, since no surviving record can say which
+  requests the missing generation applied. A chain group
   the legal-hold gate skipped holds its requests' `.dreq`s the same way a
   HEAD-held one does, which is what keeps a data-prefix-only hold from
   retiring a filter over data it is preserving.

--- a/docs/deletion-and-gc.md
+++ b/docs/deletion-and-gc.md
@@ -111,7 +111,7 @@ own parameters, not gaps a correctly declared config leaves open.
 | rule | targets | preconditions (ALL must hold) | anchor |
 |---|---|---|---|
 | orphan (first implementation, ADR-0010 §11; batched re-verify and breaker, ADR-0048 decisions 4-5) | data object with no commit record | age > grace + max_flush_lifetime (default 1 h); record absence re-verified by one fresh LIST shared by every candidate in the pass; the mass-orphan circuit breaker not tripped (or deliberately overridden) | object last_modified |
-| superseded input (ADR-0018) | L0 commit records + data objects named in a compaction record's input list | now >= record.created_unix_ns + protection_horizon | compaction record created_unix_ns |
+| superseded input (ADR-0018, HEAD-reachability gate ADR-0020) | L0 commit records + data objects named in a compaction or rewrite record's input list, or a whole superseded predecessor record together with the parts it names | now >= record.created_unix_ns + protection_horizon; the live catalog HEAD snapshot names none of the objects the delete would remove (delete blocker, see below) | compaction or rewrite record created_unix_ns |
 | unreferenced part | `l1/` object referenced by no compaction record in its bucket | a compaction record OR a retention tombstone exists for the bucket (a tombstone makes future compaction impossible, so a record-less part can never be re-referenced); age > grace + max_compaction_lifetime; the branch condition (non-reference, or record-absent-and-tombstoned) re-verified immediately before delete | part last_modified |
 | retention (ADR-0019, HEAD-reachability gate ADR-0020) | everything in a tombstoned bucket, tombstone deleted last | now >= tombstone.retired_at_ns + protection_horizon; the live catalog HEAD snapshot names no object inside the bucket (delete blocker, see below); bucket LIST-verified empty before the tombstone itself is deleted | tombstone retired_at_ns |
 | idempotency marker (ADR-0051 §5; logs and spans only, run once per signal rather than per shard) | `t/<tenant_hash>/<signal>/idem/<keyhash32>.<ingest_hour>.idm` marker object | marker's `<ingest_hour>` older than `now_hour - idem_dedup_window_hours - IDEM_MARKER_FORWARD_SKEW_TOLERANCE_HOURS`; a key that fails to parse as `<keyhash32>.<ingest_hour>.idm` is skipped, never deleted | marker key's own `<ingest_hour>` |
@@ -141,15 +141,31 @@ retention still completes (it is not permanently blocked). Without the
 blocker, a query that resolved a stale snapshot naming an already-deleted
 object would fail permanently with `SnapshotInvalidated` (503).
 
+**The superseded-input sweep is gated the same way.** The same blocker, the
+same three answers, and the same per-pass cache apply to a compaction or
+rewrite record's superseded inputs, with the question asked per object rather
+than per bucket: after a compaction or a rewrite the snapshot legitimately
+names the output parts sitting in the same bucket, so only the specific objects
+a delete would remove may be tested. The horizon alone is not enough there for
+the same reason it is not enough for retention. A selective-erasure rewrite
+record can land in any sealed hour, including one both the fold's fixed
+reconcile window and its retention-frontier band miss, and the snapshot part
+covering that hour then keeps naming the pre-rewrite inputs. An input the live
+HEAD still names is held for a later pass instead of deleted, and the pass
+reports how many objects it held under each of the two reasons below.
+
 HEAD read failures are explicit. An **absent** HEAD is NOT a block: with no
 snapshot naming anything, the sweep proceeds (ADR-0020: the catalog index is a
 pure optimization; a missing HEAD degrades to listing). A HEAD, or a covering
 part, that is **present but unreadable** (undecodable, checksum/blake3 mismatch,
-an unsupported newer format, or a HEAD-named part that is missing) blocks the
+an unsupported newer format, a HEAD-named part that is missing, or a snapshot
+entry whose identity fields do not fit the shape a fold writes) blocks the
 sweep **fail-closed**: non-reachability cannot be proven from data that cannot
 be read, and a wrongly-permitted delete is unrecoverable while a delayed one is
 not. HEAD and each covering part are read at most once per sweep pass (cached
-across the pass's buckets), not once per bucket.
+across the pass's buckets and, for superseded inputs, across the pass's
+records), never once per bucket or once per input. A pass that finds nothing
+past its horizon reads neither.
 
 The idempotency-marker rule's age gate subtracts
 `IDEM_MARKER_FORWARD_SKEW_TOLERANCE_HOURS` (1 h) from its lower bound, the
@@ -224,6 +240,20 @@ window would still call a Hit.
   input, and orphan-GC-style convergence handles crash remnants (a
   compactor that died mid-publish leaves record-less parts, which the
   unreferenced-part rule collects once old enough).
+- Superseded-input deletion is gated on HEAD reachability exactly as
+  retention is (ADR-0020, "HEAD-referenced snapshot delete blocker" above),
+  asked per object rather than per bucket. The horizon bounds a pinned
+  in-flight reader; it does not prove the *current* snapshot has stopped
+  naming the input. An input a part named by the live HEAD still references
+  is skipped, and the record that superseded it stays in place so the next
+  pass retries. A superseded predecessor record and the parts it names are
+  held or deleted together: dropping the record while a still-named part is
+  held would leave that part unreferenced, and the unreferenced-part rule
+  would then collect it and undo the hold.
+- A held input costs storage until the fold reconciles its hour or an
+  operator rebuilds HEAD; nothing else about the hour changes, and every
+  query over it keeps resolving normally. That is the deliberate trade
+  against the alternative, a permanently failing query.
 
 ## Retention sweep order
 
@@ -326,17 +356,25 @@ every bound is measured.
   that.
 
 - **Physical removal reuses the existing sweep.** A rewrite's superseded
-  inputs become inputs to `sweep_superseded`, deleted after
+  inputs become inputs to the superseded-input sweep, deleted after
   `protection_horizon`, under the same `LegalHoldCheck` gate as every other
-  delete. That sweep carries no HEAD-reachability blocker: unlike retention,
-  it deletes an input on schedule even when a snapshot part the fold has not
-  reconciled still names it (see "Scope and interactions" below for what a
-  query then sees). The `.dreq` itself contains the subject
+  delete. That sweep is gated on HEAD reachability the same way retention is
+  (ADR-0020, "HEAD-referenced snapshot delete blocker" above): an input a
+  snapshot part the fold has not reconciled still names is held rather than
+  deleted, and collected once the fold reconciles the hour or an operator
+  rebuilds HEAD (see "Scope and interactions" below for what a query sees
+  meanwhile). The `.dreq` itself contains the subject
   identifier and is therefore not kept forever: a sweep rule deletes it once
-  its `.done` exists, `now >= done.created_unix_ns + protection_horizon`, and
-  the legal-hold check passes; the horizon wait guarantees the query-time
-  filter only disappears after no resolvable snapshot can still include a
-  pre-rewrite input. The `.done` record carries only a hash of the canonical
+  its `.done` exists, `now >= done.completed_unix_ns + protection_horizon`, no
+  input a rewrite applying that request superseded is still in the store, and
+  the legal-hold check passes. The horizon and the outstanding-input check
+  together are what guarantee the query-time filter only disappears after no
+  resolvable snapshot can still include a pre-rewrite input: the horizon
+  covers the ordinary case, and the check covers the two cases that outlive
+  it, an input the HEAD gate is holding and an input a legal hold over the
+  data prefixes preserves (such a hold does not cover the request keyspace,
+  so it would otherwise retire the filter over data it is preserving). The
+  `.done` record carries only a hash of the canonical
   predicate, per-bucket dropped counts, and timestamps, no subject
   identifier, and is permanent, deny-delete audit evidence for every role
   (ADR-0055 amendment).
@@ -418,14 +456,16 @@ into them. An operator with erasure obligations must budget them deliberately.
     superseded is refreshed only when the fold reconciles that hour, through
     the fixed window or the retention-frontier band (docs/catalog-and-mvcc.md,
     "Fold reconcile pass"), or when a HEAD rebuild re-derives every hour.
-    Until then a query over that hour resolves the
-    pre-rewrite inputs from the stale part, and the query-time predicate
-    removes the erased records after fetch. Once `sweep_superseded` has
-    deleted those inputs, the same query fails closed with
-    `SnapshotInvalidated` on every attempt, because a re-resolve reads the
-    same stale HEAD, until the fold reconciles the hour or an operator
-    rebuilds HEAD. That is an availability cost, never a served pre-rewrite
-    record: the `.dreq` outlives the inputs by construction.
+    Until then the superseded-input sweep holds those inputs rather than
+    deleting them, because the live HEAD still names them. A query over that
+    hour keeps resolving the pre-rewrite inputs from the stale part and the
+    query-time predicate removes the erased records after fetch, exactly as it
+    did before the horizon elapsed; the request stays live for as long as any
+    held input does, so the filter never retires under a snapshot that can
+    still resolve one. The cost is the held storage, not a failed query, and
+    it ends when the fold reconciles the hour or an operator rebuilds HEAD:
+    the next sweep deletes the inputs, and the request becomes removable
+    behind them.
   - **ADR-0028 analytics/derived datasets are a pure query-time stage, not a
     persisted store.** `ravel-analytics` carries no clock, IO, object-store,
     or catalog (docs/analytics.md): every analytic runs in memory over query

--- a/docs/deletion-and-gc.md
+++ b/docs/deletion-and-gc.md
@@ -268,6 +268,14 @@ window would still call a Hit.
   subject was erased out of a particular set of inputs, so a record that
   disappeared while one of those inputs remained would leave that input
   present with nothing naming it as erased.
+- **The legal-hold gate decides a chain group as a whole, never part of
+  one.** Every key in the group, the raw inputs, each generation's parts, and
+  each generation's records, is checked against `LegalHoldCheck` before
+  anything is deleted; if the hold protects any one of them the whole group
+  is skipped for this pass and nothing in it is deleted. Hold scopes are per
+  prefix, so a hold covering a shard's data prefixes but not its commit
+  prefix would otherwise let one pass delete a chain's records while the
+  input bytes those records account for survive.
 - A held input costs storage until the fold reconciles its hour or an
   operator rebuilds HEAD; nothing else about the hour changes, and every
   query over it keeps resolving normally. That is the deliberate trade
@@ -383,39 +391,67 @@ every bound is measured.
   rebuilds HEAD (see "Scope and interactions" below for what a query sees
   meanwhile). The `.dreq` itself contains the subject
   identifier and is therefore not kept forever: a sweep rule deletes it once
-  its `.done` exists, `now >= done.completed_unix_ns + protection_horizon`, no
-  input any rewrite in that request's supersession chain superseded is still
-  in the store, and the legal-hold check passes. The horizon and the
-  outstanding-input check
+  its `.done` exists, `now >= done.completed_unix_ns + protection_horizon`,
+  the superseded-input sweep held nothing belonging to that request on this
+  pass, and the legal-hold check passes. The horizon and that hold
   together are what guarantee the query-time filter only disappears after no
   resolvable snapshot can still include a pre-rewrite input: the horizon
-  covers the ordinary case, and the check covers the two cases that outlive
+  covers the ordinary case, and the hold covers the two cases that outlive
   it, an input the HEAD gate is holding and an input a legal hold over the
   data prefixes preserves (such a hold does not cover the request keyspace,
   so it would otherwise retire the filter over data it is preserving). The
   `.done` record carries only a hash of the canonical
-  predicate, per-bucket dropped counts, and timestamps, no subject
+  predicate, timestamps, and optionally per-bucket dropped counts, no subject
   identifier, and is permanent, deny-delete audit evidence for every role
   (ADR-0055 amendment).
 
+- **The hold is read off the superseded-input sweep, not rediscovered.** That
+  sweep runs first in the same pass and already knows, per chain group, which
+  requests the chain applied and whether the group was deleted or held. It
+  reports two things: the request ids whose superseded inputs it held this
+  pass, for either reason the gate holds them, and the buckets in which it
+  held the inputs of a chain it could not walk back to a raw input. The
+  erasure rule holds a `.dreq` past its horizon when its request id is in the
+  first set, and also when the second set is non-empty and the request's
+  completion either names one of those buckets or names no buckets at all. No
+  part of the rule depends on the completion record enumerating buckets: a
+  completion that lists them narrows the second condition to buckets the
+  request could have touched, and a completion that lists none is treated as
+  covering every bucket where a chain was cut. The rule issues no store
+  requests of its own beyond the sweep's; it reads a verdict the sweep
+  produced while doing its own work.
+
 - **An erasure request's `.dreq` outlives every input any rewrite in its
-  supersession chain superseded.** The outstanding-input check does not look
-  only for the record that applied this request. It walks each touched
-  bucket's supersession chain from the live record back to the raw inputs at
-  its end, collecting the requests every generation applied, and holds the
-  `.dreq` when anything any generation on that chain superseded is still
-  present. A superseded generation's own parts count: they still carry
-  whatever the generation above them erased. If the walk hits a
-  generation whose record is already gone, the request that generation applied
-  is no longer named anywhere, so the check falls back to asking whether the
-  bucket still holds anything that generation could have superseded (a raw
-  input's commit record, or a part no surviving record references) and holds
-  the `.dreq` while it does. That fallback is what makes the check independent
-  of delete ordering: the filter outlives the data even on a store where an
-  older sweep already removed a record it would otherwise have needed. Both
-  conditions clear once the superseded-input and unreferenced-part rules have
-  finished the bucket, so the hold ends rather than pinning the request
-  forever.
+  supersession chain superseded.** The hold does not look only for the record
+  that applied this request. The superseded-input sweep gathers each live
+  record's whole chain, from the record back to the raw inputs at its end,
+  collecting the requests every generation applied, and reports every request
+  on a chain whose objects it held. A superseded generation's own parts count:
+  they still carry whatever the generation above them erased. When the walk
+  cannot reach a raw input because a generation's record is already gone, the
+  requests that generation applied are no longer named anywhere; the sweep
+  reports that bucket as one where a chain was cut, and every request whose
+  completion is consistent with that bucket is held with it. A chain group
+  the legal-hold gate skipped holds its requests' `.dreq`s the same way a
+  HEAD-held one does, which is what keeps a data-prefix-only hold from
+  retiring a filter over data it is preserving.
+
+- **Why the hold terminates.** The cut-chain hold counts only objects the
+  superseded-input sweep actually held on this pass, never the bare presence
+  of a commit record in the bucket: a bucket with a cut chain and no held
+  object releases the `.dreq`. Two properties make that reachable. First, the
+  delete order within a chain (inputs and each generation's parts before the
+  records that superseded them, oldest generation first) means a missing
+  generation record implies everything that generation superseded is already
+  gone, so a cut never outlives the data it stands in for; and a chain whose
+  predecessor record is absent forms no delete group at all, so it has
+  nothing to hold. Second, an object that lands in an already-swept hour
+  after the fact, a late L0 flush into a sealed bucket, is an input of no
+  record that has passed its horizon: it forms no group, is held by nothing,
+  and cannot pin any request's filter, however long it sits there. So each
+  hold is discharged by the event that released the objects behind it, the
+  fold reconciling the hour, an operator rebuilding HEAD, or a human clearing
+  the legal hold, and no state pins a request forever.
 
 ### Modifiers to the bound
 


### PR DESCRIPTION
The superseded-input sweep deleted a compaction or rewrite record's inputs once the protection horizon passed, with no check that the live catalog HEAD still resolved them. The fold reconciles a late record only inside its fixed window or the retention-frontier band, and a selective-erasure rewrite can land in any sealed hour, so for a rewrite in a mid-retention hour the published snapshot part kept naming the pre-rewrite inputs, the sweep deleted them, and every query over that hour then failed closed with `SnapshotInvalidated` until the frontier band reached the hour or an operator rebuilt HEAD.

The HEAD-reachability gate the retention sweep already uses moves into its own module and gains an object-granular form: a superseded input is held while any part the live HEAD names still carries its identity, an unreadable HEAD or part blocks the pass fail-closed, and an absent HEAD clears it. The request-cost shape is one HEAD read and one read per covering part per pass. The sweep outcome reports inputs held by a snapshot and by an unreadable HEAD, and the shard sweeps log those counts.

Holding inputs exposed a second-order hazard that an adversarial review then sharpened into a reproduced hole: when a second erasure request supersedes the first's rewrite record, the predecessor record could be deleted on the strength of its output parts alone while a stale HEAD still named its raw inputs, and the erasure request's `.dreq` guard, which found outstanding inputs only through a live record naming that request, then let the query-time filter expire with the erased subject still resolvable. The second commit closes it with two rules: a rewrite record outlives every input it superseded, transitively, so a supersession chain is gathered and gated as one group and its records are deleted in a third phase after the inputs; and a `.dreq` outlives every input any rewrite in its chain superseded, with the guard walking `superseded_record_key` back through the chain and, where the chain is cut by a missing record, falling back to a bucket residue check. Nine integration tests were each demonstrated failing first, covering the held and reconciled cases, the fail-closed unreadable HEAD, the absent HEAD, the `.dreq` ordering, the reviewer's two-request scenario, a three-deep chain, and the guard with the applying record already gone.

A second review found that the guard's only input, the completion record's per-bucket drops, is a field the server has always written empty, so in production the guard was a no-op while the new gate kept the inputs alive. The third commit re-anchors it on what the superseded sweep itself observed: the sweep returns the request ids of every rewrite record in a chain group it held and the buckets where it held inputs of a cut chain, and the erasure-request sweep holds a `.dreq` whose request appears in that set or, when cut chains hold inputs, whose completion names one of those buckets or names none at all. Because the server's caller passes no holds, the existing entry self-observes them with a gate-only pass; additive entries take precomputed holds at no cost. A cut chain now holds nothing, so the hold terminates once the fold reconciles the hour; a chain group with any legally held key is skipped whole; groups are deduplicated so the counters are exact; and the reachability gate compares a part reference's bounds with the decoded header and blocks on a mismatch. Nine more tests, each with a production-shape completion, were shown failing against the previous commit.

A third review found that the observation still inherited the deleting pass's horizon gate, so a successor rewrite inside its own protection horizon hid the chain it superseded and the older request's filter could retire with its inputs still resolvable. The fourth commit makes the observing pass gather and gate every chain regardless of the chain head's age, drops the completion record's bucket list from every decision, and pins the result with eight more tests: a successor one nanosecond short of its horizon, one exactly at it, the staggered release after a reconciling fold, a partial bucket list, and an observing pass that deletes nothing and reads the catalog exactly twice.

The deletion and catalog specs describe the rules; the deletion spec also corrects the field the `.dreq` horizon is anchored on and describes the completion record's bucket list as informational. ADR-0064's statement of the delete condition is amended under #1140.

Fixes: #1085