### PR TITLE
fix(ingest): report partial multi-shard commits for metrics and spans

### DIFF
--- a/crates/ravel-ingest/src/error.rs
+++ b/crates/ravel-ingest/src/error.rs
@@ -1,5 +1,7 @@
 //! Errors returned to strict-mode waiters and to [`crate::IngestRouter::write`].
 
+use ravel_types::CommitToken;
+
 /// Failure classification for a single shard's contribution to a write.
 ///
 /// Variants carry only owned strings (not the underlying store/publish
@@ -62,21 +64,67 @@ pub enum WriteError {
     /// `RESOURCE_EXHAUSTED`, not the 503 the other write failures take.
     #[error("ingest buffer byte budget reached")]
     BufferBudgetExceeded,
+    /// A multi-shard Strict write in which at least one shard failed *after*
+    /// one or more sibling shards had already acked their commit durably in
+    /// the same [`IngestRouter::write`](crate::IngestRouter::write) call
+    /// (issue #1130), the metrics-pipeline counterpart of
+    /// [`crate::LogWriteError::PartialWrite`]. `inner` is the underlying
+    /// single-shard classification the write would otherwise have surfaced;
+    /// `durable` carries the commit tokens the successful siblings actually
+    /// acked, in shard order, so that durable data is reportable instead of
+    /// being silently discarded by the error return.
+    ///
+    /// The router constructs this only when `durable` is non-empty: a failure
+    /// that touched no durably-committed sibling still surfaces as the bare
+    /// underlying variant, so an existing single-shard caller sees no change.
+    /// `durable` never includes a shard whose ack failed to resolve (a
+    /// panicked actor): an unresolved ack is not a durable write and reporting
+    /// it as one would be worse than the bug this closes.
+    ///
+    /// This is an information-carrying wrapper, not a new failure mode: it is
+    /// exactly as retryable as its `inner` cause ([`Self::is_retryable`]), and
+    /// a caller that ignores [`Self::durable_tokens`] behaves exactly as it did
+    /// before (the write is still reported as a failure).
+    #[error("{inner}")]
+    PartialWrite {
+        inner: Box<WriteError>,
+        durable: Vec<CommitToken>,
+    },
 }
 
 impl WriteError {
     /// Whether a client may reasonably retry the whole write after this
     /// error. `SegmentBuild` is excluded: it reflects a problem with the
-    /// input itself, not a transient condition.
+    /// input itself, not a transient condition. A [`Self::PartialWrite`] is
+    /// exactly as retryable as its underlying cause: it is the same failure,
+    /// carrying recovered sibling tokens.
     pub fn is_retryable(&self) -> bool {
-        matches!(
-            self,
+        match self {
             WriteError::ShardUnavailable
-                | WriteError::AckTimeout
-                | WriteError::Abandoned(_)
-                | WriteError::StaleProvisioningView
-                | WriteError::BufferBudgetExceeded
-        )
+            | WriteError::AckTimeout
+            | WriteError::Abandoned(_)
+            | WriteError::StaleProvisioningView
+            | WriteError::BufferBudgetExceeded => true,
+            WriteError::SegmentBuild(_)
+            | WriteError::SeriesIdCollision(_)
+            | WriteError::SeriesValueKindMismatch(_) => false,
+            WriteError::PartialWrite { inner, .. } => inner.is_retryable(),
+        }
+    }
+
+    /// The commit tokens for sibling shards that acked durable in the same
+    /// multi-shard `write()` call as this failure (issue #1130). Empty for
+    /// every variant except [`Self::PartialWrite`]: a failure that committed
+    /// no sibling durably carries no tokens, and neither does a failure whose
+    /// ack round never resolved (an [`Self::AckTimeout`], or a
+    /// [`Self::ShardUnavailable`] raised at send time before any ack was
+    /// awaited). A caller that ignores this loses only information, never
+    /// correctness -- the write is still an error.
+    pub fn durable_tokens(&self) -> &[CommitToken] {
+        match self {
+            WriteError::PartialWrite { durable, .. } => durable,
+            _ => &[],
+        }
     }
 }
 
@@ -104,5 +152,43 @@ mod tests {
         assert!(WriteError::Abandoned("x".into()).is_retryable());
         assert!(WriteError::AckTimeout.is_retryable());
         assert!(WriteError::ShardUnavailable.is_retryable());
+    }
+
+    #[test]
+    fn non_partial_variants_carry_no_durable_tokens() {
+        assert!(WriteError::ShardUnavailable.durable_tokens().is_empty());
+        assert!(WriteError::AckTimeout.durable_tokens().is_empty());
+        assert!(
+            WriteError::SegmentBuild("x".into())
+                .durable_tokens()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn partial_write_carries_tokens_and_delegates_retryability_and_display() {
+        let token = CommitToken {
+            shard: 2,
+            writer_id: uuid::Uuid::nil(),
+            epoch: 0,
+            seq: 5,
+            ingest_hour_bucket: 0,
+        };
+        // A retryable cause: the wrapper is retryable and surfaces the cause's
+        // own Display, not a new string.
+        let retryable = WriteError::PartialWrite {
+            inner: Box::new(WriteError::ShardUnavailable),
+            durable: vec![token.clone()],
+        };
+        assert!(retryable.is_retryable());
+        assert_eq!(retryable.durable_tokens(), std::slice::from_ref(&token));
+        assert_eq!(retryable.to_string(), "shard actor unavailable");
+
+        // A non-retryable cause makes the wrapper non-retryable too.
+        let not_retryable = WriteError::PartialWrite {
+            inner: Box::new(WriteError::SegmentBuild("bad".into())),
+            durable: vec![token],
+        };
+        assert!(!not_retryable.is_retryable());
     }
 }

--- a/crates/ravel-ingest/src/log_metrics.rs
+++ b/crates/ravel-ingest/src/log_metrics.rs
@@ -83,6 +83,16 @@ pub struct LogIngestMetrics {
     /// different `stream_attrs` (the fail-loud collision check
     /// `RlogWriter::finish()` performs).
     stream_id_collisions: AtomicU64,
+    /// Multi-shard Strict writes that returned
+    /// [`crate::LogWriteError::PartialWrite`] (issue #1130): at least one shard
+    /// committed durably and at least one sibling then failed in the same
+    /// `write()` call. A nonzero value means some clients saw a retryable error
+    /// for data already durable on the committed shards; a blind retry
+    /// re-ingests those shards' records, and unlike the metrics pipeline logs
+    /// have no read-time dedup, so retry duplicates unless the client supplies
+    /// an idempotency key (see docs/consistency-model.md). The metrics and span
+    /// pipelines keep the same counter.
+    partial_writes: AtomicU64,
     /// Distinct log shard actors observed dead by the router: its send half
     /// or a strict-mode ack found the shard channel closed, meaning the actor
     /// task ended (e.g. panicked) without the router shutting it down.
@@ -203,6 +213,10 @@ pub struct LogIngestMetricsSnapshot {
     pub acks_ok: u64,
     pub acks_err: u64,
     pub stream_id_collisions: u64,
+    /// Multi-shard Strict writes returned as
+    /// [`crate::LogWriteError::PartialWrite`] (issue #1130): a partial
+    /// multi-shard commit. Exported as `ingest_partial_writes_total`.
+    pub partial_writes: u64,
     pub shard_deaths: u64,
     pub stale_provisioning_flushes: u64,
     pub grace_extended_stale_flushes: u64,
@@ -393,6 +407,14 @@ impl LogIngestMetrics {
         self.stream_id_collisions.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// One multi-shard Strict write returned as
+    /// [`crate::LogWriteError::PartialWrite`] (issue #1130): at least one shard
+    /// committed durably before a sibling failed. Recorded once per such write,
+    /// at the router's error construction site.
+    pub(crate) fn record_partial_write(&self) {
+        self.partial_writes.fetch_add(1, Ordering::Relaxed);
+    }
+
     pub(crate) fn record_shard_death(&self) {
         self.shard_deaths.fetch_add(1, Ordering::Relaxed);
     }
@@ -493,6 +515,7 @@ impl LogIngestMetrics {
             acks_ok: self.acks_ok.load(Ordering::Relaxed),
             acks_err: self.acks_err.load(Ordering::Relaxed),
             stream_id_collisions: self.stream_id_collisions.load(Ordering::Relaxed),
+            partial_writes: self.partial_writes.load(Ordering::Relaxed),
             shard_deaths: self.shard_deaths.load(Ordering::Relaxed),
             stale_provisioning_flushes: self.stale_provisioning_flushes.load(Ordering::Relaxed),
             grace_extended_stale_flushes: self.grace_extended_stale_flushes.load(Ordering::Relaxed),
@@ -587,6 +610,13 @@ mod tests {
             LogIngestMetrics::record_stream_id_collision,
             LogIngestMetricsSnapshot {
                 stream_id_collisions: 1,
+                ..Default::default()
+            },
+        );
+        assert_only(
+            LogIngestMetrics::record_partial_write,
+            LogIngestMetricsSnapshot {
+                partial_writes: 1,
                 ..Default::default()
             },
         );

--- a/crates/ravel-ingest/src/log_metrics.rs
+++ b/crates/ravel-ingest/src/log_metrics.rs
@@ -87,11 +87,12 @@ pub struct LogIngestMetrics {
     /// [`crate::LogWriteError::PartialWrite`] (issue #1130): at least one shard
     /// committed durably and at least one sibling then failed in the same
     /// `write()` call. A nonzero value means some clients saw a retryable error
-    /// for data already durable on the committed shards; a blind retry
-    /// re-ingests those shards' records, and unlike the metrics pipeline logs
-    /// have no read-time dedup, so retry duplicates unless the client supplies
-    /// an idempotency key (see docs/consistency-model.md). The metrics and span
-    /// pipelines keep the same counter.
+    /// for data already durable on the committed shards; a retry re-ingests
+    /// those shards' records, and unlike the metrics pipeline logs have no
+    /// read-time dedup, so the retry duplicates them. An idempotency key does
+    /// not help here: a partial commit writes no marker (see
+    /// docs/consistency-model.md). The metrics and span pipelines keep the
+    /// same counter.
     partial_writes: AtomicU64,
     /// Distinct log shard actors observed dead by the router: its send half
     /// or a strict-mode ack found the shard channel closed, meaning the actor
@@ -215,7 +216,7 @@ pub struct LogIngestMetricsSnapshot {
     pub stream_id_collisions: u64,
     /// Multi-shard Strict writes returned as
     /// [`crate::LogWriteError::PartialWrite`] (issue #1130): a partial
-    /// multi-shard commit. Exported as `ingest_partial_writes_total`.
+    /// multi-shard commit. Exported as `ravel_ingest_partial_writes_total`.
     pub partial_writes: u64,
     pub shard_deaths: u64,
     pub stale_provisioning_flushes: u64,

--- a/crates/ravel-ingest/src/log_metrics.rs
+++ b/crates/ravel-ingest/src/log_metrics.rs
@@ -86,10 +86,11 @@ pub struct LogIngestMetrics {
     /// Multi-shard Strict writes that returned
     /// [`crate::LogWriteError::PartialWrite`] (issue #1130): at least one shard
     /// committed durably and at least one sibling then failed in the same
-    /// `write()` call. A nonzero value means some clients saw a retryable error
-    /// for data already durable on the committed shards; a retry re-ingests
+    /// `write()` call. A nonzero value means some clients saw an error,
+    /// retryable exactly when the wrapped `LogWriteError` is, for data already
+    /// durable on the committed shards; a client that does retry re-ingests
     /// those shards' records, and unlike the metrics pipeline logs have no
-    /// read-time dedup, so the retry duplicates them. An idempotency key does
+    /// read-time dedup, so that retry duplicates them. An idempotency key does
     /// not help here: a partial commit writes no marker (see
     /// docs/consistency-model.md). The metrics and span pipelines keep the
     /// same counter.

--- a/crates/ravel-ingest/src/log_router.rs
+++ b/crates/ravel-ingest/src/log_router.rs
@@ -466,6 +466,7 @@ impl LogIngestRouter {
             let error = if durable.is_empty() {
                 inner
             } else {
+                self.metrics.record_partial_write();
                 LogWriteError::PartialWrite {
                     inner: Box::new(inner),
                     durable,

--- a/crates/ravel-ingest/src/metrics.rs
+++ b/crates/ravel-ingest/src/metrics.rs
@@ -137,8 +137,9 @@ pub struct IngestMetrics {
     /// Multi-shard Strict writes that returned `WriteError::PartialWrite`
     /// (issue #1130): at least one shard committed durably and at least one
     /// sibling then failed in the same `write()` call. A nonzero value means
-    /// some clients saw a retryable error for data that is already durable on
-    /// the committed shards, so a blind retry re-ingests those shards' points
+    /// some clients saw an error, retryable exactly when the wrapped
+    /// `WriteError` is, for data that is already durable on the committed
+    /// shards; a client that does retry re-ingests those shards' points
     /// (metrics dedup by `(series_id, ts)` at read time, so it is not
     /// user-visible duplication; see docs/consistency-model.md). The logs and
     /// span pipelines keep the same counter.

--- a/crates/ravel-ingest/src/metrics.rs
+++ b/crates/ravel-ingest/src/metrics.rs
@@ -134,6 +134,15 @@ pub struct IngestMetrics {
     /// Batches rejected because two points shared a `series_id` under
     /// distinct canonical label sets (ADR-0005 fail-loud collision check).
     series_id_collisions: AtomicU64,
+    /// Multi-shard Strict writes that returned `WriteError::PartialWrite`
+    /// (issue #1130): at least one shard committed durably and at least one
+    /// sibling then failed in the same `write()` call. A nonzero value means
+    /// some clients saw a retryable error for data that is already durable on
+    /// the committed shards, so a blind retry re-ingests those shards' points
+    /// (metrics dedup by `(series_id, ts)` at read time, so it is not
+    /// user-visible duplication; see docs/consistency-model.md). The logs and
+    /// span pipelines keep the same counter.
+    partial_writes: AtomicU64,
     /// Exemplars written into a flushed object's EXEMPLARS section
     /// (ADR-0047). Attempt-time, like `flushes_by_*`: counted when the flush
     /// is built, so a flush later abandoned counts here too.
@@ -496,6 +505,10 @@ pub struct IngestMetricsSnapshot {
     pub acks_ok: u64,
     pub acks_err: u64,
     pub series_id_collisions: u64,
+    /// Multi-shard Strict writes returned as `WriteError::PartialWrite`
+    /// (issue #1130): a partial multi-shard commit. Exported as
+    /// `ingest_partial_writes_total`.
+    pub partial_writes: u64,
     pub shard_deaths: u64,
     pub exemplars_written_total: u64,
     pub exemplars_dropped_total: u64,
@@ -684,6 +697,14 @@ impl IngestMetrics {
         self.series_id_collisions.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// One multi-shard Strict write returned as `WriteError::PartialWrite`
+    /// (issue #1130): at least one shard committed durably before a sibling
+    /// failed. Recorded once per such write, at the router's error
+    /// construction site.
+    pub(crate) fn record_partial_write(&self) {
+        self.partial_writes.fetch_add(1, Ordering::Relaxed);
+    }
+
     /// One flush's exemplar outcome: `written` reached the object's EXEMPLARS
     /// section, `dropped` did not (no parent sample in the flush, or lost the
     /// flush-scoped window cap).
@@ -751,6 +772,7 @@ impl IngestMetrics {
             acks_ok: self.acks_ok.load(Ordering::Relaxed),
             acks_err: self.acks_err.load(Ordering::Relaxed),
             series_id_collisions: self.series_id_collisions.load(Ordering::Relaxed),
+            partial_writes: self.partial_writes.load(Ordering::Relaxed),
             shard_deaths: self.shard_deaths.load(Ordering::Relaxed),
             exemplars_written_total: self.exemplars_written_total.load(Ordering::Relaxed),
             exemplars_dropped_total: self.exemplars_dropped_total.load(Ordering::Relaxed),
@@ -787,6 +809,7 @@ mod tests {
         metrics.record_acks(2, true);
         metrics.record_acks(1, false);
         metrics.record_series_id_collision();
+        metrics.record_partial_write();
         metrics.record_shard_death();
         metrics.record_exemplars(2, 5);
 
@@ -804,6 +827,7 @@ mod tests {
         assert_eq!(snap.acks_ok, 2);
         assert_eq!(snap.acks_err, 1);
         assert_eq!(snap.series_id_collisions, 1);
+        assert_eq!(snap.partial_writes, 1);
         assert_eq!(snap.shard_deaths, 1);
     }
 

--- a/crates/ravel-ingest/src/metrics.rs
+++ b/crates/ravel-ingest/src/metrics.rs
@@ -507,7 +507,7 @@ pub struct IngestMetricsSnapshot {
     pub series_id_collisions: u64,
     /// Multi-shard Strict writes returned as `WriteError::PartialWrite`
     /// (issue #1130): a partial multi-shard commit. Exported as
-    /// `ingest_partial_writes_total`.
+    /// `ravel_ingest_partial_writes_total`.
     pub partial_writes: u64,
     pub shard_deaths: u64,
     pub exemplars_written_total: u64,

--- a/crates/ravel-ingest/src/router.rs
+++ b/crates/ravel-ingest/src/router.rs
@@ -447,24 +447,63 @@ impl IngestRouter {
         }
 
         // `join_all` preserves input order, so `joined[i]` is `ack_shards[i]`.
+        // On a deadline elapse the whole `join_all` future is dropped, so no
+        // per-shard ack is observed: `AckTimeout` carries no recovered tokens
+        // (a sibling that committed inside the elapsed window is unknowable
+        // here, and reporting an unresolved ack as durable would be wrong).
         let joined = tokio::time::timeout(ack_deadline, futures::future::join_all(ack_rxs))
             .await
             .map_err(|_| WriteError::AckTimeout)?;
-        let mut tokens = Vec::with_capacity(joined.len());
+
+        // Every ack resolved. Scan them all: collect every shard that acked a
+        // durable commit (issue #1130), and record the first failure in shard
+        // order so the returned classification and `mark_shard_dead` side effect
+        // are exactly what the pre-fix early-return produced. A shard whose ack
+        // failed to resolve (`RecvError`: the actor panicked mid-flush) is NOT a
+        // durable write and contributes no token.
+        let mut durable = Vec::with_capacity(joined.len());
+        let mut first_error: Option<WriteError> = None;
+        let mut dead_shard: Option<u32> = None;
         for (shard, result) in ack_shards.into_iter().zip(joined) {
-            // A `RecvError` here means the actor dropped the ack sender without
-            // sending: it panicked mid-flush (a healthy actor always acks, even
-            // on abandonment). Count the death and report it as unavailable.
-            let inner = match result {
-                Ok(inner) => inner,
+            match result {
+                Ok(Ok(token)) => durable.push(token),
+                Ok(Err(shard_error)) => {
+                    if first_error.is_none() {
+                        first_error = Some(shard_error);
+                    }
+                }
                 Err(_) => {
-                    self.mark_shard_dead(&set[shard as usize]);
-                    return Err(WriteError::ShardUnavailable);
+                    if first_error.is_none() {
+                        first_error = Some(WriteError::ShardUnavailable);
+                        dead_shard = Some(shard);
+                    }
+                }
+            }
+        }
+
+        if let Some(inner) = first_error {
+            // Preserve the exact failure semantics: the death is counted once,
+            // only when the first failure in shard order is a dropped ack, and
+            // only then (a resolved shard-level error never marked a death).
+            if let Some(shard) = dead_shard {
+                self.mark_shard_dead(&set[shard as usize]);
+            }
+            // Carry the durably-acked sibling tokens only when there are any; a
+            // failure with no partial success surfaces as the bare variant,
+            // unchanged from before this fix.
+            let error = if durable.is_empty() {
+                inner
+            } else {
+                self.metrics.record_partial_write();
+                WriteError::PartialWrite {
+                    inner: Box::new(inner),
+                    durable,
                 }
             };
-            tokens.push(inner?);
+            return Err(error);
         }
-        Ok(WriteReceipt { tokens })
+
+        Ok(WriteReceipt { tokens: durable })
     }
 
     /// Records the first observation of a shard actor's death, deduped so a

--- a/crates/ravel-ingest/src/span_error.rs
+++ b/crates/ravel-ingest/src/span_error.rs
@@ -1,6 +1,8 @@
 //! Errors returned to strict-mode waiters of the span pipeline, the span-side
 //! counterpart of [`crate::LogWriteError`].
 
+use ravel_types::CommitToken;
+
 /// Failure classification for a single span shard's contribution to a write.
 ///
 /// Variants carry only owned strings (not the underlying store/publish
@@ -47,21 +49,64 @@ pub enum SpanWriteError {
     /// The gateway maps it to HTTP 429 / gRPC `RESOURCE_EXHAUSTED`.
     #[error("ingest buffer byte budget reached")]
     BufferBudgetExceeded,
+    /// A multi-shard Strict write in which at least one shard failed *after*
+    /// one or more sibling shards had already acked their commit durably in
+    /// the same [`SpanIngestRouter::write`](crate::SpanIngestRouter::write)
+    /// call (issue #1130), the span-pipeline counterpart of
+    /// [`crate::LogWriteError::PartialWrite`]. `inner` is the underlying
+    /// single-shard classification the write would otherwise have surfaced;
+    /// `durable` carries the commit tokens the successful siblings actually
+    /// acked, in shard order, so that durable data is reportable instead of
+    /// being silently discarded by the error return.
+    ///
+    /// The router constructs this only when `durable` is non-empty: a failure
+    /// that touched no durably-committed sibling still surfaces as the bare
+    /// underlying variant, so an existing single-shard caller sees no change.
+    /// `durable` never includes a shard whose ack failed to resolve (a
+    /// panicked actor): an unresolved ack is not a durable write.
+    ///
+    /// This is an information-carrying wrapper, not a new failure mode: it is
+    /// exactly as retryable as its `inner` cause ([`Self::is_retryable`]), and
+    /// a caller that ignores [`Self::durable_tokens`] behaves exactly as it did
+    /// before (the write is still reported as a failure).
+    #[error("{inner}")]
+    PartialWrite {
+        inner: Box<SpanWriteError>,
+        durable: Vec<CommitToken>,
+    },
 }
 
 impl SpanWriteError {
     /// Whether a client may reasonably retry the whole write after this
     /// error. `SegmentBuild` is excluded: it reflects a problem with the input
-    /// itself, not a transient condition.
+    /// itself, not a transient condition. A [`Self::PartialWrite`] is exactly
+    /// as retryable as its underlying cause: it is the same failure, carrying
+    /// recovered sibling tokens.
     pub fn is_retryable(&self) -> bool {
-        matches!(
-            self,
+        match self {
             SpanWriteError::ShardUnavailable
-                | SpanWriteError::AckTimeout
-                | SpanWriteError::Abandoned(_)
-                | SpanWriteError::StaleProvisioningView
-                | SpanWriteError::BufferBudgetExceeded
-        )
+            | SpanWriteError::AckTimeout
+            | SpanWriteError::Abandoned(_)
+            | SpanWriteError::StaleProvisioningView
+            | SpanWriteError::BufferBudgetExceeded => true,
+            SpanWriteError::SegmentBuild(_) => false,
+            SpanWriteError::PartialWrite { inner, .. } => inner.is_retryable(),
+        }
+    }
+
+    /// The commit tokens for sibling shards that acked durable in the same
+    /// multi-shard `write()` call as this failure (issue #1130). Empty for
+    /// every variant except [`Self::PartialWrite`]: a failure that committed
+    /// no sibling durably carries no tokens, and neither does a failure whose
+    /// ack round never resolved (an [`Self::AckTimeout`], or a
+    /// [`Self::ShardUnavailable`] raised at send time before any ack was
+    /// awaited). A caller that ignores this loses only information, never
+    /// correctness -- the write is still an error.
+    pub fn durable_tokens(&self) -> &[CommitToken] {
+        match self {
+            SpanWriteError::PartialWrite { durable, .. } => durable,
+            _ => &[],
+        }
     }
 }
 
@@ -79,5 +124,42 @@ mod tests {
         assert!(SpanWriteError::Abandoned("x".into()).is_retryable());
         assert!(SpanWriteError::AckTimeout.is_retryable());
         assert!(SpanWriteError::ShardUnavailable.is_retryable());
+    }
+
+    #[test]
+    fn non_partial_variants_carry_no_durable_tokens() {
+        assert!(SpanWriteError::AckTimeout.durable_tokens().is_empty());
+        assert!(
+            SpanWriteError::Abandoned("x".into())
+                .durable_tokens()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn partial_write_carries_tokens_and_delegates_retryability_and_display() {
+        let token = CommitToken {
+            shard: 4,
+            writer_id: uuid::Uuid::nil(),
+            epoch: 0,
+            seq: 11,
+            ingest_hour_bucket: 0,
+        };
+        // A retryable cause: the wrapper is retryable and surfaces the cause's
+        // own Display, not a new string.
+        let retryable = SpanWriteError::PartialWrite {
+            inner: Box::new(SpanWriteError::Abandoned("data put exhausted".into())),
+            durable: vec![token.clone()],
+        };
+        assert!(retryable.is_retryable());
+        assert_eq!(retryable.durable_tokens(), std::slice::from_ref(&token));
+        assert_eq!(retryable.to_string(), "flush abandoned: data put exhausted");
+
+        // A non-retryable cause makes the wrapper non-retryable too.
+        let not_retryable = SpanWriteError::PartialWrite {
+            inner: Box::new(SpanWriteError::SegmentBuild("bad".into())),
+            durable: vec![token],
+        };
+        assert!(!not_retryable.is_retryable());
     }
 }

--- a/crates/ravel-ingest/src/span_metrics.rs
+++ b/crates/ravel-ingest/src/span_metrics.rs
@@ -73,11 +73,11 @@ pub struct SpanIngestMetrics {
     /// [`crate::SpanWriteError::PartialWrite`] (issue #1130): at least one shard
     /// committed durably and at least one sibling then failed in the same
     /// `write()` call. A nonzero value means some clients saw a retryable error
-    /// for data already durable on the committed shards; a blind retry
-    /// re-ingests those shards' spans, and like logs spans have no read-time
-    /// dedup, so retry duplicates unless the client supplies an idempotency key
-    /// (see docs/consistency-model.md). The metrics and log pipelines keep the
-    /// same counter.
+    /// for data already durable on the committed shards; a retry re-ingests
+    /// those shards' spans, and like logs spans have no read-time dedup, so
+    /// the retry duplicates them. An idempotency key does not help here: a
+    /// partial commit writes no marker (see docs/consistency-model.md). The
+    /// metrics and log pipelines keep the same counter.
     partial_writes: AtomicU64,
     /// Flushes failed closed on a stale provisioning view (ADR-0052 section 3),
     /// the span-pipeline counterpart of `IngestMetrics::stale_provisioning_flushes`.
@@ -120,7 +120,7 @@ pub struct SpanIngestMetricsSnapshot {
     pub shard_deaths: u64,
     /// Multi-shard Strict writes returned as
     /// [`crate::SpanWriteError::PartialWrite`] (issue #1130): a partial
-    /// multi-shard commit. Exported as `ingest_partial_writes_total`.
+    /// multi-shard commit. Exported as `ravel_ingest_partial_writes_total`.
     pub partial_writes: u64,
     pub stale_provisioning_flushes: u64,
     pub grace_extended_stale_flushes: u64,

--- a/crates/ravel-ingest/src/span_metrics.rs
+++ b/crates/ravel-ingest/src/span_metrics.rs
@@ -72,12 +72,14 @@ pub struct SpanIngestMetrics {
     /// Multi-shard Strict writes that returned
     /// [`crate::SpanWriteError::PartialWrite`] (issue #1130): at least one shard
     /// committed durably and at least one sibling then failed in the same
-    /// `write()` call. A nonzero value means some clients saw a retryable error
-    /// for data already durable on the committed shards; a retry re-ingests
-    /// those shards' spans, and like logs spans have no read-time dedup, so
-    /// the retry duplicates them. An idempotency key does not help here: a
-    /// partial commit writes no marker (see docs/consistency-model.md). The
-    /// metrics and log pipelines keep the same counter.
+    /// `write()` call. A nonzero value means some clients saw an error,
+    /// retryable exactly when the wrapped `SpanWriteError` is, for data
+    /// already durable on the committed shards; a client that does retry
+    /// re-ingests those shards' spans, and like logs spans have no read-time
+    /// dedup, so that retry duplicates them. An idempotency key does not help
+    /// here: a partial commit writes no marker (see
+    /// docs/consistency-model.md). The metrics and log pipelines keep the
+    /// same counter.
     partial_writes: AtomicU64,
     /// Flushes failed closed on a stale provisioning view (ADR-0052 section 3),
     /// the span-pipeline counterpart of `IngestMetrics::stale_provisioning_flushes`.

--- a/crates/ravel-ingest/src/span_metrics.rs
+++ b/crates/ravel-ingest/src/span_metrics.rs
@@ -69,6 +69,16 @@ pub struct SpanIngestMetrics {
     /// Distinct span shard actors observed dead by the router. Counted once
     /// per shard on the first observation, so it never exceeds `shard_count`.
     shard_deaths: AtomicU64,
+    /// Multi-shard Strict writes that returned
+    /// [`crate::SpanWriteError::PartialWrite`] (issue #1130): at least one shard
+    /// committed durably and at least one sibling then failed in the same
+    /// `write()` call. A nonzero value means some clients saw a retryable error
+    /// for data already durable on the committed shards; a blind retry
+    /// re-ingests those shards' spans, and like logs spans have no read-time
+    /// dedup, so retry duplicates unless the client supplies an idempotency key
+    /// (see docs/consistency-model.md). The metrics and log pipelines keep the
+    /// same counter.
+    partial_writes: AtomicU64,
     /// Flushes failed closed on a stale provisioning view (ADR-0052 section 3),
     /// the span-pipeline counterpart of `IngestMetrics::stale_provisioning_flushes`.
     stale_provisioning_flushes: AtomicU64,
@@ -108,6 +118,10 @@ pub struct SpanIngestMetricsSnapshot {
     pub acks_ok: u64,
     pub acks_err: u64,
     pub shard_deaths: u64,
+    /// Multi-shard Strict writes returned as
+    /// [`crate::SpanWriteError::PartialWrite`] (issue #1130): a partial
+    /// multi-shard commit. Exported as `ingest_partial_writes_total`.
+    pub partial_writes: u64,
     pub stale_provisioning_flushes: u64,
     pub grace_extended_stale_flushes: u64,
 }
@@ -175,6 +189,14 @@ impl SpanIngestMetrics {
         self.shard_deaths.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// One multi-shard Strict write returned as
+    /// [`crate::SpanWriteError::PartialWrite`] (issue #1130): at least one shard
+    /// committed durably before a sibling failed. Recorded once per such write,
+    /// at the router's error construction site.
+    pub(crate) fn record_partial_write(&self) {
+        self.partial_writes.fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Adjusts shard `shard`'s in-flight-flush gauge by `delta` (+1 when a
     /// flush task is spawned, -1 when it ends, including on panic via
     /// `span_shard`'s `InFlightFlushGuard`). Poison recovery rather than a
@@ -230,6 +252,7 @@ impl SpanIngestMetrics {
             acks_ok: self.acks_ok.load(Ordering::Relaxed),
             acks_err: self.acks_err.load(Ordering::Relaxed),
             shard_deaths: self.shard_deaths.load(Ordering::Relaxed),
+            partial_writes: self.partial_writes.load(Ordering::Relaxed),
             stale_provisioning_flushes: self.stale_provisioning_flushes.load(Ordering::Relaxed),
             grace_extended_stale_flushes: self.grace_extended_stale_flushes.load(Ordering::Relaxed),
         }
@@ -306,6 +329,13 @@ mod tests {
             SpanIngestMetrics::record_shard_death,
             SpanIngestMetricsSnapshot {
                 shard_deaths: 1,
+                ..Default::default()
+            },
+        );
+        assert_only(
+            SpanIngestMetrics::record_partial_write,
+            SpanIngestMetricsSnapshot {
+                partial_writes: 1,
                 ..Default::default()
             },
         );

--- a/crates/ravel-ingest/src/span_router.rs
+++ b/crates/ravel-ingest/src/span_router.rs
@@ -316,24 +316,63 @@ impl SpanIngestRouter {
         }
 
         // `join_all` preserves input order, so `joined[i]` is `ack_shards[i]`.
+        // On a deadline elapse the whole `join_all` future is dropped, so no
+        // per-shard ack is observed: `AckTimeout` carries no recovered tokens
+        // (a sibling that committed inside the elapsed window is unknowable
+        // here, and reporting an unresolved ack as durable would be wrong).
         let joined = tokio::time::timeout(ack_deadline, futures::future::join_all(ack_rxs))
             .await
             .map_err(|_| SpanWriteError::AckTimeout)?;
-        let mut tokens = Vec::with_capacity(joined.len());
+
+        // Every ack resolved. Scan them all: collect every shard that acked a
+        // durable commit (issue #1130), and record the first failure in shard
+        // order so the returned classification and `mark_shard_dead` side effect
+        // are exactly what the pre-fix early-return produced. A shard whose ack
+        // failed to resolve (`RecvError`: the actor panicked mid-flush) is NOT a
+        // durable write and contributes no token.
+        let mut durable = Vec::with_capacity(joined.len());
+        let mut first_error: Option<SpanWriteError> = None;
+        let mut dead_shard: Option<u32> = None;
         for (shard, result) in ack_shards.into_iter().zip(joined) {
-            // A `RecvError` here means the actor dropped the ack sender without
-            // sending: it panicked mid-flush (a healthy actor always acks, even
-            // on abandonment). Count the death and report it as unavailable.
-            let inner = match result {
-                Ok(inner) => inner,
+            match result {
+                Ok(Ok(token)) => durable.push(token),
+                Ok(Err(shard_error)) => {
+                    if first_error.is_none() {
+                        first_error = Some(shard_error);
+                    }
+                }
                 Err(_) => {
-                    self.mark_shard_dead(&set[shard as usize]);
-                    return Err(SpanWriteError::ShardUnavailable);
+                    if first_error.is_none() {
+                        first_error = Some(SpanWriteError::ShardUnavailable);
+                        dead_shard = Some(shard);
+                    }
+                }
+            }
+        }
+
+        if let Some(inner) = first_error {
+            // Preserve the exact failure semantics: the death is counted once,
+            // only when the first failure in shard order is a dropped ack, and
+            // only then (a resolved shard-level error never marked a death).
+            if let Some(shard) = dead_shard {
+                self.mark_shard_dead(&set[shard as usize]);
+            }
+            // Carry the durably-acked sibling tokens only when there are any; a
+            // failure with no partial success surfaces as the bare variant,
+            // unchanged from before this fix.
+            let error = if durable.is_empty() {
+                inner
+            } else {
+                self.metrics.record_partial_write();
+                SpanWriteError::PartialWrite {
+                    inner: Box::new(inner),
+                    durable,
                 }
             };
-            tokens.push(inner?);
+            return Err(error);
         }
-        Ok(SpanWriteReceipt { tokens })
+
+        Ok(SpanWriteReceipt { tokens: durable })
     }
 
     /// Records the first observation of a shard actor's death, deduped so a

--- a/crates/ravel-ingest/tests/partial_multi_shard_commit.rs
+++ b/crates/ravel-ingest/tests/partial_multi_shard_commit.rs
@@ -125,10 +125,10 @@ fn fail_shard_data_puts(shard: u32) -> FaultPlan {
 /// Non-vacuity: the failing shard (shard 1) sorts before shard 2 in the
 /// router's ascending-shard ack loop, so the pre-fix `tokens.push(inner?)`
 /// returned at shard 1 and dropped both siblings' tokens. Against that unfixed
-/// loop this test fails at `durable.len() == 2` (the recovered list is empty,
-/// and the error is the bare abandonment, not `PartialWrite`). The injected
-/// fault is asserted via the `FaultStore` counter so the abandonment is proven
-/// to have fired.
+/// loop this test fails at the `PartialWrite` match below, because the error
+/// is the bare abandonment and carries no recovered tokens at all. The
+/// injected fault is asserted via the `FaultStore` counter so the abandonment
+/// is proven to have fired.
 #[tokio::test]
 async fn metrics_partial_commit_reports_surviving_tokens_in_shard_order() {
     let shard_count = 3;
@@ -435,30 +435,22 @@ async fn ack_timeout_recovers_no_tokens_but_commit_lands_after_release() {
         assert!(gate.release(id), "held call {id} is released");
     }
 
-    // Poll (bounded) until the shard's commit record appears under its commit
-    // prefix. There is exactly one, at the key the flush chose.
+    // Shutdown joins every in-flight flush, so once it returns the released
+    // shard's commit is durable or was abandoned: one LIST decides, with no
+    // wall-clock band.
+    router.shutdown().await;
     let commit_prefix =
         keys::commit_shard_prefix(&tenant.hash(), Signal::Metrics, 0).expect("commit shard prefix");
-    let mut commit_keys: Vec<String> = Vec::new();
-    for _ in 0..200 {
-        let objects = list_all(store.as_ref(), &commit_prefix)
-            .await
-            .expect("list");
-        commit_keys = objects
-            .into_iter()
-            .map(|o| o.key)
-            .filter(|k| k.ends_with(".cmt"))
-            .collect();
-        if !commit_keys.is_empty() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
+    let commit_keys: Vec<String> = list_all(store.as_ref(), &commit_prefix)
+        .await
+        .expect("list")
+        .into_iter()
+        .map(|o| o.key)
+        .filter(|k| k.ends_with(".cmt"))
+        .collect();
     assert_eq!(
         commit_keys.len(),
         1,
         "the held shard's commit lands after release, at exactly one key: {commit_keys:?}"
     );
-
-    router.shutdown().await;
 }

--- a/crates/ravel-ingest/tests/partial_multi_shard_commit.rs
+++ b/crates/ravel-ingest/tests/partial_multi_shard_commit.rs
@@ -1,0 +1,464 @@
+//! Issue #1130: a multi-shard Strict write where some shards commit durably
+//! and at least one shard fails in the same `write()` call must report a
+//! partial commit that carries every durable sibling token, on the metrics
+//! and span routers, exactly as the log router already does. All-shards-fail
+//! stays the plain (non-partial) error, and an ack round that times out
+//! carries no tokens at all.
+//!
+//! docs/consistency-model.md "Partial multi-shard commits" is normative for
+//! all three signals.
+#![allow(clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use common::{TestClock, make_point, tenant};
+use ravel_commit::keys;
+use ravel_ingest::{
+    IngestConfig, IngestRouter, SpanIngestRouter, WriteError, WriteMode, shard_for_span,
+};
+use ravel_object_store::fault::{
+    FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, list_all};
+use ravel_otlp::NormalizedPoint;
+use ravel_otlp::traces_normalize::NormalizedSpan;
+use ravel_rspan::StatusCode;
+use ravel_types::{Signal, TenantHash, shard_for};
+
+const BASE_NS: i64 = 1_700_000_000_000_000_000;
+
+/// Flushes on the first point/span (`target_bytes: 1`) and never on age, so a
+/// strict write drives one complete flush inline and returns its outcome.
+fn flush_on_first(shard_count: u32) -> IngestConfig {
+    IngestConfig {
+        shard_count,
+        target_bytes: 1,
+        max_flush_delay: Duration::from_secs(3600),
+        flush_tick: Duration::from_millis(20),
+        put_retry_base_delay: Duration::from_millis(1),
+        put_retry_max_delay: Duration::from_millis(5),
+        ..IngestConfig::default()
+    }
+}
+
+/// First `host` label value whose point routes to `want_shard`.
+fn point_on_shard(
+    tenant: &ravel_types::TenantId,
+    want_shard: u32,
+    shard_count: u32,
+    ts_ns: i64,
+) -> NormalizedPoint {
+    for i in 0..100_000u32 {
+        let point = make_point(tenant, "cpu_usage", &[("host", &i.to_string())], ts_ns, 1.0);
+        if shard_for(&point.series_id, shard_count) == want_shard {
+            return point;
+        }
+    }
+    panic!("no series found for shard {want_shard} of {shard_count}");
+}
+
+/// A span whose `trace_id` (an incrementing little-endian counter) routes to
+/// `want_shard`. `shard_for_span` hashes the whole id, so scanning counter
+/// values finds a representative for every shard.
+fn span_on_shard(want_shard: u32, shard_count: u32, start_ns: i64) -> NormalizedSpan {
+    for i in 0..100_000u64 {
+        let mut trace_id = [0u8; 16];
+        trace_id[..8].copy_from_slice(&i.to_le_bytes());
+        if shard_for_span(&trace_id, shard_count) == want_shard {
+            return NormalizedSpan {
+                trace_id,
+                span_id: [1u8; 8],
+                parent_span_id: None,
+                name: "handle".to_string(),
+                start_ts_ns: start_ns,
+                end_ts_ns: start_ns + 100,
+                status_code: StatusCode::Unset,
+                status_message: None,
+                attrs: vec![("service.name".to_string(), "checkout".to_string())],
+            };
+        }
+    }
+    panic!("no trace routes to shard {want_shard} of {shard_count}");
+}
+
+/// Asserts the store holds exactly one commit record for `token`, proving the
+/// recovered token names a shard that actually committed.
+async fn assert_commit_record_present(
+    store: &dyn ObjectStoreBackend,
+    tenant_hash: &TenantHash,
+    signal: Signal,
+    token: &ravel_types::CommitToken,
+) {
+    let commit_key = keys::commit_key_for_token(tenant_hash, signal, token).expect("commit key");
+    let outcome = store
+        .get(&commit_key, ravel_object_store::GetRange::Full)
+        .await;
+    assert!(
+        outcome.is_ok(),
+        "durable token's commit record must exist at {commit_key}"
+    );
+}
+
+/// A `FaultPlan` that fails every data-object PUT for one shard permanently.
+/// A non-retryable store error abandons that flush on the first attempt with
+/// no backoff, so the outcome is deterministic and needs no clock advance.
+fn fail_shard_data_puts(shard: u32) -> FaultPlan {
+    let key = format!("/l0/{shard:04}/");
+    FaultPlan::empty().with_rule(
+        Rule::new(
+            Op::Put,
+            ScriptedFault::Permanent("simulated permanent data-object PUT failure".into()),
+        )
+        .with_key_contains(key)
+        .with_occurrence(Occurrence::Always),
+    )
+}
+
+/// 5a: a metrics Strict write over three shards where shard 1's flush is
+/// abandoned while shards 0 and 2 commit durably. The failure surfaces as
+/// `PartialWrite` carrying exactly the two surviving tokens in shard order.
+///
+/// Non-vacuity: the failing shard (shard 1) sorts before shard 2 in the
+/// router's ascending-shard ack loop, so the pre-fix `tokens.push(inner?)`
+/// returned at shard 1 and dropped both siblings' tokens. Against that unfixed
+/// loop this test fails at `durable.len() == 2` (the recovered list is empty,
+/// and the error is the bare abandonment, not `PartialWrite`). The injected
+/// fault is asserted via the `FaultStore` counter so the abandonment is proven
+/// to have fired.
+#[tokio::test]
+async fn metrics_partial_commit_reports_surviving_tokens_in_shard_order() {
+    let shard_count = 3;
+    let store = Arc::new(FaultStore::new(MemoryStore::new(), fail_shard_data_puts(1)));
+    let clock = TestClock::new(BASE_NS);
+    let router = IngestRouter::new(
+        flush_on_first(shard_count),
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        Signal::Metrics,
+        clock.clone(),
+    );
+
+    let tenant = tenant("acme");
+    let points = vec![
+        point_on_shard(&tenant, 0, shard_count, 1_000),
+        point_on_shard(&tenant, 1, shard_count, 2_000),
+        point_on_shard(&tenant, 2, shard_count, 3_000),
+    ];
+
+    let err = router
+        .write(
+            tenant.clone(),
+            points,
+            WriteMode::Strict,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("shard 1's flush was abandoned, so the write is a failure");
+
+    let (inner, durable) = match &err {
+        WriteError::PartialWrite { inner, durable } => (inner, durable),
+        other => panic!("expected PartialWrite, got {other:?}"),
+    };
+    assert!(
+        err.is_retryable(),
+        "an abandoned-flush partial write delegates retryability to its (retryable) inner, got {inner}"
+    );
+    assert_eq!(
+        durable.len(),
+        2,
+        "exactly the two surviving shards' tokens are recovered, got {durable:?}"
+    );
+    assert_eq!(durable[0].shard, 0, "tokens are in ascending shard order");
+    assert_eq!(durable[1].shard, 2, "tokens are in ascending shard order");
+    for token in durable {
+        assert_commit_record_present(store.as_ref(), &tenant.hash(), Signal::Metrics, token).await;
+    }
+
+    assert_eq!(
+        router.metrics().snapshot().partial_writes,
+        1,
+        "the partial write is counted exactly once"
+    );
+    assert_eq!(
+        store.fault_count(Op::Put, FaultKind::Permanent),
+        1,
+        "the permanent data-object PUT fault fired exactly once (shard 1, no retry)"
+    );
+
+    router.shutdown().await;
+}
+
+/// 5b: the span-router counterpart of 5a. Same three-shard shape, shard 1
+/// abandoned, shards 0 and 2 durable, `SpanWriteError::PartialWrite` carrying
+/// the two tokens in shard order. Non-vacuity is identical to 5a.
+#[tokio::test]
+async fn spans_partial_commit_reports_surviving_tokens_in_shard_order() {
+    let shard_count = 3;
+    let store = Arc::new(FaultStore::new(MemoryStore::new(), fail_shard_data_puts(1)));
+    let clock = TestClock::new(BASE_NS);
+    let router = SpanIngestRouter::new(
+        flush_on_first(shard_count),
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        clock.clone(),
+    );
+
+    let tenant = tenant("acme");
+    let spans = vec![
+        span_on_shard(0, shard_count, 1_000),
+        span_on_shard(1, shard_count, 2_000),
+        span_on_shard(2, shard_count, 3_000),
+    ];
+
+    let err = router
+        .write(
+            tenant.clone(),
+            spans,
+            WriteMode::Strict,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("shard 1's flush was abandoned, so the write is a failure");
+
+    let durable = match &err {
+        ravel_ingest::SpanWriteError::PartialWrite { durable, .. } => durable,
+        other => panic!("expected PartialWrite, got {other:?}"),
+    };
+    assert!(
+        err.is_retryable(),
+        "an abandoned-flush partial write delegates retryability to its (retryable) inner, got {err}"
+    );
+    assert_eq!(
+        durable.len(),
+        2,
+        "exactly the two surviving shards' tokens are recovered, got {durable:?}"
+    );
+    assert_eq!(durable[0].shard, 0, "tokens are in ascending shard order");
+    assert_eq!(durable[1].shard, 2, "tokens are in ascending shard order");
+    for token in durable {
+        assert_commit_record_present(store.as_ref(), &tenant.hash(), Signal::Spans, token).await;
+    }
+
+    assert_eq!(
+        router.metrics().snapshot().partial_writes,
+        1,
+        "the partial write is counted exactly once"
+    );
+    assert_eq!(
+        store.fault_count(Op::Put, FaultKind::Permanent),
+        1,
+        "the permanent data-object PUT fault fired exactly once (shard 1, no retry)"
+    );
+
+    router.shutdown().await;
+}
+
+/// 5c (metrics): when every involved shard fails, no shard committed durably,
+/// so the error is the plain abandonment, never `PartialWrite`. Two shards,
+/// both abandoned via a fault on every data-object PUT.
+///
+/// Non-vacuity: the fix only wraps a failure in `PartialWrite` when the durable
+/// set is non-empty; a regression that wrapped unconditionally would produce
+/// `PartialWrite` here and fail the `matches!` assertion.
+#[tokio::test]
+async fn metrics_all_shards_fail_is_plain_error_not_partial() {
+    let shard_count = 2;
+    // Fail every data-object PUT (`/l0/`) for every shard.
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(
+            Op::Put,
+            ScriptedFault::Permanent("simulated permanent data-object PUT failure".into()),
+        )
+        .with_key_contains("/l0/")
+        .with_occurrence(Occurrence::Always),
+    );
+    let store = Arc::new(FaultStore::new(MemoryStore::new(), plan));
+    let clock = TestClock::new(BASE_NS);
+    let router = IngestRouter::new(
+        flush_on_first(shard_count),
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        Signal::Metrics,
+        clock.clone(),
+    );
+
+    let tenant = tenant("acme");
+    let points = vec![
+        point_on_shard(&tenant, 0, shard_count, 1_000),
+        point_on_shard(&tenant, 1, shard_count, 2_000),
+    ];
+
+    let err = router
+        .write(
+            tenant.clone(),
+            points,
+            WriteMode::Strict,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("every shard's flush was abandoned");
+    assert!(
+        !matches!(err, WriteError::PartialWrite { .. }),
+        "no shard committed, so the error is the plain abandonment, got {err:?}"
+    );
+    assert_eq!(
+        err.durable_tokens().len(),
+        0,
+        "an all-failed write recovers no tokens"
+    );
+    assert_eq!(
+        router.metrics().snapshot().partial_writes,
+        0,
+        "an all-failed write is not counted as a partial commit"
+    );
+    assert_eq!(
+        store.fault_count(Op::Put, FaultKind::Permanent),
+        2,
+        "both shards' data PUTs were rejected once each"
+    );
+
+    router.shutdown().await;
+}
+
+/// 5c (spans): the span-router counterpart of the all-shards-fail case.
+#[tokio::test]
+async fn spans_all_shards_fail_is_plain_error_not_partial() {
+    let shard_count = 2;
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(
+            Op::Put,
+            ScriptedFault::Permanent("simulated permanent data-object PUT failure".into()),
+        )
+        .with_key_contains("/l0/")
+        .with_occurrence(Occurrence::Always),
+    );
+    let store = Arc::new(FaultStore::new(MemoryStore::new(), plan));
+    let clock = TestClock::new(BASE_NS);
+    let router = SpanIngestRouter::new(
+        flush_on_first(shard_count),
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        clock.clone(),
+    );
+
+    let tenant = tenant("acme");
+    let spans = vec![
+        span_on_shard(0, shard_count, 1_000),
+        span_on_shard(1, shard_count, 2_000),
+    ];
+
+    let err = router
+        .write(
+            tenant.clone(),
+            spans,
+            WriteMode::Strict,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("every shard's flush was abandoned");
+    assert!(
+        !matches!(err, ravel_ingest::SpanWriteError::PartialWrite { .. }),
+        "no shard committed, so the error is the plain abandonment, got {err:?}"
+    );
+    assert_eq!(
+        err.durable_tokens().len(),
+        0,
+        "an all-failed write recovers no tokens"
+    );
+    assert_eq!(
+        router.metrics().snapshot().partial_writes,
+        0,
+        "an all-failed write is not counted as a partial commit"
+    );
+    assert_eq!(
+        store.fault_count(Op::Put, FaultKind::Permanent),
+        2,
+        "both shards' data PUTs were rejected once each"
+    );
+
+    router.shutdown().await;
+}
+
+/// 5e: an ack round whose only shard's flush is held open past the ack
+/// deadline returns `AckTimeout` with no recovered tokens (a sibling that
+/// commits inside the elapsed window is unknowable to the caller). After the
+/// hold is released the flush completes: the shard's commit record is present
+/// in the store at its exact key, exactly the crash-matrix row that says a
+/// commit can land after the client already received the retryable timeout.
+///
+/// Non-vacuity: before the fix, `AckTimeout` was returned identically, so this
+/// pins the invariant the fix must not regress (no tokens on timeout) and the
+/// documented after-timeout durability, rather than the token-recovery change.
+#[tokio::test]
+async fn ack_timeout_recovers_no_tokens_but_commit_lands_after_release() {
+    let shard_count = 1;
+    let store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
+    // Hold shard 0's data-object PUT so its flush blocks before the commit
+    // record is written; the ack never resolves within the deadline.
+    let gate = store.hold(Op::Put, Some("/l0/0000/".to_string()), Occurrence::Always);
+    let clock = TestClock::new(BASE_NS);
+    let router = IngestRouter::new(
+        flush_on_first(shard_count),
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        Signal::Metrics,
+        clock.clone(),
+    );
+
+    let tenant = tenant("acme");
+    let point = point_on_shard(&tenant, 0, shard_count, 1_000);
+
+    // A short ack deadline: the held flush cannot resolve, so the whole ack
+    // round times out.
+    let err = router
+        .write(
+            tenant.clone(),
+            vec![point],
+            WriteMode::Strict,
+            Duration::from_millis(200),
+        )
+        .await
+        .expect_err("the held flush cannot ack before the deadline");
+    assert!(
+        matches!(err, WriteError::AckTimeout),
+        "a whole-round timeout is AckTimeout, got {err:?}"
+    );
+    assert_eq!(
+        err.durable_tokens().len(),
+        0,
+        "a timed-out ack round recovers no tokens"
+    );
+
+    // Release the held PUT; the shard actor completes the abandoned-caller
+    // flush in the background and its commit record lands.
+    gate.wait_until_held(1).await;
+    for id in gate.held() {
+        assert!(gate.release(id), "held call {id} is released");
+    }
+
+    // Poll (bounded) until the shard's commit record appears under its commit
+    // prefix. There is exactly one, at the key the flush chose.
+    let commit_prefix =
+        keys::commit_shard_prefix(&tenant.hash(), Signal::Metrics, 0).expect("commit shard prefix");
+    let mut commit_keys: Vec<String> = Vec::new();
+    for _ in 0..200 {
+        let objects = list_all(store.as_ref(), &commit_prefix)
+            .await
+            .expect("list");
+        commit_keys = objects
+            .into_iter()
+            .map(|o| o.key)
+            .filter(|k| k.ends_with(".cmt"))
+            .collect();
+        if !commit_keys.is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        commit_keys.len(),
+        1,
+        "the held shard's commit lands after release, at exactly one key: {commit_keys:?}"
+    );
+
+    router.shutdown().await;
+}

--- a/docs/consistency-model.md
+++ b/docs/consistency-model.md
@@ -86,9 +86,10 @@ rejected point counts and reasons.
 |---|---|---|---|---|
 | Before data PUT | absent | absent | no | client retries; nothing stored |
 | After data PUT, before commit PUT | present (orphan) | absent | no | invisible; GC after grace; client retries |
-| After commit PUT, before ack | present | present | no | visible; unkeyed client retry stores a duplicate (see above); a keyed retry replays the marker and stores nothing new, since the marker PUT precedes the ack |
+| After commit PUT, before marker PUT | present | present | no | visible; any client retry stores a duplicate (see above), keyed or not, because no marker exists yet |
+| After marker PUT, before ack (keyed logs and spans only) | present | present | no | visible; a keyed retry replays the marker and stores nothing new, since the marker PUT precedes the ack; an unkeyed retry stores a duplicate |
 | After ack | present | present | yes | durable and visible |
-| Ack round times out (flush still running) | eventually present | eventually present | no (retryable timeout) | client gets a retryable timeout with no token; each shard's flush keeps running and can commit *after* the client gave up, so the commit is durable and query-visible but its token is unobservable to that client. The retry relies on dedup, not on the ack: metrics collapse the re-ingest by `(series_id, ts)`; logs and spans have no query-time dedup, so a retry duplicates the rows/spans. An idempotency key does not cover this commit either: the marker is written only after a write the router acknowledged in full, so a keyed retry of a timed-out write re-ingests exactly like an unkeyed one, and the key starts deduplicating only from the first retry that fully succeeds (metrics have no key). |
+| Ack round times out (flush still running) | present if the flush later succeeds | present if the flush later succeeds | no (retryable timeout) | client gets a retryable timeout with no token; each shard's flush keeps running and may commit *after* the client gave up, or may still fail or be abandoned. If it commits, the data is durable and query-visible but its token is unobservable to that client. The retry relies on dedup, not on the ack: metrics collapse the re-ingest by `(series_id, ts)`; logs and spans have no query-time dedup, so a retry duplicates the rows/spans. An idempotency key does not cover this commit either: the marker is written only after a write the router acknowledged in full, so a keyed retry of a timed-out write re-ingests exactly like an unkeyed one, and the key starts deduplicating only from the first retry that fully succeeds (metrics have no key). |
 
 ## Partial multi-shard commits
 
@@ -100,18 +101,20 @@ every shard that did commit, in shard order. This holds for all three signals
 -- metrics, logs, and spans alike; the durable siblings are real, query-visible
 data, not rolled back.
 
-The error is exactly as retryable as its underlying cause, so a client may
-retry the whole write. The retry re-ingests the shards that already committed,
-and dedup is what keeps that honest: metrics collapse the re-ingest by
-`(series_id, ts)`, so it is harmless; logs and spans have no query-time dedup,
-so the retry duplicates the durable siblings' rows/spans, with or without an
-idempotency key: a partial multi-shard commit writes no idempotency marker even
-on logs and spans, for the reason given under "Opt-in client idempotency key"
-below, so the key begins deduplicating only from the first retry that commits
-in full (metrics have no key). Whichever gateway path took the write
-logs the durable-sibling count at `warn`; the OTLP protocol has no
-error-response channel to hand the recovered tokens back, and the bulk `load`
-path reports them in its residual token list instead.
+The error is exactly as retryable as its underlying cause: a client may retry
+the whole write only when that cause is retryable, and when it is not, the
+durable siblings still stand. A retry re-ingests the shards that already
+committed, and dedup is what keeps that honest: metrics collapse the re-ingest
+by `(series_id, ts)`, so it is harmless; logs and spans have no query-time
+dedup, so the retry duplicates the durable siblings' rows/spans, with or
+without an idempotency key: a partial multi-shard commit writes no idempotency
+marker even on logs and spans, for the reason given under "Opt-in client
+idempotency key" below, so the key begins deduplicating only from the first
+retry that commits in full (metrics have no key). The durable tokens reach a
+client only where the transport can carry them: the OTLP, remote-write, and
+OTAP gateways have no error-response channel for them, so each logs the
+durable-sibling count at `warn` with the tenant hash instead, and the bulk
+`load` path reports them in its residual token list.
 
 ## Duplicates and idempotency
 

--- a/docs/consistency-model.md
+++ b/docs/consistency-model.md
@@ -88,7 +88,7 @@ rejected point counts and reasons.
 | After data PUT, before commit PUT | present (orphan) | absent | no | invisible; GC after grace; client retries |
 | After commit PUT, before ack | present | present | no | visible; unkeyed client retry stores a duplicate (see above); a keyed retry replays the marker and stores nothing new, since the marker PUT precedes the ack |
 | After ack | present | present | yes | durable and visible |
-| Ack round times out (flush still running) | eventually present | eventually present | no (retryable timeout) | client gets a retryable timeout with no token; each shard's flush keeps running and can commit *after* the client gave up, so the commit is durable and query-visible but its token is unobservable to that client. The retry relies on dedup, not on the ack: metrics collapse the re-ingest by `(series_id, ts)`; logs and spans have no query-time dedup, so a retry duplicates the rows/spans unless the client supplied an idempotency key (metrics have no key). |
+| Ack round times out (flush still running) | eventually present | eventually present | no (retryable timeout) | client gets a retryable timeout with no token; each shard's flush keeps running and can commit *after* the client gave up, so the commit is durable and query-visible but its token is unobservable to that client. The retry relies on dedup, not on the ack: metrics collapse the re-ingest by `(series_id, ts)`; logs and spans have no query-time dedup, so a retry duplicates the rows/spans. An idempotency key does not cover this commit either: the marker is written only after a write the router acknowledged in full, so a keyed retry of a timed-out write re-ingests exactly like an unkeyed one, and the key starts deduplicating only from the first retry that fully succeeds (metrics have no key). |
 
 ## Partial multi-shard commits
 
@@ -104,10 +104,11 @@ The error is exactly as retryable as its underlying cause, so a client may
 retry the whole write. The retry re-ingests the shards that already committed,
 and dedup is what keeps that honest: metrics collapse the re-ingest by
 `(series_id, ts)`, so it is harmless; logs and spans have no query-time dedup,
-so the retry duplicates the durable siblings' rows/spans unless the client
-supplied an idempotency key (metrics have no key). A partial multi-shard commit
-writes no idempotency marker even on logs and spans, for the reason given under
-"Opt-in client idempotency key" below. Whichever gateway path took the write
+so the retry duplicates the durable siblings' rows/spans, with or without an
+idempotency key: a partial multi-shard commit writes no idempotency marker even
+on logs and spans, for the reason given under "Opt-in client idempotency key"
+below, so the key begins deduplicating only from the first retry that commits
+in full (metrics have no key). Whichever gateway path took the write
 logs the durable-sibling count at `warn`; the OTLP protocol has no
 error-response channel to hand the recovered tokens back, and the bulk `load`
 path reports them in its residual token list instead.

--- a/docs/consistency-model.md
+++ b/docs/consistency-model.md
@@ -88,6 +88,29 @@ rejected point counts and reasons.
 | After data PUT, before commit PUT | present (orphan) | absent | no | invisible; GC after grace; client retries |
 | After commit PUT, before ack | present | present | no | visible; unkeyed client retry stores a duplicate (see above); a keyed retry replays the marker and stores nothing new, since the marker PUT precedes the ack |
 | After ack | present | present | yes | durable and visible |
+| Ack round times out (flush still running) | eventually present | eventually present | no (retryable timeout) | client gets a retryable timeout with no token; each shard's flush keeps running and can commit *after* the client gave up, so the commit is durable and query-visible but its token is unobservable to that client. The retry relies on dedup, not on the ack: metrics collapse the re-ingest by `(series_id, ts)`; logs and spans have no query-time dedup, so a retry duplicates the rows/spans unless the client supplied an idempotency key (metrics have no key). |
+
+## Partial multi-shard commits
+
+A single Strict write fans out across every shard its rows hash to, and each
+shard commits independently. When at least one shard commits durably and at
+least one sibling then fails in the same write, the router reports a partial
+multi-shard commit: a retryable error that also carries the commit tokens of
+every shard that did commit, in shard order. This holds for all three signals
+-- metrics, logs, and spans alike; the durable siblings are real, query-visible
+data, not rolled back.
+
+The error is exactly as retryable as its underlying cause, so a client may
+retry the whole write. The retry re-ingests the shards that already committed,
+and dedup is what keeps that honest: metrics collapse the re-ingest by
+`(series_id, ts)`, so it is harmless; logs and spans have no query-time dedup,
+so the retry duplicates the durable siblings' rows/spans unless the client
+supplied an idempotency key (metrics have no key). A partial multi-shard commit
+writes no idempotency marker even on logs and spans, for the reason given under
+"Opt-in client idempotency key" below. Whichever gateway path took the write
+logs the durable-sibling count at `warn`; the OTLP protocol has no
+error-response channel to hand the recovered tokens back, and the bulk `load`
+path reports them in its residual token list instead.
 
 ## Duplicates and idempotency
 
@@ -134,8 +157,8 @@ The marker records the original request's written row/span count and its
 `x-ravel-commit-token` header value verbatim. A marker is written only for a
 request whose *every* shard committed durably; buffered-mode and
 fully-rejected requests commit no durable data and write no marker. A
-multi-shard request where some but not all shards committed
-(`LogWriteError::PartialWrite`) also writes no marker, even
+multi-shard request where some but not all shards committed (a partial
+multi-shard commit) also writes no marker, even
 though it did produce a partial durable commit: a hit on this marker's
 replay path reports the original commit token with zero rejections, so
 marking a partial commit as the request's receipt would make the next retry

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -142,6 +142,7 @@ Labels: `mode` and `signal`. The `signal` label carries `metrics`, `logs`, or
 | `ravel_ingest_acks_err_total` | Strict-mode waiters acked with a write error. |
 | `ravel_ingest_collisions_total` | Batches rejected for a series or stream identity collision. |
 | `ravel_ingest_shard_deaths_total` | Distinct shard actors observed dead by the router. |
+| `ravel_ingest_partial_writes_total` | Multi-shard strict writes that committed on some shards and then failed on a sibling. The client received a retryable error carrying the durable tokens; a rising figure means retries are re-ingesting data that already committed (see the consistency model's partial multi-shard commit section). |
 | `ravel_ingest_exemplars_written_total` | Exemplars stored on flushed objects. |
 | `ravel_ingest_exemplars_dropped_total` | Exemplars discarded by the per-series admission cap. |
 | `ravel_ingest_stale_provisioning_flushes_total` | Flushes failed closed because the router's cached shard-generation view was older than the refresh interval. A rising figure means the provisioning re-read is failing for longer than the grace window allows. |

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -142,7 +142,7 @@ Labels: `mode` and `signal`. The `signal` label carries `metrics`, `logs`, or
 | `ravel_ingest_acks_err_total` | Strict-mode waiters acked with a write error. |
 | `ravel_ingest_collisions_total` | Batches rejected for a series or stream identity collision. |
 | `ravel_ingest_shard_deaths_total` | Distinct shard actors observed dead by the router. |
-| `ravel_ingest_partial_writes_total` | Multi-shard strict writes that committed on some shards and then failed on a sibling. The client received a retryable error carrying the durable tokens; a rising figure means retries are re-ingesting data that already committed (see the consistency model's partial multi-shard commit section). |
+| `ravel_ingest_partial_writes_total` | Multi-shard strict writes the router observed committing on some shards and then failing on a sibling. The client received an error that is retryable exactly when the sibling's failure was, and the durable tokens reach it only where the transport can carry them (the OTLP, remote-write, and OTAP gateways log the durable count instead); a rising figure means retries may be re-ingesting data that already committed (see the consistency model's partial multi-shard commit section). |
 | `ravel_ingest_exemplars_written_total` | Exemplars stored on flushed objects. |
 | `ravel_ingest_exemplars_dropped_total` | Exemplars discarded by the per-series admission cap. |
 | `ravel_ingest_stale_provisioning_flushes_total` | Flushes failed closed because the router's cached shard-generation view was older than the refresh interval. A rising figure means the provisioning re-read is failing for longer than the grace window allows. |

--- a/services/ravel-server/src/ingest.rs
+++ b/services/ravel-server/src/ingest.rs
@@ -211,7 +211,24 @@ pub async fn handle_export(
         .router
         .write_values_with_exemplars(tenant, points, exemplars, mode, state.ack_deadline)
         .await
-        .map_err(IngestRequestError::Write)?;
+        .map_err(|err| {
+            // A PartialWrite's durable siblings are real, durably committed
+            // data (docs/consistency-model.md). OTLP has no error-response
+            // channel to hand their tokens back to the client, so logging the
+            // count is the only recovery this path offers. The metrics pipeline
+            // has no idempotency marker at all: dedup is by `(series_id, ts)` at
+            // read time, so a retry of these siblings is harmless rather than
+            // duplicating.
+            let durable_shard_count = err.durable_tokens().len();
+            if durable_shard_count > 0 {
+                tracing::warn!(
+                    durable_shard_count,
+                    "metric write partially committed before a sibling shard \
+                     failed"
+                );
+            }
+            IngestRequestError::Write(err)
+        })?;
 
     let partial_success = if rejected_count > 0 {
         let error_message = build_error_message(&normalized.rejected, series_cap_rejected);

--- a/services/ravel-server/src/ingest.rs
+++ b/services/ravel-server/src/ingest.rs
@@ -207,6 +207,7 @@ pub async fn handle_export(
         rejected_count += series_cap_rejected;
     }
 
+    let tenant_hash = tenant.hash();
     let receipt = state
         .router
         .write_values_with_exemplars(tenant, points, exemplars, mode, state.ack_deadline)
@@ -222,6 +223,7 @@ pub async fn handle_export(
             let durable_shard_count = err.durable_tokens().len();
             if durable_shard_count > 0 {
                 tracing::warn!(
+                    tenant_hash = %tenant_hash.to_hex(),
                     durable_shard_count,
                     "metric write partially committed before a sibling shard \
                      failed"

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -615,6 +615,10 @@ pub struct IngestPipelineSnapshot {
     pub acks_err: u64,
     pub collisions: Option<u64>,
     pub shard_deaths: u64,
+    /// Multi-shard Strict writes that committed on at least one shard and
+    /// then failed on a sibling: partial multi-shard commits, reported to the
+    /// client as a retryable error carrying the durable tokens.
+    pub partial_writes: u64,
     /// Flushes failed closed because the router's cached provisioning view for
     /// the tenant was older than the refresh interval `C` (ADR-0052 section 3).
     pub stale_provisioning_flushes: u64,
@@ -725,6 +729,7 @@ impl IngestPipelineSnapshot {
             acks_err: snapshot.acks_err,
             collisions: Some(snapshot.series_id_collisions),
             shard_deaths: snapshot.shard_deaths,
+            partial_writes: snapshot.partial_writes,
             stale_provisioning_flushes: snapshot.stale_provisioning_flushes,
             postings: None,
             metadata_sink: Some(MetadataSinkCounters {
@@ -760,6 +765,7 @@ impl IngestPipelineSnapshot {
             acks_err: snapshot.acks_err,
             collisions: Some(snapshot.stream_id_collisions),
             shard_deaths: snapshot.shard_deaths,
+            partial_writes: snapshot.partial_writes,
             stale_provisioning_flushes: snapshot.stale_provisioning_flushes,
             postings: Some(PostingsCounters {
                 objects: snapshot.postings_objects,
@@ -793,6 +799,7 @@ impl IngestPipelineSnapshot {
             acks_err: snapshot.acks_err,
             collisions: None,
             shard_deaths: snapshot.shard_deaths,
+            partial_writes: snapshot.partial_writes,
             stale_provisioning_flushes: snapshot.stale_provisioning_flushes,
             postings: None,
             metadata_sink: None,
@@ -991,6 +998,21 @@ fn render_ingest_family(out: &mut String, mode: Mode, pipelines: &[IngestPipelin
             "ravel_ingest_shard_deaths_total",
             &labels(mode, pipeline.signal),
             pipeline.shard_deaths,
+        );
+    }
+
+    write_header(
+        out,
+        "ravel_ingest_partial_writes_total",
+        "Multi-shard Strict writes that committed on some shards and failed on a sibling, by signal.",
+        "counter",
+    );
+    for pipeline in pipelines {
+        write_sample(
+            out,
+            "ravel_ingest_partial_writes_total",
+            &labels(mode, pipeline.signal),
+            pipeline.partial_writes,
         );
     }
 

--- a/services/ravel-server/src/otap_grpc.rs
+++ b/services/ravel-server/src/otap_grpc.rs
@@ -396,6 +396,7 @@ async fn write_batch(
             let durable_shard_count = err.durable_tokens().len();
             if durable_shard_count > 0 {
                 tracing::warn!(
+                    tenant_hash = %tenant.hash().to_hex(),
                     durable_shard_count,
                     "metric write partially committed before a sibling shard \
                      failed"

--- a/services/ravel-server/src/otap_grpc.rs
+++ b/services/ravel-server/src/otap_grpc.rs
@@ -389,7 +389,20 @@ async fn write_batch(
         .router
         .write_values(tenant.clone(), points, mode, ingest.ack_deadline)
         .await
-        .map_err(IngestRequestError::Write)?;
+        .map_err(|err| {
+            // A partial multi-shard commit: the durable siblings are real
+            // data, logged the way the OTLP paths log them since OTAP has no
+            // channel to hand their tokens back.
+            let durable_shard_count = err.durable_tokens().len();
+            if durable_shard_count > 0 {
+                tracing::warn!(
+                    durable_shard_count,
+                    "metric write partially committed before a sibling shard \
+                     failed"
+                );
+            }
+            IngestRequestError::Write(err)
+        })?;
     Ok(WriteOutcome {
         tokens: receipt.tokens,
         dropped_points,

--- a/services/ravel-server/src/remote_write.rs
+++ b/services/ravel-server/src/remote_write.rs
@@ -426,6 +426,7 @@ async fn remote_write(
         .count() as u64;
     let points_accepted = samples_written + histograms_written;
 
+    let tenant_hash = tenant.hash();
     let receipt = match state
         .router
         .write_values(tenant, ingest_points, WriteMode::Strict, state.ack_deadline)
@@ -439,6 +440,7 @@ async fn remote_write(
             let durable_shard_count = err.durable_tokens().len();
             if durable_shard_count > 0 {
                 tracing::warn!(
+                    tenant_hash = %tenant_hash.to_hex(),
                     durable_shard_count,
                     "metric write partially committed before a sibling shard \
                      failed"

--- a/services/ravel-server/src/remote_write.rs
+++ b/services/ravel-server/src/remote_write.rs
@@ -433,6 +433,17 @@ async fn remote_write(
     {
         Ok(receipt) => receipt,
         Err(err) => {
+            // A partial multi-shard commit: the durable siblings are real
+            // data, and remote write has no channel to hand their tokens
+            // back, so the count is logged the way the OTLP paths log it.
+            let durable_shard_count = err.durable_tokens().len();
+            if durable_shard_count > 0 {
+                tracing::warn!(
+                    durable_shard_count,
+                    "metric write partially committed before a sibling shard \
+                     failed"
+                );
+            }
             state.metrics.record_request_rejected();
             return write_error_response(err);
         }

--- a/services/ravel-server/src/traces_ingest.rs
+++ b/services/ravel-server/src/traces_ingest.rs
@@ -220,7 +220,28 @@ pub async fn handle_export_traces(
         .router
         .write(tenant.clone(), normalized.spans, mode, state.ack_deadline)
         .await
-        .map_err(SpanIngestRequestError::Write)?;
+        .map_err(|err| {
+            // A PartialWrite's durable siblings are real, durably committed
+            // data (docs/consistency-model.md "Opt-in client idempotency
+            // key"). OTLP has no error-response channel to hand their tokens
+            // back to the client, and no idempotency marker is written for
+            // them: the marker replay path always reports the original commit
+            // token with zero rejections, so marking a partial commit as the
+            // request's receipt would make the next retry skip resending the
+            // shard that never committed and permanently lose it, rather than
+            // the honest at-least-once duplication an unkeyed retry gets today.
+            // Logging the count is the only recovery this path offers.
+            let durable_shard_count = err.durable_tokens().len();
+            if durable_shard_count > 0 {
+                tracing::warn!(
+                    durable_shard_count,
+                    "span write partially committed before a sibling shard \
+                     failed; no idempotency marker written for the durable \
+                     siblings"
+                );
+            }
+            SpanIngestRequestError::Write(err)
+        })?;
 
     // Emit partial-success whenever anything was rejected, not only when a
     // whole span was lost: an attribute-only drop must still be surfaced to the

--- a/services/ravel-server/src/traces_ingest.rs
+++ b/services/ravel-server/src/traces_ingest.rs
@@ -234,6 +234,7 @@ pub async fn handle_export_traces(
             let durable_shard_count = err.durable_tokens().len();
             if durable_shard_count > 0 {
                 tracing::warn!(
+                    tenant_hash = %tenant.hash().to_hex(),
                     durable_shard_count,
                     "span write partially committed before a sibling shard \
                      failed; no idempotency marker written for the durable \


### PR DESCRIPTION
The metrics and span routers returned on the first failing shard of a multi-shard strict write and dropped the sibling tokens already committed, so a partial durable commit was reported as a plain failure; only the logs router reported it as a partial write with the durable tokens. Both routers now await every shard's ack under the one ack deadline and decide the way the logs router does: all shards succeeded returns the tokens, all failed returns the first failure, a mix returns the new `WriteError::PartialWrite` or `SpanWriteError::PartialWrite` carrying the durable tokens in shard order, and a whole-round timeout still returns `AckTimeout` with no tokens. The variants delegate `is_retryable` to the inner error and expose the durable tokens, and the server's ingest handlers log a partial commit the way the logs handler does. A `partial_writes` counter is recorded on all three signals at every site that constructs the variant.

docs/consistency-model.md now states partial commits for all three signals and adds a crash-matrix row for the acknowledgement timeout: the flush keeps running after the client receives the retryable timeout, so the commit can land afterwards with its token unobservable to that client; a retried write is deduplicated where a mechanism exists (metrics collapse re-ingest by series and timestamp at read time; logs and spans rely on a client-supplied idempotency key and duplicate without one).

Five integration tests drive the production write entry points: a three-shard write with one shard's data PUT faulted returns a partial write with exactly two durable tokens in shard order on both routers (failing before the change with the plain error), all-shards-fail returns the plain error, retryability delegates in both directions, and a held data PUT past the ack deadline returns the timeout with no tokens and then lands exactly one commit record once released.

The issue text said the logs path already had a partial-write metric; it did not, so the counter is new on all three signals.

Fleet task caefaf76-d2f9-48ac-b55b-13572fc29ca8, cherry-picked onto current main.

Fixes: #1130
Refs: #1040