### PR TITLE
feat(server): render the ingest exemplar counters on /metrics

### DIFF
--- a/docs/guides/correlation.md
+++ b/docs/guides/correlation.md
@@ -78,9 +78,13 @@ The ingest metrics hold two counters. The `exemplars_written_total` counter
 counts stored exemplars. The `exemplars_dropped_total` counter counts dropped
 exemplars. If the cap engages, the `exemplars_dropped_total` counter rises.
 
-`GET /metrics` does not expose these two counters, so an operator cannot see
-the cap engage from outside the process. The drop count appears in the flush
-logs.
+`GET /metrics` exposes both counters under the ingest family.
+`ravel_ingest_exemplars_written_total` counts the exemplars that Ravel stored
+on flushed objects. `ravel_ingest_exemplars_dropped_total` counts the
+exemplars that the cap discarded. Both carry the `mode` and `signal` labels,
+and both carry only the `signal="metrics"` series, because exemplars ride on
+metric points. A rising drop count means the cap is engaging, and an operator
+reads that from outside the process rather than from the flush logs.
 
 ## How to query exemplars
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -142,9 +142,15 @@ Labels: `mode` and `signal`. The `signal` label carries `metrics`, `logs`, or
 | `ravel_ingest_acks_err_total` | Strict-mode waiters acked with a write error. |
 | `ravel_ingest_collisions_total` | Batches rejected for a series or stream identity collision. |
 | `ravel_ingest_shard_deaths_total` | Distinct shard actors observed dead by the router. |
+| `ravel_ingest_exemplars_written_total` | Exemplars stored on flushed objects. |
+| `ravel_ingest_exemplars_dropped_total` | Exemplars discarded by the per-series admission cap. |
 
 The collisions family carries no `signal="spans"` series. Spans derive no
 identity that can collide, so that sample is structurally absent, not zero.
+
+The two exemplar families carry only the `signal="metrics"` series. Exemplars
+ride on metric points, so those samples are structurally absent for logs and
+spans, not zero.
 
 #### Per-tenant PUT attribution (`ravel_ingest_attribution_puts_total`)
 

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -627,6 +627,22 @@ pub struct IngestPipelineSnapshot {
     /// concepts, so logs and spans render no sample for this family, the
     /// same structural-absence convention `collisions` and `postings` use.
     pub metadata_sink: Option<MetadataSinkCounters>,
+    /// Exemplar admission counters. `Some` only for the metrics pipeline:
+    /// exemplars ride on metric points, so logs and spans render no sample
+    /// for this family rather than a zero that would read as "the cap never
+    /// engaged".
+    pub exemplars: Option<ExemplarCounters>,
+}
+
+/// Exemplar admission counters, mirroring
+/// [`ravel_ingest::IngestMetricsSnapshot`]'s two `exemplars_*` fields. Grouped
+/// in one struct for the same reason [`MetadataSinkCounters`] is: they are
+/// always present or always absent together, which `Option<Self>` says once
+/// instead of twice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ExemplarCounters {
+    pub written_total: u64,
+    pub dropped_total: u64,
 }
 
 /// Metric metadata sink counters (ADR-0085 decision 1), mirroring
@@ -688,6 +704,10 @@ impl IngestPipelineSnapshot {
                 flush_dropped_total: snapshot.metadata_flush_dropped_total,
                 entries_dropped_total: snapshot.metadata_entries_dropped_total,
             }),
+            exemplars: Some(ExemplarCounters {
+                written_total: snapshot.exemplars_written_total,
+                dropped_total: snapshot.exemplars_dropped_total,
+            }),
         }
     }
 
@@ -718,6 +738,7 @@ impl IngestPipelineSnapshot {
                 dynamic_columns_used_max: snapshot.dynamic_columns_used_max,
             }),
             metadata_sink: None,
+            exemplars: None,
         }
     }
 
@@ -739,6 +760,7 @@ impl IngestPipelineSnapshot {
             stale_provisioning_flushes: snapshot.stale_provisioning_flushes,
             postings: None,
             metadata_sink: None,
+            exemplars: None,
         }
     }
 }
@@ -1023,6 +1045,45 @@ fn render_ingest_family(out: &mut String, mode: Mode, pipelines: &[IngestPipelin
                 "ravel_ingest_metadata_entries_dropped_total",
                 &labels(mode, pipeline.signal),
                 counters.entries_dropped_total,
+            );
+        }
+    }
+
+    // Exemplars ride on metric points, so only the metrics pipeline sets
+    // `exemplars` and the family is empty in a logs- or spans-only process.
+    let with_exemplars: Vec<_> = pipelines
+        .iter()
+        .filter_map(|pipeline| pipeline.exemplars.map(|counters| (pipeline, counters)))
+        .collect();
+    if !with_exemplars.is_empty() {
+        write_header(
+            out,
+            "ravel_ingest_exemplars_written_total",
+            "Exemplars stored on flushed objects, by signal.",
+            "counter",
+        );
+        for (pipeline, counters) in &with_exemplars {
+            write_sample(
+                out,
+                "ravel_ingest_exemplars_written_total",
+                &labels(mode, pipeline.signal),
+                counters.written_total,
+            );
+        }
+
+        write_header(
+            out,
+            "ravel_ingest_exemplars_dropped_total",
+            "Exemplars discarded by the per-series admission cap, by signal. A rising figure \
+             says the cap is engaging; the points themselves are still ingested.",
+            "counter",
+        );
+        for (pipeline, counters) in &with_exemplars {
+            write_sample(
+                out,
+                "ravel_ingest_exemplars_dropped_total",
+                &labels(mode, pipeline.signal),
+                counters.dropped_total,
             );
         }
     }
@@ -4222,6 +4283,129 @@ mod tests {
                 "ravel_ingest_metadata_flush_gets_total{mode=\"gateway\",signal=\"spans\""
             ),
             "spans pipeline must render no metadata_sink sample"
+        );
+    }
+
+    /// The two exemplar counters render one sample each, with the family's
+    /// `{mode, signal}` labels and the driven values. Built by setting
+    /// `exemplars` directly, so this test pins the rendering alone; the
+    /// conversion from the ingest crate's snapshot is pinned by
+    /// `exemplar_counters_survive_conversion_from_ingest_snapshot` below.
+    #[test]
+    fn exemplar_counters_render_under_the_ingest_family() {
+        let mut pipeline = IngestPipelineSnapshot::from_metrics(IngestMetricsSnapshot::default());
+        pipeline.exemplars = Some(ExemplarCounters {
+            written_total: 7,
+            dropped_total: 3,
+        });
+        let ingest = vec![
+            pipeline,
+            IngestPipelineSnapshot::from_log_metrics(LogIngestMetricsSnapshot::default()),
+            IngestPipelineSnapshot::from_span_metrics(SpanIngestMetricsSnapshot::default()),
+        ];
+        let body = render(
+            Mode::Gateway,
+            &StoreMetricsSnapshot::default(),
+            &ingest,
+            &CatalogCountersSnapshot::default(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &AdmissionCountersSnapshot::default(),
+            &[],
+            0,
+            IngestBufferBudgetSnapshot::default(),
+            None,
+            None,
+            &[],
+            None,
+        );
+
+        let written = "ravel_ingest_exemplars_written_total{mode=\"gateway\",signal=\"metrics\"} 7";
+        let dropped = "ravel_ingest_exemplars_dropped_total{mode=\"gateway\",signal=\"metrics\"} 3";
+        assert_eq!(
+            body.matches(written).count(),
+            1,
+            "written counter must render exactly once:\n{body}"
+        );
+        assert_eq!(
+            body.matches(dropped).count(),
+            1,
+            "dropped counter must render exactly once:\n{body}"
+        );
+        assert!(
+            body.contains("# TYPE ravel_ingest_exemplars_written_total counter"),
+            "written counter must carry a TYPE line:\n{body}"
+        );
+        assert!(
+            body.contains("# TYPE ravel_ingest_exemplars_dropped_total counter"),
+            "dropped counter must carry a TYPE line:\n{body}"
+        );
+        assert!(
+            !body.contains("ravel_ingest_exemplars_written_total{mode=\"gateway\",signal=\"logs\""),
+            "logs pipeline must render no exemplar sample:\n{body}"
+        );
+        assert!(
+            !body
+                .contains("ravel_ingest_exemplars_dropped_total{mode=\"gateway\",signal=\"spans\""),
+            "spans pipeline must render no exemplar sample:\n{body}"
+        );
+    }
+
+    /// The values travel from the ingest crate's counters to the rendered
+    /// text: a constructor that leaves `exemplars` at zero (or `None`) while
+    /// the source snapshot carries them fails here, not in the render test
+    /// above.
+    #[test]
+    fn exemplar_counters_survive_conversion_from_ingest_snapshot() {
+        let ingest = vec![IngestPipelineSnapshot::from_metrics(
+            IngestMetricsSnapshot {
+                exemplars_written_total: 7,
+                exemplars_dropped_total: 3,
+                ..Default::default()
+            },
+        )];
+        let body = render(
+            Mode::Gateway,
+            &StoreMetricsSnapshot::default(),
+            &ingest,
+            &CatalogCountersSnapshot::default(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &AdmissionCountersSnapshot::default(),
+            &[],
+            0,
+            IngestBufferBudgetSnapshot::default(),
+            None,
+            None,
+            &[],
+            None,
+        );
+
+        assert!(
+            body.contains(
+                "ravel_ingest_exemplars_written_total{mode=\"gateway\",signal=\"metrics\"} 7"
+            ),
+            "conversion must carry the written count, not zero:\n{body}"
+        );
+        assert!(
+            body.contains(
+                "ravel_ingest_exemplars_dropped_total{mode=\"gateway\",signal=\"metrics\"} 3"
+            ),
+            "conversion must carry the dropped count, not zero:\n{body}"
         );
     }
 


### PR DESCRIPTION
The ingest pipeline already counted every exemplar it stored and dropped, but the server's ingest metrics family was built from a snapshot that carried neither figure, so an operator could not see the per-series admission cap engage without reading flush logs.

The snapshot now carries the two counters for the metrics pipeline, and the ingest family renders `ravel_ingest_exemplars_written_total` and `ravel_ingest_exemplars_dropped_total` with the family's `mode` and `signal` labels. Logs and spans have no exemplar concept, so their pipelines render no exemplar sample rather than a permanent zero, following the family's existing convention for structurally absent figures. Tests pin the exact rendered lines and that the values survive the conversion from the ingest crate's snapshot; the label allowlist is unchanged.

The correlation guide no longer states the gap, and the observability guide lists the two counters in the ingest family table. Three other ingest snapshot figures (adaptive age flushes, grace-extended stale flushes, in-flight flushes) still do not reach the rendered family; that is #1095.

Fixes: #1074