### PR TITLE
feat(sql): register the alerts and audit tables on both SQL transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ management service (SSE-KMS), legal hold, and admission limits.
 - Logs and traces are queryable over SQL only, as the `logs` and `spans` tables.
   There is no LogQL, no PromQL surface for logs, no TraceQL, no trace-by-ID
   endpoint, and no Jaeger or Tempo API.
-- Alert rule transitions and audit records are written to object storage, and no
-  shipped query surface can read them back.
 - Profiles are a reserved object-key prefix only. No ingest, no query.
 - Exemplars are stored from the OpenTelemetry Protocol (OTLP) only. Remote Write
   and OTAP decode exemplars and then discard them.
@@ -75,8 +73,8 @@ management service (SSE-KMS), legal hold, and admission limits.
 **Who should wait.** If your dashboards range over months of high-cardinality
 metrics, the missing downsampled storage will cost you on every panel. If your
 logs or traces workflow depends on LogQL, TraceQL, or the Jaeger UI, there is
-nothing here to point them at. If you need alert history to be queryable, it is
-not. If you need write acknowledgement in single-digit milliseconds, strict mode
+nothing here to point them at. If you need write acknowledgement in single-digit
+milliseconds, strict mode
 pays an object-store round trip and buffered mode gives up the crash guarantee
 above. Ravel is pre-1.0: the persistent formats are versioned contracts, and the
 surfaces around them still move.
@@ -95,8 +93,8 @@ matrix says which.
 | Prometheus Remote Write 1.0 and 2.0 ingest | metrics | `none` | yes |
 | OTAP ingest, gRPC | metrics | `otap` | yes |
 | PromQL HTTP API | metrics | `none` | yes |
-| SQL over `POST /api/v1/sql` | metrics as `samples`, logs as `logs`, traces as `spans` | `sql` | yes |
-| Flight SQL | the same three tables | `flight-sql` | yes |
+| SQL over `POST /api/v1/sql` | metrics as `samples`, logs as `logs`, traces as `spans`, alert history as `alerts`, audit records as `audit` | `sql` | yes |
+| Flight SQL | the same five tables | `flight-sql` | yes |
 
 <!-- END SUPPORT MATRIX -->
 
@@ -110,8 +108,8 @@ ingest is registered only when the process is started with `--otap`
 ([docs/otap-ingest.md](docs/otap-ingest.md)). A source build gets the same
 surfaces by passing the same `--features` list to cargo.
 
-Exactly three SQL tables are registered: `samples`, `logs`, and `spans`. SQL is
-the only way to query logs and traces.
+Exactly five SQL tables are registered: `samples`, `logs`, `spans`, `alerts`,
+and `audit`. SQL is the only way to query logs and traces.
 
 Also live:
 
@@ -123,8 +121,7 @@ Also live:
   it arrives over OTLP or through a collector's Prometheus exporter.
 - Exemplars that link a metric sample to its trace.
 - Alert rules whose every transition is written to object storage as immutable
-  data. Reading those records back needs a query surface Ravel does not
-  ship.
+  data, and readable back through the `alerts` SQL table.
 - An analytics endpoint for change point detection and summary statistics.
 - Compaction, age-based retention, and garbage collection across all signals.
 - A Kubernetes operator with a `RavelCluster` custom resource.
@@ -164,7 +161,8 @@ curl -s -H "Authorization: Bearer demo-token" \
 ```
 
 The published image carries the `sql` feature, so `POST /api/v1/sql` answers
-by default. The registered tables are `samples`, `logs`, and `spans`:
+by default. The registered tables are `samples`, `logs`, `spans`, `alerts`, and
+`audit`:
 
 <!-- ravel:run status=200; nonempty:.data.rows -->
 ```sh

--- a/crates/ravel-sql/src/alerts_scan.rs
+++ b/crates/ravel-sql/src/alerts_scan.rs
@@ -19,6 +19,12 @@
 //! DataFusion re-applies the originals above the scan and any residual predicate
 //! (`state = 'firing'`, `attrs['label.env'] = 'prod'`, ...) is evaluated there
 //! against the emitted columns.
+//!
+//! Each emitted record carries the write identity of the object it came from
+//! (`writer_id`/`writer_epoch`/`writer_seq`, ADR-1101 decision 1's row
+//! contract), stamped from that object's [`SegmentRef`] as the partition is
+//! fetched. Those three columns are what give a SQL fold over the history a
+//! total order; see crate::alerts_schema.
 
 use std::fmt;
 use std::future::Future;
@@ -27,7 +33,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use datafusion::arrow::array::{
-    ArrayRef, Int64Builder, MapBuilder, StringBuilder, TimestampNanosecondArray,
+    ArrayRef, Int64Builder, MapBuilder, StringBuilder, TimestampNanosecondArray, UInt64Builder,
 };
 use datafusion::arrow::compute::SortOptions;
 use datafusion::arrow::datatypes::SchemaRef;
@@ -52,7 +58,7 @@ use ravel_types::accounting::QueryAccounting;
 
 use crate::alerts_schema::{ALERT_ID_KEY, GENERATION_KEY, RULE_ID_KEY, STATE_KEY, alerts_schema};
 use crate::error::SqlError;
-use crate::rlog_attrs::{attr_value_to_string, find_attr, merged_attrs, retain_unerased};
+use crate::rlog_attrs::{attr_value_to_string, find_attr, merged_attrs, retain_unerased_by};
 
 /// Rows accumulated into one output batch before it is emitted.
 const BATCH_ROWS: usize = 8192;
@@ -213,9 +219,36 @@ impl ExecutionPlan for AlertsScanExec {
     }
 }
 
+/// The write identity of the object a record was read from (ADR-1101 decision
+/// 1's row contract): the three [`SegmentRef`] fields the `alerts` table
+/// promotes to columns. Carried per record rather than per partition because a
+/// partition fetches several objects and the records are then sorted together.
+#[derive(Clone)]
+struct WriteIdentity {
+    writer_id: String,
+    writer_epoch: u64,
+    writer_seq: u64,
+}
+
+impl WriteIdentity {
+    fn from_segment(seg: &SegmentRef) -> Self {
+        WriteIdentity {
+            // The hyphenated uuid string, the same spelling the commit record's
+            // own writer id renders to.
+            writer_id: seg.writer_id.to_string(),
+            writer_epoch: seg.writer_epoch,
+            writer_seq: seg.writer_seq,
+        }
+    }
+}
+
+/// One fetched alert record and the identity of the object it came from.
+type StampedRecord = (LogRecord, WriteIdentity);
+
 /// Fetch every segment in this partition and return its records sorted by
-/// `ts_ns` ascending. The ts range and the `alert_id`/`rule_id` equalities prune
-/// the fetch exactly; the residual re-applies everything above.
+/// `ts_ns` ascending, each stamped with its object's write identity. The ts
+/// range and the `alert_id`/`rule_id` equalities prune the fetch exactly; the
+/// residual re-applies everything above.
 #[allow(clippy::too_many_arguments)]
 async fn prepare_partition(
     fetcher: LogSegmentFetcher,
@@ -226,13 +259,13 @@ async fn prepare_partition(
     content: Arc<Vec<Predicate>>,
     erasure: Arc<Vec<ErasurePredicate>>,
     accounting: QueryAccounting,
-) -> DFResult<Vec<LogRecord>> {
+) -> DFResult<Vec<StampedRecord>> {
     let mut query = LogQuery::new(ts_min, ts_max).with_erasure((*erasure).clone());
     for c in content.iter() {
         query = query.with_content(c.clone());
     }
 
-    let mut out: Vec<LogRecord> = Vec::new();
+    let mut out: Vec<StampedRecord> = Vec::new();
     for seg in &segs {
         let Some(output) = fetcher
             .fetch_accounted_with_tenant(seg, tenant_hash, &query, &accounting)
@@ -241,24 +274,36 @@ async fn prepare_partition(
         else {
             continue;
         };
-        out.extend(output.records);
+        // Stamped here, where the record and the `SegmentRef` it was read from
+        // are both in hand: once the partition's records are merged and sorted
+        // there is no way back to the object.
+        let identity = WriteIdentity::from_segment(seg);
+        out.extend(
+            output
+                .records
+                .into_iter()
+                .map(|record| (record, identity.clone())),
+        );
     }
     // Scan-layer selective-erasure exclusion (ADR-0064). This is the
     // authoritative exclusion because it sees the same merged `attrs` view the
     // surface returns (resource + scope + record), so a subject named only in a
     // resource/scope attribute is dropped; the fetcher-level filter matches
     // per-record attributes alone and cannot see it.
-    retain_unerased(&mut out, &erasure)?;
+    retain_unerased_by(&mut out, &erasure, |(record, _)| record)?;
     // Stable sort so records with equal ts keep the reader's emission order.
-    out.sort_by_key(|r| r.ts_ns);
+    out.sort_by_key(|(record, _)| record.ts_ns);
     Ok(out)
 }
 
-type PrepareFuture = Pin<Box<dyn Future<Output = DFResult<Vec<LogRecord>>> + Send>>;
+type PrepareFuture = Pin<Box<dyn Future<Output = DFResult<Vec<StampedRecord>>> + Send>>;
 
 enum AlertScanState {
     Fetching(PrepareFuture),
-    Emitting { records: Vec<LogRecord>, pos: usize },
+    Emitting {
+        records: Vec<StampedRecord>,
+        pos: usize,
+    },
     Done,
 }
 
@@ -320,27 +365,36 @@ impl RecordBatchStream for AlertScanStream {
     }
 }
 
-/// Decode a slice of records into one `alerts`-schema [`RecordBatch`]. The four
-/// scalar fields are promoted from each record's merged attributes ([`find_attr`]
-/// over [`merged_attrs`]), and the full merged map is rendered into the `attrs`
-/// column, so a promoted column and the `attrs` map for the same key never
-/// disagree.
-fn build_batch(records: &[LogRecord], schema: SchemaRef) -> DFResult<RecordBatch> {
-    let ts = TimestampNanosecondArray::from(records.iter().map(|r| r.ts_ns).collect::<Vec<_>>());
+/// Decode a slice of stamped records into one `alerts`-schema [`RecordBatch`].
+/// The four scalar fields are promoted from each record's merged attributes
+/// ([`find_attr`] over [`merged_attrs`]), the full merged map is rendered into
+/// the `attrs` column, so a promoted column and the `attrs` map for the same key
+/// never disagree, and the three write-identity columns come from the object's
+/// own [`SegmentRef`], never from an attribute.
+fn build_batch(records: &[StampedRecord], schema: SchemaRef) -> DFResult<RecordBatch> {
+    let ts =
+        TimestampNanosecondArray::from(records.iter().map(|(r, _)| r.ts_ns).collect::<Vec<_>>());
 
     let mut alert_id = StringBuilder::new();
     let mut rule_id = StringBuilder::new();
     let mut state = StringBuilder::new();
     let mut generation = Int64Builder::new();
+    let mut writer_id = StringBuilder::new();
+    let mut writer_epoch = UInt64Builder::new();
+    let mut writer_seq = UInt64Builder::new();
     let mut attrs = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
 
-    for r in records {
+    for (r, identity) in records {
         let merged = merged_attrs(r)?;
 
         append_str_attr(&mut alert_id, find_attr(&merged, ALERT_ID_KEY));
         append_str_attr(&mut rule_id, find_attr(&merged, RULE_ID_KEY));
         append_str_attr(&mut state, find_attr(&merged, STATE_KEY));
         append_generation(&mut generation, find_attr(&merged, GENERATION_KEY));
+
+        writer_id.append_value(&identity.writer_id);
+        writer_epoch.append_value(identity.writer_epoch);
+        writer_seq.append_value(identity.writer_seq);
 
         for (k, v) in &merged {
             attrs.keys().append_value(k);
@@ -357,6 +411,9 @@ fn build_batch(records: &[LogRecord], schema: SchemaRef) -> DFResult<RecordBatch
         Arc::new(rule_id.finish()),
         Arc::new(state.finish()),
         Arc::new(generation.finish()),
+        Arc::new(writer_id.finish()),
+        Arc::new(writer_epoch.finish()),
+        Arc::new(writer_seq.finish()),
         Arc::new(attrs.finish()),
     ];
     debug_assert_eq!(schema.fields().len(), columns.len());

--- a/crates/ravel-sql/src/alerts_schema.rs
+++ b/crates/ravel-sql/src/alerts_schema.rs
@@ -10,14 +10,31 @@
 //! and the promoted keys themselves) through one `attrs` `Map(Utf8, Utf8)`
 //! column.
 //!
-//! | column     | arrow type                    | source                                    |
-//! |------------|-------------------------------|-------------------------------------------|
-//! | ts_ns      | Timestamp(Nanosecond, None)   | `LogRecord::ts_ns` (transition event time)|
-//! | alert_id   | Utf8, nullable                | `attrs["alert_id"]` (hex stable hash)     |
-//! | rule_id    | Utf8, nullable                | `attrs["rule_id"]`                        |
-//! | state      | Utf8, nullable                | `attrs["state"]` (firing/resolved/...)    |
-//! | generation | Int64, nullable               | `attrs["generation"]` (recursion guard)   |
-//! | attrs      | Map(Utf8, Utf8)               | full merged resource/scope + record attrs |
+//! | column       | arrow type                    | source                                    |
+//! |--------------|-------------------------------|-------------------------------------------|
+//! | ts_ns        | Timestamp(Nanosecond, None)   | `LogRecord::ts_ns` (transition event time)|
+//! | alert_id     | Utf8, nullable                | `attrs["alert_id"]` (hex stable hash)     |
+//! | rule_id      | Utf8, nullable                | `attrs["rule_id"]`                        |
+//! | state        | Utf8, nullable                | `attrs["state"]` (firing/resolved/...)    |
+//! | generation   | Int64, nullable               | `attrs["generation"]` (recursion guard)   |
+//! | writer_id    | Utf8                          | `SegmentRef::writer_id` of the object     |
+//! | writer_epoch | UInt64                        | `SegmentRef::writer_epoch`                |
+//! | writer_seq   | UInt64                        | `SegmentRef::writer_seq`                  |
+//! | attrs        | Map(Utf8, Utf8)               | full merged resource/scope + record attrs |
+//!
+//! # Why the write identity is a column
+//!
+//! The table is raw history, one row per transition (ADR-1101 decision 1), and
+//! current state is a SQL fold over it. `ts_ns` alone cannot order that fold:
+//! two evaluators can overlap briefly at a lease handover and write the same
+//! `alert_id` at the same `ts_ns`, which is why the evaluator's own fold orders
+//! by `(ts_ns, epoch, seq)`. The three identity columns expose the same keys
+//! plus `writer_id`, so `ORDER BY ts_ns DESC, writer_epoch DESC, writer_seq
+//! DESC, writer_id DESC` is a total order and a `ROW_NUMBER() = 1` fold can
+//! never return two "current" rows for one alert. They are stamped per record
+//! from the commit record of the object the record was read from
+//! (crate::alerts_scan), never from a record attribute, so a record cannot
+//! misreport its own writer.
 //!
 //! # Why a `Map` column for labels/annotations, not per-name columns
 //!
@@ -42,7 +59,10 @@ pub const ALERT_COL_ALERT_ID: usize = 1;
 pub const ALERT_COL_RULE_ID: usize = 2;
 pub const ALERT_COL_STATE: usize = 3;
 pub const ALERT_COL_GENERATION: usize = 4;
-pub const ALERT_COL_ATTRS: usize = 5;
+pub const ALERT_COL_WRITER_ID: usize = 5;
+pub const ALERT_COL_WRITER_EPOCH: usize = 6;
+pub const ALERT_COL_WRITER_SEQ: usize = 7;
+pub const ALERT_COL_ATTRS: usize = 8;
 
 /// The attribute key an alert record's stable id is carried under.
 pub const ALERT_ID_KEY: &str = "alert_id";
@@ -70,6 +90,13 @@ fn alerts_fields() -> Vec<Field> {
         // column mirrors that type exactly rather than a UInt, so a value read
         // back never has to be range-checked or reinterpreted.
         Field::new("generation", DataType::Int64, true),
+        // The write identity of the object the record was read from, stamped by
+        // the scan (ADR-1101 decision 1's row contract). Non-null: every
+        // resolved segment carries all three, so a NULL here would mean a
+        // record with no provenance rather than a missing attribute.
+        Field::new("writer_id", DataType::Utf8, false),
+        Field::new("writer_epoch", DataType::UInt64, false),
+        Field::new("writer_seq", DataType::UInt64, false),
         // Same `Map(Utf8, Utf8)` type the `logs` table's `attrs` column is built
         // on, so a built array and this declared type agree exactly.
         Field::new("attrs", label_map_type(), false),
@@ -89,7 +116,7 @@ mod tests {
     #[test]
     fn schema_columns_are_in_the_documented_order_and_type() {
         let s = alerts_schema();
-        assert_eq!(s.fields().len(), 6);
+        assert_eq!(s.fields().len(), 9);
         assert_eq!(s.field(ALERT_COL_TS).name(), "ts_ns");
         assert_eq!(
             s.field(ALERT_COL_TS).data_type(),
@@ -104,6 +131,20 @@ mod tests {
         assert_eq!(s.field(ALERT_COL_GENERATION).name(), "generation");
         assert_eq!(s.field(ALERT_COL_GENERATION).data_type(), &DataType::Int64);
         assert!(s.field(ALERT_COL_GENERATION).is_nullable());
+        // The write-identity columns (ADR-1101 decision 1) are non-null and
+        // typed to the commit record's own fields.
+        assert_eq!(s.field(ALERT_COL_WRITER_ID).name(), "writer_id");
+        assert_eq!(s.field(ALERT_COL_WRITER_ID).data_type(), &DataType::Utf8);
+        assert!(!s.field(ALERT_COL_WRITER_ID).is_nullable());
+        assert_eq!(s.field(ALERT_COL_WRITER_EPOCH).name(), "writer_epoch");
+        assert_eq!(
+            s.field(ALERT_COL_WRITER_EPOCH).data_type(),
+            &DataType::UInt64
+        );
+        assert!(!s.field(ALERT_COL_WRITER_EPOCH).is_nullable());
+        assert_eq!(s.field(ALERT_COL_WRITER_SEQ).name(), "writer_seq");
+        assert_eq!(s.field(ALERT_COL_WRITER_SEQ).data_type(), &DataType::UInt64);
+        assert!(!s.field(ALERT_COL_WRITER_SEQ).is_nullable());
         assert_eq!(s.field(ALERT_COL_ATTRS).name(), "attrs");
         assert_eq!(s.field(ALERT_COL_ATTRS).data_type(), &label_map_type());
         assert!(!s.field(ALERT_COL_ATTRS).is_nullable());

--- a/crates/ravel-sql/src/audit_schema.rs
+++ b/crates/ravel-sql/src/audit_schema.rs
@@ -17,13 +17,15 @@
 //!
 //! # Why generic, not legal-hold-specific
 //!
-//! The one audit record kind shipped so far is the legal-hold record
-//! (`kind=legal_hold`, `hold.op`, `hold.scope`, `hold.reason`), but audit is a
-//! general signal: query-audit and admin-action records (ADR-0042) will land
-//! later and write the same table. Modelling the table on the generic RLOG
-//! record shape -- every record-specific field flowing through the `attrs` map
-//! rather than a fixed set of legal-hold columns -- means those later kinds need
-//! no schema change. A predicate over a specific kind's fields
+//! Three record kinds write this signal today, all from `ravel-maintain`: the
+//! legal-hold record (`kind=legal_hold`, `hold.op`, `hold.scope`,
+//! `hold.reason`), the query-audit record (`kind=query`, `query.text`,
+//! `query.status`, `query.tenant`, the resolved window), and the reshard record
+//! (`kind=reshard`). Modelling the table on the generic RLOG record shape --
+//! every record-specific field flowing through the `attrs` map rather than a
+//! fixed set of per-kind columns -- is what let the second and third kinds land
+//! with no schema change, and what lets a fourth. A predicate over a specific
+//! kind's fields
 //! (`attrs['kind'] = 'legal_hold'`, `attrs['hold.scope'] = '...'`) is evaluated
 //! by DataFusion's residual over the `attrs` column, exactly as an arbitrary
 //! attribute predicate is on the `logs` table.

--- a/crates/ravel-sql/src/cost.rs
+++ b/crates/ravel-sql/src/cost.rs
@@ -100,6 +100,13 @@ pub fn estimate_metrics_cost(snapshot: &Snapshot, catalog_requests: u64) -> Cost
 /// both the request count and the byte sums here are exact bounds rather
 /// than padded guesses: no chase/retry safety factor applies because there
 /// is no chase/retry path to guard against.
+///
+/// This serves the `alerts` and `audit` tables too (ADR-1101 decision 1), not
+/// only `logs`. An alert record and an audit record ride RLOG v1 verbatim, so
+/// their scans fetch through the same funnel with the same shape: one
+/// `fetch_accounted_with_tenant` per relevant segment, one GET each, no
+/// separately-accounted decompression. The estimate is therefore identical,
+/// and a renamed copy per table would only invite drift.
 pub fn estimate_logs_cost(snapshot: &Snapshot, catalog_requests: u64) -> CostEstimate {
     let segments = snapshot.segments.len() as u64;
     let series: u64 = snapshot.segments.iter().map(|s| s.series_count).sum();

--- a/crates/ravel-sql/src/distributed_rlog.rs
+++ b/crates/ravel-sql/src/distributed_rlog.rs
@@ -108,7 +108,16 @@ pub const LOGS_ORDER_COLS: &[&str] = &[
 
 /// The `alerts` table's total-order key: the orderable public columns in schema
 /// order (ADR-0040). `attrs` excluded, as above.
-pub const ALERTS_ORDER_COLS: &[&str] = &["ts_ns", "alert_id", "rule_id", "state", "generation"];
+pub const ALERTS_ORDER_COLS: &[&str] = &[
+    "ts_ns",
+    "alert_id",
+    "rule_id",
+    "state",
+    "generation",
+    "writer_id",
+    "writer_epoch",
+    "writer_seq",
+];
 
 /// The `audit` table's total-order key: the orderable public columns in schema
 /// order (ADR-0040). `attrs` excluded, as above.

--- a/crates/ravel-sql/src/error.rs
+++ b/crates/ravel-sql/src/error.rs
@@ -54,18 +54,20 @@ pub const MSG_UNSATISFIABLE: &str = "requested commit token is not yet visible; 
 /// says nothing about which column, type, or plan node was at fault: those
 /// strings carry schema detail. The full error is logged server-side.
 ///
-/// It names both v1 tables rather than one: a `Plan` error is built from a
-/// bare `DataFusionError` in `crate::executor::plan_error`, which has no
-/// handle on which table the failed query targeted, and a `logs` query can
-/// fail to plan like any other (an unregistered function, an unknown
-/// column). Naming only `samples` would point a `logs` client at the wrong
-/// table.
+/// It names no table at all: a `Plan` error is built from a bare
+/// `DataFusionError` in `crate::executor::plan_error`, which has no handle on
+/// which table the failed query targeted, and a query against any registered
+/// table can fail to plan like any other (an unregistered function, an
+/// unknown column). Naming a subset would point a client at the wrong table,
+/// which is what happened while this text said "samples or logs" and the
+/// registered set grew to five.
 ///
 /// This doc cited the `attrs['k']` subscript gap as the example until
-/// `crate::map_field_planner` closed it. The reason for naming both tables
-/// never depended on that particular gap, so only the example changed.
-pub const MSG_PLAN: &str = "the SQL query could not be planned; check that it uses only the v1 subset \
-     over the samples or logs table";
+/// `crate::map_field_planner` closed it. The reason for staying
+/// table-neutral never depended on that particular gap, so only the example
+/// changed.
+pub const MSG_PLAN: &str =
+    "the SQL query could not be planned; check that it uses only the v1 subset";
 
 /// Stable client message for a DataFusion execution failure that is not one
 /// of the classes above.
@@ -137,12 +139,13 @@ pub enum SqlError {
     #[error(transparent)]
     Validation(#[from] ValidationError),
 
-    /// The query references both the `samples` and `logs` tables. ADR-0033
-    /// decision C admits exactly one signal per query in v1 (no query needs to
-    /// scan or join both metrics and logs), so this is rejected before any
-    /// catalog resolve. Its text names only the two fixed table names -- no
-    /// server state -- so it is safe to return verbatim, like a validation
-    /// error, and maps to HTTP 400.
+    /// The query references two or more of the registered tables (`samples`,
+    /// `logs`, `spans`, `alerts`, `audit`). ADR-0033 decision C admits exactly
+    /// one signal per query in v1, and ADR-0045 decision 5 and ADR-1101
+    /// decision 1 extend that rule to the third, fourth and fifth tables, so
+    /// this is rejected before any catalog resolve. Its text names only the
+    /// fixed table names -- no server state -- so it is safe to return
+    /// verbatim, like a validation error, and maps to HTTP 400.
     #[error(
         "a SQL query may reference exactly one of the samples, logs, spans, \
          alerts and audit tables; two signals cannot be scanned or joined \

--- a/crates/ravel-sql/src/error.rs
+++ b/crates/ravel-sql/src/error.rs
@@ -144,8 +144,9 @@ pub enum SqlError {
     /// server state -- so it is safe to return verbatim, like a validation
     /// error, and maps to HTTP 400.
     #[error(
-        "a SQL query may reference either the samples table or the logs table, \
-         not both; metrics and logs cannot be scanned or joined together in v1"
+        "a SQL query may reference exactly one of the samples, logs, spans, \
+         alerts and audit tables; two signals cannot be scanned or joined \
+         together in v1"
     )]
     CrossSignalQuery,
 
@@ -410,7 +411,7 @@ impl SqlError {
     pub fn client_message(&self) -> String {
         match self {
             SqlError::Validation(e) => e.to_string(),
-            // Safe to echo: the text names only the two fixed table names.
+            // Safe to echo: the text names only the fixed table names.
             SqlError::CrossSignalQuery => self.to_string(),
             // Safe to echo: `WindowTooWide` carries only the estimate and the
             // limit (counts, no object key or tenant identity), and its text
@@ -670,10 +671,15 @@ mod tests {
     fn cross_signal_query_is_a_bad_request_that_keeps_its_own_text() {
         let err = SqlError::CrossSignalQuery;
         assert_eq!(err.class(), ErrorClass::BadRequest);
-        // Its own text is returned verbatim and names both tables.
+        // Its own text is returned verbatim and names every real table, so a
+        // client that named two of them learns which set the rule covers.
         assert_eq!(err.client_message(), err.to_string());
-        assert!(err.client_message().contains("samples"));
-        assert!(err.client_message().contains("logs"));
+        for table in ["samples", "logs", "spans", "alerts", "audit"] {
+            assert!(
+                err.client_message().contains(table),
+                "the cross-signal message must name {table}"
+            );
+        }
         // It carries no server state to redact.
         assert_redacted(&err.client_message());
     }

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -11,10 +11,12 @@
 //!    injected clock (no `SystemTime::now()` in library logic).
 //!    `signal` is chosen from the query's own `FROM` clause
 //!    ([`SqlExecutor::target_signal`], ADR-0033, extended to `spans` by
-//!    ADR-0045 decision 5): `Signal::Logs` for the `logs` table,
-//!    `Signal::Spans` for the `spans` table, otherwise `Signal::Metrics`. A
-//!    query referencing two of the three tables is rejected here, before the
-//!    LIST, because v1 admits one signal per query (decision C). `name_filter` is the equality
+//!    ADR-0045 decision 5 and to `alerts`/`audit` by ADR-1101 decision 1):
+//!    `Signal::Logs` for the `logs` table, `Signal::Spans` for `spans`,
+//!    `Signal::Alerts` for `alerts`, `Signal::Audit` for `audit`, otherwise
+//!    `Signal::Metrics`. A query referencing two of the five tables is rejected
+//!    here, before the LIST, because v1 admits one signal per query
+//!    (decision C). `name_filter` is the equality
 //!    `__name__` value derived from the query's pushed-down predicates
 //!    ([`SqlExecutor::pushed_down_name_filter`]), so a metrics query
 //!    naming one metric prunes by postings exactly as PromQL does; a logs
@@ -92,6 +94,8 @@ use ravel_query::{LogSegmentFetcher, QueryError, SegmentFetcher, admit};
 use ravel_types::accounting::{CostEstimate, QueryAccounting, QueryAccountingSnapshot};
 use ravel_types::{CommitToken, METRIC_NAME_LABEL, Signal, TenantHash, TimeRange};
 
+use crate::alerts_provider::AlertsTableProvider;
+use crate::audit_provider::AuditTableProvider;
 use crate::config::SqlConfig;
 use crate::cost::{estimate_logs_cost, estimate_metrics_cost, estimate_spans_cost};
 use crate::declared::{DeclaredColumn, DeclaredColumnSource, default_declared_source};
@@ -103,14 +107,15 @@ use crate::output::QueryOutput;
 use crate::provider::RavelTableProvider;
 use crate::pushdown::extract;
 use crate::session::{
-    LOGS_TABLE, SAMPLES_TABLE, SPANS_TABLE, SessionTable, SpillDecision, build_session,
+    ALERTS_TABLE, AUDIT_TABLE, LOGS_TABLE, SAMPLES_TABLE, SPANS_TABLE, SessionTable, SpillDecision,
+    build_session,
 };
 use crate::spans_fetcher::SpanSegmentFetcher;
 use crate::spans_provider::SpansTableProvider;
 use crate::spill::{OperatorSpill, SpillCounts, SpillScratch, accumulate_spill_counts};
 use crate::validate::{referenced_base_tables, validate};
 
-/// Which of the three v1 tables (and thus which `Signal`) a query targets.
+/// Which of the five v1 tables (and thus which `Signal`) a query targets.
 /// A closed enum rather than `Signal` directly: `Signal` carries a `Profiles`
 /// variant the SQL surface has no table for, and the executor must never
 /// resolve or register that.
@@ -122,6 +127,12 @@ enum TargetSignal {
     Logs,
     /// The `spans` table, resolved against `Signal::Spans` (ADR-0045 decision 5).
     Spans,
+    /// The `alerts` table, resolved against `Signal::Alerts` (ADR-1101
+    /// decision 1).
+    Alerts,
+    /// The `audit` table, resolved against `Signal::Audit` (ADR-1101
+    /// decision 1).
+    Audit,
 }
 
 impl TargetSignal {
@@ -130,6 +141,8 @@ impl TargetSignal {
             TargetSignal::Metrics => Signal::Metrics,
             TargetSignal::Logs => Signal::Logs,
             TargetSignal::Spans => Signal::Spans,
+            TargetSignal::Alerts => Signal::Alerts,
+            TargetSignal::Audit => Signal::Audit,
         }
     }
 }
@@ -852,6 +865,23 @@ impl SqlExecutor {
                 self.span_fetcher.clone(),
                 accounting.clone(),
             ))),
+            // The two RLOG-backed tables (ADR-1101 decision 1) read through the
+            // executor's existing `log_fetcher`: an alert and an audit record
+            // ride RLOG v1 verbatim, so they share the `logs` table's accounted,
+            // tenant-checked fetch funnel and its caches. No declared columns
+            // and no column statistics apply to either.
+            TargetSignal::Alerts => SessionTable::Alerts(Arc::new(AlertsTableProvider::new(
+                snapshot,
+                tenant_hash,
+                self.log_fetcher.clone(),
+                accounting.clone(),
+            ))),
+            TargetSignal::Audit => SessionTable::Audit(Arc::new(AuditTableProvider::new(
+                snapshot,
+                tenant_hash,
+                self.log_fetcher.clone(),
+                accounting.clone(),
+            ))),
         };
 
         let decision = match &scratch {
@@ -995,9 +1025,12 @@ impl SqlExecutor {
         // safely when postings are absent or unusable.
         let name_filter = match target {
             TargetSignal::Metrics => self.pushed_down_name_filter(tenant_hash, &req.sql).await,
-            // Only a metrics query has a `__name__` postings index; neither a
-            // logs nor a spans query prunes by it.
-            TargetSignal::Logs | TargetSignal::Spans => None,
+            // Only a metrics query has a `__name__` postings index; a logs,
+            // spans, alerts, or audit query never prunes by it.
+            TargetSignal::Logs
+            | TargetSignal::Spans
+            | TargetSignal::Alerts
+            | TargetSignal::Audit => None,
         };
         let catalog_requests = self
             .catalog
@@ -1022,7 +1055,12 @@ impl SqlExecutor {
         admit(&snapshot, &origins, &self.config.engine).map_err(admission_error_to_sql)?;
         let estimate = match target {
             TargetSignal::Metrics => estimate_metrics_cost(&snapshot, catalog_requests),
-            TargetSignal::Logs => estimate_logs_cost(&snapshot, catalog_requests),
+            // The `alerts` and `audit` scans fetch through the same RLOG funnel
+            // the `logs` scan does, one GET per segment, so they share its
+            // estimate rather than a renamed copy of it (ADR-1101 decision 1).
+            TargetSignal::Logs | TargetSignal::Alerts | TargetSignal::Audit => {
+                estimate_logs_cost(&snapshot, catalog_requests)
+            }
             TargetSignal::Spans => estimate_spans_cost(&snapshot, catalog_requests),
         };
         Ok((snapshot, estimate))
@@ -1270,6 +1308,18 @@ impl SqlExecutor {
                 self.span_fetcher.clone(),
                 QueryAccounting::new(),
             ))),
+            TargetSignal::Alerts => SessionTable::Alerts(Arc::new(AlertsTableProvider::new(
+                empty_snapshot(),
+                tenant_hash,
+                self.log_fetcher.clone(),
+                QueryAccounting::new(),
+            ))),
+            TargetSignal::Audit => SessionTable::Audit(Arc::new(AuditTableProvider::new(
+                empty_snapshot(),
+                tenant_hash,
+                self.log_fetcher.clone(),
+                QueryAccounting::new(),
+            ))),
         }
     }
 
@@ -1280,15 +1330,17 @@ impl SqlExecutor {
     /// The referenced table names come from the same `DFParser` front end the
     /// validation gate uses ([`referenced_base_tables`]), never a raw-text
     /// scan. The mapping (ADR-0045 decision 5 extends the ADR-0033 two-table
-    /// rule to a third arm):
+    /// rule to a third arm, ADR-1101 decision 1 to a fourth and fifth):
     ///
     /// - references `logs` only -> [`TargetSignal::Logs`].
     /// - references `spans` only -> [`TargetSignal::Spans`].
+    /// - references `alerts` only -> [`TargetSignal::Alerts`].
+    /// - references `audit` only -> [`TargetSignal::Audit`].
     /// - references `samples` only, or references no real table ->
     ///   [`TargetSignal::Metrics`].
-    /// - references two or more of {`samples`, `logs`, `spans`} ->
-    ///   [`SqlError::CrossSignalQuery`], rejected before the catalog LIST
-    ///   (decision C: v1 admits one signal per query).
+    /// - references two or more of {`samples`, `logs`, `spans`, `alerts`,
+    ///   `audit`} -> [`SqlError::CrossSignalQuery`], rejected before the
+    ///   catalog LIST (decision C: v1 admits one signal per query).
     ///
     /// The "no real table" case (a constant query such as `SELECT 1`, or one
     /// whose only source is a CTE with no base table) defaults to `Metrics`: it
@@ -1301,9 +1353,15 @@ impl SqlExecutor {
         let has_samples = tables.contains(SAMPLES_TABLE);
         let has_logs = tables.contains(LOGS_TABLE);
         let has_spans = tables.contains(SPANS_TABLE);
-        // Naming two of the three real tables crosses signals: v1 resolves one
+        let has_alerts = tables.contains(ALERTS_TABLE);
+        let has_audit = tables.contains(AUDIT_TABLE);
+        // Naming two of the five real tables crosses signals: v1 resolves one
         // snapshot per query, so this is rejected before any catalog listing.
-        let named = u8::from(has_samples) + u8::from(has_logs) + u8::from(has_spans);
+        let named = u8::from(has_samples)
+            + u8::from(has_logs)
+            + u8::from(has_spans)
+            + u8::from(has_alerts)
+            + u8::from(has_audit);
         if named > 1 {
             return Err(SqlError::CrossSignalQuery);
         }
@@ -1311,6 +1369,10 @@ impl SqlExecutor {
             Ok(TargetSignal::Logs)
         } else if has_spans {
             Ok(TargetSignal::Spans)
+        } else if has_alerts {
+            Ok(TargetSignal::Alerts)
+        } else if has_audit {
+            Ok(TargetSignal::Audit)
         } else {
             // `samples` only, or no real table at all: metrics by default.
             Ok(TargetSignal::Metrics)
@@ -2836,6 +2898,50 @@ mod tests {
             .expect("cte named samples over logs is logs-only"),
             TargetSignal::Logs
         );
+    }
+
+    /// ADR-1101 decision 1: the fourth and fifth arms. `FROM alerts` resolves
+    /// `Signal::Alerts` and `FROM audit` resolves `Signal::Audit`, while a CTE
+    /// named after either is query-local and leaves the target alone, exactly
+    /// as for the other three tables.
+    #[test]
+    fn target_signal_maps_alerts_and_audit() {
+        assert_eq!(
+            SqlExecutor::target_signal("SELECT alert_id FROM alerts").expect("ok"),
+            TargetSignal::Alerts
+        );
+        assert_eq!(
+            SqlExecutor::target_signal("SELECT body FROM audit").expect("ok"),
+            TargetSignal::Audit
+        );
+        // A CTE named `audit` reading only `samples` is a metrics query: the
+        // name is query-local, not a base table.
+        assert_eq!(
+            SqlExecutor::target_signal(
+                "WITH audit AS (SELECT value FROM samples) SELECT count(*) FROM audit"
+            )
+            .expect("cte named audit over samples is metrics-only"),
+            TargetSignal::Metrics
+        );
+    }
+
+    /// ADR-1101 decision 1: the one-signal-per-query rule counts five names, so
+    /// a query naming `alerts` and `audit` -- or `samples` and `audit` -- is
+    /// `CrossSignalQuery`, exactly as samples+logs is.
+    #[test]
+    fn target_signal_rejects_a_query_naming_alerts_and_audit() {
+        for sql in [
+            "SELECT * FROM alerts JOIN audit ON alerts.ts_ns = audit.ts_ns",
+            "SELECT * FROM samples JOIN audit ON samples.ts = audit.ts_ns",
+            "SELECT * FROM alerts JOIN logs ON alerts.ts_ns = logs.ts",
+        ] {
+            let err = SqlExecutor::target_signal(sql)
+                .expect_err("a query naming two of the five tables is rejected");
+            assert!(
+                matches!(err, SqlError::CrossSignalQuery),
+                "expected CrossSignalQuery for {sql:?}, got {err:?}"
+            );
+        }
     }
 
     /// ADR-0045 decision 5 / ADR-0033 decision C: a cross-signal query is

--- a/crates/ravel-sql/src/flight/metadata.rs
+++ b/crates/ravel-sql/src/flight/metadata.rs
@@ -1,8 +1,9 @@
 //! The Flight SQL catalog/metadata surface: catalogs, schemas, tables, table
 //! types, and SqlInfo.
 //!
-//! Ravel exposes exactly one logical table per tenant, `samples`, in one
-//! schema of one catalog, so every answer here is a constant. That makes the
+//! Ravel exposes the same five logical tables to every tenant (`samples`,
+//! `logs`, `spans`, `alerts`, `audit`), in one schema of one catalog, so every
+//! answer here is a constant. That makes the
 //! interesting property a negative one: nothing in this module is
 //! tenant-derived, so no metadata response can differ between two tenants and
 //! therefore none can disclose another tenant's existence, table set, or
@@ -30,8 +31,12 @@ use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
 use tonic::Status;
 
+use crate::alerts_schema::alerts_schema;
+use crate::audit_schema::audit_schema;
+use crate::logs_schema::logs_schema;
 use crate::schema::public_schema;
-use crate::session::SAMPLES_TABLE;
+use crate::session::{ALERTS_TABLE, AUDIT_TABLE, LOGS_TABLE, SAMPLES_TABLE, SPANS_TABLE};
+use crate::spans_schema::spans_schema;
 
 /// The single catalog name every tenant sees.
 pub const CATALOG_NAME: &str = "ravel";
@@ -75,19 +80,29 @@ pub(super) fn db_schemas_schema(query: CommandGetDbSchemas) -> SchemaRef {
     builder.schema()
 }
 
-/// The `CommandGetTables` response: one row for `samples`, carrying the
-/// public sample schema when the request asked for schemas.
+/// The `CommandGetTables` response: one row per registered table (ADR-1101
+/// decision 1), each carrying that table's public schema when the request
+/// asked for schemas.
+///
+/// This is static catalog metadata built from the five schema functions,
+/// independent of the per-query session, which still registers exactly the one
+/// table a query targets. The `logs` row carries the base schema: a tenant with
+/// declared typed attribute columns (ADR-0090) sees a wider `logs` schema on
+/// its own statement's `FlightInfo`, which is per tenant and per query and so
+/// cannot be reported here, where every answer is a constant.
 pub(super) fn tables(query: CommandGetTables) -> Result<RecordBatch, Status> {
     let mut builder: GetTablesBuilder = query.into_builder();
-    builder
-        .append(
-            CATALOG_NAME,
-            SCHEMA_NAME,
-            SAMPLES_TABLE,
-            TABLE_TYPE,
-            &public_schema(),
-        )
-        .map_err(|err| build_error("tables", &err))?;
+    for (name, schema) in [
+        (SAMPLES_TABLE, public_schema()),
+        (LOGS_TABLE, logs_schema()),
+        (SPANS_TABLE, spans_schema()),
+        (ALERTS_TABLE, alerts_schema()),
+        (AUDIT_TABLE, audit_schema()),
+    ] {
+        builder
+            .append(CATALOG_NAME, SCHEMA_NAME, name, TABLE_TYPE, &schema)
+            .map_err(|err| build_error("tables", &err))?;
+    }
     builder.build().map_err(|err| build_error("tables", &err))
 }
 
@@ -195,16 +210,70 @@ mod tests {
         assert_eq!(column(&batch, "db_schema_name").value(0), SCHEMA_NAME);
     }
 
+    /// ADR-1101 decision 1: every registered table is listed, and each row
+    /// carries that table's own public schema. The schema half is the half a
+    /// name-only assertion would miss: listing `alerts` under the `samples`
+    /// schema is a discoverable surface that lies about its columns.
+    ///
+    /// The rows come back sorted by table name, not in the order [`tables`]
+    /// appends them: `GetTablesBuilder::build` orders its output by
+    /// (catalog, schema, table), which is what the Flight SQL specification
+    /// requires of a `CommandGetTables` response. The expectation below is
+    /// therefore the sorted list, which is what a client actually sees.
+    ///
+    /// `table_schema` is the IPC-encapsulated schema message the builder
+    /// writes, so it is compared by decoding it back through arrow-flight's own
+    /// `IpcMessage` conversion rather than by re-deriving the bytes.
     #[test]
-    fn tables_lists_exactly_the_samples_table() {
-        let batch = tables(CommandGetTables::default()).expect("built");
-        assert_eq!(batch.num_rows(), 1);
-        assert_eq!(column(&batch, "table_name").value(0), SAMPLES_TABLE);
-        assert_eq!(column(&batch, "table_type").value(0), TABLE_TYPE);
+    fn tables_lists_the_five_registered_tables() {
+        use arrow_flight::IpcMessage;
+        use datafusion::arrow::array::BinaryArray;
+        use datafusion::arrow::datatypes::Schema;
+
+        let expected: Vec<(&str, SchemaRef)> = vec![
+            (ALERTS_TABLE, alerts_schema()),
+            (AUDIT_TABLE, audit_schema()),
+            (LOGS_TABLE, logs_schema()),
+            (SAMPLES_TABLE, public_schema()),
+            (SPANS_TABLE, spans_schema()),
+        ];
+
+        let batch = tables(CommandGetTables {
+            include_schema: true,
+            ..CommandGetTables::default()
+        })
+        .expect("built");
+        assert_eq!(batch.num_rows(), expected.len());
+
+        let names = column(&batch, "table_name");
+        let got: Vec<&str> = (0..batch.num_rows()).map(|row| names.value(row)).collect();
+        let want: Vec<&str> = expected.iter().map(|(name, _)| *name).collect();
+        assert_eq!(got, want, "every registered table, in table-name order");
+
+        let types = column(&batch, "table_type");
+        let index = batch
+            .schema()
+            .index_of("table_schema")
+            .expect("table_schema column");
+        let schemas = batch
+            .column(index)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .expect("table_schema is binary");
+        for (row, (name, schema)) in expected.iter().enumerate() {
+            assert_eq!(types.value(row), TABLE_TYPE);
+            let message = IpcMessage(bytes::Bytes::copy_from_slice(schemas.value(row)));
+            let carried: Schema = Schema::try_from(message).expect("decodes");
+            assert_eq!(
+                &carried,
+                schema.as_ref(),
+                "the {name} row must carry the {name} schema"
+            );
+        }
     }
 
     /// The builders apply the request's own filter patterns, so a request
-    /// naming a different catalog gets nothing rather than the `samples` row
+    /// naming a different catalog gets nothing rather than the table rows
     /// under a name it did not ask for.
     #[test]
     fn a_non_matching_catalog_filter_yields_no_rows() {

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -94,7 +94,7 @@ pub use alerts_provider::AlertsTableProvider;
 pub use alerts_pushdown::{AlertsPushdown, extract_alerts};
 pub use alerts_schema::{
     ALERT_COL_ALERT_ID, ALERT_COL_ATTRS, ALERT_COL_GENERATION, ALERT_COL_RULE_ID, ALERT_COL_STATE,
-    ALERT_COL_TS, alerts_schema,
+    ALERT_COL_TS, ALERT_COL_WRITER_EPOCH, ALERT_COL_WRITER_ID, ALERT_COL_WRITER_SEQ, alerts_schema,
 };
 pub use audit_provider::AuditTableProvider;
 pub use audit_pushdown::{AuditPushdown, extract_audit};
@@ -157,10 +157,11 @@ pub use pushdown::Pushdown;
 pub use redact::{RedactError, redact};
 pub use schema::{internal_schema, public_schema};
 pub use session::{
-    ADMITTED_SCALARS, ADMITTED_TABLE_FUNCTIONS, ADMITTED_WINDOWS, EXCLUDED_SCALARS,
-    EXCLUDED_TABLE_FUNCTIONS, EXCLUDED_WINDOWS, EmptyObjectStoreRegistry, LOGS_TABLE,
-    SAMPLES_TABLE, SKIP_PARTIAL_AGGREGATION_PROBE_RATIO, SKIP_PARTIAL_AGGREGATION_PROBE_ROWS,
-    SPANS_TABLE, SessionTable, SpillDecision, build_session, session_config,
+    ADMITTED_SCALARS, ADMITTED_TABLE_FUNCTIONS, ADMITTED_WINDOWS, ALERTS_TABLE, AUDIT_TABLE,
+    EXCLUDED_SCALARS, EXCLUDED_TABLE_FUNCTIONS, EXCLUDED_WINDOWS, EmptyObjectStoreRegistry,
+    LOGS_TABLE, SAMPLES_TABLE, SKIP_PARTIAL_AGGREGATION_PROBE_RATIO,
+    SKIP_PARTIAL_AGGREGATION_PROBE_ROWS, SPANS_TABLE, SessionTable, SpillDecision, build_session,
+    session_config,
 };
 pub use spans_fetcher::{SpanFetchError, SpanFetchOutput, SpanRow, SpanSegmentFetcher};
 pub use spans_provider::SpansTableProvider;

--- a/crates/ravel-sql/src/rlog_attrs.rs
+++ b/crates/ravel-sql/src/rlog_attrs.rs
@@ -69,20 +69,35 @@ pub(crate) fn retain_unerased(
     records: &mut Vec<LogRecord>,
     erasure: &[ErasurePredicate],
 ) -> DFResult<()> {
+    retain_unerased_by(records, erasure, |r| r)
+}
+
+/// [`retain_unerased`] over items that carry a [`LogRecord`] alongside other
+/// per-record state, `record` selecting the record to match. The `alerts` scan
+/// pairs each record with the write identity of the object it was read from
+/// (crate::alerts_scan), and that pair must survive or be dropped as one unit;
+/// running the exclusion over a detached copy of the records would be a second
+/// implementation of the same rule, free to disagree with this one.
+pub(crate) fn retain_unerased_by<T>(
+    items: &mut Vec<T>,
+    erasure: &[ErasurePredicate],
+    record: impl Fn(&T) -> &LogRecord,
+) -> DFResult<()> {
     if erasure.is_empty() {
         return Ok(());
     }
-    let mut survivors = Vec::with_capacity(records.len());
-    for r in std::mem::take(records) {
-        let merged = merged_attrs(&r)?;
+    let mut survivors = Vec::with_capacity(items.len());
+    for item in std::mem::take(items) {
+        let r = record(&item);
+        let merged = merged_attrs(r)?;
         let erased = erasure
             .iter()
             .any(|p| p.matches_log_attrs(&merged) && (!p.has_window() || p.ts_in_window(r.ts_ns)));
         if !erased {
-            survivors.push(r);
+            survivors.push(item);
         }
     }
-    *records = survivors;
+    *items = survivors;
     Ok(())
 }
 

--- a/crates/ravel-sql/src/session.rs
+++ b/crates/ravel-sql/src/session.rs
@@ -119,6 +119,8 @@ use datafusion::object_store::ObjectStore;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use url::Url;
 
+use crate::alerts_provider::AlertsTableProvider;
+use crate::audit_provider::AuditTableProvider;
 use crate::avg::sequential_avg_udaf;
 use crate::config::SqlConfig;
 use crate::group_keys::DictionaryGroupKeysAsViews;
@@ -141,11 +143,17 @@ pub const LOGS_TABLE: &str = "logs";
 /// The spans table name (`Signal::Spans`, ADR-0045 decision 5).
 pub const SPANS_TABLE: &str = "spans";
 
+/// The alerts table name (`Signal::Alerts`, ADR-1101 decision 1).
+pub const ALERTS_TABLE: &str = "alerts";
+
+/// The audit table name (`Signal::Audit`, ADR-1101 decision 1).
+pub const AUDIT_TABLE: &str = "audit";
+
 /// The single table a query's session registers. ADR-0033 decision C admits
 /// exactly one signal per query in v1, so the executor resolves one snapshot
 /// and hands [`build_session`] one provider; the enum keeps the provider
-/// types (metrics vs logs vs spans) apart without a `dyn TableProvider`
-/// erasure.
+/// types (metrics vs logs vs spans vs alerts vs audit) apart without a
+/// `dyn TableProvider` erasure.
 pub enum SessionTable {
     /// The `samples` table over a resolved `Signal::Metrics` snapshot.
     Metrics(Arc<RavelTableProvider>),
@@ -157,6 +165,12 @@ pub enum SessionTable {
     /// this ships (ts, trace_id, duration, status_code, service_name) is a
     /// plain column comparison.
     Spans(Arc<SpansTableProvider>),
+    /// The `alerts` table over a resolved `Signal::Alerts` snapshot (ADR-1101
+    /// decision 1).
+    Alerts(Arc<AlertsTableProvider>),
+    /// The `audit` table over a resolved `Signal::Audit` snapshot (ADR-1101
+    /// decision 1).
+    Audit(Arc<AuditTableProvider>),
 }
 
 /// The v1 SQL aggregate allowlist (ADR-0022 decision 2). [`build_session`]
@@ -776,6 +790,16 @@ pub fn build_session(
         SessionTable::Spans(provider) => {
             ctx.register_table(SPANS_TABLE, provider)?;
         }
+        // Neither RLOG-backed table registers a scalar UDF: every predicate
+        // their pushdown extractors accept is a plain column comparison or an
+        // `attrs['k']` subscript, which the map-field planner registered above
+        // already serves.
+        SessionTable::Alerts(provider) => {
+            ctx.register_table(ALERTS_TABLE, provider)?;
+        }
+        SessionTable::Audit(provider) => {
+            ctx.register_table(AUDIT_TABLE, provider)?;
+        }
     }
     Ok(ctx)
 }
@@ -1111,6 +1135,24 @@ mod tests {
         )))
     }
 
+    fn alerts_table(store: &Arc<dyn ravel_object_store::ObjectStoreBackend>) -> SessionTable {
+        SessionTable::Alerts(Arc::new(AlertsTableProvider::new(
+            empty_snapshot(),
+            ravel_types::TenantHash([0u8; 16]),
+            ravel_query::LogSegmentFetcher::new(store.clone()),
+            QueryAccounting::new(),
+        )))
+    }
+
+    fn audit_table(store: &Arc<dyn ravel_object_store::ObjectStoreBackend>) -> SessionTable {
+        SessionTable::Audit(Arc::new(AuditTableProvider::new(
+            empty_snapshot(),
+            ravel_types::TenantHash([0u8; 16]),
+            ravel_query::LogSegmentFetcher::new(store.clone()),
+            QueryAccounting::new(),
+        )))
+    }
+
     /// ADR-0097 decisions 2, 3, 4, 6: the fail-closed boundary now covers all
     /// four registries, not aggregates alone. For every table variant and every
     /// registry, the admitted and excluded name sets must be disjoint, must
@@ -1217,6 +1259,11 @@ mod tests {
             ),
             ("logs", logs_table(&store), set(["has_word"].iter())),
             ("spans", spans_table(&store), empty.clone()),
+            // ADR-1101 decision 1: neither RLOG-backed table registers a scalar
+            // UDF of its own, so a leaked `has_word` (or any other per-table
+            // addendum) on one of them fails here.
+            ("alerts", alerts_table(&store), empty.clone()),
+            ("audit", audit_table(&store), empty.clone()),
         ] {
             let ctx = build_session(
                 &SqlConfig::default(),

--- a/crates/ravel-sql/tests/alerts_provider.rs
+++ b/crates/ravel-sql/tests/alerts_provider.rs
@@ -27,7 +27,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{
-    Array, Int64Array, MapArray, StringArray, StructArray, TimestampNanosecondArray,
+    Array, Int64Array, MapArray, StringArray, StructArray, TimestampNanosecondArray, UInt64Array,
 };
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::execution::TaskContext;
@@ -122,8 +122,25 @@ fn alert_record_on_resource(
 }
 
 /// Write one RLOG object from `records`, put it at `key`, and return a matching
-/// L0 [`SegmentRef`] carrying the object's true ts span.
+/// L0 [`SegmentRef`] carrying the object's true ts span, under the default
+/// write identity.
 async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> SegmentRef {
+    write_object_with_identity(store, key, records, Uuid::from_u128(1), 1, 1).await
+}
+
+/// [`write_object`] with the returned [`SegmentRef`]'s write identity chosen by
+/// the caller. The `alerts` table stamps `writer_id`/`writer_epoch`/
+/// `writer_seq` from the segment a record was read from (ADR-1101 decision 1),
+/// so a test that varies them per object can assert the stamp is per record and
+/// not a constant.
+async fn write_object_with_identity(
+    store: &MemoryStore,
+    key: &str,
+    records: &[LogRecord],
+    writer_id: Uuid,
+    writer_epoch: u64,
+    writer_seq: u64,
+) -> SegmentRef {
     let mut w = RlogWriter::new(small_blocks(), identity());
     for r in records {
         w.push(r.clone()).expect("push");
@@ -147,9 +164,9 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         series_count: 0,
         shard: 0,
         content_hash: [0u8; 32],
-        writer_id: Uuid::from_u128(1),
-        writer_epoch: 1,
-        writer_seq: 1,
+        writer_id,
+        writer_epoch,
+        writer_seq,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
@@ -408,6 +425,93 @@ async fn alert_id_and_rule_id_equality_fast_paths() {
     assert!(batches_to_rows(&collect_plan(plan).await).is_empty());
 }
 
+/// ADR-1101 decision 1's row contract: every row carries the write identity of
+/// the object it was read from, exactly. Two objects with distinct identities
+/// are scanned in one plan, and each returned row's `writer_id`/`writer_epoch`/
+/// `writer_seq` must equal the identity of the `SegmentRef` its record came
+/// from. A stamp taken per partition rather than per object, or read from a
+/// record attribute, gives one of these rows the other object's identity.
+#[tokio::test]
+async fn identity_columns_are_stamped_from_the_records_own_segment() {
+    let store = MemoryStore::new();
+
+    let first = alert_record(1, "id-a", "cpu-high", "firing", 1, &[]);
+    let second = alert_record(2, "id-b", "cpu-high", "resolved", 2, &[]);
+    let seg_a = write_object_with_identity(
+        &store,
+        "alerts/id-a.rlog",
+        std::slice::from_ref(&first),
+        Uuid::from_u128(11),
+        3,
+        4,
+    )
+    .await;
+    let seg_b = write_object_with_identity(
+        &store,
+        "alerts/id-b.rlog",
+        std::slice::from_ref(&second),
+        Uuid::from_u128(22),
+        5,
+        6,
+    )
+    .await;
+
+    // One partition, so both objects are fetched and merged by the same scan:
+    // a per-partition stamp would collapse the two identities into one.
+    let provider = provider(store, vec![seg_a.clone(), seg_b.clone()]);
+    let batches = collect_plan(provider.plan(1).expect("build plan")).await;
+
+    let mut got: Vec<(String, (String, u64, u64))> = Vec::new();
+    for batch in &batches {
+        let alert_id = col_str(batch, ravel_sql::ALERT_COL_ALERT_ID);
+        let writer_id = col_str(batch, ravel_sql::ALERT_COL_WRITER_ID);
+        let writer_epoch = batch
+            .column(ravel_sql::ALERT_COL_WRITER_EPOCH)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("writer_epoch col");
+        let writer_seq = batch
+            .column(ravel_sql::ALERT_COL_WRITER_SEQ)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("writer_seq col");
+        for i in 0..batch.num_rows() {
+            got.push((
+                alert_id.value(i).to_string(),
+                (
+                    writer_id.value(i).to_string(),
+                    writer_epoch.value(i),
+                    writer_seq.value(i),
+                ),
+            ));
+        }
+    }
+    got.sort();
+
+    let want = vec![
+        (
+            "id-a".to_string(),
+            (
+                seg_a.writer_id.to_string(),
+                seg_a.writer_epoch,
+                seg_a.writer_seq,
+            ),
+        ),
+        (
+            "id-b".to_string(),
+            (
+                seg_b.writer_id.to_string(),
+                seg_b.writer_epoch,
+                seg_b.writer_seq,
+            ),
+        ),
+    ];
+    assert_eq!(
+        got, want,
+        "each row carries its own object's write identity, hyphenated uuid included"
+    );
+}
+
 /// The `attrs` column carries the whole record attribute map (the promoted keys
 /// plus every `label.<name>`), stringified into `Map(Utf8, Utf8)`.
 #[tokio::test]
@@ -639,7 +743,7 @@ async fn pending_erasure_excludes_resource_attribute_rows() {
 /// The `(key, value)` pairs of one row's `attrs` map cell.
 fn attrs_map(batch: &RecordBatch, row: usize) -> Vec<(String, String)> {
     let map = batch
-        .column(5)
+        .column(ravel_sql::ALERT_COL_ATTRS)
         .as_any()
         .downcast_ref::<MapArray>()
         .expect("attrs map col");

--- a/crates/ravel-sql/tests/flight.rs
+++ b/crates/ravel-sql/tests/flight.rs
@@ -597,7 +597,7 @@ async fn catalog_and_metadata_methods_answer_an_authenticated_caller() {
     .await
     .expect("decodes");
     let rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
-    assert_eq!(rows, 1, "exactly the samples table");
+    assert_eq!(rows, 5, "one row per registered table");
 
     let mut request = Request::new(FlightDescriptor::new_cmd(Vec::new()));
     authed(request.metadata_mut());

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -390,9 +390,17 @@ The `audit` table columns are `ts_ns` (`Timestamp(ns)`), `severity_text`,
 `body` (both `Utf8`), and an `attrs` `Map(Utf8, Utf8)`. It is deliberately
 generic: `attrs['kind']` selects the record kind (`query` for the query-audit
 trail, `legal_hold`, `reshard`), and each kind's own fields ride the same map.
-A query over `audit` is itself audited, so it appears in the trail a later
-query reads. Resolution is per tenant hash, so a tenant reads only its own
-records, never another tenant's.
+Resolution is per tenant hash, so a tenant reads only its own records, never
+another tenant's.
+
+Legal-hold and reshard records are written by the maintenance process itself,
+so they are present on any deployment that has taken those actions.
+Query-audit records are not: every query surface submits one per executed
+statement through a sink that no shipped startup path replaces with the real
+pipeline, so on a stock build `attrs['kind'] = 'query'` selects nothing. The
+handler behavior and the record shape are already in place; only the install
+is missing. Once a deployment attaches the pipeline, a query over `audit` is
+itself audited and appears in the trail a later query reads.
 
 Beyond those fixed columns, an operator can declare per-tenant *typed
 attribute columns*: an attribute key promoted to a native `Int64`, `Boolean`,

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -344,12 +344,15 @@ limit is on the query's *start*: a narrow `start`/`end` pair costs little
 however recent it is, so the fix is always to move `start` forward, never to
 change `end`.
 
-## SQL over `samples`, `logs`, and `spans`
+<a id="sql-over-samples-logs-and-spans"></a>
 
-`POST /api/v1/sql` serves three tables from one endpoint:
-`samples` (metrics), `logs`, and `spans`. The server parses the query's `FROM`
+## SQL over `samples`, `logs`, `spans`, `alerts`, and `audit`
+
+`POST /api/v1/sql` serves five tables from one endpoint:
+`samples` (metrics), `logs`, `spans` (traces), `alerts` (alert state
+transitions), and `audit` (audit records). The server parses the query's `FROM`
 clause before it plans, and registers only that one table for the query. A
-single query may reference exactly one of the three; naming two or more of
+single query may reference exactly one of the five; naming two or more of
 them crosses signals and is rejected with an HTTP 400, before any catalog
 listing. The request body, auth, window
 (`start`/`end`), and `min_commit_token` handling are identical to the `samples`
@@ -360,6 +363,36 @@ The `logs` table columns are `ts`, `observed_ts` (both `Timestamp(ns)`),
 `attrs` `Map(Utf8, Utf8)` that merges each record's resource, scope, and
 per-record attributes (see docs/query-engine.md for the full schema and
 semantics).
+
+The `alerts` table columns are `ts_ns` (`Timestamp(ns)`, the transition's event
+time), `alert_id`, `rule_id`, `state` (all `Utf8`), `generation` (`Int64`),
+`writer_id` (`Utf8`), `writer_epoch` and `writer_seq` (both `UInt64`), and an
+`attrs` `Map(Utf8, Utf8)` carrying the rule's `label.<k>` and `annotation.<k>`
+entries alongside the promoted keys. `state` takes four values: `pending`,
+`firing`, `resolved`, and `suppressed`.
+The table is raw history, one row per state transition, never a folded
+"current state" row. Current state is a query over that history: the row that
+sorts first per `alert_id` under `ts_ns DESC, writer_epoch DESC, writer_seq
+DESC, writer_id DESC`. The three write-identity columns are what make that a
+total order, because two evaluators can overlap briefly at a lease handover and
+write the same `alert_id` at the same `ts_ns`:
+
+```sql
+SELECT alert_id, state FROM
+  (SELECT *, ROW_NUMBER() OVER (PARTITION BY alert_id
+   ORDER BY ts_ns DESC, writer_epoch DESC, writer_seq DESC, writer_id DESC) AS rn
+   FROM alerts) WHERE rn = 1 ORDER BY alert_id
+```
+
+See the [alerting guide](alerting.md) for what writes those transitions.
+
+The `audit` table columns are `ts_ns` (`Timestamp(ns)`), `severity_text`,
+`body` (both `Utf8`), and an `attrs` `Map(Utf8, Utf8)`. It is deliberately
+generic: `attrs['kind']` selects the record kind (`query` for the query-audit
+trail, `legal_hold`, `reshard`), and each kind's own fields ride the same map.
+A query over `audit` is itself audited, so it appears in the trail a later
+query reads. Resolution is per tenant hash, so a tenant reads only its own
+records, never another tenant's.
 
 Beyond those fixed columns, an operator can declare per-tenant *typed
 attribute columns*: an attribute key promoted to a native `Int64`, `Boolean`,

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -113,8 +113,10 @@ builds that feature, so the route is available there. Its response envelope is
 with one array per row under `data.rows`. A non-finite float comes back as a
 string: `NaN`, `+Inf`, and `-Inf`. Sending `Accept:
 application/vnd.apache.arrow.stream` yields an Arrow IPC stream instead, which is
-bit-exact for every float. The SQL surface registers exactly three tables, one
-per signal: `samples`, `logs`, and `spans`.
+bit-exact for every float. The SQL surface registers exactly five tables, one
+per signal: `samples` (metrics), `logs`, `spans` (traces), `alerts` (alert
+state transitions), and `audit` (audit records, including the query-audit
+trail).
 
 For the query routes, the status codes come from one shared error mapping:
 

--- a/services/ravel-server/src/query.rs
+++ b/services/ravel-server/src/query.rs
@@ -347,7 +347,9 @@ pub fn build_sql_state(
     // The metrics fetcher (RSEG), the logs fetcher (RLOG), and the spans
     // fetcher (RSPAN) all read the same object store; the executor uses
     // whichever the query's target table needs (ADR-0033, extended to `spans`
-    // by ADR-0045 decision 5).
+    // by ADR-0045 decision 5). The `alerts` and `audit` tables (ADR-1101
+    // decision 1) need no fetcher of their own: their records ride RLOG, so
+    // they read through the logs fetcher above, cache included.
     let executor = SqlExecutor::new(
         catalog,
         metrics_fetcher,

--- a/services/ravel-server/tests/flight_sql.rs
+++ b/services/ravel-server/tests/flight_sql.rs
@@ -39,15 +39,19 @@ use ravel_commit::record::NewCommitRecord;
 use ravel_commit::{keys, publish, record};
 use ravel_fleet::query_workers::QueryWorkerRecord;
 use ravel_ingest::Clock;
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::http::StaticBearerTokenResolver;
 use ravel_query::{LogSegmentFetcher, SegmentFetcher};
 use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
+use ravel_server::alerting::ALERT_SHARD;
 use ravel_server::sql::SqlState;
 use ravel_server::sql_distrib::distributed_flight_config;
 use ravel_server::{FoldTaskConfig, Mode, ServerConfig};
 use ravel_sql::{DistributedFlightConfig, SqlConfig, SqlExecutor, WorkerEndpoints};
+use ravel_types::logstream::log_stream_id;
 use ravel_types::{Label, LabelSet, Sample, SeriesId, Signal, TenantId};
 use tokio::sync::oneshot;
 use tonic::Request;
@@ -246,6 +250,94 @@ async fn publish_span_segment(
         .expect("publish span commit");
 }
 
+/// Publish one real RLOG object plus its `Signal::Alerts` commit record for
+/// `tenant` on [`ALERT_SHARD`] (ADR-1101 decision 1), the alert-signal sibling
+/// of [`publish_span_segment`]. Each `records` entry is
+/// `(ts_ns, alert_id, rule_id, state)`; the promoted attribute keys follow the
+/// ADR-0040 convention the `alerts` table reads.
+async fn publish_alert_segment(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantId,
+    records: &[(i64, &str, &str, &str)],
+) {
+    let tenant_hash = tenant.hash();
+    let alerts: Vec<LogRecord> = records
+        .iter()
+        .map(|(ts, alert_id, rule_id, state)| LogRecord {
+            stream_id: log_stream_id(&[], "alerts", "1", &[]),
+            stream_attrs: stream_attrs_bytes(&[], "alerts", "1", &[]),
+            ts_ns: *ts,
+            observed_ts_ns: *ts,
+            severity_num: 0,
+            severity_text: (*state).to_string(),
+            body: format!("alert {alert_id} {state}"),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: vec![
+                (
+                    "alert_id".to_string(),
+                    AttrValue::Str((*alert_id).to_string()),
+                ),
+                (
+                    "rule_id".to_string(),
+                    AttrValue::Str((*rule_id).to_string()),
+                ),
+                ("state".to_string(), AttrValue::Str((*state).to_string())),
+                ("generation".to_string(), AttrValue::I64(1)),
+            ],
+        })
+        .collect();
+
+    let min_event_ts_ns = alerts.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max_event_ts_ns = alerts.iter().map(|r| r.ts_ns).max().expect("nonempty");
+
+    let writer_id = Uuid::from_u128(7_000);
+    let identity = ObjectIdentity {
+        tenant_hash: tenant_hash.0,
+        shard: ALERT_SHARD,
+        writer_id: writer_id.into_bytes(),
+        writer_epoch: 1,
+        writer_seq: 1,
+    };
+    let mut writer = RlogWriter::new(RlogConfig::default(), identity);
+    for rec in &alerts {
+        writer.push(rec.clone()).expect("push alert record");
+    }
+    let bytes = writer.finish().expect("finish rlog object");
+    let content_hash: [u8; 32] = *blake3::hash(&bytes).as_bytes();
+
+    let rec = record::build(NewCommitRecord {
+        tenant_hash,
+        signal: Signal::Alerts,
+        shard: ALERT_SHARD,
+        writer_id,
+        writer_epoch: 1,
+        writer_seq: 1,
+        object_size: bytes.len() as u64,
+        content_hash,
+        sample_count: alerts.len() as u64,
+        series_count: 1,
+        min_event_ts_ns,
+        max_event_ts_ns,
+        min_ingest_ts_ns: min_event_ts_ns,
+        max_ingest_ts_ns: max_event_ts_ns,
+        segment_format_version: u32::from(ravel_ingest::LOG_SEGMENT_FORMAT_VERSION),
+        created_unix_ns: 10,
+        ingest_hour_bucket: 0,
+    })
+    .expect("valid alert commit record");
+
+    let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+    store
+        .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put alert data object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish alert commit");
+}
+
 fn sql_state(store: Arc<dyn ObjectStoreBackend>, tokens: HashMap<String, TenantId>) -> SqlState {
     sql_state_with_shards(store, tokens, 1)
 }
@@ -411,6 +503,55 @@ async fn decode(
     Ok((rows, columns))
 }
 
+/// The `table_name` column of a `CommandGetTables` `DoGet` response, in wire
+/// order.
+///
+/// The values are read through the Arrow IPC bytes rather than by downcasting
+/// the decoded arrays: arrow-flight carries arrow 58 while this crate's arrow
+/// dev-dependency is the workspace 59 pin, so an arrow 58 `StringArray` and an
+/// arrow 59 one are distinct types and `downcast_ref` would always decline.
+/// The IPC byte format is the contract the two versions share, so each
+/// `FlightData` message is re-framed into a stream message (continuation
+/// marker, little-endian metadata length, padded metadata, body) and read back
+/// with this crate's own arrow.
+fn table_names(messages: &[FlightData]) -> Vec<String> {
+    use arrow::array::{Array, StringArray};
+
+    let mut ipc: Vec<u8> = Vec::new();
+    for message in messages {
+        let mut metadata = message.data_header.to_vec();
+        while (metadata.len() + 8) % 8 != 0 {
+            metadata.push(0);
+        }
+        ipc.extend_from_slice(&u32::MAX.to_le_bytes());
+        ipc.extend_from_slice(&(metadata.len() as u32).to_le_bytes());
+        ipc.extend_from_slice(&metadata);
+        ipc.extend_from_slice(&message.data_body);
+    }
+    // End-of-stream marker: a continuation marker with a zero-length message.
+    ipc.extend_from_slice(&u32::MAX.to_le_bytes());
+    ipc.extend_from_slice(&0u32.to_le_bytes());
+
+    let reader = arrow::ipc::reader::StreamReader::try_new(ipc.as_slice(), None).expect("ipc");
+    let mut names = Vec::new();
+    for batch in reader {
+        let batch = batch.expect("batch");
+        let index = batch
+            .schema()
+            .index_of("table_name")
+            .expect("table_name column");
+        let column = batch.column(index);
+        let strings = column
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("table_name is a string column");
+        for row in 0..strings.len() {
+            names.push(strings.value(row).to_string());
+        }
+    }
+    names
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -546,6 +687,128 @@ async fn a_flight_sql_spans_query_returns_the_published_rows() {
     server.stop().await;
 }
 
+/// ADR-1101 decision 1 reachability, over Flight SQL: `GetFlightInfo` then
+/// `DoGet` for a `SELECT ... FROM alerts` statement over a real tonic channel
+/// returns the published alert transitions. Both SQL transports plan through
+/// `SqlExecutor::plan_pinned`, so this proves the second production surface
+/// reaches the newly-wired alerts path: the ticket resolves the
+/// `Signal::Alerts` snapshot at `GetFlightInfo` (over the read-side shard
+/// floor, ADR-1101 decision 2) and executes the accounted, tenant-checked RLOG
+/// scan at `DoGet`.
+#[tokio::test]
+async fn a_flight_sql_alerts_query_returns_the_published_rows() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = TenantId::new("acme".to_string());
+    publish_alert_segment(
+        store.as_ref(),
+        &tenant,
+        &[
+            (100, "aa01", "cpu-high", "firing"),
+            (200, "bb02", "mem-high", "firing"),
+            (300, "aa01", "cpu-high", "resolved"),
+        ],
+    )
+    .await;
+
+    let mut tokens = HashMap::new();
+    tokens.insert("acme-token".to_string(), tenant);
+    let state = sql_state(store, tokens);
+    let server = FlightServer::start(&state).await;
+    let mut client = server.client().await;
+
+    let command = CommandStatementQuery {
+        query: "SELECT ts_ns, alert_id, state FROM alerts \
+                WHERE alert_id = 'aa01' ORDER BY ts_ns"
+            .to_string(),
+        transaction_id: None,
+    };
+    let info = client
+        .get_flight_info(authed(descriptor(&command), "acme-token"))
+        .await
+        .expect("flight info")
+        .into_inner();
+    let ticket = info
+        .endpoint
+        .first()
+        .expect("one endpoint")
+        .ticket
+        .clone()
+        .expect("a ticket");
+
+    let stream = client
+        .do_get(authed(ticket, "acme-token"))
+        .await
+        .expect("do get")
+        .into_inner();
+    let (rows, columns) = decode(stream).await.expect("decode");
+
+    assert_eq!(rows, 2, "only alert aa01's two transitions come back");
+    assert_eq!(
+        columns,
+        vec![
+            "ts_ns".to_string(),
+            "alert_id".to_string(),
+            "state".to_string()
+        ]
+    );
+
+    server.stop().await;
+}
+
+/// ADR-1101 decision 1: `GetTables` lists every registered table over the
+/// wire. It listed only `samples` before, which under-reported `logs` and
+/// `spans` as well: a Flight client discovering the surface could not see four
+/// of the five tables it can query.
+///
+/// The wire order is by table name, which is what the Flight SQL specification
+/// requires of a `CommandGetTables` response and what
+/// `GetTablesBuilder::build` produces regardless of append order.
+#[tokio::test]
+async fn get_tables_lists_the_five_registered_tables() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = TenantId::new("acme".to_string());
+    let mut tokens = HashMap::new();
+    tokens.insert("acme-token".to_string(), tenant);
+    let state = sql_state(store, tokens);
+    let server = FlightServer::start(&state).await;
+    let mut client = server.client().await;
+
+    let command = CommandGetTables::default();
+    let info = client
+        .get_flight_info(authed(descriptor(&command), "acme-token"))
+        .await
+        .expect("flight info")
+        .into_inner();
+    let ticket = info
+        .endpoint
+        .first()
+        .expect("one endpoint")
+        .ticket
+        .clone()
+        .expect("a ticket");
+
+    let stream = client
+        .do_get(authed(ticket, "acme-token"))
+        .await
+        .expect("do get")
+        .into_inner();
+    let messages: Vec<FlightData> = stream.try_collect().await.expect("collect flight data");
+    let names = table_names(&messages);
+    assert_eq!(
+        names,
+        vec![
+            "alerts".to_string(),
+            "audit".to_string(),
+            "logs".to_string(),
+            "samples".to_string(),
+            "spans".to_string()
+        ],
+        "GetTables lists every registered table, in table-name order"
+    );
+
+    server.stop().await;
+}
+
 /// A ticket minted for one tenant, replayed with another tenant's credentials,
 /// is denied over the wire. This is the same rule ravel-sql tests in-process,
 /// asserted here against the real metadata path.
@@ -590,8 +853,10 @@ async fn a_ticket_replayed_by_another_tenant_is_denied_over_the_wire() {
     server.stop().await;
 }
 
-/// The catalog surface requires credentials, and answers one table when it
-/// has them.
+/// The catalog surface requires credentials, and answers the registered table
+/// set when it has them. The names and their schemas are pinned by
+/// `get_tables_lists_the_five_registered_tables` below; what this one owns is
+/// the default-deny.
 #[tokio::test]
 async fn the_table_listing_requires_credentials() {
     let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
@@ -643,7 +908,7 @@ async fn the_table_listing_requires_credentials() {
     .await
     .expect("decode");
     let rows: usize = batches.iter().map(|batch| batch.num_rows()).sum();
-    assert_eq!(rows, 1, "exactly the samples table");
+    assert_eq!(rows, 5, "one row per registered table");
 
     server.stop().await;
 }

--- a/services/ravel-server/tests/sql_endpoint.rs
+++ b/services/ravel-server/tests/sql_endpoint.rs
@@ -1320,19 +1320,25 @@ async fn an_alerts_plus_logs_query_is_rejected_over_http() {
 }
 
 /// A planning failure on a `logs` query returns the shared, redacted planning
-/// message -- and that message must not tell the client the problem is about
-/// the `samples` table (it named only `samples` before that fix).
+/// message, and that message names no table at all.
+///
+/// It named only `samples` once, which pointed a `logs` client at the wrong
+/// table; the fix then named `samples` and `logs`, which went stale the moment
+/// `spans`, `alerts` and `audit` were registered. `plan_error` builds this
+/// message from a bare `DataFusionError` and never knows which table the query
+/// targeted, so any table set it names is wrong for some caller. Naming none
+/// is the property that cannot go stale, and this asserts it over the whole
+/// registered set rather than over the one table that happened to be wrong.
 ///
 /// The vehicle is an unregistered function, not the `attrs['k']` subscript
 /// this change makes plannable. `attrs['k']` was the vehicle while it was
 /// the documented logs planning gap; it is now the feature under test in
 /// `a_logs_attrs_subscript_query_succeeds_over_http` below, and a test that
 /// asserts a query fails is worthless once the query is meant to succeed.
-/// What this test actually protects -- a `logs` planning failure not blaming
-/// `samples` -- is independent of which construct failed, so it keeps its
-/// value with any unplannable query.
+/// What this test protects is independent of which construct failed, so it
+/// keeps its value with any unplannable query.
 #[tokio::test]
-async fn a_logs_plan_error_does_not_blame_the_samples_table() {
+async fn a_logs_plan_error_names_no_table() {
     let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
     let tenant = TenantId::new("acme".to_string());
     publish_log_segment(
@@ -1355,16 +1361,16 @@ async fn a_logs_plan_error_does_not_blame_the_samples_table() {
     assert_eq!(value["errorType"], "execution");
     let error = value["error"].as_str().expect("error string");
     assert_eq!(error, ravel_sql::MSG_PLAN);
-    // The message must be accurate for a `logs` query: it names `logs`, and it
-    // must not tell the client the fix is about the `samples` table.
-    assert!(
-        error.contains("logs"),
-        "planning message must be accurate for a logs query: {error}"
-    );
-    assert!(
-        !error.contains("samples table"),
-        "planning message must not blame the samples table: {error}"
-    );
+    // The message must be accurate for a query against ANY registered table,
+    // so it may name none of them. Asserting over the whole set is what makes
+    // this survive the next table: the two-name version passed while three
+    // names were missing.
+    for table in ["samples", "logs", "spans", "alerts", "audit"] {
+        assert!(
+            !error.contains(table),
+            "the planning message must name no table, found {table}: {error}"
+        );
+    }
 }
 
 /// `attrs['k']` plans and answers over HTTP, which is the whole point of

--- a/services/ravel-server/tests/sql_endpoint.rs
+++ b/services/ravel-server/tests/sql_endpoint.rs
@@ -36,6 +36,7 @@ use ravel_object_store::{GetRange, ObjectStoreBackend, PutOptions, list_all};
 use ravel_query::http::StaticBearerTokenResolver;
 use ravel_query::{LogSegmentFetcher, SegmentFetcher};
 use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
+use ravel_server::alerting::ALERT_SHARD;
 use ravel_server::sql::{ARROW_STREAM_MEDIA_TYPE, SqlState, router};
 use ravel_sql::{SqlConfig, SqlExecutor};
 use ravel_types::logstream::log_stream_id;
@@ -327,6 +328,116 @@ async fn publish_span_segment(
     publish::publish(store, &rec, &RetryPolicy::default())
         .await
         .expect("publish span commit");
+}
+
+/// One alert transition record, carrying the `ravel-alerting` attribute
+/// convention (ADR-0040 decision 2) by hand: the four promoted keys
+/// (`alert_id`, `rule_id`, `state`, `generation` as an `I64`), a
+/// `label.severity` entry, and the state mirrored onto `severity_text`. Built
+/// here rather than through `ravel-alerting` so this test depends only on the
+/// attribute convention the `alerts` table reads; the drift between that
+/// convention and the real writer is pinned in
+/// `crates/ravel-sql/tests/alerts_provider.rs`.
+fn alert_record(
+    ts: i64,
+    alert_id: &str,
+    rule_id: &str,
+    state: &str,
+    generation: i64,
+    severity: &str,
+) -> LogRecord {
+    LogRecord {
+        stream_id: log_stream_id(&[], "alerts", "1", &[]),
+        stream_attrs: stream_attrs_bytes(&[], "alerts", "1", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 0,
+        severity_text: state.to_string(),
+        body: format!("alert {alert_id} {state}"),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![
+            ("alert_id".to_string(), AttrValue::Str(alert_id.to_string())),
+            ("rule_id".to_string(), AttrValue::Str(rule_id.to_string())),
+            ("state".to_string(), AttrValue::Str(state.to_string())),
+            ("generation".to_string(), AttrValue::I64(generation)),
+            (
+                "label.severity".to_string(),
+                AttrValue::Str(severity.to_string()),
+            ),
+        ],
+    }
+}
+
+/// Publish one real RLOG object plus its `Signal::Alerts` commit record for
+/// `tenant` on [`ALERT_SHARD`], the alert-signal sibling of
+/// [`publish_log_segment`]. The write identity is a parameter rather than
+/// derived from an index: the `alerts` table stamps `writer_id`/`writer_epoch`/
+/// `writer_seq` from the commit record, and the fold's tie-break is only
+/// observable when two objects share a `ts_ns` and differ in one of them.
+async fn publish_alert_segment(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantId,
+    writer_id: Uuid,
+    writer_epoch: u64,
+    writer_seq: u64,
+    records: &[LogRecord],
+) {
+    let tenant_hash = tenant.hash();
+
+    let mut min_event_ts_ns = i64::MAX;
+    let mut max_event_ts_ns = i64::MIN;
+    let mut streams = std::collections::HashSet::new();
+    for rec in records {
+        min_event_ts_ns = min_event_ts_ns.min(rec.ts_ns);
+        max_event_ts_ns = max_event_ts_ns.max(rec.ts_ns);
+        streams.insert(rec.stream_id);
+    }
+
+    let identity = ObjectIdentity {
+        tenant_hash: tenant_hash.0,
+        shard: ALERT_SHARD,
+        writer_id: writer_id.into_bytes(),
+        writer_epoch,
+        writer_seq,
+    };
+    let mut writer = RlogWriter::new(RlogConfig::default(), identity);
+    for rec in records {
+        writer.push(rec.clone()).expect("push alert record");
+    }
+    let bytes = writer.finish().expect("finish rlog object");
+    let content_hash: [u8; 32] = *blake3::hash(&bytes).as_bytes();
+
+    let rec = record::build(NewCommitRecord {
+        tenant_hash,
+        signal: Signal::Alerts,
+        shard: ALERT_SHARD,
+        writer_id,
+        writer_epoch,
+        writer_seq,
+        object_size: bytes.len() as u64,
+        content_hash,
+        sample_count: records.len() as u64,
+        series_count: streams.len() as u64,
+        min_event_ts_ns,
+        max_event_ts_ns,
+        min_ingest_ts_ns: min_event_ts_ns,
+        max_ingest_ts_ns: max_event_ts_ns,
+        segment_format_version: u32::from(ravel_ingest::LOG_SEGMENT_FORMAT_VERSION),
+        created_unix_ns: 10 + writer_seq as i64,
+        ingest_hour_bucket: 0,
+    })
+    .expect("valid alert commit record");
+
+    let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+    store
+        .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put alert data object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish alert commit");
 }
 
 fn build_router(store: Arc<dyn ObjectStoreBackend>, tokens: HashMap<String, TenantId>) -> Router {
@@ -991,6 +1102,217 @@ async fn a_spans_plus_samples_query_is_rejected_over_http() {
         &app,
         "acme-token",
         "SELECT * FROM spans JOIN samples ON spans.start_ts = samples.ts",
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{value}");
+    assert_eq!(value["status"], "error");
+}
+
+// ---------------------------------------------------------------------------
+// The `alerts` and `audit` tables over HTTP (ADR-1101 decision 1)
+// ---------------------------------------------------------------------------
+
+/// The fold-to-current-state query from ADR-1101 decision 1: the row that sorts
+/// first per `alert_id` under the total order `(ts_ns, writer_epoch,
+/// writer_seq, writer_id)` descending. The identity columns are what make it a
+/// total order: two evaluators overlapping at a lease handover can write the
+/// same `alert_id` at the same `ts_ns`, and `ts_ns` alone would leave the
+/// winner unspecified.
+const FOLD_TO_CURRENT_STATE: &str = "SELECT alert_id, state FROM \
+     (SELECT *, ROW_NUMBER() OVER (PARTITION BY alert_id \
+     ORDER BY ts_ns DESC, writer_epoch DESC, writer_seq DESC, writer_id DESC) AS rn \
+     FROM alerts) WHERE rn = 1 ORDER BY alert_id";
+
+/// ADR-1101 decision 1 reachability proof for `alerts`: a `SELECT ... FROM
+/// alerts` posted to the real `/api/v1/sql` handler over published alert
+/// records returns real rows. Before the wiring, `AlertsTableProvider`,
+/// `AlertsScanExec`, and the alert schema all existed and were tested in
+/// isolation, but no production path constructed them, so the query fell into
+/// the "no real table" default, resolved a metrics snapshot, and failed with a
+/// table-not-found planning error.
+///
+/// Four properties, in one fixture so the fold is asserted over the same
+/// history the raw queries returned: every transition comes back in order, an
+/// `alert_id` predicate selects one alert's history, the fold returns one
+/// current row per alert, and the fold's tie-break is decided by `writer_seq`
+/// when two records share a `ts_ns`.
+#[tokio::test]
+async fn sql_query_against_alerts_table_returns_rows() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = TenantId::new("acme".to_string());
+
+    // Alert A fires at 100 and resolves at 300; alert B fires at 200. One
+    // object, one write identity (writer W, epoch 1, seq 1).
+    let writer = Uuid::from_u128(7_000);
+    publish_alert_segment(
+        store.as_ref(),
+        &tenant,
+        writer,
+        1,
+        1,
+        &[
+            alert_record(100, "aa01", "cpu-high", "firing", 1, "page"),
+            alert_record(200, "bb02", "mem-high", "firing", 1, "ticket"),
+            alert_record(300, "aa01", "cpu-high", "resolved", 1, "page"),
+        ],
+    )
+    .await;
+    let app = build_router(Arc::clone(&store), tokens(&[("acme-token", "acme")]));
+
+    // (a) Every published transition comes back, in ts order, with its exact
+    // values: the reachability proof.
+    let (status, value) = post_json(
+        &app,
+        "acme-token",
+        "SELECT ts_ns, alert_id, state FROM alerts ORDER BY ts_ns",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{value}");
+    assert_eq!(value["status"], "success");
+    let rows = value["data"]["rows"].as_array().expect("rows");
+    assert_eq!(rows.len(), 3, "every published transition: {value}");
+    assert_eq!(rows[0], serde_json::json!([100, "aa01", "firing"]));
+    assert_eq!(rows[1], serde_json::json!([200, "bb02", "firing"]));
+    assert_eq!(rows[2], serde_json::json!([300, "aa01", "resolved"]));
+
+    // (b) The `alert_id` equality selects exactly that alert's history.
+    let (status, value) = post_json(
+        &app,
+        "acme-token",
+        "SELECT ts_ns, state FROM alerts WHERE alert_id = 'aa01' ORDER BY ts_ns",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{value}");
+    let rows = value["data"]["rows"].as_array().expect("rows");
+    assert_eq!(rows.len(), 2, "only alert aa01's two rows: {value}");
+    assert_eq!(rows[0], serde_json::json!([100, "firing"]));
+    assert_eq!(rows[1], serde_json::json!([300, "resolved"]));
+
+    // (c) The fold returns exactly one current row per alert.
+    let (status, value) = post_json(&app, "acme-token", FOLD_TO_CURRENT_STATE).await;
+    assert_eq!(status, StatusCode::OK, "{value}");
+    let rows = value["data"]["rows"].as_array().expect("rows");
+    assert_eq!(rows.len(), 2, "one current row per alert: {value}");
+    assert_eq!(rows[0], serde_json::json!(["aa01", "resolved"]));
+    assert_eq!(rows[1], serde_json::json!(["bb02", "firing"]));
+
+    // (d) The tie-break is pinned. A second object writes alert A `firing`
+    // again at the SAME ts_ns as its `resolved` record, under the same
+    // writer_id and epoch but a greater writer_seq. Only the identity columns
+    // can order those two rows, so the fold must now report `firing` for A.
+    publish_alert_segment(
+        store.as_ref(),
+        &tenant,
+        writer,
+        1,
+        2,
+        &[alert_record(300, "aa01", "cpu-high", "firing", 2, "page")],
+    )
+    .await;
+
+    let (status, value) = post_json(&app, "acme-token", FOLD_TO_CURRENT_STATE).await;
+    assert_eq!(status, StatusCode::OK, "{value}");
+    let rows = value["data"]["rows"].as_array().expect("rows");
+    assert_eq!(rows.len(), 2, "still one current row per alert: {value}");
+    assert_eq!(
+        rows[0],
+        serde_json::json!(["aa01", "firing"]),
+        "the greater writer_seq wins the ts_ns tie: {value}"
+    );
+    assert_eq!(rows[1], serde_json::json!(["bb02", "firing"]));
+}
+
+/// ADR-1101 decision 1 reachability proof for `audit`: a tenant reads its own
+/// query-audit trail back through the `audit` table, and the read is itself
+/// audited.
+///
+/// The first statement is audited by the `AuditMode::Required` pipeline before
+/// its response returns, so the second statement -- a query over `audit` --
+/// finds exactly that one record and reports its `kind` and verbatim
+/// `query.text`. The store then holds exactly two query-audit records: the
+/// first statement's, and the audit query's own. Exact counts, because "at
+/// least one" would pass on a surface that audited the wrong statement or
+/// double-audited.
+#[tokio::test]
+async fn sql_query_against_audit_table_returns_the_previous_querys_audit_record() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = TenantId::new("acme".to_string());
+    publish_segment(store.as_ref(), &tenant, 0, "m", &[(100, 1.0), (200, 2.5)]).await;
+    let app = build_router_with_sink(
+        Arc::clone(&store),
+        tokens(&[("acme-token", "acme")]),
+        audit_pipeline(
+            Arc::clone(&store),
+            &tenant,
+            ravel_maintain::AuditMode::Required,
+        ),
+    );
+
+    let first = "SELECT ts, value FROM samples ORDER BY ts";
+    let (status, value) = post_json(&app, "acme-token", first).await;
+    assert_eq!(status, StatusCode::OK, "{value}");
+
+    let (status, value) = post_json(
+        &app,
+        "acme-token",
+        "SELECT body, attrs['kind'], attrs['query.text'] FROM audit \
+         WHERE attrs['kind'] = 'query' ORDER BY ts_ns",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{value}");
+    assert_eq!(value["status"], "success");
+    let rows = value["data"]["rows"].as_array().expect("rows");
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly the first statement's record: {value}"
+    );
+    assert_eq!(rows[0][1], serde_json::json!("query"));
+    assert_eq!(
+        rows[0][2],
+        serde_json::json!(first),
+        "the audited statement text is verbatim: {value}"
+    );
+
+    // A query over `audit` is itself audited: the store now holds exactly two
+    // query-audit records, the first statement's and the audit query's own.
+    // Compared as a sorted pair, not by position: both records carry the same
+    // `ts_ns` (one frozen clock) and the helper returns them in commit-key
+    // listing order, which is not write order.
+    let records = query_audit_records(store.as_ref(), &tenant).await;
+    assert_eq!(
+        records.len(),
+        2,
+        "the audit query is audited like any other query"
+    );
+    let mut texts: Vec<&str> = records
+        .iter()
+        .map(|row| attr(row, "query.text").expect("every record carries its query text"))
+        .collect();
+    texts.sort_unstable();
+    let mut want = vec![
+        first,
+        "SELECT body, attrs['kind'], attrs['query.text'] FROM audit \
+         WHERE attrs['kind'] = 'query' ORDER BY ts_ns",
+    ];
+    want.sort_unstable();
+    assert_eq!(
+        texts, want,
+        "the second record is the audit query itself, verbatim"
+    );
+}
+
+/// A cross-signal query naming `alerts` and `logs` is rejected as a 400, the
+/// same way `spans` + `samples` is: ADR-1101 decision 1 extends the
+/// one-signal-per-query rule from three names to five, and the rejection
+/// happens in `target_signal` before any catalog listing.
+#[tokio::test]
+async fn an_alerts_plus_logs_query_is_rejected_over_http() {
+    let app = one_tenant_app("m", &[(100, 1.0)]).await;
+    let (status, value) = post_json(
+        &app,
+        "acme-token",
+        "SELECT * FROM alerts JOIN logs ON alerts.ts_ns = logs.ts",
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{value}");


### PR DESCRIPTION
Every alert state transition and every audited query is written to object storage as an immutable record, and the table providers that read them back existed with passing tests, but nothing in production constructed either one. A query naming `alerts` or `audit` got a table-not-found error while the records sat in the bucket. README, the HTTP API reference and three guides all said so out loud.

Register both as SQL tables four and five, following the spans wiring precedent. The session gains an `Alerts` and an `Audit` variant and registers exactly the one table a query targets, as it already did for three. The executor's `FROM`-clause routing decides over five names; naming two or more real tables is still rejected before any catalog listing, and a query with no real table still resolves as metrics. Both plan arms build their provider over the resolved snapshot with the query's tenant hash, the executor's existing log fetcher and the query's accounting handle, so alert and audit reads are cached and metered exactly like log reads and cost the same to estimate. Flight SQL's table listing now returns every registered table rather than only `samples`, which under-reported `logs` and `spans` as well.

The `alerts` table also gains the write identity of each record as three columns. Two evaluators can overlap briefly at a lease handover and write the same alert at the same timestamp, so a fold over the timestamp alone has no total order and can return two current rows for one alert. With the identity columns the documented fold returns exactly one.

Tests drive the real HTTP handler and a real Flight channel over published alert and audit objects: the exact rows, the fold to current state including a deliberate timestamp tie, that a query over `audit` is itself audited, that a cross-signal query is refused before any listing, and that the table listing carries all five schemas. Each was shown failing against the unregistered code.

Refs: ADR-1101 decision 1.

Fixes: #128
Refs: #1101
