### PR TITLE
chore(release): prepare 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,88 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.0]
+
+Object-store request cost becomes an input that the logs read path and
+compaction plan against, typed attribute column statistics ride on commit
+records so aggregates over the live tail are answered without a scan, and the
+RLOG compaction merge runs under a memory budget. The RLOG version 3 reader is
+removed.
+
+### Added
+
+- **Request-cost-aware logs fetching** (ADR-0996). `--logs-fetch-policy`
+  (`request-minimal`, `byte-minimal`, or the default `cost-based`) is resolved
+  at startup into the byte quantities the fetch layer runs on, and
+  `--logs-max-fetch-run-bytes` bounds one covering GET (default 64 MiB).
+  `--logs-request-cost-bytes` states what one saved object-store round trip is
+  worth in saved transfer bytes, and `--store-cost-profile` loads this
+  deployment's per-request and per-GiB prices; a profile that fails to parse
+  is refused at startup.
+- **An S3 request ledger.** Billed HTTP requests are counted below the retry
+  loop, so a GET that retried nine times counts ten attempts instead of one
+  call, and KMS-routed traffic is counted too. GET requests are split per phase
+  beside the wire bytes, the number of distinct data objects a query touched
+  rides on the distributed query protocol as an additive field, and PromQL
+  `query` and `query_range` responses render the per-phase split under
+  `stats.phases`. Bench reports model request cost from the same ledger on the
+  instrumented lanes; the Flight lane reports no cost rather than a false zero.
+- **Typed attribute column statistics on commit records** (ADR-0873). Log
+  ingest stamps each typed attribute column's exact min, max, and null count on
+  the commit record, the catalog carries the stamps onto the segment reference,
+  and compaction recomputes them for the segments it writes. SQL `MIN`/`MAX`
+  over a typed attribute column is answered from the union of those stamps and
+  the fold-built `.cstat` statistics with zero data GETs, which covers the live
+  tail and token-resolved segments for the first time. Column statistics also
+  carry an exact per-object integer sum, so `SUM(col + k)` and `AVG` over an
+  integer column are answered from statistics as well.
+- **`.cstat` re-keyed to snapshot-part binding** (ADR-0942): an envelope
+  version 2 keyed by data-object content hash, and an additive snapshot HEAD
+  field that references it. The column-statistics cache runs under a byte
+  budget.
+- **Bounded ephemeral spill** (ADR-0954). An opt-in, bounded scratch area for
+  SQL operators whose exactness does not depend on holding the whole input,
+  configured with `RAVEL_SQL_SPILL_DIR` and `RAVEL_SQL_SPILL_MAX_BYTES`. Off by
+  default; a statement that exceeds its memory budget without it is still
+  refused rather than approximated.
+- **Advisory compaction claims** (ADR-1029). One small advisory object per unit
+  of compaction work under `sys/maintain/claims/compaction/`, so two processes
+  that would merge the same sealed bucket do not both pay for the whole merge.
+  Correctness still rests on the compaction record's create-if-absent publish;
+  a claim only saves cost.
+- **MetricsBench** (ADR-0927): a versioned metrics workload and PromQL corpus,
+  a Remote Write 1.0 ingest lane that replays one sample stream into Ravel and
+  into config-supplied comparators, pinned comparator deployments, and a
+  request-cost regression gate that fails a candidate report outside its
+  per-figure bands.
+- **Operator surfaces**: `spec.gc.protectionHorizon` and `spec.gc.grace` render
+  the GC horizon flags on the maintain Deployment, so a bucket whose `sys/gc`
+  holds non-default values no longer crash-loops. On a fresh cluster under
+  per-role credentials the operator applies maintain first and holds the
+  request-serving Deployments until `sys/gc` exists; a cluster whose
+  request-serving Deployments already exist is never held. A bootstrap that
+  has stalled for five minutes is reported on the cluster's conditions.
+- **`ravel-cli` levers**: `maintain compact-tenant --bucket-concurrency`
+  compacts independent buckets at once, its memory knobs
+  (`--l1-part-memory-target-bytes`, `--max-l1-part-bytes`,
+  `--input-read-concurrency`) are reachable, and its report attributes peak
+  memory by phase. `load --max-flush-delay` raises the age trigger so a large
+  `--target-bytes` is reachable, a `--target-bytes` that changed no object
+  layout is reported rather than silently ignored, and the load report counts
+  each shard's flushes by trigger (size, age, final).
+- **`/metrics`** renders the ingest exemplar counters and the remaining flush
+  counters (adaptive age flushes, grace-extended stale flushes, in-flight
+  flushes).
+- **Server-verified upload checksums** in the object-store crate. The S3
+  backend can attach an `x-amz-checksum` value (CRC64-NVME or SHA-256) on
+  single-part writes so the store verifies or rejects the bytes it received.
+  Multipart uploads are excluded, and no `ravel-server` or `ravel-cli` flag
+  exposes the setting yet, so the shipped binaries still write without one.
+- **Documentation** (ADR-1040): a documentation architecture with a docs gate
+  in CI, an HTTP API reference, generated `ravel-server` and `ravel-cli` flag
+  references, a concepts page, an alerting guide, and operations pages for
+  configuration, deployment, maintenance, and troubleshooting.
+
 ### Changed
 
 - **The published `ravel-server` image builds every opt-in surface.** It is now
@@ -13,6 +95,100 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   listener and `--otap` is accepted at startup without a source build. OTAP
   ingest is still registered only when `--otap` is given. The CI lanes that
   assemble images from host-built binaries build the same feature set.
+- **Bounded-memory RLOG compaction merge** (ADR-0979). The merge opens an
+  input's cursor only once its timestamp range can overlap the record about to
+  be emitted, holds decoded blocks in their columnar form and charges them at
+  their heap estimate, prices cursor admission from block shape and reconciles
+  after decode, releases each closed segment's bytes at PUT, and runs under a
+  merge budget; `compact-tenant` divides the budget across concurrent buckets
+  only while it still carries the box-sized default. The admission change
+  emits the same records and the same segment boundaries as opening every
+  cursor at once; the number of open cursors becomes the input overlap depth
+  rather than the input count.
+- **`--max-l1-part-bytes` bounds encoded object bytes** (#872). The RLOG
+  merge closed an L1 segment against a pre-compression payload proxy, so
+  stored sizes missed the target in both directions, by several times on a
+  compressible schema. The merge now encodes to measure the real object bytes
+  and closes on that count, with the probe step capped so overshoot past the
+  target is bounded. For the same inputs, segment boundaries differ from
+  those 0.11.0 wrote.
+- **Equality matchers resolve by dictionary ordinal.** Below the sparse-series
+  threshold, a metrics catalog decode whose matchers are all positive
+  equalities resolves each value to its dictionary ordinal once and
+  materializes a label set only for a series that matched. Fetched bytes are
+  unchanged; on a deterministic in-memory fixture of 4000 series the decode
+  took 38.1 percent less wall time at 1 percent selectivity.
+- **The catalog fold** reads each covered object once in the dual publish and
+  keeps its statistics tally cache across HEAD CAS retries, so a lost CAS no
+  longer refetches every object.
+- **Typed attribute column reads** in SQL build their resolvers once per block
+  rather than once per chunk.
+- **Distributed query protocol**: the data-objects-touched count is an
+  additive slice field. An older peer omits it and the merged figure degrades
+  to the coordinator's own count. The protocol version is unchanged.
+
+### Removed
+
+- **The RLOG version 3 reader** (ADR-0892). RLOG now accepts exactly one
+  trailer version, as RSEG and RSPAN already did under ADR-0027 decision 7 and
+  ADR-0066 decision 1. Log objects written by releases before 0.11.0 are no
+  longer readable, and `maintain migrate` reads the same single-version window,
+  so a tenant that still holds them is wiped or re-ingested.
+
+### Fixed
+
+- Column-statistics objects a resolvable snapshot still referenced were
+  treated as orphans by the unreferenced-catalog-object sweep and deleted once
+  past the protection horizon, which broke queries that resolve typed-column
+  statistics through the snapshot. Both statistics carriers on HEAD are now in
+  the sweep's reachability set.
+- Three SQL exact-aggregate paths (`COUNT` under a not-equal predicate,
+  `GROUP BY` counts, and `SUM`/`AVG`) answered from a `.cstat` entry whose row
+  accounting had not been reconciled against the segment it was joined to. All
+  four readers now go through one reconciliation.
+- The shipped IAM templates granted the maintain role no write on
+  `sys/maintain/` and the query role nothing under `sys/query/`, so a maintain
+  process failed closed with `AccessDenied` on its first liveness heartbeat,
+  and a query worker on its membership heartbeat.
+- On a fresh bucket with per-role credential Secrets, gateway and query pods
+  raced maintain to create `sys/gc`, failed the create, and crash-looped. The
+  operator now orders the bootstrap, and validates `spec.gc` even when
+  maintain is disabled.
+- Compaction convergence reported a bucket converged while the winner record
+  referenced a segment that was absent and could not be re-put from this run;
+  it now fails so the bucket is retried. The scope opener emits its request
+  report on every outcome, and opener election is atomic and
+  cancellation-safe.
+- A refused row-major write into a columnar ingest buffer still left its
+  records' extrema in the typed attribute column statistics accumulator, so
+  the next flush stamped min, max, and non-null count for records the object
+  does not hold. A refused write no longer contributes.
+- `make demo` had failed on a fresh bucket since the keyed-tenancy gate
+  landed; the dev bucket is pinned unkeyed, as the compose quickstart already
+  was.
+- The startup log reported a Flight SQL listener state the build was not in.
+- A `load` at a raised `--max-flush-delay` did not complete at its own
+  settings; the drain now sweeps tail stragglers with a re-flush ticker and
+  leaves reserve headroom in the delay ceiling.
+- `ravel-cli` walk-shaped commands name the effective store in their header
+  and refuse a defaulted in-memory walk that reaches no data, instead of
+  reporting zero counters at exit 0.
+
+### Known limitations
+
+- Query latency still depends on the tenant's working set fitting in the read
+  cache; removing the full-scan floor is tracked in #849. ClickBench `q33`
+  still exceeds the per-query memory budget (#837): the bounded spill relieves
+  the aggregate, and the scan's share of the memory remains.
+- Logs and spans return overlapping records twice when two compaction records
+  with overlapping input sets are published for one bucket (#1070). Metrics
+  are unaffected, because query-time dedup collapses the overlap. A fix is in
+  review.
+- After a selective-erasure rewrite lands in a sealed hour outside the fold's
+  reconcile window, the superseded-input sweep can delete inputs a HEAD-named
+  snapshot part still resolves, and queries over that hour then fail closed
+  with `SnapshotInvalidated` until the fold reconciles the hour (#1085).
+  Subject erasure stays correct throughout. A fix is in review.
 
 ## [0.11.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4468,14 +4468,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-affinity"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
 ]
 
 [[package]]
 name = "ravel-alerting"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "hex",
@@ -4487,14 +4487,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-analytics"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ravel-bench"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrow 59.1.0",
  "arrow-flight",
@@ -4547,7 +4547,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cache"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "crc32c",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-catalog"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -4629,7 +4629,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-codec"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-commit"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-failure-tests"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "futures",
@@ -4682,7 +4682,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-fleet"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "futures",
@@ -4701,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest-router"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-logseg"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-maintain"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-object-store"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-operator"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "futures",
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otap"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ipc 59.1.0",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otlp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "promql-parser",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql-difftest"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-proto"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-query"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-remote-write"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "hex",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-rspan"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "crc32c",
  "proptest",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-segment"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sim"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5127,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sql"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tenant-resolve"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "base64 0.23.0",
@@ -5184,7 +5184,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tracing-export"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "services/*"]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.97"
@@ -26,29 +26,29 @@ expect_used = "warn"
 # Version fields pin each path dependency so cargo-deny does not count them as
 # wildcards. allow-wildcard-paths is not usable here because these
 # crates are not marked publish = false, so it does not exempt them.
-ravel-types = { path = "crates/ravel-types", version = "0.11.0" }
-ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.11.0" }
-ravel-proto = { path = "crates/ravel-proto", version = "0.11.0" }
-ravel-codec = { path = "crates/ravel-codec", version = "0.11.0" }
-ravel-object-store = { path = "crates/ravel-object-store", version = "0.11.0" }
-ravel-segment = { path = "crates/ravel-segment", version = "0.11.0" }
-ravel-logseg = { path = "crates/ravel-logseg", version = "0.11.0" }
-ravel-rspan = { path = "crates/ravel-rspan", version = "0.11.0" }
-ravel-commit = { path = "crates/ravel-commit", version = "0.11.0" }
-ravel-catalog = { path = "crates/ravel-catalog", version = "0.11.0" }
-ravel-cache = { path = "crates/ravel-cache", version = "0.11.0" }
-ravel-maintain = { path = "crates/ravel-maintain", version = "0.11.0" }
-ravel-fleet = { path = "crates/ravel-fleet", version = "0.11.0" }
-ravel-otlp = { path = "crates/ravel-otlp", version = "0.11.0" }
-ravel-otap = { path = "crates/ravel-otap", version = "0.11.0" }
-ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.11.0" }
-ravel-alerting = { path = "crates/ravel-alerting", version = "0.11.0" }
-ravel-ingest = { path = "crates/ravel-ingest", version = "0.11.0" }
-ravel-promql = { path = "crates/ravel-promql", version = "0.11.0" }
-ravel-query = { path = "crates/ravel-query", version = "0.11.0" }
-ravel-analytics = { path = "crates/ravel-analytics", version = "0.11.0" }
-ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.11.0" }
-ravel-affinity = { path = "crates/ravel-affinity", version = "0.11.0" }
+ravel-types = { path = "crates/ravel-types", version = "0.12.0" }
+ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.12.0" }
+ravel-proto = { path = "crates/ravel-proto", version = "0.12.0" }
+ravel-codec = { path = "crates/ravel-codec", version = "0.12.0" }
+ravel-object-store = { path = "crates/ravel-object-store", version = "0.12.0" }
+ravel-segment = { path = "crates/ravel-segment", version = "0.12.0" }
+ravel-logseg = { path = "crates/ravel-logseg", version = "0.12.0" }
+ravel-rspan = { path = "crates/ravel-rspan", version = "0.12.0" }
+ravel-commit = { path = "crates/ravel-commit", version = "0.12.0" }
+ravel-catalog = { path = "crates/ravel-catalog", version = "0.12.0" }
+ravel-cache = { path = "crates/ravel-cache", version = "0.12.0" }
+ravel-maintain = { path = "crates/ravel-maintain", version = "0.12.0" }
+ravel-fleet = { path = "crates/ravel-fleet", version = "0.12.0" }
+ravel-otlp = { path = "crates/ravel-otlp", version = "0.12.0" }
+ravel-otap = { path = "crates/ravel-otap", version = "0.12.0" }
+ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.12.0" }
+ravel-alerting = { path = "crates/ravel-alerting", version = "0.12.0" }
+ravel-ingest = { path = "crates/ravel-ingest", version = "0.12.0" }
+ravel-promql = { path = "crates/ravel-promql", version = "0.12.0" }
+ravel-query = { path = "crates/ravel-query", version = "0.12.0" }
+ravel-analytics = { path = "crates/ravel-analytics", version = "0.12.0" }
+ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.12.0" }
+ravel-affinity = { path = "crates/ravel-affinity", version = "0.12.0" }
 
 # async runtime / rpc / http
 tokio = { version = "1.53", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ See the [Kubernetes guide](docs/guides/kubernetes.md).
 GitHub Container Registry on every `vX.Y.Z` release tag, built from the root
 `Dockerfile`. Both `linux/amd64` and `linux/arm64` are published. Each published
 object is an OCI image index that carries an SBOM and full build provenance. The
-quickstart pins `ghcr.io/nofireai/ravel-server:0.11.0`. Override it with
+quickstart pins `ghcr.io/nofireai/ravel-server:0.12.0`. Override it with
 `RAVEL_IMAGE`.
 
 ```sh
@@ -303,12 +303,12 @@ so that is the identity in the certificate:
 
 ```sh
 cosign verify \
-  --certificate-identity 'https://github.com/NOFireAI/ravel/.github/workflows/publish-images.yml@refs/tags/v0.11.0' \
+  --certificate-identity 'https://github.com/NOFireAI/ravel/.github/workflows/publish-images.yml@refs/tags/v0.12.0' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-  ghcr.io/nofireai/ravel-server:0.11.0
+  ghcr.io/nofireai/ravel-server:0.12.0
 ```
 
-Replace `v0.11.0` and `0.11.0` with the release you are verifying. The tag ref in
+Replace `v0.12.0` and `0.12.0` with the release you are verifying. The tag ref in
 `--certificate-identity` must be the exact tag that produced the image.
 
 ## How Ravel is verified

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -29,7 +29,7 @@ ravel-promql = { workspace = true }
 # (`metricsbench_gen`) runs the gate, which a dev-dependency would be invisible
 # to. It is already a workspace member, so a `--workspace` build compiled it
 # before this edge existed too.
-ravel-promql-difftest = { path = "../ravel-promql-difftest", version = "0.11.0" }
+ravel-promql-difftest = { path = "../ravel-promql-difftest", version = "0.12.0" }
 prost = { workspace = true }
 # MetricsBench Remote Write 1.0 ingest lane (ADR-0927, issue #937, task M5).
 # `ravel-remote-write` supplies the `prometheus.WriteRequest`/`TimeSeries`/
@@ -99,7 +99,7 @@ futures = { workspace = true, optional = true }
 # ravel-sql is an internal path crate not yet listed in the workspace
 # `[workspace.dependencies]`, so it is named by path here; every other dep
 # below reuses a workspace pin.
-ravel-sql = { path = "../ravel-sql", version = "0.11.0", optional = true, features = ["flight-sql"] }
+ravel-sql = { path = "../ravel-sql", version = "0.12.0", optional = true, features = ["flight-sql"] }
 # Gated behind `sql-latency`. The spans-scan bench lane (`src/spans_scan.rs`)
 # writes its RSPAN corpus with the real span writer and drives `SpansScanExec`
 # directly, so it needs the writer/record types (`RspanWriter`, `SpanRecord`,

--- a/crates/ravel-ingest/Cargo.toml
+++ b/crates/ravel-ingest/Cargo.toml
@@ -30,7 +30,7 @@ ravel-catalog = { workspace = true }
 # [workspace.dependencies]; the root Cargo.toml is out of this task's scope, so
 # this is a version-pinned path dependency (the pin keeps cargo-deny from
 # counting it as a wildcard, matching the workspace's path-dep convention).
-ravel-rspan = { path = "../ravel-rspan", version = "0.11.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.12.0" }
 # The router live switch (ADR-0052) decodes the provisioning record read for a
 # generation refresh; prost's Message trait provides `decode`.
 prost = { workspace = true }
@@ -54,7 +54,7 @@ ravel-promql = { workspace = true }
 # zero data GETs. ravel-sql depends on ravel-catalog/ravel-query/ravel-commit/
 # ravel-logseg, none of which depend on ravel-ingest, so this dev-only edge adds
 # no cycle. No feature flag: ravel-sql's SQL surface is unconditional.
-ravel-sql = { path = "../ravel-sql", version = "0.11.0" }
+ravel-sql = { path = "../ravel-sql", version = "0.12.0" }
 # Match ravel-sql's datafusion pin exactly (same arrow 58 line) so the test's
 # SessionContext/collect interop with ravel-sql's plan types.
 datafusion = { version = "54", default-features = false, features = ["sql"] }

--- a/crates/ravel-otlp/Cargo.toml
+++ b/crates/ravel-otlp/Cargo.toml
@@ -16,7 +16,7 @@ ravel-logseg = { workspace = true }
 # Used for the span record's StatusCode and the frozen resource+scope+span
 # attribute merge rule, so trace normalization and the RSPAN writer cannot
 # drift apart on either.
-ravel-rspan = { path = "../ravel-rspan", version = "0.11.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.12.0" }
 opentelemetry-proto = { workspace = true }
 # Span events and links are stored as an opaque serialized blob in RSPAN v1
 # (ADR-0041 decision 4), which needs prost's own length-delimited encoding.

--- a/crates/ravel-query/Cargo.toml
+++ b/crates/ravel-query/Cargo.toml
@@ -95,7 +95,7 @@ ravel-cache = { workspace = true }
 # proof (tests/differential_compaction.rs) drives P4's real compactor to
 # produce write_v4 L1 parts. ravel-maintain does not depend on ravel-query,
 # so this is acyclic.
-ravel-maintain = { path = "../ravel-maintain", version = "0.11.0" }
+ravel-maintain = { path = "../ravel-maintain", version = "0.12.0" }
 proptest = { workspace = true }
 # The ADR-0046 disk cache tier (crates/ravel-query/src/cache_correctness.rs)
 # needs a real on-disk directory to construct a `ravel_cache::DiskCache`; the

--- a/deploy/docker-compose/ravel.yml
+++ b/deploy/docker-compose/ravel.yml
@@ -50,7 +50,7 @@ services:
   # already-qualified bucket it reports the existing record and exits 0, so this
   # tolerates a populated `minio-data/` across runs.
   qualify:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.11.0}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.12.0}
     depends_on:
       createbucket:
         condition: service_completed_successfully
@@ -72,7 +72,7 @@ services:
   # container boundary forbids, so the demo authenticates with a real bearer
   # token against a real tenant map, exactly as a deployment does.
   ravel-server:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.11.0}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.12.0}
     depends_on:
       qualify:
         condition: service_completed_successfully

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -32,7 +32,7 @@ That brings up five things, all from published images:
   bootstrap-and-continue path for it, so a freshly created bucket has to be
   qualified before the server starts. The step is idempotent: on an
   already-qualified bucket it reports the existing record and exits 0.
-- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.11.0` (override the pin
+- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.12.0` (override the pin
   with the `RAVEL_IMAGE` environment variable), listening on `127.0.0.1:4318`
   (HTTP) and `127.0.0.1:4317` (gRPC), with the tenant token `demo-token` mapped
   to tenant `demo-tenant`.

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -133,7 +133,7 @@ Two routes Grafana's built-in Prometheus datasource probes on every datasource
 save. They take no parameters.
 
 ```json
-{"status": "success", "data": {"version": "0.11.0", "revision": "", "branch": "", "buildUser": "", "buildDate": "", "goVersion": ""}}
+{"status": "success", "data": {"version": "0.12.0", "revision": "", "branch": "", "buildUser": "", "buildDate": "", "goVersion": ""}}
 ```
 
 `version` is Ravel's own version, not a Prometheus one. `revision` is the

--- a/services/ravel-cli/Cargo.toml
+++ b/services/ravel-cli/Cargo.toml
@@ -106,7 +106,7 @@ tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
 # `LogsTableProvider` logs path is in ravel-sql's default build (the
 # `flight-sql` feature only gates the Flight transport), so no feature is
 # needed here.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.11.0" }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.12.0" }
 # The reachability test builds a SqlExecutor's segment fetchers from ravel-query
 # (SegmentFetcher/LogSegmentFetcher/SpanSegmentFetcher); ravel-catalog is
 # already a normal dependency. Workspace pin, test construction only.
@@ -123,7 +123,7 @@ async-trait = { workspace = true }
 # ravel-server is a workspace path crate not listed in
 # `[workspace.dependencies]`, so it is named by path with a pinned version here,
 # exactly as ravel-sql above is; no new external crate enters Cargo.lock.
-ravel-server = { path = "../ravel-server", version = "0.11.0", features = ["sql"] }
+ravel-server = { path = "../ravel-server", version = "0.12.0", features = ["sql"] }
 # The reachability test's axum request/response plumbing (the same shape
 # ravel-server's own endpoint tests use). Already resolved in this workspace's
 # dependency graph; test-only.

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -154,14 +154,14 @@ reqwest = { version = "0.13", features = ["json"] }
 # ravel-rspan below are: the workspace root Cargo.toml is outside this task's
 # scope. The pin keeps cargo-deny from counting it as a wildcard path
 # dependency.
-ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.11.0" }
+ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.12.0" }
 
 # ravel-sql is declared here as a path dependency rather than through
 # `[workspace.dependencies]` because the workspace root Cargo.toml is outside
 # this task's scope. The version is pinned so cargo-deny does not count it as
 # a wildcard path dependency, matching how every other
 # internal crate is pinned.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.11.0", optional = true }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.12.0", optional = true }
 
 # Flight service codegen for the `flight-sql` feature. This is arrow 58's
 # arrow-flight, a different arrow major than the `arrow` dev-dependency below;
@@ -221,7 +221,7 @@ tokio = { workspace = true, features = ["test-util"] }
 # listed in the workspace [workspace.dependencies]; the root Cargo.toml is out
 # of this task's scope, so this is a version-pinned path dependency (the pin
 # keeps cargo-deny from counting it as a wildcard).
-ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.11.0" }
+ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.12.0" }
 uuid = { workspace = true }
 # Real-authn end-to-end test (tests/real_authn_e2e.rs): mint a JWT and build a
 # local oct (HMAC) JWKS so the OIDC resolver runs through a real HTTP request


### PR DESCRIPTION
Bumps the workspace to 0.12.0 and writes the 0.12.0 changelog section.

The version moves in `[workspace.package]`, every pinned path dependency, `Cargo.lock`, the README image pin and cosign example, the compose quickstart, and the two guides that quote the image tag and the `buildinfo` version. `scripts/check-workspace-versions.sh` passes.

Why a minor bump: ADR-0892 removed the RLOG version 3 reader, so log objects written before 0.11.0 are no longer readable. A removed reader is a persistent-format change.

The changelog lists two open defects found this cycle under known limitations, with their issues (#1070, #1085). Fixes for both are in review and will ship in a patch release.

Tagging follows the merge: `v0.12.0` is pushed only after the merge commit's own `ci.yml` run is green, since `publish-images.yml` gates on that run.