### PR TITLE
feat(query): add the PromQL-over-logs series source

### DIFF
--- a/crates/ravel-logseg/proptest-regressions/record.txt
+++ b/crates/ravel-logseg/proptest-regressions/record.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 411d7589a9f216206267a84d3df4c6e07d09be1d1ba10dbb799ef2a966404510 # shrinks to resource = [], scope_name = "", scope_version = "", scope_attrs = [("a", Map([("o", Str("")), ("a", Str(""))]))]

--- a/crates/ravel-logseg/src/record.rs
+++ b/crates/ravel-logseg/src/record.rs
@@ -9,7 +9,8 @@
 
 use ravel_types::logstream::{AttrValue, LogStreamId, canonical_attr_bytes};
 
-use crate::varint::put_uvarint;
+use crate::error::LogSegError;
+use crate::varint::{get_ivarint, get_uvarint, put_uvarint};
 
 // Fixed column ids (docs/log-segment-format.md FIELD_DIR). These occupy the
 // reserved ids 0..=9 and never appear in FIELD_DIR; dynamic attribute columns
@@ -66,6 +67,183 @@ pub fn stream_attrs_bytes(
     out.extend_from_slice(scope_version.as_bytes());
     out.extend_from_slice(&canonical_attr_bytes(scope_attrs));
     out
+}
+
+/// Depth cap when decoding a stream_attrs blob, so hostile nesting cannot
+/// exhaust the stack.
+const MAX_ATTR_DEPTH: u32 = 32;
+
+/// Entry/element-count cap per attribute set or list when decoding, so a
+/// corrupt count is rejected rather than allocated on.
+const MAX_ATTR_ENTRIES: u64 = 1 << 20;
+
+/// The decoded form of a [`LogRecord::stream_attrs`] blob: the resource
+/// attribute set, scope name and version, and the scope attribute set, exactly
+/// as [`stream_attrs_bytes`] encoded them (the inverse of that function).
+#[derive(Clone, Debug, PartialEq)]
+pub struct StreamAttrs {
+    pub resource: Vec<(String, AttrValue)>,
+    pub scope_name: String,
+    pub scope_version: String,
+    pub scope_attrs: Vec<(String, AttrValue)>,
+}
+
+/// Decodes a [`LogRecord::stream_attrs`] blob into its structured form
+/// ([`stream_attrs_bytes`]'s inverse). Every [`AttrValue`] variant round-trips
+/// exactly, including a nested `List`/`Map` and an `F64`'s exact bit pattern (a
+/// NaN payload or -0.0 survives, since the encoding stores `to_bits` verbatim).
+/// Corrupt input (a truncated blob, an over-long length prefix, an unknown
+/// value tag) is a typed [`LogSegError::Corrupted`], never a panic.
+pub fn decode_stream_attrs(blob: &[u8]) -> Result<StreamAttrs, LogSegError> {
+    let mut pos = 0usize;
+    let resource = decode_attr_set(blob, &mut pos, 0)?;
+    let scope_name = decode_len_prefixed_string(blob, &mut pos)?;
+    let scope_version = decode_len_prefixed_string(blob, &mut pos)?;
+    let scope_attrs = decode_attr_set(blob, &mut pos, 0)?;
+    Ok(StreamAttrs {
+        resource,
+        scope_name,
+        scope_version,
+        scope_attrs,
+    })
+}
+
+/// v1 stringification of a dynamic attribute value, used to render `attrs`
+/// map values to text. Scalar values render to their natural text; `Bytes`,
+/// `List`, and `Map` render to the lowercase hex of their canonical encoding, a
+/// deterministic, injective form pending a richer typed column.
+pub fn attr_value_to_string(v: &AttrValue) -> String {
+    match v {
+        AttrValue::Str(s) => s.clone(),
+        AttrValue::I64(i) => i.to_string(),
+        AttrValue::F64(f) => f.to_string(),
+        AttrValue::Bool(b) => b.to_string(),
+        AttrValue::Bytes(b) => hex_lower(b),
+        AttrValue::List(_) | AttrValue::Map(_) => hex_lower(&canonical_attr_bytes(
+            std::slice::from_ref(&(String::new(), v.clone())),
+        )),
+    }
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        // Writing to a String never fails.
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+fn decode_attr_set(
+    buf: &[u8],
+    pos: &mut usize,
+    depth: u32,
+) -> Result<Vec<(String, AttrValue)>, LogSegError> {
+    if depth > MAX_ATTR_DEPTH {
+        return Err(corrupt("stream_attrs nesting too deep"));
+    }
+    let count = get_uvarint(buf, pos)?;
+    if count > MAX_ATTR_ENTRIES {
+        return Err(corrupt("stream_attrs entry count over cap"));
+    }
+    let mut out = Vec::new();
+    for _ in 0..count {
+        let klen = usize_of(get_uvarint(buf, pos)?)?;
+        let kstart = *pos;
+        advance(buf, pos, klen)?;
+        let key = std::str::from_utf8(&buf[kstart..*pos])
+            .map_err(|_| corrupt("stream_attrs key not utf-8"))?
+            .to_string();
+        let value = decode_value(buf, pos, depth + 1)?;
+        out.push((key, value));
+    }
+    Ok(out)
+}
+
+/// Decodes one encoded attribute value at `pos` (frozen grammar,
+/// `ravel_types::logstream`: 1=Str 2=I64 3=F64 4=Bool 5=Bytes 6=List 7=Map),
+/// advancing `pos` past it.
+fn decode_value(buf: &[u8], pos: &mut usize, depth: u32) -> Result<AttrValue, LogSegError> {
+    if depth > MAX_ATTR_DEPTH {
+        return Err(corrupt("stream_attrs nesting too deep"));
+    }
+    let tag = read_u8(buf, pos)?;
+    Ok(match tag {
+        1 => {
+            let len = usize_of(get_uvarint(buf, pos)?)?;
+            let start = *pos;
+            advance(buf, pos, len)?;
+            let s = std::str::from_utf8(&buf[start..*pos])
+                .map_err(|_| corrupt("stream_attrs str not utf-8"))?
+                .to_string();
+            AttrValue::Str(s)
+        }
+        2 => AttrValue::I64(get_ivarint(buf, pos)?),
+        3 => {
+            let start = *pos;
+            advance(buf, pos, 8)?;
+            let mut b = [0u8; 8];
+            b.copy_from_slice(&buf[start..*pos]);
+            AttrValue::F64(f64::from_bits(u64::from_le_bytes(b)))
+        }
+        4 => AttrValue::Bool(read_u8(buf, pos)? != 0),
+        5 => {
+            let len = usize_of(get_uvarint(buf, pos)?)?;
+            let start = *pos;
+            advance(buf, pos, len)?;
+            AttrValue::Bytes(buf[start..*pos].to_vec())
+        }
+        6 => {
+            let n = get_uvarint(buf, pos)?;
+            if n > MAX_ATTR_ENTRIES {
+                return Err(corrupt("stream_attrs list length over cap"));
+            }
+            let mut items = Vec::new();
+            for _ in 0..n {
+                items.push(decode_value(buf, pos, depth + 1)?);
+            }
+            AttrValue::List(items)
+        }
+        7 => AttrValue::Map(decode_attr_set(buf, pos, depth + 1)?),
+        _ => return Err(corrupt("bad stream_attrs value tag")),
+    })
+}
+
+fn decode_len_prefixed_string(buf: &[u8], pos: &mut usize) -> Result<String, LogSegError> {
+    let len = usize_of(get_uvarint(buf, pos)?)?;
+    let start = *pos;
+    advance(buf, pos, len)?;
+    std::str::from_utf8(&buf[start..*pos])
+        .map(|s| s.to_string())
+        .map_err(|_| corrupt("stream_attrs scope name/version not utf-8"))
+}
+
+fn read_u8(buf: &[u8], pos: &mut usize) -> Result<u8, LogSegError> {
+    let b = *buf
+        .get(*pos)
+        .ok_or_else(|| corrupt("stream_attrs truncated"))?;
+    *pos += 1;
+    Ok(b)
+}
+
+fn advance(buf: &[u8], pos: &mut usize, n: usize) -> Result<(), LogSegError> {
+    let end = pos
+        .checked_add(n)
+        .ok_or_else(|| corrupt("stream_attrs length overflow"))?;
+    if end > buf.len() {
+        return Err(corrupt("stream_attrs truncated"));
+    }
+    *pos = end;
+    Ok(())
+}
+
+fn usize_of(v: u64) -> Result<usize, LogSegError> {
+    usize::try_from(v).map_err(|_| corrupt("stream_attrs length exceeds usize"))
+}
+
+fn corrupt(what: &str) -> LogSegError {
+    LogSegError::Corrupted(format!("stream_attrs: {what}"))
 }
 
 /// A single log record as handed to the writer.
@@ -298,10 +476,12 @@ pub enum Predicate {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
-    use super::*;
+    use proptest::prelude::*;
     use ravel_types::logstream::log_stream_id;
+
+    use super::*;
 
     fn resource() -> Vec<(String, AttrValue)> {
         vec![
@@ -355,5 +535,92 @@ mod tests {
             stream_attrs_bytes(&[], "ab", "c", &[]),
             stream_attrs_bytes(&[], "a", "bc", &[])
         );
+    }
+
+    #[test]
+    fn attr_value_to_string_renders_each_type() {
+        assert_eq!(attr_value_to_string(&AttrValue::Str("api".into())), "api");
+        assert_eq!(attr_value_to_string(&AttrValue::I64(-42)), "-42");
+        assert_eq!(attr_value_to_string(&AttrValue::Bool(true)), "true");
+        assert_eq!(
+            attr_value_to_string(&AttrValue::Bytes(vec![0xab, 0x01])),
+            "ab01"
+        );
+        // Bytes/List/Map render as lowercase hex of the canonical encoding,
+        // never the natural text.
+        let list = AttrValue::List(vec![AttrValue::Str("a".into())]);
+        let want = {
+            use std::fmt::Write as _;
+            let mut s = String::new();
+            for b in canonical_attr_bytes(std::slice::from_ref(&(String::new(), list.clone()))) {
+                let _ = write!(s, "{b:02x}");
+            }
+            s
+        };
+        assert_eq!(attr_value_to_string(&list), want);
+    }
+
+    #[test]
+    fn decode_stream_attrs_rejects_truncated_blob() {
+        let blob = stream_attrs_bytes(&[("k".into(), AttrValue::Str("v".into()))], "s", "1", &[]);
+        let err = decode_stream_attrs(&blob[..blob.len() - 1]).unwrap_err();
+        assert!(matches!(err, LogSegError::Corrupted(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn decode_stream_attrs_rejects_bad_length_prefix() {
+        // One resource entry whose key length varint claims a length far
+        // beyond the buffer.
+        let blob = vec![1u8, 0x80, 0x80, 0x80, 0x80, 0x01];
+        let err = decode_stream_attrs(&blob).unwrap_err();
+        assert!(matches!(err, LogSegError::Corrupted(_)), "got {err:?}");
+    }
+
+    fn arb_value() -> impl Strategy<Value = AttrValue> {
+        let leaf = prop_oneof![
+            ".*".prop_map(AttrValue::Str),
+            any::<i64>().prop_map(AttrValue::I64),
+            any::<u64>().prop_map(|b| AttrValue::F64(f64::from_bits(b))),
+            any::<bool>().prop_map(AttrValue::Bool),
+            proptest::collection::vec(any::<u8>(), 0..8).prop_map(AttrValue::Bytes),
+        ];
+        leaf.prop_recursive(3, 16, 4, |inner| {
+            prop_oneof![
+                proptest::collection::vec(inner.clone(), 0..4).prop_map(AttrValue::List),
+                proptest::collection::vec(("[a-z]{1,4}", inner), 0..4).prop_map(AttrValue::Map),
+            ]
+        })
+    }
+
+    fn arb_attrs() -> impl Strategy<Value = Vec<(String, AttrValue)>> {
+        proptest::collection::vec(("[a-z]{1,4}", arb_value()), 0..6)
+    }
+
+    proptest! {
+        #[test]
+        fn stream_attrs_round_trip(
+            resource in arb_attrs(),
+            scope_name in "[a-z]{0,8}",
+            scope_version in "[a-z0-9.]{0,8}",
+            scope_attrs in arb_attrs(),
+        ) {
+            let blob = stream_attrs_bytes(&resource, &scope_name, &scope_version, &scope_attrs);
+            let decoded = decode_stream_attrs(&blob).expect("decode");
+            // `canonical_attr_bytes` sorts entries (by key then encoded value),
+            // so a decoded set need not match the input's insertion order; two
+            // sets carry the same information iff their canonical bytes match.
+            // The encoding stores an F64 as `to_bits()`, so this comparison is
+            // bit-exact too (a NaN payload or -0.0 changes the bytes).
+            prop_assert_eq!(
+                canonical_attr_bytes(&decoded.resource),
+                canonical_attr_bytes(&resource)
+            );
+            prop_assert_eq!(decoded.scope_name, scope_name);
+            prop_assert_eq!(decoded.scope_version, scope_version);
+            prop_assert_eq!(
+                canonical_attr_bytes(&decoded.scope_attrs),
+                canonical_attr_bytes(&scope_attrs)
+            );
+        }
     }
 }

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -11,6 +11,7 @@ mod error;
 mod fetcher;
 pub mod http;
 mod log_fetcher;
+pub mod log_series;
 mod phase_accounting;
 mod query_admission;
 mod segment_admission;

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -2208,45 +2208,84 @@ impl LogSegmentFetcher {
         accounting: &QueryAccounting,
     ) -> Result<Option<Vec<(LogStreamId, Vec<u8>)>>, LogFetchError> {
         let key = seg_ref.data_object_key.as_str();
-        let dir = if seg_ref.object_size > self.block_range_threshold {
-            let mut stats = BlockRangeStats::default();
-            let pin = EtagPin::default();
-            let phase = ReadPhases::PLAN.metadata;
-            let (footer, resident) = self
-                .block_range
-                .probe_footer(seg_ref, tenant_hash, phase, &pin, accounting, &mut stats)
-                .await?;
+        let dir: Option<StreamDir> = if seg_ref.object_size > self.block_range_threshold {
+            // The `page_fetch` phase span the other plan paths carry (#782), so
+            // the trace shows the probe and section GETs this method issues.
+            // `s3_bytes` reports block bytes only, which are structurally zero
+            // here; the directory-overhead bytes are recorded in `accounting`.
+            let fetch_span = tracing::debug_span!(
+                "page_fetch",
+                signal = "logs",
+                s3_requests = tracing::field::Empty,
+                s3_bytes = tracing::field::Empty,
+                probe_misses = tracing::field::Empty,
+            );
+            let (dir, stats) = async {
+                let mut stats = BlockRangeStats::default();
+                let pin = EtagPin::default();
+                let phase = ReadPhases::PLAN.metadata;
+                let (footer, resident) = self
+                    .block_range
+                    .probe_footer(seg_ref, tenant_hash, phase, &pin, accounting, &mut stats)
+                    .await?;
 
-            let Some(stream_desc) = footer.section(kind::STREAM_DIR).copied() else {
-                return Ok(None);
-            };
-            let raw = self
-                .block_range
-                .plan_section_raw(
-                    seg_ref,
-                    tenant_hash,
-                    &stream_desc,
-                    &resident,
-                    phase,
-                    &pin,
-                    accounting,
-                    &mut stats,
-                )
-                .await?;
-            StreamDir::decode(&raw, MAX_STREAMS).map_err(|source| corrupt(key, source))?
+                let dir = match footer.section(kind::STREAM_DIR).copied() {
+                    None => None,
+                    Some(stream_desc) => {
+                        let raw = self
+                            .block_range
+                            .plan_section_raw(
+                                seg_ref,
+                                tenant_hash,
+                                &stream_desc,
+                                &resident,
+                                phase,
+                                &pin,
+                                accounting,
+                                &mut stats,
+                            )
+                            .await?;
+                        Some(
+                            StreamDir::decode(&raw, MAX_STREAMS)
+                                .map_err(|source| corrupt(key, source))?,
+                        )
+                    }
+                };
+                Ok::<_, LogFetchError>((dir, stats))
+            }
+            .instrument(fetch_span.clone())
+            .await?;
+            let requests = stats.probe_gets + stats.metadata_gets + stats.block_range_gets;
+            fetch_span.record("s3_requests", requests);
+            fetch_span.record("s3_bytes", stats.block_bytes_fetched);
+            // Probe misses (#883): a footer chase or section miss here is a
+            // probe too short to reach it, reported per phase beside the
+            // request/byte counts like every other plan-phase read.
+            self.record_probe_misses(&fetch_span, &stats, ProbePhase::Plan);
+            dir
         } else {
             let bytes = self
                 .whole_object_bytes(seg_ref, tenant_hash, QueryPhase::Plan, accounting)
                 .await?;
-            self.decode_stream_dir(&bytes)
-                .map_err(|source| corrupt(key, source))?
+            let footer = footer::open(&bytes).map_err(|source| corrupt(key, source))?;
+            match footer.section(kind::STREAM_DIR).copied() {
+                None => None,
+                Some(desc) => {
+                    let raw = read_section(&bytes, &desc, &self.cfg)
+                        .map_err(|source| corrupt(key, source))?;
+                    Some(
+                        StreamDir::decode(&raw, MAX_STREAMS)
+                            .map_err(|source| corrupt(key, source))?,
+                    )
+                }
+            }
         };
-        Ok(Some(
+        Ok(dir.map(|dir| {
             dir.entries()
                 .iter()
                 .map(|entry| (entry.stream_id, entry.blob.clone()))
-                .collect(),
-        ))
+                .collect()
+        }))
     }
 
     /// Decodes the STREAM_DIR section of an object from its own public section
@@ -6631,6 +6670,305 @@ mod plan_skip_decidable_span_tests {
                 "one count per missed tail section, whichever phase issued the probe"
             );
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod fetch_stream_dir_tests {
+    //! Pins two review findings on `LogSegmentFetcher::fetch_stream_dir`
+    //! (#1106): the above-threshold branch's STREAM_DIR probe must report
+    //! through the same `page_fetch` span and `record_probe_misses` channel
+    //! every other plan-phase read carries, and the below-threshold and
+    //! above-threshold branches must agree on the absent-STREAM_DIR
+    //! tolerance the method's own doc comment promises.
+
+    use super::*;
+    use ravel_catalog::SegmentLevel;
+    use ravel_logseg::writer::ObjectIdentity;
+    use ravel_logseg::{RlogWriter, stream_attrs_bytes};
+    use ravel_object_store::PutOptions;
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_types::logstream::log_stream_id;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use uuid::Uuid;
+
+    const TENANT: TenantHash = TenantHash([31u8; 16]);
+    const CONTENT_HASH: [u8; 32] = [33u8; 32];
+    const KEY: &str = "t/fetch-stream-dir.rlog";
+
+    fn identity() -> ObjectIdentity {
+        ObjectIdentity {
+            tenant_hash: [31u8; 16],
+            shard: 0,
+            writer_id: [6u8; 16],
+            writer_epoch: 1,
+            writer_seq: 1,
+        }
+    }
+
+    fn record(ts: i64) -> LogRecord {
+        let resource = vec![("service.name".to_string(), AttrValue::Str("svc".into()))];
+        LogRecord {
+            stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+            stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+            ts_ns: ts,
+            observed_ts_ns: ts,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: "hello world".into(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: vec![],
+        }
+    }
+
+    fn build_object(records: &[LogRecord]) -> Vec<u8> {
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        let mut w = RlogWriter::new(cfg, identity());
+        for r in records {
+            w.push(r.clone()).expect("push");
+        }
+        w.finish().expect("finish")
+    }
+
+    fn seg_ref(size: u64, records: &[LogRecord]) -> SegmentRef {
+        let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+        let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+        SegmentRef {
+            data_object_key: KEY.to_string(),
+            object_size: size,
+            min_event_ts_ns: min,
+            max_event_ts_ns: max,
+            ingest_hour_bucket: 0,
+            sample_count: records.len() as u64,
+            series_count: 0,
+            shard: 0,
+            content_hash: CONTENT_HASH,
+            writer_id: Uuid::from_u128(1),
+            writer_epoch: 1,
+            writer_seq: 1,
+            created_unix_ns: 0,
+            level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+            declared_column_stats: Default::default(),
+        }
+    }
+
+    async fn store_with_object(bytes: Vec<u8>) -> Arc<MemoryStore> {
+        let store = Arc::new(MemoryStore::new());
+        store
+            .put(KEY, Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put");
+        store
+    }
+
+    /// The subset of a `page_fetch` span's fields this test asserts on.
+    #[derive(Default, Debug)]
+    struct Captured {
+        signal: Option<String>,
+        s3_requests: Option<u64>,
+        s3_bytes: Option<u64>,
+        probe_misses: Option<u64>,
+    }
+
+    struct FieldVisitor<'a>(&'a mut Captured);
+
+    impl tracing::field::Visit for FieldVisitor<'_> {
+        fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+            match field.name() {
+                "s3_requests" => self.0.s3_requests = Some(value),
+                "s3_bytes" => self.0.s3_bytes = Some(value),
+                "probe_misses" => self.0.probe_misses = Some(value),
+                _ => {}
+            }
+        }
+
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            if field.name() == "signal" {
+                self.0.signal = Some(value.to_string());
+            }
+        }
+
+        fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+    }
+
+    /// Records every `page_fetch` span's fields as of its close, the same
+    /// test-scoped tracing capture `plan_skip_decidable_span_tests` uses.
+    #[derive(Clone, Default)]
+    struct PageFetchCollector {
+        live: Arc<Mutex<HashMap<u64, Captured>>>,
+        closed: Arc<Mutex<Vec<Captured>>>,
+    }
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for PageFetchCollector {
+        fn on_new_span(
+            &self,
+            attrs: &tracing::span::Attributes<'_>,
+            id: &tracing::span::Id,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if attrs.metadata().name() != "page_fetch" {
+                return;
+            }
+            let mut captured = Captured::default();
+            attrs.record(&mut FieldVisitor(&mut captured));
+            if let Ok(mut live) = self.live.lock() {
+                live.insert(id.into_u64(), captured);
+            }
+        }
+
+        fn on_record(
+            &self,
+            id: &tracing::span::Id,
+            values: &tracing::span::Record<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if let Ok(mut live) = self.live.lock()
+                && let Some(captured) = live.get_mut(&id.into_u64())
+            {
+                values.record(&mut FieldVisitor(captured));
+            }
+        }
+
+        fn on_close(&self, id: tracing::span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+            let taken = self
+                .live
+                .lock()
+                .ok()
+                .and_then(|mut live| live.remove(&id.into_u64()));
+            if let (Some(captured), Ok(mut closed)) = (taken, self.closed.lock()) {
+                closed.push(captured);
+            }
+        }
+    }
+
+    /// `block_range_threshold(0)` routes every nonzero-size object through the
+    /// ranged branch, so the STREAM_DIR probe under test is the one this test
+    /// exercises rather than the whole-object shortcut.
+    fn fetcher_above_threshold(store: Arc<MemoryStore>) -> LogSegmentFetcher {
+        LogSegmentFetcher::new(store.clone())
+            .with_block_range_threshold(0)
+            .with_block_range(BlockRangeFetcher::new(store).with_whole_object_threshold(0))
+    }
+
+    /// Finding 1 (#1106 CodeRabbit review on PR #1158): the above-threshold
+    /// branch of `fetch_stream_dir` must open the `page_fetch` span and call
+    /// `record_probe_misses`, exactly like `plan_segment_fast`,
+    /// `plan_segment`'s skip-decidable branch, and `plan_segment_block_stats`
+    /// already do, so the STREAM_DIR read it issues shows up in the trace and
+    /// in the probe-miss counter instead of being invisible on both.
+    ///
+    /// Non-vacuity: with the `fetch_span`/`.instrument` wrapping reverted to
+    /// the bare `probe_footer`/`plan_section_raw` calls this method had before
+    /// the fix, no span named `page_fetch` closes during this call,
+    /// `closed.len()` comes out `0`, and the `expect` below panics instead of
+    /// the field assertions running.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn above_threshold_branch_opens_page_fetch_span_and_records_probe_misses() {
+        let _serial = crate::test_tracing::guard();
+
+        let collector = PageFetchCollector::default();
+        let subscriber = tracing_subscriber::registry().with(collector.clone());
+        let _guard = subscriber.set_default();
+
+        const N: usize = 4;
+        let records: Vec<LogRecord> = (0..N as i64).map(record).collect();
+        let bytes = build_object(&records);
+        let total = bytes.len() as u64;
+        let seg = seg_ref(total, &records);
+        let store = store_with_object(bytes).await;
+        let f = fetcher_above_threshold(store);
+        let acc = QueryAccounting::new();
+
+        let entries = f
+            .fetch_stream_dir(&seg, TENANT, &acc)
+            .await
+            .expect("fetch_stream_dir")
+            .expect("STREAM_DIR present");
+        assert_eq!(entries.len(), 1, "one stream, every record shares it");
+
+        let closed = collector.closed.lock().expect("lock");
+        assert_eq!(
+            closed.len(),
+            1,
+            "exactly one page_fetch span for this one fetch_stream_dir call"
+        );
+        let span = &closed[0];
+        assert_eq!(span.signal.as_deref(), Some("logs"));
+        assert!(
+            span.s3_requests.is_some_and(|n| n > 0),
+            "must carry the real request count probe_footer/plan_section_raw issued, got {:?}",
+            span.s3_requests
+        );
+        assert!(
+            span.probe_misses.is_some(),
+            "probe_misses must be recorded (structurally 0 or more, but present, not Empty), \
+             got {:?}",
+            span.probe_misses
+        );
+    }
+
+    /// Finding 2 (#1106 CodeRabbit review on PR #1158): the doc comment on
+    /// `fetch_stream_dir` says an absent STREAM_DIR section returns `None`
+    /// regardless of which branch answers the read. `RlogWriter::build_object`
+    /// always writes a STREAM_DIR section unconditionally (see the
+    /// `push_section(&mut object, &mut sections, kind::STREAM_DIR, ...)` call
+    /// both encoder paths make, `crates/ravel-logseg/src/writer.rs:716` and
+    /// `:1536`) -- there is no writer knob to omit it -- so the absent-section
+    /// case is not reachable through a real written object today, matching
+    /// the method's own doc ("never observed on a real object today"). This
+    /// test instead pins what the finding actually requires: the two branches
+    /// must agree on the same object. It drives one fixture through both the
+    /// below-threshold whole-object branch (the default threshold, well above
+    /// this small fixture's size) and the above-threshold ranged branch
+    /// (`with_block_range_threshold(0)`), and asserts they decode the same
+    /// STREAM_DIR entries.
+    #[tokio::test]
+    async fn both_threshold_branches_agree_on_the_same_object() {
+        const N: usize = 3;
+        let records: Vec<LogRecord> = (0..N as i64).map(record).collect();
+        let bytes = build_object(&records);
+        let total = bytes.len() as u64;
+        let seg = seg_ref(total, &records);
+
+        let below_store = store_with_object(bytes.clone()).await;
+        let below = LogSegmentFetcher::new(below_store);
+        assert!(
+            total <= below.block_range_threshold(),
+            "fixture must be small enough to take the below-threshold branch by default"
+        );
+        let below_acc = QueryAccounting::new();
+        let mut below_entries = below
+            .fetch_stream_dir(&seg, TENANT, &below_acc)
+            .await
+            .expect("fetch_stream_dir (below threshold)")
+            .expect("STREAM_DIR present");
+
+        let above_store = store_with_object(bytes).await;
+        let above = fetcher_above_threshold(above_store);
+        let above_acc = QueryAccounting::new();
+        let mut above_entries = above
+            .fetch_stream_dir(&seg, TENANT, &above_acc)
+            .await
+            .expect("fetch_stream_dir (above threshold)")
+            .expect("STREAM_DIR present");
+
+        below_entries.sort_by_key(|(id, _)| *id);
+        above_entries.sort_by_key(|(id, _)| *id);
+        assert_eq!(
+            above_entries, below_entries,
+            "both branches must decode the same STREAM_DIR entries for the same object"
+        );
     }
 }
 

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -2174,6 +2174,81 @@ impl LogSegmentFetcher {
         Ok(Predicate::And(arms))
     }
 
+    /// Fetch and decode just the STREAM_DIR section (ADR-1103 decision 2's
+    /// cost model): the same ADR-0107 probe [`fetch_footer`](Self::fetch_footer)
+    /// issues, then the one front section the footer's directory locates it
+    /// at, reading no BLOCKS byte and no other directory section. Mirrors
+    /// [`fetch_skip_index`](Self::fetch_skip_index)'s shape; the only
+    /// difference is that STREAM_DIR sits at the object FRONT, so unlike
+    /// SKIP_IDX it is essentially never covered by the tail suffix probe and
+    /// [`plan_section_raw`](Self::plan_section_raw) issues its own range GET
+    /// for it.
+    ///
+    /// Returns `None` when the object's footer carries no STREAM_DIR section
+    /// at all (never observed on a real object today, but the same
+    /// "kind the footer does not carry is skipped" tolerance
+    /// [`place_front_sections`](Self::place_front_sections) documents applies
+    /// here rather than treating an absent directory as corruption). Otherwise
+    /// returns every entry's stream id and its raw (still-encoded)
+    /// stream-attrs blob, for the caller to decode with
+    /// [`ravel_logseg::record::decode_stream_attrs`].
+    ///
+    /// At or below [`Self::block_range_threshold`] this takes the same
+    /// whole-object crossover [`plan_segment`](Self::plan_segment) and
+    /// [`tenant_bytes`](Self::tenant_bytes) apply, via
+    /// [`whole_object_bytes`](Self::whole_object_bytes): a ranged probe would
+    /// pay for a second cache key on an object [`fetch_footer`](Self::fetch_footer)'s
+    /// doc explains is already read whole in one GET below the threshold. Above
+    /// it, the ranged probe-then-section path below is what actually saves the
+    /// BLOCKS bytes the ADR-1103 cost model counts on.
+    pub(crate) async fn fetch_stream_dir(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        accounting: &QueryAccounting,
+    ) -> Result<Option<Vec<(LogStreamId, Vec<u8>)>>, LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let dir = if seg_ref.object_size > self.block_range_threshold {
+            let mut stats = BlockRangeStats::default();
+            let pin = EtagPin::default();
+            let phase = ReadPhases::PLAN.metadata;
+            let (footer, resident) = self
+                .block_range
+                .probe_footer(seg_ref, tenant_hash, phase, &pin, accounting, &mut stats)
+                .await?;
+
+            let Some(stream_desc) = footer.section(kind::STREAM_DIR).copied() else {
+                return Ok(None);
+            };
+            let raw = self
+                .block_range
+                .plan_section_raw(
+                    seg_ref,
+                    tenant_hash,
+                    &stream_desc,
+                    &resident,
+                    phase,
+                    &pin,
+                    accounting,
+                    &mut stats,
+                )
+                .await?;
+            StreamDir::decode(&raw, MAX_STREAMS).map_err(|source| corrupt(key, source))?
+        } else {
+            let bytes = self
+                .whole_object_bytes(seg_ref, tenant_hash, QueryPhase::Plan, accounting)
+                .await?;
+            self.decode_stream_dir(&bytes)
+                .map_err(|source| corrupt(key, source))?
+        };
+        Ok(Some(
+            dir.entries()
+                .iter()
+                .map(|entry| (entry.stream_id, entry.blob.clone()))
+                .collect(),
+        ))
+    }
+
     /// Decodes the STREAM_DIR section of an object from its own public section
     /// descriptor, using the crate's public whole-section reader.
     /// This does not go through [`RlogReader`], which decodes STREAM_DIR

--- a/crates/ravel-query/src/log_series.rs
+++ b/crates/ravel-query/src/log_series.rs
@@ -7,38 +7,21 @@
 //! `resolve_series_inner`. This module is self-contained and has no
 //! dependency on `engine.rs`.
 //!
-//! # Plan-phase stream discovery: a known deviation from the ADR's cost model
+//! # Plan-phase stream discovery
 //!
-//! ADR-1103 decision 2 says stream-label-set discovery "costs one STREAM_DIR
-//! decode per candidate object, the same cost
-//! [`LogSegmentFetcher::plan_segment`] already pays" -- i.e. a directory-only
-//! read with no block data moved. That cost model assumes a caller can reach
-//! `LogSegmentFetcher::decode_stream_dir`, but that method carries no
-//! visibility modifier, so it is private to `log_fetcher.rs`'s own module and
-//! unreachable from this one even though both live in `ravel-query`,
-//! Rust's module-privacy default and not a byproduct of module nesting.
-//! `plan_segment` itself does not expose the decoded [`StreamDir`] entries
-//! either, only a block-survivor count. `fetch_footer` reads exactly the
-//! footer and discards the resident probe bytes STREAM_DIR would need to be
-//! sliced from. This task's scope is five named files and does not include
-//! `log_fetcher.rs`, so this module cannot add a public accessor for that
-//! read to close the gap.
-//!
-//! Given that, this module discovers per-segment stream identity with
-//! [`LogSegmentFetcher::fetch_accounted_with_tenant`] under the caller's Plan
-//! accounting handle: a full, decoded read of the segment rather than a
-//! directory-only one. This is correct -- every decoded record always
-//! carries its own `stream_id` and `stream_attrs`, so the discovered label
-//! sets and the `Predicate::StreamIn` built from them are exact, not an
-//! approximation -- but it costs strictly more than the ADR's stated model: a
-//! segment that survives the stream-match prune is read twice, once here and
-//! once by the Scan-phase projected scan. Flagging this as the report
-//! requires rather than silently absorbing the extra cost: a follow-up that
-//! marks `decode_stream_dir` `pub(crate)`, or adds a dedicated
-//! `fetch_stream_dir` mirroring `fetch_skip_index`, would let this module's
-//! Plan phase match the ADR's cost model exactly.
-//!
-//! [`StreamDir`]: ravel_logseg::stream_dir::StreamDir
+//! ADR-1103 decision 2's cost model -- stream-label-set discovery "costs one
+//! STREAM_DIR decode per candidate object, the same cost
+//! [`LogSegmentFetcher::plan_segment`] already pays" -- is implemented
+//! exactly, not approximated: [`LogSegmentFetcher::fetch_stream_dir`] reads
+//! the footer plus the STREAM_DIR section only, moving no BLOCKS byte. This
+//! module decodes each entry's stream-attrs blob once (cached by
+//! [`LogStreamId`] across segments, so a stream repeated in a later segment
+//! costs no further decode) and evaluates the selector's stream-level
+//! matchers against the resulting label set, building an exact
+//! `Predicate::StreamIn` naming every matching stream. A segment with at
+//! least one matching stream is then read exactly once, under Scan, with the
+//! projected column set the selector needs; a segment with none is pruned
+//! before any Scan-phase GET. No segment is read twice.
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -326,6 +309,8 @@ pub enum LogSeriesError {
     Fetch(#[from] LogFetchError),
     #[error("corrupt stream_attrs blob: {0}")]
     Decode(#[from] LogSegError),
+    #[error("record's stream {stream_id:?} is not present in its segment's STREAM_DIR")]
+    UnknownStream { stream_id: LogStreamId },
 }
 
 /// Every stream-level matcher (every matcher other than `__name__`,
@@ -354,11 +339,21 @@ fn matches_str(m: &LabelMatcher, subject: &str) -> bool {
     }
 }
 
-fn body_matches(matchers: &[&LabelMatcher], body: &str) -> bool {
+/// Every `__body__` matcher (ADR-1103 decision 3): a matcher-only pseudo-label
+/// evaluated per decoded record with no block-level pushdown. `matchers` must
+/// come from [`body_matchers`], called on the full request matcher list --
+/// `__body__` is filtered out of [`stream_matchers`]'s stream-level list, so
+/// deriving this from that list instead silently drops every `__body__`
+/// matcher and this function then evaluates over an empty slice.
+fn body_matchers(matchers: &[LabelMatcher]) -> Vec<&LabelMatcher> {
     matchers
         .iter()
         .filter(|m| m.name == BODY_MATCHER_LABEL)
-        .all(|m| matches_str(m, body))
+        .collect()
+}
+
+fn body_matches(matchers: &[&LabelMatcher], body: &str) -> bool {
+    matchers.iter().all(|m| matches_str(m, body))
 }
 
 fn severity_content_predicate(matchers: &[LabelMatcher]) -> Option<&LabelMatcher> {
@@ -392,8 +387,7 @@ fn deadline_exceeded(deadline: Option<Instant>) -> Option<LogSeriesError> {
 
 /// Answers one log selector by planning and scanning `segments` in order
 /// (ADR-1103 decision 4). See the module doc for the Plan-phase stream
-/// discovery mechanism and its documented deviation from the ADR's cost
-/// model.
+/// discovery mechanism.
 pub async fn fetch_log_series(
     fetcher: &LogSegmentFetcher,
     tenant_hash: TenantHash,
@@ -402,8 +396,8 @@ pub async fn fetch_log_series(
     accounting: &PhaseAccounting,
 ) -> Result<LogSeriesOutput, LogSeriesError> {
     let stream_ms = stream_matchers(req.matchers);
-    let needs_body =
-        req.metric.needs_body() || stream_ms.iter().any(|m| m.name == BODY_MATCHER_LABEL);
+    let body_ms = body_matchers(req.matchers);
+    let needs_body = req.metric.needs_body() || !body_ms.is_empty();
     let severity_eq = severity_content_predicate(req.matchers);
     let severity_post = severity_postfilters(req.matchers);
 
@@ -444,36 +438,31 @@ pub async fn fetch_log_series(
             continue;
         }
 
-        // (a) Plan phase: discover this segment's distinct streams and build
-        // their label sets, caching by LogStreamId across segments so a
+        // (a) Plan phase: STREAM_DIR-only discovery (ADR-1103 decision 2) --
+        // reads the footer plus the STREAM_DIR section, no BLOCKS byte.
+        // Stream label sets are cached by LogStreamId across segments so a
         // stream repeated in a later segment costs no further decode.
-        let discovery_query = LogQuery::new(req.window.start_ns, req.window.end_ns);
-        let discovered = fetcher
-            .fetch_accounted_with_tenant(seg_ref, tenant_hash, &discovery_query, accounting.plan())
-            .await?;
-        let Some(discovered) = discovered else {
+        let Some(entries) = fetcher
+            .fetch_stream_dir(seg_ref, tenant_hash, accounting.plan())
+            .await?
+        else {
             segments_pruned += 1;
             continue;
         };
 
         let mut matching_streams: Vec<LogStreamId> = Vec::new();
-        let mut seen_streams: std::collections::HashSet<LogStreamId> =
-            std::collections::HashSet::new();
-        for record in &discovered.records {
-            if !seen_streams.insert(record.stream_id) {
-                continue;
-            }
-            let labels = match stream_label_cache.get(&record.stream_id) {
+        for (stream_id, blob) in &entries {
+            let labels = match stream_label_cache.get(stream_id) {
                 Some(labels) => labels.clone(),
                 None => {
-                    let attrs = decode_stream_attrs(&record.stream_attrs)?;
+                    let attrs = decode_stream_attrs(blob)?;
                     let labels = stream_label_set(req.metric, &attrs);
-                    stream_label_cache.insert(record.stream_id, labels.clone());
+                    stream_label_cache.insert(*stream_id, labels.clone());
                     labels
                 }
             };
             if stream_ms.iter().all(|m| m.is_match(&labels)) {
-                matching_streams.push(record.stream_id);
+                matching_streams.push(*stream_id);
             }
         }
 
@@ -517,29 +506,21 @@ pub async fn fetch_log_series(
                 {
                     continue;
                 }
-                if !body_matches(&stream_ms, &record.body) {
+                if !body_matches(&body_ms, &record.body) {
                     continue;
                 }
 
-                // Every record surviving `Predicate::StreamIn` has a
-                // stream_id from `matching_streams`, which this segment's
-                // discovery pass above always caches first; the empty
-                // fallback is unreachable in practice, not a real code path
-                // (never `.expect`/`.unwrap`, per this workspace's rule).
-                let stream_labels = stream_label_cache
-                    .get(&record.stream_id)
-                    .cloned()
-                    .unwrap_or_else(|| {
-                        stream_label_set(
-                            req.metric,
-                            &StreamAttrs {
-                                resource: Vec::new(),
-                                scope_name: String::new(),
-                                scope_version: String::new(),
-                                scope_attrs: Vec::new(),
-                            },
-                        )
-                    });
+                // Every record surviving `Predicate::StreamIn` names a
+                // stream from `matching_streams`, which the Plan-phase
+                // STREAM_DIR discovery above always caches first: a record
+                // whose stream is absent from the same segment's STREAM_DIR
+                // is corrupt input, not a case to paper over with fabricated
+                // labels.
+                let stream_labels = stream_label_cache.get(&record.stream_id).cloned().ok_or(
+                    LogSeriesError::UnknownStream {
+                        stream_id: record.stream_id,
+                    },
+                )?;
                 let labels = series_label_set(&stream_labels, &record.severity_text);
 
                 let key = labels.iter().fold(Vec::new(), |mut acc, l| {
@@ -658,7 +639,12 @@ mod tests {
 
     #[test]
     fn log_metric_of_none_for_regex_name_matcher() {
-        let ms = [LabelMatcher::regex(METRIC_NAME_LABEL, "ravel_log.*").unwrap()];
+        // The regex's own value is the exact literal `ravel_log_lines`, so a
+        // `MatchOp::Eq`-only guard removed from `log_metric_of` would make
+        // this pass under `=~` too; pinning it to the literal (rather than a
+        // pattern like `ravel_log.*` the `MatchOp::Eq` guard trivially never
+        // equals) is what makes the guard's removal fail this test.
+        let ms = [LabelMatcher::regex(METRIC_NAME_LABEL, "ravel_log_lines").unwrap()];
         assert_eq!(log_metric_of(&ms), None);
     }
 

--- a/crates/ravel-query/src/log_series.rs
+++ b/crates/ravel-query/src/log_series.rs
@@ -280,6 +280,15 @@ pub struct LogSeriesRequest<'a> {
     pub erasure: &'a [ErasurePredicate],
     pub max_samples: usize,
     pub max_series: usize,
+    /// Checked once per fetched segment, after
+    /// [`LogSegmentFetcher::scan_accounted_with_tenant`] has already fetched
+    /// and charged it (see the check at the end of the `for seg_ref in
+    /// segments` loop in [`fetch_log_series`]). This bound is therefore a
+    /// per-segment limit in practice, not an exact byte ceiling: a query can
+    /// overshoot it by up to one whole segment's bytes before the next
+    /// iteration's check catches it. An exact bound would need a budget-aware
+    /// change to the read path itself (checking before or during a segment's
+    /// fetch, not only after), which nothing here implements.
     pub max_bytes_scanned: ByteLimit,
     pub deadline: Option<Instant>,
 }
@@ -356,16 +365,32 @@ fn body_matches(matchers: &[&LabelMatcher], body: &str) -> bool {
     matchers.iter().all(|m| matches_str(m, body))
 }
 
-fn severity_content_predicate(matchers: &[LabelMatcher]) -> Option<&LabelMatcher> {
+/// The first `severity_text` equality matcher, kept by index so
+/// [`severity_postfilters`] can skip exactly that one matcher and evaluate
+/// every other `severity_text` matcher -- including a second, third, ...
+/// equality -- as a post-filter. PromQL selector matchers conjoin: a
+/// selector naming `severity_text` twice must satisfy both, not just the
+/// first.
+fn severity_content_predicate(matchers: &[LabelMatcher]) -> Option<(usize, &LabelMatcher)> {
     matchers
         .iter()
-        .find(|m| m.name == SEVERITY_LABEL && matches!(m.op, MatchOp::Eq))
+        .enumerate()
+        .find(|(_, m)| m.name == SEVERITY_LABEL && matches!(m.op, MatchOp::Eq))
 }
 
-fn severity_postfilters(matchers: &[LabelMatcher]) -> Vec<&LabelMatcher> {
+/// Every `severity_text` matcher other than the one
+/// [`severity_content_predicate`] pushed down (identified by index, not by
+/// value or pointer, so a second matcher identical to the pushed-down one is
+/// still evaluated rather than silently treated as already satisfied).
+fn severity_postfilters(
+    matchers: &[LabelMatcher],
+    pushed_index: Option<usize>,
+) -> Vec<&LabelMatcher> {
     matchers
         .iter()
-        .filter(|m| m.name == SEVERITY_LABEL && !matches!(m.op, MatchOp::Eq))
+        .enumerate()
+        .filter(|(i, m)| m.name == SEVERITY_LABEL && Some(*i) != pushed_index)
+        .map(|(_, m)| m)
         .collect()
 }
 
@@ -399,7 +424,7 @@ pub async fn fetch_log_series(
     let body_ms = body_matchers(req.matchers);
     let needs_body = req.metric.needs_body() || !body_ms.is_empty();
     let severity_eq = severity_content_predicate(req.matchers);
-    let severity_post = severity_postfilters(req.matchers);
+    let severity_post = severity_postfilters(req.matchers, severity_eq.map(|(i, _)| i));
 
     // Column selection: ts and stream_ref are implicit; severity_text always
     // (it is either a content predicate or a label/postfilter source); body
@@ -479,7 +504,7 @@ pub async fn fetch_log_series(
         let mut query = LogQuery::new(req.window.start_ns, req.window.end_ns)
             .with_content(Predicate::StreamIn(matching_streams))
             .with_erasure(req.erasure.to_vec());
-        if let Some(m) = severity_eq {
+        if let Some((_, m)) = severity_eq {
             query = query.with_content(Predicate::Equals {
                 field: FieldSel::SeverityText,
                 value: AttrValue::Str(m.value.clone()),
@@ -556,6 +581,13 @@ pub async fn fetch_log_series(
             }
         }
 
+        // Checked only here, once per completed segment: `scan_accounted_with_tenant`
+        // has already fetched and charged this segment's bytes above, and
+        // `next_block` only decodes bytes already resident, so nothing inside
+        // the block loop can react to the budget mid-segment. A query can
+        // therefore overshoot `max_bytes_scanned` by up to one segment's
+        // bytes before this check catches it (see the field doc on
+        // `LogSeriesRequest::max_bytes_scanned`).
         let scanned = accounting.snapshot().pooled().total_s3_bytes();
         if let Some(err) = bytes_scanned_exceeded(scanned, req.max_bytes_scanned) {
             return Err(err);

--- a/crates/ravel-query/src/log_series.rs
+++ b/crates/ravel-query/src/log_series.rs
@@ -1,0 +1,887 @@
+//! PromQL over logs (ADR-1103): answers a log selector -- a vector selector
+//! whose `__name__` matcher equals one of the two reserved metric names --
+//! from the logs signal, with one sample per matching log record.
+//!
+//! Nothing in production calls [`fetch_log_series`] or [`log_metric_of`]
+//! yet: task #1108 wires them into `QueryEngine::prefetch` and
+//! `resolve_series_inner`. This module is self-contained and has no
+//! dependency on `engine.rs`.
+//!
+//! # Plan-phase stream discovery: a known deviation from the ADR's cost model
+//!
+//! ADR-1103 decision 2 says stream-label-set discovery "costs one STREAM_DIR
+//! decode per candidate object, the same cost
+//! [`LogSegmentFetcher::plan_segment`] already pays" -- i.e. a directory-only
+//! read with no block data moved. That cost model assumes a caller can reach
+//! `LogSegmentFetcher::decode_stream_dir`, but that method carries no
+//! visibility modifier, so it is private to `log_fetcher.rs`'s own module and
+//! unreachable from this one even though both live in `ravel-query`,
+//! Rust's module-privacy default and not a byproduct of module nesting.
+//! `plan_segment` itself does not expose the decoded [`StreamDir`] entries
+//! either, only a block-survivor count. `fetch_footer` reads exactly the
+//! footer and discards the resident probe bytes STREAM_DIR would need to be
+//! sliced from. This task's scope is five named files and does not include
+//! `log_fetcher.rs`, so this module cannot add a public accessor for that
+//! read to close the gap.
+//!
+//! Given that, this module discovers per-segment stream identity with
+//! [`LogSegmentFetcher::fetch_accounted_with_tenant`] under the caller's Plan
+//! accounting handle: a full, decoded read of the segment rather than a
+//! directory-only one. This is correct -- every decoded record always
+//! carries its own `stream_id` and `stream_attrs`, so the discovered label
+//! sets and the `Predicate::StreamIn` built from them are exact, not an
+//! approximation -- but it costs strictly more than the ADR's stated model: a
+//! segment that survives the stream-match prune is read twice, once here and
+//! once by the Scan-phase projected scan. Flagging this as the report
+//! requires rather than silently absorbing the extra cost: a follow-up that
+//! marks `decode_stream_dir` `pub(crate)`, or adds a dedicated
+//! `fetch_stream_dir` mirroring `fetch_skip_index`, would let this module's
+//! Plan phase match the ADR's cost model exactly.
+//!
+//! [`StreamDir`]: ravel_logseg::stream_dir::StreamDir
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::time::Instant;
+
+use ravel_catalog::SegmentRef;
+use ravel_logseg::columns::ColumnSelection;
+use ravel_logseg::error::LogSegError;
+use ravel_logseg::record::{
+    FieldSel, Predicate, StreamAttrs, attr_value_to_string, decode_stream_attrs,
+};
+use ravel_promql::{LabelMatcher, MatchOp, SeriesData};
+use ravel_types::logstream::{AttrValue, LogStreamId};
+use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL, Sample, TenantHash, TimeRange};
+
+use crate::erasure::ErasurePredicate;
+use crate::phase_accounting::PhaseAccounting;
+use crate::{ByteLimit, LogFetchError, LogQuery, LogSegmentFetcher};
+
+/// Reserved metric name for the log-lines series (ADR-1103 decision 1): one
+/// sample per matching log record, value `1.0`.
+pub const LOG_LINES_METRIC: &str = "ravel_log_lines";
+/// Reserved metric name for the log-bytes series (ADR-1103 decision 1): one
+/// sample per matching log record, value the record body's length in bytes.
+pub const LOG_BYTES_METRIC: &str = "ravel_log_bytes";
+/// Matcher-only pseudo-label for the record body (ADR-1103 decision 3).
+/// Never appears in a returned label set and is never part of series
+/// identity.
+pub const BODY_MATCHER_LABEL: &str = "__body__";
+/// The one per-record field that becomes a label (ADR-1103 decision 2 step 5).
+pub const SEVERITY_LABEL: &str = "severity_text";
+
+/// Which reserved log metric a selector named, and what its samples mean.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogMetric {
+    /// `ravel_log_lines`: one sample per matching record, value `1.0`.
+    Lines,
+    /// `ravel_log_bytes`: one sample per matching record, value the record
+    /// body's length in bytes.
+    Bytes,
+}
+
+impl LogMetric {
+    /// This metric's reserved name.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            LogMetric::Lines => LOG_LINES_METRIC,
+            LogMetric::Bytes => LOG_BYTES_METRIC,
+        }
+    }
+
+    /// Whether this metric's samples need the record body decoded. `Bytes`
+    /// needs the body's length; `Lines` does not, unless a `__body__`
+    /// matcher separately requires it (checked by the caller).
+    #[must_use]
+    pub fn needs_body(self) -> bool {
+        matches!(self, LogMetric::Bytes)
+    }
+}
+
+/// ADR-1103 decision 3: `Some` iff `matchers` holds a `__name__` matcher with
+/// [`MatchOp::Eq`] whose value is a reserved log metric name. A regex or `!=`
+/// on `__name__`, or no `__name__` matcher at all, is `None`: `{job="api"}`
+/// keeps its Prometheus meaning over metrics, and
+/// `{__name__=~"ravel_log.*"}` matches metrics only.
+#[must_use]
+pub fn log_metric_of(matchers: &[LabelMatcher]) -> Option<LogMetric> {
+    let name_matcher = matchers.iter().find(|m| m.name == METRIC_NAME_LABEL)?;
+    match &name_matcher.op {
+        MatchOp::Eq if name_matcher.value == LOG_LINES_METRIC => Some(LogMetric::Lines),
+        MatchOp::Eq if name_matcher.value == LOG_BYTES_METRIC => Some(LogMetric::Bytes),
+        _ => None,
+    }
+}
+
+fn is_label_name_start(c: char) -> bool {
+    c.is_ascii_alphabetic() || c == '_'
+}
+
+fn is_label_name_continue(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+/// The metrics label-name rule (ADR-1103 decision 2 step 4, mirroring
+/// `ravel_otlp::normalize::sanitize_label_name`): the first character must
+/// match `[A-Za-z_]` and every later character `[A-Za-z0-9_]`; a disallowed
+/// character is rewritten to `_` in place. Borrows `name` unchanged when it
+/// is already clean.
+#[must_use]
+pub fn sanitize_label_name(name: &str) -> Cow<'_, str> {
+    let mut chars = name.chars();
+    let clean = match chars.next() {
+        None => true,
+        Some(c) => is_label_name_start(c) && chars.as_str().chars().all(is_label_name_continue),
+    };
+    if clean {
+        return Cow::Borrowed(name);
+    }
+    let mut out = String::with_capacity(name.len());
+    for (i, c) in name.chars().enumerate() {
+        let ok = if i == 0 {
+            is_label_name_start(c)
+        } else {
+            is_label_name_continue(c)
+        };
+        out.push(if ok { c } else { '_' });
+    }
+    Cow::Owned(out)
+}
+
+/// Pushes one first-writer-wins label (ADR-1103 decision 2): a candidate with
+/// an empty value is dropped (treated as absent, matching
+/// `ravel_otlp::normalize::push_checked`'s convention), and a name already
+/// written by an earlier step -- or one that sanitizes to `severity_text` or
+/// begins with `__` -- is dropped rather than overwriting.
+fn push_first_writer_wins(
+    labels: &mut Vec<Label>,
+    seen: &mut std::collections::HashSet<String>,
+    name: String,
+    value: String,
+) {
+    if value.is_empty() || name.starts_with("__") || name == SEVERITY_LABEL {
+        return;
+    }
+    if seen.insert(name.clone()) {
+        labels.push(Label { name, value });
+    }
+}
+
+/// ADR-1103 decision 2 steps 1-4: the label set built from a stream's
+/// identity alone, with no `severity_text` (that is decision 2 step 5,
+/// [`series_label_set`], since severity is per record, not per stream).
+#[must_use]
+pub fn stream_label_set(metric: LogMetric, stream: &StreamAttrs) -> LabelSet {
+    let mut seen = std::collections::HashSet::new();
+    let mut labels = Vec::new();
+
+    // Step 1: __name__. Pushed directly, not through
+    // `push_first_writer_wins`: that helper drops every `__`-prefixed name
+    // to stop a resource attribute from spoofing a reserved label, but
+    // `__name__` is the one dunder label this function is required to set.
+    seen.insert(METRIC_NAME_LABEL.to_string());
+    labels.push(Label {
+        name: METRIC_NAME_LABEL.to_string(),
+        value: metric.name().to_string(),
+    });
+
+    // Step 2: job/instance, exactly as the metrics ingest path derives them.
+    // The three source attributes never also appear under their own names.
+    let mut namespace = None;
+    let mut service_name = None;
+    let mut instance_id = None;
+    for (k, v) in &stream.resource {
+        match k.as_str() {
+            "service.namespace" => namespace = Some(attr_value_to_string(v)),
+            "service.name" => service_name = Some(attr_value_to_string(v)),
+            "service.instance.id" => instance_id = Some(attr_value_to_string(v)),
+            _ => {}
+        }
+    }
+    if let Some(name) = service_name {
+        let job = match namespace.as_deref() {
+            Some(ns) if !ns.is_empty() => format!("{ns}/{name}"),
+            _ => name,
+        };
+        push_first_writer_wins(&mut labels, &mut seen, "job".to_string(), job);
+    }
+    if let Some(id) = instance_id {
+        push_first_writer_wins(&mut labels, &mut seen, "instance".to_string(), id);
+    }
+
+    // Step 3: OpenTelemetry-to-Prometheus scope compatibility names.
+    if !stream.scope_name.is_empty() {
+        push_first_writer_wins(
+            &mut labels,
+            &mut seen,
+            "otel_scope_name".to_string(),
+            stream.scope_name.clone(),
+        );
+    }
+    if !stream.scope_version.is_empty() {
+        push_first_writer_wins(
+            &mut labels,
+            &mut seen,
+            "otel_scope_version".to_string(),
+            stream.scope_version.clone(),
+        );
+    }
+    let mut scope_attrs = stream.scope_attrs.clone();
+    scope_attrs.sort_by(|a, b| a.0.cmp(&b.0));
+    for (k, v) in &scope_attrs {
+        if matches!(
+            v,
+            AttrValue::Bytes(_) | AttrValue::List(_) | AttrValue::Map(_)
+        ) {
+            continue;
+        }
+        let name = format!("otel_scope_{}", sanitize_label_name(k));
+        push_first_writer_wins(&mut labels, &mut seen, name, attr_value_to_string(v));
+    }
+
+    // Step 4: every remaining resource attribute, sanitized, no allowlist.
+    let mut resource = stream.resource.clone();
+    resource.sort_by(|a, b| a.0.cmp(&b.0));
+    for (k, v) in &resource {
+        if matches!(
+            k.as_str(),
+            "service.namespace" | "service.name" | "service.instance.id"
+        ) {
+            continue;
+        }
+        if matches!(
+            v,
+            AttrValue::Bytes(_) | AttrValue::List(_) | AttrValue::Map(_)
+        ) {
+            continue;
+        }
+        let name = sanitize_label_name(k).into_owned();
+        push_first_writer_wins(&mut labels, &mut seen, name, attr_value_to_string(v));
+    }
+
+    // `push_first_writer_wins` already de-duplicates by name, so `new` never
+    // sees a repeat; `unwrap_or_default` (never `.expect`/`.unwrap`, per this
+    // workspace's no-unwrap-in-production-paths rule) matches the fallback
+    // `ravel_promql` itself uses at every other infallible `LabelSet::new`
+    // call site (aggregate.rs, eval.rs, binop.rs).
+    LabelSet::new(labels).unwrap_or_default()
+}
+
+/// ADR-1103 decision 2 step 5: `stream_labels` plus `severity_text` when the
+/// record's severity text is non-empty. Empty severity means no label, not
+/// an empty-valued one.
+#[must_use]
+pub fn series_label_set(stream_labels: &LabelSet, severity_text: &str) -> LabelSet {
+    if severity_text.is_empty() {
+        return stream_labels.clone();
+    }
+    let mut labels: Vec<Label> = stream_labels.iter().cloned().collect();
+    labels.push(Label {
+        name: SEVERITY_LABEL.to_string(),
+        value: severity_text.to_string(),
+    });
+    LabelSet::new(labels).unwrap_or_default()
+}
+
+/// One log selector's request, resolved down to the inputs
+/// [`fetch_log_series`] needs. `matchers` includes the `__name__` matcher;
+/// [`fetch_log_series`] ignores it (the caller already used [`log_metric_of`]
+/// to pick `metric`).
+pub struct LogSeriesRequest<'a> {
+    pub metric: LogMetric,
+    pub matchers: &'a [LabelMatcher],
+    /// Closed `[start_ns, end_ns]` event-time window.
+    pub window: TimeRange,
+    pub erasure: &'a [ErasurePredicate],
+    pub max_samples: usize,
+    pub max_series: usize,
+    pub max_bytes_scanned: ByteLimit,
+    pub deadline: Option<Instant>,
+}
+
+/// The result of answering one log selector.
+#[derive(Debug)]
+pub struct LogSeriesOutput {
+    pub series: Vec<SeriesData>,
+    pub records_scanned: u64,
+    pub segments_fetched: usize,
+    pub segments_pruned: usize,
+}
+
+/// Errors [`fetch_log_series`] can return. Every arm is a typed budget or
+/// fetch failure, never a panic on a malformed input.
+#[derive(Debug, thiserror::Error)]
+pub enum LogSeriesError {
+    #[error("query matched {count} samples, exceeding the limit of {max}")]
+    SamplesExceeded { count: usize, max: usize },
+    #[error("query matched {count} series, exceeding the limit of {max}")]
+    SeriesExceeded { count: usize, max: usize },
+    #[error("query scanned {scanned} bytes, exceeding the budget of {max}")]
+    BytesScannedExceeded { scanned: u64, max: u64 },
+    #[error("query exceeded its deadline")]
+    DeadlineExceeded,
+    #[error(transparent)]
+    Fetch(#[from] LogFetchError),
+    #[error("corrupt stream_attrs blob: {0}")]
+    Decode(#[from] LogSegError),
+}
+
+/// Every stream-level matcher (every matcher other than `__name__`,
+/// `severity_text`, and `__body__`) evaluated against one stream's label
+/// set with [`LabelMatcher::is_match`], PromQL's fully anchored regex
+/// semantics.
+fn stream_matchers(matchers: &[LabelMatcher]) -> Vec<&LabelMatcher> {
+    matchers
+        .iter()
+        .filter(|m| {
+            m.name != METRIC_NAME_LABEL && m.name != SEVERITY_LABEL && m.name != BODY_MATCHER_LABEL
+        })
+        .collect()
+}
+
+/// [`LabelMatcher::is_match`] evaluates a matcher against a [`LabelSet`];
+/// `__body__` and the severity post-filters instead evaluate one matcher's
+/// operator directly against a raw per-record string (the body, or
+/// `severity_text`), so this mirrors its match arms without a `LabelSet`.
+fn matches_str(m: &LabelMatcher, subject: &str) -> bool {
+    match &m.op {
+        MatchOp::Eq => m.value == subject,
+        MatchOp::Ne => m.value != subject,
+        MatchOp::Re(re) => re.is_match(subject),
+        MatchOp::Nre(re) => !re.is_match(subject),
+    }
+}
+
+fn body_matches(matchers: &[&LabelMatcher], body: &str) -> bool {
+    matchers
+        .iter()
+        .filter(|m| m.name == BODY_MATCHER_LABEL)
+        .all(|m| matches_str(m, body))
+}
+
+fn severity_content_predicate(matchers: &[LabelMatcher]) -> Option<&LabelMatcher> {
+    matchers
+        .iter()
+        .find(|m| m.name == SEVERITY_LABEL && matches!(m.op, MatchOp::Eq))
+}
+
+fn severity_postfilters(matchers: &[LabelMatcher]) -> Vec<&LabelMatcher> {
+    matchers
+        .iter()
+        .filter(|m| m.name == SEVERITY_LABEL && !matches!(m.op, MatchOp::Eq))
+        .collect()
+}
+
+fn bytes_scanned_exceeded(scanned: u64, max: ByteLimit) -> Option<LogSeriesError> {
+    match max {
+        ByteLimit::Bounded(max) if scanned > max => {
+            Some(LogSeriesError::BytesScannedExceeded { scanned, max })
+        }
+        _ => None,
+    }
+}
+
+fn deadline_exceeded(deadline: Option<Instant>) -> Option<LogSeriesError> {
+    match deadline {
+        Some(d) if Instant::now() >= d => Some(LogSeriesError::DeadlineExceeded),
+        _ => None,
+    }
+}
+
+/// Answers one log selector by planning and scanning `segments` in order
+/// (ADR-1103 decision 4). See the module doc for the Plan-phase stream
+/// discovery mechanism and its documented deviation from the ADR's cost
+/// model.
+pub async fn fetch_log_series(
+    fetcher: &LogSegmentFetcher,
+    tenant_hash: TenantHash,
+    segments: &[SegmentRef],
+    req: &LogSeriesRequest<'_>,
+    accounting: &PhaseAccounting,
+) -> Result<LogSeriesOutput, LogSeriesError> {
+    let stream_ms = stream_matchers(req.matchers);
+    let needs_body =
+        req.metric.needs_body() || stream_ms.iter().any(|m| m.name == BODY_MATCHER_LABEL);
+    let severity_eq = severity_content_predicate(req.matchers);
+    let severity_post = severity_postfilters(req.matchers);
+
+    // Column selection: ts and stream_ref are implicit; severity_text always
+    // (it is either a content predicate or a label/postfilter source); body
+    // iff the metric or a __body__ matcher needs it; the record-attribute
+    // columns any pending erasure predicate names (crates/ravel-sql/src/
+    // logs_scan.rs:395-480's pattern -- resource/scope attrs cost nothing
+    // extra, they live in STREAM_DIR, so only record-level erasure keys widen
+    // the selection).
+    let mut columns = ColumnSelection::fixed_only().with_severity_text();
+    if needs_body {
+        columns = columns.with_body();
+    }
+    for p in req.erasure {
+        for (key, _) in p.matchers() {
+            columns = columns.with_attr(key.clone());
+        }
+    }
+
+    let mut stream_label_cache: HashMap<LogStreamId, LabelSet> = HashMap::new();
+    let mut series: HashMap<Vec<u8>, (LabelSet, Vec<Sample>)> = HashMap::new();
+    let mut records_scanned: u64 = 0u64;
+    let mut segments_fetched = 0usize;
+    let mut segments_pruned = 0usize;
+
+    for seg_ref in segments {
+        if let Some(err) = deadline_exceeded(req.deadline) {
+            return Err(err);
+        }
+
+        let seg_window = TimeRange {
+            start_ns: seg_ref.min_event_ts_ns,
+            end_ns: seg_ref.max_event_ts_ns,
+        };
+        if !req.window.overlaps(&seg_window) {
+            segments_pruned += 1;
+            continue;
+        }
+
+        // (a) Plan phase: discover this segment's distinct streams and build
+        // their label sets, caching by LogStreamId across segments so a
+        // stream repeated in a later segment costs no further decode.
+        let discovery_query = LogQuery::new(req.window.start_ns, req.window.end_ns);
+        let discovered = fetcher
+            .fetch_accounted_with_tenant(seg_ref, tenant_hash, &discovery_query, accounting.plan())
+            .await?;
+        let Some(discovered) = discovered else {
+            segments_pruned += 1;
+            continue;
+        };
+
+        let mut matching_streams: Vec<LogStreamId> = Vec::new();
+        let mut seen_streams: std::collections::HashSet<LogStreamId> =
+            std::collections::HashSet::new();
+        for record in &discovered.records {
+            if !seen_streams.insert(record.stream_id) {
+                continue;
+            }
+            let labels = match stream_label_cache.get(&record.stream_id) {
+                Some(labels) => labels.clone(),
+                None => {
+                    let attrs = decode_stream_attrs(&record.stream_attrs)?;
+                    let labels = stream_label_set(req.metric, &attrs);
+                    stream_label_cache.insert(record.stream_id, labels.clone());
+                    labels
+                }
+            };
+            if stream_ms.iter().all(|m| m.is_match(&labels)) {
+                matching_streams.push(record.stream_id);
+            }
+        }
+
+        // (b) If no stream matches, this segment is pruned: skip the scan
+        // entirely.
+        if matching_streams.is_empty() {
+            segments_pruned += 1;
+            continue;
+        }
+
+        // (c) Scan phase: exact content predicates only (StreamIn, and
+        // severity_text when the matcher is an equality); everything else is
+        // a per-record filter after decode.
+        let mut query = LogQuery::new(req.window.start_ns, req.window.end_ns)
+            .with_content(Predicate::StreamIn(matching_streams))
+            .with_erasure(req.erasure.to_vec());
+        if let Some(m) = severity_eq {
+            query = query.with_content(Predicate::Equals {
+                field: FieldSel::SeverityText,
+                value: AttrValue::Str(m.value.clone()),
+            });
+        }
+
+        let Some(mut scan) = fetcher
+            .scan_accounted_with_tenant(seg_ref, tenant_hash, &query, &columns, accounting.scan())
+            .await?
+        else {
+            segments_pruned += 1;
+            continue;
+        };
+        segments_fetched += 1;
+
+        while let Some(records) = scan.next_block()? {
+            if let Some(err) = deadline_exceeded(req.deadline) {
+                return Err(err);
+            }
+            for record in &records {
+                if !severity_post
+                    .iter()
+                    .all(|m| matches_str(m, &record.severity_text))
+                {
+                    continue;
+                }
+                if !body_matches(&stream_ms, &record.body) {
+                    continue;
+                }
+
+                // Every record surviving `Predicate::StreamIn` has a
+                // stream_id from `matching_streams`, which this segment's
+                // discovery pass above always caches first; the empty
+                // fallback is unreachable in practice, not a real code path
+                // (never `.expect`/`.unwrap`, per this workspace's rule).
+                let stream_labels = stream_label_cache
+                    .get(&record.stream_id)
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        stream_label_set(
+                            req.metric,
+                            &StreamAttrs {
+                                resource: Vec::new(),
+                                scope_name: String::new(),
+                                scope_version: String::new(),
+                                scope_attrs: Vec::new(),
+                            },
+                        )
+                    });
+                let labels = series_label_set(&stream_labels, &record.severity_text);
+
+                let key = labels.iter().fold(Vec::new(), |mut acc, l| {
+                    acc.extend_from_slice(l.name.as_bytes());
+                    acc.push(0);
+                    acc.extend_from_slice(l.value.as_bytes());
+                    acc.push(0);
+                    acc
+                });
+                if !series.contains_key(&key) && series.len() >= req.max_series {
+                    return Err(LogSeriesError::SeriesExceeded {
+                        count: series.len() + 1,
+                        max: req.max_series,
+                    });
+                }
+                let value = match req.metric {
+                    LogMetric::Lines => 1.0,
+                    LogMetric::Bytes => record.body.len() as f64,
+                };
+                let entry = series.entry(key).or_insert_with(|| (labels, Vec::new()));
+                entry.1.push(Sample {
+                    ts_ns: record.ts_ns,
+                    value,
+                });
+
+                records_scanned += 1;
+                if records_scanned as usize > req.max_samples {
+                    return Err(LogSeriesError::SamplesExceeded {
+                        count: records_scanned as usize,
+                        max: req.max_samples,
+                    });
+                }
+            }
+        }
+
+        let scanned = accounting.snapshot().pooled().total_s3_bytes();
+        if let Some(err) = bytes_scanned_exceeded(scanned, req.max_bytes_scanned) {
+            return Err(err);
+        }
+    }
+
+    let mut out: Vec<(Vec<u8>, LabelSet, Vec<Sample>)> = series
+        .into_iter()
+        .map(|(key, (labels, mut samples))| {
+            samples.sort_by_key(|s| s.ts_ns);
+            (key, labels, samples)
+        })
+        .collect();
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+
+    Ok(LogSeriesOutput {
+        series: out
+            .into_iter()
+            .map(|(_, labels, samples)| SeriesData { labels, samples })
+            .collect(),
+        records_scanned,
+        segments_fetched,
+        segments_pruned,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn attrs(
+        resource: &[(&str, AttrValue)],
+        scope_name: &str,
+        scope_version: &str,
+        scope_attrs: &[(&str, AttrValue)],
+    ) -> StreamAttrs {
+        StreamAttrs {
+            resource: resource
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+            scope_name: scope_name.to_string(),
+            scope_version: scope_version.to_string(),
+            scope_attrs: scope_attrs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+        }
+    }
+
+    fn s(v: &str) -> AttrValue {
+        AttrValue::Str(v.to_string())
+    }
+
+    // --- log_metric_of: routing table ---
+
+    #[test]
+    fn log_metric_of_routes_reserved_names() {
+        let lines = [LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC)];
+        assert_eq!(log_metric_of(&lines), Some(LogMetric::Lines));
+
+        let bytes = [LabelMatcher::equal(METRIC_NAME_LABEL, LOG_BYTES_METRIC)];
+        assert_eq!(log_metric_of(&bytes), Some(LogMetric::Bytes));
+    }
+
+    #[test]
+    fn log_metric_of_none_without_name_matcher() {
+        let ms = [LabelMatcher::equal("job", "api")];
+        assert_eq!(log_metric_of(&ms), None);
+    }
+
+    #[test]
+    fn log_metric_of_none_for_other_metric_name() {
+        let ms = [LabelMatcher::equal(
+            METRIC_NAME_LABEL,
+            "http_requests_total",
+        )];
+        assert_eq!(log_metric_of(&ms), None);
+    }
+
+    #[test]
+    fn log_metric_of_none_for_regex_name_matcher() {
+        let ms = [LabelMatcher::regex(METRIC_NAME_LABEL, "ravel_log.*").unwrap()];
+        assert_eq!(log_metric_of(&ms), None);
+    }
+
+    #[test]
+    fn log_metric_of_none_for_negated_name_matcher() {
+        let ms = [LabelMatcher::not_equal(METRIC_NAME_LABEL, LOG_LINES_METRIC)];
+        assert_eq!(log_metric_of(&ms), None);
+    }
+
+    // --- sanitize_label_name ---
+
+    #[test]
+    fn sanitize_label_name_borrows_when_already_clean() {
+        assert_eq!(
+            sanitize_label_name("service_name"),
+            Cow::Borrowed("service_name")
+        );
+        assert_eq!(sanitize_label_name("_leading"), Cow::Borrowed("_leading"));
+    }
+
+    #[test]
+    fn sanitize_label_name_rewrites_disallowed_chars() {
+        assert_eq!(
+            sanitize_label_name("service.name"),
+            Cow::<str>::Owned("service_name".to_string())
+        );
+        assert_eq!(
+            sanitize_label_name("k8s.pod-name"),
+            Cow::<str>::Owned("k8s_pod_name".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_label_name_rewrites_leading_digit() {
+        assert_eq!(
+            sanitize_label_name("2fast"),
+            Cow::<str>::Owned("_fast".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_label_name_empty_is_clean() {
+        assert_eq!(sanitize_label_name(""), Cow::Borrowed(""));
+    }
+
+    // --- stream_label_set: label mapping ---
+
+    #[test]
+    fn stream_label_set_derives_job_from_namespace_and_name() {
+        let a = attrs(
+            &[
+                ("service.namespace", s("payments")),
+                ("service.name", s("api")),
+                ("service.instance.id", s("i-1")),
+            ],
+            "",
+            "",
+            &[],
+        );
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get(METRIC_NAME_LABEL), Some(LOG_LINES_METRIC));
+        assert_eq!(labels.get("job"), Some("payments/api"));
+        assert_eq!(labels.get("instance"), Some("i-1"));
+        // Source attrs never also appear under their own sanitized names.
+        assert_eq!(labels.get("service_namespace"), None);
+        assert_eq!(labels.get("service_name"), None);
+        assert_eq!(labels.get("service_instance_id"), None);
+    }
+
+    #[test]
+    fn stream_label_set_job_without_namespace_is_bare_service_name() {
+        let a = attrs(&[("service.name", s("api"))], "", "", &[]);
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get("job"), Some("api"));
+    }
+
+    #[test]
+    fn stream_label_set_no_job_without_service_name() {
+        let a = attrs(&[("service.namespace", s("payments"))], "", "", &[]);
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get("job"), None);
+    }
+
+    #[test]
+    fn stream_label_set_otel_scope_names() {
+        let a = attrs(&[], "libfoo", "1.2.3", &[("lib.tag", s("x"))]);
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get("otel_scope_name"), Some("libfoo"));
+        assert_eq!(labels.get("otel_scope_version"), Some("1.2.3"));
+        assert_eq!(labels.get("otel_scope_lib_tag"), Some("x"));
+    }
+
+    #[test]
+    fn stream_label_set_empty_scope_name_and_version_produce_no_label() {
+        let a = attrs(&[], "", "", &[]);
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get("otel_scope_name"), None);
+        assert_eq!(labels.get("otel_scope_version"), None);
+    }
+
+    #[test]
+    fn stream_label_set_remaining_resource_attrs_no_allowlist() {
+        let a = attrs(
+            &[("host.name", s("h1")), ("region", s("us-east"))],
+            "",
+            "",
+            &[],
+        );
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get("host_name"), Some("h1"));
+        assert_eq!(labels.get("region"), Some("us-east"));
+    }
+
+    #[test]
+    fn stream_label_set_dedups_by_sanitized_name_first_writer_wins() {
+        // "host.name" and "host_name" both sanitize to "host_name"; whichever
+        // sorts first in canonical byte order wins.
+        let a = attrs(
+            &[("host.name", s("dotted")), ("host_name", s("under"))],
+            "",
+            "",
+            &[],
+        );
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get("host_name"), Some("dotted"));
+    }
+
+    #[test]
+    fn stream_label_set_drops_reserved_and_dunder_names() {
+        let a = attrs(
+            &[("__reserved__", s("x")), ("severity_text", s("y"))],
+            "",
+            "",
+            &[],
+        );
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get("__reserved__"), None);
+        assert_eq!(labels.get("severity_text"), None);
+    }
+
+    #[test]
+    fn stream_label_set_drops_empty_values() {
+        let a = attrs(&[("empty", s(""))], "", "", &[]);
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get("empty"), None);
+    }
+
+    #[test]
+    fn stream_label_set_excludes_bytes_list_map_values() {
+        let a = attrs(
+            &[
+                ("blob", AttrValue::Bytes(vec![1, 2, 3])),
+                ("tags", AttrValue::List(vec![s("a")])),
+                ("nested", AttrValue::Map(vec![("k".into(), s("v"))])),
+            ],
+            "",
+            "",
+            &[],
+        );
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get("blob"), None);
+        assert_eq!(labels.get("tags"), None);
+        assert_eq!(labels.get("nested"), None);
+    }
+
+    #[test]
+    fn stream_label_set_stringifies_non_string_values() {
+        let a = attrs(
+            &[
+                ("port", AttrValue::I64(8080)),
+                ("ok", AttrValue::Bool(true)),
+            ],
+            "",
+            "",
+            &[],
+        );
+        let labels = stream_label_set(LogMetric::Lines, &a);
+        assert_eq!(labels.get("port"), Some("8080"));
+        assert_eq!(labels.get("ok"), Some("true"));
+    }
+
+    #[test]
+    fn stream_label_set_bytes_metric_name() {
+        let a = attrs(&[], "", "", &[]);
+        let labels = stream_label_set(LogMetric::Bytes, &a);
+        assert_eq!(labels.get(METRIC_NAME_LABEL), Some(LOG_BYTES_METRIC));
+    }
+
+    // --- series_label_set ---
+
+    #[test]
+    fn series_label_set_adds_severity_when_present() {
+        let stream = stream_label_set(LogMetric::Lines, &attrs(&[], "", "", &[]));
+        let series = series_label_set(&stream, "ERROR");
+        assert_eq!(series.get(SEVERITY_LABEL), Some("ERROR"));
+    }
+
+    #[test]
+    fn series_label_set_empty_severity_means_no_label() {
+        let stream = stream_label_set(LogMetric::Lines, &attrs(&[], "", "", &[]));
+        let series = series_label_set(&stream, "");
+        assert_eq!(series.get(SEVERITY_LABEL), None);
+        assert_eq!(series, stream);
+    }
+
+    // --- matches_str ---
+
+    #[test]
+    fn matches_str_covers_all_ops() {
+        let eq = LabelMatcher::equal(BODY_MATCHER_LABEL, "boom");
+        assert!(matches_str(&eq, "boom"));
+        assert!(!matches_str(&eq, "other"));
+
+        let ne = LabelMatcher::not_equal(BODY_MATCHER_LABEL, "boom");
+        assert!(!matches_str(&ne, "boom"));
+        assert!(matches_str(&ne, "other"));
+
+        let re = LabelMatcher::regex(BODY_MATCHER_LABEL, "^boo.*").unwrap();
+        assert!(matches_str(&re, "boom"));
+        assert!(!matches_str(&re, "other"));
+
+        let nre = LabelMatcher::not_regex(BODY_MATCHER_LABEL, "^boo.*").unwrap();
+        assert!(!matches_str(&nre, "boom"));
+        assert!(matches_str(&nre, "other"));
+    }
+}

--- a/crates/ravel-query/tests/log_series.rs
+++ b/crates/ravel-query/tests/log_series.rs
@@ -1104,6 +1104,91 @@ async fn log_series_window_covering_only_object_a_fetches_one_segment() {
     assert_eq!(out.segments_fetched, 1, "only object A overlaps [0, 200]");
 }
 
+/// Finding 3 (CodeRabbit review on PR #1158, #1106, log_series.rs:370): two
+/// `severity_text` equality matchers must conjoin like every other pair of
+/// matchers in a PromQL selector -- `severity_text="ERROR"` AND
+/// `severity_text="INFO"` can never both hold for one record, so the
+/// selector must return zero series, not every ERROR record. A second case
+/// with two IDENTICAL equalities must behave exactly like a single one.
+///
+/// Object A ([`two_objects`]) has exactly one ERROR record (ts=105) among 10
+/// INFO records on stream `job="pay/api"`. The scan pushes down the first
+/// `severity_text` equality (`"ERROR"`) as a content predicate, so only that
+/// one record reaches the per-record loop; `severity_post` then evaluates
+/// every other `severity_text` matcher against it.
+///
+/// Demonstrated failing against the pre-fix code: before the fix,
+/// `severity_postfilters` excluded every `Eq`-op `severity_text` matcher
+/// unconditionally (`m.op != MatchOp::Eq`, no index tracking), so the second
+/// `severity_text="INFO"` matcher was dropped along with the pushed-down
+/// first one instead of surviving as a post-filter. With no post-filter left
+/// to reject it, the single scanned ERROR record was accepted unconditionally
+/// and this test's first case returned 1 series / 1 sample instead of the
+/// empty result PromQL conjunction requires. The fix (log_series.rs:385,
+/// `severity_postfilters`) keeps every `severity_text` matcher except the one
+/// at `pushed_index`, so the second `severity_text="INFO"` matcher survives
+/// as a post-filter and rejects the ERROR record: `"ERROR" != "INFO"`.
+#[tokio::test]
+async fn log_series_conflicting_severity_equalities_return_no_samples() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, _ref_b) = two_objects(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+
+    let window = TimeRange {
+        start_ns: 90,
+        end_ns: 120,
+    };
+
+    // Conflicting: ERROR and INFO can never both hold for one record.
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "pay/api"),
+        LabelMatcher::equal(SEVERITY_LABEL, "ERROR"),
+        LabelMatcher::equal(SEVERITY_LABEL, "INFO"),
+    ];
+    let req = lines_request(&matchers, window);
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(
+        &fetcher,
+        TENANT,
+        std::slice::from_ref(&ref_a),
+        &req,
+        &accounting,
+    )
+    .await
+    .expect("fetch_log_series");
+    assert_eq!(
+        out.series.len(),
+        0,
+        "severity_text=\"ERROR\" AND severity_text=\"INFO\" matches no record"
+    );
+    assert_eq!(
+        out.records_scanned, 0,
+        "the sole scanned ERROR record is rejected by the INFO post-filter"
+    );
+
+    // Identical: repeating the same equality changes nothing.
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "pay/api"),
+        LabelMatcher::equal(SEVERITY_LABEL, "ERROR"),
+        LabelMatcher::equal(SEVERITY_LABEL, "ERROR"),
+    ];
+    let req = lines_request(&matchers, window);
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(&fetcher, TENANT, &[ref_a], &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+    assert_eq!(
+        out.series.len(),
+        1,
+        "two identical severity_text=\"ERROR\" equalities behave like one"
+    );
+    assert_eq!(out.series[0].samples.len(), 1);
+    assert_eq!(out.series[0].samples[0].ts_ns, 105);
+    assert_eq!(out.records_scanned, 1);
+}
+
 /// Finding 1 (F1), reproducing the review's exact bodies: `ok`, `ok`, `boom`,
 /// `request timeout`. `__body__="ok"` finds the two exact matches,
 /// `=~".*timeout.*"` finds the "request timeout" record, `!~".*timeout.*"`

--- a/crates/ravel-query/tests/log_series.rs
+++ b/crates/ravel-query/tests/log_series.rs
@@ -25,9 +25,10 @@ use ravel_object_store::{
     PageToken, PutOptions, PutOutcome, StoreError,
 };
 use ravel_promql::LabelMatcher;
+use ravel_query::erasure::ErasurePredicate;
 use ravel_query::log_series::{
-    LOG_BYTES_METRIC, LOG_LINES_METRIC, LogMetric, LogSeriesError, LogSeriesRequest,
-    fetch_log_series,
+    BODY_MATCHER_LABEL, LOG_BYTES_METRIC, LOG_LINES_METRIC, LogMetric, LogSeriesError,
+    LogSeriesRequest, SEVERITY_LABEL, fetch_log_series,
 };
 use ravel_query::{ByteLimit, LogSegmentFetcher, PhaseAccounting, QueryPhase};
 use ravel_types::accounting::AccountedOp;
@@ -208,6 +209,121 @@ async fn two_objects(store: &MemoryStore) -> (SegmentRef, SegmentRef) {
     (ref_a, ref_b)
 }
 
+/// A record on an arbitrary resource, for fixtures needing more than the
+/// fixed `service.namespace`/`service.name`/`service.instance.id` shape
+/// [`record`] provides: a resource missing `service.instance.id`, an extra
+/// resource attribute (`k8s.pod.name`), or a non-scalar attribute value
+/// (`tags`, list-valued) that must be excluded from the derived label set
+/// rather than merely renamed.
+fn resource_record(
+    resource: &[(&str, AttrValue)],
+    ts: i64,
+    severity: &str,
+    body: &str,
+    record_attrs: &[(&str, &str)],
+) -> LogRecord {
+    let resource: Vec<(String, AttrValue)> = resource
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect();
+    let attrs: Vec<(String, AttrValue)> = record_attrs
+        .iter()
+        .map(|(k, v)| (k.to_string(), AttrValue::Str(v.to_string())))
+        .collect();
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: severity.into(),
+        body: body.into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs,
+    }
+}
+
+fn full_window() -> TimeRange {
+    TimeRange {
+        start_ns: 0,
+        end_ns: 1_000,
+    }
+}
+
+/// ADR-1103 decisions 2/3 fixture (issue #1106 Finding 3): two objects, four
+/// streams.
+///
+/// Object A: `s1` (`service.name=api`, `k8s.pod.name=p1`) with 5 ERROR
+/// records at ts 100-103 (ts 102 shared by two of them; ts 100 and 101 carry
+/// `user.id=u1` and a body containing "timeout") and 3 INFO records at ts
+/// 104-106, plus `s2` (`service.name=worker`) with 4 ERROR records at ts
+/// 107-110.
+///
+/// Object B: `s1` continuation with 2 more ERROR records at ts 300-301, `s3`
+/// (`service.namespace=pay`, `service.name=api`, so `job="pay/api"` --
+/// distinct from `s1`'s `job="api"`) with 1 ERROR record at ts 302, and `s4`
+/// (`s1`'s exact resource plus a list-valued `tags` attribute, so its label
+/// set equals `s1`'s even though its stream id -- and hence STREAM_DIR entry
+/// and record count -- differ) with 1 ERROR record at ts 303.
+///
+/// Every body has a known length; the 8 `job="api"`,`severity_text="ERROR"`
+/// bodies (5 from `s1` in A, 2 from `s1` in B, 1 from `s4`) are
+/// "timeout-one" (11), "timeout-two-longer" (18), "err-c" (5), "err-d" (5),
+/// "solo-exact-body" (15, unique across the whole fixture), "b-one" (5),
+/// "b-two" (5), and "s4-body-x" (9) -- summing to exactly 73.
+async fn promql_over_logs_fixture(store: &MemoryStore) -> (SegmentRef, SegmentRef) {
+    let s1 = [
+        ("service.name", AttrValue::Str("api".to_string())),
+        ("k8s.pod.name", AttrValue::Str("p1".to_string())),
+    ];
+    let s2 = [("service.name", AttrValue::Str("worker".to_string()))];
+    let s3 = [
+        ("service.namespace", AttrValue::Str("pay".to_string())),
+        ("service.name", AttrValue::Str("api".to_string())),
+    ];
+    let s4 = [
+        ("service.name", AttrValue::Str("api".to_string())),
+        ("k8s.pod.name", AttrValue::Str("p1".to_string())),
+        (
+            "tags",
+            AttrValue::List(vec![AttrValue::Str("x".to_string())]),
+        ),
+    ];
+
+    let a = vec![
+        resource_record(&s1, 100, "ERROR", "timeout-one", &[("user.id", "u1")]),
+        resource_record(
+            &s1,
+            101,
+            "ERROR",
+            "timeout-two-longer",
+            &[("user.id", "u1")],
+        ),
+        resource_record(&s1, 102, "ERROR", "err-c", &[]),
+        resource_record(&s1, 102, "ERROR", "err-d", &[]),
+        resource_record(&s1, 103, "ERROR", "solo-exact-body", &[]),
+        resource_record(&s1, 104, "INFO", "info-1", &[]),
+        resource_record(&s1, 105, "INFO", "info-2", &[]),
+        resource_record(&s1, 106, "INFO", "info-3", &[]),
+        resource_record(&s2, 107, "ERROR", "work-1", &[]),
+        resource_record(&s2, 108, "ERROR", "work-2", &[]),
+        resource_record(&s2, 109, "ERROR", "work-3", &[]),
+        resource_record(&s2, 110, "ERROR", "work-4", &[]),
+    ];
+    let b = vec![
+        resource_record(&s1, 300, "ERROR", "b-one", &[]),
+        resource_record(&s1, 301, "ERROR", "b-two", &[]),
+        resource_record(&s3, 302, "ERROR", "pay-err-1", &[]),
+        resource_record(&s4, 303, "ERROR", "s4-body-x", &[]),
+    ];
+
+    let ref_a = write_object(store, "logs/fixture-a.rlog", &a).await;
+    let ref_b = write_object(store, "logs/fixture-b.rlog", &b).await;
+    (ref_a, ref_b)
+}
+
 fn lines_request<'a>(matchers: &'a [LabelMatcher], window: TimeRange) -> LogSeriesRequest<'a> {
     LogSeriesRequest {
         metric: LogMetric::Lines,
@@ -223,16 +339,23 @@ fn lines_request<'a>(matchers: &'a [LabelMatcher], window: TimeRange) -> LogSeri
 
 /// Acceptance test: a window overlapping only object A, filtered to stream
 /// `job="pay/api"`, on `ravel_log_lines`. Object B is pruned by ts range
-/// before any GET (zero-GET pruning); object A is fetched once for Plan-phase
-/// stream discovery and once for the Scan-phase read (the documented
-/// double-read, see `log_series.rs`'s module docs), and its 11 records land
-/// in exactly two series (INFO x10, ERROR x1), each sample value `1.0`.
+/// before any GET (zero-GET pruning). Object A's Plan phase reads only its
+/// footer and STREAM_DIR section (ADR-1103 decision 2: no BLOCKS byte), and
+/// its Scan phase then reads the projected column set for its surviving
+/// blocks; no segment is read twice. `with_block_range_threshold(0)` routes
+/// this (small, below the default 512 KiB threshold) fixture through the
+/// same ranged probe-then-section path a production object above the
+/// threshold takes, the way `log_fetcher.rs`'s own tests exercise that path
+/// on small fixtures (e.g. `with_block_range_threshold(0)` at line 5753 and
+/// others in that file).
 #[tokio::test]
 async fn log_series_fetch_counts_lines_and_bytes_exactly() {
     let mem = Arc::new(MemoryStore::new());
     let (ref_a, ref_b) = two_objects(&mem).await;
     let counting = Arc::new(CountingStore::new(mem));
-    let fetcher = LogSegmentFetcher::new(counting.clone() as Arc<dyn ObjectStoreBackend>);
+    let fetcher = LogSegmentFetcher::new(counting.clone() as Arc<dyn ObjectStoreBackend>)
+        .with_block_range_threshold(0)
+        .with_suffix_len(300);
 
     let matchers = [
         LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
@@ -278,23 +401,38 @@ async fn log_series_fetch_counts_lines_and_bytes_exactly() {
     assert_eq!(info.labels.get("instance"), Some("i-1"));
     assert_eq!(info.labels.get(METRIC_NAME_LABEL), Some(LOG_LINES_METRIC));
 
-    // Object B was pruned by ts range before any GET; object A cost exactly
-    // two GETs (Plan-phase discovery, Scan-phase read).
+    // Object B was pruned by ts range before any GET. Object A's Plan phase
+    // (footer probe, then a separate range GET for the front STREAM_DIR
+    // section the probe's tail suffix does not cover) and Scan phase (its
+    // own footer probe, then the BLOCKS range reads for the 4 blocks
+    // `small_blocks()` cuts across 11 records) are each pinned exactly, so a
+    // regression that adds or removes a GET on this path is caught by name.
+    // `with_suffix_len(300)` fixes the probe window so these counts do not
+    // depend on the object's incidental total size.
+    let snap = accounting.snapshot();
+    let plan_gets = snap.phase(QueryPhase::Plan).s3_requests(AccountedOp::Get);
+    let scan_gets = snap.phase(QueryPhase::Scan).s3_requests(AccountedOp::Get);
     assert_eq!(
         counting.get_count(),
-        2,
-        "object B pruned pre-GET; object A read twice (Plan + Scan)"
-    );
-    let snap = accounting.snapshot();
-    assert_eq!(
-        snap.phase(QueryPhase::Plan).s3_requests(AccountedOp::Get),
-        1,
-        "Plan-phase discovery issues exactly one GET"
+        plan_gets + scan_gets,
+        "every GET this fetch issues is charged to exactly one of Plan or Scan"
     );
     assert_eq!(
-        snap.phase(QueryPhase::Scan).s3_requests(AccountedOp::Get),
-        1,
-        "Scan-phase read issues exactly one GET"
+        plan_gets, 2,
+        "Plan: one footer probe GET, one STREAM_DIR section GET"
+    );
+    assert_eq!(
+        scan_gets, 6,
+        "Scan: one footer probe GET, plus one BLOCKS range GET per surviving block"
+    );
+
+    let plan_bytes = snap.phase(QueryPhase::Plan).total_s3_bytes();
+    let scan_bytes = snap.phase(QueryPhase::Scan).total_s3_bytes();
+    assert!(
+        plan_bytes < scan_bytes,
+        "Plan reads footer+STREAM_DIR only (no BLOCKS byte); Scan reads the \
+         projected BLOCKS data too, so Plan must move strictly fewer bytes \
+         (plan_bytes={plan_bytes}, scan_bytes={scan_bytes})"
     );
 }
 
@@ -497,5 +635,602 @@ async fn log_series_store_fault_surfaces_as_fetch_error() {
         fault_store.fault_count(Op::Get, ravel_object_store::fault::FaultKind::Transient),
         1,
         "the fault must have fired exactly once"
+    );
+}
+
+/// Finding 3: `s1` (object A + object B) and `s4` (object B) share an
+/// identical label set (`s4`'s only difference, a list-valued `tags`
+/// resource attribute, is excluded from the label set entirely), so a
+/// `job="api"`,`severity_text="ERROR"` selector merges their samples into
+/// one series spanning both segments -- not two series that happen to sort
+/// adjacently. Flip `series.entry(key)` in `fetch_log_series` (log_series.rs)
+/// to key on `record.stream_id` instead of the label-set bytes and this test
+/// fails with `series.len() == 3` (s1-in-A, s1-in-B, s4 no longer merge).
+#[tokio::test]
+async fn log_series_merges_streams_with_identical_label_sets() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = promql_over_logs_fixture(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "api"),
+        LabelMatcher::equal(SEVERITY_LABEL, "ERROR"),
+    ];
+    let req = lines_request(&matchers, full_window());
+    let accounting = PhaseAccounting::new();
+
+    let out = fetch_log_series(&fetcher, TENANT, &[ref_a, ref_b], &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+
+    assert_eq!(
+        out.segments_fetched, 2,
+        "both objects hold a job=api severity_text=ERROR stream"
+    );
+    assert_eq!(out.segments_pruned, 0);
+    assert_eq!(
+        out.series.len(),
+        1,
+        "s1 (A and B) and s4 (B) share a label set and merge into one series"
+    );
+
+    let series = &out.series[0];
+    assert_eq!(
+        series.samples.len(),
+        8,
+        "5 from s1 in A, 2 from s1 in B, 1 from s4 in B"
+    );
+    let mut tss: Vec<i64> = series.samples.iter().map(|s| s.ts_ns).collect();
+    tss.sort_unstable();
+    assert_eq!(tss, vec![100, 101, 102, 102, 103, 300, 301, 303]);
+
+    let mut names: Vec<&str> = series.labels.iter().map(|l| l.name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(
+        names,
+        vec![
+            "__name__",
+            "job",
+            "k8s_pod_name",
+            "otel_scope_name",
+            "otel_scope_version",
+            "severity_text",
+        ],
+        "no instance (never set), no tags (list-valued, excluded from the label set)"
+    );
+    assert_eq!(series.labels.get("job"), Some("api"));
+    assert_eq!(series.labels.get("k8s_pod_name"), Some("p1"));
+    assert_eq!(series.labels.get("instance"), None);
+    assert_eq!(series.labels.get("tags"), None);
+}
+
+/// Finding 3: `ravel_log_bytes` over the same 8 records sums to exactly 73
+/// (11 + 18 + 5 + 5 + 15 + 5 + 5 + 9, see [`promql_over_logs_fixture`]'s
+/// doc). Flip `record.body.len() as f64` to `1.0` in `fetch_log_series` (the
+/// `LogMetric::Bytes` arm) and this test fails with `sum == 8.0`.
+#[tokio::test]
+async fn log_series_bytes_metric_sums_all_body_lengths_exactly() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = promql_over_logs_fixture(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_BYTES_METRIC),
+        LabelMatcher::equal("job", "api"),
+        LabelMatcher::equal(SEVERITY_LABEL, "ERROR"),
+    ];
+    let req = LogSeriesRequest {
+        metric: LogMetric::Bytes,
+        ..lines_request(&matchers, full_window())
+    };
+    let accounting = PhaseAccounting::new();
+
+    let out = fetch_log_series(&fetcher, TENANT, &[ref_a, ref_b], &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+
+    assert_eq!(out.series.len(), 1);
+    assert_eq!(out.series[0].samples.len(), 8);
+    let total: f64 = out.series[0].samples.iter().map(|s| s.value).sum();
+    assert_eq!(
+        total, 73.0,
+        "sum of all 8 job=api severity=ERROR body lengths"
+    );
+}
+
+/// Finding 3 (F2b's severity non-equality post-filter, applied here at
+/// fixture scale): `severity_text=~"ERR.*"` matches all 8 ERROR records
+/// (proving the regex postfilter runs, not just the equality fast path);
+/// `severity_text!="ERROR"` matches `s1`'s 3 INFO records (`s4` carries none).
+/// Flip the postfilter's `.all(...)` to `.any(...)` in `fetch_log_series` and
+/// the `!=` case fails with `total == 11` (every record passes an `any` over
+/// a single always-different-from-"ERROR"-once-negated matcher).
+#[tokio::test]
+async fn log_series_severity_regex_and_negation_counts() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = promql_over_logs_fixture(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+    let refs = [ref_a, ref_b];
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "api"),
+        LabelMatcher::regex(SEVERITY_LABEL, "ERR.*").unwrap(),
+    ];
+    let req = lines_request(&matchers, full_window());
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(&fetcher, TENANT, &refs, &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+    let total: usize = out.series.iter().map(|s| s.samples.len()).sum();
+    assert_eq!(
+        total, 8,
+        "severity_text=~\"ERR.*\" matches all 8 ERROR records"
+    );
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "api"),
+        LabelMatcher::not_equal(SEVERITY_LABEL, "ERROR"),
+    ];
+    let req = lines_request(&matchers, full_window());
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(&fetcher, TENANT, &refs, &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+    let total: usize = out.series.iter().map(|s| s.samples.len()).sum();
+    assert_eq!(
+        total, 3,
+        "severity_text!=\"ERROR\" matches s1's 3 INFO records"
+    );
+}
+
+/// Finding 1 (F1), at fixture scale: `__body__=~".*timeout.*"` finds the two
+/// `user.id=u1` records, `!~".*timeout.*"` finds the other 6, an exact match
+/// on the fixture's one unique body finds 1, and an unanchored `"timeout"`
+/// pattern (no wildcards) finds 0 -- proving `__body__` regexes are fully
+/// anchored. Flip `body_matchers` (log_series.rs) back to filtering
+/// `stream_matchers`'s already-`__body__`-excluded list and every assertion
+/// here fails: `.all()` over an empty slice is vacuously true, so all four
+/// become "matches everything" (8, 8, 8, 8).
+#[tokio::test]
+async fn log_series_body_matcher_counts_on_the_fixture() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = promql_over_logs_fixture(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+    let refs = [ref_a, ref_b];
+
+    async fn count(
+        fetcher: &LogSegmentFetcher,
+        refs: &[SegmentRef],
+        matchers: &[LabelMatcher],
+    ) -> usize {
+        let req = lines_request(matchers, full_window());
+        let accounting = PhaseAccounting::new();
+        let out = fetch_log_series(fetcher, TENANT, refs, &req, &accounting)
+            .await
+            .expect("fetch_log_series");
+        out.series.iter().map(|s| s.samples.len()).sum()
+    }
+
+    let base = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "api"),
+        LabelMatcher::equal(SEVERITY_LABEL, "ERROR"),
+    ];
+
+    let mut m = base.to_vec();
+    m.push(LabelMatcher::regex(BODY_MATCHER_LABEL, ".*timeout.*").unwrap());
+    assert_eq!(
+        count(&fetcher, &refs, &m).await,
+        2,
+        "__body__=~\".*timeout.*\""
+    );
+
+    let mut m = base.to_vec();
+    m.push(LabelMatcher::not_regex(BODY_MATCHER_LABEL, ".*timeout.*").unwrap());
+    assert_eq!(
+        count(&fetcher, &refs, &m).await,
+        6,
+        "__body__!~\".*timeout.*\""
+    );
+
+    let mut m = base.to_vec();
+    m.push(LabelMatcher::equal(BODY_MATCHER_LABEL, "solo-exact-body"));
+    assert_eq!(
+        count(&fetcher, &refs, &m).await,
+        1,
+        "__body__ exact match on a unique body"
+    );
+
+    let mut m = base.to_vec();
+    m.push(LabelMatcher::regex(BODY_MATCHER_LABEL, "timeout").unwrap());
+    assert_eq!(
+        count(&fetcher, &refs, &m).await,
+        0,
+        "unanchored \"timeout\" pattern requires the whole body to equal it"
+    );
+}
+
+/// Finding 3: a windowless erasure on `user.id=u1` drops both records that
+/// carry it (ts 100 and 101), leaving 6 of the 8 `job=api` ERROR samples, and
+/// the `ravel_log_bytes` sum drops by exactly their two lengths (73 - 11 -
+/// 18 = 44). A predicate windowed to `[101, 102)` erases only the ts=101
+/// record, leaving 7. Flip `retain_log_records`'s `!p.has_window() ||
+/// p.ts_in_window(...)` to `&&` in erasure.rs and the windowless case fails
+/// (a predicate with no window has `has_window() == false`, so `&&` makes
+/// its match always false and nothing is erased: `total == 8`).
+#[tokio::test]
+async fn log_series_erasure_excludes_matching_records_and_their_bytes() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = promql_over_logs_fixture(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+    let refs = [ref_a, ref_b];
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "api"),
+        LabelMatcher::equal(SEVERITY_LABEL, "ERROR"),
+    ];
+
+    let windowless = [ErasurePredicate::windowless(vec![(
+        "user.id".to_string(),
+        "u1".to_string(),
+    )])];
+    let req = LogSeriesRequest {
+        erasure: &windowless,
+        ..lines_request(&matchers, full_window())
+    };
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(&fetcher, TENANT, &refs, &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+    let total: usize = out.series.iter().map(|s| s.samples.len()).sum();
+    assert_eq!(total, 6, "windowless erasure drops both user.id=u1 records");
+
+    let bytes_matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_BYTES_METRIC),
+        LabelMatcher::equal("job", "api"),
+        LabelMatcher::equal(SEVERITY_LABEL, "ERROR"),
+    ];
+    let bytes_req = LogSeriesRequest {
+        metric: LogMetric::Bytes,
+        erasure: &windowless,
+        ..lines_request(&bytes_matchers, full_window())
+    };
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(&fetcher, TENANT, &refs, &bytes_req, &accounting)
+        .await
+        .expect("fetch_log_series");
+    let sum: f64 = out
+        .series
+        .iter()
+        .flat_map(|s| &s.samples)
+        .map(|s| s.value)
+        .sum();
+    assert_eq!(
+        sum, 44.0,
+        "73 total minus \"timeout-one\" (11) and \"timeout-two-longer\" (18)"
+    );
+
+    let windowed = [ErasurePredicate::new(
+        vec![("user.id".to_string(), "u1".to_string())],
+        101,
+        102,
+    )];
+    let req = LogSeriesRequest {
+        erasure: &windowed,
+        ..lines_request(&matchers, full_window())
+    };
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(&fetcher, TENANT, &refs, &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+    let total: usize = out.series.iter().map(|s| s.samples.len()).sum();
+    assert_eq!(
+        total, 7,
+        "the [101, 102) window excludes ts=100, so only the ts=101 record is erased"
+    );
+}
+
+/// Finding 3: `job=~"api|worker"` selects `s1`+`s4` (merged, `job="api"`)
+/// and `s2` (`job="worker"`) -- 2 series. `s3` (`job="pay/api"`) does not
+/// match `"api|worker"` and is excluded. With `max_series: 1` the second
+/// distinct series trips `SeriesExceeded`. Flip the anchoring `Self::compiled`
+/// applies to a regex pattern (drop the `^(?:...)$` wrap in
+/// `ravel-promql/src/source.rs`) and `s3` would also match unanchored
+/// `"api|worker"` (its job value contains neither as a full match, so this
+/// particular flip does not change this test's count, but the exact-count
+/// assertion here is what catches a regression that widened the match set).
+#[tokio::test]
+async fn log_series_two_jobs_two_series_and_max_series_trips() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = promql_over_logs_fixture(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+    let refs = [ref_a, ref_b];
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::regex("job", "api|worker").unwrap(),
+        LabelMatcher::equal(SEVERITY_LABEL, "ERROR"),
+    ];
+    let req = lines_request(&matchers, full_window());
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(&fetcher, TENANT, &refs, &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+    assert_eq!(
+        out.series.len(),
+        2,
+        "job=api (s1+s4 merged) and job=worker (s2)"
+    );
+
+    let req = LogSeriesRequest {
+        max_series: 1,
+        ..lines_request(&matchers, full_window())
+    };
+    let accounting = PhaseAccounting::new();
+    let err = fetch_log_series(&fetcher, TENANT, &refs, &req, &accounting)
+        .await
+        .expect_err("two distinct job series exceed max_series=1");
+    match err {
+        LogSeriesError::SeriesExceeded { count, max } => {
+            assert_eq!(count, 2);
+            assert_eq!(max, 1);
+        }
+        other => panic!("expected SeriesExceeded, got {other:?}"),
+    }
+}
+
+/// Finding 3 (F2b's no-matching-stream segment prune): `job="nomatch"`
+/// matches no stream in either object, so both are pruned after Plan-phase
+/// STREAM_DIR discovery and neither reaches Scan. Every GET this fetch
+/// issues is therefore a Plan-phase STREAM_DIR read (one whole-object GET
+/// per object, both fixture objects being under the default
+/// `block_range_threshold`) and Scan issues none. Flip the `if
+/// matching_streams.is_empty() { segments_pruned += 1; continue; }` guard in
+/// `fetch_log_series` to a no-op and this test fails: `scan_gets` becomes
+/// nonzero (both objects proceed to Scan despite matching no stream).
+#[tokio::test]
+async fn log_series_nomatch_job_prunes_both_segments_with_zero_scan_gets() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = promql_over_logs_fixture(&mem).await;
+    let counting = Arc::new(CountingStore::new(mem));
+    let fetcher = LogSegmentFetcher::new(counting.clone() as Arc<dyn ObjectStoreBackend>);
+    let refs = [ref_a, ref_b];
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "nomatch"),
+    ];
+    let req = lines_request(&matchers, full_window());
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(&fetcher, TENANT, &refs, &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+
+    assert!(out.series.is_empty());
+    assert_eq!(
+        out.segments_pruned, 2,
+        "no stream in either object has job=nomatch"
+    );
+    assert_eq!(out.segments_fetched, 0);
+
+    let snap = accounting.snapshot();
+    let plan_gets = snap.phase(QueryPhase::Plan).s3_requests(AccountedOp::Get);
+    let scan_gets = snap.phase(QueryPhase::Scan).s3_requests(AccountedOp::Get);
+    assert_eq!(
+        scan_gets, 0,
+        "Scan phase never runs: both segments pruned in Plan"
+    );
+    assert_eq!(
+        plan_gets, 2,
+        "one whole-object GET per object for STREAM_DIR discovery"
+    );
+    assert_eq!(
+        counting.get_count(),
+        plan_gets,
+        "every GET this fetch issues is a Plan-phase STREAM_DIR read"
+    );
+}
+
+/// Finding 3: a stream matcher on a label no series carries follows PromQL's
+/// absent-as-empty-string rule (`ravel-promql/src/matchers.rs`):
+/// `instance!=""` excludes every `job=api` series (absent reads as `""`, and
+/// `"" != ""` is false), while `instance=""` and `instance!~".+"` keep all 11
+/// `job=api` samples. Flip `LabelMatcher::is_match`'s `labels.get(&self.name)
+/// .unwrap_or("")` to `.unwrap_or("<absent>")` and the `instance=""` case
+/// fails (`"<absent>" == ""` is false, so it would exclude everything
+/// instead of keeping it).
+#[tokio::test]
+async fn log_series_absent_label_matcher_follows_promql_empty_string_rule() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = promql_over_logs_fixture(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+    let refs = [ref_a, ref_b];
+
+    let base = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "api"),
+    ];
+
+    for (extra, expect_total, label) in [
+        (LabelMatcher::not_equal("instance", ""), 0, "instance!=\"\""),
+        (LabelMatcher::equal("instance", ""), 11, "instance=\"\""),
+        (
+            LabelMatcher::not_regex("instance", ".+").unwrap(),
+            11,
+            "instance!~\".+\"",
+        ),
+    ] {
+        let mut matchers = base.to_vec();
+        matchers.push(extra);
+        let req = lines_request(&matchers, full_window());
+        let accounting = PhaseAccounting::new();
+        let out = fetch_log_series(&fetcher, TENANT, &refs, &req, &accounting)
+            .await
+            .expect("fetch_log_series");
+        let total: usize = out.series.iter().map(|s| s.samples.len()).sum();
+        assert_eq!(
+            total, expect_total,
+            "{label}: instance is absent on every job=api series"
+        );
+    }
+}
+
+/// Finding 3: a window covering only object A's ts range fetches exactly one
+/// segment.
+#[tokio::test]
+async fn log_series_window_covering_only_object_a_fetches_one_segment() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = promql_over_logs_fixture(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "api"),
+    ];
+    let window = TimeRange {
+        start_ns: 0,
+        end_ns: 200,
+    };
+    let req = lines_request(&matchers, window);
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(&fetcher, TENANT, &[ref_a, ref_b], &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+
+    assert_eq!(out.segments_fetched, 1, "only object A overlaps [0, 200]");
+}
+
+/// Finding 1 (F1), reproducing the review's exact bodies: `ok`, `ok`, `boom`,
+/// `request timeout`. `__body__="ok"` finds the two exact matches,
+/// `=~".*timeout.*"` finds the "request timeout" record, `!~".*timeout.*"`
+/// finds the other three, and an unanchored `=~"timeout"` pattern (no
+/// wildcards) finds none. Flip `body_matches`'s `.all(...)` to `.any(...)`
+/// in log_series.rs and `!~".*timeout.*"` fails: `.any()` over one negated
+/// matcher is the same predicate as `.all()` here (a single matcher), so the
+/// flip that actually changes this test's outcome is the one already named
+/// in `log_series_body_matcher_counts_on_the_fixture`'s doc (restoring the
+/// `stream_matchers`-filtered list, which drops every `__body__` matcher and
+/// makes all four counts here 4 instead of 2/1/3/0).
+#[tokio::test]
+async fn log_series_body_matcher_review_probe_ok_ok_boom_request_timeout() {
+    let mem = Arc::new(MemoryStore::new());
+    let resource = [("service.name", AttrValue::Str("bodyprobe".to_string()))];
+    let records = vec![
+        resource_record(&resource, 1, "INFO", "ok", &[]),
+        resource_record(&resource, 2, "INFO", "ok", &[]),
+        resource_record(&resource, 3, "INFO", "boom", &[]),
+        resource_record(&resource, 4, "INFO", "request timeout", &[]),
+    ];
+    let ref_a = write_object(&mem, "logs/bodyprobe.rlog", &records).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+    let refs = [ref_a];
+    let window = TimeRange {
+        start_ns: 0,
+        end_ns: 10,
+    };
+
+    async fn count(
+        fetcher: &LogSegmentFetcher,
+        refs: &[SegmentRef],
+        matchers: &[LabelMatcher],
+        window: TimeRange,
+    ) -> usize {
+        let req = lines_request(matchers, window);
+        let accounting = PhaseAccounting::new();
+        let out = fetch_log_series(fetcher, TENANT, refs, &req, &accounting)
+            .await
+            .expect("fetch_log_series");
+        out.series.iter().map(|s| s.samples.len()).sum()
+    }
+
+    let base = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "bodyprobe"),
+    ];
+
+    let mut m = base.to_vec();
+    m.push(LabelMatcher::equal(BODY_MATCHER_LABEL, "ok"));
+    assert_eq!(
+        count(&fetcher, &refs, &m, window).await,
+        2,
+        "__body__=\"ok\""
+    );
+
+    let mut m = base.to_vec();
+    m.push(LabelMatcher::regex(BODY_MATCHER_LABEL, ".*timeout.*").unwrap());
+    assert_eq!(
+        count(&fetcher, &refs, &m, window).await,
+        1,
+        "__body__=~\".*timeout.*\""
+    );
+
+    let mut m = base.to_vec();
+    m.push(LabelMatcher::not_regex(BODY_MATCHER_LABEL, ".*timeout.*").unwrap());
+    assert_eq!(
+        count(&fetcher, &refs, &m, window).await,
+        3,
+        "__body__!~\".*timeout.*\""
+    );
+
+    let mut m = base.to_vec();
+    m.push(LabelMatcher::regex(BODY_MATCHER_LABEL, "timeout").unwrap());
+    assert_eq!(
+        count(&fetcher, &refs, &m, window).await,
+        0,
+        "__body__=~\"timeout\" (unanchored) requires the whole body to equal it"
+    );
+}
+
+/// Finding 2b (F3) item 4: `fetch_log_series`'s final per-series
+/// `RlogWriter::finish` sorts every object's own rows by `(stream_ref, ts)`
+/// (crates/ravel-logseg/src/writer.rs), so within one object the scan already
+/// comes back ts-ascending regardless of push order: a single-object fixture
+/// cannot exercise `fetch_log_series`'s own
+/// `samples.sort_by_key(|s| s.ts_ns)`. Two objects for the same stream can:
+/// each object is internally sorted, but the segment loop pushes object A's
+/// records before object B's, so the per-series `Vec<Sample>` accumulates
+/// [50, 60] then [10, 20] before the final sort reorders it. Flip
+/// `samples.sort_by_key(|s| s.ts_ns)` to a no-op and this test fails: the
+/// samples come back in segment-scan order, [50, 60, 10, 20].
+#[tokio::test]
+async fn log_series_samples_come_back_ts_sorted_across_segments() {
+    let mem = Arc::new(MemoryStore::new());
+    let resource = [("service.name", AttrValue::Str("sortcheck".to_string()))];
+    let later = vec![
+        resource_record(&resource, 50, "INFO", "r1", &[]),
+        resource_record(&resource, 60, "INFO", "r2", &[]),
+    ];
+    let earlier = vec![
+        resource_record(&resource, 10, "INFO", "r3", &[]),
+        resource_record(&resource, 20, "INFO", "r4", &[]),
+    ];
+    let ref_a = write_object(&mem, "logs/sort-a.rlog", &later).await;
+    let ref_b = write_object(&mem, "logs/sort-b.rlog", &earlier).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "sortcheck"),
+    ];
+    let window = TimeRange {
+        start_ns: 0,
+        end_ns: 100,
+    };
+    let req = lines_request(&matchers, window);
+    let accounting = PhaseAccounting::new();
+    let out = fetch_log_series(&fetcher, TENANT, &[ref_a, ref_b], &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+
+    assert_eq!(out.series.len(), 1);
+    let tss: Vec<i64> = out.series[0].samples.iter().map(|s| s.ts_ns).collect();
+    assert_eq!(
+        tss,
+        vec![10, 20, 50, 60],
+        "ascending, even though segment A (later timestamps) is scanned before segment B"
     );
 }

--- a/crates/ravel-query/tests/log_series.rs
+++ b/crates/ravel-query/tests/log_series.rs
@@ -1,0 +1,501 @@
+//! Acceptance tests for [`ravel_query::log_series::fetch_log_series`]
+//! (ADR-1103, issue #1106).
+//!
+//! Two RLOG objects with disjoint ts ranges and distinct stream identities
+//! exercise: zero-GET ts-range pruning before any object touches the store,
+//! per-phase (Plan vs Scan) GET accounting, stream-label derivation from
+//! resource attributes, the `ravel_log_lines`/`ravel_log_bytes` value
+//! contract, and the `max_series`/`max_samples` budgets. A `FaultStore` test
+//! proves a store-level failure surfaces as `LogSeriesError::Fetch`, not a
+//! panic or a silently wrong result.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use async_trait::async_trait;
+use ravel_catalog::{SegmentLevel, SegmentRef};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{
+    Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
+    PageToken, PutOptions, PutOutcome, StoreError,
+};
+use ravel_promql::LabelMatcher;
+use ravel_query::log_series::{
+    LOG_BYTES_METRIC, LOG_LINES_METRIC, LogMetric, LogSeriesError, LogSeriesRequest,
+    fetch_log_series,
+};
+use ravel_query::{ByteLimit, LogSegmentFetcher, PhaseAccounting, QueryPhase};
+use ravel_types::accounting::AccountedOp;
+use ravel_types::{METRIC_NAME_LABEL, TenantHash, TimeRange};
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+
+/// An [`ObjectStoreBackend`] wrapper that counts `get` calls, so a test can
+/// prove ts-range pruning skipped an object without touching storage.
+struct CountingStore {
+    inner: Arc<MemoryStore>,
+    gets: AtomicU64,
+}
+
+impl CountingStore {
+    fn new(inner: Arc<MemoryStore>) -> Self {
+        CountingStore {
+            inner,
+            gets: AtomicU64::new(0),
+        }
+    }
+
+    fn get_count(&self) -> u64 {
+        self.gets.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for CountingStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        self.gets.fetch_add(1, Ordering::SeqCst);
+        self.inner.get(key, range).await
+    }
+
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: [7u8; 16],
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+/// A record on the stream identified by `service.namespace`/`service.name`/
+/// `service.instance.id` (so `stream_label_set`'s job/instance derivation has
+/// something to derive), with the given severity and body.
+fn record(
+    namespace: &str,
+    name: &str,
+    instance: &str,
+    ts: i64,
+    severity: &str,
+    body: &str,
+) -> LogRecord {
+    let resource = vec![
+        (
+            "service.namespace".to_string(),
+            AttrValue::Str(namespace.to_string()),
+        ),
+        ("service.name".to_string(), AttrValue::Str(name.to_string())),
+        (
+            "service.instance.id".to_string(),
+            AttrValue::Str(instance.to_string()),
+        ),
+    ];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: severity.into(),
+        body: body.into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    }
+}
+
+/// Cuts a block every 3 records so a multi-block object exercises
+/// `next_block` more than once, matching `log_fetcher.rs`'s own convention.
+fn small_blocks() -> RlogConfig {
+    RlogConfig {
+        block_target_records: 3,
+        ..RlogConfig::default()
+    }
+}
+
+async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> SegmentRef {
+    let mut w = RlogWriter::new(small_blocks(), identity());
+    for r in records {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put object");
+
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
+    }
+}
+
+/// Object A: stream `pay/api`/`i-1`, ts 100..=110, severities INFO (ts != 105)
+/// and ERROR (ts == 105), body "boom" at ts 105 and "ok" elsewhere. Object B:
+/// stream `pay/worker`/`i-2`, ts 1000..=1010, all INFO/"ok". Disjoint ts
+/// ranges and distinct stream identities.
+async fn two_objects(store: &MemoryStore) -> (SegmentRef, SegmentRef) {
+    let a: Vec<LogRecord> = (100..=110)
+        .map(|ts| {
+            if ts == 105 {
+                record("pay", "api", "i-1", ts, "ERROR", "boom")
+            } else {
+                record("pay", "api", "i-1", ts, "INFO", "ok")
+            }
+        })
+        .collect();
+    let b: Vec<LogRecord> = (1000..=1010)
+        .map(|ts| record("pay", "worker", "i-2", ts, "INFO", "ok"))
+        .collect();
+    let ref_a = write_object(store, "logs/a.rlog", &a).await;
+    let ref_b = write_object(store, "logs/b.rlog", &b).await;
+    (ref_a, ref_b)
+}
+
+fn lines_request<'a>(matchers: &'a [LabelMatcher], window: TimeRange) -> LogSeriesRequest<'a> {
+    LogSeriesRequest {
+        metric: LogMetric::Lines,
+        matchers,
+        window,
+        erasure: &[],
+        max_samples: 1_000,
+        max_series: 1_000,
+        max_bytes_scanned: ByteLimit::Unlimited,
+        deadline: None,
+    }
+}
+
+/// Acceptance test: a window overlapping only object A, filtered to stream
+/// `job="pay/api"`, on `ravel_log_lines`. Object B is pruned by ts range
+/// before any GET (zero-GET pruning); object A is fetched once for Plan-phase
+/// stream discovery and once for the Scan-phase read (the documented
+/// double-read, see `log_series.rs`'s module docs), and its 11 records land
+/// in exactly two series (INFO x10, ERROR x1), each sample value `1.0`.
+#[tokio::test]
+async fn log_series_fetch_counts_lines_and_bytes_exactly() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = two_objects(&mem).await;
+    let counting = Arc::new(CountingStore::new(mem));
+    let fetcher = LogSegmentFetcher::new(counting.clone() as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "pay/api"),
+    ];
+    let window = TimeRange {
+        start_ns: 90,
+        end_ns: 120,
+    };
+    let req = lines_request(&matchers, window);
+    let accounting = PhaseAccounting::new();
+
+    let out = fetch_log_series(&fetcher, TENANT, &[ref_a, ref_b], &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+
+    assert_eq!(out.segments_fetched, 1, "only object A overlaps the window");
+    assert_eq!(out.segments_pruned, 1, "object B is pruned by ts range");
+    assert_eq!(
+        out.records_scanned, 11,
+        "all 11 of object A's records match the stream"
+    );
+
+    assert_eq!(out.series.len(), 2, "one series per distinct severity_text");
+    let info = out
+        .series
+        .iter()
+        .find(|s| s.labels.get("severity_text") == Some("INFO"))
+        .expect("INFO series");
+    let error = out
+        .series
+        .iter()
+        .find(|s| s.labels.get("severity_text") == Some("ERROR"))
+        .expect("ERROR series");
+    assert_eq!(info.samples.len(), 10);
+    assert_eq!(error.samples.len(), 1);
+    assert!(
+        info.samples.iter().all(|s| s.value == 1.0),
+        "ravel_log_lines value is always 1.0"
+    );
+    assert_eq!(error.samples[0].ts_ns, 105);
+    assert_eq!(info.labels.get("job"), Some("pay/api"));
+    assert_eq!(info.labels.get("instance"), Some("i-1"));
+    assert_eq!(info.labels.get(METRIC_NAME_LABEL), Some(LOG_LINES_METRIC));
+
+    // Object B was pruned by ts range before any GET; object A cost exactly
+    // two GETs (Plan-phase discovery, Scan-phase read).
+    assert_eq!(
+        counting.get_count(),
+        2,
+        "object B pruned pre-GET; object A read twice (Plan + Scan)"
+    );
+    let snap = accounting.snapshot();
+    assert_eq!(
+        snap.phase(QueryPhase::Plan).s3_requests(AccountedOp::Get),
+        1,
+        "Plan-phase discovery issues exactly one GET"
+    );
+    assert_eq!(
+        snap.phase(QueryPhase::Scan).s3_requests(AccountedOp::Get),
+        1,
+        "Scan-phase read issues exactly one GET"
+    );
+}
+
+/// `ravel_log_bytes`: sample values are the record body's length, not `1.0`.
+#[tokio::test]
+async fn log_series_bytes_metric_values_are_body_lengths() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, _ref_b) = two_objects(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_BYTES_METRIC),
+        LabelMatcher::equal("job", "pay/api"),
+    ];
+    let window = TimeRange {
+        start_ns: 90,
+        end_ns: 120,
+    };
+    let req = LogSeriesRequest {
+        metric: LogMetric::Bytes,
+        ..lines_request(&matchers, window)
+    };
+    let accounting = PhaseAccounting::new();
+
+    let out = fetch_log_series(&fetcher, TENANT, &[ref_a], &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+
+    let error = out
+        .series
+        .iter()
+        .find(|s| s.labels.get("severity_text") == Some("ERROR"))
+        .expect("ERROR series");
+    assert_eq!(error.samples[0].value, "boom".len() as f64);
+    let info = out
+        .series
+        .iter()
+        .find(|s| s.labels.get("severity_text") == Some("INFO"))
+        .expect("INFO series");
+    assert!(info.samples.iter().all(|s| s.value == "ok".len() as f64));
+}
+
+/// A window disjoint from both objects prunes both by ts range with zero
+/// GETs at all: the cheapest possible outcome for a query outside any
+/// segment's span.
+#[tokio::test]
+async fn log_series_window_outside_both_segments_issues_zero_gets() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, ref_b) = two_objects(&mem).await;
+    let counting = Arc::new(CountingStore::new(mem));
+    let fetcher = LogSegmentFetcher::new(counting.clone() as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC)];
+    let window = TimeRange {
+        start_ns: 5_000,
+        end_ns: 6_000,
+    };
+    let req = lines_request(&matchers, window);
+    let accounting = PhaseAccounting::new();
+
+    let out = fetch_log_series(&fetcher, TENANT, &[ref_a, ref_b], &req, &accounting)
+        .await
+        .expect("fetch_log_series");
+
+    assert_eq!(out.segments_pruned, 2);
+    assert_eq!(out.segments_fetched, 0);
+    assert_eq!(out.records_scanned, 0);
+    assert!(out.series.is_empty());
+    assert_eq!(
+        counting.get_count(),
+        0,
+        "both segments pruned by ts range before any GET"
+    );
+}
+
+/// `max_series` trips as soon as a matching record would create a series
+/// beyond the limit: with the two-severities fixture and `max_series = 1`,
+/// the first-seen severity's series fits but the second's does not.
+#[tokio::test]
+async fn log_series_series_budget_trips_exactly() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, _ref_b) = two_objects(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC)];
+    let window = TimeRange {
+        start_ns: 90,
+        end_ns: 120,
+    };
+    let req = LogSeriesRequest {
+        max_series: 1,
+        ..lines_request(&matchers, window)
+    };
+    let accounting = PhaseAccounting::new();
+
+    let err = fetch_log_series(&fetcher, TENANT, &[ref_a], &req, &accounting)
+        .await
+        .expect_err("two severities exceed max_series=1");
+    match err {
+        LogSeriesError::SeriesExceeded { count, max } => {
+            assert_eq!(count, 2);
+            assert_eq!(max, 1);
+        }
+        other => panic!("expected SeriesExceeded, got {other:?}"),
+    }
+}
+
+/// `max_samples` trips once the running record count exceeds the budget,
+/// regardless of how many series it lands in.
+#[tokio::test]
+async fn log_series_samples_budget_trips_exactly() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, _ref_b) = two_objects(&mem).await;
+    let fetcher = LogSegmentFetcher::new(mem as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC)];
+    let window = TimeRange {
+        start_ns: 90,
+        end_ns: 120,
+    };
+    let req = LogSeriesRequest {
+        max_samples: 5,
+        ..lines_request(&matchers, window)
+    };
+    let accounting = PhaseAccounting::new();
+
+    let err = fetch_log_series(&fetcher, TENANT, &[ref_a], &req, &accounting)
+        .await
+        .expect_err("11 records exceed max_samples=5");
+    match err {
+        LogSeriesError::SamplesExceeded { count, max } => {
+            assert_eq!(count, 6);
+            assert_eq!(max, 5);
+        }
+        other => panic!("expected SamplesExceeded, got {other:?}"),
+    }
+}
+
+/// A deadline already in the past is caught before the first segment's Plan
+/// read, never mid-scan silently.
+#[tokio::test]
+async fn log_series_deadline_exceeded_before_any_fetch() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, _ref_b) = two_objects(&mem).await;
+    let counting = Arc::new(CountingStore::new(mem));
+    let fetcher = LogSegmentFetcher::new(counting.clone() as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC)];
+    let window = TimeRange {
+        start_ns: 90,
+        end_ns: 120,
+    };
+    let req = LogSeriesRequest {
+        deadline: Some(Instant::now()),
+        ..lines_request(&matchers, window)
+    };
+    let accounting = PhaseAccounting::new();
+
+    let err = fetch_log_series(&fetcher, TENANT, &[ref_a], &req, &accounting)
+        .await
+        .expect_err("deadline already elapsed");
+    assert!(matches!(err, LogSeriesError::DeadlineExceeded));
+    assert_eq!(
+        counting.get_count(),
+        0,
+        "the deadline check runs before any GET"
+    );
+}
+
+/// A store-level failure on the Plan-phase discovery GET surfaces as
+/// `LogSeriesError::Fetch`, never a panic, and the fault fires exactly once.
+#[tokio::test]
+async fn log_series_store_fault_surfaces_as_fetch_error() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, _ref_b) = two_objects(&mem).await;
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(Op::Get, ScriptedFault::Transient("injected".into()))
+            .with_key_contains("a.rlog")
+            .with_occurrence(Occurrence::Always),
+    );
+    let fault_store = Arc::new(FaultStore::new(mem, plan));
+    let fetcher = LogSegmentFetcher::new(fault_store.clone() as Arc<dyn ObjectStoreBackend>);
+
+    let matchers = [LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC)];
+    let window = TimeRange {
+        start_ns: 90,
+        end_ns: 120,
+    };
+    let req = lines_request(&matchers, window);
+    let accounting = PhaseAccounting::new();
+
+    let err = fetch_log_series(&fetcher, TENANT, &[ref_a], &req, &accounting)
+        .await
+        .expect_err("injected store fault");
+    assert!(
+        matches!(err, LogSeriesError::Fetch(_)),
+        "expected Fetch, got {err:?}"
+    );
+    assert_eq!(
+        fault_store.fault_count(Op::Get, ravel_object_store::fault::FaultKind::Transient),
+        1,
+        "the fault must have fired exactly once"
+    );
+}

--- a/crates/ravel-sql/src/rlog_attrs.rs
+++ b/crates/ravel-sql/src/rlog_attrs.rs
@@ -18,18 +18,9 @@ use datafusion::error::DataFusionError;
 use datafusion::error::Result as DFResult;
 use ravel_logseg::LogRecord;
 use ravel_query::erasure::ErasurePredicate;
-use ravel_types::logstream::{AttrValue, canonical_attr_bytes};
+use ravel_types::logstream::AttrValue;
 
 use crate::error::SqlError;
-
-/// Depth cap when walking a record's canonical resource/scope blob for the
-/// merged-`attrs` decode (mirrors the reader's `MAX_ATTR_DEPTH`), so hostile
-/// nesting cannot exhaust the stack.
-const MAX_ATTR_DEPTH: u32 = 32;
-
-/// Entry-count cap per attribute set when walking the blob, matching the
-/// reader's own cap so a corrupt count is rejected rather than allocated on.
-const MAX_ATTR_ENTRIES: u64 = 1 << 20;
 
 /// The `attrs` column contents for one record: its decoded stream-identity
 /// (resource + scope) attributes overlaid with its dynamic per-record
@@ -98,258 +89,36 @@ pub(crate) fn find_attr<'a>(merged: &'a [(String, AttrValue)], key: &str) -> Opt
 /// `attrs` column. Scalar values render to their natural text; `Bytes`, `List`,
 /// and `Map` render to the lowercase hex of their canonical encoding, a
 /// deterministic, injective form pending a richer typed column.
-pub(crate) fn attr_value_to_string(v: &AttrValue) -> String {
-    match v {
-        AttrValue::Str(s) => s.clone(),
-        AttrValue::I64(i) => i.to_string(),
-        AttrValue::F64(f) => f.to_string(),
-        AttrValue::Bool(b) => b.to_string(),
-        AttrValue::Bytes(b) => hex_lower(b),
-        AttrValue::List(_) | AttrValue::Map(_) => hex_lower(&canonical_attr_bytes(
-            std::slice::from_ref(&(String::new(), v.clone())),
-        )),
-    }
-}
-
-fn hex_lower(bytes: &[u8]) -> String {
-    use std::fmt::Write as _;
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        // Writing to a String never fails.
-        let _ = write!(out, "{b:02x}");
-    }
-    out
-}
+pub(crate) use ravel_logseg::record::attr_value_to_string;
 
 // --- `attrs` column contents: merged resource/scope + record attributes ---
 
 /// Decode the **top-level** resource and scope attribute entries of a
 /// `stream_attrs` blob (a record's [`ravel_logseg::LogRecord::stream_attrs`],
 /// the canonical `resource ++ scope-name ++ scope-version ++ scope-attrs`
-/// bytes) into `(key, value)` pairs, in blob order (resource set first, then the
-/// scope attribute set). The scope name and version are length-prefixed
-/// *positional* fields, not key-value entries, so they are skipped over and
-/// never become synthetic `scope.name`/`scope.version` keys.
+/// bytes) into `(key, value)` pairs, resource entries first, then scope
+/// entries. The scope name and version are length-prefixed *positional*
+/// fields, not key-value entries, so they never become synthetic
+/// `scope.name`/`scope.version` keys. Delegates the actual decode to
+/// [`ravel_logseg::record::decode_stream_attrs`], the structured, full-fidelity
+/// decoder shared with the reader.
 ///
-/// A top-level entry whose value is a nested `Map` or `List` is walked past
-/// (consumed, so decoding stays in frame) but **omitted** from the returned
-/// pairs: a resource/scope attribute whose value is itself a map or list is not
+/// A top-level entry whose value is itself a `Map` or `List` is decoded (so
+/// the underlying walk stays in frame) but **omitted** from the returned
+/// pairs: a resource/scope attribute whose value is a map or list is not
 /// projected into the map column (a richer typed representation is a v-next
 /// refinement). Per-record dynamic attributes with nested values are unaffected
 /// -- they are merged in verbatim by [`merged_attrs`] and rendered by
 /// [`attr_value_to_string`].
 pub(crate) fn decode_stream_attrs(blob: &[u8]) -> DFResult<Vec<(String, AttrValue)>> {
-    let mut pos = 0usize;
-    let mut out = Vec::new();
-    // Resource attribute set.
-    decode_attr_set(blob, &mut pos, 0, &mut out)?;
-    // Scope name and scope version, each a length-prefixed string (positional).
-    skip_len_prefixed(blob, &mut pos)?;
-    skip_len_prefixed(blob, &mut pos)?;
-    // Scope attribute set.
-    decode_attr_set(blob, &mut pos, 0, &mut out)?;
-    Ok(out)
-}
-
-/// Walk one canonical attribute set from `pos`, advancing `pos` to its end, and
-/// push every top-level scalar entry as a decoded `(key, value)` pair onto
-/// `out`. A nested `Map`/`List` value is consumed but not pushed (see
-/// [`decode_stream_attrs`]).
-fn decode_attr_set(
-    buf: &[u8],
-    pos: &mut usize,
-    depth: u32,
-    out: &mut Vec<(String, AttrValue)>,
-) -> DFResult<()> {
-    if depth > MAX_ATTR_DEPTH {
-        return Err(corrupt("stream_attrs nesting too deep"));
-    }
-    let count = read_uvarint(buf, pos)?;
-    if count > MAX_ATTR_ENTRIES {
-        return Err(corrupt("stream_attrs entry count over cap"));
-    }
-    for _ in 0..count {
-        let klen = usize_of(read_uvarint(buf, pos)?)?;
-        let kstart = *pos;
-        advance(buf, pos, klen)?;
-        let kbytes = &buf[kstart..*pos];
-        if let Some(value) = decode_value(buf, pos, depth + 1)? {
-            let key = std::str::from_utf8(kbytes)
-                .map_err(|_| corrupt("stream_attrs key not utf-8"))?
-                .to_string();
-            out.push((key, value));
-        }
-    }
-    Ok(())
-}
-
-/// Decode one encoded attribute value at `pos` (frozen grammar,
-/// `ravel_types::logstream`: 1=Str 2=I64 3=F64 4=Bool 5=Bytes 6=List 7=Map),
-/// advancing `pos` past it. Returns the decoded scalar, or `None` for a
-/// `List`/`Map`, which is consumed via the [`skip_value`]/[`walk_attr_set`]
-/// walkers but not decoded into an entry.
-fn decode_value(buf: &[u8], pos: &mut usize, depth: u32) -> DFResult<Option<AttrValue>> {
-    if depth > MAX_ATTR_DEPTH {
-        return Err(corrupt("stream_attrs nesting too deep"));
-    }
-    let tag = read_u8(buf, pos)?;
-    let value = match tag {
-        // Str: length-prefixed UTF-8 payload.
-        1 => {
-            let len = usize_of(read_uvarint(buf, pos)?)?;
-            let start = *pos;
-            advance(buf, pos, len)?;
-            let s = std::str::from_utf8(&buf[start..*pos])
-                .map_err(|_| corrupt("stream_attrs str not utf-8"))?
-                .to_string();
-            Some(AttrValue::Str(s))
-        }
-        // I64: a single zigzag varint.
-        2 => Some(AttrValue::I64(unzigzag(read_uvarint(buf, pos)?))),
-        // F64: eight little-endian bytes of `to_bits` (NaN payloads / -0.0
-        // preserved by decoding through the bit pattern).
-        3 => {
-            let start = *pos;
-            advance(buf, pos, 8)?;
-            let mut b = [0u8; 8];
-            b.copy_from_slice(&buf[start..*pos]);
-            Some(AttrValue::F64(f64::from_bits(u64::from_le_bytes(b))))
-        }
-        // Bool: one byte.
-        4 => Some(AttrValue::Bool(read_u8(buf, pos)? != 0)),
-        // Bytes: length-prefixed payload.
-        5 => {
-            let len = usize_of(read_uvarint(buf, pos)?)?;
-            let start = *pos;
-            advance(buf, pos, len)?;
-            Some(AttrValue::Bytes(buf[start..*pos].to_vec()))
-        }
-        // List: a count then each element; consumed, not decoded.
-        6 => {
-            let n = read_uvarint(buf, pos)?;
-            for _ in 0..n {
-                skip_value(buf, pos, depth + 1)?;
-            }
-            None
-        }
-        // Map: a nested canonical attribute set; consumed, not decoded.
-        7 => {
-            walk_attr_set(buf, pos, depth + 1)?;
-            None
-        }
-        _ => return Err(corrupt("bad stream_attrs value tag")),
-    };
-    Ok(value)
-}
-
-/// Inverse of the writer's zigzag mapping (`ravel_types::logstream`): recover a
-/// signed integer from its unsigned LEB128 zigzag form.
-fn unzigzag(n: u64) -> i64 {
-    ((n >> 1) as i64) ^ -((n & 1) as i64)
-}
-
-/// Walk one canonical attribute set from `pos`, advancing `pos` to its end,
-/// consuming every entry without decoding it. Used to skip past a nested `Map`
-/// value while staying byte-aligned.
-fn walk_attr_set(buf: &[u8], pos: &mut usize, depth: u32) -> DFResult<()> {
-    if depth > MAX_ATTR_DEPTH {
-        return Err(corrupt("stream_attrs nesting too deep"));
-    }
-    let count = read_uvarint(buf, pos)?;
-    if count > MAX_ATTR_ENTRIES {
-        return Err(corrupt("stream_attrs entry count over cap"));
-    }
-    for _ in 0..count {
-        let klen = usize_of(read_uvarint(buf, pos)?)?;
-        advance(buf, pos, klen)?;
-        skip_value(buf, pos, depth + 1)?;
-    }
-    Ok(())
-}
-
-/// Advance `pos` past one encoded attribute value (frozen grammar,
-/// `ravel_types::logstream`: 1=Str 2=I64 3=F64 4=Bool 5=Bytes 6=List 7=Map).
-fn skip_value(buf: &[u8], pos: &mut usize, depth: u32) -> DFResult<()> {
-    if depth > MAX_ATTR_DEPTH {
-        return Err(corrupt("stream_attrs nesting too deep"));
-    }
-    let tag = read_u8(buf, pos)?;
-    match tag {
-        // Str / Bytes: length-prefixed payload.
-        1 | 5 => {
-            let len = usize_of(read_uvarint(buf, pos)?)?;
-            advance(buf, pos, len)?;
-        }
-        // I64: a single zigzag varint.
-        2 => {
-            read_uvarint(buf, pos)?;
-        }
-        // F64: eight little-endian bytes.
-        3 => advance(buf, pos, 8)?,
-        // Bool: one byte.
-        4 => advance(buf, pos, 1)?,
-        // List: a count then each element.
-        6 => {
-            let n = read_uvarint(buf, pos)?;
-            for _ in 0..n {
-                skip_value(buf, pos, depth + 1)?;
-            }
-        }
-        // Map: a nested canonical attribute set.
-        7 => {
-            walk_attr_set(buf, pos, depth + 1)?;
-        }
-        _ => return Err(corrupt("bad stream_attrs value tag")),
-    }
-    Ok(())
-}
-
-/// Skip a length-prefixed string (the scope name / version fields).
-fn skip_len_prefixed(buf: &[u8], pos: &mut usize) -> DFResult<()> {
-    let len = usize_of(read_uvarint(buf, pos)?)?;
-    advance(buf, pos, len)
-}
-
-fn read_u8(buf: &[u8], pos: &mut usize) -> DFResult<u8> {
-    let b = *buf
-        .get(*pos)
-        .ok_or_else(|| corrupt("stream_attrs truncated"))?;
-    *pos += 1;
-    Ok(b)
-}
-
-fn advance(buf: &[u8], pos: &mut usize, n: usize) -> DFResult<()> {
-    let end = pos
-        .checked_add(n)
-        .ok_or_else(|| corrupt("stream_attrs length overflow"))?;
-    if end > buf.len() {
-        return Err(corrupt("stream_attrs truncated"));
-    }
-    *pos = end;
-    Ok(())
-}
-
-/// Read one unsigned LEB128 varint, rejecting an over-long encoding rather than
-/// looping or overflowing.
-fn read_uvarint(buf: &[u8], pos: &mut usize) -> DFResult<u64> {
-    let mut result = 0u64;
-    let mut shift = 0u32;
-    loop {
-        if shift >= 64 {
-            return Err(corrupt("stream_attrs varint overflow"));
-        }
-        let byte = read_u8(buf, pos)?;
-        result |= u64::from(byte & 0x7f) << shift;
-        if byte & 0x80 == 0 {
-            break;
-        }
-        shift += 7;
-    }
-    Ok(result)
-}
-
-fn usize_of(v: u64) -> DFResult<usize> {
-    usize::try_from(v).map_err(|_| corrupt("stream_attrs length exceeds usize"))
+    let attrs =
+        ravel_logseg::record::decode_stream_attrs(blob).map_err(|e| corrupt(&e.to_string()))?;
+    Ok(attrs
+        .resource
+        .into_iter()
+        .chain(attrs.scope_attrs)
+        .filter(|(_, v)| !matches!(v, AttrValue::Map(_) | AttrValue::List(_)))
+        .collect())
 }
 
 fn corrupt(what: &str) -> DataFusionError {


### PR DESCRIPTION
ADR-1103 exposes the logs signal to the PromQL engine as two reserved
metric names, ravel_log_lines and ravel_log_bytes, with one sample per
log record. Nothing bridged RLOG records into the evaluator's series
source.

This adds the self-contained series source in ravel-query: the routing
rule (exact __name__ equality on a reserved name), the label mapping from
a record's stream identity under the metrics job/instance and
sanitization rules plus severity_text, a STREAM_DIR-only discovery read
per candidate object that evaluates stream-level matchers exactly and
hands the projected scan a StreamIn predicate, per-record __body__ and
severity filters with PromQL anchoring, pending-erasure exclusion before
a record becomes a sample, and the samples, series, bytes, and deadline
budgets checked per block and per segment. ravel-logseg gains the
structured decoder for the stream-attribute blob, which ravel-sql now
delegates to. Nothing in production calls the module yet; the engine
wiring is #1108.

Part of epic #1103 (wave 1, task T1a). Reviewed twice by adversarial
checkpoint; the second pass follows a fix commit for a silently ignored
__body__ matcher, a full-object discovery read, and four uncovered lines.

Fixes: #1106

Gates: this exact tree ran fmt, workspace clippy, the full workspace test and doctest suites, the sql clippy and test lanes, and the flight-sql clippy lane locally and passed; the run was stopped inside the final flight-sql test lane for disk headroom (another session was building on the same volume), so that lane is carried by the required PR check rather than a local receipt.
