### PR TITLE
fix(maintain): write erasure bucket drops and narrow the truncated hold

### DIFF
--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -1677,6 +1677,37 @@ async fn resolve_already_exists_rewrite(
     })
 }
 
+/// What one rewrite dropped in one bucket for one request: the bucket
+/// identity an `ErasureCompletion.bucket_drops` entry names, plus the request
+/// the count belongs to. A completion record is per request, so a driver
+/// collecting these across a scan needs the request id to route each count
+/// into the right record. The count is the row (metrics samples), log record,
+/// or span count that rewrite physically removed for that request in that
+/// bucket, and is zero for an applicable request the bucket held nothing for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppliedBucketDrop {
+    pub request_id: String,
+    pub signal: Signal,
+    pub shard: u32,
+    pub ingest_hour_bucket: u32,
+    pub dropped_count: u64,
+}
+
+/// The bucket's `drops` re-keyed to the bucket identity a completion record
+/// names, one entry per request the rewrite applied.
+fn applied_bucket_drops(bucket: &Bucket, drops: &[RewriteDrop]) -> Vec<AppliedBucketDrop> {
+    drops
+        .iter()
+        .map(|d| AppliedBucketDrop {
+            request_id: d.request_id.clone(),
+            signal: bucket.signal,
+            shard: bucket.shard,
+            ingest_hour_bucket: bucket.ingest_hour_bucket,
+            dropped_count: d.dropped_count,
+        })
+        .collect()
+}
+
 /// The result of an [`erasure_rewrite_bucket`] call. Every variant except
 /// [`ErasureRewriteOutcome::Rewritten`] means the bucket was left untouched,
 /// with the reason -- mirroring [`crate::compact::CompactionOutcome`]'s shape
@@ -1706,12 +1737,25 @@ pub enum ErasureRewriteOutcome {
     /// superseded target -- not the original L0 inputs) and lands a no-op
     /// `RewriteRecord` (`dropped_count: 0`) superseding the prior one,
     /// repeatable every pass, churning generations while erasing nothing.
-    AlreadyApplied,
+    ///
+    /// `request_ids` are the overlapping requests this bucket was skipped for,
+    /// in the order they were pending. Their dropped counts belong to a rewrite
+    /// generation an earlier pass published, so this pass cannot state them:
+    /// the live record's own `drops` carry `dropped_count: 0` for a request an
+    /// earlier generation in the same chain already erased. A driver collecting
+    /// [`AppliedBucketDrop`]s therefore knows, from this list, that its
+    /// collection is not the complete set of buckets that applied those
+    /// requests.
+    AlreadyApplied { request_ids: Vec<String> },
     /// Built and published (or converged / abandoned): `parts` output parts
-    /// written, `publish` records how the `RewriteRecord` PUT resolved.
+    /// written, `publish` records how the `RewriteRecord` PUT resolved, and
+    /// `drops` carries this bucket's dropped count for every request the
+    /// rewrite applied (one entry per applicable request, `dropped_count: 0`
+    /// included).
     Rewritten {
         parts: usize,
         publish: PublishOutcome,
+        drops: Vec<AppliedBucketDrop>,
     },
 }
 
@@ -1763,7 +1807,11 @@ fn invalidate_after_publish(memo: &mut MaintainMemo, bucket: &Bucket, publish: &
 /// that overlaps the bucket is batched into one build/publish call, so a
 /// bucket is never rewritten once per request -- one `RewriteRecord` per
 /// bucket per rewrite generation, with a `drops[]` entry (possibly
-/// `dropped_count: 0`) for every applicable request.
+/// `dropped_count: 0`) for every applicable request. A successful rewrite
+/// returns those drops to the caller as [`AppliedBucketDrop`]s so a driver
+/// scanning many buckets can write each request's completion record with the
+/// per-bucket counts that record's shape carries, without re-reading the
+/// rewrite records it just published.
 ///
 /// Every step through `overlapping` is signal-generic; only the
 /// matcher/build step below dispatches on `bucket.signal` to the metrics
@@ -1828,10 +1876,15 @@ pub async fn erasure_rewrite_bucket(
             .iter()
             .all(|p| applied.contains(&p.request.request_id))
     {
-        return Ok(ErasureRewriteOutcome::AlreadyApplied);
+        return Ok(ErasureRewriteOutcome::AlreadyApplied {
+            request_ids: overlapping
+                .iter()
+                .map(|p| p.request.request_id.clone())
+                .collect(),
+        });
     }
 
-    let (parts, publish) = match bucket.signal {
+    let (parts, drops, publish) = match bucket.signal {
         Signal::Metrics => {
             let applicable: Vec<ApplicableRequest> = overlapping
                 .iter()
@@ -1868,10 +1921,11 @@ pub async fn erasure_rewrite_bucket(
             )
             .await?;
             let parts = build.parts.len();
+            let drops = applied_bucket_drops(bucket, &build.drops);
             let publish =
                 publish_rewrite_record(store, config, clock, bucket, supersession, build, start_ns)
                     .await?;
-            (parts, publish)
+            (parts, drops, publish)
         }
         Signal::Logs => {
             let applicable: Vec<ApplicableLogRequest> = overlapping
@@ -1908,10 +1962,11 @@ pub async fn erasure_rewrite_bucket(
             )
             .await?;
             let parts = build.parts.len();
+            let drops = applied_bucket_drops(bucket, &build.drops);
             let publish =
                 publish_rewrite_record(store, config, clock, bucket, supersession, build, start_ns)
                     .await?;
-            (parts, publish)
+            (parts, drops, publish)
         }
         Signal::Spans => {
             let applicable: Vec<ApplicableSpanRequest> = overlapping
@@ -1948,10 +2003,11 @@ pub async fn erasure_rewrite_bucket(
             )
             .await?;
             let parts = build.parts.len();
+            let drops = applied_bucket_drops(bucket, &build.drops);
             let publish =
                 publish_rewrite_record(store, config, clock, bucket, supersession, build, start_ns)
                     .await?;
-            (parts, publish)
+            (parts, drops, publish)
         }
         other => {
             return Err(MaintainError::Invariant(format!(
@@ -1961,7 +2017,11 @@ pub async fn erasure_rewrite_bucket(
     };
 
     invalidate_after_publish(memo, bucket, &publish);
-    Ok(ErasureRewriteOutcome::Rewritten { parts, publish })
+    Ok(ErasureRewriteOutcome::Rewritten {
+        parts,
+        publish,
+        drops,
+    })
 }
 
 /// The catalog-resolver completion verdict for one bucket (ADR-0064 §4 F1).
@@ -2498,7 +2558,7 @@ mod tests {
         .expect("rewrite");
 
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!("expected Rewritten, got {other:?}"),
         };
         assert_eq!(parts, 1);
@@ -2813,8 +2873,11 @@ mod tests {
         .expect("pass 2 succeeds");
         assert_eq!(
             outcome2,
-            ErasureRewriteOutcome::AlreadyApplied,
-            "second pass over an already-rewritten bucket must skip, not republish"
+            ErasureRewriteOutcome::AlreadyApplied {
+                request_ids: vec![Uuid::from_u128(7).to_string()],
+            },
+            "second pass over an already-rewritten bucket must skip, not republish, \
+             and must name the request it skipped for"
         );
         let after2 = crate::read::list_bucket(&store, &bucket())
             .await
@@ -2935,7 +2998,7 @@ mod tests {
         .expect("rewrite must succeed even when >=2 live L0 commits share a series_id");
 
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!("expected Rewritten, got {other:?}"),
         };
         assert_eq!(parts, 1);
@@ -3007,7 +3070,7 @@ mod tests {
         .expect("rewrite");
 
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!(
                 "expected Rewritten -- a windowed request matching physically-stored \
                  event timestamps must select the bucket even when those timestamps \
@@ -3081,7 +3144,7 @@ mod tests {
         .expect("rewrite");
 
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!("expected Rewritten, got {other:?}"),
         };
         assert_eq!(parts, 1);
@@ -3351,7 +3414,7 @@ mod tests {
         .expect("rewrite");
 
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!("expected Rewritten, got {other:?}"),
         };
         assert_eq!(parts, 1);
@@ -3516,7 +3579,7 @@ mod tests {
         .expect("rewrite must merge >=2 live L0 inputs into one part");
 
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!("expected Rewritten, got {other:?}"),
         };
         assert_eq!(
@@ -3846,7 +3909,7 @@ mod tests {
         .await
         .expect("erasure rewrite");
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!("expected Rewritten, got {other:?}"),
         };
         assert_eq!(publish, PublishOutcome::Published);
@@ -4404,7 +4467,7 @@ mod tests {
         .expect("rewrite");
 
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!("expected Rewritten, got {other:?}"),
         };
         assert_eq!(parts, 1);
@@ -4566,7 +4629,7 @@ mod tests {
         .expect("rewrite must merge >=2 live L0 inputs into one part");
 
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!("expected Rewritten, got {other:?}"),
         };
         assert_eq!(
@@ -4750,7 +4813,7 @@ mod tests {
         .expect("rewrite");
 
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!("expected Rewritten, got {other:?}"),
         };
         assert_eq!(parts, 1);
@@ -4921,7 +4984,7 @@ mod tests {
         .await
         .expect("erasure rewrite");
         let (parts, publish) = match outcome {
-            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            ErasureRewriteOutcome::Rewritten { parts, publish, .. } => (parts, publish),
             other => panic!("expected Rewritten, got {other:?}"),
         };
         assert_eq!(publish, PublishOutcome::Published);

--- a/crates/ravel-maintain/src/lib.rs
+++ b/crates/ravel-maintain/src/lib.rs
@@ -79,10 +79,10 @@ pub use config::{
 };
 pub use discover::discover_tenants;
 pub use erasure_rewrite::{
-    ApplicableRequest, BucketErasureCompletion, ErasureMatcher, ErasureRewriteOutcome,
-    PendingErasureRequest, RewriteBuild, RewriteSupersession, bucket_erasure_completion,
-    bucket_may_overlap, build_rewrite, erasure_rewrite_bucket, pending_erasure_requests,
-    publish_rewrite_record,
+    ApplicableRequest, AppliedBucketDrop, BucketErasureCompletion, ErasureMatcher,
+    ErasureRewriteOutcome, PendingErasureRequest, RewriteBuild, RewriteSupersession,
+    bucket_erasure_completion, bucket_may_overlap, build_rewrite, erasure_rewrite_bucket,
+    pending_erasure_requests, publish_rewrite_record,
 };
 pub use error::{MaintainError, MergeCursorBudgetSite, Result};
 pub use gc_config::{

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -527,7 +527,10 @@ async fn referenced_l0_identities(
 /// supersession chain it could not walk to the end (a generation's record was
 /// already gone). The requests the missing generation applied are not
 /// discoverable from any surviving record, so the erasure-request sweep holds
-/// every `.dreq` that could name such a bucket.
+/// every `.dreq` whose completion record names such a bucket among the buckets
+/// its rewrite applied in, plus every `.dreq` whose completion names no bucket
+/// at all (the completion states no scope, so any truncated bucket in the
+/// signal could be one of its own).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HeldBucket {
     pub shard: u32,
@@ -546,8 +549,11 @@ pub struct HeldBucket {
 /// erasure-request sweep consumes: this pass is the only component that
 /// already knows, per chain group, both which erasure requests the group's
 /// generations applied and whether the group was held. Publishing that here
-/// is what lets rule 6 decide without a walk of its own, and without depending
-/// on a completion record's optional per-bucket drop list.
+/// is what lets rule 6 decide without a walk of its own. Neither field depends
+/// on a completion record: `held_request_ids` alone decides a hold, and
+/// `held_truncated_buckets` is the fallback for the requests no surviving
+/// record names, which rule 6 then matches against each candidate
+/// completion's own bucket list.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SupersededSweepOutcome {
     /// Superseded commit, compaction, and rewrite records deleted (or, under
@@ -614,10 +620,12 @@ impl SupersededSweepOutcome {
 /// This is the whole input to the erasure-request guard. Rule 6 asks no
 /// question of its own about supersession chains: rule 2 already walked them,
 /// already gated them, and already knows which requests the objects it held
-/// predate. A completion record's `bucket_drops` plays no part in it at all,
-/// neither to decide a hold nor to narrow which buckets are observed: the
-/// field is optional on the wire, and a list that is present but partial is
-/// indistinguishable from a complete one.
+/// predate. `request_ids` decides a hold on its own. `truncated_buckets` is
+/// matched against the candidate `.dreq`'s completion record, whose bucket
+/// list states which buckets that request's rewrite applied in; a completion
+/// with no bucket list states no scope and is held by any truncated bucket in
+/// the signal. Which buckets are *observed* is never narrowed by a completion:
+/// the observation covers the whole signal either way.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SupersededHolds {
     /// [`SupersededSweepOutcome::held_request_ids`], unioned across shards.
@@ -2222,7 +2230,9 @@ pub struct ErasureRequestSweepOutcome {
 ///   2 fills while it gates: `request_ids` when a held group names the request,
 ///   and `truncated_buckets` when a held group's chain could not be walked to
 ///   the end, in which case the requests the missing generation applied are
-///   named by no surviving record and the bucket stands in for them. This
+///   named by no surviving record and the bucket stands in for them -- for the
+///   requests whose own completion record names that bucket, and for every
+///   request whose completion names no bucket at all. This
 ///   costs no LIST and no GET of its own beyond rule 2's own pass. The holds
 ///   cover every supersession chain in the signal, not only the ones old
 ///   enough to delete: an object's age says nothing about whether a snapshot
@@ -2231,12 +2241,17 @@ pub struct ErasureRequestSweepOutcome {
 /// - the [`LeaseCheck`] passes: a legal hold over the `del/` keyspace pins the
 ///   request exactly as it pins any other object.
 ///
-/// A completion's `bucket_drops` is informational only. No part of this rule
-/// reads it: not the hold decision, and not the scope of the observation the
-/// six-argument entry runs. The field is optional on the wire, is written
-/// empty by the production writer, and a writer that does populate it is not
-/// obliged to enumerate every bucket it touched, so a present list can be
-/// partial. Any truncated bucket in the signal therefore holds any candidate.
+/// A completion's `bucket_drops` scopes the truncated-bucket clause, and
+/// nothing else. It never decides a hold on its own, never overrides
+/// `request_ids`, and never narrows the scope of the observation the
+/// six-argument entry runs (that pass still covers the whole signal). The
+/// server's rewrite pass writes an entry per bucket it applied the request in,
+/// or writes no entries at all when it cannot state that set completely, so a
+/// non-empty list is the request's full applied-bucket set and an empty one is
+/// no statement: a candidate whose completion carries no entries keeps the
+/// original whole-signal behaviour and is held by any truncated bucket in the
+/// signal. Completions written before the field was populated read as exactly
+/// that case.
 ///
 /// A completion whose `completed_unix_ns` is zero is treated fail-safe as "not
 /// yet a valid horizon anchor" and its `.dreq` is kept: a zero anchor would
@@ -2345,7 +2360,7 @@ async fn sweep_erasure_requests_inner(
     // Split the requests into the ones this pass could delete and the ones a
     // cheaper condition already keeps, before any hold is observed: an
     // ordinary pass has no candidate and does no further work.
-    let mut candidates: Vec<(&Uuid, &String)> = Vec::new();
+    let mut candidates: Vec<(&Uuid, &String, &ErasureCompletion)> = Vec::new();
     let mut kept = 0usize;
     for (request_id, dreq_key) in &dreq_keys {
         let Some(completion) = completions.get(request_id) else {
@@ -2368,7 +2383,7 @@ async fn sweep_erasure_requests_inner(
             kept += 1;
             continue;
         }
-        candidates.push((request_id, dreq_key));
+        candidates.push((request_id, dreq_key, completion));
     }
 
     if candidates.is_empty() {
@@ -2391,21 +2406,15 @@ async fn sweep_erasure_requests_inner(
 
     let mut deleted = 0usize;
     let mut held_by_superseded_inputs = 0usize;
-    for (request_id, dreq_key) in candidates {
+    for (request_id, dreq_key, completion) in candidates {
         // The horizon has elapsed, but rule 2 may have held an object one of
         // this request's rewrites superseded: an input the live HEAD still
         // names, one under an unreadable snapshot part, or a chain a legal
         // hold over the data prefixes touches. A snapshot can still resolve
         // such an object, so the filter stays.
-        // A held chain rule 2 could not walk to the end names requests no
-        // surviving record does, so any such bucket stands in for them. The
-        // completion's own `bucket_drops` are not consulted: the field is
-        // optional on the wire, a production writer leaves it empty, and
-        // nothing forces a writer that does fill it to enumerate every bucket
-        // it touched. Narrowing on a list that may be partial would release a
-        // filter over a bucket the request did touch.
         let request_id_s = request_id.to_string();
-        let held = holds.request_ids.contains(&request_id_s) || !holds.truncated_buckets.is_empty();
+        let held = holds.request_ids.contains(&request_id_s)
+            || truncated_hold_applies(completion, &holds.truncated_buckets);
         if held {
             tracing::warn!(
                 tenant_hash = %tenant.to_hex(),
@@ -2434,17 +2443,53 @@ async fn sweep_erasure_requests_inner(
     })
 }
 
+/// Whether rule 2's truncated-bucket fallback holds this candidate `.dreq`.
+///
+/// A held chain rule 2 could not walk to the end applied requests no surviving
+/// record names, so the bucket stands in for them. Which requests it stands in
+/// for is read off each candidate's own completion record: an entry in
+/// `bucket_drops` is a durable statement that this request's rewrite applied
+/// in that bucket, and a truncated bucket the list does not name cannot be one
+/// this request's rewrite superseded anything in. Matching on `(shard, ingest
+/// hour)` alone is exact here because both sides are already scoped to one
+/// signal: the sweep runs per `(tenant, signal)`, and a completion's entries
+/// must all carry the completion's own signal (`validate_completion`).
+///
+/// An empty `bucket_drops` is not a statement that the request touched no
+/// bucket, it is the absence of any statement -- a completion written before
+/// the field was populated, or one whose pass could not state the complete
+/// set. Such a candidate keeps the original whole-signal behaviour: any
+/// truncated bucket in the signal holds it.
+fn truncated_hold_applies(
+    completion: &ErasureCompletion,
+    truncated: &BTreeSet<HeldBucket>,
+) -> bool {
+    if truncated.is_empty() {
+        return false;
+    }
+    if completion.bucket_drops.is_empty() {
+        return true;
+    }
+    completion.bucket_drops.iter().any(|d| {
+        truncated.contains(&HeldBucket {
+            shard: d.shard,
+            ingest_hour_bucket: d.ingest_hour_bucket,
+        })
+    })
+}
+
 /// Observe what rule 2 holds, without deleting anything, for a rule-6 caller
 /// that has no [`SupersededHolds`] of its own.
 ///
 /// The observation always covers the whole signal: the commit keyspace is
 /// listed once to enumerate its shards, and every shard is observed across
-/// every hour. It is never narrowed by a candidate completion's `bucket_drops`.
-/// That field is optional on the wire and nothing makes a writer that fills it
-/// enumerate every bucket it touched, so a partial list would silently exclude
-/// the bucket whose chain holds the request. Shard enumeration is one LIST for
-/// the pass, and a shard with no commit key holds nothing, so the whole-signal
-/// scope costs listing, never correctness.
+/// every hour. It is never narrowed by a candidate completion's `bucket_drops`,
+/// which scopes only which candidates a truncated bucket then holds
+/// ([`truncated_hold_applies`]): observing fewer shards would drop
+/// `held_request_ids` entries too, and that set is what holds a request whose
+/// chain rule 2 *could* walk. Shard enumeration is one LIST for the pass, and
+/// a shard with no commit key holds nothing, so the whole-signal scope costs
+/// listing, never correctness.
 ///
 /// The pass runs only when there is a `.dreq` past its horizon to decide about.
 async fn observe_superseded_holds(

--- a/crates/ravel-maintain/tests/superseded_head_gate.rs
+++ b/crates/ravel-maintain/tests/superseded_head_gate.rs
@@ -417,12 +417,13 @@ async fn rewrite_created_ns(store: &dyn ObjectStoreBackend, key: &str) -> i64 {
 
 /// Whether a seeded `.done` carries per-bucket dropped counts.
 ///
-/// [`Drops::Absent`] is the production shape: the server's completion writer
-/// publishes `bucket_drops` empty, so no rule may depend on it being
-/// populated. [`Drops::Present`] is the optional narrowing hint a completion
-/// may carry. Every test that seeds the hint has a production-shape twin
-/// asserting the same holds, so a rule that only works on the hint cannot
-/// pass this suite.
+/// [`Drops::Absent`] names no bucket, which is what a completion written
+/// before the pass collected per-bucket counts carries, and also what the pass
+/// writes when it cannot state a complete bucket list. Every rule must keep
+/// holding on such a record. [`Drops::Present`] names [`OLD_HOUR`], the bucket
+/// these fixtures rewrite. Every test that seeds counts has a twin asserting
+/// the same holds out of an empty list, so a rule that only works on a
+/// populated list cannot pass this suite.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Drops {
     Present,
@@ -1505,6 +1506,170 @@ async fn cut_chain_holds_the_bucket_case(drops: Drops) {
     );
 }
 
+// --- (f2) a truncated bucket holds only what it could have touched ----------
+
+/// One completion `bucket_drops` entry in [`SHARD`]'s `hour`, the shape the
+/// server's pass publishes for every bucket a request's rewrite applied.
+fn drop_in(hour: u32, dropped_count: u64) -> ErasureBucketDrop {
+    ErasureBucketDrop {
+        signal: signal::to_proto(Signal::Metrics) as i32,
+        shard: SHARD,
+        ingest_hour_bucket: hour,
+        dropped_count,
+    }
+}
+
+/// Leave [`OLD_HOUR`] reported as a truncated bucket holding inputs, by the
+/// same reachable route [`cut_chain_holds_the_bucket_case`] takes: three
+/// generations, a pass whose last record delete faults (so R1's record is gone
+/// and the chain is cut), then a store whose catalog HEAD cannot be read.
+///
+/// Returns that second store. A `.dreq` sweep against it observes exactly one
+/// truncated bucket, `(SHARD, OLD_HOUR)`. Unlike that case's step 2 this plan
+/// carries no blanket delete fault, so a filter the guard does release is
+/// physically deleted.
+async fn truncated_old_hour(
+    mem: &Arc<MemoryStore>,
+    clock: &FixedClock,
+    created: i64,
+) -> FaultStore<Arc<MemoryStore>> {
+    let fixture = seed_chain(mem, clock, created, 3, Some(200)).await;
+    clock.set(past_horizon(created));
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(Op::Delete, ScriptedFault::Timeout).with_key_contains(fixture.chain[1].clone()),
+    );
+    let store = FaultStore::new(mem.clone(), plan);
+    assert!(
+        sweep(&store, clock).await.is_err(),
+        "the faulted delete of R2's record surfaces as a pass error"
+    );
+    assert!(
+        mem.head(&fixture.chain[0]).await.is_err(),
+        "R1's record went first: the chain is cut at the generation that applied X"
+    );
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Get, ScriptedFault::CorruptRange).with_key_contains(head_key()));
+    FaultStore::new(mem.clone(), plan)
+}
+
+/// The truncated-bucket clause covers the requests that bucket could have
+/// touched, not every request in the signal. [`OLD_HOUR`]'s chain is cut and
+/// its residue is held, so objects in that bucket may still carry pre-erasure
+/// rows. Request A's completion names that bucket, so A's filter must outlive
+/// them. Request B's completion names another hour only: nothing the cut chain
+/// holds can carry B's subject, so B's filter retires on its horizon.
+///
+/// Neither request is named by any surviving record, so the request-id clause
+/// holds neither one and the bucket clause decides both.
+///
+/// Flip-line proof: replace the `truncated_hold_applies(completion, ...)` arm
+/// of the `held` decision in `sweep_erasure_requests_inner` with
+/// `!holds.truncated_buckets.is_empty()`. B is then held on a bucket its
+/// completion does not name: `deleted == 1` fails with 0, and the surviving-key
+/// assertion fails with B's `.dreq` still present.
+#[tokio::test]
+async fn a_truncated_bucket_holds_only_the_requests_its_completion_names() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let store = truncated_old_hour(&mem, &clock, created).await;
+
+    let (dreq_a, _) = seed_dreq_and_done_with_drops(
+        mem.as_ref(),
+        request_id_n(10),
+        "absent10",
+        created,
+        vec![drop_in(OLD_HOUR, 2)],
+    )
+    .await;
+    let (dreq_b, _) = seed_dreq_and_done_with_drops(
+        mem.as_ref(),
+        request_id_n(11),
+        "absent11",
+        created,
+        vec![drop_in(RECENT_HOUR, 1)],
+    )
+    .await;
+
+    let dreq = sweep_erasure_requests(
+        &store,
+        &clock,
+        &cfg(),
+        &NoLeases,
+        &tenant_hash(),
+        Signal::Metrics,
+    )
+    .await
+    .expect("dreq sweep");
+    assert_eq!(
+        dreq.deleted, 1,
+        "B's filter: its completion names no bucket the sweep held"
+    );
+    assert_eq!(dreq.kept, 1);
+    assert_eq!(
+        dreq.held_by_superseded_inputs, 1,
+        "A's filter, by the truncated bucket its completion names"
+    );
+    let both: BTreeSet<String> = [dreq_a.clone(), dreq_b].into_iter().collect();
+    assert_eq!(both.len(), 2, "two distinct requests");
+    assert_eq!(
+        present_keys(mem.as_ref(), &both).await,
+        BTreeSet::from([dreq_a]),
+        "exactly A's .dreq survives the pass"
+    );
+}
+
+/// The legacy fallback. A completion carrying no `bucket_drops` makes no
+/// statement about which buckets its request touched, which is not the same
+/// claim as touching none: every completion written before the pass collected
+/// per-bucket counts carries an empty list. A truncated bucket holds such a
+/// request whatever hour it is in, which is the whole-signal behaviour those
+/// records keep.
+///
+/// Flip-line proof: delete the `completion.bucket_drops.is_empty()` early
+/// return from `truncated_hold_applies`. The empty list then matches no
+/// truncated bucket, the filter is deleted on its horizon, and both
+/// `deleted == 0` and the surviving-key assertion fail.
+#[tokio::test]
+async fn a_completion_naming_no_bucket_is_held_by_a_truncated_bucket() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let store = truncated_old_hour(&mem, &clock, created).await;
+
+    let (dreq_c, _) = seed_dreq_and_done_for(
+        mem.as_ref(),
+        request_id_n(12),
+        "absent12",
+        created,
+        Drops::Absent,
+    )
+    .await;
+
+    let dreq = sweep_erasure_requests(
+        &store,
+        &clock,
+        &cfg(),
+        &NoLeases,
+        &tenant_hash(),
+        Signal::Metrics,
+    )
+    .await
+    .expect("dreq sweep");
+    assert_eq!(
+        dreq.deleted, 0,
+        "a completion that names no bucket is held by any truncated bucket"
+    );
+    assert_eq!(dreq.kept, 1);
+    assert_eq!(dreq.held_by_superseded_inputs, 1);
+    let only: BTreeSet<String> = BTreeSet::from([dreq_c]);
+    assert_eq!(
+        present_keys(mem.as_ref(), &only).await,
+        only,
+        "the .dreq is physically present"
+    );
+}
+
 // --- (g) the whole ordering, end to end, across a crash and a fold ----------
 
 /// Two requests over two generations, in production completion shape. R1
@@ -2496,8 +2661,9 @@ async fn staggered_chain_release_case(drops: Drops) {
 /// A completion that names one of the two buckets its request touched. The
 /// bucket it omits is the one whose inputs are still HEAD-named, so narrowing
 /// the observation by that list would release the filter over data the request
-/// erased a subject out of. `bucket_drops` is informational only: the hold is
-/// decided over every chain in the signal.
+/// erased a subject out of. The list scopes the truncated-bucket clause and
+/// nothing else: which chains the pass observes, and which request ids a held
+/// chain carries, are read off the store.
 ///
 /// The two touched buckets are real, not asserted: X was applied in
 /// [`OLD_HOUR`] and in [`RECENT_HOUR`], and the second fold reconciles only the

--- a/docs/deletion-and-gc.md
+++ b/docs/deletion-and-gc.md
@@ -417,9 +417,18 @@ every bound is measured.
   data prefixes preserves (such a hold does not cover the request keyspace,
   so it would otherwise retire the filter over data it is preserving). The
   `.done` record carries only a hash of the canonical
-  predicate, timestamps, and optionally per-bucket dropped counts, no subject
+  predicate, timestamps, and per-bucket dropped counts, no subject
   identifier, and is permanent, deny-delete audit evidence for every role
-  (ADR-0055 amendment).
+  (ADR-0055 amendment). The pass writes one bucket entry per bucket whose
+  rewrite it applied for this request, in bucket order, each naming the
+  bucket's signal, shard, and ingest hour with the exact number of samples the
+  rewrite dropped there; a bucket it rewrote and dropped nothing in appears
+  with a count of zero, and a bucket it skipped does not appear. That list is
+  either complete or absent: when the pass cannot state the whole set, because
+  some bucket in the request's scope was already rewritten by an earlier pass
+  and this one has no count for it, it writes no bucket entries at all rather
+  than a partial list. A permanent audit record makes no partial claim, and
+  the sweep rule below reads the difference.
 
 - **The hold is read off the superseded-input sweep, not rediscovered.** That
   sweep runs first in the same pass and already knows, per chain group, which
@@ -428,7 +437,8 @@ every bound is measured.
   pass, for either reason the gate holds them, and the buckets in which it
   held the inputs of a chain it could not walk back to a raw input. The
   erasure rule holds a `.dreq` past its horizon when its request id is in the
-  first set, or when the second set is non-empty at all.
+  first set, or when one of those buckets is a bucket this request could have
+  touched.
 
   **The hold is computed over every supersession chain a HEAD-named part
   still resolves, whether or not the chain is old enough to delete.** Two
@@ -444,13 +454,30 @@ every bound is measured.
   horizon; that a pass could not have deleted it is not recorded and not
   consulted.
 
-  **A completion record's bucket list is informational only.** No part of this
-  rule reads `bucket_drops`: not the hold decision, and not the scope of the
-  observation. The field is optional on the wire, is written empty by the
-  production completion writer, and a writer that does populate it is not
-  obliged to enumerate every bucket it touched, so a present list can be
-  partial. Narrowing either the decision or the observation by such a list
-  would release the filter over a bucket the request did touch. The
+  **A completion record's bucket list scopes the cut-chain clause, and
+  nothing else.** A cut chain names no requests, so the bucket it was cut in
+  stands in for them; which requests it stands in for is decided per
+  candidate, from that candidate's own completion record. A bucket entry is a
+  durable statement that this request's rewrite applied in that bucket, so a
+  cut-chain bucket the list does not name is a bucket nothing this request
+  erased from can be held in, and the filter retires on its horizon. Matching
+  the entry against the reported bucket on shard and ingest hour is exact
+  because both sides are already scoped to one signal: the pass runs per
+  tenant and signal, and every entry in a completion must carry that
+  completion's own signal.
+
+  An empty bucket list is not a statement that the request touched no bucket,
+  it is the absence of any statement: a completion written before the pass
+  carried per-bucket counts, and one whose pass suppressed an incomplete list,
+  both look the same on the wire. Such a candidate keeps the original
+  whole-signal behaviour, held while any cut-chain bucket exists in the
+  signal. Reading an empty list as "no buckets" would retire those filters
+  over data a cut chain is still holding.
+
+  Nothing else in the rule reads the list, in particular not the scope of the
+  observation. A populated list from any writer other than the pass may still
+  be partial, and narrowing the observation by one would leave a bucket the
+  request did touch unobserved. The
   observation is therefore always whole-signal: one listing of the commit
   keyspace enumerates the signal's shards, and every shard is observed across
   every hour. A shard with no commit key holds nothing, so that scope costs
@@ -467,9 +494,10 @@ every bound is measured.
   they still carry whatever the generation above them erased. When the walk
   cannot reach a raw input because a generation's record is already gone, the
   requests that generation applied are no longer named anywhere; the sweep
-  reports that bucket as one where a chain was cut, and any candidate `.dreq`
-  is held while such a bucket exists, since no surviving record can say which
-  requests the missing generation applied. A chain group
+  reports that bucket as one where a chain was cut, and a candidate `.dreq`
+  whose completion names that bucket, or names no bucket at all, is held while
+  it exists, since no surviving record can say which requests the missing
+  generation applied. A chain group
   the legal-hold gate skipped holds its requests' `.dreq`s the same way a
   HEAD-held one does, which is what keeps a data-prefix-only hold from
   retiring a filter over data it is preserving.

--- a/services/ravel-server/src/maintain.rs
+++ b/services/ravel-server/src/maintain.rs
@@ -85,15 +85,17 @@ use ravel_ingest::{Clock as _, SystemClock};
 use ravel_maintain::scan::{MaintainMemo, MaintainReport, scan_and_maintain_with_memo};
 use ravel_maintain::worker_set::{DEFAULT_UNIT_CONCURRENCY, run_bounded};
 use ravel_maintain::{
-    Bucket, Clock, CompactorConfig, DEFAULT_MEMO_SNAPSHOT_STALENESS_NS, ErasureRewriteOutcome,
-    LeaseCheck, LegalHoldCheck, MaintainError, PendingErasureRequest, QUERY_AUDIT_SHARD,
-    RetentionConfig, WorkerSet, erasure_rewrite_bucket, pending_erasure_requests,
-    read_all_memo_snapshots, scan_and_compact, sweep_audit_retention, sweep_erasure_requests,
-    sweep_idempotency_markers, sweep_shard, sweep_shard_zoned, sweep_unreferenced_catalog_objects,
-    write_memo_snapshot,
+    AppliedBucketDrop, Bucket, Clock, CompactorConfig, DEFAULT_MEMO_SNAPSHOT_STALENESS_NS,
+    ErasureRewriteOutcome, LeaseCheck, LegalHoldCheck, MaintainError, PendingErasureRequest,
+    QUERY_AUDIT_SHARD, RetentionConfig, WorkerSet, erasure_rewrite_bucket,
+    pending_erasure_requests, read_all_memo_snapshots, scan_and_compact, sweep_audit_retention,
+    sweep_erasure_requests, sweep_idempotency_markers, sweep_shard, sweep_shard_zoned,
+    sweep_unreferenced_catalog_objects, write_memo_snapshot,
 };
 use ravel_object_store::{ObjectStoreBackend, PutOptions, StoreError};
-use ravel_proto::commit::v1::{ErasureCompletion, ErasureDeferralCause, ErasureRequest};
+use ravel_proto::commit::v1::{
+    ErasureBucketDrop, ErasureCompletion, ErasureDeferralCause, ErasureRequest,
+};
 use ravel_types::{Signal, TenantHash};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -1619,6 +1621,20 @@ struct ErasureRewritePass {
     /// `.done` is withheld even when `deferred` is false: completion follows the
     /// resolver the query path trusts, not the pass's own live-record hop.
     catalog_blocked: std::collections::HashSet<String>,
+    /// Per request, the buckets this pass rewrote for it and what each rewrite
+    /// dropped there, in bucket order (shard ascending, then ingest hour
+    /// ascending). This is what the request's `.done` records in its
+    /// `bucket_drops`.
+    bucket_drops: std::collections::BTreeMap<String, Vec<AppliedBucketDrop>>,
+    /// `request_id`s whose `bucket_drops` above is NOT the complete set of
+    /// buckets that applied the request, because some in-scope bucket was
+    /// `AlreadyApplied`: an earlier pass rewrote it, and the count that pass
+    /// dropped there is not restatable from the live record (a later
+    /// generation's `drops` carry `dropped_count: 0` for a request an earlier
+    /// generation already erased). Such a request's completion is written with
+    /// no bucket list at all rather than a partial one, which is what keeps the
+    /// erasure-request sweep's truncated-bucket clause whole-signal for it.
+    drops_incomplete: std::collections::HashSet<String>,
 }
 
 /// Rewrite every bucket of one `(tenant, signal)` against `pending`
@@ -1635,7 +1651,14 @@ struct ErasureRewritePass {
 /// guard and is deliberately counted, not re-driven: a bucket whose live
 /// record already names every overlapping request must not republish, or every
 /// tick would land a fresh no-op rewrite superseding the last one and churn
-/// generations forever.
+/// generations forever. It does mark the requests it skipped for in
+/// `drops_incomplete`: their applied-bucket set spans more than this pass, so
+/// this pass cannot state it.
+///
+/// Every rewritten bucket's per-request dropped counts are collected into
+/// `bucket_drops`, which is what each request's `.done` then records. Only a
+/// rewrite contributes: a bucket the pass skipped erased nothing this pass and
+/// so names no count of its own.
 #[allow(clippy::too_many_arguments)]
 async fn erasure_rewrite_pass(
     store: &dyn ObjectStoreBackend,
@@ -1670,12 +1693,22 @@ async fn erasure_rewrite_pass(
             match erasure_rewrite_bucket(store, clock, compactor, hold, &bucket, pending, memo)
                 .await
             {
-                Ok(ErasureRewriteOutcome::Rewritten { parts, publish }) => {
+                Ok(ErasureRewriteOutcome::Rewritten {
+                    parts,
+                    publish,
+                    drops,
+                }) => {
                     pass.rewritten += 1;
                     // An abandoned publish wrote no record, so this bucket
                     // does not yet name the pending requests.
                     if matches!(publish, ravel_maintain::PublishOutcome::Abandoned) {
                         pass.deferred = true;
+                    }
+                    for drop in drops {
+                        pass.bucket_drops
+                            .entry(drop.request_id.clone())
+                            .or_default()
+                            .push(drop);
                     }
                     tracing::info!(
                         tenant = %tenant.to_hex(),
@@ -1687,7 +1720,10 @@ async fn erasure_rewrite_pass(
                         "maintenance: erasure rewrite published for a bucket"
                     );
                 }
-                Ok(ErasureRewriteOutcome::AlreadyApplied) => pass.already_applied += 1,
+                Ok(ErasureRewriteOutcome::AlreadyApplied { request_ids }) => {
+                    pass.already_applied += 1;
+                    pass.drops_incomplete.extend(request_ids);
+                }
                 Ok(
                     ErasureRewriteOutcome::NoApplicableRequests | ErasureRewriteOutcome::Tombstoned,
                 ) => pass.out_of_scope += 1,
@@ -1763,6 +1799,13 @@ async fn erasure_rewrite_pass(
             }
         }
     }
+    // Bucket order, stated rather than inherited: the scan already visits
+    // shards and hours ascending, and a completion record's bucket list is
+    // permanent audit evidence that should not change shape if that ever
+    // changes.
+    for drops in pass.bucket_drops.values_mut() {
+        drops.sort_by_key(|d| (d.shard, d.ingest_hour_bucket));
+    }
     pass
 }
 
@@ -1777,19 +1820,27 @@ async fn erasure_rewrite_pass(
 /// identifier, which is the entire reason `.dreq` and `.done` are separate
 /// objects.
 ///
-/// `bucket_drops` is left empty: the authoritative per-bucket dropped counts
-/// are durable in each bucket's own `RewriteRecord.drops`, and
-/// `ErasureRewriteOutcome` does not surface them to a driver (the live-record
-/// resolution that would read them back is private to ravel-maintain).
-/// Fabricating zeroes here would put wrong counts in a permanent audit record,
-/// so the field stays empty until ravel-maintain returns real ones; flagged as
-/// a follow-up.
+/// `bucket_drops` carries `drops`: one entry per bucket this pass rewrote for
+/// the request, with the exact row, log record, or span count that rewrite
+/// removed there (zero included -- the bucket was applied). The counts come
+/// back from `erasure_rewrite_bucket` as [`AppliedBucketDrop`]s, which is the
+/// same data each bucket's own `RewriteRecord.drops` holds durably, so nothing
+/// here is inferred or fabricated.
+///
+/// An empty `drops` writes no bucket list. That is the honest encoding of two
+/// different situations, and callers downstream must treat it as "this record
+/// states no bucket scope", never as "the request touched no bucket": a
+/// completion written for a request every in-scope bucket had `AlreadyApplied`
+/// (an earlier pass did the erasing, and its counts are not restatable from
+/// the live record), and a completion written before this field was populated
+/// at all.
 async fn write_erasure_completion(
     store: &dyn ObjectStoreBackend,
     now_ns: i64,
     tenant: &TenantHash,
     signal: Signal,
     request: &ErasureRequest,
+    drops: &[AppliedBucketDrop],
 ) -> Result<bool, MaintainError> {
     let completion = ErasureCompletion {
         format_version: ravel_commit::erasure::FORMAT_VERSION,
@@ -1797,7 +1848,15 @@ async fn write_erasure_completion(
         signal: ravel_commit::signal::to_proto(signal) as i32,
         request_id: request.request_id.clone(),
         predicate_hash: erasure_predicate_hash(request).to_vec(),
-        bucket_drops: Vec::new(),
+        bucket_drops: drops
+            .iter()
+            .map(|d| ErasureBucketDrop {
+                signal: ravel_commit::signal::to_proto(d.signal) as i32,
+                shard: d.shard,
+                ingest_hour_bucket: d.ingest_hour_bucket,
+                dropped_count: d.dropped_count,
+            })
+            .collect(),
         requested_unix_ns: request.created_unix_ns,
         // A completion can never precede its own request in the durable
         // record (the codec rejects that pair outright), so a backwards or
@@ -1912,6 +1971,8 @@ async fn run_erasure_pass(
                 not_sealed = pass.not_sealed,
                 deferred = pass.deferred,
                 catalog_blocked = pass.catalog_blocked.len(),
+                requests_with_bucket_drops = pass.bucket_drops.len(),
+                drops_incomplete = pass.drops_incomplete.len(),
                 "maintenance: erasure rewrite pass complete"
             );
 
@@ -1946,12 +2007,25 @@ async fn run_erasure_pass(
                         );
                         continue;
                     }
+                    // A partial bucket list would be read as this request's
+                    // complete applied-bucket set by the erasure-request
+                    // sweep, so a request some bucket only had
+                    // `AlreadyApplied` for records no list at all.
+                    let drops: &[AppliedBucketDrop] =
+                        if pass.drops_incomplete.contains(&entry.request.request_id) {
+                            &[]
+                        } else {
+                            pass.bucket_drops
+                                .get(&entry.request.request_id)
+                                .map_or(&[], Vec::as_slice)
+                        };
                     match write_erasure_completion(
                         store,
                         clock.now_ns(),
                         tenant,
                         signal,
                         &entry.request,
+                        drops,
                     )
                     .await
                     {
@@ -2732,25 +2806,46 @@ mod tests {
     /// compaction pass leaves the live record set as raw L0 and the erasure
     /// rewrite is what acts on it.
     async fn publish_erasable_bucket(store: &dyn ObjectStoreBackend, tenant: &TenantId) {
+        publish_erasable_bucket_at(store, tenant, 0, 1).await;
+    }
+
+    /// The same sealed metrics bucket as [`publish_erasable_bucket`], at
+    /// ingest hour `hour`, with `subject_samples` samples on the subject's
+    /// series (the bystander always keeps exactly one). Two buckets published
+    /// with different `subject_samples` give a rewrite pass two distinct exact
+    /// dropped counts to report.
+    async fn publish_erasable_bucket_at(
+        store: &dyn ObjectStoreBackend,
+        tenant: &TenantId,
+        hour: u32,
+        subject_samples: u64,
+    ) {
         let tenant_hash = tenant.hash();
         let mut series: Vec<SeriesInput> = [TEST_ERASED_SUBJECT, TEST_SURVIVING_SUBJECT]
             .into_iter()
             .map(|subject| {
                 let labels = subject_labels(subject);
+                let sample_count = if subject == TEST_ERASED_SUBJECT {
+                    subject_samples
+                } else {
+                    1
+                };
                 SeriesInput {
                     series_id: SeriesId::compute(tenant, "http_requests", &labels)
                         .expect("series id"),
                     labels,
-                    samples: vec![Sample {
-                        ts_ns: 1_000,
-                        value: 1.0,
-                    }],
+                    samples: (0..sample_count)
+                        .map(|i| Sample {
+                            ts_ns: 1_000 + i as i64,
+                            value: 1.0,
+                        })
+                        .collect(),
                 }
             })
             .collect();
         series.sort_by_key(|s| s.series_id);
 
-        let writer_id = Uuid::from_u128(9_100);
+        let writer_id = Uuid::from_u128(9_100 + u128::from(hour));
         let written = SegmentWriter::write(
             series,
             SegmentIdentity {
@@ -2783,8 +2878,10 @@ mod tests {
             min_ingest_ts_ns: written.summary.min_event_ts_ns,
             max_ingest_ts_ns: written.summary.max_event_ts_ns,
             segment_format_version: 1,
-            created_unix_ns: 10,
-            ingest_hour_bucket: 0,
+            // The record's creation time has to sit inside the ingest hour it
+            // declares (`IngestHourInconsistent` rejects any other pair).
+            created_unix_ns: i64::from(hour) * TEST_NS_PER_HOUR + 10,
+            ingest_hour_bucket: hour,
         })
         .expect("valid commit record");
 
@@ -3006,6 +3103,88 @@ mod tests {
         assert!(
             store.get(&dreq_key, GetRange::Full).await.is_ok(),
             "the .dreq (which carries the subject) must survive: the erasure is not complete"
+        );
+    }
+
+    /// A completion record carries the per-bucket dropped counts its documented
+    /// shape describes: one entry per bucket the pass rewrote for the request,
+    /// in bucket order, each with that bucket's exact count.
+    ///
+    /// Two sealed buckets hold the subject in the same shard, one sample in
+    /// ingest hour 0 and two in ingest hour 1. One `run_erasure_pass` rewrites
+    /// both and completes the request, so the `.done` it writes must name
+    /// exactly those two buckets with counts 1 and 2 -- not an empty list, and
+    /// not one entry per pass.
+    ///
+    /// The flip that proves this test bites: write `bucket_drops: Vec::new()`
+    /// in `write_erasure_completion` and the exact-list assertion below fails
+    /// with an empty list.
+    #[tokio::test]
+    async fn done_records_the_per_bucket_dropped_counts_of_every_rewritten_bucket() {
+        let store = MemoryStore::new();
+        let tenant_id = TenantId::new("acme");
+        let tenant = tenant_id.hash();
+
+        // One sample of the subject in hour 0, two in hour 1: distinct exact
+        // counts, so a list that mixed the buckets up would fail below.
+        publish_erasable_bucket_at(&store, &tenant_id, 0, 1).await;
+        publish_erasable_bucket_at(&store, &tenant_id, 1, 2).await;
+
+        let request_id = Uuid::from_u128(0x1104);
+        submit_erasure_request(
+            &store,
+            &tenant,
+            Signal::Metrics,
+            request_id,
+            TEST_ERASED_SUBJECT,
+            TEST_ERASURE_NOW_NS,
+        )
+        .await;
+        let done_key =
+            keys::erasure_completion_key(&tenant, Signal::Metrics, request_id).expect("done key");
+
+        let clock = ravel_maintain::FixedClock::new(TEST_ERASURE_NOW_NS);
+        let compactor = CompactorConfig::default();
+        let hold = ravel_maintain::NoLeases;
+        let mut memo = MaintainMemo::with_default_interval();
+
+        run_erasure_pass(
+            &store,
+            &clock,
+            &compactor,
+            &hold,
+            &tenant,
+            Signal::Metrics,
+            1,
+            &mut memo,
+        )
+        .await;
+
+        let got = store
+            .get(&done_key, GetRange::Full)
+            .await
+            .expect("the pass rewrote both buckets, so the .done must be written");
+        let completion =
+            ravel_commit::erasure::decode_completion(&got.data).expect("decode completion");
+        let metrics_proto = ravel_commit::signal::to_proto(Signal::Metrics) as i32;
+        assert_eq!(
+            completion.bucket_drops,
+            vec![
+                ErasureBucketDrop {
+                    signal: metrics_proto,
+                    shard: 0,
+                    ingest_hour_bucket: 0,
+                    dropped_count: 1,
+                },
+                ErasureBucketDrop {
+                    signal: metrics_proto,
+                    shard: 0,
+                    ingest_hour_bucket: 1,
+                    dropped_count: 2,
+                },
+            ],
+            "the completion must carry one drop per rewritten bucket, in bucket order, with \
+             each bucket's exact dropped sample count"
         );
     }
 


### PR DESCRIPTION
The server's erasure completion writer always wrote an empty per-bucket drop list into the `.done` record, so the audit record did not match its documented shape, and the erasure-request sweep held every `.dreq` in a signal past its horizon while any truncated chain in that signal held inputs, keeping unrelated requests' plaintext subject predicates alive.

The rewrite pass now returns each bucket's applied drop (request, signal, shard, ingest hour, dropped count) and the completion writer emits them in bucket order: a bucket rewritten with zero drops appears with count 0, a skipped bucket does not appear. A request whose pass found a bucket already applied gets no bucket list at all rather than a partial one, because a partial list could release a `.dreq` while a truncated bucket that did apply the request still holds pre-erasure inputs. The sweep's truncated clause now holds a `.dreq` only when its completion names a truncated bucket the sweep held this pass, matched on shard and ingest hour within the signal; a completion with no bucket list, whether written before this change or under the complete-or-absent rule, keeps the whole-signal hold. The held-request-ids clause is unchanged.

Tests shown failing first: the server's completion carries exactly two drops with exact counts (was empty); an unrelated request's `.dreq` retires while a truncated bucket elsewhere holds inputs and the request whose chain was cut is still held, with exact keys and counts; a completion naming no bucket is still held by any truncated bucket. Every existing sweep and completion-gate test passes.

Reported residual, not fixed: a windowed request whose bucket's post-rewrite event bounds shrink below its window reads as having no applicable requests on a later pass, so that bucket is silently absent from the list; tracked as a follow-up.

Fleet task d0416f2d-1555-4d99-93de-b61b1b068334, cherry-picked onto current main.

Fixes: #1104
Fixes: #1142
Refs: #1040