### PR TITLE
ci: give each main push its own concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,16 @@ env:
 
 # Cancel a superseded run for the same ref so a force-push to an open PR does
 # not leave the old run burning coverage/k8s minutes to completion (ADR-0053
-# D3). Keyed on the workflow plus the ref. `cancel-in-progress` is disabled on
-# `main` itself: a push to main is history other things build on, so its run
-# must always finish rather than be cancelled by the next push. It stays true
-# for PR and merge-queue refs, where only the latest run matters.
+# D3). Keyed on the workflow plus the ref for PR and merge-queue refs, where
+# only the latest run matters. A push to main is history other things build
+# on (the coverage lane runs only there, and the image publish gate needs a
+# successful run for the tagged SHA), so every main push gets its own group:
+# GitHub keeps at most one pending run per group and cancels the previous
+# pending one when another is queued, so a shared main group with
+# `cancel-in-progress: false` still loses the run of any push that queued
+# behind a running run.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.ref == 'refs/heads/main' && format('ci-main-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
Every push to main shared one concurrency group with cancel-in-progress
off. That keeps the running run alive, but GitHub holds at most one
pending run per group and cancels the previous pending run whenever a
new one queues, so when three pushes land while the first run is in
progress the middle push never gets a run. On 2026-09-02 three main
runs were cancelled this way, including the 0.12.0 release commit's
rerun, which the image publish gate needs green.

Key main runs by SHA so they never queue behind each other, and keep
the shared per-ref group with cancel-in-progress for PR and merge-queue
refs, where only the latest run matters. Reruns of older main runs use
the workflow file from their own commit, so they stay in the old group
and nothing new joins it to cancel them.

The workflow file is not compiled by any local gate; the proof is this PR's own ci.yml run plus the first two main pushes after it lands running side by side instead of one cancelling the other.

Fixes: #1145