### PR TITLE
fix(ingest): stamp declared columns over the merged attribute view

### DIFF
--- a/crates/ravel-ingest/src/log_declared_stats.rs
+++ b/crates/ravel-ingest/src/log_declared_stats.rs
@@ -25,17 +25,30 @@
 //! stamp is always internally consistent with the record's own row count and
 //! its own reader never drops it (decision 3, "a flush must never emit a stamp
 //! its own reader would drop").
+//!
+//! "The attribute" above is the one the reader resolves, which is the MERGED
+//! view, not the record's own attribute set: a declared column's value for a
+//! row is the record's attribute when the record sets that key (at any value
+//! kind), and otherwise the row's stream-level resource or scope attribute of
+//! the same name (`ravel_sql`'s `logs_scan::merged_value`). A fold over record
+//! attributes alone stamps `null_count == sample_count` for a column whose
+//! values live on the resource or scope attributes, and that affirmative
+//! all-NULL statement is what the metadata-only aggregate path answers `NULL`
+//! from (issue #1057). So each stream's attributes are decoded once, per
+//! stream, and a row that does not set a declared key contributes its stream's
+//! value instead of a NULL.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 
 use ravel_catalog::DeclaredColumnType;
-use ravel_logseg::ColumnarLogBatch;
+use ravel_logseg::{ColumnarLogBatch, stream_attr_pairs};
 use ravel_otlp::logs_normalize::NormalizedLogRecord;
 use ravel_types::declared_stats::{
     DeclaredColumnStat, DeclaredStatType, DeclaredStatValue, TYPED_ATTR_COLUMN_TYPE_BOOL,
     TYPED_ATTR_COLUMN_TYPE_BYTES, TYPED_ATTR_COLUMN_TYPE_I64, TYPED_ATTR_COLUMN_TYPE_STR,
 };
-use ravel_types::logstream::AttrValue;
+use ravel_types::logstream::{AttrValue, LogStreamId};
 
 /// The `ravel.sys.v1.TypedAttrColumnType` tag a declared column's type is
 /// stored as, so a declared column reaches [`DeclaredStatAccum::build_stamps`]
@@ -101,10 +114,88 @@ impl<T: Ord + Copy> Running<T> {
 /// Per-column running extrema, split by observed value kind so the non-null
 /// count of a declared column of one type is not inflated by same-named values
 /// of the other type (which read NULL for that declaration).
+///
+/// The two epochs implement first-occurrence-wins within one record: a record
+/// is folded under a fresh epoch, and a kind that has already taken its value
+/// from that record carries the record's epoch. This replaces a per-record
+/// `seen` list scanned once per attribute, so a wide record costs one hash
+/// lookup per attribute rather than a scan over its own attributes.
 #[derive(Default, Clone, Copy, Debug)]
 struct ColumnAccum {
     i64: Option<Running<i64>>,
     boolean: Option<Running<bool>>,
+    /// Epoch of the record this column's I64 running value last took a value
+    /// from, or 0 before any (epochs start at 1).
+    i64_epoch: u64,
+    /// The same for the BOOL running value.
+    bool_epoch: u64,
+}
+
+/// A stream-level attribute value of a stamp-eligible kind, as the fallback a
+/// row of that stream reads for a declared column it does not set itself.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum StreamValue {
+    I64(i64),
+    Bool(bool),
+}
+
+/// One stream-level attribute that can serve as a fallback, with the count of
+/// this buffer's rows in that stream which override it by setting the same key.
+#[derive(Clone, Copy, Debug)]
+struct StreamAttrState {
+    value: StreamValue,
+    /// Rows of this stream in the buffer that set this key themselves, at any
+    /// value kind. Those rows read the record's value (or NULL, if its kind
+    /// does not match the declaration), never this fallback.
+    overrides: u64,
+    /// Epoch of the record this override count last counted, so a record
+    /// repeating the key counts once.
+    epoch: u64,
+}
+
+/// One stream's contribution to the merged view: how many of the buffer's rows
+/// belong to it, and the stream-level attributes those rows fall back to.
+#[derive(Default)]
+struct StreamState {
+    rows: u64,
+    /// Only the names whose first blob occurrence (resource set before scope
+    /// set, the order the reader's `find_attr` resolves) is I64 or BOOL. A name
+    /// whose first occurrence is of any other kind reads NULL for a declaration
+    /// either way, so it is dropped at decode time and costs nothing per record.
+    attrs: HashMap<String, StreamAttrState>,
+}
+
+/// Decode one STREAM_DIR blob into the fallbacks its rows read, or `None` if
+/// the blob does not decode.
+fn stream_state(blob: &[u8]) -> Option<StreamState> {
+    let pairs = stream_attr_pairs(blob).ok()?;
+    let mut first: HashMap<String, Option<StreamValue>> = HashMap::with_capacity(pairs.len());
+    for (name, value) in pairs {
+        // First occurrence wins whatever its kind, matching the reader: an
+        // ineligible first occurrence shadows a same-named eligible one behind
+        // it, so it must be recorded as "claimed, no fallback".
+        first.entry(name).or_insert(match value {
+            AttrValue::I64(v) => Some(StreamValue::I64(v)),
+            AttrValue::Bool(b) => Some(StreamValue::Bool(b)),
+            _ => None,
+        });
+    }
+    let attrs = first
+        .into_iter()
+        .filter_map(|(name, value)| {
+            value.map(|value| {
+                (
+                    name,
+                    StreamAttrState {
+                        value,
+                        overrides: 0,
+                        epoch: 0,
+                    },
+                )
+            })
+        })
+        .collect();
+    Some(StreamState { rows: 0, attrs })
 }
 
 /// The log shard actor's per-buffer accumulator of stamp-eligible declared
@@ -117,45 +208,78 @@ pub(crate) struct DeclaredStatAccum {
     /// attribute keys, strictly fewer than the attribute occurrences the buffer
     /// already holds.
     cols: HashMap<String, ColumnAccum>,
+    /// The stream-level half of the merged view, keyed by stream id so each
+    /// stream's blob is decoded once per buffer rather than once per record.
+    /// The declared set is unknown until flush time, so this holds every
+    /// eligible stream attribute the buffer's streams carry; on the common
+    /// shape (resource attributes are service identity strings) it holds none.
+    streams: HashMap<LogStreamId, StreamState>,
+    /// Monotonic per-record counter driving the first-occurrence-wins epochs.
+    /// Starts at 0 and is incremented before each record is folded, so a live
+    /// epoch is never 0.
+    epoch: u64,
+    /// Set when a stream's attribute blob did not decode, which leaves the
+    /// merged view unknown for that stream's rows. The buffer then stamps
+    /// nothing: an affirmative statement over a view this fold could not
+    /// resolve is exactly the wrong answer decision 3 forbids.
+    stream_attrs_undecodable: bool,
+}
+
+/// Fold one I64 attribute value of the record being folded under `epoch`.
+fn observe_i64(cols: &mut HashMap<String, ColumnAccum>, epoch: u64, name: &str, v: i64) {
+    match cols.get_mut(name) {
+        Some(col) => {
+            if col.i64_epoch == epoch {
+                return;
+            }
+            col.i64_epoch = epoch;
+            match &mut col.i64 {
+                Some(run) => run.observe(v),
+                slot @ None => *slot = Some(Running::start(v)),
+            }
+        }
+        None => {
+            cols.insert(
+                name.to_string(),
+                ColumnAccum {
+                    i64: Some(Running::start(v)),
+                    boolean: None,
+                    i64_epoch: epoch,
+                    bool_epoch: 0,
+                },
+            );
+        }
+    }
+}
+
+/// Fold one BOOL attribute value of the record being folded under `epoch`.
+fn observe_bool(cols: &mut HashMap<String, ColumnAccum>, epoch: u64, name: &str, b: bool) {
+    match cols.get_mut(name) {
+        Some(col) => {
+            if col.bool_epoch == epoch {
+                return;
+            }
+            col.bool_epoch = epoch;
+            match &mut col.boolean {
+                Some(run) => run.observe(b),
+                slot @ None => *slot = Some(Running::start(b)),
+            }
+        }
+        None => {
+            cols.insert(
+                name.to_string(),
+                ColumnAccum {
+                    i64: None,
+                    boolean: Some(Running::start(b)),
+                    i64_epoch: 0,
+                    bool_epoch: epoch,
+                },
+            );
+        }
+    }
 }
 
 impl DeclaredStatAccum {
-    fn observe_i64(&mut self, name: &str, v: i64) {
-        match self.cols.get_mut(name) {
-            Some(col) => match &mut col.i64 {
-                Some(run) => run.observe(v),
-                slot @ None => *slot = Some(Running::start(v)),
-            },
-            None => {
-                self.cols.insert(
-                    name.to_string(),
-                    ColumnAccum {
-                        i64: Some(Running::start(v)),
-                        boolean: None,
-                    },
-                );
-            }
-        }
-    }
-
-    fn observe_bool(&mut self, name: &str, b: bool) {
-        match self.cols.get_mut(name) {
-            Some(col) => match &mut col.boolean {
-                Some(run) => run.observe(b),
-                slot @ None => *slot = Some(Running::start(b)),
-            },
-            None => {
-                self.cols.insert(
-                    name.to_string(),
-                    ColumnAccum {
-                        i64: None,
-                        boolean: Some(Running::start(b)),
-                    },
-                );
-            }
-        }
-    }
-
     fn merge_i64(&mut self, name: &str, min: i64, max: i64, count: u64) {
         match self.cols.get_mut(name) {
             Some(col) => match &mut col.i64 {
@@ -178,6 +302,8 @@ impl DeclaredStatAccum {
                             non_null: count,
                         }),
                         boolean: None,
+                        i64_epoch: 0,
+                        bool_epoch: 0,
                     },
                 );
             }
@@ -206,6 +332,8 @@ impl DeclaredStatAccum {
                             max,
                             non_null: count,
                         }),
+                        i64_epoch: 0,
+                        bool_epoch: 0,
                     },
                 );
             }
@@ -218,26 +346,48 @@ impl DeclaredStatAccum {
     /// occurrence, matching the writer's first-occurrence-wins column slot), so
     /// no column's non-null count can exceed the buffer's row count and the
     /// derived `null_count` can never go negative.
+    ///
+    /// The record's own attributes are folded here; the stream-level half of
+    /// the merged view is folded in [`Self::build_stamps`], from the per-stream
+    /// row count and the count of rows that set the key themselves, which is
+    /// what this records in [`StreamAttrState::overrides`]. Deferring it is
+    /// what lets the fold stay O(1) per attribute without knowing the declared
+    /// set, which the flush only resolves from the tenant config later.
     pub(crate) fn observe_records(&mut self, records: &[NormalizedLogRecord]) {
-        // Reused across records so the per-record dedup allocates once, not per
-        // record. `(name, kind-tag)` where the tag distinguishes I64 from BOOL.
-        let mut seen: Vec<(&str, u8)> = Vec::new();
+        let Self {
+            cols,
+            streams,
+            epoch,
+            stream_attrs_undecodable,
+        } = self;
         for rec in records {
-            seen.clear();
+            *epoch += 1;
+            let stream = match streams.entry(rec.stream_id) {
+                Entry::Occupied(slot) => slot.into_mut(),
+                Entry::Vacant(slot) => match stream_state(&rec.stream_attrs) {
+                    Some(state) => slot.insert(state),
+                    None => {
+                        *stream_attrs_undecodable = true;
+                        continue;
+                    }
+                },
+            };
+            stream.rows += 1;
             for (name, value) in &rec.attrs {
-                let (kind, is_i64, iv, bv) = match value {
-                    AttrValue::I64(v) => (0u8, true, *v, false),
-                    AttrValue::Bool(b) => (1u8, false, 0, *b),
-                    _ => continue,
-                };
-                if seen.contains(&(name.as_str(), kind)) {
-                    continue;
+                // A record that sets the key at ANY value kind overrides its
+                // stream's attribute of the same name, the reader's
+                // `record_sets_key` rule: a wrong-typed record value reads NULL
+                // for the declaration rather than falling back.
+                if let Some(attr) = stream.attrs.get_mut(name.as_str())
+                    && attr.epoch != *epoch
+                {
+                    attr.epoch = *epoch;
+                    attr.overrides += 1;
                 }
-                seen.push((name.as_str(), kind));
-                if is_i64 {
-                    self.observe_i64(name, iv);
-                } else {
-                    self.observe_bool(name, bv);
+                match value {
+                    AttrValue::I64(v) => observe_i64(cols, *epoch, name, *v),
+                    AttrValue::Bool(b) => observe_bool(cols, *epoch, name, *b),
+                    _ => {}
                 }
             }
         }
@@ -248,6 +398,7 @@ impl DeclaredStatAccum {
     /// first-occurrence-wins rule, so its `cells.len()` is the column's non-null
     /// row count), which lets each column be folded in a single pass.
     pub(crate) fn observe_batch(&mut self, batch: &ColumnarLogBatch) {
+        self.observe_batch_streams(batch);
         for col in &batch.dyn_columns {
             match col.cells.first() {
                 Some(AttrValue::I64(_)) => {
@@ -291,6 +442,84 @@ impl DeclaredStatAccum {
                 _ => {}
             }
         }
+        self.observe_batch_overrides(batch);
+    }
+
+    /// The stream-level half of a columnar batch: each distinct stream's blob
+    /// decoded once, and the batch's rows charged to the stream they belong to.
+    fn observe_batch_streams(&mut self, batch: &ColumnarLogBatch) {
+        let mut rows_per_ref = vec![0u64; batch.stream_ids.len()];
+        for stream_ref in &batch.stream_refs {
+            match rows_per_ref.get_mut(*stream_ref as usize) {
+                Some(rows) => *rows += 1,
+                // A stream_ref with no STREAM_DIR entry is a malformed batch,
+                // not something to stamp an affirmative statement over.
+                None => self.stream_attrs_undecodable = true,
+            }
+        }
+        for (i, stream_id) in batch.stream_ids.iter().enumerate() {
+            let rows = rows_per_ref.get(i).copied().unwrap_or(0);
+            let stream = match self.streams.entry(*stream_id) {
+                Entry::Occupied(slot) => slot.into_mut(),
+                Entry::Vacant(slot) => {
+                    match batch.stream_attrs.get(i).and_then(|b| stream_state(b)) {
+                        Some(state) => slot.insert(state),
+                        None => {
+                            self.stream_attrs_undecodable = true;
+                            continue;
+                        }
+                    }
+                }
+            };
+            stream.rows += rows;
+        }
+    }
+
+    /// Count, per stream attribute that can serve as a fallback, the batch rows
+    /// that set the same key themselves and therefore override it.
+    ///
+    /// The scan is skipped entirely unless one of the batch's streams carries an
+    /// eligible attribute, which is the shape a service-identity resource set
+    /// produces: the columnar path then costs exactly what it did before.
+    fn observe_batch_overrides(&mut self, batch: &ColumnarLogBatch) {
+        let mut names: Vec<String> = Vec::new();
+        for stream_id in &batch.stream_ids {
+            if let Some(stream) = self.streams.get(stream_id) {
+                for name in stream.attrs.keys() {
+                    if !names.iter().any(|n| n == name) {
+                        names.push(name.clone());
+                    }
+                }
+            }
+        }
+        for name in &names {
+            for row in 0..batch.num_rows {
+                let set_here = batch
+                    .dyn_columns
+                    .iter()
+                    .any(|col| col.name == *name && col.validity.get(row))
+                    || batch
+                        .residual_attrs
+                        .get(row)
+                        .is_some_and(|extra| extra.iter().any(|(k, _)| k == name));
+                if !set_here {
+                    continue;
+                }
+                let Some(stream_ref) = batch.stream_refs.get(row) else {
+                    continue;
+                };
+                let Some(stream_id) = batch.stream_ids.get(*stream_ref as usize) else {
+                    continue;
+                };
+                if let Some(attr) = self
+                    .streams
+                    .get_mut(stream_id)
+                    .and_then(|stream| stream.attrs.get_mut(name))
+                {
+                    attr.overrides += 1;
+                }
+            }
+        }
     }
 
     /// Build the stamps for one flush from the accumulated extrema and the
@@ -313,6 +542,9 @@ impl DeclaredStatAccum {
         declared: &[(String, u32)],
         sample_count: u64,
     ) -> Vec<DeclaredColumnStat> {
+        if self.stream_attrs_undecodable {
+            return Vec::new();
+        }
         let mut out = Vec::new();
         for (name, tag) in declared {
             let stat_type = match DeclaredStatType::from_tag(*tag) {
@@ -322,7 +554,11 @@ impl DeclaredStatAccum {
             let col = self.cols.get(name);
             let stat = match stat_type {
                 DeclaredStatType::I64 => {
-                    let run = col.and_then(|c| c.i64);
+                    let run =
+                        self.fold_fallbacks(name, col.and_then(|c| c.i64), |value| match value {
+                            StreamValue::I64(v) => Some(v),
+                            StreamValue::Bool(_) => None,
+                        });
                     build_one(
                         name,
                         DeclaredStatType::I64,
@@ -337,7 +573,15 @@ impl DeclaredStatAccum {
                     )
                 }
                 DeclaredStatType::Bool => {
-                    let run = col.and_then(|c| c.boolean);
+                    let run =
+                        self.fold_fallbacks(
+                            name,
+                            col.and_then(|c| c.boolean),
+                            |value| match value {
+                                StreamValue::Bool(b) => Some(b),
+                                StreamValue::I64(_) => None,
+                            },
+                        );
                     build_one(
                         name,
                         DeclaredStatType::Bool,
@@ -357,6 +601,45 @@ impl DeclaredStatAccum {
             }
         }
         out
+    }
+
+    /// Add the stream-level half of the merged view for one declared column to
+    /// the running extrema its records produced.
+    ///
+    /// Every row of a stream whose attributes supply a matching-typed value for
+    /// `name`, other than the rows that set `name` themselves, reads that value.
+    /// Those rows are non-null for the declaration and carry a single value, so
+    /// they fold in as one `(value, value, count)` merge per stream rather than
+    /// row by row.
+    fn fold_fallbacks<T: Ord + Copy>(
+        &self,
+        name: &str,
+        mut run: Option<Running<T>>,
+        typed: impl Fn(StreamValue) -> Option<T>,
+    ) -> Option<Running<T>> {
+        for stream in self.streams.values() {
+            let Some(attr) = stream.attrs.get(name) else {
+                continue;
+            };
+            let Some(value) = typed(attr.value) else {
+                continue;
+            };
+            let count = stream.rows.saturating_sub(attr.overrides);
+            if count == 0 {
+                continue;
+            }
+            match &mut run {
+                Some(r) => r.merge(value, value, count),
+                slot @ None => {
+                    *slot = Some(Running {
+                        min: value,
+                        max: value,
+                        non_null: count,
+                    })
+                }
+            }
+        }
+        run
     }
 }
 
@@ -396,10 +679,28 @@ mod tests {
         (name.to_string(), TYPED_ATTR_COLUMN_TYPE_BOOL)
     }
 
-    fn rec(attrs: Vec<(&str, AttrValue)>) -> NormalizedLogRecord {
+    /// A STREAM_DIR blob carrying `res` as the resource set and `scope` as the
+    /// scope set, in the frozen layout the reader's fallback resolves over.
+    fn blob(res: &[(&str, AttrValue)], scope: &[(&str, AttrValue)]) -> Vec<u8> {
+        let owned = |pairs: &[(&str, AttrValue)]| -> Vec<(String, AttrValue)> {
+            pairs
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect()
+        };
+        ravel_logseg::stream_attrs_bytes(&owned(res), "scope", "", &owned(scope))
+    }
+
+    /// A record on the stream identified by `stream` (any distinct byte per
+    /// distinct blob) whose stream-level attributes are `stream_attrs`.
+    fn rec_in(
+        stream: u8,
+        stream_attrs: &[u8],
+        attrs: Vec<(&str, AttrValue)>,
+    ) -> NormalizedLogRecord {
         NormalizedLogRecord {
-            stream_id: LogStreamId([0u8; 16]),
-            stream_attrs: Vec::new(),
+            stream_id: LogStreamId([stream; 16]),
+            stream_attrs: stream_attrs.to_vec(),
             ts_ns: 0,
             observed_ts_ns: 0,
             severity_num: 0,
@@ -410,6 +711,11 @@ mod tests {
             flags: 0,
             attrs: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
         }
+    }
+
+    /// A record on a stream whose resource and scope attribute sets are empty.
+    fn rec(attrs: Vec<(&str, AttrValue)>) -> NormalizedLogRecord {
+        rec_in(0, &blob(&[], &[]), attrs)
     }
 
     fn stat<'a>(stamps: &'a [DeclaredColumnStat], name: &str) -> Option<&'a DeclaredColumnStat> {
@@ -572,5 +878,164 @@ mod tests {
         // EventDate was declared but never seen: it stamps all-null.
         let s = stat(&stamps, "EventDate").expect("declared, all-null");
         assert_eq!(s.null_count(), 1);
+    }
+
+    /// Prove-the-test: drop the `fold_fallbacks` call from `build_stamps`'s I64
+    /// arm and this stamps `min: None, max: None, null_count: 3`, the
+    /// affirmative all-NULL statement issue #1057 is about.
+    #[test]
+    fn resource_attribute_supplies_the_value_no_record_sets() {
+        let stream = blob(&[("k", AttrValue::I64(7))], &[]);
+        let mut acc = DeclaredStatAccum::default();
+        acc.observe_records(&[
+            rec_in(1, &stream, vec![("other", AttrValue::I64(1))]),
+            rec_in(1, &stream, vec![]),
+            rec_in(1, &stream, vec![("other", AttrValue::I64(2))]),
+        ]);
+        let stamps = acc.build_stamps(&[i64_col("k")], 3);
+        let s = stat(&stamps, "k").expect("stamped");
+        assert_eq!(s.min(), Some(DeclaredStatValue::I64(7)));
+        assert_eq!(s.max(), Some(DeclaredStatValue::I64(7)));
+        assert_eq!(s.null_count(), 0);
+    }
+
+    /// Prove-the-test: stop counting `overrides` in `observe_records` and the
+    /// overriding row is counted twice (non_null 4 over 3 rows), which
+    /// `build_one`'s `checked_sub` turns into no stamp at all; keep the count
+    /// but drop the fallback fold and `min` reads 2 with `null_count` 2.
+    #[test]
+    fn record_value_overrides_the_resource_attribute_for_its_row_only() {
+        let stream = blob(&[("k", AttrValue::I64(7))], &[]);
+        let mut acc = DeclaredStatAccum::default();
+        acc.observe_records(&[
+            rec_in(1, &stream, vec![("k", AttrValue::I64(2))]),
+            rec_in(1, &stream, vec![]),
+            rec_in(1, &stream, vec![("other", AttrValue::Bool(true))]),
+        ]);
+        let stamps = acc.build_stamps(&[i64_col("k")], 3);
+        let s = stat(&stamps, "k").expect("stamped");
+        assert_eq!(s.min(), Some(DeclaredStatValue::I64(2)));
+        assert_eq!(s.max(), Some(DeclaredStatValue::I64(7)));
+        assert_eq!(s.null_count(), 0);
+    }
+
+    /// Prove-the-test: skip the scope set when decoding the blob (parse only
+    /// the resource set) and this stamps all-NULL over 3 rows.
+    #[test]
+    fn scope_attribute_supplies_the_value_for_a_declared_bool_column() {
+        let stream = blob(&[], &[("flag", AttrValue::Bool(true))]);
+        let mut acc = DeclaredStatAccum::default();
+        acc.observe_records(&[
+            rec_in(2, &stream, vec![]),
+            rec_in(2, &stream, vec![("other", AttrValue::I64(1))]),
+            rec_in(2, &stream, vec![]),
+        ]);
+        let stamps = acc.build_stamps(&[bool_col("flag")], 3);
+        let s = stat(&stamps, "flag").expect("stamped");
+        assert_eq!(s.min(), Some(DeclaredStatValue::Bool(true)));
+        assert_eq!(s.max(), Some(DeclaredStatValue::Bool(true)));
+        assert_eq!(s.null_count(), 0);
+    }
+
+    #[test]
+    fn wrong_typed_record_value_suppresses_the_stream_fallback() {
+        // The reader resolves the record's own value whenever the record sets
+        // the key at ANY kind, so a row carrying `k` as a Str reads NULL for the
+        // I64 declaration rather than falling back to the resource attribute.
+        let stream = blob(&[("k", AttrValue::I64(7))], &[]);
+        let mut acc = DeclaredStatAccum::default();
+        acc.observe_records(&[
+            rec_in(1, &stream, vec![("k", AttrValue::Str("x".to_string()))]),
+            rec_in(1, &stream, vec![]),
+        ]);
+        let stamps = acc.build_stamps(&[i64_col("k")], 2);
+        let s = stat(&stamps, "k").expect("stamped");
+        assert_eq!(s.min(), Some(DeclaredStatValue::I64(7)));
+        assert_eq!(s.max(), Some(DeclaredStatValue::I64(7)));
+        assert_eq!(s.null_count(), 1);
+    }
+
+    #[test]
+    fn stream_attribute_of_an_ineligible_kind_is_not_a_fallback() {
+        // A resource attribute of a kind the declaration cannot read is a NULL
+        // for every row of the stream, exactly as an absent one is.
+        let stream = blob(&[("k", AttrValue::Str("seven".to_string()))], &[]);
+        let mut acc = DeclaredStatAccum::default();
+        acc.observe_records(&[rec_in(1, &stream, vec![]), rec_in(1, &stream, vec![])]);
+        let stamps = acc.build_stamps(&[i64_col("k")], 2);
+        let s = stat(&stamps, "k").expect("stamped");
+        assert_eq!(s.min(), None);
+        assert_eq!(s.max(), None);
+        assert_eq!(s.null_count(), 2);
+    }
+
+    #[test]
+    fn each_stream_contributes_its_own_fallback() {
+        let a = blob(&[("k", AttrValue::I64(7))], &[]);
+        let b = blob(&[("k", AttrValue::I64(-3))], &[]);
+        let mut acc = DeclaredStatAccum::default();
+        acc.observe_records(&[
+            rec_in(1, &a, vec![]),
+            rec_in(2, &b, vec![]),
+            rec_in(2, &b, vec![("k", AttrValue::I64(100))]),
+        ]);
+        let stamps = acc.build_stamps(&[i64_col("k")], 3);
+        let s = stat(&stamps, "k").expect("stamped");
+        assert_eq!(s.min(), Some(DeclaredStatValue::I64(-3)));
+        assert_eq!(s.max(), Some(DeclaredStatValue::I64(100)));
+        assert_eq!(s.null_count(), 0);
+    }
+
+    #[test]
+    fn an_undecodable_stream_blob_stamps_nothing() {
+        // The merged view is unresolvable for that stream's rows, so the flush
+        // makes no statement at all rather than an affirmative wrong one.
+        let mut acc = DeclaredStatAccum::default();
+        acc.observe_records(&[rec_in(1, &[0xff, 0xff], vec![("k", AttrValue::I64(1))])]);
+        assert!(acc.build_stamps(&[i64_col("k")], 1).is_empty());
+    }
+
+    #[test]
+    fn columnar_batch_folds_the_same_merged_view_as_the_row_path() {
+        use ravel_logseg::LogRecord;
+
+        let stream = blob(&[("k", AttrValue::I64(7))], &[]);
+        let to_logrecord = |r: &NormalizedLogRecord| LogRecord {
+            stream_id: r.stream_id,
+            stream_attrs: r.stream_attrs.clone(),
+            ts_ns: r.ts_ns,
+            observed_ts_ns: r.observed_ts_ns,
+            severity_num: r.severity_num,
+            severity_text: r.severity_text.clone(),
+            body: r.body.clone(),
+            trace_id: None,
+            span_id: None,
+            flags: r.flags,
+            attrs: r.attrs.clone(),
+        };
+        let records = vec![
+            rec_in(1, &stream, vec![("k", AttrValue::I64(2))]),
+            rec_in(1, &stream, vec![]),
+            rec_in(1, &stream, vec![("other", AttrValue::I64(5))]),
+        ];
+        let batch =
+            ColumnarLogBatch::from_records(&records.iter().map(to_logrecord).collect::<Vec<_>>());
+
+        let mut columnar = DeclaredStatAccum::default();
+        columnar.observe_batch(&batch);
+        let columnar = columnar.build_stamps(&[i64_col("k")], 3);
+        let s = stat(&columnar, "k").expect("stamped");
+        assert_eq!(s.min(), Some(DeclaredStatValue::I64(2)));
+        assert_eq!(s.max(), Some(DeclaredStatValue::I64(7)));
+        assert_eq!(s.null_count(), 0);
+
+        let mut row = DeclaredStatAccum::default();
+        row.observe_records(&records);
+        let row = row.build_stamps(&[i64_col("k")], 3);
+        assert_eq!(row.len(), 1);
+        assert_eq!(columnar.len(), 1);
+        assert_eq!(row[0].min(), s.min());
+        assert_eq!(row[0].max(), s.max());
+        assert_eq!(row[0].null_count(), s.null_count());
     }
 }

--- a/crates/ravel-ingest/src/log_declared_stats.rs
+++ b/crates/ravel-ingest/src/log_declared_stats.rs
@@ -158,10 +158,11 @@ struct StreamAttrState {
 #[derive(Default)]
 struct StreamState {
     rows: u64,
-    /// Only the names whose first blob occurrence (resource set before scope
-    /// set, the order the reader's `find_attr` resolves) is I64 or BOOL. A name
-    /// whose first occurrence is of any other kind reads NULL for a declaration
-    /// either way, so it is dropped at decode time and costs nothing per record.
+    /// Only the names whose first non-List/Map blob occurrence (resource set
+    /// before scope set, the order the reader's `find_attr` resolves) is I64
+    /// or BOOL. A name whose first non-List/Map occurrence is of any other
+    /// kind reads NULL for a declaration either way, so it is dropped at
+    /// decode time and costs nothing per record.
     attrs: HashMap<String, StreamAttrState>,
 }
 
@@ -171,9 +172,17 @@ fn stream_state(blob: &[u8]) -> Option<StreamState> {
     let pairs = stream_attr_pairs(blob).ok()?;
     let mut first: HashMap<String, Option<StreamValue>> = HashMap::with_capacity(pairs.len());
     for (name, value) in pairs {
-        // First occurrence wins whatever its kind, matching the reader: an
-        // ineligible first occurrence shadows a same-named eligible one behind
-        // it, so it must be recorded as "claimed, no fallback".
+        // The reader's decoder (`ravel_sql::rlog_attrs::decode_value`) never
+        // pushes a List or Map entry into the pairs it resolves over, so such
+        // an occurrence must not claim the key here either: skip it and let a
+        // later occurrence of the same name compete.
+        if matches!(value, AttrValue::List(_) | AttrValue::Map(_)) {
+            continue;
+        }
+        // First occurrence whose value is not a List or Map wins, matching
+        // the reader: an ineligible (but decoded) first occurrence shadows a
+        // same-named eligible one behind it, so it must be recorded as
+        // "claimed, no fallback".
         first.entry(name).or_insert(match value {
             AttrValue::I64(v) => Some(StreamValue::I64(v)),
             AttrValue::Bool(b) => Some(StreamValue::Bool(b)),
@@ -1037,5 +1046,55 @@ mod tests {
         assert_eq!(row[0].min(), s.min());
         assert_eq!(row[0].max(), s.max());
         assert_eq!(row[0].null_count(), s.null_count());
+    }
+
+    /// Issue #1057 finding 1: a stream whose RESOURCE attributes carry the
+    /// declared key as a List and whose SCOPE attributes carry it as a
+    /// matching-typed I64 must fall back to the scope value, exactly what the
+    /// reader's decoder resolves (it never decodes a List entry at all, so it
+    /// moves straight to the next occurrence of the key).
+    ///
+    /// Prove-the-test: drop the `AttrValue::List(_) | AttrValue::Map(_)` skip
+    /// from `stream_state` and the List's first occurrence claims `k` with no
+    /// fallback, stamping min 2, max 2, null_count 2 over these same records
+    /// (the base's wrong answer) instead of min 2, max 7, null_count 0.
+    #[test]
+    fn list_resource_attribute_is_skipped_for_a_matching_scope_fallback() {
+        let stream = blob(
+            &[("k", AttrValue::List(vec![AttrValue::I64(1)]))],
+            &[("k", AttrValue::I64(7))],
+        );
+        let mut acc = DeclaredStatAccum::default();
+        acc.observe_records(&[
+            rec_in(1, &stream, vec![("k", AttrValue::I64(2))]),
+            rec_in(1, &stream, vec![]),
+            rec_in(1, &stream, vec![]),
+        ]);
+        let stamps = acc.build_stamps(&[i64_col("k")], 3);
+        let s = stat(&stamps, "k").expect("stamped");
+        assert_eq!(s.min(), Some(DeclaredStatValue::I64(2)));
+        assert_eq!(s.max(), Some(DeclaredStatValue::I64(7)));
+        assert_eq!(s.null_count(), 0);
+    }
+
+    /// Same stream shape as above, but no record sets `k` itself: every row
+    /// reads the scope fallback the List resource attribute must not shadow.
+    #[test]
+    fn list_resource_attribute_is_skipped_when_no_record_overrides() {
+        let stream = blob(
+            &[("k", AttrValue::List(vec![AttrValue::I64(1)]))],
+            &[("k", AttrValue::I64(7))],
+        );
+        let mut acc = DeclaredStatAccum::default();
+        acc.observe_records(&[
+            rec_in(1, &stream, vec![]),
+            rec_in(1, &stream, vec![]),
+            rec_in(1, &stream, vec![]),
+        ]);
+        let stamps = acc.build_stamps(&[i64_col("k")], 3);
+        let s = stat(&stamps, "k").expect("stamped");
+        assert_eq!(s.min(), Some(DeclaredStatValue::I64(7)));
+        assert_eq!(s.max(), Some(DeclaredStatValue::I64(7)));
+        assert_eq!(s.null_count(), 0);
     }
 }

--- a/crates/ravel-ingest/tests/declared_column_stamps.rs
+++ b/crates/ravel-ingest/tests/declared_column_stamps.rs
@@ -110,6 +110,48 @@ fn record_on(
     }
 }
 
+/// The same as [`record_on`], but the stream's SCOPE attributes also carry
+/// `scope_extra` beyond an otherwise-empty scope set, so a declared column's
+/// stream-level fallback can be exercised on either half of the merged view
+/// in one stream (issue #1057 finding 1: a List/Map resource occurrence must
+/// not shadow a matching-typed scope occurrence behind it).
+fn record_on_scoped(
+    res_extra: &[(&str, AttrValue)],
+    scope_extra: &[(&str, AttrValue)],
+    ts_ns: i64,
+    attrs: Vec<(&str, AttrValue)>,
+) -> NormalizedLogRecord {
+    let mut res: Vec<(String, AttrValue)> = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )];
+    res.extend(
+        res_extra
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect::<Vec<_>>(),
+    );
+    let scope_attrs: Vec<(String, AttrValue)> = scope_extra
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect();
+    let stream_id = log_stream_id(&res, "scope", "", &scope_attrs);
+    let stream_attrs = ravel_logseg::stream_attrs_bytes(&res, "scope", "", &scope_attrs);
+    NormalizedLogRecord {
+        stream_id,
+        stream_attrs,
+        ts_ns,
+        observed_ts_ns: ts_ns,
+        severity_num: 9,
+        severity_text: "INFO".to_string(),
+        body: "row".to_string(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+    }
+}
+
 /// Write the tenant's declared typed columns so the flush's config read resolves
 /// them and stamps their extrema.
 async fn declare_columns(store: &dyn ObjectStoreBackend, columns: Vec<DeclaredTypedColumn>) {
@@ -560,7 +602,11 @@ async fn stamped_min_max_count(
 ///
 /// Prove-the-test: fold only the record's own attributes (drop the stream-level
 /// fallback from `DeclaredStatAccum::build_stamps`) and the stamp becomes
-/// `min == None, max == None, null_count == 3`, so both answers come back NULL.
+/// `min == None, max == None, null_count == 3`, the affirmative all-NULL claim
+/// issue #1057 is about. DataFusion's aggregate-statistics rule declines that
+/// NULL min/max scalar, so `MIN`/`MAX` would still fall back to a scan and
+/// answer correctly; only `COUNT` trusts the stamp outright and would answer
+/// 0 against a true 3.
 #[tokio::test]
 async fn stream_level_declared_value_answers_min_max_end_to_end() {
     let records = (0..3)
@@ -637,6 +683,64 @@ async fn record_override_of_a_stream_level_value_answers_end_to_end() {
     assert_eq!(min, Some(2), "MIN answered from the stamp");
     assert_eq!(max, Some(7), "MAX answered from the stamp");
     assert_eq!(count, Some(3));
+    assert!(
+        !plan_text.contains("LogsScanExec"),
+        "the scan is elided:\n{plan_text}"
+    );
+    assert_eq!(gets, 0, "a statement answered from stamps reads no data");
+}
+
+/// Issue #1057 finding 1, end to end: a stream whose RESOURCE attributes carry
+/// the declared column as a List (the shape `ravel_otlp::logs_normalize::
+/// convert_attrs` produces from real OTLP input) and whose SCOPE attributes
+/// carry it as a matching-typed I64 must answer from the scope value for the
+/// rows that do not set the key themselves -- the List occurrence must not
+/// shadow the scope occurrence behind it, exactly as the reader's decoder
+/// (which never decodes a List entry at all) resolves it.
+///
+/// Prove-the-test: drop the `AttrValue::List(_) | AttrValue::Map(_)` skip from
+/// `stream_state` (`crates/ravel-ingest/src/log_declared_stats.rs`) and this
+/// answers `2, 2, 1` (the base's wrong answer, with a data scan needed to even
+/// get COUNT right) instead of `2, 7, 3` with the scan elided and zero GETs.
+#[tokio::test]
+async fn list_resource_attribute_falls_back_to_scope_value_end_to_end() {
+    let stream_res = [(COL, AttrValue::List(vec![AttrValue::I64(1)]))];
+    let stream_scope = [(COL, AttrValue::I64(7))];
+    let records = vec![
+        record_on_scoped(
+            &stream_res,
+            &stream_scope,
+            BASE_NS,
+            vec![(COL, AttrValue::I64(2))],
+        ),
+        record_on_scoped(&stream_res, &stream_scope, BASE_NS + 1, vec![]),
+        record_on_scoped(&stream_res, &stream_scope, BASE_NS + 2, vec![]),
+    ];
+
+    let (commit, (min, max, count), plan_text, gets) = stamped_min_max_count(records).await;
+
+    let read = read_commit_record(&commit);
+    assert!(
+        read.dropped().is_empty(),
+        "the flush's own reader drops nothing it stamped"
+    );
+    assert_eq!(commit.sample_count, 3);
+    let ev = read.column(COL).expect("EventDate stamped");
+    assert_eq!(
+        ev.min(),
+        Some(ravel_types::declared_stats::DeclaredStatValue::I64(2)),
+        "the record's own value wins for its row"
+    );
+    assert_eq!(
+        ev.max(),
+        Some(ravel_types::declared_stats::DeclaredStatValue::I64(7)),
+        "the two rows that set nothing read the scope's 7, not the List"
+    );
+    assert_eq!(ev.null_count(), 0);
+
+    assert_eq!(min, Some(2), "MIN answered from the stamp");
+    assert_eq!(max, Some(7), "MAX answered from the stamp");
+    assert_eq!(count, Some(3), "every row counts as non-NULL");
     assert!(
         !plan_text.contains("LogsScanExec"),
         "the scan is elided:\n{plan_text}"

--- a/crates/ravel-ingest/tests/declared_column_stamps.rs
+++ b/crates/ravel-ingest/tests/declared_column_stamps.rs
@@ -70,10 +70,28 @@ fn flush_on_first() -> IngestConfig {
 /// One log record under a fixed stream, carrying whichever declared attributes
 /// `attrs` names (absent when the list omits the key: a NULL for that column).
 fn record(ts_ns: i64, attrs: Vec<(&str, AttrValue)>) -> NormalizedLogRecord {
-    let res: Vec<(String, AttrValue)> = vec![(
+    record_on(&[], ts_ns, attrs)
+}
+
+/// The same, on a stream whose resource attributes carry `res_extra` beyond the
+/// fixed `service.name`. A declared key placed there is the stream-level half of
+/// the merged attribute view: it is what a record that does not set the key
+/// reads.
+fn record_on(
+    res_extra: &[(&str, AttrValue)],
+    ts_ns: i64,
+    attrs: Vec<(&str, AttrValue)>,
+) -> NormalizedLogRecord {
+    let mut res: Vec<(String, AttrValue)> = vec![(
         "service.name".to_string(),
         AttrValue::Str("api".to_string()),
     )];
+    res.extend(
+        res_extra
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect::<Vec<_>>(),
+    );
     let scope_attrs: Vec<(String, AttrValue)> = Vec::new();
     let stream_id = log_stream_id(&res, "scope", "", &scope_attrs);
     let stream_attrs = ravel_logseg::stream_attrs_bytes(&res, "scope", "", &scope_attrs);
@@ -454,4 +472,174 @@ async fn two_flushes_stamp_from_their_own_buffers() {
         objects.iter().any(|m| m.key == c2.object_key),
         "second flush's data object is durable"
     );
+}
+
+/// Write `records` through the real router, then answer
+/// `MIN`/`MAX`/`COUNT` over `COL` from the resolved snapshot. Returns the
+/// commit record of the single flush, the three answers, the plan text, and the
+/// GETs the measured query window cost.
+async fn stamped_min_max_count(
+    records: Vec<NormalizedLogRecord>,
+) -> (
+    CommitRecord,
+    (Option<i64>, Option<i64>, Option<i64>),
+    String,
+    u64,
+) {
+    let store = Arc::new(InstrumentedStore::new(MemoryStore::new()));
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::clone(&store) as Arc<dyn ObjectStoreBackend>;
+    let clock = TestClock::new(BASE_NS);
+    declare_columns(backend.as_ref(), i64_col_decl()).await;
+
+    let router = LogIngestRouter::new(flush_on_first(), Arc::clone(&backend), clock.clone());
+    let receipt = router
+        .write(
+            tenant(),
+            records,
+            WriteMode::Strict,
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        .expect("strict write flushes");
+    assert_eq!(receipt.tokens.len(), 1, "one object for one flush");
+    router.shutdown().await;
+
+    let commit = commit_record_for(backend.as_ref(), &receipt.tokens[0]).await;
+
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(&backend), CatalogConfig::default()).expect("catalog"));
+    let snapshot = catalog
+        .resolve(
+            &tenant_hash(),
+            Signal::Logs,
+            TimeRange {
+                start_ns: 0,
+                end_ns: i64::MAX,
+            },
+            &[],
+            BASE_NS + 1_000,
+        )
+        .await
+        .expect("resolve logs snapshot");
+
+    let provider = LogsTableProvider::new(
+        snapshot,
+        tenant_hash(),
+        LogSegmentFetcher::new(Arc::clone(&backend)),
+        QueryAccounting::new(),
+    )
+    .with_declared_columns(vec![DeclaredColumn::new(COL, DeclaredType::I64)]);
+    let ctx = logs_session(provider);
+
+    let gets_before = store.metrics().snapshot().get.calls;
+    let sql = format!(r#"SELECT MIN("{COL}"), MAX("{COL}"), COUNT("{COL}") FROM logs"#);
+    let plan = ctx
+        .sql(&sql)
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let plan_text = displayable(plan.as_ref()).indent(true).to_string();
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    let gets = store.metrics().snapshot().get.calls - gets_before;
+
+    let answers = (
+        single_i64_value(&batches, 0),
+        single_i64_value(&batches, 1),
+        single_i64_value(&batches, 2),
+    );
+    (commit, answers, plan_text, gets)
+}
+
+/// Issue #1057, end to end: a declared column whose value lives on the stream's
+/// RESOURCE attributes, set by no record, is the value every record reads. The
+/// flush stamps it, and `MIN`/`MAX` answer with it off the stamp alone.
+///
+/// Prove-the-test: fold only the record's own attributes (drop the stream-level
+/// fallback from `DeclaredStatAccum::build_stamps`) and the stamp becomes
+/// `min == None, max == None, null_count == 3`, so both answers come back NULL.
+#[tokio::test]
+async fn stream_level_declared_value_answers_min_max_end_to_end() {
+    let records = (0..3)
+        .map(|i| record_on(&[(COL, AttrValue::I64(7))], BASE_NS + i, vec![]))
+        .collect::<Vec<_>>();
+
+    let (commit, (min, max, count), plan_text, gets) = stamped_min_max_count(records).await;
+
+    let read = read_commit_record(&commit);
+    assert!(
+        read.dropped().is_empty(),
+        "the flush's own reader drops nothing it stamped"
+    );
+    assert_eq!(commit.sample_count, 3);
+    let ev = read.column(COL).expect("EventDate stamped");
+    assert_eq!(
+        ev.min(),
+        Some(ravel_types::declared_stats::DeclaredStatValue::I64(7)),
+        "the resource attribute is the value all three rows read"
+    );
+    assert_eq!(
+        ev.max(),
+        Some(ravel_types::declared_stats::DeclaredStatValue::I64(7))
+    );
+    assert_eq!(
+        ev.null_count(),
+        0,
+        "no row is NULL: the stream supplies the value"
+    );
+
+    assert_eq!(min, Some(7), "MIN answered from the stamp");
+    assert_eq!(max, Some(7), "MAX answered from the stamp");
+    assert_eq!(count, Some(3), "every row counts as non-NULL");
+    assert!(
+        !plan_text.contains("LogsScanExec"),
+        "the scan is elided, which is what makes the answer exact:\n{plan_text}"
+    );
+    assert_eq!(gets, 0, "a statement answered from stamps reads no data");
+}
+
+/// The override half of the merged view, end to end: one record sets the
+/// declared key itself, the other two read the stream's value. The extrema span
+/// both.
+///
+/// Prove-the-test: count the stream-level value for every row instead of
+/// `rows - overrides` and the answers stay `7`/`7`, losing the record's `2`.
+#[tokio::test]
+async fn record_override_of_a_stream_level_value_answers_end_to_end() {
+    let stream_res = [(COL, AttrValue::I64(7))];
+    let records = vec![
+        record_on(&stream_res, BASE_NS, vec![]),
+        record_on(&stream_res, BASE_NS + 1, vec![(COL, AttrValue::I64(2))]),
+        record_on(&stream_res, BASE_NS + 2, vec![]),
+    ];
+
+    let (commit, (min, max, count), plan_text, gets) = stamped_min_max_count(records).await;
+
+    let read = read_commit_record(&commit);
+    assert!(read.dropped().is_empty(), "nothing dropped");
+    assert_eq!(commit.sample_count, 3);
+    let ev = read.column(COL).expect("EventDate stamped");
+    assert_eq!(
+        ev.min(),
+        Some(ravel_types::declared_stats::DeclaredStatValue::I64(2)),
+        "the record's own value wins for its row"
+    );
+    assert_eq!(
+        ev.max(),
+        Some(ravel_types::declared_stats::DeclaredStatValue::I64(7)),
+        "the two rows that set nothing still read the stream's 7"
+    );
+    assert_eq!(ev.null_count(), 0);
+
+    assert_eq!(min, Some(2), "MIN answered from the stamp");
+    assert_eq!(max, Some(7), "MAX answered from the stamp");
+    assert_eq!(count, Some(3));
+    assert!(
+        !plan_text.contains("LogsScanExec"),
+        "the scan is elided:\n{plan_text}"
+    );
+    assert_eq!(gets, 0, "a statement answered from stamps reads no data");
 }

--- a/crates/ravel-logseg/src/lib.rs
+++ b/crates/ravel-logseg/src/lib.rs
@@ -47,7 +47,9 @@ pub use columns::ColumnSelection;
 pub use error::LogSegError;
 pub use footer::{SuffixOutcome, open_from_suffix};
 pub use ranged::{RlogRangeReader, StreamBlockLoc, StreamBlockRows, StreamBlockSpan};
-pub use reader::{BlockScan, RlogReader, ScanStats, decode_section, read_section};
+pub use reader::{
+    BlockScan, RlogReader, ScanStats, decode_section, read_section, stream_attr_pairs,
+};
 pub use record::{FieldSel, FieldType, LogRecord, Predicate, stream_attrs_bytes};
 pub use writer::{ObjectIdentity, RlogConfig, RlogWriter};
 

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -1467,7 +1467,13 @@ pub fn phrase_match(value: &[u8], word: &str) -> bool {
 /// of a record's stream and per-record attributes). Kept in this crate so the
 /// merge does not depend on `ravel-sql`
 /// (docs/adrs/0049-rlog-postings.md amendment 2026-08-03).
-pub(crate) fn stream_attr_pairs(blob: &[u8]) -> Result<Vec<(String, AttrValue)>, LogSegError> {
+///
+/// Public because the declared-column statistics producers resolve the same
+/// merged view: `ravel-ingest`'s flush fold and `ravel-maintain`'s compaction
+/// fold both need a stream's attributes to decide what a record that does not
+/// set a declared key reads. The blob grammar is frozen, so a second decoder
+/// elsewhere would be a copy that can drift from this one.
+pub fn stream_attr_pairs(blob: &[u8]) -> Result<Vec<(String, AttrValue)>, LogSegError> {
     use crate::varint::get_uvarint;
     let mut pos = 0usize;
     let mut pairs = decode_attr_set(blob, &mut pos, 0)?;

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -190,9 +190,10 @@
 //! `sum(part.series_count)`, which counts a straddling stream once per part it
 //! appears in; it is reported, never used as a gate.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use futures::stream::{StreamExt, TryStreamExt, iter as stream_iter};
 use ravel_commit::keys;
@@ -207,7 +208,7 @@ use ravel_logseg::record::{
 use ravel_logseg::skip_index::SkipIndex;
 use ravel_logseg::{
     AttrValue, FieldType, LogRecord, LogStreamId, RlogConfig, RlogRangeReader, RlogWriter,
-    StreamBlockLoc, StreamBlockRows, decode_section,
+    StreamBlockLoc, StreamBlockRows, decode_section, stream_attr_pairs,
     writer::{ObjectIdentity, WriteStats},
 };
 use ravel_object_store::{GetRange, ObjectStoreBackend};
@@ -775,6 +776,11 @@ pub(crate) async fn merge_catalogs(
     // under version 4 (ADR-0699 decision 1, a block's pages are spread across
     // its group's column chunks) -- so raw resident bytes stay bounded to one
     // such unit per input, never a whole stream or the whole bucket.
+    // Resolve the merged attribute view's stream-level half once for the whole
+    // output (ADR-0873 decision 3, issue #1057): every stream's blob is right
+    // here, decoded once, rather than re-derived per record in the fold.
+    let declared = Arc::new(DeclaredSchema::build(&declared, &merged));
+
     let identity = compactor_identity(bucket, config);
     let tracker = config.merge_memory_tracker.as_ref();
     let mut sink = PartSink {
@@ -894,9 +900,10 @@ struct PartSink<'a> {
     identity: ObjectIdentity,
     indexed_fields: Vec<String>,
     /// The declared eligible columns each output part recomputes stamps for
-    /// (ADR-0873 decision 3). Empty on the erasure-rewrite route, whose parts
-    /// stay unstamped (the wave-3 staleness rule), and on metrics/spans buckets.
-    declared: Vec<(String, DeclaredStatType)>,
+    /// (ADR-0873 decision 3), with each stream's stream-level values for them.
+    /// Empty on the erasure-rewrite route, whose parts stay unstamped (the
+    /// wave-3 staleness rule), and on metrics/spans buckets.
+    declared: Arc<DeclaredSchema>,
     tracker: Option<&'a MergeMemoryTracker>,
     /// Whether a closed part is encoded but not PUT. Not read from `config`:
     /// the erasure rewrite defers every part PUT to its own publish path (which
@@ -922,7 +929,7 @@ impl PartSink<'_> {
             self.current = Some(PartBuilder::new(
                 &self.identity,
                 &self.indexed_fields,
-                &self.declared,
+                Arc::clone(&self.declared),
             ));
         }
         let mut over_memory = false;
@@ -1118,17 +1125,116 @@ impl<T: Ord + Copy> Running<T> {
 }
 
 /// One declared column's running extrema over the records pushed to a part. Only
-/// the [`Running`] matching `ty` is ever populated: a declared I64 column counts
-/// an I64 value as non-null and reads a same-named BOOL value (or an absent one)
-/// as NULL, and vice versa -- the wave-5a `(name, value kind)` rule.
+/// the [`Running`] matching the column's declared type is ever populated: a
+/// declared I64 column counts an I64 value as non-null and reads a same-named
+/// BOOL value (or an absent one) as NULL, and vice versa -- the wave-5a
+/// `(name, value kind)` rule.
+///
+/// The column's name and type live in the per-object [`DeclaredSchema`] rather
+/// than here: a name compare per record per column is what made the fold
+/// O(attrs x cols) in String comparisons.
+#[derive(Default)]
 struct ColumnAccum {
-    name: String,
-    ty: DeclaredStatType,
     i64_run: Option<Running<i64>>,
     bool_run: Option<Running<bool>>,
-    /// First-occurrence-wins within the record currently being folded: set once
-    /// this column has taken a value from that record, cleared before the next.
-    seen_this_record: bool,
+    /// The epoch of the record that last set this column's key, at any value
+    /// kind. A record that sets the key overrides its stream's attribute of the
+    /// same name, so this suppresses the fallback for that record.
+    mention_epoch: u64,
+    /// The epoch of the record this column last took a matching-typed value
+    /// from: first-occurrence-wins within one record.
+    value_epoch: u64,
+}
+
+/// The declared eligible columns a compaction output stamps, indexed for the
+/// per-record fold, plus the stream-level half of the merged view each of the
+/// object's streams supplies.
+///
+/// Built once per merge from the STREAM_DIR blobs the merge already collected
+/// (one decode per stream in the object, never one per record) and shared by
+/// every part through an [`Arc`], since every part of a compaction stamps the
+/// same column set over the same streams.
+#[derive(Default)]
+struct DeclaredSchema {
+    /// The declared columns, in the order stamps are emitted.
+    cols: Vec<(String, DeclaredStatType)>,
+    /// Declared name to index into `cols`. A record's attribute costs one hash
+    /// lookup here instead of a String compare against every declared column.
+    index: HashMap<String, usize>,
+    /// Per stream, the declared columns its resource or scope attributes supply
+    /// a matching-typed value for, as `(column index, value)`. A stream
+    /// carrying none has no entry, which is the common shape (resource
+    /// attributes are service identity strings), and its records pay nothing.
+    fallbacks: HashMap<LogStreamId, Vec<(usize, DeclaredStatValue)>>,
+    /// Set when a stream's attribute blob did not decode, which leaves the
+    /// merged view unknown for that stream's records. Every part of the merge
+    /// then stamps nothing rather than an affirmative statement over a view the
+    /// fold could not resolve.
+    unresolved: bool,
+}
+
+impl DeclaredSchema {
+    /// Index `declared` and resolve each stream's fallbacks from its STREAM_DIR
+    /// blob. `streams` is the merge's own stream map, so each blob is decoded
+    /// exactly once per output object.
+    fn build(
+        declared: &[(String, DeclaredStatType)],
+        streams: &BTreeMap<LogStreamId, Vec<u8>>,
+    ) -> Self {
+        let mut schema = DeclaredSchema {
+            cols: declared.to_vec(),
+            index: declared
+                .iter()
+                .enumerate()
+                .map(|(i, (name, _))| (name.clone(), i))
+                .collect(),
+            fallbacks: HashMap::new(),
+            unresolved: false,
+        };
+        if declared.is_empty() {
+            return schema;
+        }
+        for (stream_id, blob) in streams {
+            let pairs = match stream_attr_pairs(blob) {
+                Ok(pairs) => pairs,
+                Err(_) => {
+                    schema.unresolved = true;
+                    continue;
+                }
+            };
+            let mut claimed: BTreeSet<usize> = BTreeSet::new();
+            let mut values: Vec<(usize, DeclaredStatValue)> = Vec::new();
+            for (name, value) in pairs {
+                let Some(&i) = schema.index.get(name.as_str()) else {
+                    continue;
+                };
+                // First occurrence wins whatever its kind, matching the
+                // reader's `find_attr` over the resource set then the scope
+                // set: an ineligible or wrong-typed first occurrence shadows a
+                // same-named eligible one behind it, and reads NULL.
+                if !claimed.insert(i) {
+                    continue;
+                }
+                let typed = match (schema.cols[i].1, value) {
+                    (DeclaredStatType::I64, AttrValue::I64(v)) => DeclaredStatValue::I64(v),
+                    (DeclaredStatType::Bool, AttrValue::Bool(b)) => DeclaredStatValue::Bool(b),
+                    _ => continue,
+                };
+                values.push((i, typed));
+            }
+            if !values.is_empty() {
+                schema.fallbacks.insert(*stream_id, values);
+            }
+        }
+        schema
+    }
+
+    /// The stream-level values a record of `stream_id` falls back to.
+    fn fallbacks_for(&self, stream_id: LogStreamId) -> &[(usize, DeclaredStatValue)] {
+        self.fallbacks
+            .get(&stream_id)
+            .map_or(&[][..], |values| values.as_slice())
+    }
 }
 
 /// The per-part fold of declared-column extrema for the compaction output
@@ -1137,6 +1243,13 @@ struct ColumnAccum {
 /// declared columns only, first-occurrence-wins per record, and a stamp whose
 /// `null_count` is derived as `sample_count - non_null` so the part's own reader
 /// ([`ravel_commit::declared_stats::read_compaction_part`]) never drops it.
+///
+/// Like the ingest side it folds the MERGED attribute view, not the record's
+/// own attributes: a record that does not set a declared key reads its stream's
+/// resource or scope attribute of that name, so the part's stamp describes what
+/// a reader resolves rather than what the record literally carries (issue
+/// #1057). The stream-level half comes from the per-object [`DeclaredSchema`],
+/// which decoded each stream's blob once for the whole merge.
 ///
 /// Unlike the ingest side it is seeded with the declared column set up front
 /// (from [`declared_columns_from_inputs`]), so it tracks only the columns it
@@ -1150,63 +1263,102 @@ struct ColumnAccum {
 /// the next [`PartBuilder`] and is folded only there.
 #[derive(Default)]
 struct DeclaredStatAccum {
+    /// The declared column set and the merged view's stream-level half, shared
+    /// with every other part of the same merge.
+    schema: Arc<DeclaredSchema>,
+    /// Running extrema, positionally aligned with `schema.cols`.
     cols: Vec<ColumnAccum>,
+    /// Monotonic per-record counter driving the first-occurrence-wins and
+    /// override epochs. Incremented before each record, so a live epoch is
+    /// never 0.
+    epoch: u64,
 }
 
 impl DeclaredStatAccum {
-    /// Build a fold over the declared eligible columns. The set comes from
+    /// Build a fold over a merge's declared eligible columns. The set comes from
     /// [`declared_columns_from_inputs`], which reads each input's decoded
     /// stamps through the commit-side reader whose type tags admit only I64
     /// and BOOL, so every column here is one of the two.
-    fn new(declared: &[(String, DeclaredStatType)]) -> Self {
-        let cols = declared
-            .iter()
-            .map(|(name, ty)| ColumnAccum {
-                name: name.clone(),
-                ty: *ty,
-                i64_run: None,
-                bool_run: None,
-                seen_this_record: false,
-            })
-            .collect();
-        DeclaredStatAccum { cols }
+    fn new(schema: Arc<DeclaredSchema>) -> Self {
+        let mut cols = Vec::new();
+        cols.resize_with(schema.cols.len(), ColumnAccum::default);
+        DeclaredStatAccum {
+            schema,
+            cols,
+            epoch: 0,
+        }
     }
 
-    /// Fold one record's attributes. Each declared column takes at most one
-    /// non-null row from the record: the first attribute matching its name AND
-    /// its declared value kind wins, and a repeat (or a same-named value of the
-    /// other kind, or an absence) is a NULL for the declaration, so no column's
-    /// non-null count can exceed the part's row count and the derived
-    /// `null_count` can never go negative.
-    fn observe_record(&mut self, attrs: &[(String, AttrValue)]) {
+    /// Fold one record's merged attribute view. Each declared column takes at
+    /// most one non-null row from the record: the first attribute matching its
+    /// name AND its declared value kind wins, and a repeat (or a same-named
+    /// value of the other kind, or an absence with no stream-level value) is a
+    /// NULL for the declaration, so no column's non-null count can exceed the
+    /// part's row count and the derived `null_count` can never go negative.
+    ///
+    /// A column the record does not name at all takes its stream's resource or
+    /// scope value, when the stream supplies one of the declared kind. A record
+    /// that names the column at ANY value kind suppresses that fallback, which
+    /// is the reader's override order.
+    ///
+    /// Cost is one hash lookup per record attribute plus one pass over the
+    /// record's stream's fallback list, with no String comparison per
+    /// (attribute, column) pair.
+    fn observe_record(&mut self, r: &LogRecord) {
         if self.cols.is_empty() {
             return;
         }
-        for c in &mut self.cols {
-            c.seen_this_record = false;
+        let Self {
+            schema,
+            cols,
+            epoch,
+        } = self;
+        *epoch += 1;
+        for (name, value) in &r.attrs {
+            let Some(&i) = schema.index.get(name.as_str()) else {
+                continue;
+            };
+            let Some(c) = cols.get_mut(i) else {
+                continue;
+            };
+            c.mention_epoch = *epoch;
+            if c.value_epoch == *epoch {
+                continue;
+            }
+            match (schema.cols[i].1, value) {
+                (DeclaredStatType::I64, AttrValue::I64(v)) => {
+                    match &mut c.i64_run {
+                        Some(run) => run.observe(*v),
+                        None => c.i64_run = Some(Running::start(*v)),
+                    }
+                    c.value_epoch = *epoch;
+                }
+                (DeclaredStatType::Bool, AttrValue::Bool(b)) => {
+                    match &mut c.bool_run {
+                        Some(run) => run.observe(*b),
+                        None => c.bool_run = Some(Running::start(*b)),
+                    }
+                    c.value_epoch = *epoch;
+                }
+                _ => {}
+            }
         }
-        for (name, value) in attrs {
-            for c in &mut self.cols {
-                if c.seen_this_record || c.name != *name {
-                    continue;
-                }
-                match (c.ty, value) {
-                    (DeclaredStatType::I64, AttrValue::I64(v)) => {
-                        match &mut c.i64_run {
-                            Some(r) => r.observe(*v),
-                            None => c.i64_run = Some(Running::start(*v)),
-                        }
-                        c.seen_this_record = true;
-                    }
-                    (DeclaredStatType::Bool, AttrValue::Bool(b)) => {
-                        match &mut c.bool_run {
-                            Some(r) => r.observe(*b),
-                            None => c.bool_run = Some(Running::start(*b)),
-                        }
-                        c.seen_this_record = true;
-                    }
-                    _ => {}
-                }
+        for (i, value) in schema.fallbacks_for(r.stream_id) {
+            let Some(c) = cols.get_mut(*i) else {
+                continue;
+            };
+            if c.mention_epoch == *epoch {
+                continue;
+            }
+            match value {
+                DeclaredStatValue::I64(v) => match &mut c.i64_run {
+                    Some(run) => run.observe(*v),
+                    None => c.i64_run = Some(Running::start(*v)),
+                },
+                DeclaredStatValue::Bool(b) => match &mut c.bool_run {
+                    Some(run) => run.observe(*b),
+                    None => c.bool_run = Some(Running::start(*b)),
+                },
             }
         }
     }
@@ -1218,9 +1370,12 @@ impl DeclaredStatAccum {
     /// `null_count = sample_count - non_null`), so `read_compaction_part` drops
     /// none of them.
     fn build_stamps(&self, sample_count: u64) -> Vec<DeclaredColumnStat> {
+        if self.schema.unresolved {
+            return Vec::new();
+        }
         let mut out = Vec::new();
-        for c in &self.cols {
-            let observed = match c.ty {
+        for (c, (name, ty)) in self.cols.iter().zip(self.schema.cols.iter()) {
+            let observed = match ty {
                 DeclaredStatType::I64 => c.i64_run.map(|r| {
                     (
                         DeclaredStatValue::I64(r.min),
@@ -1236,7 +1391,7 @@ impl DeclaredStatAccum {
                     )
                 }),
             };
-            if let Some(stat) = build_one(&c.name, c.ty, observed, sample_count) {
+            if let Some(stat) = build_one(name, *ty, observed, sample_count) {
                 out.push(stat);
             }
         }
@@ -1337,7 +1492,7 @@ impl PartBuilder {
     fn new(
         identity: &ObjectIdentity,
         indexed_fields: &[String],
-        declared: &[(String, DeclaredStatType)],
+        declared: Arc<DeclaredSchema>,
     ) -> Self {
         PartBuilder {
             identity: *identity,
@@ -1384,7 +1539,7 @@ impl PartBuilder {
         // estimates ride (ADR-0873 decision 3). Done here, once per pushed
         // record, so the exact-encode probe -- which clones `records` without
         // re-pushing -- never double-counts a record.
-        self.declared_accum.observe_record(&r.attrs);
+        self.declared_accum.observe_record(&r);
         self.records.push(r);
         if let Some(t) = tracker {
             t.set_writer_bytes(self.estimate);

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -1205,13 +1205,22 @@ impl DeclaredSchema {
             let mut claimed: BTreeSet<usize> = BTreeSet::new();
             let mut values: Vec<(usize, DeclaredStatValue)> = Vec::new();
             for (name, value) in pairs {
+                // The reader's decoder (`ravel_sql::rlog_attrs::decode_value`)
+                // never pushes a List or Map entry into the pairs `find_attr`
+                // resolves over, so such an occurrence must not claim the key
+                // here either: skip it and let a later occurrence of the same
+                // name compete.
+                if matches!(value, AttrValue::List(_) | AttrValue::Map(_)) {
+                    continue;
+                }
                 let Some(&i) = schema.index.get(name.as_str()) else {
                     continue;
                 };
-                // First occurrence wins whatever its kind, matching the
-                // reader's `find_attr` over the resource set then the scope
-                // set: an ineligible or wrong-typed first occurrence shadows a
-                // same-named eligible one behind it, and reads NULL.
+                // First occurrence whose value is not a List or Map wins,
+                // matching the reader's `find_attr` over the resource set
+                // then the scope set: an ineligible (but decoded) or
+                // wrong-typed first occurrence shadows a same-named eligible
+                // one behind it, and reads NULL.
                 if !claimed.insert(i) {
                     continue;
                 }

--- a/crates/ravel-maintain/tests/rlog_declared_stamps.rs
+++ b/crates/ravel-maintain/tests/rlog_declared_stamps.rs
@@ -100,13 +100,37 @@ fn split_config() -> CompactorConfig {
 /// A synthetic stream `n`'s id and canonical resource+scope blob, identical to
 /// the crate's own RLOG test helper: the id is the true hash of the blob.
 fn stream_ident(n: u32) -> (LogStreamId, Vec<u8>) {
-    let res = vec![(
+    stream_ident_with(n, &[])
+}
+
+/// The same, with `extra` resource attributes beyond the service identity, so a
+/// declared column's values can live on the stream rather than on the records.
+fn stream_ident_with(n: u32, extra: &[(&str, AttrValue)]) -> (LogStreamId, Vec<u8>) {
+    let mut res = vec![(
         "service.name".to_string(),
         AttrValue::Str(format!("svc{n}")),
     )];
+    res.extend(extra.iter().map(|(k, v)| ((*k).to_string(), v.clone())));
     let id = log_stream_id(&res, "scope", "1", &[]);
     let blob = ravel_logseg::stream_attrs_bytes(&res, "scope", "1", &[]);
     (id, blob)
+}
+
+/// One record at `ts` on an explicit stream, carrying `attrs` and nothing else.
+fn rec_on(stream: &(LogStreamId, Vec<u8>), ts: i64, attrs: Vec<(&str, AttrValue)>) -> LogRecord {
+    LogRecord {
+        stream_id: stream.0,
+        stream_attrs: stream.1.clone(),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body_of(ts),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+    }
 }
 
 /// A body of exactly [`BODY_LEN`] bytes, tagged with `ts` so distinct records
@@ -365,7 +389,7 @@ fn part_bool(p: &CompactionPart, name: &str) -> (Option<bool>, Option<bool>, u64
 /// asserted here. `non_null + null_count == sample_count` is checked on every
 /// part, the invariant `read_compaction_part` relies on.
 ///
-/// Prove-the-test: delete the `self.declared_accum.observe_record(&r.attrs)`
+/// Prove-the-test: delete the `self.declared_accum.observe_record(&r)`
 /// call in `PartBuilder::push` (crates/ravel-maintain/src/rlog.rs) and every
 /// part stamps all-NULL, so each `Some(..)` min/max assertion fails.
 #[tokio::test]
@@ -427,6 +451,77 @@ async fn each_output_part_stamps_exactly_its_own_records() {
         part_bool(p1, CACHE),
         (Some(true), Some(true), 1),
         "part1 cache true, one NULL (D)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 1b: the fold is over the MERGED attribute view (issue #1057).
+// ---------------------------------------------------------------------------
+
+/// A declared column whose values live on the stream's resource attributes is
+/// stamped at its stream-level value for every record that does not set the key
+/// itself, exactly as a reader resolves it -- not as an affirmative all-NULL.
+///
+/// Both inputs carry the pre-fix L0 stamp for this shape (all-NULL over their
+/// own rows, since no record sets `STATUS`), so this also pins the
+/// recompute-never-copy rule: the output part's stamp is what the compactor
+/// folded, not what the inputs claimed.
+///
+/// Prove-the-test: delete the `schema.fallbacks_for(r.stream_id)` loop at the
+/// end of `DeclaredStatAccum::observe_record` (crates/ravel-maintain/src/rlog.rs)
+/// and the part stamps `(None, None, 3)` instead of `(Some(7), Some(7), 0)`.
+#[tokio::test]
+async fn part_stamps_the_stream_level_value_of_a_declared_column() {
+    let store = MemoryStore::new();
+    let stream = stream_ident_with(5, &[(STATUS, AttrValue::I64(7))]);
+    let input_1 = vec![rec_on(&stream, 1000, vec![]), rec_on(&stream, 3000, vec![])];
+    let input_2 = vec![rec_on(&stream, 2000, vec![])];
+    seed(&store, Uuid::from_u128(20), 1, &input_1, true).await;
+    seed(&store, Uuid::from_u128(21), 2, &input_2, true).await;
+
+    let record = compact_and_record(&store, &CompactorConfig::default()).await;
+    assert_eq!(record.parts.len(), 1, "three small records -> one part");
+    let p = &record.parts[0];
+    assert_eq!(p.sample_count, 3);
+    assert_eq!(
+        part_i64(p, STATUS),
+        (Some(7), Some(7), 0),
+        "every row reads the stream's status 7"
+    );
+    assert_eq!(
+        part_bool(p, CACHE),
+        (None, None, 3),
+        "a column neither the records nor the stream carry is all-NULL"
+    );
+}
+
+/// A record that sets the declared key overrides its stream's value for that
+/// row only, at any value kind: the I64 row reads 2, the Str row reads NULL
+/// (never the stream's 7), and the untouched row reads 7.
+#[tokio::test]
+async fn record_attribute_overrides_the_stream_level_value_for_its_row() {
+    let store = MemoryStore::new();
+    let stream = stream_ident_with(6, &[(STATUS, AttrValue::I64(7))]);
+    let input_1 = vec![
+        rec_on(&stream, 1000, vec![(STATUS, AttrValue::I64(2))]),
+        rec_on(&stream, 3000, vec![]),
+    ];
+    let input_2 = vec![rec_on(
+        &stream,
+        2000,
+        vec![(STATUS, AttrValue::Str("nope".to_string()))],
+    )];
+    seed(&store, Uuid::from_u128(30), 1, &input_1, true).await;
+    seed(&store, Uuid::from_u128(31), 2, &input_2, true).await;
+
+    let record = compact_and_record(&store, &CompactorConfig::default()).await;
+    assert_eq!(record.parts.len(), 1);
+    let p = &record.parts[0];
+    assert_eq!(p.sample_count, 3);
+    assert_eq!(
+        part_i64(p, STATUS),
+        (Some(2), Some(7), 1),
+        "2 from the record, 7 from the stream, one NULL for the Str row"
     );
 }
 

--- a/crates/ravel-maintain/tests/rlog_declared_stamps.rs
+++ b/crates/ravel-maintain/tests/rlog_declared_stamps.rs
@@ -116,6 +116,30 @@ fn stream_ident_with(n: u32, extra: &[(&str, AttrValue)]) -> (LogStreamId, Vec<u
     (id, blob)
 }
 
+/// The same as [`stream_ident_with`], but also carrying `scope_extra`
+/// attributes beyond an otherwise-empty scope set, so a declared column's
+/// stream-level fallback can be exercised on either half of the merged view
+/// in one stream (issue #1057 finding 1: a List/Map resource occurrence must
+/// not shadow a matching-typed scope occurrence behind it).
+fn stream_ident_with_scope(
+    n: u32,
+    res_extra: &[(&str, AttrValue)],
+    scope_extra: &[(&str, AttrValue)],
+) -> (LogStreamId, Vec<u8>) {
+    let mut res = vec![(
+        "service.name".to_string(),
+        AttrValue::Str(format!("svc{n}")),
+    )];
+    res.extend(res_extra.iter().map(|(k, v)| ((*k).to_string(), v.clone())));
+    let scope: Vec<(String, AttrValue)> = scope_extra
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), v.clone()))
+        .collect();
+    let id = log_stream_id(&res, "scope", "1", &scope);
+    let blob = ravel_logseg::stream_attrs_bytes(&res, "scope", "1", &scope);
+    (id, blob)
+}
+
 /// One record at `ts` on an explicit stream, carrying `attrs` and nothing else.
 fn rec_on(stream: &(LogStreamId, Vec<u8>), ts: i64, attrs: Vec<(&str, AttrValue)>) -> LogRecord {
     LogRecord {
@@ -522,6 +546,46 @@ async fn record_attribute_overrides_the_stream_level_value_for_its_row() {
         part_i64(p, STATUS),
         (Some(2), Some(7), 1),
         "2 from the record, 7 from the stream, one NULL for the Str row"
+    );
+}
+
+/// Issue #1057 finding 1: a stream whose RESOURCE attributes carry the
+/// declared column as a List and whose SCOPE attributes carry it as a
+/// matching-typed I64 must fall back to the scope value for a row that does
+/// not set the key itself, exactly as the compaction record's own reader
+/// resolves it -- the same shape as `list_resource_attribute_is_skipped_for_a_
+/// matching_scope_fallback` in `ravel-ingest`, recomputed by the compactor.
+///
+/// Prove-the-test: drop the `AttrValue::List(_) | AttrValue::Map(_)` skip
+/// from `DeclaredSchema::build` (crates/ravel-maintain/src/rlog.rs) and the
+/// List's first occurrence claims `STATUS` with no fallback, so the part
+/// stamps `(Some(2), Some(2), 2)` (the base's wrong answer) instead of
+/// `(Some(2), Some(7), 0)`.
+#[tokio::test]
+async fn part_stamps_skip_list_resource_for_a_matching_scope_fallback() {
+    let store = MemoryStore::new();
+    let stream = stream_ident_with_scope(
+        7,
+        &[(STATUS, AttrValue::List(vec![AttrValue::I64(1)]))],
+        &[(STATUS, AttrValue::I64(7))],
+    );
+    let input_1 = vec![
+        rec_on(&stream, 1000, vec![(STATUS, AttrValue::I64(2))]),
+        rec_on(&stream, 3000, vec![]),
+    ];
+    let input_2 = vec![rec_on(&stream, 2000, vec![])];
+    seed(&store, Uuid::from_u128(40), 1, &input_1, true).await;
+    seed(&store, Uuid::from_u128(41), 2, &input_2, true).await;
+
+    let record = compact_and_record(&store, &CompactorConfig::default()).await;
+    assert_eq!(record.parts.len(), 1, "three small records -> one part");
+    let p = &record.parts[0];
+    assert_eq!(p.sample_count, 3);
+    assert_eq!(
+        part_i64(p, STATUS),
+        (Some(2), Some(7), 0),
+        "the List resource occurrence is skipped; the scope's 7 is the \
+         fallback for the two rows that do not set STATUS themselves"
     );
 }
 

--- a/docs/adrs/0873-commit-record-declared-min-max.md
+++ b/docs/adrs/0873-commit-record-declared-min-max.md
@@ -1278,9 +1278,11 @@ scope-level value). Both shipped producers instead fold the records
 themselves, and both folded a record's own attribute set only. That made a
 declared column whose values live on the stream's resource or scope
 attributes stamp `null_count == sample_count` with absent extrema, which is
-an affirmative all-NULL statement rather than an absent one, so the
-metadata-only aggregate path answered `MIN`/`MAX` with NULL and `COUNT` with
-zero over a column every row of the object resolves a value for.
+an affirmative all-NULL statement rather than an absent one. DataFusion's
+aggregate-statistics rule declines a NULL min/max scalar, so `MIN`/`MAX`
+fell back to a scan and were still correct; only `COUNT` trusted the
+statement outright and answered zero over a column every row of the object
+resolves a value for.
 
 The basis is unchanged by this amendment; it is restated because the
 implementation had drifted from it. For every row, both producers now

--- a/docs/adrs/0873-commit-record-declared-min-max.md
+++ b/docs/adrs/0873-commit-record-declared-min-max.md
@@ -1268,6 +1268,31 @@ Where decision 4 describes the union degenerating to the `.cstat` carrier
 alone for a declared `STR` or `BYTES` column, that now describes `BYTES`
 only; the `STR` case is not a degenerate union but no union at all.
 
+## Amendment 2026-09-03: the stamp's basis is the merged attribute view
+
+Issue #1057. Decision 3 describes the L0 and L1 folds in terms of the
+writer's per-block NumStats, which count merged-view resolution per row
+(docs/log-segment-format.md, "What a numeric stat bounds": a row that
+resolves a name off its stream layer contributes its resource- or
+scope-level value). Both shipped producers instead fold the records
+themselves, and both folded a record's own attribute set only. That made a
+declared column whose values live on the stream's resource or scope
+attributes stamp `null_count == sample_count` with absent extrema, which is
+an affirmative all-NULL statement rather than an absent one, so the
+metadata-only aggregate path answered `MIN`/`MAX` with NULL and `COUNT` with
+zero over a column every row of the object resolves a value for.
+
+The basis is unchanged by this amendment; it is restated because the
+implementation had drifted from it. For every row, both producers now
+resolve the value the reader resolves (`ravel_sql`'s
+`logs_scan::merged_value`): the record's own attribute when the record sets
+that key at any value kind, and otherwise the row's stream-level resource or
+scope attribute of the same name, first blob occurrence winning. A stream's
+attributes are decoded once per stream per object, never per record. When a
+stream's attribute blob does not decode, the producer emits no stamps at all
+for that object rather than an affirmative statement over an unresolved
+view, which is the fail-closed reading of decision 3's staleness rule.
+
 ## Out-of-scope findings, reported not fixed
 
 1. **docs/adrs/README.md index drift**: the index (111 rows) is missing


### PR DESCRIPTION
Both producers of declared-column min/max stamps folded only a record's own attributes, while the query-time value of a declared column is the merged view: the record's attribute when it sets the key, else the stream's resource or scope attribute of that key. A declared integer or boolean column carried only on resource or scope attributes therefore got an affirmative all-null stamp, and the reader answered MIN and MAX as NULL and pruned the parts. An exact-semantics violation for any OTLP tenant with resource-borne declared columns.

The ingest fold now resolves the merged view: per stream it keeps the row count and, per eligible stream-level key, how many rows set the key themselves, and each stream contributes its stream-level value for the remaining rows; the stream blob is decoded once per stream from the attributes the flush already holds, and an undecodable blob yields no stamp for the object so the reader falls back to a scan. The row path and the columnar batch path share the fold. The compaction recompute builds a per-object declared schema with a name-to-index map and a per-stream fallback list, so observing a record costs one hash lookup per attribute instead of a string comparison per attribute-column pair (about ten thousand per record at the ClickBench shape).

Ten tests were shown failing first, among them: a resource attribute supplies the value no record sets (stamp min 7, max 7, null count 0); a record value overrides the resource value for its row only (min 2, max 7); a scope boolean column; the compaction recompute produces the same stamp; and an end-to-end test that writes through the log router and runs MIN, MAX, and COUNT through the SQL planner, asserting the answers, no logs scan operator in the plan, and zero object-store GETs. ADR-0873 gains an amendment stating the merged-view basis for both producers. One additive export in ravel-logseg makes the reader's stream-attribute decoder available to both producers rather than duplicating the frozen grammar.

Reported, not fixed: ADR-0873 decision 3 says both folds run over the writer's per-block NumStats, while both shipped producers fold the records directly (predates this change); and docs/catalog-and-mvcc.md still describes the stamp's NULL as record-level absence. Both tracked as follow-ups.

Fleet task a7800169-af11-46f9-b42b-4bf0ed9dc025, cherry-picked onto current main.

Fixes: #1057
Refs: #1040