### PR TITLE
ci: give each push to main its own concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,16 @@ env:
 
 # Cancel a superseded run for the same ref so a force-push to an open PR does
 # not leave the old run burning coverage/k8s minutes to completion (ADR-0053
-# D3). Keyed on the workflow plus the ref. `cancel-in-progress` is disabled on
-# `main` itself: a push to main is history other things build on, so its run
-# must always finish rather than be cancelled by the next push. It stays true
-# for PR and merge-queue refs, where only the latest run matters.
+# D3). Keyed on the workflow plus the ref for PR and merge-queue refs, where
+# only the latest run matters. A push to main is history other things build
+# on (the coverage lane runs only there, and the publish gate needs a
+# successful run for the tagged SHA), so every main push gets its own group,
+# keyed on the commit SHA: GitHub holds at most one pending run per group and
+# cancels the previous pending run whenever a new one is queued, so a shared
+# main group with `cancel-in-progress` off still lost the run of any push that
+# was queued when the next push arrived (#1145).
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.ref == 'refs/heads/main' && format('ci-main-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
Every push to `main` shared one concurrency group with `cancel-in-progress` off. GitHub keeps at most one pending run per group and cancels the previous pending run when a new one is queued, so any main push that was still queued when the next push arrived lost its `ci.yml` run entirely. Three main commits lost their run on 2026-09-02, including the 0.12.0 release commit `4513c991`, whose rerun after a flaky coverage failure (#1143) was cancelled by the next merge. The publish gate requires a successful `ci.yml` run for the tagged SHA, so the release cannot ship until its SHA can hold a run to completion.

Main pushes now get a group keyed on the commit SHA, so they never queue behind each other. PR and merge-queue refs keep the per-ref group and cancel-in-progress. Reruns of existing main runs stay in the old group, which nothing new joins.

Fixes #1145.
