### PR TITLE
docs: define disaster-recovery level 0 on the versioned bucket

### DIFF
--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -230,19 +230,23 @@ aws s3api get-bucket-versioning --bucket <primary>
 # Primary: the enabled lifecycle rules. Pass only when one row carries
 # noncurrent_days equal to E_v, one carries expired_delete_markers true,
 # and one carries abort_mpu_days of 7 or less (the contract's required
-# AbortIncompleteMultipartUpload rule).
+# AbortIncompleteMultipartUpload rule), AND each of those rows has an
+# empty scope (both scope columns null: the rule covers the whole bucket)
+# or a scope that, across the rows, covers every t/ prefix. A rule scoped
+# to one prefix leaves noncurrent versions elsewhere unbounded, and the
+# +E_v bound does not hold.
 aws s3api get-bucket-lifecycle-configuration --bucket <primary> \
-  --query 'Rules[?Status==`Enabled`].{id:ID,noncurrent_days:NoncurrentVersionExpiration.NoncurrentDays,expired_delete_markers:Expiration.ExpiredObjectDeleteMarker,abort_mpu_days:AbortIncompleteMultipartUpload.DaysAfterInitiation}' \
+  --query 'Rules[?Status==`Enabled`].{id:ID,scope:Filter.Prefix,legacy_scope:Prefix,noncurrent_days:NoncurrentVersionExpiration.NoncurrentDays,expired_delete_markers:Expiration.ExpiredObjectDeleteMarker,abort_mpu_days:AbortIncompleteMultipartUpload.DaysAfterInitiation}' \
   --output table
 
 # Primary: replication v2, DeleteMarkerReplication enabled, RTC (if required)
 aws s3api get-bucket-replication --bucket <primary>
 
-# Replica: versioning ON, and the same rule check with noncurrent_days
-# equal to E_v_r and expired_delete_markers true.
+# Replica: versioning ON, and the same rule and scope check with
+# noncurrent_days equal to E_v_r and expired_delete_markers true.
 aws s3api get-bucket-versioning --bucket <replica>
 aws s3api get-bucket-lifecycle-configuration --bucket <replica> \
-  --query 'Rules[?Status==`Enabled`].{id:ID,noncurrent_days:NoncurrentVersionExpiration.NoncurrentDays,expired_delete_markers:Expiration.ExpiredObjectDeleteMarker}' \
+  --query 'Rules[?Status==`Enabled`].{id:ID,scope:Filter.Prefix,legacy_scope:Prefix,noncurrent_days:NoncurrentVersionExpiration.NoncurrentDays,expired_delete_markers:Expiration.ExpiredObjectDeleteMarker}' \
   --output table
 
 # Object Lock enabled on the bucket, and whether a bucket default
@@ -325,8 +329,12 @@ verified operation.
 4. **Verify before serving.** `verify-custody` clean, `catalog verify` clean,
    and a canary query set over known-ingested data.
 5. **Re-protect before the first process starts.** The restore bucket must
-   meet the baseline before Ravel writes to it: versioning on and Object Lock
-   enabled. At levels 0 and 1 that means no default retention and the
+   meet the baseline before Ravel writes to it: versioning on with the
+   primary's `NoncurrentDays = E_v` rule and expired-delete-marker cleanup
+   installed (a promoted replica still carries `E_v_r`; replace it), and
+   Object Lock enabled. Without the lifecycle rules the erasure bound does
+   not hold for anything written from this point. At levels 0 and 1 that
+   also means no default retention and the
    retention mechanism pointed at the restore bucket and backfilled over the
    restored objects: objects restored before the mechanism runs carry no
    retention, so run the backfill and confirm one current and one noncurrent
@@ -339,9 +347,9 @@ verified operation.
    pays off here: processes mint fresh writer ids and epochs, no local state
    exists to reconcile, and the operator issues fresh per-mode storage
    credentials scoped to the restore bucket.
-7. **Replicate and close out.** Re-establish the lifecycle rules and
-   replication to a new replica before declaring the incident closed. An
-   unreplicated restored primary is level 0.
+7. **Replicate and close out.** Re-establish replication to a new replica,
+   with the replica's own versioning and lifecycle rules, before declaring
+   the incident closed. Until that is done the deployment is level 0.
 
 ## RPO and RTO: defined here, published only from a rehearsal
 

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -138,8 +138,10 @@ Replication to a replica bucket:
 - Replication **v2 configuration** with `DeleteMarkerReplication` **enabled**,
   RTC **recommended**.
 - The replica lives in a **different region** and a **different account**,
-  encrypted under a **different KMS key** (`ReplicaKmsKeyID`), and holds its
-  own `NoncurrentDays = E_v_r` expiration rule.
+  encrypted under a **different KMS key** (`ReplicaKmsKeyID`). Replication
+  requires versioning on both buckets, so the replica is versioned too, and
+  it carries its own `NoncurrentDays = E_v_r` expiration rule and
+  expired-delete-marker cleanup.
 - Ravel processes never hold replica-account credentials; the replication
   channel is the only writer to the replica.
 
@@ -198,7 +200,9 @@ is one knob controlling two windows.**
 
 - It is the **disaster-detection budget**: after an accidental or malicious
   mass delete, the operator has `E_v` to notice and restore the noncurrent
-  versions on the primary, plus `E_v_r` on the replica at level 1.
+  versions on the primary. At level 1 the replica has its own window,
+  replication lag plus `E_v_r`; the two windows run side by side and do not
+  add up.
 - It is simultaneously the **erasure-residue window**: erased bytes persist as
   noncurrent versions for `E_v`.
 
@@ -210,26 +214,36 @@ service level agreement. This runbook refuses to pick a number for you.
 
 Ravel cannot enforce most of this and does not pretend to. `ravel-cli store
 qualify` probes whether Object Lock and versioning appear enabled and reports
-lifecycle-rule state, but **replication configuration is invisible to the
-object-store layer**, so verification of the replication controls is an
+whether a lifecycle rule is present, not what the rule says, and
+**replication configuration is invisible to the object-store layer**, so
+verification of the lifecycle values and the replication controls is an
 explicit platform-CLI step and not something Ravel checked. The versioning
 and `NoncurrentDays = E_v` lifecycle checks apply at level 0 and level 1
-alike; the replication checks are level 1 only. Run these against the actual
-buckets:
+alike; the replication and replica checks are level 1 only. Run these against
+the actual buckets, and treat a missing row or a differing value as a failed
+check:
 
 ```sh
 # Primary: versioning ON
 aws s3api get-bucket-versioning --bucket <primary>
 
-# Primary: NoncurrentDays = E_v expiration + expired-delete-marker cleanup
-aws s3api get-bucket-lifecycle-configuration --bucket <primary>
+# Primary: the enabled lifecycle rules. Pass only when one row carries
+# noncurrent_days equal to E_v, one carries expired_delete_markers true,
+# and one carries abort_mpu_days of 7 or less (the contract's required
+# AbortIncompleteMultipartUpload rule).
+aws s3api get-bucket-lifecycle-configuration --bucket <primary> \
+  --query 'Rules[?Status==`Enabled`].{id:ID,noncurrent_days:NoncurrentVersionExpiration.NoncurrentDays,expired_delete_markers:Expiration.ExpiredObjectDeleteMarker,abort_mpu_days:AbortIncompleteMultipartUpload.DaysAfterInitiation}' \
+  --output table
 
 # Primary: replication v2, DeleteMarkerReplication enabled, RTC (if required)
 aws s3api get-bucket-replication --bucket <primary>
 
-# Replica: versioning ON, NoncurrentDays = E_v_r expiration
+# Replica: versioning ON, and the same rule check with noncurrent_days
+# equal to E_v_r and expired_delete_markers true.
 aws s3api get-bucket-versioning --bucket <replica>
-aws s3api get-bucket-lifecycle-configuration --bucket <replica>
+aws s3api get-bucket-lifecycle-configuration --bucket <replica> \
+  --query 'Rules[?Status==`Enabled`].{id:ID,noncurrent_days:NoncurrentVersionExpiration.NoncurrentDays,expired_delete_markers:Expiration.ExpiredObjectDeleteMarker}' \
+  --output table
 
 # Object Lock enabled on the bucket, and whether a bucket default
 # retention D is set (a default retention is level 2; the scoped posture
@@ -397,7 +411,7 @@ record: a real end-to-end run against MinIO is what fills a row.
 |---|---|---|---|
 | **Every level** | Object Lock enabled on the bucket and versioning ON; at levels 0 and 1, no bucket default retention and an operator-run mechanism applying per-object retention in compliance mode to `sys/`, provisioning records, commit records and catalog HEAD history (level 2 replaces the mechanism with its bucket default retention); `--require-bucket-protection` gates startup on the bucket half (Object Lock enabled, versioning on), and the mechanism or the default retention is verified out of band | None; those prefixes hold no erasable subject value | Not a recovery control |
 | **level 0** (default) | Versioning + `NoncurrentDays = E_v` + expired-delete-marker cleanup; no replica | Primary `+E_v` | None; bucket loss is total loss |
-| **level 1** (recommended) | Level 0 plus a replica: different region/account/KMS key, replication v2 with `DeleteMarkerReplication`, RTC recommended, `NoncurrentDays = E_v_r` | Primary `+E_v`; replica residue is replication lag + `E_v_r` (requires `DeleteMarkerReplication`) | Defined here; **unmeasured** until a rehearsal record exists. RTC gives RPO a 15-minute ceiling; without RTC, unbounded |
+| **level 1** (recommended) | Level 0 plus a replica: different region/account/KMS key, replication v2 with `DeleteMarkerReplication`, RTC recommended; the replica versioned with `NoncurrentDays = E_v_r` and expired-delete-marker cleanup | Primary `+E_v`; replica residue is replication lag + `E_v_r` (requires `DeleteMarkerReplication`) | Defined here; **unmeasured** until a rehearsal record exists. RTC gives RPO a 15-minute ceiling; without RTC, unbounded |
 | **level 2** (optional) | level 1 plus a bucket default retention `D`, which S3 applies to every object including the data objects | `max(bound, D)`; query-time exclusion still immediate | As level 1 |
 
 `DeleteMarkerReplication` is mandatory for any erasure-obligated deployment;

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -103,8 +103,25 @@ modifiers apply to are in
 
 ### level 0, no replication (default)
 
-Unversioned bucket beyond the protected prefixes. Erasure bounds hold as
-stated in [consistency-model.md](../consistency-model.md) with no modifiers.
+The bucket is versioned. Versioning is not optional here and it is not
+scoped to some prefixes: the baseline above requires it, because Object Lock
+cannot be enabled without it, and S3 versioning is bucket-wide. There is no
+bucket that is versioned only under the protected prefixes. So every
+overwrite and delete of a data object leaves a noncurrent version behind.
+
+Level 0 pairs that versioning with a `NoncurrentDays = E_v`
+noncurrent-version expiration rule and expired-delete-marker cleanup, and
+adds no replica. Its physical erasure bound is the primary bound plus
+`+E_v`, the same primary half level 1 states: erased bytes persist as
+noncurrent versions until the rule reaps them. The base bounds are in
+[consistency-model.md](../consistency-model.md); the `+E_v` modifier is in
+[deletion-and-gc.md](../deletion-and-gc.md#modifiers-to-the-bound).
+
+Versioning on without that lifecycle rule is not a level. Without the rule
+the noncurrent residue is unbounded and the bounds in this guide do not
+apply: every delete becomes a soft delete that survives indefinitely while
+every layer above keeps reporting success.
+
 RPO and RTO: none; bucket loss is total loss. This remains a **supported
 posture**, but its blast radius is total: every durable byte (data objects,
 commit records, manifests, catalog snapshots, control objects under `sys/`)
@@ -112,12 +129,9 @@ lives in one bucket, and Ravel itself cannot recover from losing it.
 
 ### level 1, replicated (the recommended posture)
 
-On the primary bucket:
-
-- Versioning **ON**, paired with a `NoncurrentDays = E_v` noncurrent-version
-  expiration rule and expired-delete-marker cleanup. Versioning on without
-  that pairing is an unsupported configuration: it turns every Ravel delete
-  into a soft delete while every layer above keeps reporting success.
+Level 0 plus a replica. The primary keeps the level-0 configuration
+unchanged: versioning on, the `NoncurrentDays = E_v` noncurrent-version
+expiration rule, and expired-delete-marker cleanup.
 
 Replication to a replica bucket:
 
@@ -179,12 +193,12 @@ the cross-account replica stand in for a bucket default retention at level 1.
 
 ## `E_v` is one knob controlling two windows
 
-The load-bearing design insight of level 1: **`E_v` is one knob controlling two
-windows.**
+`E_v` is present from level 0, since the bucket is versioned there. **`E_v`
+is one knob controlling two windows.**
 
 - It is the **disaster-detection budget**: after an accidental or malicious
-  mass delete, the operator has `E_v_r`, plus `E_v` if the deletes were simple
-  deletes, to notice and restore noncurrent versions.
+  mass delete, the operator has `E_v` to notice and restore the noncurrent
+  versions on the primary, plus `E_v_r` on the replica at level 1.
 - It is simultaneously the **erasure-residue window**: erased bytes persist as
   noncurrent versions for `E_v`.
 
@@ -198,8 +212,10 @@ Ravel cannot enforce most of this and does not pretend to. `ravel-cli store
 qualify` probes whether Object Lock and versioning appear enabled and reports
 lifecycle-rule state, but **replication configuration is invisible to the
 object-store layer**, so verification of the replication controls is an
-explicit platform-CLI step and not something Ravel checked. Run these against
-the actual buckets:
+explicit platform-CLI step and not something Ravel checked. The versioning
+and `NoncurrentDays = E_v` lifecycle checks apply at level 0 and level 1
+alike; the replication checks are level 1 only. Run these against the actual
+buckets:
 
 ```sh
 # Primary: versioning ON
@@ -380,8 +396,8 @@ record: a real end-to-end run against MinIO is what fills a row.
 | Level | Controls | Erasure-bound consequence | RPO/RTO |
 |---|---|---|---|
 | **Every level** | Object Lock enabled on the bucket and versioning ON; at levels 0 and 1, no bucket default retention and an operator-run mechanism applying per-object retention in compliance mode to `sys/`, provisioning records, commit records and catalog HEAD history (level 2 replaces the mechanism with its bucket default retention); `--require-bucket-protection` gates startup on the bucket half (Object Lock enabled, versioning on), and the mechanism or the default retention is verified out of band | None; those prefixes hold no erasable subject value | Not a recovery control |
-| **level 0** (default) | No replication | None; bounds as in consistency-model.md | None; bucket loss is total loss |
-| **level 1** (recommended) | Primary: versioning + `NoncurrentDays = E_v` + expired-delete-marker cleanup. Replica: different region/account/KMS key, replication v2 with `DeleteMarkerReplication`, RTC recommended, `NoncurrentDays = E_v_r` | Primary `+E_v`; replica residue is replication lag + `E_v_r` (requires `DeleteMarkerReplication`) | Defined here; **unmeasured** until a rehearsal record exists. RTC gives RPO a 15-minute ceiling; without RTC, unbounded |
+| **level 0** (default) | Versioning + `NoncurrentDays = E_v` + expired-delete-marker cleanup; no replica | Primary `+E_v` | None; bucket loss is total loss |
+| **level 1** (recommended) | Level 0 plus a replica: different region/account/KMS key, replication v2 with `DeleteMarkerReplication`, RTC recommended, `NoncurrentDays = E_v_r` | Primary `+E_v`; replica residue is replication lag + `E_v_r` (requires `DeleteMarkerReplication`) | Defined here; **unmeasured** until a rehearsal record exists. RTC gives RPO a 15-minute ceiling; without RTC, unbounded |
 | **level 2** (optional) | level 1 plus a bucket default retention `D`, which S3 applies to every object including the data objects | `max(bound, D)`; query-time exclusion still immediate | As level 1 |
 
 `DeleteMarkerReplication` is mandatory for any erasure-obligated deployment;


### PR DESCRIPTION
The disaster-recovery guide described level 0 as an unversioned bucket beyond the protected prefixes and stated its erasure bound with no noncurrent-version term. The baseline on the same page requires versioning, because Object Lock cannot be enabled without it, and S3 versioning is bucket-wide, so that description contradicted the page it sat on.

Level 0 is now the versioned bucket with the noncurrent-version expiration rule and expired-delete-marker cleanup and no replica, with its physical erasure bound stated as the primary bound plus `E_v`, the same primary half level 1 already stated. Level 1 becomes level 0 plus a replica. Versioning without the lifecycle rule is named as not a level, with the unbounded residue that implies. The `E_v` section, the verification preamble, and the summary table follow. The consistency and deletion specs already frame their bounds on a versioned bucket and are unchanged.

Fixes: #1089