### PR TITLE
docs(adr): amend ADR-0873 for the .cstat identity and STR rule

### DIFF
--- a/crates/ravel-sql/tests/logs_declared_minmax_from_stamps.rs
+++ b/crates/ravel-sql/tests/logs_declared_minmax_from_stamps.rs
@@ -1308,3 +1308,183 @@ async fn the_stamped_bool_answer_equals_the_scanned_answer() {
     );
     assert_eq!(from_stats.gets, 0);
 }
+
+// ---------------------------------------------------------------------------
+// The `.cstat` row-accounting reconciliation (ADR-0873 decision 2, clause 4's
+// `.cstat` arm) at the statement level: what a query ANSWERS when an entry's
+// `non_null_count + null_count` does not reach the joined segment's row count.
+// The plan-time half of these cases, asserted as a drop-metric delta, is in
+// declared_stat_cstat_drops.rs; here the assertion is the number the statement
+// returns, so an entry wrongly accepted shows up as a wrong answer.
+// ---------------------------------------------------------------------------
+
+/// The stale-claim segment: it holds both the corpus minimum and the corpus
+/// maximum, so an entry of its that is wrongly accepted takes both extrema out
+/// of the answer while the statement still succeeds.
+const STALE_SEG_ROWS: &[(i64, Option<i64>)] =
+    &[(400, Some(9_000)), (401, Some(9_500)), (402, None)];
+/// Its companion, stamped by a correct writer, holding values strictly inside
+/// the stale segment's range.
+const COMPANION_SEG_ROWS: &[(i64, Option<i64>)] = &[(500, Some(9_100)), (501, Some(9_200))];
+
+/// A `.cstat` entry whose counts are stated outright rather than derived from
+/// the rows the object holds, which is what [`cstat_for`] does. Only this form
+/// can express an entry that does not reconcile against the joined
+/// `SegmentRef::sample_count`.
+fn cstat_counts(
+    non_null_count: u64,
+    null_count: u64,
+    min: Option<i64>,
+    max: Option<i64>,
+) -> ColumnStat {
+    ColumnStat {
+        name: COL.to_string(),
+        declared_type: 2, // ravel.sys.v1.TypedAttrColumnType::I64
+        non_null_count,
+        null_count,
+        min: min.map(i64_value),
+        max: max.map(i64_value),
+        dictionary_present: false,
+        dictionary: Vec::new(),
+        sum: None,
+    }
+}
+
+/// An entry accounting for two of the segment's three rows describes an object
+/// that does not exist, so it lends no `Exact` extremum and the statement
+/// scans to the object's real extrema. Its extrema are deliberately values no
+/// row carries: the answer is the assertion that the scan, not the entry,
+/// produced it.
+///
+/// Prove-the-test: delete the `accounted != Some(seg.sample_count)` refusal
+/// block in `reconciled_column_stat` (crates/ravel-sql/src/logs_scan.rs). The
+/// plan then loses its `LogsScanExec`, the statement answers
+/// `(Some(-1), Some(42))` from the entry with zero GETs, and the column
+/// statistics read `Precision::Exact(Int64(-1))`.
+#[tokio::test]
+async fn an_unreconciled_cstat_entry_lends_no_exact_extremum() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/unreconciled.rlog", 1, SEG_A_ROWS).await;
+    // 2 + 0 = 2, against a three-row segment.
+    let stats = loaded_stats(vec![(&a, vec![cstat_counts(2, 0, Some(-1), Some(42))])]);
+    let snapshot = snapshot_of(vec![a]);
+
+    let plan_stats = scan_stats(snapshot.clone(), Some(Arc::clone(&stats)));
+    let col = declared_col_stats(&plan_stats);
+    assert_eq!(
+        col.min_value,
+        Precision::Absent,
+        "an unreconciled entry grants no MIN"
+    );
+    assert_eq!(
+        col.max_value,
+        Precision::Absent,
+        "nor a MAX: the whole entry is refused"
+    );
+
+    let out = min_max_over_store(&store, snapshot, Some(stats)).await;
+    assert!(
+        out.plan.contains("LogsScanExec"),
+        "an unreconciled entry must fail closed to a scan; plan was:\n{}",
+        out.plan
+    );
+    assert_eq!(
+        out.answer,
+        (Some(18_500), Some(19_000)),
+        "the scan answers the object's real extrema, not the entry's -1 and 42"
+    );
+    assert_eq!(out.objects_touched, 1, "the one segment, opened once");
+}
+
+/// The reconciled half of the same segment, which is what keeps the refusal
+/// above from being satisfied by a reader that refuses every entry: `2 + 1 == 3
+/// == sample_count`, so the entry answers at plan time with no `LogsScanExec`
+/// and zero GETs.
+///
+/// Prove-the-test: change the refusal in `reconciled_column_stat` to
+/// `accounted != Some(seg.sample_count + 1)` and this plan regains its
+/// `LogsScanExec` and its GETs while the test above still passes.
+#[tokio::test]
+async fn a_reconciled_cstat_entry_still_answers_from_statistics() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let a = write_segment(&store, "logs/reconciled.rlog", 1, SEG_A_ROWS).await;
+    let stats = loaded_stats(vec![(
+        &a,
+        vec![cstat_counts(2, 1, Some(18_500), Some(19_000))],
+    )]);
+    let snapshot = snapshot_of(vec![a]);
+
+    let plan_stats = scan_stats(snapshot.clone(), Some(Arc::clone(&stats)));
+    let col = declared_col_stats(&plan_stats);
+    assert_eq!(
+        col.min_value,
+        Precision::Exact(ScalarValue::Int64(Some(18_500))),
+        "a reconciled entry still lends an exact MIN"
+    );
+    assert_eq!(
+        col.max_value,
+        Precision::Exact(ScalarValue::Int64(Some(19_000)))
+    );
+
+    let out = min_max_over_store(&store, snapshot, Some(stats)).await;
+    assert!(
+        !out.plan.contains("LogsScanExec"),
+        "a reconciled entry answers at plan time; plan was:\n{}",
+        out.plan
+    );
+    assert_eq!(out.answer, (Some(18_500), Some(19_000)));
+    assert_eq!(out.gets, 0, "no data object may be read");
+    assert_eq!(out.objects_touched, 0);
+}
+
+/// The stale all-NULL claim: an entry with zero non-null rows and both extrema
+/// absent, internally consistent under the presence rule, whose `null_count`
+/// equals the rows it claims to describe but not the rows the joined segment
+/// holds (2, against a three-row object). Accepting it would cover the segment
+/// while contributing nothing, which is silent absence: the corpus minimum and
+/// maximum both live in that segment, so the answer would collapse to the
+/// companion segment's narrower range with no scan and no error.
+///
+/// Prove-the-test: delete the same `accounted != Some(seg.sample_count)` block
+/// in `reconciled_column_stat`. The stale entry is then accepted as an exact
+/// all-NULL coverage statement, the plan loses its `LogsScanExec`, and the
+/// statement answers `(Some(9_100), Some(9_200))` instead of the true
+/// `(Some(9_000), Some(9_500))`.
+#[tokio::test]
+async fn a_stale_all_null_cstat_claim_does_not_answer_null() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let stale = write_segment(&store, "logs/stale.rlog", 1, STALE_SEG_ROWS).await;
+    let companion = write_segment(&store, "logs/companion.rlog", 2, COMPANION_SEG_ROWS).await;
+    // 0 + 2 = 2, against a three-row segment: an all-NULL claim over rows the
+    // object does not have.
+    let stats = loaded_stats(vec![(&stale, vec![cstat_counts(0, 2, None, None)])]);
+    let snapshot = snapshot_of(vec![
+        stale,
+        stamped(
+            &companion,
+            vec![encode_stamp(&stamp_for(COMPANION_SEG_ROWS))],
+        ),
+    ]);
+
+    let plan_stats = scan_stats(snapshot.clone(), Some(Arc::clone(&stats)));
+    let col = declared_col_stats(&plan_stats);
+    assert_eq!(
+        col.min_value,
+        Precision::Absent,
+        "a stale all-NULL claim is refused, not accepted as an exact NULL"
+    );
+    assert_eq!(col.max_value, Precision::Absent);
+
+    let out = min_max_over_store(&store, snapshot, Some(stats)).await;
+    assert!(
+        out.plan.contains("LogsScanExec"),
+        "a stale claim must fail closed to a scan; plan was:\n{}",
+        out.plan
+    );
+    assert_eq!(
+        out.answer,
+        (Some(9_000), Some(9_500)),
+        "both extrema live in the segment whose entry was refused"
+    );
+    assert_eq!(out.objects_touched, 2, "both segments opened, once each");
+}

--- a/docs/adrs/0873-commit-record-declared-min-max.md
+++ b/docs/adrs/0873-commit-record-declared-min-max.md
@@ -1226,6 +1226,48 @@ flowchart TD
   claims in `CompactionPart` with ADR-0815's, first-to-land takes the
   lower numbers; this ADR claims only field 12.
 
+## Amendment: the .cstat carrier joins by entry identity and STR extrema stay .cstat-only
+
+Amended 2026-09-03. Two statements above do not describe the shipped reader.
+Decision 4 says both carriers of the union resolve through one segment
+identity, the data object's content hash. Decision 2 says a `.cstat` `STR`
+extremum is answered at `Precision::Exact` today and mandates a positive
+regression test for that. The code does neither, and the decision here is
+that the code is right and this document moves to it. The decisions' original
+text stands as written except where this section supersedes it.
+
+The `.cstat` side of the union joins by the entry identity the fold already
+writes into the object: ingest hour bucket, shard, writer id, writer epoch,
+and writer sequence. The stamp side joins by content hash in the only sense a
+stamp can, since it rides the resolved segment reference itself and that
+reference's content hash is the record's. Both lookups start from one
+resolved segment reference and read fields of that reference, so the two
+carriers are matched to the same segment through the reference rather than
+through two independently stored keys that could name different segments.
+That is what keeps this inside ADR-0942 rather than beside it. What it
+introduces is nothing: no new field on any object, no key a reader must
+store, compare across objects, or keep converging with another. The identity
+tuple is the fold's existing per-entry key and the content hash is the
+record's existing one; neither is a name this ADR invents, and no durable
+object gains a second way to be addressed. What ADR-0942 forbade was a join
+key that covered many segments at once and so merged their statistics. The
+entry identity has the opposite property, naming exactly one flush of one
+shard in one ingest hour, and a compacted segment carries the nil writer id,
+matches no `.cstat` entry, and falls back to a scan.
+
+A `.cstat` `STR` extremum is never consulted. The read side declines a
+declared `STR` column before either carrier is examined, because the column
+is projected as a dictionary-encoded string and has no scalar form on the
+statistics path, so `MIN` and `MAX` over a declared `STR` column are answered
+by scanning. Decision 2's "from today" claim for `STR` is withdrawn, and with
+it the positive regression test that decision mandates for a `STR` entry: no
+such test can pass against a reader that never reaches the entry. The `BYTES`
+half of that mandate stands unchanged, since `BYTES` is excluded from the
+stamp vocabulary, is read from `.cstat`, and does reach `Precision::Exact`.
+Where decision 4 describes the union degenerating to the `.cstat` carrier
+alone for a declared `STR` or `BYTES` column, that now describes `BYTES`
+only; the `STR` case is not a degenerate union but no union at all.
+
 ## Out-of-scope findings, reported not fixed
 
 1. **docs/adrs/README.md index drift**: the index (111 rows) is missing

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -231,9 +231,12 @@ Two carriers feed it, unioned per segment and per column (ADR-0873 decision
   snapshot entry (field 15) that resolution already reads. Because it rides
   those records, it covers the live tail above the fold watermark and
   token-resolved segments, which no fold-built sibling object can;
-- the ADR-0850/0942 `.cstat` entry, joined by segment identity, which is the
-  carrier for pre-stamp sealed history and the only carrier for `Str`/`Bytes`
-  extrema.
+- the ADR-0850/0942 `.cstat` entry, joined by the entry identity (ingest hour
+  bucket, shard, writer id, writer epoch, writer sequence), which is the
+  carrier for pre-stamp sealed history and the only carrier for `Bytes`
+  extrema. A declared `Str` column is declined before either carrier is read,
+  since it is projected as a dictionary-encoded string with no scalar form on
+  this path, so `MIN`/`MAX` over one is always answered by the scan.
 
 **The write side of the stamp carrier does not exist.** Nothing in the
 flush or compaction path calls the stamp writers in
@@ -263,18 +266,24 @@ of the `stats_are_exact` gate above:
 - an entry either carrier's reader refuses: a stamp of an ineligible type, a
   stamp whose type disagrees with the tenant's declaration, a duplicated
   entry name (ADR-0873 clause 6 drops every occurrence, so a duplicate never
-  reaches a reader as coverage), or a `.cstat` entry whose extrema presence
-  disagrees with its `non_null_count`;
+  reaches a reader as coverage), a `.cstat` entry whose extrema presence
+  disagrees with its `non_null_count`, or a `.cstat` entry whose row
+  accounting (`non_null_count + null_count`) does not reconcile against the
+  joined `SegmentRef::sample_count`;
 - the two carriers disagreeing about one segment in `min`, `max`, or
   `null_count`. Nothing is ever combined across carriers: both claim to
   describe the same rows of one immutable object exactly, so a disagreement
   means one of them is wrong and no answer is safe.
 
-A `null_count` is reported `Exact` only when every covering carrier proved it,
-which means the stamp: a `.cstat` entry's row accounting is not reconciled
-against the joined `SegmentRef::sample_count` on this path, and an unreconciled
-figure would answer `COUNT(col)` from something nothing checked. The extrema are
-exact either way.
+A `.cstat` entry's row accounting is reconciled against the joined
+`SegmentRef::sample_count` before the entry grants anything, and the refusal
+covers the whole entry, extrema included: an entry whose counts do not add up
+to the segment's rows describes rows the object does not have, so no figure it
+carries describes the object the query reads. A `null_count` is reported
+`Exact` only when every covering carrier proved its figure, which means the
+stamp: reconciliation is a fail-closed gate on what a `.cstat` entry may grant,
+not a promotion of its NULL count to a proven one, so a `.cstat`-only column
+answers `MIN`/`MAX` exactly and leaves `COUNT(col)` to the scan.
 
 One statistics shape is exact and still does not shortcut the query. A declared
 column that reads NULL in every touched row has an exactly-NULL extremum, and
@@ -295,9 +304,11 @@ the numbers may be read.
 statistics entries a reader dropped, one per dropped entry, labelled by the
 carrier that was read: `commit-record`, `compaction-part`, `snapshot-entry`, and
 `cstat`. The first three are the stamp reads in `ravel-commit`; the `cstat`
-label is reported by `ravel-sql`'s `.cstat` reader, which counts exactly two
-refusals as defects (a duplicated column name, and extrema presence that
-contradicts the row accounting) and treats a missing object, segment, or column
+label is reported by `ravel-sql`'s `.cstat` reader, which counts exactly three
+refusals as defects (a duplicated column name, extrema presence that
+contradicts the row accounting, and row accounting that does not reconcile
+against the joined `SegmentRef::sample_count`) and treats a missing object,
+segment, or column
 entry as the ordinary uncovered state. Each READ of a defective carrier
 increments the label again: there is no per-entry deduplication, because it
 would need unbounded state keyed by (object, column) on a path walked once per


### PR DESCRIPTION
Three divergences between the `.cstat` statistics lane and ADR-0873 were checked against the current tree. Two are real and are resolved by recording the shipped behaviour: the `.cstat` side of the statistics union joins by the entry identity (ingest hour, shard, writer id, epoch, sequence) while the stamp side joins by content hash, and both are matched to one segment through the joined segment reference, which adds no second durable identity; and a declared string column is declined before either carrier is read, so string extrema are answered by scan and the positive string test decision 2 mandated is withdrawn (bytes columns still reach exact). Both are stated in a dated amendment; the decisions' original text is untouched, and the query-engine page's sentences on the two carriers now match.

The third item, that an unreconciled `.cstat` entry could lend an exact extremum, is already resolved on main: the entry's `non_null_count + null_count` is reconciled against the joined segment's sample count and the whole entry is refused otherwise, which also refuses a stale all-null claim. Three statement-level tests now pin that through the executor: an unreconciled entry lends no exact minimum, a stale all-null claim does not answer null, and a reconciled entry still answers from statistics; each was shown failing with the reconciliation removed or its comparand shifted.

Fleet task a3487ca9-3fb2-4034-a1ba-5af71d54ca54, cherry-picked onto current main.

Fixes: #1023
Refs: #1040