### PR TITLE
fix(catalog): resolve overlapping compaction records to one authoritative

### DIFF
--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -2148,6 +2148,24 @@ impl Catalog {
                 .await?;
             input_set_hashes.insert(record.input_set_hash.clone());
             newest_record_created_ns = newest_record_created_ns.max(record.created_unix_ns);
+            compaction_records.push((ckey.clone(), record));
+        }
+
+        // Overlapping input sets in one bucket (issue #1070): query-time dedup
+        // rescues only metrics, so serving both overlapping records' parts
+        // returns logs and spans rows twice. Pick one authoritative record per
+        // overlap component; its losers' parts are skipped below and only the
+        // WINNING records' inputs join `excluded`, so a loser input no winner
+        // names falls through to the raw-L0 pass. Disjoint records are not in
+        // conflict and both stay (see
+        // [`select_authoritative_compaction_records`] for the coverage
+        // argument).
+        let losing_compaction_records =
+            select_authoritative_compaction_records(&compaction_records);
+        for (ckey, record) in &compaction_records {
+            if losing_compaction_records.contains(ckey) {
+                continue;
+            }
             for input in &record.inputs {
                 excluded.insert((
                     input.writer_id.clone(),
@@ -2155,7 +2173,6 @@ impl Catalog {
                     input.writer_seq,
                 ));
             }
-            compaction_records.push((ckey.clone(), record));
         }
 
         // Load every rewrite record (ADR-0064 decision 3). Same-bucket, key
@@ -2206,7 +2223,7 @@ impl Catalog {
         // (event-bound filtered). A record whose whole output a live rewrite
         // superseded is skipped -- its parts would resurrect erased records.
         for (ckey, record) in &compaction_records {
-            if superseded_records.contains(ckey) {
+            if superseded_records.contains(ckey) || losing_compaction_records.contains(ckey) {
                 continue;
             }
             for part in &record.parts {
@@ -2246,8 +2263,10 @@ impl Catalog {
         }
 
         // Two compaction records with different input_set_hash in one bucket:
-        // both parts sets are already included above (harmless overlap); alarm
-        // loudly (docs/catalog-and-mvcc.md step 3, §3.6 row 11).
+        // disjoint sets both serve above (harmless); overlapping sets resolved
+        // to one authoritative record above (issue #1070). Either way this is
+        // an interlock anomaly worth alarming on loudly (docs/catalog-and-mvcc.md
+        // step 3, §3.6 row 11).
         if input_set_hashes.len() > 1 {
             self.compaction_input_set_conflicts
                 .fetch_add(1, Ordering::Relaxed);
@@ -3298,6 +3317,108 @@ fn build_rewrite_l1_segment_ref(
         // or future writer until the recompute path lands with its own tests.
         declared_column_stats: DeclaredColumnStats::default(),
     })
+}
+
+/// Select one authoritative compaction record per *overlap component* of a
+/// bucket, returning the keys of the records whose output parts must be
+/// IGNORED (the losers). Shared by snapshot resolution (`process_bucket`) and
+/// the index fold (`classify_bucket`) so a live resolve and a folded snapshot
+/// derive identical bucket state.
+///
+/// Two compaction records are in conflict when their input sets overlap (share
+/// at least one L0 input identity). Query-time dedup by `(series_id, ts)`
+/// collapses such an overlap for metrics, but logs and spans have no
+/// query-time dedup, so serving both records' parts returns the overlapping
+/// rows twice. Records connected transitively by overlap form one component;
+/// within each component of two or more records exactly one stays
+/// authoritative and the rest are losers. A record overlapping no other
+/// (a singleton component) is not in conflict and stays authoritative, so
+/// disjoint records keep today's behaviour (both served).
+///
+/// Tie-break: the authoritative record is the one with the lexicographically
+/// smallest `input_set_hash`, its key string breaking the impossible
+/// exact-hash tie. `input_set_hash` is a collision-resistant digest of the
+/// record's input identity set, so this is a stable total order every replica
+/// computes identically from the record bytes alone, with no dependence on
+/// wall-clock, listing order, or which compactor won the race.
+///
+/// Coverage (why dropping a loser's parts loses no data): a loser `L` shares a
+/// component with its winner `W`. Each of `L`'s inputs is either also an input
+/// of `W` (served inside `W`'s parts) or named by no authoritative record in
+/// the bucket (served as a raw L0 segment by the caller's unlisted-L0 pass) --
+/// it cannot be an input of another component's winner, since a shared input
+/// would have merged the two components. So every L0 input of the bucket is
+/// served exactly once: inside exactly one authoritative record's parts, or as
+/// one raw L0 segment. The one residual exposure is a loser input already
+/// swept behind its now-ignored compaction record; publish-time refusal in
+/// ravel-maintain (out of scope here) closes that window durably.
+pub(crate) fn select_authoritative_compaction_records(
+    records: &[(String, Arc<CompactionRecord>)],
+) -> HashSet<String> {
+    if records.len() < 2 {
+        return HashSet::new();
+    }
+
+    // Union-find over record indices: union two records whenever they name the
+    // same input identity, so a component is a maximal set of records linked by
+    // input-set overlap.
+    let mut parent: Vec<usize> = (0..records.len()).collect();
+    fn find(parent: &mut [usize], mut x: usize) -> usize {
+        while parent[x] != x {
+            parent[x] = parent[parent[x]];
+            x = parent[x];
+        }
+        x
+    }
+    let mut owner: HashMap<(String, u64, u64), usize> = HashMap::new();
+    for (i, (_key, record)) in records.iter().enumerate() {
+        for input in &record.inputs {
+            let identity = (
+                input.writer_id.clone(),
+                input.writer_epoch,
+                input.writer_seq,
+            );
+            if let Some(&j) = owner.get(&identity) {
+                let rj = find(&mut parent, j);
+                let ri = find(&mut parent, i);
+                if ri != rj {
+                    parent[ri] = rj;
+                }
+            } else {
+                owner.insert(identity, i);
+            }
+        }
+    }
+
+    // Group record indices by component root.
+    let mut components: HashMap<usize, Vec<usize>> = HashMap::new();
+    for i in 0..records.len() {
+        let root = find(&mut parent, i);
+        components.entry(root).or_default().push(i);
+    }
+
+    // Within each multi-record component keep the smallest-`input_set_hash`
+    // record; every other record in that component is a loser.
+    let mut losing: HashSet<String> = HashSet::new();
+    for members in components.values() {
+        if members.len() < 2 {
+            continue;
+        }
+        if let Some(&winner) = members.iter().min_by(|&&a, &&b| {
+            records[a]
+                .1
+                .input_set_hash
+                .cmp(&records[b].1.input_set_hash)
+                .then_with(|| records[a].0.cmp(&records[b].0))
+        }) {
+            for &m in members {
+                if m != winner {
+                    losing.insert(records[m].0.clone());
+                }
+            }
+        }
+    }
+    losing
 }
 
 /// Resolve one rewrite record's supersession into the two unified exclusion

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -1,6 +1,7 @@
 //! Snapshot resolution: listing-based discovery over commit records
 //! (docs/catalog-and-mvcc.md "Snapshot resolution", ADR-0003, ADR-0010 §2/§10).
 
+use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -2163,7 +2164,7 @@ impl Catalog {
         let losing_compaction_records =
             select_authoritative_compaction_records(&compaction_records);
         for (ckey, record) in &compaction_records {
-            if losing_compaction_records.contains(ckey) {
+            if losing_compaction_records.contains(ckey.as_str()) {
                 continue;
             }
             for input in &record.inputs {
@@ -2223,7 +2224,9 @@ impl Catalog {
         // (event-bound filtered). A record whose whole output a live rewrite
         // superseded is skipped -- its parts would resurrect erased records.
         for (ckey, record) in &compaction_records {
-            if superseded_records.contains(ckey) || losing_compaction_records.contains(ckey) {
+            if superseded_records.contains(ckey)
+                || losing_compaction_records.contains(ckey.as_str())
+            {
                 continue;
             }
             for part in &record.parts {
@@ -3321,9 +3324,9 @@ fn build_rewrite_l1_segment_ref(
 
 /// Select one authoritative compaction record per *overlap component* of a
 /// bucket, returning the keys of the records whose output parts must be
-/// IGNORED (the losers). Shared by snapshot resolution (`process_bucket`) and
-/// the index fold (`classify_bucket`) so a live resolve and a folded snapshot
-/// derive identical bucket state.
+/// IGNORED (the losers). Shared by snapshot resolution (`process_bucket`), the
+/// index fold (`classify_bucket`), the superseded-input sweep, and the erasure
+/// completion gate, so every one of them derives identical bucket state.
 ///
 /// Two compaction records are in conflict when their input sets overlap (share
 /// at least one L0 input identity). Query-time dedup by `(series_id, ts)`
@@ -3335,12 +3338,18 @@ fn build_rewrite_l1_segment_ref(
 /// (a singleton component) is not in conflict and stays authoritative, so
 /// disjoint records keep today's behaviour (both served).
 ///
-/// Tie-break: the authoritative record is the one with the lexicographically
-/// smallest `input_set_hash`, its key string breaking the impossible
-/// exact-hash tie. `input_set_hash` is a collision-resistant digest of the
-/// record's input identity set, so this is a stable total order every replica
-/// computes identically from the record bytes alone, with no dependence on
-/// wall-clock, listing order, or which compactor won the race.
+/// Tie-break, in order: the LARGEST input set (the count of distinct input
+/// identities the record names), then the lexicographically smallest
+/// `input_set_hash`, then the record key. Preferring the maximal set is what
+/// keeps as much of the bucket as possible inside compacted parts: a record
+/// whose input set is a strict superset of another's always wins, so a
+/// superset/subset pair leaves no input outside the winner at all. The two
+/// fallbacks make the order total; `input_set_hash` is a collision-resistant
+/// digest of the record's input identity set, and the key is the impossible
+/// exact-hash tie. Every term is a pure function of the record bytes, so every
+/// replica, the index fold, the sweep, and the erasure completion gate compute
+/// the same winner, with no dependence on wall-clock, listing order, or which
+/// compactor won the race.
 ///
 /// Coverage (why dropping a loser's parts loses no data): a loser `L` shares a
 /// component with its winner `W`. Each of `L`'s inputs is either also an input
@@ -3349,15 +3358,38 @@ fn build_rewrite_l1_segment_ref(
 /// it cannot be an input of another component's winner, since a shared input
 /// would have merged the two components. So every L0 input of the bucket is
 /// served exactly once: inside exactly one authoritative record's parts, or as
-/// one raw L0 segment. The one residual exposure is a loser input already
-/// swept behind its now-ignored compaction record; publish-time refusal in
-/// ravel-maintain (out of scope here) closes that window durably.
-pub(crate) fn select_authoritative_compaction_records(
-    records: &[(String, Arc<CompactionRecord>)],
-) -> HashSet<String> {
+/// one raw L0 segment. A loser-only input therefore stays load-bearing, which
+/// is why the sweep treats an input as superseded only where an authoritative
+/// record names it, and why the erasure completion gate keeps such an input in
+/// its live view.
+pub fn select_authoritative_compaction_records<K, R>(records: &[(K, R)]) -> HashSet<&str>
+where
+    K: AsRef<str>,
+    R: Borrow<CompactionRecord>,
+{
     if records.len() < 2 {
         return HashSet::new();
     }
+    // Each record's input identities, deduplicated once: the union-find below
+    // walks them, and the tie-break counts them. A malformed record naming the
+    // same input twice must not thereby claim a larger set.
+    let identities: Vec<HashSet<(&str, u64, u64)>> = records
+        .iter()
+        .map(|(_key, record)| {
+            record
+                .borrow()
+                .inputs
+                .iter()
+                .map(|input| {
+                    (
+                        input.writer_id.as_str(),
+                        input.writer_epoch,
+                        input.writer_seq,
+                    )
+                })
+                .collect()
+        })
+        .collect();
 
     // Union-find over record indices: union two records whenever they name the
     // same input identity, so a component is a maximal set of records linked by
@@ -3370,22 +3402,17 @@ pub(crate) fn select_authoritative_compaction_records(
         }
         x
     }
-    let mut owner: HashMap<(String, u64, u64), usize> = HashMap::new();
-    for (i, (_key, record)) in records.iter().enumerate() {
-        for input in &record.inputs {
-            let identity = (
-                input.writer_id.clone(),
-                input.writer_epoch,
-                input.writer_seq,
-            );
-            if let Some(&j) = owner.get(&identity) {
+    let mut owner: HashMap<(&str, u64, u64), usize> = HashMap::new();
+    for (i, inputs) in identities.iter().enumerate() {
+        for identity in inputs {
+            if let Some(&j) = owner.get(identity) {
                 let rj = find(&mut parent, j);
                 let ri = find(&mut parent, i);
                 if ri != rj {
                     parent[ri] = rj;
                 }
             } else {
-                owner.insert(identity, i);
+                owner.insert(*identity, i);
             }
         }
     }
@@ -3397,23 +3424,29 @@ pub(crate) fn select_authoritative_compaction_records(
         components.entry(root).or_default().push(i);
     }
 
-    // Within each multi-record component keep the smallest-`input_set_hash`
-    // record; every other record in that component is a loser.
-    let mut losing: HashSet<String> = HashSet::new();
+    // Within each multi-record component keep the maximal-input-set record;
+    // every other record in that component is a loser.
+    let mut losing: HashSet<&str> = HashSet::new();
     for members in components.values() {
         if members.len() < 2 {
             continue;
         }
         if let Some(&winner) = members.iter().min_by(|&&a, &&b| {
-            records[a]
-                .1
-                .input_set_hash
-                .cmp(&records[b].1.input_set_hash)
-                .then_with(|| records[a].0.cmp(&records[b].0))
+            identities[b]
+                .len()
+                .cmp(&identities[a].len())
+                .then_with(|| {
+                    records[a]
+                        .1
+                        .borrow()
+                        .input_set_hash
+                        .cmp(&records[b].1.borrow().input_set_hash)
+                })
+                .then_with(|| records[a].0.as_ref().cmp(records[b].0.as_ref()))
         }) {
             for &m in members {
                 if m != winner {
-                    losing.insert(records[m].0.clone());
+                    losing.insert(records[m].0.as_ref());
                 }
             }
         }

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -2472,10 +2472,11 @@ impl Catalog {
         // conflict would ever be observed for the ordinary case.
         self.check_rewrite_siblings(shard, hour, &rewrite_records, &superseded_records);
 
-        // Compaction parts: contribute each non-superseded record's parts as
-        // level-1 entries. Two records with different input sets in one
-        // bucket both contribute (a harmless overlap the resolver alarms on
-        // but still serves).
+        // Compaction parts: contribute each non-superseded, authoritative
+        // record's parts as level-1 entries. Records whose input sets overlap
+        // resolve to one winner per overlap component, exactly as the live
+        // resolver picks it; a loser's parts are skipped and any input only
+        // the loser names stays a raw level-0 entry.
         for (ckey, record) in &compaction_records {
             if superseded_records.contains(ckey.as_str())
                 || losing_compaction_records.contains(ckey.as_str())

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -2410,7 +2410,7 @@ impl Catalog {
         let losing_compaction_records =
             crate::catalog::select_authoritative_compaction_records(&compaction_records);
         for (ckey, record) in &compaction_records {
-            if losing_compaction_records.contains(ckey) {
+            if losing_compaction_records.contains(ckey.as_str()) {
                 continue;
             }
             for input in &record.inputs {
@@ -2478,7 +2478,7 @@ impl Catalog {
         // but still serves).
         for (ckey, record) in &compaction_records {
             if superseded_records.contains(ckey.as_str())
-                || losing_compaction_records.contains(ckey)
+                || losing_compaction_records.contains(ckey.as_str())
             {
                 continue;
             }

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -2329,9 +2329,13 @@ impl Catalog {
     /// A retention tombstone makes the bucket contribute nothing: neither its
     /// L1 parts nor its L0 records are folded in (ADR-0019 section 3). Each
     /// compaction record contributes its parts as level-1 entries and
-    /// supersedes its named L0 inputs; two records with different input sets in
+    /// supersedes its named L0 inputs; two records with DISJOINT input sets in
     /// one bucket both contribute (a harmless overlap the resolver alarms on
-    /// but still serves). A selective-erasure rewrite record (ADR-0064
+    /// but still serves), while two whose input sets OVERLAP resolve to one
+    /// authoritative record through
+    /// [`crate::catalog::select_authoritative_compaction_records`] (issue
+    /// #1070), the loser's parts skipped and its uncovered inputs folded in as
+    /// raw L0. A selective-erasure rewrite record (ADR-0064
     /// decision 3, amended) contributes its own output parts as level-1
     /// entries and supersedes either its named L0 inputs directly, or -- when
     /// it names a `superseded_record_key` instead -- whatever that
@@ -2393,6 +2397,22 @@ impl Catalog {
                 .load_and_validate_compaction(tenant, signal, shard, ckey, accounting)
                 .await?;
             counters.get_requests += 1;
+            compaction_records.push(((*ckey).to_string(), record));
+        }
+
+        // Overlapping input sets in one bucket (issue #1070): pick one
+        // authoritative record per overlap component through the SAME helper
+        // snapshot resolution uses, so a folded snapshot and a live resolve
+        // never disagree on which record wins. A loser's parts are skipped
+        // below and only WINNING records' inputs join `excluded`, so a loser
+        // input no winner names is folded in as a raw L0. Disjoint records are
+        // not in conflict and both contribute.
+        let losing_compaction_records =
+            crate::catalog::select_authoritative_compaction_records(&compaction_records);
+        for (ckey, record) in &compaction_records {
+            if losing_compaction_records.contains(ckey) {
+                continue;
+            }
             for input in &record.inputs {
                 excluded.insert((
                     input.writer_id.clone(),
@@ -2400,7 +2420,6 @@ impl Catalog {
                     input.writer_seq,
                 ));
             }
-            compaction_records.push(((*ckey).to_string(), record));
         }
 
         // Load rewrite records (ADR-0064 decision 3), verified against their
@@ -2458,7 +2477,9 @@ impl Catalog {
         // bucket both contribute (a harmless overlap the resolver alarms on
         // but still serves).
         for (ckey, record) in &compaction_records {
-            if superseded_records.contains(ckey.as_str()) {
+            if superseded_records.contains(ckey.as_str())
+                || losing_compaction_records.contains(ckey)
+            {
                 continue;
             }
             for part in &record.parts {

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -32,6 +32,7 @@ pub use auth_token_map::{
 };
 pub use catalog::Catalog;
 pub use catalog::resolve_rewrite_supersession;
+pub use catalog::select_authoritative_compaction_records;
 pub use column_stats_resolve::{LoadColumnStatsError, LoadedColumnStats, unique_column_stat};
 pub use config::{
     CatalogConfig, DEFAULT_BYTE_CACHE_MAX_BYTES, DEFAULT_BYTE_CACHE_MAX_ENTRIES,

--- a/crates/ravel-catalog/tests/compaction_overlap_resolution.rs
+++ b/crates/ravel-catalog/tests/compaction_overlap_resolution.rs
@@ -3,10 +3,11 @@
 //! input sets overlap, query-time dedup by `(series_id, ts)` collapses the
 //! overlap for metrics, but logs and spans have no query-time dedup and would
 //! return the overlapping records twice. The resolver picks one authoritative
-//! record per overlap component (smallest `input_set_hash`), serves its parts,
-//! and serves any input the winner does not name as a raw L0 segment.
+//! record per overlap component (largest input set, then smallest
+//! `input_set_hash`, then the record key), serves its parts, and serves any
+//! input the winner does not name as a raw L0 segment.
 //!
-//! Every test drives a resolve through the real `Catalog` against a
+//! Every test drives a resolve or a fold through the real `Catalog` against a
 //! `MemoryStore`, the same reachability the fix has (the resolver runs on
 //! every query). No segment bytes are needed: resolution reads only records.
 
@@ -76,6 +77,14 @@ async fn put_l0(store: &dyn ObjectStoreBackend, record: &CommitRecord) {
 }
 
 fn part(part_index: u32, seed: u8) -> CompactionPart {
+    part_with_rows(part_index, seed, 10)
+}
+
+/// A part carrying an exact row count, for the tests that assert the resolved
+/// snapshot's rows equal the union of the inputs' rows. A compaction of logs
+/// or spans concatenates its inputs, so a part's `sample_count` is the sum of
+/// the rows of the inputs the record names.
+fn part_with_rows(part_index: u32, seed: u8, sample_count: u64) -> CompactionPart {
     let start = i64::from(HOUR) * NS_PER_HOUR;
     CompactionPart {
         part_index,
@@ -83,7 +92,7 @@ fn part(part_index: u32, seed: u8) -> CompactionPart {
         last_series_id: vec![0xff; 16],
         content_hash: vec![seed; 32],
         object_size: 4096,
-        sample_count: 10,
+        sample_count,
         series_count: 2,
         run_count: 3,
         min_event_ts_ns: start,
@@ -95,8 +104,9 @@ fn part(part_index: u32, seed: u8) -> CompactionPart {
 
 /// Build and PUT a compaction record naming `inputs` for `signal`. `seed`
 /// drives the record's `input_set_hash` (and thus its key and the resolver's
-/// tie-break) independently of `inputs`, so a test can pin which of two
-/// overlapping records wins.
+/// hash tie-break) independently of `inputs`, so a test can pin which of two
+/// equal-cardinality overlapping records wins. Returns the record so a test
+/// can reconstruct its part keys.
 async fn put_compaction_record(
     store: &dyn ObjectStoreBackend,
     signal: Signal,
@@ -104,7 +114,7 @@ async fn put_compaction_record(
     parts: Vec<CompactionPart>,
     created_unix_ns: i64,
     seed: &[u8],
-) {
+) -> CompactionRecord {
     let input_set_hash = *blake3::hash(seed).as_bytes();
     let record = CompactionRecord {
         format_version: 1,
@@ -138,6 +148,7 @@ async fn put_compaction_record(
         )
         .await
         .expect("put compaction record");
+    record
 }
 
 fn hour_range_and_now() -> (TimeRange, i64) {
@@ -171,8 +182,10 @@ fn l0_keys(snapshot: &ravel_catalog::Snapshot) -> Vec<String> {
 }
 
 /// Order two seeds by their `input_set_hash`, returning
-/// `(smaller_hash_seed, larger_hash_seed)`. The resolver's tie-break keeps the
-/// smaller-hash record, so a test hands the winning role the smaller seed.
+/// `(smaller_hash_seed, larger_hash_seed)`. Between records of EQUAL input-set
+/// cardinality the resolver keeps the smaller-hash one, so such a test hands
+/// the winning role the smaller seed. Where the cardinalities differ the hash
+/// does not decide, and a test pins the winner by input count instead.
 fn order_by_hash<'a>(x: &'a [u8], y: &'a [u8]) -> (&'a [u8], &'a [u8]) {
     if blake3::hash(x).as_bytes() <= blake3::hash(y).as_bytes() {
         (x, y)
@@ -286,8 +299,10 @@ async fn overlapping_spans_records_resolve_to_one_authoritative() {
 }
 
 /// An L0 named only by the LOSING record (not by the winner) is not lost: it
-/// falls through to the raw-L0 pass and is served as an L0 segment. The winner
-/// names `[a]`; the loser names `[a, c]`, overlapping on `a` but adding `c`.
+/// falls through to the raw-L0 pass and is served as an L0 segment. The two
+/// records have equal input-set cardinality and neither set contains the
+/// other, so the hash decides: the winner names `[a, b]` and the loser names
+/// `[a, c]`, overlapping on `a`.
 ///
 /// Flipped to watch it fail before the fix: the change that builds `excluded`
 /// from WINNING records only (catalog.rs). Before the fix `excluded` unions
@@ -301,17 +316,20 @@ async fn losing_records_uncovered_l0_input_is_served_as_raw_l0() {
     let (range, now) = hour_range_and_now();
 
     let a = l0_record(Signal::Logs, Uuid::new_v4(), 1, now);
-    let c = l0_record(Signal::Logs, Uuid::new_v4(), 2, now);
+    let b = l0_record(Signal::Logs, Uuid::new_v4(), 2, now);
+    let c = l0_record(Signal::Logs, Uuid::new_v4(), 3, now);
     put_l0(store.as_ref(), &a).await;
+    put_l0(store.as_ref(), &b).await;
     put_l0(store.as_ref(), &c).await;
 
-    // Winner names [a] (smaller seed); loser names [a, c] (overlap on a, extra
-    // c). c is named by no winner, so it must be served as a raw L0.
+    // Winner names [a, b] (smaller seed); loser names [a, c] (overlap on a,
+    // extra c). Same cardinality, so the hash decides. c is named by no
+    // winner, so it must be served as a raw L0.
     let (win_seed, lose_seed) = order_by_hash(b"set-1", b"set-2");
     put_compaction_record(
         store.as_ref(),
         Signal::Logs,
-        &[&a],
+        &[&a, &b],
         vec![part(0, 1)],
         now,
         win_seed,
@@ -459,4 +477,374 @@ async fn overlapping_conflicts_counter_increments_exactly_once() {
         "resolved to one authoritative record"
     );
     assert_eq!(snapshot.segments.len(), 1);
+}
+
+/// Rows a resolve serves, summed over its segments. Logs and spans have no
+/// query-time dedup (docs/consistency-model.md): the distributed merge
+/// concatenates the per-slice results and sorts them, so the rows a query
+/// returns are exactly the rows of the resolved segments.
+fn served_rows(snapshot: &ravel_catalog::Snapshot) -> u64 {
+    snapshot.segments.iter().map(|s| s.sample_count).sum()
+}
+
+/// The three seeds ordered by their `input_set_hash`, ascending. A test that
+/// needs the maximal-cardinality record to lose the hash comparison hands it
+/// the last one.
+fn seeds_by_hash(seeds: [&[u8]; 3]) -> [&[u8]; 3] {
+    let mut ordered = seeds;
+    ordered.sort_by_key(|s| *blake3::hash(s).as_bytes());
+    ordered
+}
+
+fn sorted(mut keys: Vec<String>) -> Vec<String> {
+    keys.sort();
+    keys
+}
+
+/// A logs bucket with two overlapping records serves the UNION of the inputs'
+/// rows, not their sum. `a`, `b` and `c` carry one row each; the winner's part
+/// carries the two rows of `[a, b]` and the loser's the two rows of `[a, c]`.
+/// The union is three rows: two inside the winner's part plus the one row of
+/// the uncovered input `c`, served raw.
+///
+/// Flipped to watch it fail: make `select_authoritative_compaction_records`
+/// return an empty set (catalog.rs), which is how the resolver behaved before
+/// issue #1070. Both parts are then served and `a`'s row is counted twice, so
+/// `served_rows` is 4 and the `== 3` assertion below fails.
+#[tokio::test]
+async fn overlapping_logs_rows_equal_the_union_not_the_sum() {
+    let store = Arc::new(MemoryStore::new());
+    let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let (range, now) = hour_range_and_now();
+
+    let a = l0_record(Signal::Logs, Uuid::new_v4(), 1, now);
+    let b = l0_record(Signal::Logs, Uuid::new_v4(), 2, now);
+    let c = l0_record(Signal::Logs, Uuid::new_v4(), 3, now);
+    put_l0(store.as_ref(), &a).await;
+    put_l0(store.as_ref(), &b).await;
+    put_l0(store.as_ref(), &c).await;
+
+    let (win_seed, lose_seed) = order_by_hash(b"rows-1", b"rows-2");
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a, &b],
+        vec![part_with_rows(0, 1, 2)],
+        now,
+        win_seed,
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a, &c],
+        vec![part_with_rows(0, 2, 2)],
+        now,
+        lose_seed,
+    )
+    .await;
+
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Logs, range, &[], now)
+        .await
+        .expect("resolve");
+
+    assert_eq!(
+        served_rows(&snapshot),
+        3,
+        "the union of a, b and c, with a served once"
+    );
+    assert_eq!(l1_keys(&snapshot).len(), 1, "only the winner's part");
+    assert_eq!(l0_keys(&snapshot).len(), 1, "the uncovered input c, raw");
+}
+
+/// The same for spans, which have no query-time dedup either.
+///
+/// Flipped to watch it fail: the same empty-set flip as above; `served_rows`
+/// becomes 4.
+#[tokio::test]
+async fn overlapping_spans_rows_equal_the_union_not_the_sum() {
+    let store = Arc::new(MemoryStore::new());
+    let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let (range, now) = hour_range_and_now();
+
+    let a = l0_record(Signal::Spans, Uuid::new_v4(), 1, now);
+    let b = l0_record(Signal::Spans, Uuid::new_v4(), 2, now);
+    let c = l0_record(Signal::Spans, Uuid::new_v4(), 3, now);
+    put_l0(store.as_ref(), &a).await;
+    put_l0(store.as_ref(), &b).await;
+    put_l0(store.as_ref(), &c).await;
+
+    let (win_seed, lose_seed) = order_by_hash(b"rows-1", b"rows-2");
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Spans,
+        &[&a, &b],
+        vec![part_with_rows(0, 1, 2)],
+        now,
+        win_seed,
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Spans,
+        &[&a, &c],
+        vec![part_with_rows(0, 2, 2)],
+        now,
+        lose_seed,
+    )
+    .await;
+
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Spans, range, &[], now)
+        .await
+        .expect("resolve");
+
+    assert_eq!(
+        served_rows(&snapshot),
+        3,
+        "the union of a, b and c, with a served once"
+    );
+    assert_eq!(l1_keys(&snapshot).len(), 1, "only the winner's part");
+    assert_eq!(l0_keys(&snapshot).len(), 1, "the uncovered input c, raw");
+}
+
+/// The folded index names exactly what a live resolve serves: the winner's L1
+/// entry and, as a raw L0 entry, the input only the loser names. The winner
+/// names the three-input set `[a, b, c]` and carries the LARGER hash, so the
+/// maximal-set tie-break is what selects it.
+///
+/// Fails on the branch before the tie-break change: the smaller-hash record
+/// `[a, d]` wins there, so the folded snapshot names that record's part and
+/// carries `b` and `c` as raw L0 entries. The `l1_keys` equality below fails
+/// (it names the loser's part key), and so does the `l0_keys` equality (two
+/// entries, `b` and `c`, instead of the one entry `d`).
+#[tokio::test]
+async fn fold_of_overlapping_records_names_the_winner_and_the_uncovered_input() {
+    let store = Arc::new(MemoryStore::new());
+    let hour_start = i64::from(HOUR) * NS_PER_HOUR;
+    let created = hour_start + 60_000_000_000;
+    // Six hours past the bucket, so the fold's watermark seals it.
+    let now = hour_start + 6 * NS_PER_HOUR;
+    let range = TimeRange {
+        start_ns: hour_start,
+        end_ns: now,
+    };
+
+    let a = l0_record(Signal::Logs, Uuid::new_v4(), 1, created);
+    let b = l0_record(Signal::Logs, Uuid::new_v4(), 2, created);
+    let c = l0_record(Signal::Logs, Uuid::new_v4(), 3, created);
+    let d = l0_record(Signal::Logs, Uuid::new_v4(), 4, created);
+    for record in [&a, &b, &c, &d] {
+        put_l0(store.as_ref(), record).await;
+    }
+
+    // The maximal set takes the LARGER hash, so only cardinality can select
+    // it. The two records overlap on a.
+    let (lose_seed, win_seed) = order_by_hash(b"fold-1", b"fold-2");
+    let winner = put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a, &b, &c],
+        vec![part_with_rows(0, 1, 3)],
+        created,
+        win_seed,
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a, &d],
+        vec![part_with_rows(0, 2, 2)],
+        created,
+        lose_seed,
+    )
+    .await;
+
+    let winner_part_key =
+        keys::reconstruct_l1_part_key(&winner, &winner.parts[0]).expect("winner part key");
+    let d_key = keys::reconstruct_data_key(&d).expect("d data key");
+
+    // Resolve from the direct listing first, then fold and resolve again: the
+    // index fold and the resolver must derive the same bucket state.
+    let before_catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let before = before_catalog
+        .resolve(&tenant(), Signal::Logs, range, &[], now)
+        .await
+        .expect("resolve before fold");
+
+    let fold_catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let report = fold_catalog
+        .fold(&tenant(), Signal::Logs, Uuid::new_v4(), now, &[], None)
+        .await
+        .expect("fold");
+    assert!(!report.no_op, "the fold sealed the bucket");
+
+    let after_catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let after = after_catalog
+        .resolve(&tenant(), Signal::Logs, range, &[], now)
+        .await
+        .expect("resolve after fold");
+
+    assert_eq!(
+        l1_keys(&after),
+        vec![winner_part_key.clone()],
+        "the folded snapshot names only the winner's L1 entry"
+    );
+    assert_eq!(
+        l0_keys(&after),
+        vec![d_key.clone()],
+        "and the loser's uncovered input as a raw L0 entry"
+    );
+    assert_eq!(after.segments.len(), 2);
+    assert_eq!(
+        before, after,
+        "a live resolve returns the identical segment set"
+    );
+}
+
+/// A transitive component: A overlaps B on `b`, B overlaps C on `d`, and A and
+/// C are disjoint. All three are one component, and the maximal record B wins
+/// even though it carries the largest hash. The inputs only A and C name (`a`
+/// and `e`) are served raw; the inputs B names (`b`, `c`, `d`) are served
+/// inside B's part, once each.
+///
+/// Fails on the branch before the tie-break change: the smallest-hash record A
+/// wins there, so `l1_keys` names A's part and `l0_keys` is `[c, d, e]`. Both
+/// equalities below fail.
+#[tokio::test]
+async fn transitive_overlap_component_resolves_to_the_maximal_record() {
+    let store = Arc::new(MemoryStore::new());
+    let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let (range, now) = hour_range_and_now();
+
+    let a = l0_record(Signal::Logs, Uuid::new_v4(), 1, now);
+    let b = l0_record(Signal::Logs, Uuid::new_v4(), 2, now);
+    let c = l0_record(Signal::Logs, Uuid::new_v4(), 3, now);
+    let d = l0_record(Signal::Logs, Uuid::new_v4(), 4, now);
+    let e = l0_record(Signal::Logs, Uuid::new_v4(), 5, now);
+    for record in [&a, &b, &c, &d, &e] {
+        put_l0(store.as_ref(), record).await;
+    }
+
+    // A takes the smallest hash and B the largest, so only cardinality can
+    // select B.
+    let [a_seed, c_seed, b_seed] = seeds_by_hash([b"tri-1", b"tri-2", b"tri-3"]);
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a, &b],
+        vec![part_with_rows(0, 1, 2)],
+        now,
+        a_seed,
+    )
+    .await;
+    let winner = put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&b, &c, &d],
+        vec![part_with_rows(0, 2, 3)],
+        now,
+        b_seed,
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&d, &e],
+        vec![part_with_rows(0, 3, 2)],
+        now,
+        c_seed,
+    )
+    .await;
+
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Logs, range, &[], now)
+        .await
+        .expect("resolve");
+
+    let winner_part_key =
+        keys::reconstruct_l1_part_key(&winner, &winner.parts[0]).expect("winner part key");
+    let a_key = keys::reconstruct_data_key(&a).expect("a data key");
+    let e_key = keys::reconstruct_data_key(&e).expect("e data key");
+
+    assert_eq!(
+        l1_keys(&snapshot),
+        vec![winner_part_key],
+        "the maximal record of the component serves its part"
+    );
+    assert_eq!(
+        sorted(l0_keys(&snapshot)),
+        sorted(vec![a_key, e_key]),
+        "the inputs no winner names are served raw"
+    );
+    assert_eq!(snapshot.segments.len(), 3);
+    assert_eq!(
+        served_rows(&snapshot),
+        5,
+        "each of the five inputs' rows served once"
+    );
+    assert_eq!(catalog.compaction_input_set_conflicts(), 1);
+}
+
+/// A strict superset wins over a smaller-hash subset, and leaves nothing
+/// outside the winner: every input of the component is named by the winner, so
+/// the snapshot is exactly one L1 part.
+///
+/// Fails on the branch before the tie-break change: the smaller-hash subset
+/// `[a, b]` wins there, `c` is served as a raw L0, and the `l0_keys().is_empty
+/// ()` and `segments.len() == 1` assertions below fail (one raw L0, two
+/// segments).
+#[tokio::test]
+async fn strict_superset_input_set_wins_over_the_smaller_hash() {
+    let store = Arc::new(MemoryStore::new());
+    let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let (range, now) = hour_range_and_now();
+
+    let a = l0_record(Signal::Logs, Uuid::new_v4(), 1, now);
+    let b = l0_record(Signal::Logs, Uuid::new_v4(), 2, now);
+    let c = l0_record(Signal::Logs, Uuid::new_v4(), 3, now);
+    for record in [&a, &b, &c] {
+        put_l0(store.as_ref(), record).await;
+    }
+
+    let (lose_seed, win_seed) = order_by_hash(b"sup-1", b"sup-2");
+    let winner = put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a, &b, &c],
+        vec![part_with_rows(0, 1, 3)],
+        now,
+        win_seed,
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a, &b],
+        vec![part_with_rows(0, 2, 2)],
+        now,
+        lose_seed,
+    )
+    .await;
+
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Logs, range, &[], now)
+        .await
+        .expect("resolve");
+
+    let winner_part_key =
+        keys::reconstruct_l1_part_key(&winner, &winner.parts[0]).expect("winner part key");
+    assert_eq!(
+        l1_keys(&snapshot),
+        vec![winner_part_key],
+        "the superset record serves its part"
+    );
+    assert_eq!(
+        l0_keys(&snapshot),
+        Vec::<String>::new(),
+        "the superset leaves no input outside itself"
+    );
+    assert_eq!(snapshot.segments.len(), 1);
+    assert_eq!(served_rows(&snapshot), 3);
 }

--- a/crates/ravel-catalog/tests/compaction_overlap_resolution.rs
+++ b/crates/ravel-catalog/tests/compaction_overlap_resolution.rs
@@ -1,0 +1,462 @@
+//! Resolve-time conflict resolution for overlapping compaction records
+//! (issue #1070). When one sealed bucket holds two compaction records whose
+//! input sets overlap, query-time dedup by `(series_id, ts)` collapses the
+//! overlap for metrics, but logs and spans have no query-time dedup and would
+//! return the overlapping records twice. The resolver picks one authoritative
+//! record per overlap component (smallest `input_set_hash`), serves its parts,
+//! and serves any input the winner does not name as a raw L0 segment.
+//!
+//! Every test drives a resolve through the real `Catalog` against a
+//! `MemoryStore`, the same reachability the fix has (the resolver runs on
+//! every query). No segment bytes are needed: resolution reads only records.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use prost::Message;
+use ravel_catalog::{Catalog, CatalogConfig, SegmentLevel};
+use ravel_commit::record::{self, NewCommitRecord};
+use ravel_commit::{keys, signal};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_proto::commit::v1::{
+    CommitRecord, CompactionInputIdentity, CompactionPart, CompactionRecord,
+};
+use ravel_segment::VERSION_V7;
+use ravel_types::{Signal, TenantHash, TimeRange};
+use uuid::Uuid;
+
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+const HOUR: u32 = 500_000;
+
+fn tenant() -> TenantHash {
+    TenantHash([0xab; 16])
+}
+
+fn config(shard_count: u32) -> CatalogConfig {
+    CatalogConfig {
+        shard_count,
+        ..Default::default()
+    }
+}
+
+/// A self-consistent L0 commit record for `signal`. No segment bytes:
+/// resolution reads only the record.
+fn l0_record(signal: Signal, writer_id: Uuid, seq: u64, created_unix_ns: i64) -> CommitRecord {
+    let start = i64::from(HOUR) * NS_PER_HOUR;
+    record::build(NewCommitRecord {
+        tenant_hash: tenant(),
+        signal,
+        shard: 0,
+        writer_id,
+        writer_epoch: 1,
+        writer_seq: seq,
+        object_size: 100,
+        content_hash: [seq as u8 ^ 0x5a; 32],
+        sample_count: 1,
+        series_count: 1,
+        min_event_ts_ns: start,
+        max_event_ts_ns: start + 100,
+        min_ingest_ts_ns: start,
+        max_ingest_ts_ns: start + 100,
+        segment_format_version: u32::from(VERSION_V7),
+        created_unix_ns,
+        ingest_hour_bucket: HOUR,
+    })
+    .expect("valid record")
+}
+
+async fn put_l0(store: &dyn ObjectStoreBackend, record: &CommitRecord) {
+    let key = keys::commit_key_for_record(record).expect("commit key");
+    store
+        .put(&key, record::encode(record), PutOptions::create_if_absent())
+        .await
+        .expect("put commit record");
+}
+
+fn part(part_index: u32, seed: u8) -> CompactionPart {
+    let start = i64::from(HOUR) * NS_PER_HOUR;
+    CompactionPart {
+        part_index,
+        first_series_id: vec![0u8; 16],
+        last_series_id: vec![0xff; 16],
+        content_hash: vec![seed; 32],
+        object_size: 4096,
+        sample_count: 10,
+        series_count: 2,
+        run_count: 3,
+        min_event_ts_ns: start,
+        max_event_ts_ns: start + 100,
+        segment_format_version: u32::from(VERSION_V7),
+        declared_column_stats: Vec::new(),
+    }
+}
+
+/// Build and PUT a compaction record naming `inputs` for `signal`. `seed`
+/// drives the record's `input_set_hash` (and thus its key and the resolver's
+/// tie-break) independently of `inputs`, so a test can pin which of two
+/// overlapping records wins.
+async fn put_compaction_record(
+    store: &dyn ObjectStoreBackend,
+    signal: Signal,
+    inputs: &[&CommitRecord],
+    parts: Vec<CompactionPart>,
+    created_unix_ns: i64,
+    seed: &[u8],
+) {
+    let input_set_hash = *blake3::hash(seed).as_bytes();
+    let record = CompactionRecord {
+        format_version: 1,
+        tenant_hash: tenant().0.to_vec(),
+        signal: signal::to_proto(signal) as i32,
+        shard: 0,
+        ingest_hour_bucket: HOUR,
+        level: 1,
+        inputs: inputs
+            .iter()
+            .map(|r| CompactionInputIdentity {
+                writer_id: r.writer_id.clone(),
+                writer_epoch: r.writer_epoch,
+                writer_seq: r.writer_seq,
+            })
+            .collect(),
+        input_set_hash: input_set_hash.to_vec(),
+        parts,
+        created_unix_ns,
+    };
+    let hash16: String = input_set_hash[..8]
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    let key = keys::compaction_record_key(&tenant(), signal, 0, HOUR, &hash16).expect("record key");
+    store
+        .put(
+            &key,
+            record.encode_to_vec().into(),
+            PutOptions::create_if_absent(),
+        )
+        .await
+        .expect("put compaction record");
+}
+
+fn hour_range_and_now() -> (TimeRange, i64) {
+    let start = i64::from(HOUR) * NS_PER_HOUR;
+    let now = start + 30 * 60_000_000_000;
+    (
+        TimeRange {
+            start_ns: start,
+            end_ns: start + NS_PER_HOUR,
+        },
+        now,
+    )
+}
+
+fn l1_keys(snapshot: &ravel_catalog::Snapshot) -> Vec<String> {
+    snapshot
+        .segments
+        .iter()
+        .filter(|s| matches!(s.level, SegmentLevel::L1 { .. }))
+        .map(|s| s.data_object_key.clone())
+        .collect()
+}
+
+fn l0_keys(snapshot: &ravel_catalog::Snapshot) -> Vec<String> {
+    snapshot
+        .segments
+        .iter()
+        .filter(|s| matches!(s.level, SegmentLevel::L0))
+        .map(|s| s.data_object_key.clone())
+        .collect()
+}
+
+/// Order two seeds by their `input_set_hash`, returning
+/// `(smaller_hash_seed, larger_hash_seed)`. The resolver's tie-break keeps the
+/// smaller-hash record, so a test hands the winning role the smaller seed.
+fn order_by_hash<'a>(x: &'a [u8], y: &'a [u8]) -> (&'a [u8], &'a [u8]) {
+    if blake3::hash(x).as_bytes() <= blake3::hash(y).as_bytes() {
+        (x, y)
+    } else {
+        (y, x)
+    }
+}
+
+/// Two overlapping records in one logs bucket resolve to the ONE authoritative
+/// record's parts, not both. The winner names the superset `[a, b]`, so the
+/// loser adds no uncovered input and the snapshot is exactly one L1 part.
+///
+/// Flipped to watch it fail before the fix: the `losing_compaction_records`
+/// skip in `process_bucket`'s part-inclusion loop (catalog.rs). Without it the
+/// resolver includes both records' parts, so `l1_keys().len()` is 2 and the
+/// `== 1` assertion below fails.
+#[tokio::test]
+async fn overlapping_logs_records_resolve_to_one_authoritative() {
+    let store = Arc::new(MemoryStore::new());
+    let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let (range, now) = hour_range_and_now();
+
+    let a = l0_record(Signal::Logs, Uuid::new_v4(), 1, now);
+    let b = l0_record(Signal::Logs, Uuid::new_v4(), 2, now);
+    put_l0(store.as_ref(), &a).await;
+    put_l0(store.as_ref(), &b).await;
+
+    // Winner names [a, b] (superset); loser names [a] (overlap on a). The
+    // winner takes the smaller-hash seed so the tie-break is pinned.
+    let (win_seed, lose_seed) = order_by_hash(b"set-1", b"set-2");
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a, &b],
+        vec![part(0, 1)],
+        now,
+        win_seed,
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a],
+        vec![part(0, 2)],
+        now,
+        lose_seed,
+    )
+    .await;
+
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Logs, range, &[], now)
+        .await
+        .expect("resolve");
+
+    assert_eq!(
+        l1_keys(&snapshot).len(),
+        1,
+        "one authoritative L1 part, not both"
+    );
+    assert_eq!(snapshot.segments.len(), 1, "no uncovered L0 leftover");
+    assert_eq!(catalog.compaction_input_set_conflicts(), 1);
+}
+
+/// The same for spans: overlapping records resolve to one authoritative part.
+///
+/// Flipped to watch it fail before the fix: same skip as above; without it
+/// `l1_keys().len()` is 2.
+#[tokio::test]
+async fn overlapping_spans_records_resolve_to_one_authoritative() {
+    let store = Arc::new(MemoryStore::new());
+    let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let (range, now) = hour_range_and_now();
+
+    let a = l0_record(Signal::Spans, Uuid::new_v4(), 1, now);
+    let b = l0_record(Signal::Spans, Uuid::new_v4(), 2, now);
+    put_l0(store.as_ref(), &a).await;
+    put_l0(store.as_ref(), &b).await;
+
+    let (win_seed, lose_seed) = order_by_hash(b"set-1", b"set-2");
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Spans,
+        &[&a, &b],
+        vec![part(0, 1)],
+        now,
+        win_seed,
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Spans,
+        &[&a],
+        vec![part(0, 2)],
+        now,
+        lose_seed,
+    )
+    .await;
+
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Spans, range, &[], now)
+        .await
+        .expect("resolve");
+
+    assert_eq!(
+        l1_keys(&snapshot).len(),
+        1,
+        "one authoritative L1 part, not both"
+    );
+    assert_eq!(snapshot.segments.len(), 1, "no uncovered L0 leftover");
+    assert_eq!(catalog.compaction_input_set_conflicts(), 1);
+}
+
+/// An L0 named only by the LOSING record (not by the winner) is not lost: it
+/// falls through to the raw-L0 pass and is served as an L0 segment. The winner
+/// names `[a]`; the loser names `[a, c]`, overlapping on `a` but adding `c`.
+///
+/// Flipped to watch it fail before the fix: the change that builds `excluded`
+/// from WINNING records only (catalog.rs). Before the fix `excluded` unions
+/// every record's inputs, so `c` is excluded and served (double-counted)
+/// inside the loser's part instead: `l0_keys().len()` is 0 and the `== 1`
+/// assertion below fails.
+#[tokio::test]
+async fn losing_records_uncovered_l0_input_is_served_as_raw_l0() {
+    let store = Arc::new(MemoryStore::new());
+    let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let (range, now) = hour_range_and_now();
+
+    let a = l0_record(Signal::Logs, Uuid::new_v4(), 1, now);
+    let c = l0_record(Signal::Logs, Uuid::new_v4(), 2, now);
+    put_l0(store.as_ref(), &a).await;
+    put_l0(store.as_ref(), &c).await;
+
+    // Winner names [a] (smaller seed); loser names [a, c] (overlap on a, extra
+    // c). c is named by no winner, so it must be served as a raw L0.
+    let (win_seed, lose_seed) = order_by_hash(b"set-1", b"set-2");
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a],
+        vec![part(0, 1)],
+        now,
+        win_seed,
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a, &c],
+        vec![part(0, 2)],
+        now,
+        lose_seed,
+    )
+    .await;
+
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Logs, range, &[], now)
+        .await
+        .expect("resolve");
+
+    assert_eq!(l1_keys(&snapshot).len(), 1, "only the winner's part");
+    let served_l0 = l0_keys(&snapshot);
+    assert_eq!(
+        served_l0.len(),
+        1,
+        "the loser's uncovered input c survives as L0"
+    );
+    let c_key = keys::reconstruct_data_key(&c).expect("c data key");
+    assert_eq!(served_l0[0], c_key, "the survivor is exactly c");
+    assert_eq!(snapshot.segments.len(), 2, "one L1 part plus raw L0 c");
+    assert_eq!(catalog.compaction_input_set_conflicts(), 1);
+}
+
+/// Two records with DISJOINT input sets are not in conflict: both still
+/// resolve, exactly as before the fix. This pins that the conflict rule fires
+/// only on overlap.
+///
+/// Flipped to watch it fail (the assertion is load-bearing): make
+/// `select_authoritative_compaction_records` treat any two records as
+/// conflicting (drop the per-component `members.len() < 2` guard and pick one
+/// winner across the whole bucket). Then one disjoint record is wrongly
+/// dropped, `l1_keys().len()` is 1, and the `== 2` assertion below fails.
+#[tokio::test]
+async fn disjoint_records_both_resolve() {
+    let store = Arc::new(MemoryStore::new());
+    let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let (range, now) = hour_range_and_now();
+
+    let a = l0_record(Signal::Logs, Uuid::new_v4(), 1, now);
+    let b = l0_record(Signal::Logs, Uuid::new_v4(), 2, now);
+    put_l0(store.as_ref(), &a).await;
+    put_l0(store.as_ref(), &b).await;
+
+    // Disjoint: [a] and [b] share no input identity.
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a],
+        vec![part(0, 1)],
+        now,
+        b"set-1",
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&b],
+        vec![part(0, 2)],
+        now,
+        b"set-2",
+    )
+    .await;
+
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Logs, range, &[], now)
+        .await
+        .expect("resolve");
+
+    assert_eq!(
+        l1_keys(&snapshot).len(),
+        2,
+        "disjoint records both serve their parts"
+    );
+    assert_eq!(
+        snapshot.segments.len(),
+        2,
+        "both inputs excluded, no L0 leftover"
+    );
+    assert_eq!(catalog.compaction_input_set_conflicts(), 1);
+}
+
+/// The conflicts counter increments exactly once for the overlapping case (not
+/// zero, not per-record). Paired with the `l1_keys().len() == 1` assertion so
+/// the test also pins that the overlap was actually resolved to one record.
+///
+/// Flipped to watch the counter assertion fail: change the counter site's
+/// `fetch_add(1, ...)` to `fetch_add(2, ...)` in `process_bucket`
+/// (catalog.rs); the `== 1` below then fails. The `l1_keys().len() == 1`
+/// assertion additionally fails before the fix, as in the tests above.
+#[tokio::test]
+async fn overlapping_conflicts_counter_increments_exactly_once() {
+    let store = Arc::new(MemoryStore::new());
+    let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let (range, now) = hour_range_and_now();
+
+    let a = l0_record(Signal::Logs, Uuid::new_v4(), 1, now);
+    let b = l0_record(Signal::Logs, Uuid::new_v4(), 2, now);
+    put_l0(store.as_ref(), &a).await;
+    put_l0(store.as_ref(), &b).await;
+
+    // Overlap on b; winner names the superset [a, b].
+    let (win_seed, lose_seed) = order_by_hash(b"set-1", b"set-2");
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&a, &b],
+        vec![part(0, 1)],
+        now,
+        win_seed,
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        Signal::Logs,
+        &[&b],
+        vec![part(0, 2)],
+        now,
+        lose_seed,
+    )
+    .await;
+
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Logs, range, &[], now)
+        .await
+        .expect("resolve");
+
+    assert_eq!(
+        catalog.compaction_input_set_conflicts(),
+        1,
+        "once per conflicted bucket"
+    );
+    assert_eq!(
+        l1_keys(&snapshot).len(),
+        1,
+        "resolved to one authoritative record"
+    );
+    assert_eq!(snapshot.segments.len(), 1);
+}

--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -2072,8 +2072,22 @@ pub async fn bucket_erasure_completion(
     // Build the query path's two exclusion sets. `excluded` names raw L0
     // identities that a compaction or rewrite superseded; `superseded_records`
     // names whole compaction/rewrite records whose output parts are dropped.
+    //
+    // Overlapping compaction records resolve to one authoritative record per
+    // overlap component, through the same function the snapshot resolver and
+    // the index fold use: only a WINNER's inputs are excluded, so an input
+    // only a loser names stays in `live_l0` because that is where a query
+    // reads it from, and a loser's parts are dropped below. Building the
+    // exclusion set from every record instead would hide a resolvable raw L0
+    // from this gate and let a `.done` be written while the subject is still
+    // returnable.
+    let losing_records =
+        ravel_catalog::select_authoritative_compaction_records(&compaction_records);
     let mut excluded: HashSet<(String, u64, u64)> = HashSet::new();
-    for (_, record) in &compaction_records {
+    for (key, record) in &compaction_records {
+        if losing_records.contains(key.as_str()) {
+            continue;
+        }
         for input in &record.inputs {
             excluded.insert((
                 input.writer_id.clone(),
@@ -2082,6 +2096,7 @@ pub async fn bucket_erasure_completion(
             ));
         }
     }
+    let losing_records: HashSet<String> = losing_records.into_iter().map(str::to_owned).collect();
     let mut superseded_records: HashSet<String> = HashSet::new();
     if !rewrite_records.is_empty() {
         let compaction_by_key: HashMap<&str, &CompactionRecord> = compaction_records
@@ -2138,7 +2153,7 @@ pub async fn bucket_erasure_completion(
         .collect();
     let live_compactions: Vec<&CompactionRecord> = compaction_records
         .iter()
-        .filter(|(key, _)| !superseded_records.contains(key))
+        .filter(|(key, _)| !superseded_records.contains(key) && !losing_records.contains(key))
         .map(|(_, record)| record)
         .collect();
     let live_rewrites: Vec<&RewriteRecord> = rewrite_records

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -105,6 +105,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use prost::Message;
+use ravel_catalog::select_authoritative_compaction_records;
 use ravel_commit::keys::{self, BucketEntry, KeyError, parse_ingest_hour_string};
 use ravel_commit::record;
 use ravel_object_store::{GetRange, ObjectMeta, ObjectStoreBackend, StoreError, list_all};
@@ -743,6 +744,13 @@ async fn sweep_superseded_impl(
         .map(|r| r.superseded_record_key.as_str())
         .filter(|k| !k.is_empty())
         .collect();
+    // Every compaction record in scope, read once for the pass, and the input
+    // identities the AUTHORITATIVE records of each bucket name. A record whose
+    // inputs overlap another's may be the loser of its overlap component, and
+    // the resolver serves an input only the loser names as a raw L0 segment
+    // rather than from any part: see [`AuthoritativeInputs`].
+    let compactions = load_compaction_records(store, &entries).await?;
+    let authoritative = AuthoritativeInputs::from_records(&compactions);
 
     // Phase A: gather every group this pass could delete, deduplicated by
     // chain identity across the whole pass. Two live rewrites naming the same
@@ -776,7 +784,7 @@ async fn sweep_superseded_impl(
         // group applied themselves.
         let (gathered, applied) = match entry {
             BucketEntry::CompactionRecord(_) => {
-                let Some(record) = get_compaction_record_opt(store, key).await? else {
+                let Some(record) = compactions.get(key) else {
                     continue;
                 };
                 // Horizon gate anchored on the durable created_unix_ns. It
@@ -790,8 +798,9 @@ async fn sweep_superseded_impl(
                 {
                     continue;
                 }
+                let superseded = authoritative.superseded_view(record);
                 (
-                    gather_l0_inputs(store, tenant, signal, shard, &record).await?,
+                    gather_l0_inputs(store, tenant, signal, shard, &superseded).await?,
                     Vec::new(),
                 )
             }
@@ -993,6 +1002,109 @@ async fn load_rewrite_records(
     Ok(out)
 }
 
+/// GET every compaction record among `entries`, keyed by its commit key,
+/// tolerant of a key that vanished between the pass's LIST and now.
+async fn load_compaction_records(
+    store: &dyn ObjectStoreBackend,
+    entries: &[(String, BucketEntry)],
+) -> Result<HashMap<String, CompactionRecord>> {
+    let mut out: HashMap<String, CompactionRecord> = HashMap::new();
+    for (key, entry) in entries {
+        if !matches!(entry, BucketEntry::CompactionRecord(_)) {
+            continue;
+        }
+        if let Some(record) = get_compaction_record_opt(store, key).await? {
+            out.insert(key.clone(), record);
+        }
+    }
+    Ok(out)
+}
+
+/// The input identities the authoritative compaction records of each
+/// ingest-hour bucket name.
+///
+/// Compaction records whose input sets overlap resolve to one authoritative
+/// record per overlap component
+/// ([`select_authoritative_compaction_records`], the same function the
+/// snapshot resolver and the index fold use). The losers' parts are served
+/// from nowhere, and an input only a loser names is served as a raw L0
+/// segment: it is the sole server of its rows. So an input is superseded only
+/// where an authoritative record names it. Treating a loser's whole input set
+/// as superseded deletes that sole server and turns duplicate rows into
+/// missing rows. A loser's own parts become unreferenced instead and fall to
+/// rule 3.
+#[derive(Default)]
+struct AuthoritativeInputs {
+    by_bucket: HashMap<u32, HashSet<(String, u64, u64)>>,
+}
+
+impl AuthoritativeInputs {
+    fn from_records(records: &HashMap<String, CompactionRecord>) -> Self {
+        // Per bucket, because an overlap component is a property of one
+        // ingest-hour bucket: that is the unit the resolver reads.
+        let mut per_bucket: HashMap<u32, Vec<(&str, &CompactionRecord)>> = HashMap::new();
+        for (key, record) in records {
+            per_bucket
+                .entry(record.ingest_hour_bucket)
+                .or_default()
+                .push((key.as_str(), record));
+        }
+        let mut by_bucket: HashMap<u32, HashSet<(String, u64, u64)>> = HashMap::new();
+        for (bucket, in_bucket) in per_bucket {
+            let losing = select_authoritative_compaction_records(&in_bucket);
+            let mut identities: HashSet<(String, u64, u64)> = HashSet::new();
+            for (key, record) in &in_bucket {
+                if losing.contains(key) {
+                    continue;
+                }
+                for input in &record.inputs {
+                    identities.insert((
+                        input.writer_id.clone(),
+                        input.writer_epoch,
+                        input.writer_seq,
+                    ));
+                }
+            }
+            by_bucket.insert(bucket, identities);
+        }
+        Self { by_bucket }
+    }
+
+    /// The subset of `record`'s inputs this rule may treat as superseded: the
+    /// ones an authoritative record of the same bucket also names. For a
+    /// winner that is its whole input set; for a loser it is the overlap with
+    /// its winner.
+    fn superseded_view(&self, record: &CompactionRecord) -> SupersededSubset {
+        let authoritative = self.by_bucket.get(&record.ingest_hour_bucket);
+        let inputs = record
+            .inputs
+            .iter()
+            .filter(|input| {
+                authoritative.is_some_and(|set| {
+                    set.contains(&(
+                        input.writer_id.clone(),
+                        input.writer_epoch,
+                        input.writer_seq,
+                    ))
+                })
+            })
+            .cloned()
+            .collect();
+        SupersededSubset {
+            inputs,
+            ingest_hour_bucket: record.ingest_hour_bucket,
+        }
+    }
+}
+
+/// The superseded-input view of one compaction record: its inputs narrowed to
+/// the ones an authoritative record names. Carries the record's own bucket so
+/// [`gather_l0_inputs`] reconstructs the same keys it would from the record.
+struct SupersededSubset {
+    inputs: Vec<CompactionInputIdentity>,
+    ingest_hour_bucket: u32,
+}
+
 /// One indivisible deletion unit for rule 2: the records to delete first, the
 /// data objects to delete after them, and the snapshot identities those
 /// objects carry so the HEAD-reachability gate can decide the whole unit at
@@ -1191,6 +1303,15 @@ impl SupersededInputs for CompactionRecord {
 }
 
 impl SupersededInputs for RewriteRecord {
+    fn inputs(&self) -> &[CompactionInputIdentity] {
+        &self.inputs
+    }
+    fn ingest_hour_bucket(&self) -> u32 {
+        self.ingest_hour_bucket
+    }
+}
+
+impl SupersededInputs for SupersededSubset {
     fn inputs(&self) -> &[CompactionInputIdentity] {
         &self.inputs
     }

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -1031,8 +1031,10 @@ async fn load_compaction_records(
 /// segment: it is the sole server of its rows. So an input is superseded only
 /// where an authoritative record names it. Treating a loser's whole input set
 /// as superseded deletes that sole server and turns duplicate rows into
-/// missing rows. A loser's own parts become unreferenced instead and fall to
-/// rule 3.
+/// missing rows. A loser's own parts stay referenced for as long as the losing
+/// record exists (the reference map does not distinguish winners from losers,
+/// and a node that has not adopted this rule may still serve them), so this
+/// pass reclaims nothing of the loser's.
 #[derive(Default)]
 struct AuthoritativeInputs {
     by_bucket: HashMap<u32, HashSet<(String, u64, u64)>>,

--- a/crates/ravel-maintain/tests/overlapping_compaction_records.rs
+++ b/crates/ravel-maintain/tests/overlapping_compaction_records.rs
@@ -1,0 +1,518 @@
+//! The superseded-input sweep and the erasure completion gate follow the same
+//! authoritative-record rule the resolver does (issue #1070).
+//!
+//! When one sealed bucket holds two compaction records whose input sets
+//! overlap, the catalog picks one authoritative record per overlap component
+//! and serves any input the winner does not name as a raw L0 segment. An input
+//! only a LOSER names is therefore the sole server of its rows, and both
+//! maintenance paths here have to see it that way: the sweep must not delete
+//! it as superseded, and the completion gate must not treat it as invisible.
+//!
+//! Both fixtures drive the production entries (`sweep_superseded`,
+//! `sweep_unreferenced_parts`, `bucket_erasure_completion`) against a
+//! `MemoryStore`. Each test's doc comment names the assertion that fails
+//! without the fix.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod common;
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use common::*;
+use prost::Message;
+use ravel_commit::{erasure, keys, signal};
+use ravel_maintain::{
+    Bucket, CompactorConfig, FixedClock, NoLeases, PendingErasureRequest,
+    bucket_erasure_completion, sweep_superseded, sweep_unreferenced_parts,
+};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions, list_all};
+use ravel_proto::commit::v1::{
+    CompactionInputIdentity, CompactionPart, CompactionRecord, ErasurePredicateMatcher,
+    ErasureRequest, RewriteDrop, RewriteRecord,
+};
+use ravel_types::Signal;
+use uuid::Uuid;
+
+/// Event-time base of the logs bucket the fixtures use.
+fn hour_ns() -> i64 {
+    i64::from(HOUR) * NS_PER_HOUR
+}
+
+fn cfg() -> CompactorConfig {
+    CompactorConfig::default()
+}
+
+/// Well past every record's protection horizon, so a deleting sweep pass is
+/// not gated on age.
+fn past_horizon_ns() -> i64 {
+    hour_ns() + cfg().protection_horizon_ns + NS_PER_HOUR
+}
+
+/// Every object key in the store, for exact before/after set comparisons.
+async fn all_keys(store: &dyn ObjectStoreBackend) -> BTreeSet<String> {
+    list_all(store, "t/")
+        .await
+        .expect("list")
+        .into_iter()
+        .map(|m| m.key)
+        .collect()
+}
+
+/// The identity of a seeded L0 input, as a compaction record names it.
+fn input_identity(writer_id: Uuid, epoch: u64, seq: u64) -> CompactionInputIdentity {
+    CompactionInputIdentity {
+        writer_id: writer_id.to_string(),
+        writer_epoch: epoch,
+        writer_seq: seq,
+    }
+}
+
+/// An L1 part covering `[min_ts, max_ts]`. `seed` distinguishes two records'
+/// part objects by content hash, so their reconstructed keys differ.
+fn part(seed: u8, min_ts: i64, max_ts: i64) -> CompactionPart {
+    CompactionPart {
+        part_index: 0,
+        first_series_id: vec![0u8; 16],
+        last_series_id: vec![0xff; 16],
+        content_hash: vec![seed; 32],
+        object_size: 4096,
+        sample_count: 2,
+        series_count: 1,
+        run_count: 1,
+        min_event_ts_ns: min_ts,
+        max_event_ts_ns: max_ts,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Vec::new(),
+    }
+}
+
+/// Publish a compaction record over `inputs` into `bucket`, plus a real object
+/// at each of its parts' reconstructed keys so the unreferenced-part sweep has
+/// something to list. `seed` drives the record's `input_set_hash` (and so its
+/// key and the resolver's hash tie-break) independently of `inputs`. Returns
+/// the record key and the record.
+async fn put_compaction_record(
+    store: &dyn ObjectStoreBackend,
+    bucket: &Bucket,
+    inputs: Vec<CompactionInputIdentity>,
+    parts: Vec<CompactionPart>,
+    created_unix_ns: i64,
+    seed: &[u8],
+) -> (String, CompactionRecord) {
+    let input_set_hash = *blake3::hash(seed).as_bytes();
+    let record = CompactionRecord {
+        format_version: 1,
+        tenant_hash: bucket.tenant_hash.0.to_vec(),
+        signal: signal::to_proto(bucket.signal) as i32,
+        shard: bucket.shard,
+        ingest_hour_bucket: bucket.ingest_hour_bucket,
+        level: 1,
+        inputs,
+        input_set_hash: input_set_hash.to_vec(),
+        parts,
+        created_unix_ns,
+    };
+    for p in &record.parts {
+        let part_key = keys::reconstruct_l1_part_key(&record, p).expect("part key");
+        store
+            .put(
+                &part_key,
+                bytes::Bytes::from_static(b"l1-part"),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put part object");
+    }
+    let hash16 = hex_prefix(&input_set_hash);
+    let key = keys::compaction_record_key(
+        &bucket.tenant_hash,
+        bucket.signal,
+        bucket.shard,
+        bucket.ingest_hour_bucket,
+        &hash16,
+    )
+    .expect("record key");
+    store
+        .put(
+            &key,
+            record.encode_to_vec().into(),
+            PutOptions::create_if_absent(),
+        )
+        .await
+        .expect("put compaction record");
+    (key, record)
+}
+
+fn hex_prefix(hash: &[u8; 32]) -> String {
+    hash[..8].iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Publish a rewrite record into `bucket`. Exactly one of `inputs` (raw-L0
+/// supersession) and `superseded_record_key` (whole-record supersession) is
+/// set, as the format requires. Every applied request id lands in `drops`, so
+/// the completion gate treats the output as safe for those requests.
+#[allow(clippy::too_many_arguments)]
+async fn put_rewrite_record(
+    store: &dyn ObjectStoreBackend,
+    bucket: &Bucket,
+    inputs: Vec<CompactionInputIdentity>,
+    superseded_record_key: &str,
+    parts: Vec<CompactionPart>,
+    applied: &[Uuid],
+    created_unix_ns: i64,
+) -> String {
+    let request_ids: Vec<String> = applied.iter().map(Uuid::to_string).collect();
+    let superseded = if superseded_record_key.is_empty() {
+        None
+    } else {
+        Some(superseded_record_key)
+    };
+    let input_set_hash = erasure::compute_rewrite_input_set_hash(&inputs, superseded, &request_ids);
+    let record = RewriteRecord {
+        format_version: 1,
+        tenant_hash: bucket.tenant_hash.0.to_vec(),
+        signal: signal::to_proto(bucket.signal) as i32,
+        shard: bucket.shard,
+        ingest_hour_bucket: bucket.ingest_hour_bucket,
+        inputs,
+        input_set_hash: input_set_hash.to_vec(),
+        parts,
+        drops: request_ids
+            .iter()
+            .map(|id| RewriteDrop {
+                request_id: id.clone(),
+                dropped_count: 1,
+            })
+            .collect(),
+        created_unix_ns,
+        superseded_record_key: superseded_record_key.to_string(),
+    };
+    for p in &record.parts {
+        let part_key = keys::reconstruct_rewrite_part_key(&record, p).expect("rewrite part key");
+        store
+            .put(
+                &part_key,
+                bytes::Bytes::from_static(b"rw-part"),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put rewrite part object");
+    }
+    let key = keys::rewrite_record_key_for(&record).expect("rewrite record key");
+    store
+        .put(
+            &key,
+            record.encode_to_vec().into(),
+            PutOptions::create_if_absent(),
+        )
+        .await
+        .expect("put rewrite record");
+    key
+}
+
+/// The data-object key of the L0 input at `commit_key`.
+async fn data_key_of(store: &dyn ObjectStoreBackend, commit_key: &str) -> String {
+    let bytes = get_full(store, commit_key).await;
+    let record = ravel_commit::record::decode(&bytes).expect("decode commit record");
+    keys::reconstruct_data_key(&record).expect("data key")
+}
+
+/// Order two seeds by their `input_set_hash`: `(smaller, larger)`. Between two
+/// records of equal input-set cardinality the smaller hash wins.
+fn order_by_hash<'a>(x: &'a [u8], y: &'a [u8]) -> (&'a [u8], &'a [u8]) {
+    if blake3::hash(x).as_bytes() <= blake3::hash(y).as_bytes() {
+        (x, y)
+    } else {
+        (y, x)
+    }
+}
+
+/// The superseded-input sweep deletes only what an AUTHORITATIVE compaction
+/// record supersedes. The bucket holds two overlapping records: the winner
+/// names `[a, b]` and the loser names `[a, d]`, so `d` is served as a raw L0
+/// and must survive. The clock is past the protection horizon and no HEAD
+/// object exists, so the reachability gate clears everything the pass gathers.
+///
+/// The failing assertion before the fix is the first one: the sweep gathers
+/// every compaction record's inputs, so it deletes `d`'s data object and
+/// commit record too, and the surviving-key set does not contain them
+/// (`records_deleted` is 3 rather than 2). Turning the sole server of `d`'s
+/// rows into a missing object is the finding this test pins.
+///
+/// The two rule-3 assertions at the end pin the honest current behaviour: the
+/// unreferenced-part sweep marks EVERY compaction record's parts as
+/// referenced, so the loser's part survives while the loser's record does, and
+/// is collected on the pass after that record is gone.
+#[tokio::test]
+async fn sweep_keeps_the_input_only_a_losing_record_names() {
+    let store = Arc::new(MemoryStore::new());
+    let b = logs_bucket();
+    let base = hour_ns();
+
+    let a_writer = Uuid::from_u128(0xA1);
+    let b_writer = Uuid::from_u128(0xA2);
+    let d_writer = Uuid::from_u128(0xA3);
+    let a_commit = seed_rlog_input(
+        store.as_ref(),
+        a_writer,
+        1,
+        1,
+        &[log_record(1, base + 1_000, "a")],
+    )
+    .await;
+    let b_commit = seed_rlog_input(
+        store.as_ref(),
+        b_writer,
+        1,
+        2,
+        &[log_record(1, base + 2_000, "b")],
+    )
+    .await;
+    let d_commit = seed_rlog_input(
+        store.as_ref(),
+        d_writer,
+        1,
+        3,
+        &[log_record(2, base + 3_000, "d")],
+    )
+    .await;
+    let a_data = data_key_of(store.as_ref(), &a_commit).await;
+    let b_data = data_key_of(store.as_ref(), &b_commit).await;
+    let d_data = data_key_of(store.as_ref(), &d_commit).await;
+
+    // Equal input-set cardinality, so the hash decides. The winner names
+    // [a, b]; the loser names [a, d], overlapping on a and adding d.
+    let (win_seed, lose_seed) = order_by_hash(b"sweep-win", b"sweep-lose");
+    put_compaction_record(
+        store.as_ref(),
+        &b,
+        vec![
+            input_identity(a_writer, 1, 1),
+            input_identity(b_writer, 1, 2),
+        ],
+        vec![part(0x11, base + 1_000, base + 2_000)],
+        base,
+        win_seed,
+    )
+    .await;
+    let (loser_key, loser) = put_compaction_record(
+        store.as_ref(),
+        &b,
+        vec![
+            input_identity(a_writer, 1, 1),
+            input_identity(d_writer, 1, 3),
+        ],
+        vec![part(0x22, base + 1_000, base + 3_000)],
+        base,
+        lose_seed,
+    )
+    .await;
+    let loser_part_key =
+        keys::reconstruct_l1_part_key(&loser, &loser.parts[0]).expect("loser part key");
+
+    let before = all_keys(store.as_ref()).await;
+    let clock = FixedClock::new(past_horizon_ns());
+    let outcome = sweep_superseded(
+        store.as_ref(),
+        &clock,
+        &cfg(),
+        &NoLeases,
+        &b.tenant_hash,
+        b.signal,
+        b.shard,
+    )
+    .await
+    .expect("sweep");
+
+    let after = all_keys(store.as_ref()).await;
+    let deleted: BTreeSet<String> = before.difference(&after).cloned().collect();
+    assert_eq!(
+        deleted,
+        BTreeSet::from([
+            a_commit.clone(),
+            a_data.clone(),
+            b_commit.clone(),
+            b_data.clone()
+        ]),
+        "only the winner's inputs are superseded"
+    );
+    assert!(
+        after.contains(&d_commit) && after.contains(&d_data),
+        "the input only the loser names still serves its rows"
+    );
+    assert_eq!(outcome.records_deleted, 2);
+    assert_eq!(outcome.data_deleted, 2);
+    assert_eq!(outcome.held_by_snapshot, 0);
+    assert_eq!(outcome.held_by_unreadable_head, 0);
+
+    // Rule 3 while the loser's record is present: its parts are referenced by
+    // that record, so nothing is collected.
+    let collected = sweep_unreferenced_parts(
+        store.as_ref(),
+        &clock,
+        &cfg(),
+        &NoLeases,
+        &b.tenant_hash,
+        b.signal,
+        b.shard,
+    )
+    .await
+    .expect("rule 3");
+    assert_eq!(collected, 0, "a record's own parts are referenced");
+
+    // With the loser's record gone, its part is unreferenced and collected.
+    store.delete(&loser_key).await.expect("delete loser record");
+    let collected = sweep_unreferenced_parts(
+        store.as_ref(),
+        &clock,
+        &cfg(),
+        &NoLeases,
+        &b.tenant_hash,
+        b.signal,
+        b.shard,
+    )
+    .await
+    .expect("rule 3");
+    assert_eq!(collected, 1, "exactly the loser's one part");
+    let after = all_keys(store.as_ref()).await;
+    assert!(!after.contains(&loser_part_key));
+}
+
+/// An erasure request whose subject lives in a raw L0 only a LOSING compaction
+/// record names is not complete until that L0 is superseded, and IS complete
+/// once it has been.
+///
+/// The bucket holds the winner over `[a, b]`, whose part sits outside the
+/// request window, and the loser over `[a, d]`, whose part covers `d`'s rows
+/// inside the window. The resolver serves `d` as a raw L0, so while `d` is
+/// there the subject is still returnable and the bucket is incomplete. The
+/// first assertion pins that: without the `excluded` half of the fix, `d` is
+/// invisible to the gate, and only the loser's part -- which no query reads --
+/// keeps the answer accidentally right.
+///
+/// The failing assertion before the fix is the second phase's
+/// `blocked.len() == 0`. Once a rewrite has superseded `d` and named the
+/// request, nothing live serves the subject; but the gate kept the loser's
+/// record in its live view, that record's part overlaps the window, and the
+/// bucket reported blocked forever. A request that never completes retains its
+/// `.dreq`, and its subject with it, which is the outcome ADR-0064 decision 5
+/// exists to prevent.
+#[tokio::test]
+async fn erasure_completion_sees_the_l0_only_a_losing_record_names() {
+    let store = Arc::new(MemoryStore::new());
+    let b = logs_bucket();
+    let base = hour_ns();
+    let request_id = Uuid::from_u128(0x0E45);
+
+    let a_writer = Uuid::from_u128(0xB1);
+    let b_writer = Uuid::from_u128(0xB2);
+    let d_writer = Uuid::from_u128(0xB3);
+    // a and b carry no subject and sit early in the hour; d carries the
+    // subject and sits inside the request window.
+    seed_rlog_input(
+        store.as_ref(),
+        a_writer,
+        1,
+        1,
+        &[log_record(1, base + 1_000, "keep")],
+    )
+    .await;
+    seed_rlog_input(
+        store.as_ref(),
+        b_writer,
+        1,
+        2,
+        &[log_record(1, base + 2_000, "keep")],
+    )
+    .await;
+    seed_rlog_input(
+        store.as_ref(),
+        d_writer,
+        1,
+        3,
+        &[log_record(2, base + 9_000, "victim")],
+    )
+    .await;
+
+    let (win_seed, lose_seed) = order_by_hash(b"erase-win", b"erase-lose");
+    put_compaction_record(
+        store.as_ref(),
+        &b,
+        vec![
+            input_identity(a_writer, 1, 1),
+            input_identity(b_writer, 1, 2),
+        ],
+        vec![part(0x33, base + 1_000, base + 2_000)],
+        base,
+        win_seed,
+    )
+    .await;
+    put_compaction_record(
+        store.as_ref(),
+        &b,
+        vec![
+            input_identity(a_writer, 1, 1),
+            input_identity(d_writer, 1, 3),
+        ],
+        vec![part(0x44, base + 1_000, base + 9_000)],
+        base,
+        lose_seed,
+    )
+    .await;
+
+    let pending = vec![PendingErasureRequest {
+        request_key: keys::erasure_request_key(&b.tenant_hash, Signal::Logs, request_id)
+            .expect("dreq key"),
+        request: ErasureRequest {
+            format_version: 1,
+            tenant_hash: b.tenant_hash.0.to_vec(),
+            signal: signal::to_proto(Signal::Logs) as i32,
+            request_id: request_id.to_string(),
+            created_unix_ns: base,
+            predicate: vec![ErasurePredicateMatcher {
+                key: "service.name".to_string(),
+                value: "svc2".to_string(),
+            }],
+            window_start_ns: base + 5_000,
+            window_end_ns: base + 20_000,
+            reason: String::new(),
+        },
+    }];
+
+    let clock = FixedClock::new(sealed_now_ns());
+    let completion =
+        bucket_erasure_completion(store.as_ref(), &clock, &cfg(), &NoLeases, &b, &pending)
+            .await
+            .expect("completion");
+    assert!(
+        completion.blocked.contains(&request_id.to_string()),
+        "the raw L0 only the loser names still serves the subject"
+    );
+    assert_eq!(completion.blocked.len(), 1);
+    assert!(!completion.unresolved);
+
+    // Once a rewrite supersedes that raw L0 as well, nothing live serves the
+    // subject and the bucket is complete.
+    put_rewrite_record(
+        store.as_ref(),
+        &b,
+        vec![input_identity(d_writer, 1, 3)],
+        "",
+        vec![part(0x66, base + 1_000, base + 2_000)],
+        &[request_id],
+        base + 2_000_000,
+    )
+    .await;
+    let completion =
+        bucket_erasure_completion(store.as_ref(), &clock, &cfg(), &NoLeases, &b, &pending)
+            .await
+            .expect("completion");
+    assert_eq!(
+        completion.blocked.len(),
+        0,
+        "the subject is provably gone from the bucket"
+    );
+    assert!(!completion.unresolved);
+}

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -894,8 +894,11 @@ carries them as a comma-separated list in `x-ravel-commit-token`.
      interlock-violation metric if its created_unix_ns postdates the newest
      compaction/rewrite record (it should have been sealed before that ran).
    Two compaction records in one bucket with different input_set_hash:
-   include both parts sets and all L0s not covered by either (correct
-   under overlap harmlessness; ADR-0018), and alarm loudly.
+   disjoint input sets include both parts sets and all L0s not covered by
+   either (correct under overlap harmlessness; ADR-0018); overlapping input
+   sets resolve to one authoritative record per overlap group, whose parts
+   are included and whose inputs are excluded, with every input only a losing
+   record names served as a raw L0. Either way, alarm loudly.
 4. Filter the remaining L0 commit records: [min_event_ts, max_event_ts]
    overlaps the query range.
 5. For each `min_token`: reconstruct its commit key and GET it directly
@@ -1191,11 +1194,15 @@ input sets are disjoint it includes both segment sets plus any L0 input covered
 by neither, harmless under the property above. When they overlap, query-time
 dedup would collapse the duplicate for metrics but not for logs or spans (which
 have none), so the resolver picks one authoritative record per overlap group by
-the smallest `input_set_hash`, with the record key as the tie fallback,
-includes that record's segments, serves every input the winner does not name
-as a raw L0 segment, and ignores the other records' segments; among the
-compaction records each input is then served from one place, inside the
-chosen record's segments or as a raw L0. Either way it raises
+the largest input set, then the smallest `input_set_hash`, with the record
+key as the final fallback, includes that record's segments, serves every
+input the winner does not name as a raw L0 segment, and ignores the other
+records' segments; among the compaction records each input is then served
+from one place, inside the chosen record's segments or as a raw L0.
+Preferring the largest input set leaves the fewest inputs to serve raw, so
+the bucket reads mostly from compacted parts rather than falling back to the
+L0 objects a smaller winner would not cover. All three keys are computed from
+record bytes alone, so every replica and the index fold pick the same winner. Either way it raises
 `ravel_catalog_compaction_input_set_conflicts_total` for a human to look at.
 Durably refusing to publish a second overlapping record is a publish-time step
 in ravel-maintain; the resolve-time tie-break keeps reads correct until then.

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -1189,8 +1189,9 @@ dedup would collapse the duplicate for metrics but not for logs or spans (which
 have none), so the resolver picks one authoritative record per overlap group by
 the smallest `input_set_hash`, includes that record's segments, serves every
 input the winner does not name as a raw L0 segment, and ignores the other
-records' segments; every input of the bucket is then served exactly once,
-either inside the chosen record's segments or as a raw L0. Either way it raises
+records' segments; every input of the bucket is then served from one place
+only, inside the chosen record's segments or as a raw L0, and none is served
+twice or dropped. Either way it raises
 `ravel_catalog_compaction_input_set_conflicts_total` for a human to look at.
 Durably refusing to publish a second overlapping record is a publish-time step
 in ravel-maintain; the resolve-time tie-break keeps reads correct until then.

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -601,9 +601,8 @@ already-sealed hours:
   watermark_hour_old]`, inclusive at both ends. `watermark_hour_old` is the
   boundary the incremental range excludes, so the reconcile window and the
   incremental range are adjacent, never overlapping. `fold_reconcile_window_hours`
-  defaults to 26 hours: longer than `protection_horizon` (the age gate before
-  the sweeper may physically delete a superseded compaction input, 25 h 5 min
-  on the defaults) by a slack margin.
+  defaults to 26 hours: `protection_horizon` (24 h, the age gate before the
+  sweeper may physically delete a superseded compaction input) plus slack.
   Because the sweeper only deletes an input after that horizon, any record
   whose supersession could invalidate a snapshot entry is observed by a
   reconcile pass before its inputs can disappear, provided the record lands
@@ -673,10 +672,7 @@ normally days) behind the watermark, so the fixed window alone would never
 observe it, and the snapshot would keep naming the retired bucket's segments
 forever. The retention-frontier reconcile below covers exactly that case.
 (This closes a latent correctness gap; see ADR-0063 Consequences and
-ADR-0020.) A rewrite record takes the same two routes and no third: inside
-the fixed window it is applied on the next fold, in an hour at or
-approaching the retirement frontier it is applied by the frontier band, and
-in between it waits for the frontier band to reach its hour.
+ADR-0020.)
 
 ## Retention-frontier reconcile (ADR-0020 delete blocker)
 
@@ -1185,13 +1181,19 @@ of a bucket that would trip it reports the violation.
 Racing compactors over one sealed bucket are serialized by `CreateIfAbsent`
 picking a single winner; a loser's segments are unreferenced objects that age
 out under the same rule. Two records that legitimately name different input
-sets (rare, from concurrent partial seals) are not reconciled automatically.
-The resolver includes both segment sets plus any L0 input covered by neither
-and raises `ravel_catalog_compaction_input_set_conflicts_total` for a human
-to look at. For metrics that is harmless under the property above. Logs and
-spans have no query-time dedup, so where the two input sets overlap a query
-returns the overlapping records twice until a human reconciles the bucket;
-the counter is the signal to do so.
+sets (rare, from concurrent partial seals) are not reconciled automatically,
+and the resolver derives an identical answer on every replica. When the two
+input sets are disjoint it includes both segment sets plus any L0 input covered
+by neither, harmless under the property above. When they overlap, query-time
+dedup would collapse the duplicate for metrics but not for logs or spans (which
+have none), so the resolver picks one authoritative record per overlap group by
+the smallest `input_set_hash`, includes that record's segments, serves every
+input the winner does not name as a raw L0 segment, and ignores the other
+records' segments; every input of the bucket is then served exactly once,
+either inside the chosen record's segments or as a raw L0. Either way it raises
+`ravel_catalog_compaction_input_set_conflicts_total` for a human to look at.
+Durably refusing to publish a second overlapping record is a publish-time step
+in ravel-maintain; the resolve-time tie-break keeps reads correct until then.
 
 ## Online resharding (ADR-0052)
 
@@ -1204,8 +1206,8 @@ until retention ages their hours out.
 
 Activation lead time. Activation is denominated in ingest-hour buckets and is
 placed `L` hours ahead: `activation_hour = now_hour + L`, with
-`L >= ceil(C / 1 h) + 1` hours, where `C` is the router's provisioning-record
-refresh interval (default 60 s, so the floor is 2 hours). `ravel-cli provision reshard`
+`L >= ceil(C) + 1` hours, where `C` is the router's provisioning-record refresh
+interval (default 60 s, so the floor is 2 hours). `ravel-cli provision reshard`
 refuses a shorter lead. Every live writer re-reads the record at least once per
 `C`, so that floor guarantees each writer either observes the new generation
 before it activates or has already stopped on record staleness. Nothing routes

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -601,8 +601,9 @@ already-sealed hours:
   watermark_hour_old]`, inclusive at both ends. `watermark_hour_old` is the
   boundary the incremental range excludes, so the reconcile window and the
   incremental range are adjacent, never overlapping. `fold_reconcile_window_hours`
-  defaults to 26 hours: `protection_horizon` (24 h, the age gate before the
-  sweeper may physically delete a superseded compaction input) plus slack.
+  defaults to 26 hours: longer than `protection_horizon` (the age gate before
+  the sweeper may physically delete a superseded compaction input, 25 h 5 min
+  on the defaults) by a slack margin.
   Because the sweeper only deletes an input after that horizon, any record
   whose supersession could invalidate a snapshot entry is observed by a
   reconcile pass before its inputs can disappear, provided the record lands
@@ -672,7 +673,10 @@ normally days) behind the watermark, so the fixed window alone would never
 observe it, and the snapshot would keep naming the retired bucket's segments
 forever. The retention-frontier reconcile below covers exactly that case.
 (This closes a latent correctness gap; see ADR-0063 Consequences and
-ADR-0020.)
+ADR-0020.) A rewrite record takes the same two routes and no third: inside
+the fixed window it is applied on the next fold, in an hour at or
+approaching the retirement frontier it is applied by the frontier band, and
+in between it waits for the frontier band to reach its hour.
 
 ## Retention-frontier reconcile (ADR-0020 delete blocker)
 
@@ -1187,11 +1191,11 @@ input sets are disjoint it includes both segment sets plus any L0 input covered
 by neither, harmless under the property above. When they overlap, query-time
 dedup would collapse the duplicate for metrics but not for logs or spans (which
 have none), so the resolver picks one authoritative record per overlap group by
-the smallest `input_set_hash`, includes that record's segments, serves every
-input the winner does not name as a raw L0 segment, and ignores the other
-records' segments; every input of the bucket is then served from one place
-only, inside the chosen record's segments or as a raw L0, and none is served
-twice or dropped. Either way it raises
+the smallest `input_set_hash`, with the record key as the tie fallback,
+includes that record's segments, serves every input the winner does not name
+as a raw L0 segment, and ignores the other records' segments; among the
+compaction records each input is then served from one place, inside the
+chosen record's segments or as a raw L0. Either way it raises
 `ravel_catalog_compaction_input_set_conflicts_total` for a human to look at.
 Durably refusing to publish a second overlapping record is a publish-time step
 in ravel-maintain; the resolve-time tie-break keeps reads correct until then.
@@ -1207,8 +1211,8 @@ until retention ages their hours out.
 
 Activation lead time. Activation is denominated in ingest-hour buckets and is
 placed `L` hours ahead: `activation_hour = now_hour + L`, with
-`L >= ceil(C) + 1` hours, where `C` is the router's provisioning-record refresh
-interval (default 60 s, so the floor is 2 hours). `ravel-cli provision reshard`
+`L >= ceil(C / 1 h) + 1` hours, where `C` is the router's provisioning-record
+refresh interval (default 60 s, so the floor is 2 hours). `ravel-cli provision reshard`
 refuses a shorter lead. Every live writer re-reads the record at least once per
 `C`, so that floor guarantees each writer either observes the new generation
 before it activates or has already stopped on record staleness. Nothing routes

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -273,8 +273,8 @@ different but overlapping input sets are rarer, and serving both would return
 the overlapping records twice for logs and spans, which have no query-time
 deduplication. The resolver picks one authoritative record per overlap group by
 a deterministic tie-break, serves any input the winner does not name as a raw
-segment, ignores the other records' segments, and raises a metric, so every
-input is served exactly once while an operator reconciles the bucket.
+segment, ignores the other records' segments, and raises a metric, so no
+input is served twice or dropped while an operator reconciles the bucket.
 
 Retention expires data by age against the tenant's configured policy. Like
 every deletion in Ravel it is a durable transaction first, a tombstone
@@ -293,12 +293,12 @@ constraint rather than a hope. Compaction never deduplicates and conserves
 the record count exactly; a snapshot that sees a compaction record excludes
 the inputs it names, and for metrics query-time deduplication also collapses
 any duplicate that slips through, so every intermediate state of a
-compaction is query-correct. The one exception is two compaction records
-over a logs or spans bucket that name different input sets: where those
-sets overlap, the overlapping records are returned twice;
+compaction is query-correct. Two compaction records over one bucket that
+name overlapping input sets are resolved to one authoritative record, as
+above, so that state is query-correct too;
 `ravel_catalog_compaction_input_set_conflicts_total` counts the buckets in
-that state, and since no command reconciles one, a rise in it is the signal
-to investigate the bucket by hand. The sweep physically
+it, and since no command reconciles one, a rise in it is the signal to
+investigate the bucket by hand. The sweep physically
 removes only what no live
 snapshot references, and only after a protection horizon. A snapshot
 resolved before, during, or after either loop returns the same rows.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -272,7 +272,8 @@ segments are unreferenced objects that age out. Two records that instead name
 different but overlapping input sets are rarer, and serving both would return
 the overlapping records twice for logs and spans, which have no query-time
 deduplication. The resolver picks one authoritative record per overlap group by
-a deterministic tie-break, serves any input the winner does not name as a raw
+the smallest input-set hash, with the record key as the tie fallback, serves
+any input the winner does not name as a raw
 segment, ignores the other records' segments, and raises a metric, so no
 input is served twice or dropped while an operator reconciles the bucket.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -272,10 +272,14 @@ segments are unreferenced objects that age out. Two records that instead name
 different but overlapping input sets are rarer, and serving both would return
 the overlapping records twice for logs and spans, which have no query-time
 deduplication. The resolver picks one authoritative record per overlap group by
-the smallest input-set hash, with the record key as the tie fallback, serves
-any input the winner does not name as a raw
+the largest input set, then the smallest input-set hash, with the record key
+as the final fallback, serves any input the winner does not name as a raw
 segment, ignores the other records' segments, and raises a metric, so no
 input is served twice or dropped while an operator reconciles the bucket.
+Preferring the largest input set leaves the fewest inputs to serve raw. The
+sweep and the erasure completion gate follow the same choice: an input only a
+losing record names is still the one a query reads, so it is neither deleted
+as superseded nor treated as already rewritten.
 
 Retention expires data by age against the tenant's configured policy. Like
 every deletion in Ravel it is a durable transaction first, a tombstone

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -268,7 +268,13 @@ publish time. Before that put, the run checks that the record counts of its
 inputs and its outputs are exactly equal and aborts if they are not, because
 publish is the point of no return. Two compactors racing on one bucket
 converge: create-if-absent picks one record as the winner, and the loser's
-segments are unreferenced objects that age out.
+segments are unreferenced objects that age out. Two records that instead name
+different but overlapping input sets are rarer, and serving both would return
+the overlapping records twice for logs and spans, which have no query-time
+deduplication. The resolver picks one authoritative record per overlap group by
+a deterministic tie-break, serves any input the winner does not name as a raw
+segment, ignores the other records' segments, and raises a metric, so every
+input is served exactly once while an operator reconciles the bucket.
 
 Retention expires data by age against the tenant's configured policy. Like
 every deletion in Ravel it is a durable transaction first, a tombstone

--- a/docs/deletion-and-gc.md
+++ b/docs/deletion-and-gc.md
@@ -267,9 +267,10 @@ window would still call a Hit.
   also names them, so an input only a loser names is left in place, because
   that raw object is where a query still reads those rows from. Deleting it on
   the strength of the losing record alone would turn duplicated rows into
-  missing rows. The losing record's own parts are nothing but unreferenced
-  objects once the record is gone, and the unreferenced-part rule collects them
-  on age as usual.
+  missing rows. The losing record's own parts are served from nowhere, but
+  they stay referenced for as long as the losing record exists, and no rule
+  removes a losing record today: the sweep reclaims neither, so an overlap
+  leaves the loser's parts in place as a bounded storage cost.
 - **A rewrite record outlives every input it superseded.** A whole
   supersession chain, from the live record back to the raw inputs its oldest
   generation superseded, is one indivisible delete unit: the HEAD gate decides

--- a/docs/deletion-and-gc.md
+++ b/docs/deletion-and-gc.md
@@ -259,6 +259,17 @@ window would still call a Hit.
   held or deleted together: dropping the record while a still-named part is
   held would leave that part unreferenced, and the unreferenced-part rule
   would then collect it and undo the hold.
+- **An input is superseded only where the record a query reads names it.**
+  When two compaction records in one bucket name overlapping input sets, the
+  resolver picks one authoritative record per overlap group and serves every
+  input the winner does not name as a raw segment. The sweep applies that same
+  choice: a losing record's inputs count as superseded only where the winner
+  also names them, so an input only a loser names is left in place, because
+  that raw object is where a query still reads those rows from. Deleting it on
+  the strength of the losing record alone would turn duplicated rows into
+  missing rows. The losing record's own parts are nothing but unreferenced
+  objects once the record is gone, and the unreferenced-part rule collects them
+  on age as usual.
 - **A rewrite record outlives every input it superseded.** A whole
   supersession chain, from the live record back to the raw inputs its oldest
   generation superseded, is one indivisible delete unit: the HEAD gate decides
@@ -379,7 +390,11 @@ every bound is measured.
   rewrite pass's own one-hop live-record view instead would let a `.done` land
   while a snapshot still resolves an L0 input the one hop never excluded
   (ADR-0064 §4); the completion gate blocks exactly
-  that.
+  that. Overlapping compaction records are read here under the same
+  authoritative-record rule the resolver and the sweep use: only a winning
+  record's inputs count as compacted away, so a raw L0 that only a losing
+  record names stays in the gate's live set, and a losing record's parts,
+  which no query reads, do not by themselves keep a request blocked.
 
 - **Physical removal reuses the existing sweep.** A rewrite's superseded
   inputs become inputs to the superseded-input sweep, deleted after


### PR DESCRIPTION
When two compaction records in one sealed bucket named overlapping input sets, the resolver served both records' output parts. Query-time dedup collapses that for metrics, but logs and spans have no query-time dedup, so the overlapping rows came back twice until a human reconciled the bucket.

The resolver and the index fold now share one rule: compaction records that share at least one input form an overlap component, and within a component of two or more records exactly one is authoritative, chosen by the smallest input-set hash with the key as the tie fallback, so every replica and every fold compute the same winner from record bytes alone. A loser's parts are skipped and only winners' inputs are excluded, so an input named only by a loser falls through to the raw segment pass and is served from one place. Disjoint records are not in conflict and keep today's behavior, and the conflicts counter still fires once per bucket holding more than one input set. Tests build overlapping records for logs and for spans and pin one authoritative record, the survival of a loser's uncovered input as a raw segment, both disjoint records resolving, and the counter incrementing exactly one time; each overlapping test fails against the previous resolver.

The residual exposure is a loser input that the superseded-input sweep already deleted behind its now-ignored record; publish-time refusal of an overlapping record and the sweep's treatment of a loser's inputs belong in ravel-maintain and are #1099. The executor hit the fleet's 4-hour runtime ceiling during its gate run after committing; CI runs the full gates here.

Fixes: #1070