### PR TITLE
feat(operator): render GC horizon flags from spec.gc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4831,6 +4831,7 @@ dependencies = [
  "clap",
  "futures",
  "hex",
+ "humantime",
  "k8s-openapi",
  "kube",
  "kube-runtime",

--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -157,14 +157,14 @@
                             "type": "boolean"
                           },
                           "hosts": {
-                            "description": "Hostnames the ingest Ingress answers on. Empty renders a single\nhost-less rule, which matches any host reaching the controller.\n\nLegacy `backend: ingressNginx` only. `gateway.exposure.gatewayAPI\n.hostnames` is the equivalent field for Gateway API exposure; the two\nare independent and neither reads the other.",
+                            "description": "Hostnames the ingest Ingress answers on. Empty renders a single\nhost-less rule, which matches any host reaching the controller.\n\nLegacy `backend: ingressNginx` only. `gateway.exposure.gatewayApi\n.hostnames` is the equivalent field for Gateway API exposure; the two\nare independent and neither reads the other.",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "ingressClassName": {
-                            "description": "`spec.ingressClassName` on the rendered Ingress objects. Omit to let the\ncluster's default IngressClass apply.\n\nLegacy `backend: ingressNginx` only. Has no effect under\n`backend: ravelNative`, and no effect on `gateway.exposure.gatewayAPI`\nrouting (Gateway API attachment goes through `exposure.gatewayAPI\n.gatewayRef` instead, ADR-0080 decision 2).",
+                            "description": "`spec.ingressClassName` on the rendered Ingress objects. Omit to let the\ncluster's default IngressClass apply.\n\nLegacy `backend: ingressNginx` only. Has no effect under\n`backend: ravelNative`, and no effect on `gateway.exposure.gatewayApi`\nrouting (Gateway API attachment goes through `exposure.gatewayApi\n.gatewayRef` instead, ADR-0080 decision 2).",
                             "nullable": true,
                             "type": "string"
                           },
@@ -262,6 +262,23 @@
                         "rule": "!has(self.ingestAffinity) || !has(self.ingestAffinity.key) || !has(self.ingestAffinity.key.source) || self.ingestAffinity.key.source != 'canonicalTenant' || !has(self.ingestAffinity.backend) || self.ingestAffinity.backend != 'ingressNginx'"
                       }
                     ]
+                  },
+                  "gc": {
+                    "description": "Garbage-collection horizons that must match the bucket's stored `sys/gc`\nvalues. Only the maintain tier validates against `sys/gc`, so these\nrender onto the maintain Deployment. Omit the whole block, or either\nfield, to render no flag and let the server's compiled-in default apply,\nbyte-identical to a cluster that never set it.",
+                    "nullable": true,
+                    "properties": {
+                      "grace": {
+                        "description": "The GC grace period (`--gc-grace`). It must equal the grace stored in the\nbucket's `sys/gc` object, which you read with `ravel-cli gc-config show`,\nor the maintain pod refuses to start. Unset renders no flag and the\nserver's compiled-in default applies.",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "protectionHorizon": {
+                        "description": "The GC protection horizon (`--gc-protection-horizon`). It must equal the\nprotection horizon stored in the bucket's `sys/gc` object, which you read\nwith `ravel-cli gc-config show`, or the maintain pod refuses to start.\nUnset renders no flag and the server's compiled-in default applies.",
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
                   },
                   "image": {
                     "description": "Container image for every mode's pod (`ravel-server`).",

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -215,6 +215,8 @@ A minimal example is in
 | `spec.maintain.enabled` | boolean | `true` | `false` deletes the maintain Deployment. |
 | `spec.maintain.intervalSecs` | integer | none | `--maintain-interval-secs`. |
 | `spec.maintain.resources` | object | none | |
+| `spec.gc.protectionHorizon` | string | none | `--gc-protection-horizon` on the maintain pods, a duration such as `25h5m`. It must equal the protection horizon stored in the bucket's `sys/gc`, read with `ravel-cli gc-config show`, or the maintain pods refuse to start. Unset renders no flag and the server's default applies. |
+| `spec.gc.grace` | string | none | `--gc-grace` on the maintain pods, a duration such as `24h`. It must equal the grace stored in the bucket's `sys/gc`, read with `ravel-cli gc-config show`, or the maintain pods refuse to start. Unset renders no flag and the server's default applies. |
 | `spec.retention.default` | string | none | Duration string, e.g. `30d`. |
 | `spec.retention.tenants` | map | none | Per-tenant overrides, tenant name to duration. |
 

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -568,17 +568,18 @@ conflict rather than a silent overwrite. Every value must be strictly positive:
 an all-zero configuration would satisfy the inequality trivially and be
 impossible for any mode to match, so it is rejected.
 
-The Kubernetes operator exposes no GC-horizon fields: it deploys every pod
-with the shipped defaults. On a fresh bucket with a shared credential the
-first pod bootstraps `sys/gc` from those defaults and every pod validates
+The Kubernetes operator carries a `spec.gc` block with `protectionHorizon` and
+`grace` for exactly this case. On a fresh bucket with a shared credential the
+first pod bootstraps `sys/gc` from the shipped defaults and every pod validates
 trivially; with per-role credential Secrets the operator applies the maintain
 Deployment first and its pod creates the object, as above. On a bucket whose
-stored protection horizon
-or grace differs from the shipped defaults (set with `gc-config set`), the
-operator's maintain pods refuse to start, because the must-match rule has no
-operator field to satisfy it; the other two stored values do not affect
-startup. Keep such a bucket on the shipped horizon and grace, or run
-maintenance outside the operator.
+stored protection horizon or grace was set to a non-default value with
+`gc-config set`, set `spec.gc.protectionHorizon` and `spec.gc.grace` to the
+stored values, which you read with `ravel-cli gc-config show`, and the operator
+renders `--gc-protection-horizon` and `--gc-grace` onto the maintain pods so
+they satisfy the must-match rule and start. Leave the block, or either field,
+unset to keep the shipped default; the other two stored values do not affect
+startup.
 
 ### Age-based retention
 

--- a/services/ravel-operator/Cargo.toml
+++ b/services/ravel-operator/Cargo.toml
@@ -21,6 +21,11 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 ravel-tracing-export = { workspace = true }
 thiserror = { workspace = true }
+# Validates spec.gc horizon strings at render time using the same parser the
+# server flags accept, so an invalid duration is a typed render error instead of
+# a flag the maintain pod rejects at startup (#1083). Already a workspace pin;
+# adds no new external crate.
+humantime = { workspace = true }
 futures = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 # sys/auth reconciliation (ADR-0072 decision 4, #897): the operator is the

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -1741,6 +1741,7 @@ mod tests {
             },
             query: QuerySpec::default(),
             maintain: MaintainSpec::default(),
+            gc: None,
             retention: None,
             shard_overrides: None,
         }
@@ -2446,6 +2447,7 @@ mod tests {
                 gateway: Default::default(),
                 query: Default::default(),
                 maintain: Default::default(),
+                gc: None,
                 retention: None,
                 shard_overrides: None,
             }

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -94,6 +94,14 @@ pub struct RavelClusterSpec {
     #[serde(default)]
     pub maintain: MaintainSpec,
 
+    /// Garbage-collection horizons that must match the bucket's stored `sys/gc`
+    /// values. Only the maintain tier validates against `sys/gc`, so these
+    /// render onto the maintain Deployment. Omit the whole block, or either
+    /// field, to render no flag and let the server's compiled-in default apply,
+    /// byte-identical to a cluster that never set it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gc: Option<GcSpec>,
+
     /// Age-based retention: a default window plus per-tenant overrides. Enforced
     /// only by the maintain tier, so these render onto the maintain Deployment.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -599,6 +607,33 @@ impl Default for MaintainSpec {
             credentials_secret_ref: None,
         }
     }
+}
+
+/// Garbage-collection horizons rendered onto the maintain tier
+/// (`--gc-protection-horizon`, `--gc-grace`).
+///
+/// Both fields are humantime duration strings in the syntax the server flags
+/// accept (`24h`, `25h5m`). Each is validated at render time and rendered
+/// verbatim, so the operator never reinterprets a duration; an invalid or empty
+/// value is a render error naming the field, not a flag the server would reject
+/// at startup. The engine deadline (`--gc-max-query-duration`) is a different
+/// quantity and is deliberately absent here.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GcSpec {
+    /// The GC protection horizon (`--gc-protection-horizon`). It must equal the
+    /// protection horizon stored in the bucket's `sys/gc` object, which you read
+    /// with `ravel-cli gc-config show`, or the maintain pod refuses to start.
+    /// Unset renders no flag and the server's compiled-in default applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protection_horizon: Option<String>,
+
+    /// The GC grace period (`--gc-grace`). It must equal the grace stored in the
+    /// bucket's `sys/gc` object, which you read with `ravel-cli gc-config show`,
+    /// or the maintain pod refuses to start. Unset renders no flag and the
+    /// server's compiled-in default applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grace: Option<String>,
 }
 
 /// Retention policy (`--retention-default`, repeatable `--retention-tenant`).
@@ -1670,6 +1705,65 @@ mod tests {
             overrides.lead_hours, MIN_RESHARD_LEAD_HOURS,
             "omitting leadHours must default to the minimum, not zero"
         );
+    }
+
+    #[test]
+    fn gc_block_is_optional_with_both_horizon_fields_optional() {
+        // #1083. The GC block is a new optional sibling of retention: an
+        // existing RavelCluster that never heard of it deserializes with None,
+        // so the maintain pod carries no --gc- flag and the server's compiled-in
+        // default applies (byte-identical to today). Both horizon fields inside
+        // it are optional too, so a spec may set one, both, or neither.
+        let crd = ravel_cluster_crd();
+        let gc = crd.spec.versions[0]
+            .schema
+            .as_ref()
+            .expect("schema")
+            .open_api_v3_schema
+            .as_ref()
+            .expect("root schema")
+            .properties
+            .as_ref()
+            .expect("root props")
+            .get("spec")
+            .expect("spec prop")
+            .properties
+            .as_ref()
+            .expect("spec props")
+            .get("gc")
+            .expect("gc prop")
+            .clone();
+        let gc_props = gc.properties.as_ref().expect("gc props");
+        assert!(
+            gc_props.contains_key("protectionHorizon"),
+            "gc must expose protectionHorizon in its schema"
+        );
+        assert!(
+            gc_props.contains_key("grace"),
+            "gc must expose grace in its schema"
+        );
+        // Neither field is required: the block may set one, both, or neither.
+        let required = gc.required.clone().unwrap_or_default();
+        assert!(
+            !required.contains(&"protectionHorizon".to_string())
+                && !required.contains(&"grace".to_string()),
+            "both gc horizon fields must be optional, required was {required:?}"
+        );
+
+        let base = serde_json::json!({
+            "image": "ravel:dev",
+            "shards": 4,
+            "storage": { "s3": { "bucket": "b", "credentialsSecretRef": { "name": "creds" } } }
+        });
+        let spec: RavelClusterSpec = serde_json::from_value(base.clone()).expect("deserialize");
+        assert_eq!(spec.gc, None, "omitting the block deserializes to None");
+
+        let mut with_gc = base;
+        with_gc["gc"] = serde_json::json!({ "protectionHorizon": "26h" });
+        let spec: RavelClusterSpec = serde_json::from_value(with_gc).expect("deserialize");
+        let gc = spec.gc.expect("gc present");
+        assert_eq!(gc.protection_horizon.as_deref(), Some("26h"));
+        assert_eq!(gc.grace, None, "grace may be set independently of horizon");
     }
 
     #[test]

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -67,6 +67,24 @@ pub enum RenderError {
          (canonical-tenant cannot start with no resolver)"
     )]
     CanonicalTenantResolverMissing,
+
+    /// A `spec.gc` horizon field holds a value that is not a valid humantime
+    /// duration (or is empty). Rendering it verbatim would put a flag on the
+    /// maintain pod that `ravel-server` rejects at startup, crash-looping the
+    /// tier; the render fails here instead so the controller records a
+    /// `Degraded` condition whose message names the offending field. `field` is
+    /// the camelCase CRD field name (`protectionHorizon` or `grace`).
+    #[error(
+        "spec.gc.{field} value {value:?} is not a valid humantime duration; use a duration such \
+         as 24h or 25h5m matching the value stored in sys/gc (read it with ravel-cli gc-config \
+         show)"
+    )]
+    GcHorizonInvalid {
+        /// The camelCase CRD field name that failed to validate.
+        field: &'static str,
+        /// The rejected value, as written in the spec.
+        value: String,
+    },
 }
 
 /// HTTP listener port (OTLP/HTTP, query API, and the `/healthz` `/readyz`
@@ -660,9 +678,9 @@ pub fn desired_maintain_deployment(
     spec: &RavelClusterSpec,
     instance: &str,
     ctx: &RenderCtx,
-) -> Option<Deployment> {
+) -> Result<Option<Deployment>, RenderError> {
     if !spec.maintain.enabled {
-        return None;
+        return Ok(None);
     }
     let mut args = vec![
         "--mode".to_string(),
@@ -675,6 +693,24 @@ pub fn desired_maintain_deployment(
     if let Some(secs) = spec.maintain.interval_secs {
         args.push("--maintain-interval-secs".to_string());
         args.push(secs.to_string());
+    }
+    // GC horizons (#1083): rendered only on this tier, and only when set, since
+    // maintain is the only role that validates itself against `sys/gc`. The
+    // value is validated as a humantime duration and then rendered verbatim, so
+    // an invalid string is a typed render error naming the field rather than a
+    // flag the maintain pod would reject at startup, and a valid one is never
+    // reinterpreted.
+    if let Some(gc) = &spec.gc {
+        if let Some(horizon) = &gc.protection_horizon {
+            validate_gc_duration("protectionHorizon", horizon)?;
+            args.push("--gc-protection-horizon".to_string());
+            args.push(horizon.clone());
+        }
+        if let Some(grace) = &gc.grace {
+            validate_gc_duration("grace", grace)?;
+            args.push("--gc-grace".to_string());
+            args.push(grace.clone());
+        }
     }
     if let Some(retention) = &spec.retention {
         if let Some(default) = &retention.default {
@@ -697,7 +733,7 @@ pub fn desired_maintain_deployment(
         ..Default::default()
     }];
 
-    Some(deployment(
+    Ok(Some(deployment(
         spec,
         instance,
         "maintain",
@@ -708,7 +744,21 @@ pub fn desired_maintain_deployment(
         spec.maintain.resources.as_ref(),
         "RollingUpdate",
         &tier_secrets_checksum(spec, ctx, tier_override),
-    ))
+    )))
+}
+
+/// Validate a `spec.gc` horizon string as a humantime duration, the same syntax
+/// the `ravel-server` flags accept. An empty or unparseable value is a
+/// [`RenderError::GcHorizonInvalid`] naming `field`; a valid one returns `Ok`
+/// and the caller renders the original string verbatim.
+fn validate_gc_duration(field: &'static str, value: &str) -> Result<(), RenderError> {
+    if value.is_empty() || humantime::parse_duration(value).is_err() {
+        return Err(RenderError::GcHorizonInvalid {
+            field,
+            value: value.to_string(),
+        });
+    }
+    Ok(())
 }
 
 /// Build a ClusterIP Service selecting `component`'s pods on the given ports.
@@ -1795,13 +1845,15 @@ pub struct DesiredObjects {
 
 /// Render every Kubernetes object a `RavelCluster` reconcile applies.
 ///
-/// Returns `Result` for forward compatibility with a render error that must
-/// fail the whole reconcile, but is infallible today: the one render error that
-/// currently exists (the ravel-native router's, ADR-0080 decision 3) is
-/// captured in [`DesiredObjects::router_render_error`] rather than propagated,
-/// so a misconfigured router degrades only the router and every other tier
-/// still reconciles. The controller turns a captured router error into a
-/// `Degraded` condition rather than applying a broken Deployment.
+/// Returns `Result` for a render error that must fail the whole reconcile: an
+/// invalid `spec.gc` horizon (#1083) propagates here so the controller records a
+/// `Degraded` condition rather than shipping a maintain pod with a flag the
+/// server rejects at startup. The router's render error (the ravel-native
+/// router's, ADR-0080 decision 3) is instead captured in
+/// [`DesiredObjects::router_render_error`] rather than propagated, so a
+/// misconfigured router degrades only the router and every other tier still
+/// reconciles. Both paths end at a `Degraded` condition; they differ only in
+/// blast radius.
 pub fn desired_objects(
     spec: &RavelClusterSpec,
     instance: &str,
@@ -1857,7 +1909,7 @@ pub fn desired_objects(
         router_render_error,
         query_deployment: desired_query_deployment(spec, instance, ctx),
         query_service: desired_query_service(spec, instance),
-        maintain_deployment: desired_maintain_deployment(spec, instance, ctx),
+        maintain_deployment: desired_maintain_deployment(spec, instance, ctx)?,
         gc_bootstrap,
     })
 }
@@ -1868,7 +1920,7 @@ mod tests {
     use super::*;
     use crate::crd::{
         AffinityBackend, AffinityKeySpec, DEFAULT_AFFINITY_SUBSET_SIZE, FoldSpec,
-        GatewayApiExposureSpec, GatewayExposureSpec, GatewayReference, GatewaySpec,
+        GatewayApiExposureSpec, GatewayExposureSpec, GatewayReference, GatewaySpec, GcSpec,
         IngestAffinitySpec, LocalSecretRef, MaintainSpec, QuerySpec, RetentionSpec, S3Spec,
         StorageSpec,
     };
@@ -1918,6 +1970,7 @@ mod tests {
                 resources: None,
                 credentials_secret_ref: None,
             },
+            gc: None,
             retention: Some(RetentionSpec {
                 default: Some("30d".to_string()),
                 tenants: BTreeMap::from([("acme".to_string(), "7d".to_string())]),
@@ -2002,8 +2055,127 @@ mod tests {
         assert_eq!(arg_value(&args_of(&g), "--shards").as_deref(), Some("8"));
         assert_eq!(arg_value(&args_of(&q), "--shards").as_deref(), Some("8"));
         // And also into maintain, which sweeps every shard.
-        let m = desired_maintain_deployment(&spec, "prod", &ctx()).expect("maintain enabled");
+        let m = desired_maintain_deployment(&spec, "prod", &ctx())
+            .expect("no gc render error")
+            .expect("maintain enabled");
         assert_eq!(arg_value(&args_of(&m), "--shards").as_deref(), Some("8"));
+    }
+
+    #[test]
+    fn gc_horizons_render_the_two_flags_on_maintain_only() {
+        // #1083. protectionHorizon and grace on spec.gc render as
+        // --gc-protection-horizon and --gc-grace with those exact values on the
+        // maintain container, and on no other tier: only maintain validates
+        // itself against sys/gc, so only maintain carries the horizons.
+        let mut spec = base_spec();
+        spec.gc = Some(GcSpec {
+            protection_horizon: Some("26h".to_string()),
+            grace: Some("25h".to_string()),
+        });
+        let m = desired_maintain_deployment(&spec, "prod", &ctx())
+            .expect("no gc render error")
+            .expect("maintain enabled");
+        let margs = args_of(&m);
+        assert_eq!(
+            arg_value(&margs, "--gc-protection-horizon").as_deref(),
+            Some("26h"),
+            "maintain must render the protection horizon verbatim: {margs:?}"
+        );
+        assert_eq!(
+            arg_value(&margs, "--gc-grace").as_deref(),
+            Some("25h"),
+            "maintain must render the grace verbatim: {margs:?}"
+        );
+
+        // Neither flag reaches gateway or query.
+        let g = desired_gateway_deployment(&spec, "prod", &ctx());
+        let q = desired_query_deployment(&spec, "prod", &ctx());
+        for dep in [&g, &q] {
+            let args = args_of(dep);
+            assert!(
+                !args.iter().any(|a| a.starts_with("--gc-")),
+                "no --gc- flag belongs on gateway/query: {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unset_gc_renders_no_gc_flag_on_any_container() {
+        // #1083. With spec.gc unset the maintain pod carries no --gc- flag at
+        // all, so the server's compiled-in default applies, byte-identical to a
+        // cluster that never set it. Asserted as the exact absence of any
+        // --gc-* arg, not a count.
+        let spec = base_spec();
+        assert_eq!(spec.gc, None);
+        let g = desired_gateway_deployment(&spec, "prod", &ctx());
+        let q = desired_query_deployment(&spec, "prod", &ctx());
+        let m = desired_maintain_deployment(&spec, "prod", &ctx())
+            .expect("no gc render error")
+            .expect("maintain enabled");
+        for dep in [&g, &q, &m] {
+            let args = args_of(dep);
+            assert!(
+                !args.iter().any(|a| a.starts_with("--gc-")),
+                "unset spec.gc must render no --gc- flag: {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_gc_horizon_is_a_render_error_naming_the_field() {
+        // #1083. A non-duration or empty value must be a typed render error
+        // naming the field, never a flag the maintain pod would reject at
+        // startup. The error propagates out of desired_objects, so the
+        // controller degrades the cluster instead of shipping a broken pod.
+        let mut spec = base_spec();
+        spec.gc = Some(GcSpec {
+            protection_horizon: Some("not-a-duration".to_string()),
+            grace: None,
+        });
+        assert_eq!(
+            desired_maintain_deployment(&spec, "prod", &ctx())
+                .expect_err("an invalid horizon must be a render error"),
+            RenderError::GcHorizonInvalid {
+                field: "protectionHorizon",
+                value: "not-a-duration".to_string(),
+            }
+        );
+        assert!(
+            matches!(
+                desired_objects(&spec, "prod", "ns", &ctx()),
+                Err(RenderError::GcHorizonInvalid {
+                    field: "protectionHorizon",
+                    ..
+                })
+            ),
+            "an invalid horizon must propagate out of desired_objects"
+        );
+
+        // An empty grace names grace specifically, not the horizon.
+        let mut spec = base_spec();
+        spec.gc = Some(GcSpec {
+            protection_horizon: Some("24h".to_string()),
+            grace: Some(String::new()),
+        });
+        assert_eq!(
+            desired_maintain_deployment(&spec, "prod", &ctx())
+                .expect_err("an empty grace must be a render error"),
+            RenderError::GcHorizonInvalid {
+                field: "grace",
+                value: String::new(),
+            }
+        );
+
+        // The error text names the field, so the Degraded message the
+        // controller derives from it points the operator at the exact knob.
+        assert!(
+            RenderError::GcHorizonInvalid {
+                field: "protectionHorizon",
+                value: "nope".to_string(),
+            }
+            .to_string()
+            .contains("spec.gc.protectionHorizon")
+        );
     }
 
     #[test]
@@ -2016,7 +2188,9 @@ mod tests {
         assert!(spec.deployment_key_secret_ref.is_none());
         let g = desired_gateway_deployment(&spec, "prod", &ctx());
         let q = desired_query_deployment(&spec, "prod", &ctx());
-        let m = desired_maintain_deployment(&spec, "prod", &ctx()).expect("maintain enabled");
+        let m = desired_maintain_deployment(&spec, "prod", &ctx())
+            .expect("no gc render error")
+            .expect("maintain enabled");
         for dep in [&g, &q, &m] {
             let args = args_of(dep);
             assert!(
@@ -2054,7 +2228,9 @@ mod tests {
         });
         let g = desired_gateway_deployment(&spec, "prod", &ctx());
         let q = desired_query_deployment(&spec, "prod", &ctx());
-        let m = desired_maintain_deployment(&spec, "prod", &ctx()).expect("maintain enabled");
+        let m = desired_maintain_deployment(&spec, "prod", &ctx())
+            .expect("no gc render error")
+            .expect("maintain enabled");
         for dep in [&g, &q, &m] {
             let args = args_of(dep);
             assert!(
@@ -2203,7 +2379,9 @@ mod tests {
         // a RollingUpdate strategy. The default (base_spec sets replicas=1) must
         // still yield exactly one pod, so an existing cluster is unaffected.
         let spec = base_spec();
-        let m = desired_maintain_deployment(&spec, "prod", &ctx()).expect("enabled");
+        let m = desired_maintain_deployment(&spec, "prod", &ctx())
+            .expect("no gc render error")
+            .expect("enabled");
         let dspec = m.spec.as_ref().expect("spec");
         assert_eq!(dspec.replicas, Some(1));
         assert_eq!(
@@ -2246,7 +2424,9 @@ mod tests {
         // env as gateway and query, using the same RenderCtx tenant list.
         let spec = base_spec();
         let ctx = ctx();
-        let m = desired_maintain_deployment(&spec, "prod", &ctx).expect("enabled");
+        let m = desired_maintain_deployment(&spec, "prod", &ctx)
+            .expect("no gc render error")
+            .expect("enabled");
         let g = desired_gateway_deployment(&spec, "prod", &ctx);
 
         let margs = args_of(&m);
@@ -2295,7 +2475,11 @@ mod tests {
     fn maintain_disabled_yields_none() {
         let mut spec = base_spec();
         spec.maintain.enabled = false;
-        assert!(desired_maintain_deployment(&spec, "prod", &ctx()).is_none());
+        assert!(
+            desired_maintain_deployment(&spec, "prod", &ctx())
+                .expect("no gc render error")
+                .is_none()
+        );
     }
 
     #[test]
@@ -2320,7 +2504,9 @@ mod tests {
         let mut spec = base_spec();
         spec.maintain.replicas = 2;
         let ctx = ctx();
-        let m = desired_maintain_deployment(&spec, "prod", &ctx).expect("enabled");
+        let m = desired_maintain_deployment(&spec, "prod", &ctx)
+            .expect("no gc render error")
+            .expect("enabled");
         let dspec = m.spec.as_ref().expect("spec");
 
         assert_eq!(dspec.replicas, Some(2), "maintain must render two pods");
@@ -2387,7 +2573,9 @@ mod tests {
         for dep in [
             desired_gateway_deployment(&spec, "prod", &ctx()),
             desired_query_deployment(&spec, "prod", &ctx()),
-            desired_maintain_deployment(&spec, "prod", &ctx()).expect("enabled"),
+            desired_maintain_deployment(&spec, "prod", &ctx())
+                .expect("no gc render error")
+                .expect("enabled"),
         ] {
             let c = container_of(&dep);
             let live = c
@@ -2424,7 +2612,9 @@ mod tests {
         for dep in [
             desired_gateway_deployment(&spec, "prod", &ctx),
             desired_query_deployment(&spec, "prod", &ctx),
-            desired_maintain_deployment(&spec, "prod", &ctx).expect("enabled"),
+            desired_maintain_deployment(&spec, "prod", &ctx)
+                .expect("no gc render error")
+                .expect("enabled"),
         ] {
             assert_eq!(
                 checksum_of(&dep).as_deref(),
@@ -2570,7 +2760,9 @@ mod tests {
 
         let g = desired_gateway_deployment(&spec, "prod", &ctx);
         let q = desired_query_deployment(&spec, "prod", &ctx);
-        let m = desired_maintain_deployment(&spec, "prod", &ctx).expect("enabled");
+        let m = desired_maintain_deployment(&spec, "prod", &ctx)
+            .expect("no gc render error")
+            .expect("enabled");
 
         for (dep, expect) in [(&g, "gw-creds"), (&q, "qy-creds"), (&m, "mt-creds")] {
             assert_eq!(
@@ -2622,8 +2814,12 @@ mod tests {
                 desired_query_deployment(&explicit_spec, "prod", &ctx),
             ),
             (
-                desired_maintain_deployment(&none_spec, "prod", &ctx).expect("enabled"),
-                desired_maintain_deployment(&explicit_spec, "prod", &ctx).expect("enabled"),
+                desired_maintain_deployment(&none_spec, "prod", &ctx)
+                    .expect("no gc render error")
+                    .expect("enabled"),
+                desired_maintain_deployment(&explicit_spec, "prod", &ctx)
+                    .expect("no gc render error")
+                    .expect("enabled"),
             ),
         ];
         for (unset, explicit) in pairs {
@@ -2643,7 +2839,9 @@ mod tests {
         // shared Secret, so they roll together exactly as before this change.
         let g = desired_gateway_deployment(&none_spec, "prod", &ctx);
         let q = desired_query_deployment(&none_spec, "prod", &ctx);
-        let m = desired_maintain_deployment(&none_spec, "prod", &ctx).expect("enabled");
+        let m = desired_maintain_deployment(&none_spec, "prod", &ctx)
+            .expect("no gc render error")
+            .expect("enabled");
         let shared_checksum = secrets_checksum(Some("tok-1"), Some("cred-1"), None);
         assert_eq!(checksum_of(&g).as_deref(), Some(shared_checksum.as_str()));
         assert_eq!(checksum_of(&q).as_deref(), Some(shared_checksum.as_str()));
@@ -2693,8 +2891,12 @@ mod tests {
         let g_after = desired_gateway_deployment(&over_spec, "prod", &after);
         let q_before = desired_query_deployment(&over_spec, "prod", &before);
         let q_after = desired_query_deployment(&over_spec, "prod", &after);
-        let m_before = desired_maintain_deployment(&over_spec, "prod", &before).expect("enabled");
-        let m_after = desired_maintain_deployment(&over_spec, "prod", &after).expect("enabled");
+        let m_before = desired_maintain_deployment(&over_spec, "prod", &before)
+            .expect("no gc render error")
+            .expect("enabled");
+        let m_after = desired_maintain_deployment(&over_spec, "prod", &after)
+            .expect("no gc render error")
+            .expect("enabled");
 
         assert_ne!(
             checksum_of(&g_before),
@@ -2736,9 +2938,12 @@ mod tests {
         let ga = desired_gateway_deployment(&shared_spec, "prod", &shared_after);
         let qb = desired_query_deployment(&shared_spec, "prod", &shared_before);
         let qa = desired_query_deployment(&shared_spec, "prod", &shared_after);
-        let mb =
-            desired_maintain_deployment(&shared_spec, "prod", &shared_before).expect("enabled");
-        let ma = desired_maintain_deployment(&shared_spec, "prod", &shared_after).expect("enabled");
+        let mb = desired_maintain_deployment(&shared_spec, "prod", &shared_before)
+            .expect("no gc render error")
+            .expect("enabled");
+        let ma = desired_maintain_deployment(&shared_spec, "prod", &shared_after)
+            .expect("no gc render error")
+            .expect("enabled");
         assert_ne!(checksum_of(&gb), checksum_of(&ga), "gateway must roll");
         assert_ne!(checksum_of(&qb), checksum_of(&qa), "query must roll");
         assert_ne!(checksum_of(&mb), checksum_of(&ma), "maintain must roll");
@@ -3565,8 +3770,12 @@ mod tests {
         let ga = desired_gateway_deployment(&spec, "prod", &after);
         let qb = desired_query_deployment(&spec, "prod", &before);
         let qa = desired_query_deployment(&spec, "prod", &after);
-        let mb = desired_maintain_deployment(&spec, "prod", &before).expect("enabled");
-        let ma = desired_maintain_deployment(&spec, "prod", &after).expect("enabled");
+        let mb = desired_maintain_deployment(&spec, "prod", &before)
+            .expect("no gc render error")
+            .expect("enabled");
+        let ma = desired_maintain_deployment(&spec, "prod", &after)
+            .expect("no gc render error")
+            .expect("enabled");
         assert_ne!(
             checksum_of(&gb),
             checksum_of(&ga),

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -679,6 +679,10 @@ pub fn desired_maintain_deployment(
     instance: &str,
     ctx: &RenderCtx,
 ) -> Result<Option<Deployment>, RenderError> {
+    // Validate before the enabled check: an invalid `spec.gc` is a
+    // misconfiguration to surface even when no maintain Deployment renders,
+    // otherwise it would sit silent until the tier is turned on.
+    validate_gc_spec(spec)?;
     if !spec.maintain.enabled {
         return Ok(None);
     }
@@ -702,12 +706,10 @@ pub fn desired_maintain_deployment(
     // reinterpreted.
     if let Some(gc) = &spec.gc {
         if let Some(horizon) = &gc.protection_horizon {
-            validate_gc_duration("protectionHorizon", horizon)?;
             args.push("--gc-protection-horizon".to_string());
             args.push(horizon.clone());
         }
         if let Some(grace) = &gc.grace {
-            validate_gc_duration("grace", grace)?;
             args.push("--gc-grace".to_string());
             args.push(grace.clone());
         }
@@ -747,16 +749,37 @@ pub fn desired_maintain_deployment(
     )))
 }
 
-/// Validate a `spec.gc` horizon string as a humantime duration, the same syntax
-/// the `ravel-server` flags accept. An empty or unparseable value is a
-/// [`RenderError::GcHorizonInvalid`] naming `field`; a valid one returns `Ok`
-/// and the caller renders the original string verbatim.
+/// Validate every set `spec.gc` field, whether or not the maintain tier
+/// renders this pass.
+fn validate_gc_spec(spec: &RavelClusterSpec) -> Result<(), RenderError> {
+    if let Some(gc) = &spec.gc {
+        if let Some(horizon) = &gc.protection_horizon {
+            validate_gc_duration("protectionHorizon", horizon)?;
+        }
+        if let Some(grace) = &gc.grace {
+            validate_gc_duration("grace", grace)?;
+        }
+    }
+    Ok(())
+}
+
+/// Validate a `spec.gc` horizon string the way the `ravel-server` flags do: a
+/// humantime duration that is positive and fits in nanoseconds. An empty,
+/// unparseable, zero, or too-large value is a [`RenderError::GcHorizonInvalid`]
+/// naming `field`; a valid one returns `Ok` and the caller renders the original
+/// string verbatim.
 fn validate_gc_duration(field: &'static str, value: &str) -> Result<(), RenderError> {
-    if value.is_empty() || humantime::parse_duration(value).is_err() {
-        return Err(RenderError::GcHorizonInvalid {
-            field,
-            value: value.to_string(),
-        });
+    let invalid = || RenderError::GcHorizonInvalid {
+        field,
+        value: value.to_string(),
+    };
+    if value.is_empty() {
+        return Err(invalid());
+    }
+    let dur = humantime::parse_duration(value).map_err(|_| invalid())?;
+    let ns = i64::try_from(dur.as_nanos()).map_err(|_| invalid())?;
+    if ns <= 0 {
+        return Err(invalid());
     }
     Ok(())
 }
@@ -2119,6 +2142,68 @@ mod tests {
                 "unset spec.gc must render no --gc- flag: {args:?}"
             );
         }
+    }
+
+    #[test]
+    fn invalid_gc_horizon_is_a_render_error_even_with_maintain_disabled() {
+        // With no maintain Deployment to render, an invalid spec.gc would
+        // otherwise pass silently and only surface once the tier is enabled.
+        let mut spec = base_spec();
+        spec.maintain.enabled = false;
+        spec.gc = Some(GcSpec {
+            protection_horizon: None,
+            grace: Some("not-a-duration".to_string()),
+        });
+        assert_eq!(
+            desired_maintain_deployment(&spec, "prod", &ctx())
+                .expect_err("an invalid grace must be a render error with maintain disabled"),
+            RenderError::GcHorizonInvalid {
+                field: "grace",
+                value: "not-a-duration".to_string(),
+            }
+        );
+        assert!(
+            matches!(
+                desired_objects(&spec, "prod", "ns", &ctx()),
+                Err(RenderError::GcHorizonInvalid { field: "grace", .. })
+            ),
+            "the error must propagate out of desired_objects with maintain disabled"
+        );
+    }
+
+    #[test]
+    fn zero_gc_horizon_is_rejected_like_the_server_rejects_it() {
+        // ravel-server refuses a non-positive --gc-* duration at startup, so a
+        // zero must be a render error rather than a flag on a crash-looping pod.
+        for (horizon, grace, field, value) in [
+            (Some("0s"), None, "protectionHorizon", "0s"),
+            (Some("24h"), Some("0h"), "grace", "0h"),
+        ] {
+            let mut spec = base_spec();
+            spec.gc = Some(GcSpec {
+                protection_horizon: horizon.map(str::to_string),
+                grace: grace.map(str::to_string),
+            });
+            assert_eq!(
+                desired_maintain_deployment(&spec, "prod", &ctx())
+                    .expect_err("a zero duration must be a render error"),
+                RenderError::GcHorizonInvalid {
+                    field,
+                    value: value.to_string(),
+                }
+            );
+        }
+        // A positive value still renders.
+        let mut spec = base_spec();
+        spec.gc = Some(GcSpec {
+            protection_horizon: Some("1s".to_string()),
+            grace: None,
+        });
+        assert!(
+            desired_maintain_deployment(&spec, "prod", &ctx())
+                .expect("a positive duration renders")
+                .is_some()
+        );
     }
 
     #[test]


### PR DESCRIPTION
The maintain mode refuses to start unless its protection horizon and grace flags equal the values stored in `sys/gc`, and the operator rendered every pod with the shipped defaults with no field to change them, so a bucket whose `sys/gc` had been set to other values could not run maintenance under the operator at all.

The `RavelCluster` resource gains an optional `spec.gc` block with `protectionHorizon` and `grace` as humantime duration strings. When set, the maintain Deployment renders `--gc-protection-horizon` and `--gc-grace` with those values verbatim; unset renders no flag, byte-identical to before. A value that is empty or not a valid duration is a render error that surfaces as `Degraded=True` with a message naming the field, so it never reaches a pod as a flag the server would reject. The generated CRD manifest is regenerated, which also picked up three description strings that had drifted from the source. Tests pin the exact rendered args on the maintain container and their absence on gateway and query, the exact absence with `spec.gc` unset, the render error for an invalid value, and the schema shape.

The Kubernetes guide documents the two fields, and the configuration guide replaces its statement of the limitation with how to set them from `ravel-cli gc-config show`. The operator crate takes the workspace's existing humantime pin; no new external dependency.

Fixes: #1083