### PR TITLE
fix(maintain): resolve the retention window like the fold does

### DIFF
--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -887,10 +887,10 @@ impl Catalog {
                 None
             }
         };
-        let tenant_retention_ns: Option<i64> = tenant_config
-            .as_ref()
-            .and_then(|cfg| cfg.retention_ns)
-            .or(default_retention_ns);
+        let tenant_retention_ns: Option<i64> = crate::tenant_config::resolve_retention_window(
+            tenant_config.as_ref(),
+            default_retention_ns,
+        );
         // ADR-0850: the tenant's configured typed logs attribute columns, if
         // any. `None`/absent config/a read failure all mean "no configured
         // columns" -- unlike `retention_ns`, `typed_attr_columns` has no

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -82,5 +82,5 @@ pub use tenant_config::{
     DeclaredColumnType, DeclaredTypedColumn, FIXED_LOGS_SQL_COLUMNS,
     SetOutcome as TenantConfigSetOutcome, TENANT_CONFIG_FORMAT_VERSION, TenantConfig,
     TenantConfigError, TenantLifecycleState, TypedAttrColumnError, config_key, read_config,
-    read_config_values, set_tenant_config, validate_typed_attr_columns,
+    read_config_values, resolve_retention_window, set_tenant_config, validate_typed_attr_columns,
 };

--- a/crates/ravel-catalog/src/tenant_config.rs
+++ b/crates/ravel-catalog/src/tenant_config.rs
@@ -280,6 +280,25 @@ impl TenantConfig {
     }
 }
 
+/// The one retention-window precedence shared by the catalog fold and the
+/// retention sweep: the durable per-tenant [`TenantConfig::retention_ns`] wins
+/// when the record is present and carries `Some`, otherwise
+/// `default_retention_ns` -- the deployment-wide window the caller already
+/// resolved from the CLI-derived config (the per-tenant override if set, else
+/// the deployment default). An absent record (`None`) or one whose
+/// `retention_ns` is unset both fall through to the default; a tenant with
+/// neither resolves to `None` (no retention). The durable record wins over the
+/// CLI per-tenant override when both are set. Stated once here so the fold and
+/// the sweep never resolve different windows for the same tenant.
+pub fn resolve_retention_window(
+    tenant_config: Option<&TenantConfig>,
+    default_retention_ns: Option<i64>,
+) -> Option<i64> {
+    tenant_config
+        .and_then(|cfg| cfg.retention_ns)
+        .or(default_retention_ns)
+}
+
 /// A typed config-record failure. Every variant is fatal to the touch that
 /// raised it, the fail-closed-on-any-anomaly discipline `ProvisioningError` and
 /// `KeyEpochError` follow. None warn and continue.

--- a/crates/ravel-maintain/src/retention.rs
+++ b/crates/ravel-maintain/src/retention.rs
@@ -40,6 +40,7 @@ use ravel_object_store::{
     GetRange, ObjectStoreBackend, PutOptions, StoreError, UploadChecksum, list_all,
 };
 use ravel_proto::commit::v1::{CommitRecord, CompactionRecord, RetentionTombstone};
+use ravel_types::TenantHash;
 
 use crate::bucket::Bucket;
 use crate::clock::Clock;
@@ -87,6 +88,45 @@ pub enum RetentionOutcome {
     BlockedBySnapshot(SnapshotBlock),
 }
 
+/// Resolve a tenant's effective retention window the same way the catalog fold
+/// does (ADR-0078): overlay the durable per-tenant `TenantConfig.retention_ns`
+/// on the deployment default that `RetentionConfig::window_for` yields (the
+/// `--retention-tenant` per-tenant override if set, else `--retention-default`).
+/// The durable record is read from the same object store, under the same key,
+/// through the same decoder the fold uses
+/// ([`ravel_catalog::read_config_values`]), and the precedence is the single one
+/// stated in [`ravel_catalog::resolve_retention_window`] -- durable record wins,
+/// then CLI per-tenant override, then CLI default -- so the sweep and the fold
+/// never resolve different windows for the same tenant. Without this the sweep
+/// read only the CLI map and would tombstone an hour a longer durable window
+/// keeps, which the fold's frontier reconcile never drops, stalling the physical
+/// sweep on a repeating `BlockedBySnapshot`.
+///
+/// A config-read fault fails the resolution closed (propagates the error) rather
+/// than falling back to the possibly shorter CLI window: a tombstone is
+/// irreversible, so a transient store fault must never shorten the window and
+/// retire a bucket the durable record would keep. The sweep is idempotent, so
+/// the pass simply retries on the next tick.
+pub async fn resolve_retention_window_ns(
+    store: &dyn ObjectStoreBackend,
+    retention: &RetentionConfig,
+    tenant: &TenantHash,
+) -> Result<Option<i64>> {
+    let default_retention_ns = retention.window_for(tenant);
+    let tenant_config = ravel_catalog::read_config_values(store, tenant)
+        .await
+        .map_err(|e| {
+            MaintainError::Invariant(format!(
+                "tenant config read failed while resolving retention window for {}: {e}",
+                tenant.to_hex()
+            ))
+        })?;
+    Ok(ravel_catalog::resolve_retention_window(
+        tenant_config.as_ref(),
+        default_retention_ns,
+    ))
+}
+
 /// Run one retention pass over a single sealed bucket (ADR-0019):
 /// evaluate expiry, write the tombstone if newly expired, and run the
 /// horizon-gated physical sweep if a tombstone is already present and its
@@ -101,8 +141,9 @@ pub async fn retention_sweep_bucket(
     lease: &dyn LeaseCheck,
     bucket: &Bucket,
 ) -> Result<RetentionOutcome> {
+    let window_ns = resolve_retention_window_ns(store, retention, &bucket.tenant_hash).await?;
     let mut reach = SnapshotReachability::new();
-    retention_sweep_bucket_with_reach(&mut reach, store, clock, config, retention, lease, bucket)
+    retention_sweep_bucket_with_reach(&mut reach, store, clock, config, window_ns, lease, bucket)
         .await
 }
 
@@ -113,17 +154,25 @@ pub async fn retention_sweep_bucket(
 /// public [`retention_sweep_bucket`] wraps this with a fresh per-call cache;
 /// [`crate::scan::scan_and_maintain_with_memo`] owns one cache for the whole
 /// per-(tenant, signal, shard) pass and calls this directly.
+///
+/// `window_ns` is the tenant's effective retention window already resolved by
+/// [`resolve_retention_window_ns`] (durable record over CLI, ADR-0078). The
+/// caller resolves it once per pass -- the window is constant across a tenant's
+/// buckets, so reading the durable config per bucket would be one redundant GET
+/// per bucket -- and threads the same value into every bucket of the pass, so
+/// the sweep, the pass's zone classification, and the fold all use one window.
+/// `None` means no retention policy for this tenant.
 #[allow(clippy::too_many_arguments)]
 pub async fn retention_sweep_bucket_with_reach(
     reach: &mut SnapshotReachability,
     store: &dyn ObjectStoreBackend,
     clock: &dyn Clock,
     config: &CompactorConfig,
-    retention: &RetentionConfig,
+    window_ns: Option<i64>,
     lease: &dyn LeaseCheck,
     bucket: &Bucket,
 ) -> Result<RetentionOutcome> {
-    let Some(window_ns) = retention.window_for(&bucket.tenant_hash) else {
+    let Some(window_ns) = window_ns else {
         return Ok(RetentionOutcome::NoPolicy);
     };
     let now = clock.now_ns();
@@ -193,26 +242,28 @@ pub async fn maintain_bucket(
     lease: &dyn LeaseCheck,
     bucket: &Bucket,
 ) -> Result<(RetentionOutcome, Option<CompactionOutcome>)> {
+    let window_ns = resolve_retention_window_ns(store, retention, &bucket.tenant_hash).await?;
     let mut reach = SnapshotReachability::new();
-    maintain_bucket_with_reach(&mut reach, store, clock, config, retention, lease, bucket).await
+    maintain_bucket_with_reach(&mut reach, store, clock, config, window_ns, lease, bucket).await
 }
 
 /// [`maintain_bucket`] with a caller-owned [`SnapshotReachability`] cache
 /// shared across the buckets of one sweep pass (ADR-0076 request cost, see
 /// [`retention_sweep_bucket_with_reach`]). The public [`maintain_bucket`] wraps
-/// this with a fresh per-call cache.
+/// this with a fresh per-call cache. `window_ns` is the pass-resolved retention
+/// window (see [`retention_sweep_bucket_with_reach`]).
 #[allow(clippy::too_many_arguments)]
 pub async fn maintain_bucket_with_reach(
     reach: &mut SnapshotReachability,
     store: &dyn ObjectStoreBackend,
     clock: &dyn Clock,
     config: &CompactorConfig,
-    retention: &RetentionConfig,
+    window_ns: Option<i64>,
     lease: &dyn LeaseCheck,
     bucket: &Bucket,
 ) -> Result<(RetentionOutcome, Option<CompactionOutcome>)> {
     let outcome =
-        retention_sweep_bucket_with_reach(reach, store, clock, config, retention, lease, bucket)
+        retention_sweep_bucket_with_reach(reach, store, clock, config, window_ns, lease, bucket)
             .await?;
     let compaction = match outcome {
         // The bucket is (or is being) retired, or its delete is blocked by a

--- a/crates/ravel-maintain/src/scan.rs
+++ b/crates/ravel-maintain/src/scan.rs
@@ -18,6 +18,7 @@ use crate::config::{CompactorConfig, NS_PER_HOUR, RetentionConfig};
 use crate::error::{MaintainError, Result};
 use crate::retention::{
     RetentionOutcome, SnapshotBlock, SnapshotReachability, maintain_bucket_with_reach,
+    resolve_retention_window_ns,
 };
 use crate::sweep::LeaseCheck;
 
@@ -1143,7 +1144,12 @@ pub async fn scan_and_maintain_with_memo(
     let now = clock.now_ns();
     let hours = list_shard_hours(store, &tenant_hash, signal, shard).await?;
     let present: HashSet<u32> = hours.iter().copied().collect();
-    let retention_window_ns = retention.window_for(&tenant_hash);
+    // Resolve the tenant's effective retention window once for the whole pass
+    // (durable record over CLI, ADR-0078; the same window the fold resolves).
+    // The window is constant across a tenant's buckets, so this is one config
+    // GET per pass rather than one per bucket, and every bucket's retention
+    // decision and this pass's zone classification use the same value.
+    let retention_window_ns = resolve_retention_window_ns(store, retention, &tenant_hash).await?;
 
     // One HEAD-reachability cache for the whole pass: the delete-blocker gate
     // (ADR-0020) reads the catalog HEAD at most once and each covering snapshot
@@ -1170,9 +1176,16 @@ pub async fn scan_and_maintain_with_memo(
         }
 
         let bucket = Bucket::new(tenant_hash, signal, shard, hour);
-        let (retention_outcome, compaction) =
-            maintain_bucket_with_reach(&mut reach, store, clock, config, retention, lease, &bucket)
-                .await?;
+        let (retention_outcome, compaction) = maintain_bucket_with_reach(
+            &mut reach,
+            store,
+            clock,
+            config,
+            retention_window_ns,
+            lease,
+            &bucket,
+        )
+        .await?;
         match retention_outcome {
             // The bucket is (being) retired; compaction was skipped by design.
             RetentionOutcome::Tombstoned

--- a/crates/ravel-maintain/tests/retention.rs
+++ b/crates/ravel-maintain/tests/retention.rs
@@ -12,7 +12,7 @@ use common::*;
 use proptest::prelude::*;
 use ravel_commit::keys;
 use ravel_maintain::config::DEFAULT_MAX_INGEST_LAG_NS;
-use ravel_maintain::retention::{is_expired, max_event_ts};
+use ravel_maintain::retention::{is_expired, max_event_ts, resolve_retention_window_ns};
 use ravel_maintain::scan::scan_and_maintain;
 use ravel_maintain::{
     Bucket, CompactionOutcome, CompactorConfig, FixedClock, NoLeases, RetentionConfig,
@@ -1277,6 +1277,380 @@ async fn scan_reports_blocked_by_snapshot_counter() {
         "the HEAD-reachability block is counted on MaintainReport"
     );
     assert_eq!(r2.blocked_by_unreadable_head, 0);
+}
+
+// --- #1131: the sweep resolves the retention window like the fold ----------
+
+/// Count the commit records currently present in a bucket.
+async fn count_commit_records(store: &dyn ObjectStoreBackend, bucket: &Bucket) -> usize {
+    let prefix = keys::commit_shard_hour_prefix(
+        &bucket.tenant_hash,
+        bucket.signal,
+        bucket.shard,
+        bucket.ingest_hour_bucket,
+    )
+    .unwrap();
+    list_all(store, &prefix)
+        .await
+        .unwrap()
+        .iter()
+        .filter(|m| {
+            matches!(
+                keys::partition_bucket_entry(&m.key),
+                Ok(keys::BucketEntry::CommitRecord(_))
+            )
+        })
+        .count()
+}
+
+/// Count the retention tombstones currently present in a bucket.
+async fn count_tombstones(store: &dyn ObjectStoreBackend, bucket: &Bucket) -> usize {
+    let prefix = keys::commit_shard_hour_prefix(
+        &bucket.tenant_hash,
+        bucket.signal,
+        bucket.shard,
+        bucket.ingest_hour_bucket,
+    )
+    .unwrap();
+    list_all(store, &prefix)
+        .await
+        .unwrap()
+        .iter()
+        .filter(|m| {
+            matches!(
+                keys::partition_bucket_entry(&m.key),
+                Ok(keys::BucketEntry::Tombstone(_))
+            )
+        })
+        .count()
+}
+
+/// #1131 (a): a tenant whose durable `retention_ns` is 48h under a CLI default
+/// of 24h. The sweep must resolve the durable 48h window (exactly as the fold
+/// does, ADR-0078), so an hour aged ~30h is NOT tombstoned (exact kept count)
+/// and one aged ~50h IS (exact tombstoned count).
+///
+/// Failing assertion against pre-fix code: `assert_eq!(out_30,
+/// RetentionOutcome::NotExpired)` (and `count_tombstones(.., &bucket_30) == 0`).
+/// Pre-fix the sweep resolved the window from `RetentionConfig::window_for`
+/// alone (the CLI 24h map), never reading `TenantConfig.retention_ns`, so the
+/// 30h-old hour is expired and tombstoned: the outcome is `Tombstoned` and the
+/// tombstone count is 1.
+#[tokio::test]
+async fn sweep_honors_durable_window_over_shorter_cli_default() {
+    let store = Arc::new(MemoryStore::new());
+    let config = cfg();
+    let cli_default = 24 * NS_PER_HOUR;
+    let durable = 48 * NS_PER_HOUR;
+    let retention = RetentionConfig::from_policy(
+        RetentionPolicy {
+            default: Some(cli_default),
+            tenants: vec![],
+        },
+        &config,
+        DEFAULT_MAX_INGEST_LAG_NS,
+    )
+    .expect("cli retention config");
+    write_tenant_retention(store.as_ref(), durable).await;
+
+    let now = (i64::from(HOUR) + 60) * NS_PER_HOUR;
+    let clock = FixedClock::new(now);
+
+    // Aged ~30h: kept under 48h, expired under 24h.
+    let hour_30 = HOUR + 30;
+    let bucket_30 = bucket_at(hour_30);
+    seed_input(
+        store.as_ref(),
+        &InputSpec::new_at(
+            hour_30,
+            Uuid::from_u128(0x30),
+            1,
+            1,
+            vec![raw_series(
+                "m",
+                &[("k", "h30")],
+                &[(i64::from(hour_30) * NS_PER_HOUR + 1_000, 1.0)],
+            )],
+        ),
+    )
+    .await;
+
+    // Aged ~50h: expired under both 48h and 24h.
+    let hour_50 = HOUR + 10;
+    let bucket_50 = bucket_at(hour_50);
+    seed_input(
+        store.as_ref(),
+        &InputSpec::new_at(
+            hour_50,
+            Uuid::from_u128(0x50),
+            1,
+            1,
+            vec![raw_series(
+                "m",
+                &[("k", "h50")],
+                &[(i64::from(hour_50) * NS_PER_HOUR + 1_000, 2.0)],
+            )],
+        ),
+    )
+    .await;
+
+    // The 30h-old hour: kept by the durable 48h window.
+    let out_30 = retention_sweep_bucket(
+        store.as_ref(),
+        &clock,
+        &config,
+        &retention,
+        &NoLeases,
+        &bucket_30,
+    )
+    .await
+    .expect("sweep h30");
+    assert_eq!(
+        out_30,
+        RetentionOutcome::NotExpired,
+        "the durable 48h window keeps the 30h-old hour (pre-fix reads CLI 24h and tombstones it)"
+    );
+    assert_eq!(
+        count_tombstones(store.as_ref(), &bucket_30).await,
+        0,
+        "no tombstone for the kept hour"
+    );
+    assert_eq!(
+        count_commit_records(store.as_ref(), &bucket_30).await,
+        1,
+        "the kept hour's commit record is untouched"
+    );
+
+    // The 50h-old hour: expired even under the durable 48h window.
+    let out_50 = retention_sweep_bucket(
+        store.as_ref(),
+        &clock,
+        &config,
+        &retention,
+        &NoLeases,
+        &bucket_50,
+    )
+    .await
+    .expect("sweep h50");
+    assert_eq!(
+        out_50,
+        RetentionOutcome::Tombstoned,
+        "the 50h-old hour expires under the durable 48h window"
+    );
+    assert_eq!(
+        count_tombstones(store.as_ref(), &bucket_50).await,
+        1,
+        "exactly one tombstone for the expired hour"
+    );
+}
+
+/// #1131 (b): the liveness stall. With a durable window longer than the CLI
+/// default and a live HEAD naming the hour, the sweep must resolve the durable
+/// window and leave the hour retained -- never tombstone it -- so the physical
+/// sweep never repeats `BlockedBySnapshot` waiting for a frontier reconcile
+/// that (at the durable window) would not drop the hour.
+///
+/// Failing assertion against pre-fix code: `assert_eq!(pass1,
+/// RetentionOutcome::NotExpired)`. Pre-fix the sweep resolves the CLI 24h
+/// window and tombstones the 30h-old hour; a pass past the horizon then returns
+/// `BlockedBySnapshot(SnapshotBlock::Named)` on every tick, because the fold
+/// (at the durable window) keeps naming the hour and its frontier reconcile
+/// never drops it -- the stall this fix removes.
+#[tokio::test]
+async fn durable_window_avoids_blocked_by_snapshot_stall() {
+    let store = Arc::new(MemoryStore::new());
+    let config = cfg();
+    let cli_default = 24 * NS_PER_HOUR;
+    let durable = 200 * NS_PER_HOUR;
+    let retention = RetentionConfig::from_policy(
+        RetentionPolicy {
+            default: Some(cli_default),
+            tenants: vec![],
+        },
+        &config,
+        DEFAULT_MAX_INGEST_LAG_NS,
+    )
+    .expect("cli retention config");
+    write_tenant_retention(store.as_ref(), durable).await;
+
+    let now = (i64::from(HOUR) + 60) * NS_PER_HOUR;
+    let clock = FixedClock::new(now);
+    let hour_30 = HOUR + 30;
+    let bucket_30 = bucket_at(hour_30);
+    seed_input(
+        store.as_ref(),
+        &InputSpec::new_at(
+            hour_30,
+            Uuid::from_u128(0x31),
+            1,
+            1,
+            vec![raw_series(
+                "m",
+                &[("k", "h30")],
+                &[(i64::from(hour_30) * NS_PER_HOUR + 1_000, 1.0)],
+            )],
+        ),
+    )
+    .await;
+
+    // A live HEAD naming the hour: the fold overlays the durable window, so its
+    // frontier reconcile keeps this hour. The sweep must agree and keep it too.
+    let default_retention_ns = retention.window_for(&tenant_hash());
+    fold_head(&store, Signal::Metrics, now, default_retention_ns).await;
+
+    // First sweep: retained under the durable window, no tombstone written.
+    let pass1 = retention_sweep_bucket(
+        store.as_ref(),
+        &clock,
+        &config,
+        &retention,
+        &NoLeases,
+        &bucket_30,
+    )
+    .await
+    .expect("sweep pass 1");
+    assert_eq!(
+        pass1,
+        RetentionOutcome::NotExpired,
+        "the durable window keeps the hour; pre-fix reads CLI 24h and tombstones it"
+    );
+    assert_eq!(count_tombstones(store.as_ref(), &bucket_30).await, 0);
+
+    // The fold's frontier reconcile runs (watermark advanced). At the durable
+    // window it does not drop the hour, matching the sweep.
+    fold_head(
+        &store,
+        Signal::Metrics,
+        now + 3 * NS_PER_HOUR,
+        default_retention_ns,
+    )
+    .await;
+
+    // A second sweep, past the protection horizon: still retained, never
+    // BlockedBySnapshot. Pre-fix the hour is tombstoned and this pass returns
+    // BlockedBySnapshot(Named) on every tick.
+    clock.set(now + config.protection_horizon_ns + 1);
+    let pass2 = retention_sweep_bucket(
+        store.as_ref(),
+        &clock,
+        &config,
+        &retention,
+        &NoLeases,
+        &bucket_30,
+    )
+    .await
+    .expect("sweep pass 2");
+    assert_ne!(
+        pass2,
+        RetentionOutcome::BlockedBySnapshot(SnapshotBlock::Named),
+        "the durable window means the hour is never tombstoned, so no snapshot block"
+    );
+    assert_eq!(
+        pass2,
+        RetentionOutcome::NotExpired,
+        "the hour is reported retained on the second pass"
+    );
+    assert_eq!(count_tombstones(store.as_ref(), &bucket_30).await, 0);
+}
+
+/// #1131 (c): the fold and the sweep resolve the SAME window (exact ns) for a
+/// tenant with a durable record, one with only a CLI override, and one with
+/// neither. Also pins the precedence tiebreak: a durable record wins over a CLI
+/// per-tenant override.
+///
+/// Failing assertion against pre-fix code: in case 1, `assert_eq!(sweep,
+/// Some(durable))`. To reproduce the pre-fix resolution, make
+/// `resolve_retention_window_ns` return `Ok(retention.window_for(tenant))`
+/// (ignore the durable record): the sweep then resolves the CLI override (36h),
+/// not the durable 48h, and diverges from the fold.
+#[tokio::test]
+async fn fold_and_sweep_resolve_the_same_window() {
+    let config = cfg();
+    let cli_default = 24 * NS_PER_HOUR;
+    let cli_override = 36 * NS_PER_HOUR;
+    let durable = 48 * NS_PER_HOUR;
+
+    // Resolve the window through both paths: the sweep's new async resolver, and
+    // the fold's own resolution (read the durable record the same way and
+    // overlay it on the deployment default services/ravel-server/src/fold.rs
+    // hands to Catalog::fold, `RetentionConfig::window_for`).
+    async fn resolve_both(
+        store: &dyn ObjectStoreBackend,
+        retention: &RetentionConfig,
+    ) -> (Option<i64>, Option<i64>) {
+        let th = tenant_hash();
+        let sweep = resolve_retention_window_ns(store, retention, &th)
+            .await
+            .expect("sweep resolves window");
+        let tenant_config = ravel_catalog::read_config_values(store, &th)
+            .await
+            .expect("read tenant config");
+        let fold = ravel_catalog::resolve_retention_window(
+            tenant_config.as_ref(),
+            retention.window_for(&th),
+        );
+        (sweep, fold)
+    }
+
+    // Case 1: a durable record present (with a CLI override too) -> durable wins.
+    {
+        let store = Arc::new(MemoryStore::new());
+        let retention = RetentionConfig::from_policy(
+            RetentionPolicy {
+                default: Some(cli_default),
+                tenants: vec![(TENANT.to_string(), cli_override)],
+            },
+            &config,
+            DEFAULT_MAX_INGEST_LAG_NS,
+        )
+        .expect("retention config");
+        write_tenant_retention(store.as_ref(), durable).await;
+        let (sweep, fold) = resolve_both(store.as_ref(), &retention).await;
+        assert_eq!(
+            sweep,
+            Some(durable),
+            "the durable record wins over the CLI per-tenant override"
+        );
+        assert_eq!(fold, Some(durable));
+        assert_eq!(
+            sweep, fold,
+            "the sweep and the fold resolve the same window"
+        );
+    }
+
+    // Case 2: only a CLI per-tenant override, no durable record.
+    {
+        let store = Arc::new(MemoryStore::new());
+        let retention = RetentionConfig::from_policy(
+            RetentionPolicy {
+                default: Some(cli_default),
+                tenants: vec![(TENANT.to_string(), cli_override)],
+            },
+            &config,
+            DEFAULT_MAX_INGEST_LAG_NS,
+        )
+        .expect("retention config");
+        let (sweep, fold) = resolve_both(store.as_ref(), &retention).await;
+        assert_eq!(sweep, Some(cli_override));
+        assert_eq!(fold, Some(cli_override));
+        assert_eq!(
+            sweep, fold,
+            "the sweep and the fold resolve the same window"
+        );
+    }
+
+    // Case 3: neither a durable record nor any CLI policy.
+    {
+        let store = Arc::new(MemoryStore::new());
+        let retention = RetentionConfig::default();
+        let (sweep, fold) = resolve_both(store.as_ref(), &retention).await;
+        assert_eq!(sweep, None);
+        assert_eq!(fold, None);
+        assert_eq!(
+            sweep, fold,
+            "the sweep and the fold resolve the same window"
+        );
+    }
 }
 
 /// Deliverable 5 (counters): the fail-closed undecodable-HEAD block is

--- a/crates/ravel-maintain/tests/scan.rs
+++ b/crates/ravel-maintain/tests/scan.rs
@@ -274,8 +274,8 @@ async fn warm_memo_skips_terminal_buckets_with_fewer_list_and_get_calls() {
     );
     assert_eq!(
         cold_get,
-        3 * u64::from(N),
-        "2 commit + 1 compaction GET per bucket"
+        3 * u64::from(N) + 1,
+        "2 commit + 1 compaction GET per bucket, plus one config GET per pass"
     );
 
     // Tick 3 (warm): every bucket is skipped straight from the memo.
@@ -297,14 +297,20 @@ async fn warm_memo_skips_terminal_buckets_with_fewer_list_and_get_calls() {
     assert_eq!(r3.skipped_terminal, N as usize);
     assert_eq!(r3.already_done, 0);
     // The warm steady-state tick issues only the single shard-level
-    // list_delimited: no per-bucket List, no GET.
+    // list_delimited and the one per-pass config GET (durable retention
+    // window, resolved once per pass for zone classification and the
+    // retention decision): no per-bucket List, no per-bucket GET.
     assert_eq!(list_delimited_delta(&before_warm, &after_warm), 1);
     assert_eq!(
         list_delta(&before_warm, &after_warm),
         0,
         "no per-bucket LISTs"
     );
-    assert_eq!(get_delta(&before_warm, &after_warm), 0, "no GETs");
+    assert_eq!(
+        get_delta(&before_warm, &after_warm),
+        1,
+        "one config GET per pass, no per-bucket GETs"
+    );
     assert!(0 < cold_list && 0 < cold_get, "cold tick did real work");
 }
 
@@ -363,7 +369,9 @@ async fn fresh_memo_after_restart_re_evaluates_and_skips_nothing() {
     );
 
     // Restart: a fresh, cold memo. Its first tick skips nothing and redoes the
-    // full per-bucket work (2 LISTs + 3 GETs per bucket).
+    // full per-bucket work (2 LISTs + 3 GETs per bucket), plus one config GET
+    // for the whole pass: the tenant's retention window is resolved once per
+    // pass (durable record over CLI, ADR-0078), not once per bucket.
     let mut fresh = MaintainMemo::new(DEFAULT_MEMO_REVERIFY_INTERVAL_NS);
     let before = store.metrics().snapshot();
     let r_fresh = scan_and_maintain_with_memo(
@@ -389,7 +397,9 @@ async fn fresh_memo_after_restart_re_evaluates_and_skips_nothing() {
         "every bucket re-evaluated"
     );
     assert_eq!(list_delta(&before, &after), 2 * u64::from(N));
-    assert_eq!(get_delta(&before, &after), 3 * u64::from(N));
+    // 3 GETs per bucket, plus one config GET resolving the retention window once
+    // for the pass.
+    assert_eq!(get_delta(&before, &after), 3 * u64::from(N) + 1);
     assert_eq!(fresh.len(), N as usize, "the fresh memo re-learned the set");
 }
 
@@ -609,7 +619,8 @@ async fn warm_start_skips_terminal_buckets_without_reads() {
     }
 
     // The seeded worker's first tick skips every bucket straight from the
-    // seed: no redundant per-bucket LIST, no GET, only the shard listing.
+    // seed: no redundant per-bucket LIST or GET, only the shard listing and
+    // the one per-pass config GET (durable retention window).
     let before = store.metrics().snapshot();
     let report = scan_and_maintain_with_memo(
         &mut seeded,
@@ -643,8 +654,8 @@ async fn warm_start_skips_terminal_buckets_without_reads() {
     );
     assert_eq!(
         get_delta(&before, &after),
-        0,
-        "no GETs after a durable warm start"
+        1,
+        "only the per-pass config GET after a durable warm start"
     );
 }
 
@@ -765,8 +776,8 @@ async fn ownership_handoff_seeds_successor_from_predecessor_snapshot() {
     );
     assert_eq!(
         get_delta(&before, &after),
-        0,
-        "no per-bucket GETs on handoff warm start"
+        1,
+        "only the per-pass config GET on handoff warm start"
     );
     assert_eq!(
         list_delta(&before, &after),

--- a/docs/deletion-and-gc.md
+++ b/docs/deletion-and-gc.md
@@ -305,6 +305,19 @@ window would still call a Hit.
   max(max_event_ts) across both.
 - Observing a tombstone invalidates that bucket's cached commit and
   compaction records (the trigger ADR-0010 §10 promises).
+- The retention window a sweep applies to a bucket is resolved by a single
+  precedence, the same one the fold applies (ADR-0078): the durable per-tenant
+  retention window wins when set, otherwise the deployment default, where the
+  deployment default is the per-tenant deployment override if one is configured
+  and the deployment-wide default otherwise. So a durable per-tenant record
+  overrides both deployment settings. The sweep reads that durable record from
+  object storage under the same key and through the same decoder the fold uses,
+  so the sweep and the fold always resolve the same window for a tenant. This
+  agreement is required, not incidental: the two passes run independently, and a
+  sweep using a shorter window than the fold would tombstone an hour the fold's
+  snapshot still names and whose retention-frontier reconcile never drops,
+  leaving the physical sweep blocked on the HEAD-referenced-snapshot delete
+  blocker on every pass.
 - Retention is durable and irreversible: raising a tenant's retention
   window after a bucket is tombstoned never resurrects it. A token whose
   bucket is tombstoned resolves as satisfied with zero segments, not as


### PR DESCRIPTION
The catalog fold and the retention sweep resolved a tenant's retention window from different sources: the fold overlaid the durable per-tenant retention on the deployment default, while the sweep read only the CLI flags and never the durable record. When the durable window was longer, the sweep tombstoned an hour the fold's frontier still kept, HEAD kept naming it, and the delete blocker fired on every pass, a repeating liveness stall.

One precedence now lives in the catalog crate: the durable per-tenant retention wins when set, else the deployment default (the CLI per-tenant override when configured, else the deployment-wide default). The fold calls it where it used to inline the overlay, and the sweep resolves the window through it after reading the durable record with the same store key and decoder the fold uses. A read fault fails closed: the sweep never shortens the window to the CLI default and retires a bucket the durable record would keep. The window is resolved once per tenant, signal, and shard pass and threaded into every bucket decision and the zone classification, which costs one configuration GET per pass; the exact request-count assertions in the scan tests were updated for it.

Three tests were shown failing with the resolver stubbed to the CLI lookup: a 48-hour durable window under a 24-hour CLI default keeps an hour aged 30 hours (exactly one commit record, zero tombstones) and tombstones one aged 50 hours (exactly one); the sweep followed by the fold's frontier reconcile no longer yields a blocked outcome on the second pass; and the fold and the sweep resolve identical windows for a tenant with a durable record, with only a CLI override, and with neither. The deletion spec states the single precedence.

Fleet task eeddf699-3dcc-488f-9a1f-c93971a3540d, cherry-picked onto current main.

Fixes: #1131
Refs: #1040