### PR TITLE
feat(promql): pin evaluator contract for equal-timestamp samples

### DIFF
--- a/crates/ravel-promql/src/aggregate.rs
+++ b/crates/ravel-promql/src/aggregate.rs
@@ -815,6 +815,57 @@ mod tests {
     }
 
     #[test]
+    fn sum_by_job_aggregates_exact_total_over_duplicate_timestamp_series() {
+        // ADR-1103: two series under the same `job`, each carrying
+        // equal-timestamp duplicates within the range window, so the total
+        // only comes out right if `count_over_time` counts every duplicate
+        // record and `sum by (job)` then adds both series' exact counts.
+        // Demonstrated failing by dropping the second and third duplicate
+        // samples from either series before storing them (see
+        // `range_query_over_equal_timestamp_samples_steps_exactly` in
+        // eval.rs, same underlying bug): the total would read 4 instead of
+        // 6.
+        use crate::eval::ms_to_ns;
+        let m = |ms: i64| ms_to_ns(ms).expect("no overflow");
+        let src = TestSource::new()
+            .with_series(
+                &[("__name__", "x"), ("job", "a"), ("region", "us")],
+                &[
+                    (m(8 * 60_000), 1.0),
+                    (m(8 * 60_000), 2.0),
+                    (m(9 * 60_000), 3.0),
+                ],
+            )
+            .expect("valid series")
+            .with_series(
+                &[("__name__", "x"), ("job", "a"), ("region", "eu")],
+                &[
+                    (m(7 * 60_000), 4.0),
+                    (m(7 * 60_000), 5.0),
+                    (m(7 * 60_000), 6.0),
+                ],
+            )
+            .expect("valid series");
+
+        let v = Evaluator::new()
+            .instant(&src, "sum by (job) (count_over_time(x[5m]))", 10 * 60_000)
+            .expect("must evaluate");
+        let result: Vec<(Vec<(String, String)>, f64)> = v
+            .into_iter()
+            .map(|s| {
+                (
+                    s.labels
+                        .iter()
+                        .map(|l| (l.name.clone(), l.value.clone()))
+                        .collect(),
+                    s.value,
+                )
+            })
+            .collect();
+        assert_eq!(result, vec![(labels(&[("job", "a")]), 6.0)]);
+    }
+
+    #[test]
     fn sum_with_no_modifier_collapses_to_one_group() {
         assert_eq!(eval_vector("sum(m)"), vec![(vec![], 6.0)]);
     }

--- a/crates/ravel-promql/src/eval.rs
+++ b/crates/ravel-promql/src/eval.rs
@@ -2217,6 +2217,53 @@ mod tests {
     }
 
     #[test]
+    fn range_query_over_equal_timestamp_samples_steps_exactly() {
+        // ADR-1103: a log-derived series can carry several samples at one
+        // timestamp. One lone sample at 500ms plus three samples sharing
+        // 6000ms, `count_over_time(x[10s])` stepped every 5s from 1000ms to
+        // 16000ms:
+        //   t=1000ms:  window (-9000, 1000]  -> the lone sample only:      1
+        //   t=6000ms:  window (-4000, 6000]  -> lone + all 3 duplicates:   4
+        //     (right-open boundary lands exactly on the duplicated
+        //     timestamp, 6000; inclusive, so all three count)
+        //   t=11000ms: window (1000, 11000]  -> the 3 duplicates only:     3
+        //   t=16000ms: window (6000, 16000]  -> nothing:                  0
+        //     (left-open boundary lands exactly on the duplicated
+        //     timestamp, 6000; exclusive, so all three are dropped)
+        // Demonstrated failing by dropping the second and third duplicate
+        // samples before storing them (`with_series` keeping only one
+        // sample per timestamp): every non-zero step count above would be
+        // off by 2 at t=6000ms and by 2 at t=11000ms.
+        let lone_ns = ms_to_ns(500).expect("no overflow");
+        let dup_ns = ms_to_ns(6_000).expect("no overflow");
+        let source = TestSource::new()
+            .with_series(
+                &[("__name__", "x")],
+                &[(lone_ns, 1.0), (dup_ns, 2.0), (dup_ns, 3.0), (dup_ns, 4.0)],
+            )
+            .expect("valid series");
+
+        let value = Evaluator::new()
+            .eval_range(&source, "count_over_time(x[10s])", 1_000, 16_000, 5_000)
+            .expect("range evaluates");
+        let Value::Matrix(matrix) = value else {
+            panic!("count_over_time is a matrix");
+        };
+        assert_eq!(matrix.len(), 1, "one series");
+        let samples = &matrix[0].1;
+        let got: Vec<(i64, f64)> = samples.iter().map(|s| (s.ts_ns, s.value)).collect();
+        assert_eq!(
+            got,
+            vec![
+                (ms_to_ns(1_000).expect("no overflow"), 1.0),
+                (ms_to_ns(6_000).expect("no overflow"), 4.0),
+                (ms_to_ns(11_000).expect("no overflow"), 3.0),
+            ],
+            "the t=16000ms step has zero count and emits no sample at all"
+        );
+    }
+
+    #[test]
     fn lookback_boundary_excludes_exactly_5m_before_t() {
         // Sample exactly 5m before T is excluded (lookback start is
         // exclusive); a sample exactly at T is included.
@@ -2336,6 +2383,32 @@ mod tests {
             .expect("evaluates");
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].value, 9.0);
+    }
+
+    #[test]
+    fn equal_timestamp_instant_selection_picks_greatest_value_bits() {
+        // ADR-1103: unlike `duplicate_timestamp_resolves_by_normative_order_not_vec_position`
+        // above (a source violating the SHOULD-dedup contract), these three
+        // samples are legitimate distinct log records that happen to share a
+        // timestamp. Instant selection still applies exactly one rule
+        // regardless of why the samples it is choosing among share a
+        // timestamp: pick the greatest `value.to_bits()`, never vector
+        // position. Demonstrated failing by making `pick_sample` return the
+        // last sample in the slice instead of the greatest-bits one (e.g.
+        // reverting eval.rs's `pick_sample` to `samples.last()`), which would
+        // pick 4.0 here instead of the correct 9.0.
+        let ts_ns = ms_to_ns(minutes(1)).expect("no overflow");
+        let source = TestSource::new()
+            .with_series(
+                &[("__name__", "x")],
+                &[(ts_ns, 4.0), (ts_ns, 9.0), (ts_ns, 2.0)],
+            )
+            .expect("valid series");
+        let result = Evaluator::new()
+            .instant(&source, "x", minutes(1))
+            .expect("evaluates");
+        assert_eq!(result.len(), 1, "exactly one sample per series");
+        assert_eq!(result[0].value, 9.0, "greatest value.to_bits() wins");
     }
 
     #[test]
@@ -2567,6 +2640,42 @@ mod tests {
         // -120 is itself a multiple; left-open means the result still
         // advances past it, landing on the same -60 as the -90 case above.
         assert_eq!(align_up_to_step(-120, 60).expect("fits"), -60);
+    }
+
+    #[test]
+    fn subquery_over_duplicate_timestamp_samples_steps_exactly() {
+        // ADR-1103: `count_over_time(x[5m])[10m:5m]` evaluated at t=12m.
+        // Grid step is 5m; the subquery window is (2m, 12m], and the
+        // left-open epoch-aligned grid (see `align_up_to_step` above) yields
+        // exactly two points, 5m and 10m:
+        //   t=5m:  inner window (0m, 5m]   -> the lone sample at 1m only: 1
+        //   t=10m: inner window (5m, 10m]  -> all 3 duplicates at 6m:      3
+        // Demonstrated failing the same way as
+        // `range_query_over_equal_timestamp_samples_steps_exactly`: dropping
+        // the second and third duplicate sample before storing them would
+        // read 1 instead of 3 at t=10m.
+        let lone_ns = ms_to_ns(minutes(1)).expect("no overflow");
+        let dup_ns = ms_to_ns(minutes(6)).expect("no overflow");
+        let source = TestSource::new()
+            .with_series(
+                &[("__name__", "x")],
+                &[(lone_ns, 1.0), (dup_ns, 2.0), (dup_ns, 3.0), (dup_ns, 4.0)],
+            )
+            .expect("valid series");
+
+        let value = Evaluator::new()
+            .eval_instant(&source, "count_over_time(x[5m])[10m:5m]", minutes(12))
+            .expect("subquery evaluates");
+        let Value::Matrix(matrix) = value else {
+            panic!("expected a matrix, got {value:?}");
+        };
+        assert_eq!(matrix.len(), 1);
+        let (_, samples) = &matrix[0];
+        let got: Vec<(i64, f64)> = samples
+            .iter()
+            .map(|s| (s.ts_ns / NS_PER_MS, s.value))
+            .collect();
+        assert_eq!(got, vec![(minutes(5), 1.0), (minutes(10), 3.0)]);
     }
 
     #[test]

--- a/crates/ravel-promql/src/functions/over_time.rs
+++ b/crates/ravel-promql/src/functions/over_time.rs
@@ -473,6 +473,37 @@ mod tests {
         }
     }
 
+    /// ADR-1103: a log-derived series delivers one sample per record, so
+    /// two records logged at the same nanosecond are two real samples, not
+    /// a duplicate to collapse. A window holding [t1=3, t2=5, t2=7, t3=9]
+    /// (two samples sharing `t2`) must be reduced as four samples by every
+    /// `_over_time` reducer, matching Prometheus' `[3,5,7,9]` on the same
+    /// four values. Demonstrated failing by deduping the window to one
+    /// sample per timestamp before reducing (e.g. inserting a
+    /// `samples.dedup_by_key(|s| s.ts_ns)` ahead of each call below) fails
+    /// every assertion (a three-sample reduction instead of four).
+    #[test]
+    fn equal_timestamp_samples_count_individually() {
+        let samples = [
+            sample(0, 3.0),
+            sample(1_000, 5.0),
+            sample(1_000, 7.0),
+            sample(2_000, 9.0),
+        ];
+        let w = window(0, 2_000, 2_000);
+        assert_eq!(count_over_time(&samples, w), Some(4.0));
+        assert_eq!(sum_over_time(&samples, w), Some(24.0));
+        assert_eq!(avg_over_time(&samples, w), Some(6.0));
+        assert_eq!(max_over_time(&samples, w), Some(9.0));
+        assert_eq!(min_over_time(&samples, w), Some(3.0));
+        // Prometheus quantile(0.5) over the four sorted values [3,5,7,9]:
+        // rank = 0.5*3 = 1.5, interpolating halfway between index 1 (5) and
+        // index 2 (7).
+        assert_eq!(quantile_over_time(0.5, &samples, w), Some(6.0));
+        assert_eq!(last_over_time(&samples, w), Some(9.0));
+        assert_eq!(present_over_time(&samples, w), Some(1.0));
+    }
+
     #[test]
     fn sum_over_time_adds_every_sample() {
         let samples = [sample(0, 1.0), sample(1_000, 2.0), sample(2_000, 3.5)];

--- a/crates/ravel-promql/src/functions/rate.rs
+++ b/crates/ravel-promql/src/functions/rate.rs
@@ -111,10 +111,16 @@ fn histogram_extrapolated_rate(
     is_counter: bool,
     is_rate: bool,
 ) -> Option<FloatHistogram> {
-    let mut reduced = histogram::histogram_rate(samples, is_counter)?;
-
     let first_ts = samples[0].0;
     let last_ts = samples[samples.len() - 1].0;
+    // See the matching guard in `extrapolated_rate`: a zero-duration window
+    // (every sample sharing one timestamp) has no defined rate and returns
+    // no sample rather than a NaN-producing division.
+    if last_ts == first_ts {
+        return None;
+    }
+
+    let mut reduced = histogram::histogram_rate(samples, is_counter)?;
 
     let duration_to_start = ns_diff_to_seconds(first_ts, w.start_ns);
     let duration_to_end = ns_diff_to_seconds(w.end_ns, last_ts);
@@ -182,6 +188,15 @@ fn deriv(samples: &[Sample], _w: RangeWindow) -> Option<f64> {
     if samples.len() < 2 {
         return None;
     }
+    // ADR-1103: every sample sharing one timestamp makes every regression `x`
+    // value identical, so `var_x` is exactly zero and the slope is a 0.0/0.0
+    // NaN rather than a defined value; standard Prometheus storage dedups to
+    // one sample per timestamp so this state has no oracle behavior to match
+    // (same reasoning as `extrapolated_rate`'s zero-duration guard), so this
+    // drops the window instead of returning NaN.
+    if samples[samples.len() - 1].ts_ns == samples[0].ts_ns {
+        return None;
+    }
     // Anchored to the window's first sample (not the query's evaluation
     // instant) purely for floating-point accuracy: Prometheus does the same
     // to keep `x` values small (prometheus/prometheus#2674). `predict_linear`
@@ -193,6 +208,11 @@ fn deriv(samples: &[Sample], _w: RangeWindow) -> Option<f64> {
 
 fn predict_linear(samples: &[Sample], w: RangeWindow, duration_seconds: f64) -> Option<f64> {
     if samples.len() < 2 {
+        return None;
+    }
+    // See `deriv`'s matching guard: a zero-duration window has no defined
+    // slope.
+    if samples[samples.len() - 1].ts_ns == samples[0].ts_ns {
         return None;
     }
     let (slope, intercept) = linear_regression(samples, w.eval_ts_ns);
@@ -216,6 +236,17 @@ fn extrapolated_rate(
     }
     let first = samples[0];
     let last = samples[samples.len() - 1];
+    // ADR-1103: a log-derived series can deliver every sample in the window
+    // at one timestamp (`first == last`). Standard Prometheus storage dedups
+    // to one sample per timestamp, so this state cannot arise there and the
+    // ported formula below (which divides by `sampled_interval`) has no
+    // oracle behavior to match; a zero-duration window has no defined rate,
+    // mirroring `instant_value`'s existing `sampledInterval == 0` drop, so
+    // this returns no sample rather than the 0.0/0.0 NaN the division would
+    // otherwise produce.
+    if last.ts_ns == first.ts_ns {
+        return None;
+    }
 
     let mut result_value = last.value - first.value;
     if is_counter {
@@ -588,6 +619,30 @@ mod tests {
     }
 
     #[test]
+    fn rate_over_all_equal_timestamp_samples_is_none_not_nan() {
+        // ADR-1103: a log-derived series can deliver every sample in the
+        // window at one timestamp. Standard Prometheus storage dedups to one
+        // sample per timestamp, so `first == last` cannot arise there and
+        // the ported formula (which divides by `sampled_interval`) has no
+        // oracle behavior to match; a zero-duration window is defined here
+        // to have no rate, mirroring `instant_value`'s existing
+        // `sampledInterval == 0` drop. Demonstrated failing by deleting the
+        // `if last.ts_ns == first.ts_ns { return None; }` guard at the top
+        // of `extrapolated_rate` in this file: without it, `last.value -
+        // first.value == 0.0` divided by a zero `sampled_interval` produces
+        // `NaN`, not a dropped sample.
+        let samples = [
+            sample(60_000, 1.0),
+            sample(60_000, 2.0),
+            sample(60_000, 3.0),
+        ];
+        let w = window(0, 300_000, 300_000);
+        assert_eq!(rate(&samples, w), None);
+        assert_eq!(increase(&samples, w), None);
+        assert_eq!(delta(&samples, w), None);
+    }
+
+    #[test]
     fn rate_extrapolates_to_the_window_boundary() {
         // Four samples, evenly spaced 60s apart, starting exactly at the
         // window's left edge and ending exactly at its right edge: no
@@ -793,6 +848,27 @@ mod tests {
     fn predict_linear_single_sample_is_none() {
         let samples = [sample(0, 1.0)];
         assert_eq!(predict_linear(&samples, window(0, 0, 300_000), 60.0), None);
+    }
+
+    #[test]
+    fn deriv_and_predict_linear_over_all_equal_timestamp_samples_are_none_not_nan() {
+        // ADR-1103 audit finding beyond the named test list: every sample
+        // sharing one timestamp makes every regression `x` value identical,
+        // so `var_x` (and `cov_xy`) are exactly zero and the slope is a
+        // 0.0/0.0 NaN, not caught by `linear_regression`'s existing
+        // `const_y` special case (which only handles identical *values*, not
+        // identical *timestamps*). Demonstrated failing by deleting the
+        // `if samples[samples.len() - 1].ts_ns == samples[0].ts_ns { return
+        // None; }` guard in `deriv` (and the matching one in
+        // `predict_linear`) in this file.
+        let samples = [
+            sample(60_000, 1.0),
+            sample(60_000, 2.0),
+            sample(60_000, 3.0),
+        ];
+        let w = window(0, 300_000, 300_000);
+        assert_eq!(deriv(&samples, w), None);
+        assert_eq!(predict_linear(&samples, w, 60.0), None);
     }
 
     #[test]

--- a/crates/ravel-promql/src/source.rs
+++ b/crates/ravel-promql/src/source.rs
@@ -36,6 +36,29 @@ use crate::histogram::FloatHistogram;
 /// vector position. That is defense-in-depth, not a second tiebreak rule: it
 /// is the normative order's own final comparison, so it can never contradict
 /// the deduped input the engine hands over.
+///
+/// That SHOULD is not a MUST: a source MAY deliver several samples with
+/// equal `ts_ns` in one series when each is a distinct underlying record
+/// rather than competing versions of one sample (ADR-1103 "PromQL over
+/// logs": a log-derived series carries one sample per log line, and two
+/// lines logged in the same nanosecond are two real samples, neither a
+/// duplicate to resolve). For such a source, a range-vector function
+/// receives every sample its window selects, with no dedup step anywhere
+/// between the source and the function, and then applies its own defined
+/// semantics to that slice: `count_over_time` counts records rather than
+/// distinct timestamps, `sum_over_time`/`avg_over_time`/`min_over_time`/
+/// `max_over_time`/`quantile_over_time` fold every one of them,
+/// `last_over_time` selects one, and `absent_over_time` only asks whether
+/// the window held any.
+/// Instant selection still applies the tie rule above: `pick_sample` picks
+/// one sample per series at the selected timestamp regardless of why the
+/// samples it is choosing among share that timestamp.
+///
+/// Regardless of which case applies, `samples` MUST be sorted ascending by
+/// `ts_ns` by the time it reaches the evaluator (the sort MUST be stable
+/// when duplicates are present, keeping equal-timestamp samples adjacent in
+/// their original relative order): the evaluator's binary search assumes
+/// this and does not re-sort.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SeriesData {
     pub labels: LabelSet,


### PR DESCRIPTION
ADR-1103 feeds the evaluator log-derived series with one sample per log
record, so two records logged in the same nanosecond arrive as two samples
with equal timestamps. The SeriesData contract only described the metrics
merge, which dedups per timestamp, and two function families divided by a
zero interval when every sample in a window shared one timestamp.

This amends the SeriesData contract (equal timestamps allowed when each
sample is a distinct record; sorted ascending, stable; range functions
count every sample; instant selection keeps the greatest-value-bits tie
rule), makes rate, increase, delta and their histogram forms return no
sample instead of NaN over a zero-duration window, gives deriv and
predict_linear the same guard (a 0.0/0.0 slope the const_y special case
did not cover), and pins the behavior with tests that were each shown
failing against a deliberate dedup or a removed guard. Series with
distinct timestamps are unaffected.

Part of epic #1103 (wave 1, task T2).

Fixes: #1107
