### PR TITLE
test(query): observe both page_fetch closes in the carried-footer test

### DIFF
--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -4065,9 +4065,20 @@ mod tests {
     /// ambient one. Before the fix, this test fails: the collector observes
     /// `s3_requests`/`s3_bytes` recorded on `"request_span"`.
     #[tokio::test]
+    // Holds the test_tracing serialization guard across `.await`; the
+    // current-thread test runtime runs this future to completion with no other
+    // task, so there is no deadlock risk the lint guards against.
+    #[allow(clippy::await_holding_lock)]
     async fn phase_spans_never_record_onto_the_ambient_span_when_disabled() {
         use tracing_subscriber::layer::SubscriberExt;
         use tracing_subscriber::util::SubscriberInitExt;
+
+        // This installs an INFO-only subscriber, whose max-level hint is
+        // process-global: while it is the default it disables every
+        // `debug_span!` on every thread. A concurrent test that counts such
+        // spans would silently miss them. Hold the shared guard so this test
+        // never overlaps those (see `crate::test_tracing`).
+        let _serial = crate::test_tracing::guard();
 
         let collector = RecordCollector::default();
         let subscriber = tracing_subscriber::registry()

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -15,6 +15,8 @@ mod phase_accounting;
 mod query_admission;
 mod segment_admission;
 pub mod span_fetcher;
+#[cfg(test)]
+pub(crate) mod test_tracing;
 
 pub use config::{
     ByteLimit, DEFAULT_DEADLINE, DEFAULT_FETCH_CONCURRENCY, DEFAULT_LOG_MAX_FETCH_RUN_BYTES,

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -6350,7 +6350,18 @@ mod plan_skip_decidable_span_tests {
     /// would route through and which this test's own sibling `plan_segment`
     /// tests, several of which also open `page_fetch` spans, would pollute.
     #[tokio::test]
+    // Holds the test_tracing serialization guard across `.await`; the
+    // current-thread test runtime runs this future to completion with no other
+    // task, so there is no deadlock risk the lint guards against.
+    #[allow(clippy::await_holding_lock)]
     async fn skip_decidable_branch_opens_page_fetch_span() {
+        // Counts a `debug_span!` `page_fetch` span, so it is subject to the same
+        // process-global max-level race as
+        // `a_carried_footer_is_counted_once_across_plan_and_scan`. The guard
+        // pins the global level floor at TRACE and serializes against any
+        // concurrent sub-DEBUG subscriber; see crate::test_tracing.
+        let _serial = crate::test_tracing::guard();
+
         let collector = PageFetchCollector::default();
         let subscriber = tracing_subscriber::registry().with(collector.clone());
         let _guard = subscriber.set_default();
@@ -6450,7 +6461,21 @@ mod plan_skip_decidable_span_tests {
     /// predicate-free half alone; hardcoding it to `false` (no gate at all)
     /// fails the NumRange half alone.
     #[tokio::test]
+    // Holds the test_tracing serialization guard across `.await`; the
+    // current-thread test runtime runs this future to completion with no other
+    // task, so there is no deadlock risk the lint guards against.
+    #[allow(clippy::await_holding_lock)]
     async fn a_carried_footer_is_counted_once_across_plan_and_scan() {
+        // The `page_fetch` spans this counts are `debug_span!`s, so they are
+        // enabled only while the process-global max-level hint is at least
+        // DEBUG. That hint is a single atomic recomputed by callsite churn on
+        // every thread, and a default-less thread lowers it to OFF, while a
+        // sibling INFO-only subscriber lowers it to INFO; either silently
+        // disables one of the two spans and drops the count to 1. The guard
+        // pins the floor at TRACE and serializes against the sub-DEBUG
+        // subscriber (see crate::test_tracing).
+        let _serial = crate::test_tracing::guard();
+
         // (query, plan-phase misses, scan-phase misses). The predicate-free
         // query takes `plan_segment_fast`, whose `fetch_footer` reads no tail
         // section and counts nothing, leaving both misses to the scan. The

--- a/crates/ravel-query/src/test_tracing.rs
+++ b/crates/ravel-query/src/test_tracing.rs
@@ -1,0 +1,62 @@
+//! Support for tests that open and count `debug_span!`-level spans while the
+//! crate's unit tests share one process (`cargo test --lib`, the coverage lane).
+//!
+//! Two process-global properties of `tracing` make such a test flaky under the
+//! parallel harness, and this module neutralizes both:
+//!
+//! 1. Whether a `debug_span!` is enabled at all is gated by a single global
+//!    max-level atomic (`LevelFilter::current()`). That atomic is recomputed
+//!    every time any thread registers a new callsite or installs/drops a
+//!    default subscriber, and each recompute sets it from the *recomputing
+//!    thread's* current subscriber. A thread with no thread-local default falls
+//!    back to the process default, which is `NoSubscriber` (max-level hint
+//!    `OFF`). So while hundreds of tests on parallel threads churn callsites and
+//!    thread-local defaults, the atomic briefly drops to `OFF`, and a
+//!    `debug_span!` created in that window on another thread is silently
+//!    disabled -- never opened, never counted. [`install_floor`] pins a process
+//!    default whose hint is `TRACE`, so every recompute floors the atomic at
+//!    `TRACE` and the span is always enabled. It is a bare `Registry` with no
+//!    collecting layer, and a test's own `set_default` subscriber takes
+//!    precedence for span dispatch, so this default never observes any test's
+//!    spans -- it exists only to hold the level floor.
+//!
+//! 2. A subscriber whose max-level hint is below `DEBUG` (an `INFO`-only
+//!    subscriber) lowers that same atomic to `INFO` on its own thread while it
+//!    is the default, disabling `debug_span!` on every other thread for that
+//!    window. A test that installs such a subscriber and a test that counts
+//!    debug spans must therefore not run at the same time. [`guard`] returns a
+//!    process-wide lock that both kinds of test hold for their whole body, so
+//!    they never overlap.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::{LazyLock, Mutex, MutexGuard, Once};
+
+use tracing_subscriber::util::SubscriberInitExt;
+
+static TRACING_LEVEL_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+static FLOOR: Once = Once::new();
+
+/// Install, once for the process, a bare `Registry` as the global default so
+/// the global max-level atomic is floored at `TRACE`. Idempotent: only the
+/// first call installs anything, and it is a no-op if a global default is
+/// already set (`set_default` on the registry returns an error we ignore).
+fn install_floor() {
+    FLOOR.call_once(|| {
+        // A no-op registry: it allocates span ids and drops them, records
+        // nothing, and is overridden on any thread that sets its own default.
+        // Its only job is to keep `LevelFilter::current()` at TRACE.
+        let _ = tracing_subscriber::registry().try_init();
+    });
+}
+
+/// Acquire the process-wide guard for a tracing-level-sensitive test and ensure
+/// the global level floor is installed. Hold the returned guard for the whole
+/// test body: it serializes this test against every other test that either
+/// counts debug spans or installs a sub-`DEBUG` subscriber.
+pub(crate) fn guard() -> MutexGuard<'static, ()> {
+    install_floor();
+    TRACING_LEVEL_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}


### PR DESCRIPTION
The carried-footer test in the log fetcher counted `page_fetch` spans on a thread-local subscriber and occasionally saw one close instead of two in the coverage lane. The cause was none of the three hypotheses in the ticket. Whether a debug span is enabled is gated by a process-global max-level atomic that tracing recomputes on every callsite registration and every default-subscriber install or drop, using the recomputing thread's current subscriber. A worker thread with no thread-local default falls back to the process default subscriber, whose hint is off, and a sibling test that installs an info-only subscriber lowers the same atomic to info. Either window drops the global level below debug while the test runs, so a span created on the test's own thread is disabled at creation and never opened, closed, or counted.

Reproduced 7 failures in 40 full-binary runs under the coverage lane's flags; instrumentation at the span site showed the span disabled at creation. Serializing the three level-sensitive tests alone did not fix it (12 of 50 still failed), because any default-less registration resets the atomic.

The fix is a test-only helper that installs, once per process, a registry with no layers as the global default, which floors the level atomic at trace without observing any spans (each test's thread-local subscriber keeps dispatch precedence, so tests still cannot see each other's spans), plus a shared guard that serializes the level-sensitive tests against the info-only installer, whose thread-local hint a floor cannot cover. The two sibling span-counting tests hold the same guard. After the fix: 0 failures in 50 coverage runs and 0 in 10 normal runs.

The dispatch asked to avoid a process-global subscriber to keep tests from observing each other's spans; a layer-free registry observes nothing and is the only mechanism that pins the level floor, so it is used deliberately.

Fleet task b58c3cdb-c5ab-4a88-a824-a20be117026a, cherry-picked onto current main.

Fixes: #1143
Refs: #1040