### PR TITLE
fix(image): build flight-sql and otap into the published server image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,7 +456,11 @@ jobs:
   # any of them -- an unreachable e2e test path, four bench binaries that
   # never link -- ships undetected. This lane proves each combination still
   # compiles (`cargo check`), and for one of them also runs its tests:
-  #   - ravel-server --features otap            (links ravel-otap + arrow tree)
+  #   - ravel-server --features otap            (links ravel-otap + arrow tree;
+  #                                              the image lanes build it in
+  #                                              release together with sql and
+  #                                              flight-sql, this is the fast
+  #                                              probe of the feature alone)
   #   - ravel-bench --features parquet-baseline (arrow/parquet/object_store)
   #   - ravel-bench --features flight-egress    (ravel-sql/datafusion/flight)
   #   - ravel-bench --features profiling        (pprof/inferno flamegraph lane)
@@ -1032,7 +1036,7 @@ jobs:
       # server image, so it can no longer be left out (see Dockerfile.prebuilt).
       - name: Build the release binaries on the host
         run: |
-          cargo build --release --locked -p ravel-server --features sql
+          cargo build --release --locked -p ravel-server --features sql,flight-sql,otap
           cargo build --release --locked -p ravel-cli
           cargo build --release --locked -p ravel-operator
       - name: Assemble both images from the prebuilt binaries
@@ -1395,7 +1399,8 @@ jobs:
           fail_ci_if_error: false
 
   # Container-first quickstart verification (ADR-0081 decisions 5, 6, 7). Builds
-  # the pull request's OWN ravel-server (--features sql) and ravel-cli on the
+  # the pull request's OWN ravel-server (the shipping `--features
+  # sql,flight-sql,otap`) and ravel-cli on the
   # runner with the shared sccache/rust-cache, assembles a runtime image from
   # them via Dockerfile.prebuilt (both binaries, because that file's `server`
   # target COPYs ravel-cli for the store-qualification path too), brings up
@@ -1481,10 +1486,10 @@ jobs:
         if: steps.filter.outputs.run == 'true'
       # Both binaries: Dockerfile.prebuilt's `server` target COPYs ravel-server
       # AND ravel-cli, so a context missing the CLI fails the docker build.
-      - name: Build ravel-server (sql) and ravel-cli on the host
+      - name: Build ravel-server (sql,flight-sql,otap) and ravel-cli on the host
         if: steps.filter.outputs.run == 'true'
         run: |
-          cargo build --release --locked -p ravel-server --features sql
+          cargo build --release --locked -p ravel-server --features sql,flight-sql,otap
           cargo build --release --locked -p ravel-cli
       - name: Assemble the runtime image from the prebuilt binaries
         if: steps.filter.outputs.run == 'true'

--- a/.github/workflows/k8s-nightly.yml
+++ b/.github/workflows/k8s-nightly.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Build the release binaries on the host
         run: |
-          cargo build --release --locked -p ravel-server --features sql
+          cargo build --release --locked -p ravel-server --features sql,flight-sql,otap
           cargo build --release --locked -p ravel-cli
           cargo build --release --locked -p ravel-operator
       - name: Assemble both images from the prebuilt binaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **The published `ravel-server` image builds every opt-in surface.** It is now
+  built with `--features sql,flight-sql,otap`, so Flight SQL answers on the gRPC
+  listener and `--otap` is accepted at startup without a source build. OTAP
+  ingest is still registered only when `--otap` is given. The CI lanes that
+  assemble images from host-built binaries build the same feature set.
+
 ## [0.11.0]
 
 The log segment format moves to RLOG v4 and the logs query path becomes

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,15 @@ WORKDIR /app
 # keeps the build context small.
 COPY . .
 
-# ravel-server with the `sql` feature (POST /api/v1/sql). `flight-sql` stays
-# off while unimplemented (ADR-0034 decision 5). ravel-cli has no feature flags
-# and is built plain. --locked builds against the committed Cargo.lock.
+# ravel-server with every opt-in surface the workspace ships: `sql` (POST
+# /api/v1/sql), `flight-sql` (Flight SQL on the gRPC listener), and `otap`
+# (OpenTelemetry Arrow metrics ingest, registered only when the process is
+# started with `--otap`). ADR-0034 decision 5 kept `flight-sql` off while the
+# service was unimplemented; it serves ad-hoc statements now. The README
+# support matrix names this feature set, and the CI lanes that assemble images
+# from host-built binaries (ci.yml k8s-integration and quickstart-verify,
+# k8s-nightly.yml) build the same one. ravel-cli has no feature flags and is
+# built plain. --locked builds against the committed Cargo.lock.
 #
 # CARGO_BUILD_JOBS is capped, not left at cargo's default (one job per host
 # core): the root Cargo.toml's release profile (lto = "thin", codegen-units =
@@ -44,7 +50,7 @@ COPY . .
 # since this Dockerfile has to build on whatever the CI runner and every
 # developer's machine actually provide, not just the box this was measured on.
 ENV CARGO_BUILD_JOBS=2
-RUN cargo build --release --locked -p ravel-server --features sql \
+RUN cargo build --release --locked -p ravel-server --features sql,flight-sql,otap \
     && cargo build --release --locked -p ravel-cli \
     && cargo build --release --locked -p ravel-operator \
     && cargo build --release --locked -p ravel-ingest-router
@@ -52,8 +58,9 @@ RUN cargo build --release --locked -p ravel-server --features sql \
 # Split debug info out of each binary (ADR-0086 decision 3). The four cargo
 # invocations above stay four and stay separate: this workspace is
 # resolver = "3", so collapsing them into one -p ... -p ... --features
-# ravel-server/sql would unify the DataFusion feature tree into the other three
-# binaries and silently change what ships. [profile.release] debug = 1 also
+# ravel-server/sql,ravel-server/flight-sql,ravel-server/otap would unify the
+# DataFusion and arrow feature trees into the other three binaries and silently
+# change what ships. [profile.release] debug = 1 also
 # stays (ADR-0036 depends on it for line-level profiling); rather than dropping
 # symbols to shrink the artifact, we separate them here and strip the shipped
 # copy. Order matters: extract the .debug copy FIRST, then strip and link, or

--- a/README.md
+++ b/README.md
@@ -65,16 +65,12 @@ management service (SSE-KMS), legal hold, and admission limits.
   endpoint, and no Jaeger or Tempo API.
 - Alert rule transitions and audit records are written to object storage, and no
   shipped query surface can read them back.
-- Flight SQL and OTAP (OpenTelemetry Arrow) ingest exist in the source and no
-  published image builds them. Both need a source build with their cargo
-  feature turned on.
 - Profiles are a reserved object-key prefix only. No ingest, no query.
 - Exemplars are stored from the OpenTelemetry Protocol (OTLP) only. Remote Write
   and OTAP decode exemplars and then discard them.
 - Distributed read fan-out is off unless `--distributed-query` and
-  `--fragment-key-file` are both given. The PromQL lane is in the published
-  image; the SQL lane exists only in a `flight-sql` build, which no published
-  image is.
+  `--fragment-key-file` are both given. The PromQL lane and the SQL lane (on
+  the Flight SQL service) are both in the published image.
 
 **Who should wait.** If your dashboards range over months of high-cardinality
 metrics, the missing downsampled storage will cost you on every panel. If your
@@ -97,20 +93,22 @@ matrix says which.
 |---|---|---|---|
 | OTLP ingest, HTTP and gRPC | metrics, logs, traces | `none` | yes |
 | Prometheus Remote Write 1.0 and 2.0 ingest | metrics | `none` | yes |
-| OTAP ingest, gRPC | metrics | `otap` | no |
+| OTAP ingest, gRPC | metrics | `otap` | yes |
 | PromQL HTTP API | metrics | `none` | yes |
 | SQL over `POST /api/v1/sql` | metrics as `samples`, logs as `logs`, traces as `spans` | `sql` | yes |
-| Flight SQL | the same three tables | `flight-sql` | no |
+| Flight SQL | the same three tables | `flight-sql` | yes |
 
 <!-- END SUPPORT MATRIX -->
 
 No crate in the workspace declares a default feature set, so `sql`,
 `flight-sql`, and `otap` are off in any build that does not ask for them. The
-published `ravel-server` image is built with `--features sql`, so
-`POST /api/v1/sql` answers there. OTAP ingest needs the `otap` feature at build
-time and the `--otap` flag at startup, and Flight SQL needs the `flight-sql`
-feature; no published image carries either. Flight SQL runs ad-hoc statements,
-and prepared statements return `unimplemented`.
+published `ravel-server` image is built with `--features sql,flight-sql,otap`,
+so all three are compiled in. `POST /api/v1/sql` and Flight SQL answer as soon
+as the server is up; Flight SQL is a gRPC service on the gRPC listener, runs
+ad-hoc statements, and returns `unimplemented` for prepared statements. OTAP
+ingest is registered only when the process is started with `--otap`
+([docs/otap-ingest.md](docs/otap-ingest.md)). A source build gets the same
+surfaces by passing the same `--features` list to cargo.
 
 Exactly three SQL tables are registered: `samples`, `logs`, and `spans`. SQL is
 the only way to query logs and traces.
@@ -165,7 +163,7 @@ curl -s -H "Authorization: Bearer demo-token" \
   'http://127.0.0.1:4318/api/v1/query?query=system_cpu_load_average_1m'
 ```
 
-The published image is built with `--features sql`, so `POST /api/v1/sql` answers
+The published image carries the `sql` feature, so `POST /api/v1/sql` answers
 by default. The registered tables are `samples`, `logs`, and `spans`:
 
 <!-- ravel:run status=200; nonempty:.data.rows -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -152,8 +152,8 @@ exact protocol or byte layout, or when you are changing the code.
 - [analytics.md](analytics.md): the analytics stage behind
   `POST /api/v1/analytics`: change point detection and summary statistics
   with a robust (median and scaled median absolute deviation) centre.
-- [otap-ingest.md](otap-ingest.md): OpenTelemetry Arrow ingest, behind a
-  cargo feature and a runtime flag, metrics only.
+- [otap-ingest.md](otap-ingest.md): OpenTelemetry Arrow ingest, metrics only,
+  compiled into the published image and registered by the `--otap` flag.
 - [explorer/](explorer/index.html): an interactive map of the crates and
   the flows that cross them. Open the file in a browser.
 

--- a/docs/diagrams/k8s-ci-integration.svg
+++ b/docs/diagrams/k8s-ci-integration.svg
@@ -41,7 +41,7 @@
   <rect x="40" y="300" width="280" height="70" rx="6" fill="#a9c9e6" stroke="#1f4e79" stroke-width="2"/>
   <text x="180" y="322" font-size="12.5" font-weight="bold" text-anchor="middle" fill="#17191c">cargo build --release</text>
   <text x="180" y="338" font-size="10.5" text-anchor="middle" fill="#17191c">on the runner (host), sccache-warmed;</text>
-  <text x="180" y="352" font-size="10.5" text-anchor="middle" fill="#17191c">--features sql for server, matching the shipping build</text>
+  <text x="180" y="352" font-size="10.5" text-anchor="middle" fill="#17191c">--features sql,flight-sql,otap, as the shipping build</text>
 
   <line x1="320" y1="335" x2="360" y2="335" stroke="#383e46" stroke-width="2" marker-end="url(#arrow)"/>
 

--- a/docs/guides/distributed-query.md
+++ b/docs/guides/distributed-query.md
@@ -11,8 +11,8 @@ Two scope limits before anything else. On the engine's own fan-out lane only
 the metrics signal distributes: a slice for logs or spans is answered
 `Unsupported` and the whole query runs on the coordinator. The SQL lane has a
 separate distributed scan, installed on the Flight SQL service, so it exists
-only in a build carrying the `flight-sql` cargo feature, which no published
-image builds.
+only in a build carrying the `flight-sql` cargo feature. The published image
+is such a build.
 
 For the engine-internal specification (slice partitioning, the merge order,
 the budget re-enforcement rules, the credential model) read
@@ -468,11 +468,11 @@ Deliberately:
 - **Logs and spans, on the engine's fan-out lane.** Only the metrics signal
   distributes there. A slice for any other signal is answered `Unsupported`,
   and the whole query runs locally.
-- **Anything at all, in a default build's SQL lane.** The SQL-lane distributed
-  scan is installed on the Flight SQL service, which only exists behind the
-  `flight-sql` cargo feature. In a build without that feature, and therefore in
-  every published image, no SQL statement distributes regardless of the
-  `--distributed-query` flags.
+- **Anything at all, in a build without `flight-sql`.** The SQL-lane
+  distributed scan is installed on the Flight SQL service, which only exists
+  behind the `flight-sql` cargo feature. The published image builds it; a
+  source build that leaves the feature off distributes no SQL statement
+  regardless of the `--distributed-query` flags.
 - **Straggler hedging and slice rebalancing.** A slow-but-alive worker is
   waited on; only a failed or unavailable one is re-dispatched. An oversized
   ingest shard makes an oversized slice, because a shard is never split.

--- a/docs/internal/development.md
+++ b/docs/internal/development.md
@@ -22,11 +22,12 @@ generated OTLP export, and queries it back by commit token
 ([scripts/demo.sh](../../scripts/demo.sh)).
 
 One capability difference to keep in mind: the published image is built with
-`--features sql`, so `POST /api/v1/sql` works in the compose quickstart. `make
-demo` builds the default feature set and does **not** enable `sql`, so the SQL
-endpoint is unavailable on the from-source path. PromQL, ingest, and the rest
-are identical on both. To exercise the SQL surface from source, run
-`ravel-server` yourself with `--features sql`, or use the compose quickstart.
+`--features sql,flight-sql,otap`, so `POST /api/v1/sql` and Flight SQL work in
+the compose quickstart and `--otap` is accepted there. `make demo` builds the
+default feature set and enables none of the three, so those surfaces are
+unavailable on the from-source path. PromQL, ingest, and the rest are identical
+on both. To exercise them from source, run `ravel-server` yourself with the
+same `--features` list, or use the compose quickstart.
 
 ## Fast local iteration
 

--- a/docs/otap-ingest.md
+++ b/docs/otap-ingest.md
@@ -6,8 +6,10 @@ ADR-0011 records the decisions.
 Enabling OTAP takes two things, not one: `ravel-server` must be built with
 the `otap` cargo feature, which links the arrow decode stack, and the
 process must be started with `--otap`, which registers the service. Either
-alone serves nothing, the flag does not exist in a build without the
-feature, and no published image builds it.
+alone serves nothing, and the flag does not exist in a build without the
+feature. The published `ravel-server` image is built with the feature, so
+there `--otap` is the only step; a source build passes `--features otap`
+to cargo (the workspace declares no default features).
 
 OTAP here is metrics only. The vendored protos declare `ArrowLogsService`
 and `ArrowTracesService`, but the tree implements neither: `ravel-server`
@@ -27,7 +29,7 @@ The receiver replies per batch with `BatchStatus` (ack/nack + retry hint).
 This is NOT generic Arrow Flight. Flight's `DoPut` could carry the same
 batches, but the OTel collector ecosystem speaks OTAP (`otelarrow`
 exporter), so OTAP is the interoperable surface. Flight SQL is a query
-surface and it ships, behind the `flight-sql` cargo feature that no
+surface and it ships, behind the `flight-sql` cargo feature, which the
 published image builds (ADR-0006, docs/query-engine.md). No Flight ingest
 path exists; if one is ever wanted, it reuses everything below except the
 stream state machine.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -966,7 +966,7 @@ Logs/Alerts/Audit/Spans distributed *search* is the SQL surface (log and trace
 search runs through the `logs`/`alerts`/`audit`/`spans` tables, not PromQL); the
 PromQL engine's own fetch/federation flow drives `Signal::Metrics` only today.
 The SQL-lane distributed scan that drives that log and trace search is a
-separate step, and it exists only in a `flight-sql` build, which no published
+separate step, and it exists only in a `flight-sql` build, which the published
 image is; see "The SQL-lane distributed scan" below.
 
 ### The log/span coordinator merge: order-independent, no dedup
@@ -1050,9 +1050,8 @@ query-worker roster and the same cost thresholds the PromQL distributed lane
 uses, whenever `--distributed-query` is on in `all` or `query` mode. Absent
 that flag the service runs every statement whole-set on the coordinator.
 
-The whole seam sits behind the `flight-sql` cargo feature, and no published
-image builds that feature, so reaching this code takes a build that asks for
-it.
+The whole seam sits behind the `flight-sql` cargo feature. The published image
+builds that feature; a source build reaches this code only by asking for it.
 
 ### Budgets and the fault matrix
 

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -192,9 +192,9 @@ per-tenant labels on the admission and query families are opt-in
 ## Not on this HTTP surface
 
 - Flight SQL is behind the `flight-sql` cargo feature and is a gRPC service on
-  the gRPC listener, not an HTTP route. No published image builds that feature.
+  the gRPC listener, not an HTTP route. The published image builds that feature.
 - OTAP (OpenTelemetry Arrow Protocol) metrics ingest is a gRPC service that
-  needs both the `otap` cargo feature and the `--otap` runtime flag. No published
-  image builds it.
+  needs both the `otap` cargo feature and the `--otap` runtime flag. The
+  published image builds the feature; the flag is still required.
 - OTLP ingest for metrics, logs, and traces is additionally available over
   gRPC on the gRPC listener; this page documents the HTTP form.

--- a/docs/reference/ravel-server-flags.md
+++ b/docs/reference/ravel-server-flags.md
@@ -2,7 +2,10 @@
 
 Every command-line flag `ravel-server` accepts, with its environment variable,
 default, and the first line of its help. The table is generated from the
-binary's clap definition, sorted by flag name.
+binary's clap definition, sorted by flag name. It is rendered from a build
+with no optional cargo features, so `--otap`, which exists only in an `otap`
+build (the published image is one), is not in the table;
+[otap-ingest.md](../otap-ingest.md) documents it.
 
 For the routes the server exposes rather than the flags that configure it, see
 [the HTTP API reference](http-api.md).

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -186,9 +186,9 @@ tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
 # OTAP (OpenTelemetry Arrow) metrics ingest on the gRPC listener: registers
 # `ArrowMetricsService` alongside the OTLP gRPC services. Off by default so the
 # default server build links neither `ravel-otap` nor the arrow dependency tree
-# it carries (docs/otap-ingest.md: "the gateway builds without it by default
-# until the bench panel justifies default-on"). Metrics only for now; the OTAP
-# logs and traces services are follow-up work.
+# it carries; the published image turns it on, and `--otap` stays the runtime
+# opt-in that registers the service (docs/otap-ingest.md). Metrics only for
+# now; the OTAP logs and traces services are follow-up work.
 otap = ["dep:ravel-otap"]
 
 # `POST /api/v1/sql`. Off by default: enabling it links datafusion into the
@@ -198,10 +198,9 @@ sql = ["dep:ravel-sql"]
 
 # Flight SQL on the gRPC listener. Implies `sql`: both surfaces execute through
 # ravel-sql, so there is no deployment that wants Flight without it
-# (the ravel-sql feature matrix). Off by default for
-# the same reason `sql` is. Today this registers an unimplemented service so
-# the wiring and the version pairing are proven; the real methods arrive with
-# ravel-sql's `flight` module.
+# (the ravel-sql feature matrix). Off by default for the same reason `sql` is;
+# the published image turns it on. Ad-hoc statements are served by ravel-sql's
+# `flight` module, and the prepared-statement methods answer UNIMPLEMENTED.
 flight-sql = ["sql", "ravel-sql/flight-sql", "dep:arrow-flight"]
 
 [dev-dependencies]

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -1689,9 +1689,16 @@ pub async fn start(
                     &settings.sql_ticket_secret(),
                 )
             });
-        sql_state
+        let service = sql_state
             .as_ref()
-            .map(|state| flight::service(state, ceiling, distributed))
+            .map(|state| flight::service(state, ceiling, distributed));
+        if service.is_some() {
+            tracing::info!(
+                "Flight SQL registered on the gRPC listener; ad-hoc statements are served, \
+                 prepared statements answer UNIMPLEMENTED"
+            );
+        }
+        service
     };
     // The ADR-0071 fragment `SeriesFetch` service is a
     // cluster-internal query surface: it binds this listener too, so a

--- a/services/ravel-server/src/main.rs
+++ b/services/ravel-server/src/main.rs
@@ -489,12 +489,6 @@ async fn main() -> anyhow::Result<()> {
     let running =
         ravel_server::start(config, store, store_background, store_metrics, cache).await?;
     tracing::info!(http = %running.http_addr, grpc = ?running.grpc_addr, "ravel-server listening");
-    if cfg!(feature = "flight-sql") {
-        tracing::info!(
-            "Flight SQL is registered on the gRPC listener, but every method answers \
-             UNIMPLEMENTED because the service is not yet implemented"
-        );
-    }
 
     wait_for_shutdown_signal().await;
     tracing::info!("shutdown signal received, draining");


### PR DESCRIPTION
The published `ravel-server` image was built with `--features sql` only, so Flight SQL and OTAP ingest needed a source build, and the README said so. This builds the image with `--features sql,flight-sql,otap`, and makes the CI lanes that assemble images from host-built binaries (k8s-integration, quickstart-verify, k8s-nightly) build the same set, so the image they test is the image that ships.

OTAP stays a runtime opt-in: `--otap` still decides whether ArrowMetricsService is registered. Flight SQL serves ad-hoc statements; prepared statements answer UNIMPLEMENTED, as before.

The startup log that claimed every Flight SQL method answers UNIMPLEMENTED was stale and fired in modes that never build the service. It now logs the real state where the service is built, and only when one is built.

Docs updated to match: README support matrix and feature paragraphs, docs/README.md, docs/otap-ingest.md, docs/query-engine.md, docs/guides/distributed-query.md, docs/reference/http-api.md, the ravel-server-flags.md header (the table is rendered from a default-feature build, so it explains where `--otap` is documented), docs/internal/development.md, the k8s CI diagram, and CHANGELOG.

Verified locally: `cargo check -p ravel-server --features sql,flight-sql,otap`, clippy on ravel-server and ravel-sql with `--features flight-sql,otap --all-targets -D warnings` and on ravel-server with default features, `cargo fmt --all --check`, `python3 scripts/check_docs.py`, `scripts/check-doc-drift.sh`, and actionlint on the two workflows. The root Dockerfile build runs in this PR's path-gated `docker-build` job, and the `run-k8s` label runs the kind lane against the changed build step.

Noticed while sweeping, not changed here: docs/guides/inspecting-data.md says no published image carries `ravel-cli`, but the server image copies it in (Dockerfile) and the compose quickstart runs it for store qualification.
