### PR TITLE
fix(catalog): floor the alerts and audit scan set at pinned shards

### DIFF
--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -1621,7 +1621,8 @@ impl Catalog {
             // decision and `list_window_by_prefix`'s shard loop must agree on
             // that wider bound so the decision stays consistent with what is
             // scanned.
-            let suffix_scan_shards = crate::provisioning::max_scan_count_over_range(
+            let suffix_scan_shards = crate::provisioning::scan_shards_over_range(
+                signal,
                 &generations,
                 listing_start_hour,
                 window_end_hour,
@@ -1881,7 +1882,7 @@ impl Catalog {
     /// costs 8 LISTs, not 24.
     ///
     /// The per-shard LIST bound is the union scan set over the suffix
-    /// ([`crate::provisioning::max_scan_count_over_range`]): a per-shard LIST
+    /// ([`crate::provisioning::scan_shards_over_range`]): a per-shard LIST
     /// cannot vary its shard bound per hour, so it lists up to the max seen
     /// over the range. A bucket whose shard index is outside its OWN hour's
     /// `scan_count` is then dropped before `process_bucket`, so the INCLUDED
@@ -1904,8 +1905,10 @@ impl Catalog {
         accounting: &QueryAccounting,
     ) -> Result<HashMap<String, SegmentRef>, CatalogError> {
         // Union scan set over the suffix: the widest per-shard bound any hour
-        // in the range needs (a per-shard LIST cannot vary per hour).
-        let scan_shards = crate::provisioning::max_scan_count_over_range(
+        // in the range needs (a per-shard LIST cannot vary per hour), floored
+        // at the signal's writer-pinned shards.
+        let scan_shards = crate::provisioning::scan_shards_over_range(
+            signal,
             generations,
             listing_start_hour,
             window_end_hour,
@@ -1936,7 +1939,12 @@ impl Catalog {
                 // retiring generation's higher shards past their slack window).
                 // Drop those buckets so the included set matches the
                 // per-(shard, hour) loop exactly, which never listed them.
-                let hour_scan = crate::provisioning::scan_count(
+                // Floored at the signal's writer-pinned shards (ADR-1101
+                // decision 2), the same floor the union bound above applies:
+                // an unfloored check here would list an alerts/audit writer's
+                // pinned shard and then discard it.
+                let hour_scan = crate::provisioning::scan_shards_for_hour(
+                    signal,
                     generations,
                     hour,
                     crate::provisioning::DEFAULT_SCAN_SLACK_HOURS,
@@ -2379,7 +2387,9 @@ impl Catalog {
         let tenant_prefix = format!("t/{}/", tenant.to_hex());
         // Shard bound is the union scan set over every hour in the listing
         // suffix (ADR-0052 section 4), not the static
-        // `self.config.shard_count`. `max_scan_count_over_range` keeps a
+        // `self.config.shard_count`, and floored at the signal's
+        // writer-pinned shards (ADR-1101 decision 2).
+        // `max_scan_count_over_range` keeps a
         // retiring larger generation's higher shard indices in scope for
         // `DEFAULT_SCAN_SLACK_HOURS` past its successor's activation, so on a
         // shard-count decrease a straggler routed under the old count into an
@@ -2387,7 +2397,8 @@ impl Catalog {
         // ([`Catalog::list_window_bounded`]) uses this same bound; a per-shard
         // recursive LIST cannot vary the bound per hour, so it takes the max
         // over the range.
-        let scan_shards = crate::provisioning::max_scan_count_over_range(
+        let scan_shards = crate::provisioning::scan_shards_over_range(
+            signal,
             generations,
             listing_start_hour,
             window_end_hour,
@@ -3621,6 +3632,8 @@ fn build_segment_ref(key: &str, record: &CommitRecord) -> Result<SegmentRef, Cat
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use bytes::Bytes;
     use ravel_commit::publish::{self, RetryPolicy};
     use ravel_commit::record::NewCommitRecord;
@@ -3649,9 +3662,35 @@ mod tests {
     }
 
     /// Build, PUT the data object, and publish a fully self-consistent
-    /// commit record for one segment. Each call uses a fresh writer id.
+    /// commit record for one segment under [`Signal::Metrics`]. Each call uses
+    /// a fresh writer id. [`publish_segment_for`] is the same for any signal.
     async fn publish_segment(
         store: &MemoryStore,
+        shard: u32,
+        seq: u64,
+        ingest_hour_bucket: u32,
+        created_unix_ns: i64,
+        min_event_ts_ns: i64,
+        max_event_ts_ns: i64,
+    ) -> CommitRecord {
+        publish_segment_for(
+            store,
+            Signal::Metrics,
+            shard,
+            seq,
+            ingest_hour_bucket,
+            created_unix_ns,
+            min_event_ts_ns,
+            max_event_ts_ns,
+        )
+        .await
+    }
+
+    /// [`publish_segment`] for an arbitrary signal.
+    #[allow(clippy::too_many_arguments)]
+    async fn publish_segment_for(
+        store: &MemoryStore,
+        signal: Signal,
         shard: u32,
         seq: u64,
         ingest_hour_bucket: u32,
@@ -3664,7 +3703,7 @@ mod tests {
         let content_hash = content_hash_for(&payload);
         let record = record::build(NewCommitRecord {
             tenant_hash: tenant(),
-            signal: Signal::Metrics,
+            signal,
             shard,
             writer_id,
             writer_epoch: 1,
@@ -3690,6 +3729,141 @@ mod tests {
             .await
             .expect("publish");
         record
+    }
+
+    /// ADR-1101 decision 2, the read-side shard floor: the audit writers pin
+    /// shards 0 (`AUDIT_HOLD_SHARD`) and 1 (`QUERY_AUDIT_SHARD`) by constant,
+    /// and audit is never provisioned, so a `--shards 1` process resolves it
+    /// through the implicit generation 0 at count 1. Without the floor the
+    /// scan set is shard 0 alone and every query-audit record is silently
+    /// missing from the snapshot. `resolve_pruned_with_admission` is the exact
+    /// entry point `ravel-sql`'s executor calls for every SQL query.
+    ///
+    /// FLIP (pre-fix demonstration): make `Signal::fixed_read_shards` return
+    /// `0` for `Signal::Audit` (crates/ravel-types/src/lib.rs, the
+    /// `Signal::Audit => 2` arm). The key-set assertion then sees only the
+    /// shard 0 key, and the LIST count drops from 3 to 2.
+    #[tokio::test]
+    async fn an_audit_resolve_under_one_configured_shard_lists_the_query_audit_shard() {
+        let store = Arc::new(MemoryStore::new());
+        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+        let hour = 500_000u32;
+        let now = i64::from(hour) * NS_PER_HOUR + 30 * 60_000_000_000;
+
+        // One record on each shard the audit writers pin. Written as literals
+        // rather than the constants themselves: those live in ravel-maintain,
+        // which depends on this crate. `const _` assertions beside each
+        // constant pin them to this floor.
+        let hold =
+            publish_segment_for(&store, Signal::Audit, 0, 1, hour, now, now - 1_000, now).await;
+        let query_audit =
+            publish_segment_for(&store, Signal::Audit, 1, 1, hour, now, now - 1_000, now).await;
+
+        let range = TimeRange {
+            start_ns: now - 1_000,
+            end_ns: now,
+        };
+        let accounting = QueryAccounting::new();
+        let (snapshot, _origins) = catalog
+            .resolve_pruned_with_admission(
+                &tenant(),
+                Signal::Audit,
+                range,
+                &[],
+                now,
+                None,
+                &accounting,
+            )
+            .await
+            .expect("audit resolve");
+
+        let resolved: BTreeSet<String> = snapshot
+            .segments
+            .iter()
+            .map(|seg| seg.data_object_key.clone())
+            .collect();
+        let expected: BTreeSet<String> = [&hold, &query_audit]
+            .into_iter()
+            .map(|record| keys::reconstruct_data_key(record).expect("data key"))
+            .collect();
+        assert_eq!(resolved, expected);
+
+        // LIST derivation, config(1) with provisioning enforcement off:
+        //   - `read_scan_generations` issues no request (enforcement off, so
+        //     the single implicit generation 0 at shard_count 1 is synthesized
+        //     with no store read), and the snapshot window path only GETs.
+        //   - the window is hours 499998..=500000 (3 hours) and the floored
+        //     scan set is 2 shards, so 6 buckets, well under the 720-bucket
+        //     prefix crossover: `list_window_bounded` runs and issues one
+        //     bounded LIST per shard in `0..2`, one page each (MemoryStore's
+        //     default page size is 1000, and there are 2 objects total).
+        //   - `list_pending_erasure` drains the empty `del/` prefix in one
+        //     page: 1 LIST.
+        // Total: 2 + 1 = 3.
+        assert_eq!(accounting.snapshot().s3_requests(AccountedOp::List), 3);
+    }
+
+    /// The control for
+    /// `an_audit_resolve_under_one_configured_shard_lists_the_query_audit_shard`:
+    /// the floor is per signal, not a global widening. Logs has no pinned
+    /// writers, so the same store and the same `config(1)` scan shard 0 only,
+    /// leave a shard 1 record unlisted, and cost exactly one LIST less.
+    ///
+    /// FLIP (pre-fix demonstration): make `Signal::fixed_read_shards` return
+    /// `1` for `Signal::Logs` (add a `Signal::Logs => 1` arm in
+    /// crates/ravel-types/src/lib.rs). Nothing changes -- the floor 1 equals
+    /// the configured count. Returning `2` for `Signal::Logs` makes both
+    /// assertions fail (the shard 1 key appears and the LIST count rises to
+    /// 3), which is what pins the per-signal scoping.
+    #[tokio::test]
+    async fn a_logs_resolve_under_one_configured_shard_lists_only_shard_zero() {
+        let store = Arc::new(MemoryStore::new());
+        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+        let hour = 500_000u32;
+        let now = i64::from(hour) * NS_PER_HOUR + 30 * 60_000_000_000;
+
+        let shard_zero =
+            publish_segment_for(&store, Signal::Logs, 0, 1, hour, now, now - 1_000, now).await;
+        let shard_one =
+            publish_segment_for(&store, Signal::Logs, 1, 1, hour, now, now - 1_000, now).await;
+
+        let range = TimeRange {
+            start_ns: now - 1_000,
+            end_ns: now,
+        };
+        let accounting = QueryAccounting::new();
+        let (snapshot, _origins) = catalog
+            .resolve_pruned_with_admission(
+                &tenant(),
+                Signal::Logs,
+                range,
+                &[],
+                now,
+                None,
+                &accounting,
+            )
+            .await
+            .expect("logs resolve");
+
+        let resolved: BTreeSet<String> = snapshot
+            .segments
+            .iter()
+            .map(|seg| seg.data_object_key.clone())
+            .collect();
+        let expected: BTreeSet<String> =
+            [keys::reconstruct_data_key(&shard_zero).expect("data key")]
+                .into_iter()
+                .collect();
+        assert_eq!(resolved, expected);
+        assert!(
+            !resolved.contains(&keys::reconstruct_data_key(&shard_one).expect("data key")),
+            "logs has no pinned writers, so shard 1 is outside a --shards 1 scan set"
+        );
+
+        // Same derivation as the audit case with an unfloored scan set of 1
+        // shard: 1 bounded LIST for shard 0, plus 1 for the empty `del/`
+        // prefix. Total 2, exactly one fewer than audit's 3.
+        assert_eq!(accounting.snapshot().s3_requests(AccountedOp::List), 2);
     }
 
     #[tokio::test]

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -2389,7 +2389,7 @@ impl Catalog {
         // suffix (ADR-0052 section 4), not the static
         // `self.config.shard_count`, and floored at the signal's
         // writer-pinned shards (ADR-1101 decision 2).
-        // `max_scan_count_over_range` keeps a
+        // `scan_shards_over_range` (through `max_scan_count_over_range`) keeps a
         // retiring larger generation's higher shard indices in scope for
         // `DEFAULT_SCAN_SLACK_HOURS` past its successor's activation, so on a
         // shard-count decrease a straggler routed under the old count into an

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -64,7 +64,8 @@ pub use provisioning::{
     append_generation, current_floor, current_floor_from_store, max_scan_count_over_range,
     provisioning_key, raise_format_floor, read_floors, read_floors_checked, read_floors_from_store,
     read_generations, read_generations_checked, read_generations_from_store, scan_count,
-    shard_ceiling, stable_generation_for_hour, validate_or_adopt,
+    scan_shards_for_hour, scan_shards_over_range, shard_ceiling, stable_generation_for_hour,
+    validate_or_adopt,
 };
 pub use seal_divergence::{
     EntryIdentity, SealDivergenceError, SealDivergenceReport, verify_seal_divergence,

--- a/crates/ravel-catalog/src/provisioning.rs
+++ b/crates/ravel-catalog/src/provisioning.rs
@@ -575,6 +575,55 @@ pub fn max_scan_count_over_range(
     }
 }
 
+/// The scan-set width a reader must use over `[start_hour, end_hour]` for
+/// `signal`: [`max_scan_count_over_range`] floored at the signal's
+/// writer-pinned shard count (ADR-1101 decision 2).
+///
+/// Alerts and audit writers pin fixed shard indices by constant
+/// (`ALERT_SHARD`, `AUDIT_HOLD_SHARD`, `QUERY_AUDIT_SHARD`) instead of hashing
+/// a series into `0..shard_count`, and neither signal is ever provisioned, so
+/// both resolve through the implicit generation 0 at the process
+/// `shard_count`. Without the floor a `--shards 1` deployment derives a scan
+/// set of shard 0 alone and silently omits every record the query-audit writer
+/// pinned to shard 1. The floor is a floor, never a cap: a wider generation
+/// history or a larger configured `shard_count` still wins.
+///
+/// This is the ONLY function the catalog's over-a-range scan-set derivations
+/// may call. Calling [`max_scan_count_over_range`] directly from a read path
+/// reintroduces the silent miss, and having each derivation apply its own
+/// floor lets them disagree about how wide the fan-out is; the crossover
+/// decision and the path it selects must agree exactly.
+/// [`scan_shards_for_hour`] is the per-hour sibling.
+pub fn scan_shards_over_range(
+    signal: Signal,
+    generations: &[ShardGeneration],
+    start_hour: u32,
+    end_hour: u32,
+    slack_hours: u32,
+) -> u32 {
+    max_scan_count_over_range(generations, start_hour, end_hour, slack_hours)
+        .max(signal.fixed_read_shards())
+}
+
+/// The scan-set width a reader must use for the single ingest-hour bucket
+/// `hour` for `signal`: [`scan_count`] floored at the signal's writer-pinned
+/// shard count, the per-hour sibling of [`scan_shards_over_range`] and the
+/// same floor for the same reason (ADR-1101 decision 2).
+///
+/// The over-a-range bound and this per-hour bound are two halves of one rule:
+/// a per-shard LIST cannot vary its bound per hour, so it lists up to the
+/// range max and each listed bucket is then re-checked against its own hour.
+/// A floored range bound with an unfloored per-hour check lists the pinned
+/// shard and then discards it, which is the silent miss again one step later.
+pub fn scan_shards_for_hour(
+    signal: Signal,
+    generations: &[ShardGeneration],
+    hour: u32,
+    slack_hours: u32,
+) -> u32 {
+    scan_count(generations, hour, slack_hours).max(signal.fixed_read_shards())
+}
+
 /// The generation that *unambiguously* owns ingest-hour bucket `hour`, or
 /// `None` when more than one generation's shards can hold that hour's data
 /// (ADR-0103 decision 1(b)). The generation-identity sibling of [`scan_count`]:
@@ -2574,6 +2623,78 @@ mod tests {
             ),
             scan_count(&gens, last_covered_hour, DEFAULT_SCAN_SLACK_HOURS),
             "a single-hour range agrees with the per-hour rule"
+        );
+    }
+
+    /// The alerts and audit floor (ADR-1101 decision 2) raises a narrower
+    /// generation history and never caps a wider one.
+    ///
+    /// FLIP (pre-fix demonstration): make `Signal::fixed_read_shards` return
+    /// `0` for `Signal::Audit` (crates/ravel-types/src/lib.rs, the
+    /// `Signal::Audit => 2` arm). The `shard_count` 1 audit assertion then
+    /// reads 1 instead of 2.
+    #[test]
+    fn scan_shards_over_range_floors_at_the_signals_fixed_read_shards() {
+        // A single implicit generation at the process `shard_count`, exactly
+        // what `read_scan_generations` returns for an unprovisioned signal.
+        let narrow = [sg(0, 1, 0)];
+        assert_eq!(
+            scan_shards_over_range(Signal::Audit, &narrow, 0, 1_000, DEFAULT_SCAN_SLACK_HOURS),
+            2,
+            "audit pins shards 0 and 1, so a --shards 1 reader must scan both"
+        );
+        assert_eq!(
+            scan_shards_over_range(Signal::Alerts, &narrow, 0, 1_000, DEFAULT_SCAN_SLACK_HOURS),
+            1
+        );
+        assert_eq!(
+            scan_shards_over_range(Signal::Logs, &narrow, 0, 1_000, DEFAULT_SCAN_SLACK_HOURS),
+            1,
+            "no pinned writers: the history alone decides"
+        );
+        assert_eq!(
+            scan_shards_over_range(Signal::Metrics, &narrow, 0, 1_000, DEFAULT_SCAN_SLACK_HOURS),
+            1
+        );
+
+        // A floor, never a cap: every signal takes the wider history.
+        let wide = [sg(0, 4, 0)];
+        for signal in [Signal::Audit, Signal::Alerts, Signal::Logs, Signal::Metrics] {
+            assert_eq!(
+                scan_shards_over_range(signal, &wide, 0, 1_000, DEFAULT_SCAN_SLACK_HOURS),
+                4,
+                "signal {signal:?} takes the history's wider count, not the floor"
+            );
+        }
+    }
+
+    /// The per-hour sibling floors identically, so the union LIST bound and
+    /// the per-hour re-check in `list_window_bounded` cannot disagree about a
+    /// pinned shard.
+    ///
+    /// FLIP (pre-fix demonstration): the same `Signal::Audit => 2` arm; the
+    /// `shard_count` 1 audit assertion then reads 1.
+    #[test]
+    fn scan_shards_for_hour_floors_at_the_signals_fixed_read_shards() {
+        let narrow = [sg(0, 1, 0)];
+        assert_eq!(
+            scan_shards_for_hour(Signal::Audit, &narrow, 500_000, DEFAULT_SCAN_SLACK_HOURS),
+            2
+        );
+        assert_eq!(
+            scan_shards_for_hour(Signal::Alerts, &narrow, 500_000, DEFAULT_SCAN_SLACK_HOURS),
+            1
+        );
+        assert_eq!(
+            scan_shards_for_hour(Signal::Logs, &narrow, 500_000, DEFAULT_SCAN_SLACK_HOURS),
+            1
+        );
+
+        let wide = [sg(0, 4, 0)];
+        assert_eq!(
+            scan_shards_for_hour(Signal::Audit, &wide, 500_000, DEFAULT_SCAN_SLACK_HOURS),
+            4,
+            "floor, not cap"
         );
     }
 

--- a/crates/ravel-maintain/src/legal_hold.rs
+++ b/crates/ravel-maintain/src/legal_hold.rs
@@ -81,6 +81,10 @@ use crate::sweep::LeaseCheck;
 /// colocated for the fold; it is unrelated to the data shards a hold's scope
 /// may cover.
 pub const AUDIT_HOLD_SHARD: u32 = 0;
+// Moving this writer to a shard outside the reader's floor (ADR-1101
+// decision 2) fails the build here rather than silently dropping every
+// legal-hold record from audit queries.
+const _: () = assert!(AUDIT_HOLD_SHARD < Signal::Audit.fixed_read_shards());
 
 /// `attrs` key marking an audit record as a legal-hold record. An audit record
 /// without this key (an ordinary query/admin audit entry) is ignored here.

--- a/crates/ravel-maintain/src/query_audit.rs
+++ b/crates/ravel-maintain/src/query_audit.rs
@@ -57,8 +57,8 @@
 
 use ravel_logseg::{AttrValue, LogStreamId, stream_attrs_bytes};
 use ravel_object_store::ObjectStoreBackend;
-use ravel_types::TenantHash;
 use ravel_types::logstream::log_stream_id;
+use ravel_types::{Signal, TenantHash};
 use uuid::Uuid;
 
 use crate::audit_pipeline::AuditEvent;
@@ -68,6 +68,10 @@ use crate::error::Result;
 /// The [`Signal::Audit`] shard query-audit records are written to. Deliberately
 /// distinct from [`crate::legal_hold::AUDIT_HOLD_SHARD`] - see the module doc.
 pub const QUERY_AUDIT_SHARD: u32 = 1;
+// Moving this writer to a shard outside the reader's floor (ADR-1101
+// decision 2) fails the build here rather than silently dropping every
+// query-audit record from audit queries.
+const _: () = assert!(QUERY_AUDIT_SHARD < Signal::Audit.fixed_read_shards());
 
 /// `attrs` key marking an audit record's kind. A query-audit record carries
 /// [`KIND_QUERY`]; a legal-hold record carries `legal_hold`.

--- a/crates/ravel-types/src/lib.rs
+++ b/crates/ravel-types/src/lib.rs
@@ -41,6 +41,28 @@ impl Signal {
             Signal::Audit => "u",
         }
     }
+
+    /// The number of shards a reader must always scan for this signal, because
+    /// its writers pin fixed shard indices by constant rather than hashing a
+    /// series into `0..shard_count` (ADR-1101 decision 2).
+    ///
+    /// Three writers pin themselves this way: `ALERT_SHARD` (0) on
+    /// [`Signal::Alerts`], and `AUDIT_HOLD_SHARD` (0) plus
+    /// `QUERY_AUDIT_SHARD` (1) on [`Signal::Audit`]. Alerts and audit are
+    /// never provisioned, so they resolve through the implicit generation 0 at
+    /// the process `shard_count`; a `--shards 1` deployment would derive a
+    /// scan set of shard 0 only and silently miss every query-audit record.
+    ///
+    /// This is a floor, never a cap. The generation history and a larger
+    /// configured `shard_count` can only widen the scan set above it; they can
+    /// never narrow it below.
+    pub const fn fixed_read_shards(self) -> u32 {
+        match self {
+            Signal::Alerts => 1,
+            Signal::Audit => 2,
+            Signal::Metrics | Signal::Logs | Signal::Spans | Signal::Profiles => 0,
+        }
+    }
 }
 
 /// Logical tenant identifier as resolved by authentication. Never appears in
@@ -592,6 +614,28 @@ pub enum TypeError {
 mod tests {
     use super::*;
     use crate::logstream::LogStreamId;
+
+    /// Every signal is classified explicitly, by an exhaustive match rather
+    /// than a wildcard arm, so adding a variant later fails to compile here
+    /// until someone decides whether its writers pin a shard index.
+    #[test]
+    fn fixed_read_shards_is_zero_for_every_signal_without_pinned_writers() {
+        for signal in [
+            Signal::Metrics,
+            Signal::Logs,
+            Signal::Spans,
+            Signal::Profiles,
+            Signal::Alerts,
+            Signal::Audit,
+        ] {
+            let expected = match signal {
+                Signal::Alerts => 1,
+                Signal::Audit => 2,
+                Signal::Metrics | Signal::Logs | Signal::Spans | Signal::Profiles => 0,
+            };
+            assert_eq!(signal.fixed_read_shards(), expected, "signal {signal:?}");
+        }
+    }
 
     #[test]
     fn shard_for_log_matches_leading_bytes_mod_shard_count() {

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -192,7 +192,9 @@ every observed shard index is below the configured `shard_count`; a higher
 observed index proves the value would hide data and refuses without writing.
 `shard_count` is immutable per generation; the generation history is
 append-only; the shard-index domain of hour `h` is `0..scan_count(h)`
-(ADR-0052, online resharding). A reshard appends a
+(ADR-0052, online resharding), floored at `Signal::fixed_read_shards()` for
+the alerts and audit signals whose writers pin fixed shard indices (ADR-1101
+decision 2; see "Online resharding" below). A reshard appends a
 `(generation, shard_count, activation_hour)` entry to this record under
 `CasVersion` (`ravel_catalog::append_generation`); every existing byte of
 history is immutable, and the scalar `shard_count` field stays equal to
@@ -386,7 +388,9 @@ and the CAS read/write helpers.
 - `shard`: zero-padded 4-digit decimal. `shard_count` is immutable per
   generation; the generation history is append-only; the shard-index domain
   of hour `h` is `0..scan_count(h)` (ADR-0052, superseding ADR-0010 §9's
-  "immutable per (tenant, signal)"). A reshard appends a new generation with
+  "immutable per (tenant, signal)"), floored at `Signal::fixed_read_shards()`
+  for `a` and `u`, whose writers pin fixed shard indices (ADR-1101 decision
+  2). A reshard appends a new generation with
   a future `activation_hour`; existing data is never moved or re-keyed, and
   reads derive the per-hour shard set from the history.
 - `ingest_hour`: `YYYYMMDDTHH` UTC formatted from the pinned

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -1249,6 +1249,18 @@ generation was already active for is rejected loudly with a fail-closed
 hours were written under, and serving it would silently omit data below its own
 watermark.
 
+A read-side shard floor for the pinned signals. The alerts and audit writers do
+not hash a series into `0..shard_count`; they pin fixed shard indices by
+constant (`ALERT_SHARD` 0, `AUDIT_HOLD_SHARD` 0, `QUERY_AUDIT_SHARD` 1), and
+neither signal is ever provisioned, so both resolve through the implicit
+generation 0 at the process `shard_count`. A reader's scan set for hour `h` is
+therefore `max(scan_count(h), Signal::fixed_read_shards())` for every signal:
+1 for alerts, 2 for audit, 0 elsewhere (ADR-1101 decision 2). It is a floor
+only. A wider generation history or a larger configured `shard_count` raises
+the scan set above it and nothing lowers it below, so a `--shards 1`
+deployment still lists the query-audit shard instead of silently omitting every
+record pinned to it.
+
 Commit tokens are unaffected. A token minted under any generation resolves
 forever, because token resolution reconstructs the exact key from the token's
 own fields and never consults `shard_count` (ADR-0052 section 6).

--- a/services/ravel-server/src/alerting.rs
+++ b/services/ravel-server/src/alerting.rs
@@ -101,6 +101,10 @@ pub const DEFAULT_QUERY_DEADLINE: Duration = Duration::from_secs(30);
 /// write-path benefit. Fixed rather than configurable so a reader always knows
 /// where an alert history lives.
 pub const ALERT_SHARD: u32 = 0;
+// Moving this writer to a shard outside the reader's floor (ADR-1101
+// decision 2) fails the build here rather than silently dropping every alert
+// record from alerts queries.
+const _: () = assert!(ALERT_SHARD < Signal::Alerts.fixed_read_shards());
 
 /// The writer epoch every alert record carries. Flush identity is
 /// `(writer_id, epoch, seq)` and each evaluator task mints a fresh v4


### PR DESCRIPTION
The alert and audit writers pin their shards by constant: alerts on shard 0, legal-hold audit records on shard 0, query-audit records on shard 1. `Catalog::resolve` derives the shards it lists from the (tenant, signal) shard-generation history, and for a signal with no provisioning record that is the implicit generation 0 at the process `--shards` value. `ravel-cli provision adopt` provisions metrics, logs, and spans only, so alerts and audit always take that path, and a `--shards 1` deployment would list shard 0 and never the query-audit shard: an exact-looking, silently incomplete answer once the `audit` table is registered (#128).

`Signal::fixed_read_shards` (Alerts 1, Audit 2, every other signal 0) is a read-side floor. The catalog's scan-set derivations take the maximum of the generation history and that floor through two helpers in `provisioning.rs` (the range bound and the per-hour re-check that `list_window_bounded` applies after listing, which would otherwise have dropped the floored shard one step later). The writer constants pin themselves to the floor with compile-time assertions, so moving a writer past it fails the build rather than the query. The floor is a floor, never a cap: a wider history or `--shards` widens the scan exactly as before.

Tests pin the exact segment set and the exact LIST count of an audit resolve under `shard_count 1` through `resolve_pruned_with_admission`, with a logs control under the same config that lists one shard fewer; the floor helpers and the per-signal values have unit tests; the assertions were shown failing with the Audit floor set to 0.

ADR-1101 decision 2 (#1116).

Fixes: #1117
Refs: #1101
