### PR TITLE
chore(release): prepare 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,162 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.13.0]
+
+A stock `ravel-server` now sizes its query budgets from the host it runs on, so
+a deployment no longer has to know six flags to scan a large tenant, and a
+container sizes against the memory it may actually use. The two catalog defects
+the 0.12.0 notes listed as known limitations are fixed, and the object-store
+contract is checked by a TLA+ harness in CI.
+
+### Added
+
+- **TLA+ verification harness** (ADR-1113). `scripts/check-tla.sh` runs TLC over
+  every area under `formal/tla` with `smoke`, `exhaustive`, `negative`,
+  `traceability`, `ci`, and `all` subcommands; the TLC jar is pinned by sha256
+  (or supplied through `RAVEL_TLA_TOOLS_JAR` and verified, never downloaded),
+  Java 17 or newer is required, and every run writes one row per config to
+  `.cache/tla/last-run.tsv`. The first area models the object-store contract
+  (`docs/object-store-contract.md`): create-if-absent single winner, CAS on a
+  fresh version, read-after-write including lost responses, monotonic versions
+  across delete and recreate, multipart invisible until complete, listing
+  completeness and consumer consistency. Three negative controls must fail with
+  the exit code and property their `.expect` file pins (two invariants, one
+  liveness property), state-space bands are enforced on passing runs, and a
+  traceability table maps each requirement to its invariant and Rust symbol,
+  naming the rows whose backend half is still an assumption. CI runs the fast
+  lane when a formal area, the harness, an implementation crate the models cite,
+  or a normative document changes; `tla-nightly.yml` runs the exhaustive lane on
+  a schedule.
+- **`ravel-cli cache reclaim-legacy --cache-dir <dir> [--apply]`** (#826).
+  Lists (dry run) or deletes cache entry files left at the pre-namespacing
+  `<cache-dir>/<shard>/<file>` layout, which the current cache never reads,
+  evicts, or counts. Only entry files whose names map back to a cache key are
+  touched; a foreign file keeps its directory. Safe while a node is live.
+- **Partial multi-shard commits are reported for metrics and spans** (#1130).
+  `WriteError` and `SpanWriteError` gain a `PartialWrite` variant matching the
+  log router's: both routers now await every shard's acknowledgement and return
+  the durable sibling tokens when some shards committed and others failed. The
+  partial-commit count is exported as `ravel_ingest_partial_writes_total` for
+  all three signals.
+- **`sql_latency_bench --logs-fetch-policy` and `--logs-block-range-threshold`**
+  (#1139), mirroring the server's flags with the same names and defaults, so the
+  in-process lane routes logs fetches the way `ravel-server` does: at the default
+  cost-based policy every object is read whole in one covering GET.
+  `--logs-request-cost-bytes` is now optional and wins over the policy when set.
+  Report provenance records the policy and the effective threshold, and a figure
+  the report cannot know is labelled "not recorded" rather than as the server's
+  configuration.
+
+### Changed
+
+- **Server budgets are resolved at startup, most of them from the host**
+  (#1141, amending ADR-0088). When the flag is unset, `ravel-server` now
+  resolves: `--fetch-concurrency` to twice the available cores (floor 8), the
+  fetcher read cache (`--cache-max-bytes`) to 80% of usable memory and the
+  catalog byte cache to 5%, `--sql-max-query-bytes` to 25% and
+  `--sql-tenant-max-bytes` to 50%. `--max-segments` (1,000,000) and
+  `--gc-max-query-duration` (11 minutes, still validated against the durable
+  `sys/gc` ceiling) are fixed defaults that do not vary with the host. Usable
+  memory is `/proc/meminfo`'s `MemTotal` **capped by the cgroup memory limit**
+  (cgroup v2 `memory.max`, else v1 `memory.limit_in_bytes`; `max`, the v1
+  no-limit sentinel, `0`, and malformed content are treated as no cap), so a
+  container no longer sizes its caches and pools against host memory it cannot
+  use. An explicit flag wins; an explicit per-query SQL pool raises a
+  non-explicit tenant ceiling rather than being clamped by it, and an explicit
+  `--cache-max-bytes` bounds both caches as before. Where memory cannot be read
+  (a non-Linux host), the memory-derived values fall back to the previous
+  constants. The startup log names each resolved value, its source, and the
+  resolved deadline in milliseconds. These ceilings are LRU caps, not
+  reservations. Before this change a freshly loaded ClickBench tenant (8,424
+  objects) could not be scanned at all against the previous 1,024 segment cap;
+  the measured ClickBench figures for a server at these defaults are recorded on
+  #968.
+- **Overlapping compaction records resolve to one authoritative record**
+  (#1070). When two compaction records in one sealed bucket name overlapping
+  input sets, the catalog keeps one winner per overlap group (largest input set,
+  then smallest `input_set_hash`, then record key), serves its parts, and serves
+  an input only a losing record names as a raw L0 segment, so logs and spans are
+  served once instead of twice. The superseded-input sweep and the erasure
+  completion gate follow the same choice, so an input only a loser names is
+  never deleted from under a query. Publish-time refusal of a second overlapping
+  record is left to a follow-up in `ravel-maintain`.
+- **Declared-column statistics are stamped in one slot-keyed pass per record**
+  (#1135). The bulk-load stamp no longer rescans a record's occurrences per slot
+  or allocates per record; on the 104-column ClickBench shape it measured 11.39x
+  faster per record on the measuring host, with byte-identical output. The
+  bundled benchmark enforces a 2x floor, not the measured ratio, which is host
+  dependent.
+- **A timed-out or cancelled query records the cost it incurred** (#840) instead
+  of a zero-cost outcome; an object-store GET is counted when it is issued, its
+  bytes when it completes.
+- **Alerts and audit scan sets are floored at their pinned shard counts.** A
+  `--shards 1` deployment silently dropped every query-audit record from every
+  audit query, with no error and no counter; the fixed read-shard count is now a
+  floor (1 for alerts, 2 for audit).
+- **CI: each push to `main` has its own concurrency group** (#1145), so a queued
+  main run is no longer cancelled by the next merge and a release commit can
+  always obtain the green `ci.yml` run the publish gate needs.
+
+### Fixed
+
+- **Erasure and GC holds** (#1085, ADR-0064 amended in #1140). The
+  superseded-input sweep is gated on live-HEAD reachability, so an input a
+  HEAD-named snapshot part still resolves is held rather than deleted; a
+  supersession chain is deleted as one unit, its own records last of all, so a
+  rewrite record outlives every input it superseded; an erasure request's
+  `.dreq` and its query-time filter are held past their horizon while any input
+  a rewrite applying that request superseded is still in the store, with the
+  hold read off the sweep itself rather than a completion field the production
+  writer never populates; the hold is observed on every chain in scope, young or
+  aged; request ids are compared in one canonical form; a chain group with a
+  legally held key is skipped whole; and a part reference whose declared bounds
+  disagree with its header blocks fail-closed. Before these fixes an erased
+  subject could become servable again after its filter was retired while its
+  pre-rewrite inputs were still present.
+- **Idempotent retry of a partially committed write** (#1130). The consistency
+  model and the counter comments claimed a keyed retry of a timed-out or
+  partially committed write is deduplicated; the idempotency marker is written
+  only after a fully acknowledged write, so the key deduplicates from the first
+  retry that commits in full. Every partial-commit warning carries the tenant
+  hash.
+- **`cache reclaim-legacy`** removes regular files only (a symlink or directory
+  with an entry-shaped name is left alone) and fails on a listing error instead
+  of under-reporting (#826).
+
+### Documentation
+
+- ADR-1103 decides PromQL over logs: the logs signal exposed to the existing
+  PromQL engine as `ravel_log_lines` and `ravel_log_bytes`, with a `__body__`
+  matcher. A decision record only; no endpoint ships in this release.
+- ADR-0873 is amended to the shipped behaviour: an erasure rewrite part carries
+  no declared min/max stamp at all, replacing decision 3's never-implemented
+  recompute.
+- The catalog and concepts pages state the overlapping-record guarantee and the
+  full tie-break; the deletion and GC document states the real inputs of the
+  erasure hold and why it terminates; the ingest and consistency pages qualify
+  partial-commit retryability; the query, configuration, caching and
+  admission-limits guides state which budgets resolve from host resources and
+  which are fixed; the ClickBench internal pages record the new bench flags and
+  note that passes taken before them are not comparable with passes at defaults.
+
+### Known limitations
+
+- Query latency still depends on the tenant's working set fitting in the read
+  cache; removing the full-scan floor is tracked in #849. The derived cache
+  default makes that working set fit on a host sized for the tenant, but does
+  not remove the floor.
+- The heaviest ClickBench aggregates over the whole table can exceed the derived
+  per-query SQL pool on a 30 GB host and abort with `query memory budget
+  exhausted`. Raise `--sql-max-query-bytes` (and the tenant ceiling with it) to
+  run them.
+- The read cache and the SQL pools are sized independently, so their ceilings
+  can sum past the host's memory. They are LRU caps rather than reservations, so
+  this is a policy gap rather than a measured fault; coordinating them under one
+  process-wide budget is tracked in #1170.
+- Completion records carry no per-bucket dropped counts from the production
+  writer; the erasure hold no longer depends on them.
+
 ## [0.12.0]
 
 Object-store request cost becomes an input that the logs read path and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4468,14 +4468,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-affinity"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
 ]
 
 [[package]]
 name = "ravel-alerting"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "hex",
@@ -4487,14 +4487,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-analytics"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ravel-bench"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "arrow 59.1.0",
  "arrow-flight",
@@ -4547,7 +4547,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cache"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "crc32c",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-catalog"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-codec"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-commit"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-failure-tests"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "futures",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-fleet"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "futures",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4734,7 +4734,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest-router"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-logseg"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4778,7 +4778,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-maintain"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-object-store"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-operator"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "clap",
  "futures",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otap"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ipc 59.1.0",
@@ -4878,7 +4878,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otlp"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "promql-parser",
@@ -4910,7 +4910,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql-difftest"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4938,7 +4938,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-proto"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4947,7 +4947,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-query"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-remote-write"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "hex",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-rspan"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "crc32c",
  "proptest",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-segment"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-server"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sim"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sql"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tenant-resolve"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "axum",
  "base64 0.23.0",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tracing-export"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "services/*"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.97"
@@ -26,29 +26,29 @@ expect_used = "warn"
 # Version fields pin each path dependency so cargo-deny does not count them as
 # wildcards. allow-wildcard-paths is not usable here because these
 # crates are not marked publish = false, so it does not exempt them.
-ravel-types = { path = "crates/ravel-types", version = "0.12.0" }
-ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.12.0" }
-ravel-proto = { path = "crates/ravel-proto", version = "0.12.0" }
-ravel-codec = { path = "crates/ravel-codec", version = "0.12.0" }
-ravel-object-store = { path = "crates/ravel-object-store", version = "0.12.0" }
-ravel-segment = { path = "crates/ravel-segment", version = "0.12.0" }
-ravel-logseg = { path = "crates/ravel-logseg", version = "0.12.0" }
-ravel-rspan = { path = "crates/ravel-rspan", version = "0.12.0" }
-ravel-commit = { path = "crates/ravel-commit", version = "0.12.0" }
-ravel-catalog = { path = "crates/ravel-catalog", version = "0.12.0" }
-ravel-cache = { path = "crates/ravel-cache", version = "0.12.0" }
-ravel-maintain = { path = "crates/ravel-maintain", version = "0.12.0" }
-ravel-fleet = { path = "crates/ravel-fleet", version = "0.12.0" }
-ravel-otlp = { path = "crates/ravel-otlp", version = "0.12.0" }
-ravel-otap = { path = "crates/ravel-otap", version = "0.12.0" }
-ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.12.0" }
-ravel-alerting = { path = "crates/ravel-alerting", version = "0.12.0" }
-ravel-ingest = { path = "crates/ravel-ingest", version = "0.12.0" }
-ravel-promql = { path = "crates/ravel-promql", version = "0.12.0" }
-ravel-query = { path = "crates/ravel-query", version = "0.12.0" }
-ravel-analytics = { path = "crates/ravel-analytics", version = "0.12.0" }
-ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.12.0" }
-ravel-affinity = { path = "crates/ravel-affinity", version = "0.12.0" }
+ravel-types = { path = "crates/ravel-types", version = "0.13.0" }
+ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.13.0" }
+ravel-proto = { path = "crates/ravel-proto", version = "0.13.0" }
+ravel-codec = { path = "crates/ravel-codec", version = "0.13.0" }
+ravel-object-store = { path = "crates/ravel-object-store", version = "0.13.0" }
+ravel-segment = { path = "crates/ravel-segment", version = "0.13.0" }
+ravel-logseg = { path = "crates/ravel-logseg", version = "0.13.0" }
+ravel-rspan = { path = "crates/ravel-rspan", version = "0.13.0" }
+ravel-commit = { path = "crates/ravel-commit", version = "0.13.0" }
+ravel-catalog = { path = "crates/ravel-catalog", version = "0.13.0" }
+ravel-cache = { path = "crates/ravel-cache", version = "0.13.0" }
+ravel-maintain = { path = "crates/ravel-maintain", version = "0.13.0" }
+ravel-fleet = { path = "crates/ravel-fleet", version = "0.13.0" }
+ravel-otlp = { path = "crates/ravel-otlp", version = "0.13.0" }
+ravel-otap = { path = "crates/ravel-otap", version = "0.13.0" }
+ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.13.0" }
+ravel-alerting = { path = "crates/ravel-alerting", version = "0.13.0" }
+ravel-ingest = { path = "crates/ravel-ingest", version = "0.13.0" }
+ravel-promql = { path = "crates/ravel-promql", version = "0.13.0" }
+ravel-query = { path = "crates/ravel-query", version = "0.13.0" }
+ravel-analytics = { path = "crates/ravel-analytics", version = "0.13.0" }
+ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.13.0" }
+ravel-affinity = { path = "crates/ravel-affinity", version = "0.13.0" }
 
 # async runtime / rpc / http
 tokio = { version = "1.53", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ See the [Kubernetes guide](docs/guides/kubernetes.md).
 GitHub Container Registry on every `vX.Y.Z` release tag, built from the root
 `Dockerfile`. Both `linux/amd64` and `linux/arm64` are published. Each published
 object is an OCI image index that carries an SBOM and full build provenance. The
-quickstart pins `ghcr.io/nofireai/ravel-server:0.12.0`. Override it with
+quickstart pins `ghcr.io/nofireai/ravel-server:0.13.0`. Override it with
 `RAVEL_IMAGE`.
 
 ```sh
@@ -303,12 +303,12 @@ so that is the identity in the certificate:
 
 ```sh
 cosign verify \
-  --certificate-identity 'https://github.com/NOFireAI/ravel/.github/workflows/publish-images.yml@refs/tags/v0.12.0' \
+  --certificate-identity 'https://github.com/NOFireAI/ravel/.github/workflows/publish-images.yml@refs/tags/v0.13.0' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-  ghcr.io/nofireai/ravel-server:0.12.0
+  ghcr.io/nofireai/ravel-server:0.13.0
 ```
 
-Replace `v0.12.0` and `0.12.0` with the release you are verifying. The tag ref in
+Replace `v0.13.0` and `0.13.0` with the release you are verifying. The tag ref in
 `--certificate-identity` must be the exact tag that produced the image.
 
 ## How Ravel is verified

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -29,7 +29,7 @@ ravel-promql = { workspace = true }
 # (`metricsbench_gen`) runs the gate, which a dev-dependency would be invisible
 # to. It is already a workspace member, so a `--workspace` build compiled it
 # before this edge existed too.
-ravel-promql-difftest = { path = "../ravel-promql-difftest", version = "0.12.0" }
+ravel-promql-difftest = { path = "../ravel-promql-difftest", version = "0.13.0" }
 prost = { workspace = true }
 # MetricsBench Remote Write 1.0 ingest lane (ADR-0927, issue #937, task M5).
 # `ravel-remote-write` supplies the `prometheus.WriteRequest`/`TimeSeries`/
@@ -99,7 +99,7 @@ futures = { workspace = true, optional = true }
 # ravel-sql is an internal path crate not yet listed in the workspace
 # `[workspace.dependencies]`, so it is named by path here; every other dep
 # below reuses a workspace pin.
-ravel-sql = { path = "../ravel-sql", version = "0.12.0", optional = true, features = ["flight-sql"] }
+ravel-sql = { path = "../ravel-sql", version = "0.13.0", optional = true, features = ["flight-sql"] }
 # Gated behind `sql-latency`. The spans-scan bench lane (`src/spans_scan.rs`)
 # writes its RSPAN corpus with the real span writer and drives `SpansScanExec`
 # directly, so it needs the writer/record types (`RspanWriter`, `SpanRecord`,

--- a/crates/ravel-ingest/Cargo.toml
+++ b/crates/ravel-ingest/Cargo.toml
@@ -30,7 +30,7 @@ ravel-catalog = { workspace = true }
 # [workspace.dependencies]; the root Cargo.toml is out of this task's scope, so
 # this is a version-pinned path dependency (the pin keeps cargo-deny from
 # counting it as a wildcard, matching the workspace's path-dep convention).
-ravel-rspan = { path = "../ravel-rspan", version = "0.12.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.13.0" }
 # The router live switch (ADR-0052) decodes the provisioning record read for a
 # generation refresh; prost's Message trait provides `decode`.
 prost = { workspace = true }
@@ -54,7 +54,7 @@ ravel-promql = { workspace = true }
 # zero data GETs. ravel-sql depends on ravel-catalog/ravel-query/ravel-commit/
 # ravel-logseg, none of which depend on ravel-ingest, so this dev-only edge adds
 # no cycle. No feature flag: ravel-sql's SQL surface is unconditional.
-ravel-sql = { path = "../ravel-sql", version = "0.12.0" }
+ravel-sql = { path = "../ravel-sql", version = "0.13.0" }
 # Match ravel-sql's datafusion pin exactly (same arrow 58 line) so the test's
 # SessionContext/collect interop with ravel-sql's plan types.
 datafusion = { version = "54", default-features = false, features = ["sql"] }

--- a/crates/ravel-otlp/Cargo.toml
+++ b/crates/ravel-otlp/Cargo.toml
@@ -16,7 +16,7 @@ ravel-logseg = { workspace = true }
 # Used for the span record's StatusCode and the frozen resource+scope+span
 # attribute merge rule, so trace normalization and the RSPAN writer cannot
 # drift apart on either.
-ravel-rspan = { path = "../ravel-rspan", version = "0.12.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.13.0" }
 opentelemetry-proto = { workspace = true }
 # Span events and links are stored as an opaque serialized blob in RSPAN v1
 # (ADR-0041 decision 4), which needs prost's own length-delimited encoding.

--- a/crates/ravel-query/Cargo.toml
+++ b/crates/ravel-query/Cargo.toml
@@ -95,7 +95,7 @@ ravel-cache = { workspace = true }
 # proof (tests/differential_compaction.rs) drives P4's real compactor to
 # produce write_v4 L1 parts. ravel-maintain does not depend on ravel-query,
 # so this is acyclic.
-ravel-maintain = { path = "../ravel-maintain", version = "0.12.0" }
+ravel-maintain = { path = "../ravel-maintain", version = "0.13.0" }
 proptest = { workspace = true }
 # The ADR-0046 disk cache tier (crates/ravel-query/src/cache_correctness.rs)
 # needs a real on-disk directory to construct a `ravel_cache::DiskCache`; the

--- a/deploy/docker-compose/ravel.yml
+++ b/deploy/docker-compose/ravel.yml
@@ -50,7 +50,7 @@ services:
   # already-qualified bucket it reports the existing record and exits 0, so this
   # tolerates a populated `minio-data/` across runs.
   qualify:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.12.0}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.13.0}
     depends_on:
       createbucket:
         condition: service_completed_successfully
@@ -72,7 +72,7 @@ services:
   # container boundary forbids, so the demo authenticates with a real bearer
   # token against a real tenant map, exactly as a deployment does.
   ravel-server:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.12.0}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.13.0}
     depends_on:
       qualify:
         condition: service_completed_successfully

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -32,7 +32,7 @@ That brings up five things, all from published images:
   bootstrap-and-continue path for it, so a freshly created bucket has to be
   qualified before the server starts. The step is idempotent: on an
   already-qualified bucket it reports the existing record and exits 0.
-- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.12.0` (override the pin
+- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.13.0` (override the pin
   with the `RAVEL_IMAGE` environment variable), listening on `127.0.0.1:4318`
   (HTTP) and `127.0.0.1:4317` (gRPC), with the tenant token `demo-token` mapped
   to tenant `demo-tenant`.

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -133,7 +133,7 @@ Two routes Grafana's built-in Prometheus datasource probes on every datasource
 save. They take no parameters.
 
 ```json
-{"status": "success", "data": {"version": "0.12.0", "revision": "", "branch": "", "buildUser": "", "buildDate": "", "goVersion": ""}}
+{"status": "success", "data": {"version": "0.13.0", "revision": "", "branch": "", "buildUser": "", "buildDate": "", "goVersion": ""}}
 ```
 
 `version` is Ravel's own version, not a Prometheus one. `revision` is the

--- a/services/ravel-cli/Cargo.toml
+++ b/services/ravel-cli/Cargo.toml
@@ -109,7 +109,7 @@ tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
 # `LogsTableProvider` logs path is in ravel-sql's default build (the
 # `flight-sql` feature only gates the Flight transport), so no feature is
 # needed here.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.12.0" }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.13.0" }
 # The reachability test builds a SqlExecutor's segment fetchers from ravel-query
 # (SegmentFetcher/LogSegmentFetcher/SpanSegmentFetcher); ravel-catalog is
 # already a normal dependency. Workspace pin, test construction only.
@@ -126,7 +126,7 @@ async-trait = { workspace = true }
 # ravel-server is a workspace path crate not listed in
 # `[workspace.dependencies]`, so it is named by path with a pinned version here,
 # exactly as ravel-sql above is; no new external crate enters Cargo.lock.
-ravel-server = { path = "../ravel-server", version = "0.12.0", features = ["sql"] }
+ravel-server = { path = "../ravel-server", version = "0.13.0", features = ["sql"] }
 # The reachability test's axum request/response plumbing (the same shape
 # ravel-server's own endpoint tests use). Already resolved in this workspace's
 # dependency graph; test-only.

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -154,14 +154,14 @@ reqwest = { version = "0.13", features = ["json"] }
 # ravel-rspan below are: the workspace root Cargo.toml is outside this task's
 # scope. The pin keeps cargo-deny from counting it as a wildcard path
 # dependency.
-ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.12.0" }
+ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.13.0" }
 
 # ravel-sql is declared here as a path dependency rather than through
 # `[workspace.dependencies]` because the workspace root Cargo.toml is outside
 # this task's scope. The version is pinned so cargo-deny does not count it as
 # a wildcard path dependency, matching how every other
 # internal crate is pinned.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.12.0", optional = true }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.13.0", optional = true }
 
 # Flight service codegen for the `flight-sql` feature. This is arrow 58's
 # arrow-flight, a different arrow major than the `arrow` dev-dependency below;
@@ -221,7 +221,7 @@ tokio = { workspace = true, features = ["test-util"] }
 # listed in the workspace [workspace.dependencies]; the root Cargo.toml is out
 # of this task's scope, so this is a version-pinned path dependency (the pin
 # keeps cargo-deny from counting it as a wildcard).
-ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.12.0" }
+ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.13.0" }
 uuid = { workspace = true }
 # Real-authn end-to-end test (tests/real_authn_e2e.rs): mint a JWT and build a
 # local oct (HMAC) JWKS so the OIDC resolver runs through a real HTTP request


### PR DESCRIPTION
Bumps the workspace to 0.13.0 and writes the 0.13.0 changelog section.

The version moves in `[workspace.package]`, every pinned path dependency,
`Cargo.lock`, the README image pin and cosign example, the compose quickstart,
and the two guides that quote the image tag and the `buildinfo` version.
`scripts/check-workspace-versions.sh` passes and `scripts/check_docs.py` is clean.

Why a minor bump: `ravel-server` now resolves six query budgets at startup
instead of using compiled-in constants, four of them from the host (#1141), so a
deployment that relied on the old defaults gets different behaviour without
changing a flag. A container also sizes against its cgroup memory limit rather
than the host's `MemTotal`.

The changelog section was fact-checked against the commit bodies and the code on
main before committing. That pass corrected nine claims, including a
fixed-versus-derived conflation for `--max-segments` and the engine deadline, an
inverted delete order in the erasure-chain bullet, a wrong object count, and an
overstated ClickBench framing; and it added four user-facing changes the first
draft omitted (the cgroup cap, the alerts and audit shard floor, the ADR-0873
amendment, and the millisecond deadline log). Competitor comparisons are not in
this file: the measured figures live on #968.

Tagging follows the merge: `v0.13.0` is pushed only after the merge commit's own
`ci.yml` run is green, since `publish-images.yml` gates on that run.

Refs: #1141
