### PR TITLE
fix(server): record the cost a timed-out or cancelled query incurred

### DIFF
--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -3342,8 +3342,11 @@ mod tests {
                 .await
         });
 
-        // Block until the GET is genuinely parked inside the store.
-        gate.wait_until_held(1).await;
+        // Block until the GET is genuinely parked inside the store. Bounded so
+        // a fetch that stops issuing exactly one GET fails instead of hanging.
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(1))
+            .await
+            .expect("the fetch issues its GET within 30 s");
         assert_eq!(
             gate.held_count(),
             1,
@@ -3367,7 +3370,11 @@ mod tests {
         for id in gate.held() {
             assert!(gate.release(id), "held id must release");
         }
-        let (soa, _stats) = handle.await.expect("join fetch task").expect("fetch");
+        let (soa, _stats) = tokio::time::timeout(std::time::Duration::from_secs(30), handle)
+            .await
+            .expect("the released fetch completes within 30 s")
+            .expect("join fetch task")
+            .expect("fetch");
         assert_eq!(soa.len(), 2);
 
         let done = accounting.snapshot();

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -713,9 +713,13 @@ impl SegmentFetcher {
     /// `guarded_get`/`ensure_ranges` call, or a query whose in-flight GETs
     /// already fill the pool could wait on itself.
     ///
-    /// Only a successful GET is recorded, matching `QueryAccounting`'s
-    /// "completed store request" wording; a failed GET propagates its error
-    /// unrecorded.
+    /// The request is counted at ISSUE time, once the in-flight permit is held
+    /// and immediately before the backend `get` is awaited, so a future dropped
+    /// or timed out while that `get` is still pending still shows the request it
+    /// started; the transferred bytes are added only at completion, when their
+    /// length is known. Counting on issue rather than completion means a failed
+    /// GET is now counted too (one issued request), which is the honest figure
+    /// for a query that spent a round trip only to error.
     async fn store_get(
         &self,
         key: &str,
@@ -726,8 +730,8 @@ impl SegmentFetcher {
             self.get_semaphore.acquire().await.map_err(|_| {
                 StoreError::Transient("fetch concurrency semaphore closed".to_string())
             })?;
-        let got = self.store.get(key, range).await?;
         accounting.record_s3_request(AccountedOp::Get);
+        let got = self.store.get(key, range).await?;
         accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
         Ok(got)
     }
@@ -2143,12 +2147,10 @@ impl SegmentFetcher {
         matchers: &[LabelMatcher],
         accounting: &QueryAccounting,
     ) -> Result<Vec<SeriesEntry>, FetchError> {
-        let phase = PhaseAccounting::new();
-        let result = self
-            .fetch_series_phase_accounted(tenant_hash, seg_ref, matchers, &phase)
-            .await;
-        accounting.merge_snapshot(&phase.snapshot().pooled());
-        result
+        let phase = PhaseAccounting::pooled_over(accounting);
+
+        self.fetch_series_phase_accounted(tenant_hash, seg_ref, matchers, &phase)
+            .await
     }
 
     /// Phase-split counterpart of
@@ -2156,9 +2158,10 @@ impl SegmentFetcher {
     /// same behavior, but every GET is recorded against the phase that
     /// issued it (plan for [`open_segment`](Self::open_segment), probe for
     /// [`decode_selected`](Self::decode_selected)) rather than pooled onto
-    /// one handle. `fetch_series_accounted` is now a thin wrapper over this
-    /// that folds the four phase totals back into its single
-    /// `QueryAccounting` handle, so its own callers (`ravel-sql`'s direct
+    /// one handle. `fetch_series_accounted` is a thin wrapper over this that
+    /// runs it against a [`PhaseAccounting::pooled_over`] its single
+    /// `QueryAccounting` handle, so every GET records straight onto that one
+    /// handle (live, as it is issued) and its callers (`ravel-sql`'s direct
     /// calls included) see unchanged pooled numbers.
     pub(crate) async fn fetch_series_phase_accounted(
         &self,
@@ -2211,11 +2214,10 @@ impl SegmentFetcher {
         matchers: &[LabelMatcher],
         accounting: &QueryAccounting,
     ) -> Result<Vec<FetchedSeries>, FetchError> {
-        let phase = PhaseAccounting::new();
+        let phase = PhaseAccounting::pooled_over(accounting);
         let result = self
             .fetch_runs(tenant_hash, seg_ref, matchers, false, &phase)
             .await;
-        accounting.merge_snapshot(&phase.snapshot().pooled());
         let (runs, _stats) = result?;
         Ok(runs.into_iter().map(RunDecode::into_aos).collect())
     }
@@ -2245,11 +2247,10 @@ impl SegmentFetcher {
         matchers: &[LabelMatcher],
         accounting: &QueryAccounting,
     ) -> Result<(Vec<FetchedSeriesSoa>, FetchStats), FetchError> {
-        let phase = PhaseAccounting::new();
+        let phase = PhaseAccounting::pooled_over(accounting);
         let result = self
             .fetch_runs(tenant_hash, seg_ref, matchers, true, &phase)
             .await;
-        accounting.merge_snapshot(&phase.snapshot().pooled());
         let (runs, stats) = result?;
         Ok((runs.into_iter().map(RunDecode::into_soa).collect(), stats))
     }
@@ -2281,11 +2282,10 @@ impl SegmentFetcher {
         matchers: &[LabelMatcher],
         accounting: &QueryAccounting,
     ) -> Result<Vec<FetchedHistogramSeries>, FetchError> {
-        let phase = PhaseAccounting::new();
+        let phase = PhaseAccounting::pooled_over(accounting);
         let result = self
             .fetch_histogram_runs(tenant_hash, seg_ref, matchers, &phase)
             .await;
-        accounting.merge_snapshot(&phase.snapshot().pooled());
         let runs = result?;
         Ok(runs
             .into_iter()
@@ -2340,12 +2340,10 @@ impl SegmentFetcher {
         ),
         FetchError,
     > {
-        let phase = PhaseAccounting::new();
-        let result = self
-            .fetch_soa_and_histograms_phase_accounted(tenant_hash, seg_ref, matchers, &phase)
-            .await;
-        accounting.merge_snapshot(&phase.snapshot().pooled());
-        result
+        let phase = PhaseAccounting::pooled_over(accounting);
+
+        self.fetch_soa_and_histograms_phase_accounted(tenant_hash, seg_ref, matchers, &phase)
+            .await
     }
 
     /// Phase-split counterpart of
@@ -2354,9 +2352,10 @@ impl SegmentFetcher {
     /// for why both forms exist. `engine.rs` calls this directly with a real,
     /// persistent `PhaseAccounting` for end-to-end phase visibility;
     /// `fetch_soa_and_histograms_accounted` is a thin wrapper over this that
-    /// folds the four phase totals back into its single `QueryAccounting`
-    /// handle, so its own callers (`ravel-sql`'s direct calls included) see
-    /// unchanged pooled numbers.
+    /// runs it against a [`PhaseAccounting::pooled_over`] its single
+    /// `QueryAccounting` handle, so every GET records straight onto that one
+    /// handle (live, as it is issued) and its callers (`ravel-sql`'s direct
+    /// calls included) see unchanged pooled numbers.
     pub(crate) async fn fetch_soa_and_histograms_phase_accounted(
         &self,
         tenant_hash: TenantHash,
@@ -3297,6 +3296,91 @@ mod tests {
         );
         assert_eq!(snapshot.segments_opened, 1);
         assert_eq!(snapshot.series_matched, 2);
+    }
+
+    /// A GET is accounted at issue time: while it is held open inside the
+    /// backend and has not yet returned, it already counts as exactly one
+    /// issued request with zero bytes (the length is unknown until it
+    /// resolves). This is what makes a future dropped or timed out mid-GET
+    /// record the request it started. `FaultStore`'s hold gate parks the GET
+    /// inside the store, so the count is asserted while the call is provably
+    /// pending, not after it completed.
+    #[tokio::test]
+    async fn a_held_get_counts_as_one_issued_request_while_pending() {
+        use ravel_object_store::fault::{GateHandle, Occurrence};
+
+        // Same fixture object, re-homed into a FaultStore so a hold gate can
+        // park its GET. `write_test_segment`'s object is well under the
+        // whole-object threshold, so the fetch issues a single whole-object
+        // GET -- the one call the gate holds.
+        let (source, tenant_hash, seg_ref) = write_test_segment().await;
+        let object_bytes = source
+            .get(&seg_ref.data_object_key, GetRange::Full)
+            .await
+            .expect("read back test segment")
+            .data;
+        let memory = MemoryStore::new();
+        memory
+            .put(
+                &seg_ref.data_object_key,
+                object_bytes.clone(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put segment object");
+        let fault = Arc::new(FaultStore::new(memory, FaultPlan::default()));
+        let gate: GateHandle = fault.hold(Op::Get, None, Occurrence::Always);
+        let backend: Arc<dyn ObjectStoreBackend> = fault;
+        let fetcher = SegmentFetcher::new(backend);
+
+        let accounting = QueryAccounting::new();
+        let fetch_accounting = accounting.clone();
+        let seg = seg_ref.clone();
+        let handle = tokio::spawn(async move {
+            fetcher
+                .fetch_soa_accounted(tenant_hash, &seg, &[], &fetch_accounting)
+                .await
+        });
+
+        // Block until the GET is genuinely parked inside the store.
+        gate.wait_until_held(1).await;
+        assert_eq!(
+            gate.held_count(),
+            1,
+            "exactly one GET is held; the fault fired"
+        );
+
+        let pending = accounting.snapshot();
+        assert_eq!(
+            pending.s3_requests(AccountedOp::Get),
+            1,
+            "the in-flight GET is counted as one issued request while still pending"
+        );
+        assert_eq!(
+            pending.s3_bytes(AccountedOp::Get),
+            0,
+            "no bytes are charged until the GET returns and its length is known"
+        );
+
+        // Release the held GET and let the fetch finish: the bytes are now
+        // charged, and the request count does not double.
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+        let (soa, _stats) = handle.await.expect("join fetch task").expect("fetch");
+        assert_eq!(soa.len(), 2);
+
+        let done = accounting.snapshot();
+        assert_eq!(
+            done.s3_requests(AccountedOp::Get),
+            1,
+            "the same GET stays one request after it completes"
+        );
+        assert_eq!(
+            done.s3_bytes(AccountedOp::Get),
+            object_bytes.len() as u64,
+            "the whole-object GET charges exactly the object's byte length at completion"
+        );
     }
 
     /// ADR-0044: accounting must be pure observation. The accounted and

--- a/crates/ravel-query/src/phase_accounting.rs
+++ b/crates/ravel-query/src/phase_accounting.rs
@@ -267,6 +267,11 @@ impl PhaseAccounting {
     /// completion. A caller that needs the genuine per-phase split (the PromQL
     /// engine) threads a persistent [`PhaseAccounting::new`] through the whole
     /// query instead and never routes through these pooled wrappers.
+    ///
+    /// Never fold a handle built this way back through
+    /// [`snapshot`](Self::snapshot) and [`pooled`](PhaseAccountingSnapshot::pooled):
+    /// its four phases are one counter, so pooling its snapshot would count
+    /// every request and byte four times. Read `accounting.snapshot()` instead.
     #[must_use]
     pub fn pooled_over(accounting: &QueryAccounting) -> Self {
         PhaseAccounting {

--- a/crates/ravel-query/src/phase_accounting.rs
+++ b/crates/ravel-query/src/phase_accounting.rs
@@ -253,6 +253,30 @@ impl PhaseAccounting {
         PhaseAccounting::default()
     }
 
+    /// A handle whose four phases are all clones of `accounting`, so every
+    /// store call the fetch pipeline charges to any phase lands directly on
+    /// that one shared handle -- live, at the instant it is recorded, not in a
+    /// per-phase buffer folded in only once the fetch returns.
+    ///
+    /// The pooled read entry points (`SegmentFetcher::fetch_*_accounted`) use
+    /// this. They discard the per-phase split anyway -- they immediately
+    /// [`pooled`](Self::pooled) the four handles back into one -- so sharing
+    /// loses nothing, and it lets a query that is timed out or dropped
+    /// mid-fetch still show the requests and bytes the in-flight fetch had
+    /// already issued, instead of recording that cost only if the fetch runs to
+    /// completion. A caller that needs the genuine per-phase split (the PromQL
+    /// engine) threads a persistent [`PhaseAccounting::new`] through the whole
+    /// query instead and never routes through these pooled wrappers.
+    #[must_use]
+    pub fn pooled_over(accounting: &QueryAccounting) -> Self {
+        PhaseAccounting {
+            resolve: accounting.clone(),
+            plan: accounting.clone(),
+            probe: accounting.clone(),
+            scan: accounting.clone(),
+        }
+    }
+
     /// The resolve phase's handle.
     #[must_use]
     pub fn resolve(&self) -> &QueryAccounting {

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -259,6 +259,55 @@ pub struct SqlOutcome {
     pub spill_by_operator: Vec<OperatorSpill>,
 }
 
+/// A shared, cloneable view of the [`QueryAccounting`] for the query currently
+/// running under [`SqlExecutor::execute_accounted`]. It lets a caller snapshot
+/// the cost incurred so far at any instant, including on the two exits that
+/// never yield a [`SqlOutcome`]: a wall-deadline trip (the `execute` timeout
+/// wrapper drops the run future and returns [`SqlError::DeadlineExceeded`]) and
+/// the whole execute future being dropped mid-fetch (a client disconnect). On
+/// the success path the snapshot equals the returned [`SqlOutcome::accounting`].
+///
+/// The executor re-points this at each attempt's own handle: the snapshot retry
+/// builds a fresh [`QueryAccounting`] per attempt, and installing the live view
+/// on each keeps a discarded first attempt's counters from lingering in a later
+/// read, matching how [`SqlOutcome::accounting`] reports only the successful
+/// attempt.
+#[derive(Clone, Default)]
+pub struct LiveAccounting(Arc<Mutex<QueryAccounting>>);
+
+impl LiveAccounting {
+    /// A live view whose counters are all zero until an execution installs the
+    /// first attempt's handle.
+    pub fn new() -> Self {
+        LiveAccounting::default()
+    }
+
+    /// Snapshot the current attempt's counters. Safe from any thread at any
+    /// time, including a `Drop` running after the execute future was dropped
+    /// mid-await: the attempt's counter block lives behind an `Arc` this view
+    /// shares, so it outlives the dropped future.
+    pub fn snapshot(&self) -> QueryAccountingSnapshot {
+        self.lock().snapshot()
+    }
+
+    /// Point this view at `accounting` (the attempt about to run). Clones the
+    /// handle, so the two share one atomic counter block and every increment
+    /// the attempt makes is visible through [`Self::snapshot`].
+    fn install(&self, accounting: &QueryAccounting) {
+        *self.lock() = accounting.clone();
+    }
+
+    /// Lock the inner slot, recovering a poisoned guard. The slot holds one
+    /// cheap-to-clone handle and no torn state, so recovering is safe and
+    /// strictly better than failing every later snapshot.
+    fn lock(&self) -> std::sync::MutexGuard<'_, QueryAccounting> {
+        match self.0.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
 /// Executes SQL for any tenant against one catalog and object store.
 ///
 /// The executor holds no DataFusion state: it is the per-tenant memory
@@ -453,17 +502,40 @@ impl SqlExecutor {
         tenant_hash: TenantHash,
         req: &SqlRequest,
     ) -> Result<SqlOutcome, SqlError> {
+        self.execute_accounted(tenant_hash, req, &LiveAccounting::new())
+            .await
+    }
+
+    /// [`Self::execute`], with a caller-owned [`LiveAccounting`] the caller can
+    /// snapshot at any instant, independent of how the query ends.
+    ///
+    /// The server's cost guard passes one so a timed-out or dropped query still
+    /// records the requests and bytes it actually issued: neither a
+    /// [`SqlError::DeadlineExceeded`] nor the run future being dropped mid-fetch
+    /// carries those figures otherwise. On the success path the returned
+    /// [`SqlOutcome::accounting`] equals `live.snapshot()`.
+    pub async fn execute_accounted(
+        &self,
+        tenant_hash: TenantHash,
+        req: &SqlRequest,
+        live: &LiveAccounting,
+    ) -> Result<SqlOutcome, SqlError> {
         // Step 1: the security gate runs before any catalog or plan work.
         validate(&req.sql)?;
 
         let millis = u64::try_from(req.deadline.as_millis()).unwrap_or(u64::MAX);
-        tokio::time::timeout(req.deadline, self.run(tenant_hash, req))
+        tokio::time::timeout(req.deadline, self.run(tenant_hash, req, live))
             .await
             .unwrap_or(Err(SqlError::DeadlineExceeded { millis }))
     }
 
     /// The resolve/plan/execute loop, minus validation and the deadline.
-    async fn run(&self, tenant_hash: TenantHash, req: &SqlRequest) -> Result<SqlOutcome, SqlError> {
+    async fn run(
+        &self,
+        tenant_hash: TenantHash,
+        req: &SqlRequest,
+        live: &LiveAccounting,
+    ) -> Result<SqlOutcome, SqlError> {
         let mut stats = SqlStats::default();
 
         // Resolve the tenant's declared typed attribute columns once for the
@@ -482,6 +554,11 @@ impl SqlExecutor {
         // into the retry's.
         for attempt in 0..2u32 {
             let accounting = QueryAccounting::new();
+            // Re-point the caller's live view at this attempt's handle before
+            // any store call, so a snapshot taken from a `Drop` or after a
+            // deadline trip reflects exactly this attempt's issued cost and
+            // never a discarded prior attempt's.
+            live.install(&accounting);
             let (snapshot, estimate) = self.resolve(tenant_hash, req, &accounting).await?;
             stats.resolves += 1;
             stats.attempts += 1;

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -124,7 +124,9 @@ pub use error::{
     ErrorClass, MSG_CORRUPT, MSG_EXECUTION, MSG_INTERNAL, MSG_PLAN, MSG_SPILL_DISABLED_MARKER,
     MSG_SPILL_QUOTA_MARKER, MSG_SPILL_UNAVAILABLE, MSG_UNAVAILABLE, MSG_UNSATISFIABLE, SqlError,
 };
-pub use executor::{PinnedQuery, PinnedStream, SqlExecutor, SqlOutcome, SqlRequest, SqlStats};
+pub use executor::{
+    LiveAccounting, PinnedQuery, PinnedStream, SqlExecutor, SqlOutcome, SqlRequest, SqlStats,
+};
 #[cfg(feature = "flight-sql")]
 pub use flight::{
     DEFAULT_GC_PROTECTION_HORIZON, FlightAuth, FlightClock, FlightSqlConfig, RavelFlightSqlService,

--- a/crates/ravel-sql/tests/live_accounting.rs
+++ b/crates/ravel-sql/tests/live_accounting.rs
@@ -1,0 +1,52 @@
+//! The live accounting handle a caller hands to
+//! [`SqlExecutor::execute_accounted`] must equal the query's own final
+//! accounting on the success path, so the same figures the server records on a
+//! timeout or a dropped future (read from that handle) are the query's real
+//! cost and not an independent, drifting count.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod util;
+
+use ravel_sql::LiveAccounting;
+use util::{Fixture, SegSpec, SeriesSpec, request, tenant_id};
+
+/// On a successful query the live handle's snapshot equals
+/// `SqlOutcome::accounting` field-for-field: the handle the guard reads on the
+/// non-success exits is the very same counter block the success path reports.
+#[tokio::test]
+async fn success_snapshot_equals_the_live_handle_at_completion() {
+    let tenant = tenant_id("acme");
+    let fixture = Fixture::memory(&[(
+        &tenant,
+        &[SegSpec::new(
+            10,
+            1,
+            1,
+            vec![SeriesSpec::new("m", vec![(100, 1.0), (200, 2.5)])],
+        )],
+    )])
+    .await;
+
+    let live = LiveAccounting::new();
+    let outcome = fixture
+        .executor
+        .execute_accounted(
+            tenant.hash(),
+            &request("SELECT ts, value FROM samples ORDER BY ts"),
+            &live,
+        )
+        .await
+        .expect("query succeeds");
+
+    // Meaningful only if the query actually touched the store.
+    assert!(
+        outcome.accounting.total_s3_requests() >= 1,
+        "the query must have issued at least one store request"
+    );
+    assert_eq!(
+        live.snapshot(),
+        outcome.accounting,
+        "the guard's live snapshot equals the success snapshot field-for-field"
+    );
+}

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -446,8 +446,10 @@ query incurred up to that point, not zeros. This works because an object-store
 request is counted the moment it is issued, so a fetch still outstanding when
 the deadline trips or the caller goes away is already counted; only its
 transferred bytes wait until the fetch returns, since their length is not known
-before then. A query that times out or is cancelled therefore reports the same
-request count a completed run would, and the bytes it had received so far.
+before then. A query that times out or is cancelled therefore reports every
+request it issued before it stopped, including any still outstanding at that
+moment, and the bytes of the fetches that had completed by then. Fetches the
+query would have issued later, had it run on, are not counted.
 
 ### Metric metadata cache (`query_metadata_cache_*`)
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -439,6 +439,16 @@ accounting behind these numbers.
 | `ravel_query_estimated_store_bytes_total` | Pre-execution upper-envelope estimate of object-store bytes. |
 | `ravel_query_estimated_decompressed_bytes_total` | Pre-execution upper-envelope estimate of decompressed sample bytes. |
 
+Alongside the cost, the SQL query endpoint records each query's final outcome:
+success, error, timeout, or cancelled. A timeout or a cancelled outcome (the
+client disconnected while the query was still running) carries the cost the
+query incurred up to that point, not zeros. This works because an object-store
+request is counted the moment it is issued, so a fetch still outstanding when
+the deadline trips or the caller goes away is already counted; only its
+transferred bytes wait until the fetch returns, since their length is not known
+before then. A query that times out or is cancelled therefore reports the same
+request count a completed run would, and the bytes it had received so far.
+
 ### Metric metadata cache (`query_metadata_cache_*`)
 
 Labels: `mode` only. This is the per-process cache over each tenant's metric

--- a/services/ravel-server/src/sql.rs
+++ b/services/ravel-server/src/sql.rs
@@ -62,8 +62,8 @@ use ravel_maintain::{QueryAuditSink, QueryStatus, query_audit_event};
 use ravel_object_store::ObjectStoreBackend;
 use ravel_query::QueryAdmissionController;
 use ravel_query::http::TenantResolver;
-use ravel_sql::{ErrorClass, SqlError, SqlExecutor, SqlRequest};
-use ravel_types::accounting::{AccountedOp, CostEstimate, QueryAccountingSnapshot};
+use ravel_sql::{ErrorClass, LiveAccounting, SqlError, SqlExecutor, SqlRequest};
+use ravel_types::accounting::{CostEstimate, QueryAccountingSnapshot};
 use ravel_types::{CommitToken, TenantHash, TimeRange};
 use serde::Deserialize;
 use serde_json::json;
@@ -161,19 +161,32 @@ struct SqlBody {
 /// the whole `run` future dropped mid-`execute().await` -- `Drop::drop` runs
 /// unconditionally (Rust guarantees this for every value dropped by scope
 /// exit, `return`, `?`, panic, or an abandoned `.await`) and folds a
-/// zero-accounting `Canceled` record instead. There is no path through `run`
-/// that skips both.
+/// `Canceled` record whose cost is read live from the executor's accounting
+/// handle, so a query that fetched objects for two minutes and was then
+/// dropped records what it actually spent, not zeros.
+///
+/// The guard holds a [`LiveAccounting`] handed to `SqlExecutor::execute_accounted`,
+/// which re-points it at the running attempt's counters. Both `finish` and
+/// `drop` snapshot it, so a timeout, a mid-fetch drop, and every error path
+/// record the requests and bytes issued up to that instant with the right
+/// status.
 struct CostGuard<'a> {
     metrics: &'a crate::metrics::QueryAccountingMetrics,
     tenant_hash: TenantHash,
+    live: LiveAccounting,
     finished: bool,
 }
 
 impl<'a> CostGuard<'a> {
-    fn new(metrics: &'a crate::metrics::QueryAccountingMetrics, tenant_hash: TenantHash) -> Self {
+    fn new(
+        metrics: &'a crate::metrics::QueryAccountingMetrics,
+        tenant_hash: TenantHash,
+        live: LiveAccounting,
+    ) -> Self {
         CostGuard {
             metrics,
             tenant_hash,
+            live,
             finished: false,
         }
     }
@@ -195,45 +208,30 @@ impl<'a> CostGuard<'a> {
 impl Drop for CostGuard<'_> {
     fn drop(&mut self) {
         if !self.finished {
+            // The run future was dropped mid-`execute` (a client disconnect
+            // while the query was still doing object-store work). Record the
+            // cost issued up to this instant, read live from the executor's
+            // accounting handle -- not zeros.
             self.metrics.record_outcome(
                 self.tenant_hash,
                 QueryOutcomeStatus::Canceled,
-                &QueryAccountingSnapshot::default(),
+                &self.live.snapshot(),
                 &CostEstimate::new(0, 0, 0, 0, 0),
             );
         }
     }
 }
 
-/// Best-effort outcome status and accounting for a failed query, derived from
-/// the `SqlError` variant alone. Only [`SqlError::TooManyBytesScanned`] and
-/// [`SqlError::RequestBudgetExceeded`] carry the exact counters that tripped
-/// them; every other variant -- including `DeadlineExceeded`, a wall-deadline
-/// timeout -- is recorded with a zero snapshot. This is a real gap, not an
-/// oversight: `SqlExecutor::execute` (crates/ravel-sql/src/executor.rs) owns
-/// its `QueryAccounting` handle entirely internally and exposes it only on
-/// `SqlOutcome` on the success path, so a timeout or any other error variant
-/// without its own embedded figures has no accounting data this module can
-/// reach. Closing that gap needs a ravel-sql API change (out of this task's
-/// `services/ravel-server`-only scope) to expose the live handle, or the
-/// figures, on every error path -- flagged in this task's report rather than
-/// worked around here.
-fn error_cost(err: &SqlError) -> (QueryOutcomeStatus, QueryAccountingSnapshot, CostEstimate) {
-    let status = match err.class() {
+/// The outcome status for a failed query, from the `SqlError` class alone. A
+/// wall-deadline trip is a `Timeout`; every other error is an `Error`. The cost
+/// recorded alongside it is read from the live accounting handle, not derived
+/// from the error variant, so `DeadlineExceeded` and a dropped future carry the
+/// real requests and bytes the query issued rather than zeros.
+fn error_status(err: &SqlError) -> QueryOutcomeStatus {
+    match err.class() {
         ErrorClass::Timeout => QueryOutcomeStatus::Timeout,
         _ => QueryOutcomeStatus::Error,
-    };
-    let mut snapshot = QueryAccountingSnapshot::default();
-    match err {
-        SqlError::TooManyBytesScanned { scanned, .. } => {
-            snapshot.s3_bytes[AccountedOp::Get.index()] = *scanned;
-        }
-        SqlError::RequestBudgetExceeded { requests, .. } => {
-            snapshot.s3_requests[AccountedOp::Get.index()] = *requests;
-        }
-        _ => {}
     }
-    (status, snapshot, CostEstimate::new(0, 0, 0, 0, 0))
 }
 
 async fn handle(State(state): State<SqlState>, req: Request<Body>) -> Response {
@@ -284,10 +282,15 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
         s3_bytes = tracing::field::Empty,
     );
 
+    // The live accounting handle: the executor re-points it at the running
+    // query's counters, and the guard snapshots it on every exit -- including
+    // the dropped-future and timeout exits that carry no `SqlOutcome`.
+    let live = LiveAccounting::new();
+
     // Constructed before `execute` is awaited so a dropped `run` future
     // (client disconnect mid-query) still folds a Canceled record through its
     // `Drop` -- see `CostGuard`'s doc comment for the full mechanism.
-    let cost_guard = CostGuard::new(&state.query_accounting, tenant_hash);
+    let cost_guard = CostGuard::new(&state.query_accounting, tenant_hash, live.clone());
 
     // The query has now reached execution for a resolved tenant, so it is
     // auditable (ADR-0042 decision 4, ADR-0062 §2a). Run it, then submit
@@ -298,7 +301,7 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
     // are not audited: there is no executed query to attribute.
     let result = state
         .executor
-        .execute(tenant_hash, &request)
+        .execute_accounted(tenant_hash, &request, &live)
         .instrument(span.clone())
         .await;
     let status = match &result {
@@ -319,8 +322,14 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
             );
         }
         Err(err) => {
-            let (outcome_status, snapshot, estimate) = error_cost(err);
-            cost_guard.finish(outcome_status, &snapshot, &estimate);
+            // The live handle carries the requests and bytes the query issued
+            // before it failed, including a fetch still outstanding when a
+            // deadline tripped. The estimate is only known on the success path.
+            cost_guard.finish(
+                error_status(err),
+                &live.snapshot(),
+                &CostEstimate::new(0, 0, 0, 0, 0),
+            );
         }
     }
 

--- a/services/ravel-server/tests/sql_endpoint.rs
+++ b/services/ravel-server/tests/sql_endpoint.rs
@@ -30,7 +30,7 @@ use ravel_logseg::{
     AttrValue, LogRecord, Predicate, RlogConfig, RlogReader, RlogWriter, stream_attrs_bytes,
 };
 use ravel_maintain::QUERY_AUDIT_SHARD;
-use ravel_object_store::fault::{FaultPlan, FaultStore, Op, Rule, ScriptedFault};
+use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{GetRange, ObjectStoreBackend, PutOptions, list_all};
 use ravel_query::http::StaticBearerTokenResolver;
@@ -1615,106 +1615,108 @@ async fn a_query_that_reads_objects_then_fails_records_the_bytes_it_actually_rea
     );
 }
 
-/// A backend wrapping `inner` whose `get` sleeps for `delay` (real tokio
-/// time) before delegating. `MemoryStore`'s own operations never yield to the
-/// executor, so `tokio::time::timeout` (`crates/ravel-sql/src/executor.rs`)
-/// never gets a chance to race a bare `MemoryStore`: the wrapped future
-/// resolves on its very first poll regardless of how small the configured
-/// deadline is, timer included. This wrapper forces a genuine `.await` that
-/// returns `Pending` for real wall-clock time, so a short deadline set below
-/// `delay` deterministically fires while a real GET is outstanding.
-struct DelayedGet<S> {
-    inner: S,
-    delay: Duration,
-}
-
-#[async_trait::async_trait]
-impl<S: ObjectStoreBackend> ObjectStoreBackend for DelayedGet<S> {
-    async fn put(
-        &self,
-        key: &str,
-        data: bytes::Bytes,
-        opts: PutOptions,
-    ) -> Result<ravel_object_store::PutOutcome, ravel_object_store::StoreError> {
-        self.inner.put(key, data, opts).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: GetRange,
-    ) -> Result<ravel_object_store::GetOutcome, ravel_object_store::StoreError> {
-        tokio::time::sleep(self.delay).await;
-        self.inner.get(key, range).await
-    }
-
-    async fn head(
-        &self,
-        key: &str,
-    ) -> Result<ravel_object_store::ObjectMeta, ravel_object_store::StoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn list(
-        &self,
-        prefix: &str,
-        page: Option<ravel_object_store::PageToken>,
-    ) -> Result<ravel_object_store::ListPage, ravel_object_store::StoreError> {
-        self.inner.list(prefix, page).await
-    }
-
-    async fn list_delimited(
-        &self,
-        prefix: &str,
-    ) -> Result<ravel_object_store::DelimitedList, ravel_object_store::StoreError> {
-        self.inner.list_delimited(prefix).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ravel_object_store::StoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn capabilities(&self) -> ravel_object_store::Capabilities {
-        self.inner.capabilities()
-    }
-}
-
-/// A query that exceeds its wall-clock deadline must record `Timeout`, not
-/// `Error` and not nothing. `DelayedGet` (200ms) plus a 5ms deadline makes the
-/// trip fire deterministically while a real GET is genuinely outstanding, the
-/// same shape issue #809's motivating incident describes.
+/// Publish the single-segment metrics fixture into `store` and run `query`
+/// through a plain (ungated) router to success, returning that run's recorded
+/// total requests and bytes plus the data object's byte size.
 ///
-/// This test proves the STATUS split only: it does NOT prove the recorded
-/// cost reflects that real object-store work, because `SqlExecutor::execute`
-/// (crates/ravel-sql/src/executor.rs, out of this task's
-/// `services/ravel-server`-only scope) keeps its `QueryAccounting` handle
-/// entirely internal and does not expose it, or the figures it holds, on a
-/// `DeadlineExceeded` return -- so `error_cost` in `sql.rs` has no non-zero
-/// figures to record for this variant (see its doc comment). Closing that
-/// gap needs a `ravel-sql` API change, out of scope here and named in this
-/// task's final report.
-#[tokio::test]
-async fn a_query_that_exceeds_its_deadline_records_timeout_status() {
-    let inner: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+/// The timeout and cancellation tests hold the data-object GET open with a
+/// `FaultStore` gate, so the query never receives those bytes. Its recorded
+/// cost must then be exactly this success cost with the held object's bytes
+/// subtracted, while the request count is unchanged -- because a GET is counted
+/// at issue, so the held request is counted even though it never completed.
+/// Deriving the expected figures from a real successful run keeps them exact
+/// without a hand-computed magic number.
+async fn baseline_cost_and_object_size(query: &str) -> (u64, u64, u64) {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
     let tenant = TenantId::new("acme".to_string());
-    publish_segment(inner.as_ref(), &tenant, 0, "m", &[(100, 1.0), (200, 2.5)]).await;
-    let delayed_store: Arc<dyn ObjectStoreBackend> = Arc::new(DelayedGet {
-        inner,
-        delay: Duration::from_millis(200),
-    });
+    publish_segment(store.as_ref(), &tenant, 0, "m", &[(100, 1.0), (200, 2.5)]).await;
 
-    let (app, query_accounting) = build_router_with_config_and_deadline(
-        delayed_store,
+    let (app, accounting) = build_router_with_config(
+        Arc::clone(&store),
         tokens(&[("acme-token", "acme")]),
         SqlConfig::default(),
-        Duration::from_millis(5),
+    );
+    let (status, value) = post_json(&app, "acme-token", query).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "baseline query must succeed: {value}"
+    );
+    let baseline = only_outcome_row(
+        &accounting,
+        ravel_server::metrics::QueryOutcomeStatus::Success,
     );
 
-    let (status, value) = post_json(&app, "acme-token", "SELECT ts, value FROM samples").await;
+    let object_size = data_object_size(store.as_ref()).await;
+    assert!(
+        baseline.counters.s3_bytes > object_size,
+        "the whole-object read's bytes must dominate the recorded total for the \
+         subtraction below to be meaningful"
+    );
+    assert!(
+        baseline.counters.s3_requests >= 1,
+        "the baseline must have issued at least one store request"
+    );
+    (
+        baseline.counters.s3_requests,
+        baseline.counters.s3_bytes,
+        object_size,
+    )
+}
+
+/// Byte size of the single published `.rseg` data object in `store`. The
+/// fixture publishes exactly one data object; catalog records carry no `rseg`
+/// key, so the filter is unambiguous.
+async fn data_object_size(store: &dyn ObjectStoreBackend) -> u64 {
+    let metas = list_all(store, "").await.expect("list objects");
+    let data: Vec<_> = metas.iter().filter(|m| m.key.contains("rseg")).collect();
+    assert_eq!(
+        data.len(),
+        1,
+        "the fixture must publish exactly one data object, found: {:?}",
+        data.iter().map(|m| &m.key).collect::<Vec<_>>()
+    );
+    data[0].size
+}
+
+/// A query that trips its wall deadline while a real GET is outstanding records
+/// `Timeout` with the exact cost it incurred up to that instant, not zeros. A
+/// `FaultStore` gate holds the data-object GET open forever, so the deadline
+/// fires with that GET issued but unfinished. The recorded request count equals
+/// the successful run's (the held GET was counted the moment it was issued),
+/// and the recorded byte count equals the successful run's minus the object's
+/// bytes, which never transferred.
+#[tokio::test]
+async fn a_query_that_exceeds_its_deadline_records_the_cost_it_incurred() {
+    let query = "SELECT ts, value FROM samples ORDER BY ts";
+    let (baseline_requests, baseline_bytes, object_size) =
+        baseline_cost_and_object_size(query).await;
+
+    let fault = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::default()));
+    let tenant = TenantId::new("acme".to_string());
+    publish_segment(fault.as_ref(), &tenant, 0, "m", &[(100, 1.0), (200, 2.5)]).await;
+    // Hold every data-object GET open forever. Catalog resolve reads no `.rseg`
+    // object, so it completes and the query parks on the one data GET the fetch
+    // issues; the wall deadline then fires while that GET is outstanding.
+    let gate = fault.hold(Op::Get, Some("rseg".to_string()), Occurrence::Always);
+    let store: Arc<dyn ObjectStoreBackend> = fault;
+
+    let (app, query_accounting) = build_router_with_config_and_deadline(
+        store,
+        tokens(&[("acme-token", "acme")]),
+        SqlConfig::default(),
+        Duration::from_millis(500),
+    );
+
+    let (status, value) = post_json(&app, "acme-token", query).await;
     assert_eq!(
         status,
         StatusCode::GATEWAY_TIMEOUT,
         "a deadline trip must reach the client as a timeout status: {value}"
+    );
+    assert!(
+        gate.held_count() >= 1,
+        "the data GET must have been issued and held; the fault fired"
     );
 
     let timed_out = only_outcome_row(
@@ -1722,96 +1724,48 @@ async fn a_query_that_exceeds_its_deadline_records_timeout_status() {
         ravel_server::metrics::QueryOutcomeStatus::Timeout,
     );
     assert_eq!(timed_out.counters.queries, 1);
+    assert_eq!(
+        timed_out.counters.s3_requests, baseline_requests,
+        "the timed-out query counts the GET it issued before the deadline, exactly \
+         as the successful run did"
+    );
+    assert_eq!(
+        timed_out.counters.s3_bytes,
+        baseline_bytes - object_size,
+        "the timed-out query records every byte it read except the held object's, \
+         which never transferred"
+    );
+    // Recorded exactly once, as Timeout: no zero-cost Canceled or Error row.
+    assert!(
+        query_accounting
+            .outcome_snapshot()
+            .iter()
+            .all(|r| r.status == ravel_server::metrics::QueryOutcomeStatus::Timeout)
+    );
 }
 
-/// A backend wrapping `inner` whose `get` signals `entered` the instant it is
-/// called, then blocks on `proceed` before delegating -- so a test can drive
-/// a request until it is genuinely suspended inside a real in-flight GET,
-/// then tear the request future down without ever unblocking it. Every other
-/// method delegates straight through.
-struct BlockingOnFirstGet<S> {
-    inner: S,
-    entered: Arc<tokio::sync::Notify>,
-    proceed: Arc<tokio::sync::Notify>,
-}
-
-#[async_trait::async_trait]
-impl<S: ObjectStoreBackend> ObjectStoreBackend for BlockingOnFirstGet<S> {
-    async fn put(
-        &self,
-        key: &str,
-        data: bytes::Bytes,
-        opts: PutOptions,
-    ) -> Result<ravel_object_store::PutOutcome, ravel_object_store::StoreError> {
-        self.inner.put(key, data, opts).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: GetRange,
-    ) -> Result<ravel_object_store::GetOutcome, ravel_object_store::StoreError> {
-        self.entered.notify_one();
-        self.proceed.notified().await;
-        self.inner.get(key, range).await
-    }
-
-    async fn head(
-        &self,
-        key: &str,
-    ) -> Result<ravel_object_store::ObjectMeta, ravel_object_store::StoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn list(
-        &self,
-        prefix: &str,
-        page: Option<ravel_object_store::PageToken>,
-    ) -> Result<ravel_object_store::ListPage, ravel_object_store::StoreError> {
-        self.inner.list(prefix, page).await
-    }
-
-    async fn list_delimited(
-        &self,
-        prefix: &str,
-    ) -> Result<ravel_object_store::DelimitedList, ravel_object_store::StoreError> {
-        self.inner.list_delimited(prefix).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ravel_object_store::StoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn capabilities(&self) -> ravel_object_store::Capabilities {
-        self.inner.capabilities()
-    }
-}
-
-/// Deliverable 5: the request future being DROPPED mid-flight (a client
-/// disconnect while a real GET is outstanding), not merely returning an
-/// error, must still record a `Canceled` cost. This is reachable from a real
-/// caller today: axum drops the whole per-request future, `CostGuard`
-/// included, the instant a client disconnects mid-query, exactly as `.abort()`
-/// drops this test's spawned task below -- `handle`/`run` never gets a chance
-/// to run any code after the dropped `.await`, which is the entire point of
-/// `CostGuard` living in a `Drop` impl rather than at the end of the happy
-/// path.
+/// The request future being DROPPED mid-flight (a client disconnect while a
+/// real GET is outstanding), not merely returning an error, records `Canceled`
+/// with the exact cost it incurred, not zeros. A `FaultStore` gate holds the
+/// data GET open; the test waits until it is genuinely held, then aborts the
+/// request task, dropping the whole `run` future -- `CostGuard`'s `Drop`
+/// records the live cost. axum drops the per-request future the same way the
+/// instant a client disconnects. The counts match the successful run's minus
+/// the held object's bytes, which never transferred.
 #[tokio::test]
-async fn a_dropped_request_future_records_a_canceled_cost() {
-    let inner: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
-    let tenant = TenantId::new("acme".to_string());
-    publish_segment(inner.as_ref(), &tenant, 0, "m", &[(100, 1.0), (200, 2.5)]).await;
+async fn a_dropped_request_future_records_the_cost_it_incurred() {
+    let query = "SELECT ts, value FROM samples ORDER BY ts";
+    let (baseline_requests, baseline_bytes, object_size) =
+        baseline_cost_and_object_size(query).await;
 
-    let entered = Arc::new(tokio::sync::Notify::new());
-    let proceed = Arc::new(tokio::sync::Notify::new());
-    let blocking_store: Arc<dyn ObjectStoreBackend> = Arc::new(BlockingOnFirstGet {
-        inner,
-        entered: Arc::clone(&entered),
-        proceed: Arc::clone(&proceed),
-    });
+    let fault = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::default()));
+    let tenant = TenantId::new("acme".to_string());
+    publish_segment(fault.as_ref(), &tenant, 0, "m", &[(100, 1.0), (200, 2.5)]).await;
+    let gate = fault.hold(Op::Get, Some("rseg".to_string()), Occurrence::Always);
+    let store: Arc<dyn ObjectStoreBackend> = fault;
 
     let (app, query_accounting) = build_router_with_config(
-        blocking_store,
+        store,
         tokens(&[("acme-token", "acme")]),
         SqlConfig::default(),
     );
@@ -1828,20 +1782,24 @@ async fn a_dropped_request_future_records_a_canceled_cost() {
 
     let task = tokio::spawn(async move { app.oneshot(request).await });
 
-    // Waits until the request is genuinely suspended inside the real GET
-    // (`BlockingOnFirstGet::get` signals `entered` before blocking on
-    // `proceed`), not until some fixed delay has elapsed.
-    // Bounded on purpose. If a future change serves this read without issuing a
-    // `get` (a cache, a range-free plan, an early error), an unbounded wait
-    // would hang until the CI job times out with nothing naming the cause.
-    tokio::time::timeout(std::time::Duration::from_secs(30), entered.notified())
+    // Wait until the data GET is genuinely parked inside the store. Bounded on
+    // purpose: if a future change serves this read without a GET, this fails
+    // loudly instead of hanging until the CI job times out.
+    tokio::time::timeout(Duration::from_secs(30), gate.wait_until_held(1))
         .await
-        .expect("the request must reach BlockingOnFirstGet::get; if it no longer issues a get, this test's premise is stale");
+        .expect(
+            "the request must reach a held data GET; if it no longer issues one, \
+             this test's premise is stale",
+        );
+    assert_eq!(
+        gate.held_count(),
+        1,
+        "exactly one data GET is held; the fault fired"
+    );
 
-    // Abort, never signaling `proceed`: the request future -- including
-    // `run`'s local `cost_guard` -- is dropped mid-`.await`, exactly as a
-    // real client disconnect would drop it. Nothing after the blocked
-    // `.await` ever runs; `entered`/`proceed` are otherwise unused after this.
+    // Abort, never releasing: the run future -- including `run`'s local
+    // `cost_guard` -- is dropped mid-`.await`, exactly as a real client
+    // disconnect would drop it.
     task.abort();
     let joined = task.await;
     assert!(
@@ -1854,7 +1812,18 @@ async fn a_dropped_request_future_records_a_canceled_cost() {
         ravel_server::metrics::QueryOutcomeStatus::Canceled,
     );
     assert_eq!(canceled.counters.queries, 1);
-    // No Success or Error row: the only fold that happened was the Drop path.
+    assert_eq!(
+        canceled.counters.s3_requests, baseline_requests,
+        "the dropped query counts the GET it issued before the drop, exactly as \
+         the successful run did"
+    );
+    assert_eq!(
+        canceled.counters.s3_bytes,
+        baseline_bytes - object_size,
+        "the dropped query records every byte it read except the held object's, \
+         which never transferred"
+    );
+    // The only fold that happened was the Drop path.
     assert!(
         query_accounting
             .outcome_snapshot()


### PR DESCRIPTION
A query that fetched objects and then timed out or was cancelled recorded a zero-cost outcome, because the SQL executor owned its accounting handle internally and exposed it only on the success path, and the cost guard's drop and error paths substituted an empty snapshot. A query that read for two minutes and then died read as free with a status label.

The executor now runs against a live accounting handle the caller owns and re-points it at each attempt before any store call, so the guard reads a real snapshot on drop and on every error path. The fetcher counts a GET when it is issued, once the in-flight permit is held and just before the backend call, and adds the bytes at completion when their length is known, so a future dropped mid-call still shows the request it started; the pooled fetch entry points record straight onto the query handle instead of merging a private snapshot at the end, which is what made an in-flight GET invisible before. The per-phase split is unchanged, and a failed GET is now counted as one issued request. Four tests were each demonstrated failing: a held GET counts as one issued request while pending, the success snapshot equals the live handle at completion, and the timeout and cancellation tests pin the exact request and byte figures against a captured baseline rather than the presence of a row.

The observability guide states that timeout and cancelled outcomes carry the cost incurred to that point and that a request counts when issued. The Flight SQL path constructs no cost guard and is unchanged.

Fixes: #840