### PR TITLE
feat(query): answer PromQL log selectors from the logs signal

### DIFF
--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -358,7 +358,12 @@ impl QueryEngine {
             .with_max_concurrent_gets(config.fetch_concurrency)
             .with_request_cost_bytes(config.logs_request_cost_bytes)
             .with_max_fetch_run_bytes(fetch_run_bytes)
-            .unwrap_or_else(|_| {
+            .unwrap_or_else(|err| {
+                tracing::warn!(
+                    error = %err,
+                    fetch_run_bytes,
+                    "invalid logs_max_fetch_run_bytes; using the log fetcher's default bound"
+                );
                 LogSegmentFetcher::new(store.clone())
                     .with_block_range_threshold(config.logs_block_range_threshold)
                     .with_max_concurrent_gets(config.fetch_concurrency)
@@ -864,10 +869,7 @@ impl QueryEngine {
 
             let mut warnings = Vec::new();
             if self.federation.is_some() {
-                warnings.push(format!(
-                    "{} is answered by this cluster only; log series are not federated",
-                    metric.name()
-                ));
+                warnings.push(log_not_federated_warning(metric.name()));
             }
 
             let by_id = build_series_by_id(
@@ -1164,9 +1166,7 @@ impl QueryEngine {
         // populates for a skipped remote.
         if self.federation.is_some() {
             for name in fed_metric_names {
-                stats.warnings.push(format!(
-                    "{name} is answered by this cluster only; log series are not federated"
-                ));
+                stats.warnings.push(log_not_federated_warning(name));
             }
         }
 
@@ -2766,6 +2766,13 @@ mod name_filter_tests {
         let one_bypasses = vec![plan(re("^foo.*$")), plan(re("foo|bar"))];
         assert!(shared_equality_name_filter(&one_bypasses).is_none());
     }
+}
+
+/// ADR-1103 decision 5: a federated query answers a log selector locally
+/// only, never fanning it to a remote cluster. Shared by both call sites so
+/// the two `warnings` entries this produces cannot drift apart.
+fn log_not_federated_warning(name: &str) -> String {
+    format!("{name} is answered by this cluster only; log series are not federated")
 }
 
 /// Parses `query` as a bare vector selector (Phase 1 scope) and returns its

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -31,6 +31,8 @@ use crate::fetcher::{
     FetchError, FetchStats, FetchedHistogramSeries, FetchedSeriesSoa, ReadCache, SamplePriority,
     SegmentFetcher,
 };
+use crate::log_fetcher::{LogFetchError, LogSegmentFetcher};
+use crate::log_series;
 use crate::phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot};
 use crate::segment_admission;
 
@@ -318,6 +320,10 @@ fn estimate_cost(
 pub struct QueryEngine {
     catalog: Arc<Catalog>,
     fetcher: SegmentFetcher,
+    /// Fetches log segments for `ravel_log_lines`/`ravel_log_bytes`
+    /// selectors (ADR-1103). Built from the same store as `fetcher`,
+    /// with the logs-specific fetch bounds from `config`.
+    log_fetcher: LogSegmentFetcher,
     config: EngineConfig,
     /// ADR-0071 distributed read fan-out. `None` is the default:
     /// the engine runs the local fetch path untouched. `Some` opts this engine
@@ -338,9 +344,30 @@ impl QueryEngine {
         store: Arc<dyn ObjectStoreBackend>,
         config: EngineConfig,
     ) -> Self {
+        // `EngineConfig::validate` is not run by every caller of `new`
+        // (services/ravel-server/src/query.rs's non-SQL path calls this
+        // infallibly), so a zero bound is substituted here rather than
+        // propagated as a constructor error.
+        let fetch_run_bytes = if config.logs_max_fetch_run_bytes == 0 {
+            crate::config::DEFAULT_LOG_MAX_FETCH_RUN_BYTES
+        } else {
+            config.logs_max_fetch_run_bytes
+        };
+        let log_fetcher = LogSegmentFetcher::new(store.clone())
+            .with_block_range_threshold(config.logs_block_range_threshold)
+            .with_max_concurrent_gets(config.fetch_concurrency)
+            .with_request_cost_bytes(config.logs_request_cost_bytes)
+            .with_max_fetch_run_bytes(fetch_run_bytes)
+            .unwrap_or_else(|_| {
+                LogSegmentFetcher::new(store.clone())
+                    .with_block_range_threshold(config.logs_block_range_threshold)
+                    .with_max_concurrent_gets(config.fetch_concurrency)
+                    .with_request_cost_bytes(config.logs_request_cost_bytes)
+            });
         QueryEngine {
             catalog,
             fetcher: SegmentFetcher::new(store),
+            log_fetcher,
             config,
             distributed: None,
             federation: None,
@@ -381,7 +408,9 @@ impl QueryEngine {
     /// [`ReadCache::Tiered`] so the disk tier reaches this engine's fetcher.
     #[must_use]
     pub fn with_cache(mut self, cache: impl Into<ReadCache>) -> Self {
-        self.fetcher = self.fetcher.with_cache(cache);
+        let cache = cache.into();
+        self.fetcher = self.fetcher.with_cache(cache.clone());
+        self.log_fetcher = self.log_fetcher.with_cache(cache);
         self
     }
 
@@ -699,6 +728,12 @@ impl QueryEngine {
         min_tokens: &[CommitToken],
         now_ns: i64,
     ) -> Result<(Vec<(SeriesId, LabelSet)>, QueryStats), QueryError> {
+        if let Some(metric) = log_series::log_metric_of(matchers) {
+            return self
+                .resolve_log_series_inner(tenant_hash, metric, matchers, window, min_tokens, now_ns)
+                .await;
+        }
+
         let name_filter = equality_name_filter(matchers);
         // Discovery does not push aggregation down (ADR-0103 is scalar-sample
         // pushdown), so it ignores the resolve's generation history.
@@ -771,10 +806,90 @@ impl QueryEngine {
         let ((series, warnings, partial), mut stats) = self
             .resolve_snapshot_with_retry(
                 tenant_hash,
+                Signal::Metrics,
                 window,
                 min_tokens,
                 now_ns,
                 name_filter.as_deref(),
+                1,
+                attempt,
+            )
+            .await?;
+        stats.partial = partial;
+        stats.warnings = warnings;
+        Ok((series, stats))
+    }
+
+    /// Discovery-path counterpart of the metrics branch above, for a
+    /// `match[]` selector naming `ravel_log_lines`/`ravel_log_bytes`
+    /// (ADR-1103). Resolves `Signal::Logs` directly with no name-postings
+    /// filter, contributes each derived series' label set the same way a
+    /// metrics series would (same erasure, same dedup-by-label-set via
+    /// `build_series_by_id`), and never fans the selector to a remote
+    /// cluster: a federated deployment gets a warning annotation instead,
+    /// mirroring `prefetch`'s log lane rather than `federate_discovery`.
+    async fn resolve_log_series_inner(
+        &self,
+        tenant_hash: TenantHash,
+        metric: log_series::LogMetric,
+        matchers: &[LabelMatcher],
+        window: TimeRange,
+        min_tokens: &[CommitToken],
+        now_ns: i64,
+    ) -> Result<(Vec<(SeriesId, LabelSet)>, QueryStats), QueryError> {
+        let attempt = |snapshot: Snapshot,
+                       _generations: Vec<ShardGeneration>,
+                       accounting: PhaseAccounting| async move {
+            let erasure = snapshot_erasure_predicates(&snapshot);
+            let req = log_series::LogSeriesRequest {
+                metric,
+                matchers,
+                window,
+                erasure: &erasure,
+                max_samples: self.config.max_samples,
+                max_series: self.config.max_series,
+                max_bytes_scanned: self.config.max_bytes_scanned,
+                max_s3_requests: self.config.max_s3_requests,
+                deadline: None,
+            };
+            let out = log_series::fetch_log_series(
+                &self.log_fetcher,
+                tenant_hash,
+                &snapshot.segments,
+                &req,
+                &accounting,
+            )
+            .await
+            .map_err(|err| self.map_log_series_error(err))?;
+
+            let mut warnings = Vec::new();
+            if self.federation.is_some() {
+                warnings.push(format!(
+                    "{} is answered by this cluster only; log series are not federated",
+                    metric.name()
+                ));
+            }
+
+            let by_id = build_series_by_id(
+                out.series
+                    .into_iter()
+                    .map(|s| (log_series_discovery_id(&s.labels), s.labels)),
+                self.config.max_series,
+            )?;
+            Ok((
+                (by_id.into_iter().collect::<Vec<_>>(), warnings, false),
+                FetchStats::default(),
+            ))
+        };
+
+        let ((series, warnings, partial), mut stats) = self
+            .resolve_snapshot_with_retry(
+                tenant_hash,
+                Signal::Logs,
+                window,
+                min_tokens,
+                now_ns,
+                None,
                 1,
                 attempt,
             )
@@ -864,17 +979,15 @@ impl QueryEngine {
         Ok((series, outcome.warnings, outcome.partial))
     }
 
-    /// Prefetches every selector `plan_selectors` reported: one shared
-    /// snapshot resolved against the union of every selector's own fetch
-    /// window (`padded_range`, docs/query-engine.md), then one
-    /// concurrency-bounded, independently budget-checked fetch+merge per
-    /// selector's own matchers against that snapshot. A selector's fetch
-    /// only prunes by its own matchers server-side; a later
-    /// `SeriesSource::query` call still clips to its own window, so
-    /// combining every selector's already-merged series into one flat
-    /// source is correct regardless of how widely the selectors' windows
-    /// or matchers differ. An empty plan list (a query with no selectors,
-    /// e.g. a bare scalar or string literal) skips storage entirely.
+    /// Prefetches every selector `plan_selectors` reported, for BOTH signals
+    /// (ADR-1103 decision 4/5): metrics selectors run through
+    /// [`Self::prefetch_metric_plans`] unchanged, and any `ravel_log_lines`/
+    /// `ravel_log_bytes` selector (`log_series::log_metric_of`) runs on a
+    /// separate lane that resolves `Signal::Logs` directly, never through
+    /// distributed fan-out or federation, and spends only the query-wide
+    /// budget the metrics lane left remaining. A query naming no log metric
+    /// takes the metrics-only path with zero added cost or `Signal::Logs`
+    /// resolves.
     async fn prefetch(
         &self,
         tenant_hash: TenantHash,
@@ -888,6 +1001,205 @@ impl QueryEngine {
                 MergedSource {
                     series: Vec::new(),
                     histogram_series: Vec::new(),
+                    log_series: Vec::new(),
+                    precomputed_count: None,
+                },
+                QueryStats::default(),
+            ));
+        }
+
+        let metric_plans: Vec<SelectorPlan> = plans
+            .iter()
+            .filter(|p| log_series::log_metric_of(&p.matchers).is_none())
+            .cloned()
+            .collect();
+        let log_plans: Vec<SelectorPlan> = plans
+            .iter()
+            .filter(|p| log_series::log_metric_of(&p.matchers).is_some())
+            .cloned()
+            .collect();
+
+        let (mut source, mut stats) = self
+            .prefetch_metric_plans(tenant_hash, &metric_plans, eval_window, min_tokens, now_ns)
+            .await?;
+
+        if log_plans.is_empty() {
+            return Ok((source, stats));
+        }
+
+        let log_windows: Vec<TimeRange> = log_plans
+            .iter()
+            .map(|plan| selector_fetch_window(plan, eval_window))
+            .collect::<Result<_, _>>()?;
+        let mut log_padded = log_windows[0];
+        for w in &log_windows[1..] {
+            log_padded.start_ns = log_padded.start_ns.min(w.start_ns);
+            log_padded.end_ns = log_padded.end_ns.max(w.end_ns);
+        }
+
+        // The log lane never retries on `NotFound` the way
+        // `resolve_snapshot_with_retry` does for metrics: it runs strictly
+        // after the metrics lane has already produced its result, so a
+        // concurrent GC/compaction race here is the same
+        // `SnapshotInvalidated` class of rare failure the metrics lane's own
+        // second attempt exists to paper over, not a case worth duplicating
+        // that machinery for.
+        let log_accounting = PhaseAccounting::new();
+        let (log_snapshot, _log_generations) = self
+            .resolve_bounded(
+                tenant_hash,
+                Signal::Logs,
+                log_padded,
+                min_tokens,
+                now_ns,
+                None,
+                log_accounting.resolve(),
+            )
+            .await?;
+
+        // ADR-1103 decision 4 step 4: a query with both a metrics and a log
+        // selector must not spend two full `max_segments` budgets. Each
+        // `resolve_bounded` call above already checked its OWN sealed-segment
+        // count individually (`segment_admission::admit`); this adds the
+        // cumulative check across both lanes, using each lane's total
+        // resolved segment count (not just the sealed subset `admit` checks)
+        // as a conservative approximation -- `resolve_bounded` does not
+        // return the sealed/exempt split to its caller.
+        let total_segments = stats.segments_fetched + log_snapshot.segments.len() as u64;
+        if total_segments as usize > self.config.max_segments {
+            return Err(QueryError::TooManySegments {
+                count: total_segments as usize,
+                max: self.config.max_segments,
+            });
+        }
+
+        let erasure = snapshot_erasure_predicates(&log_snapshot);
+
+        // Remaining query-wide budget after the metrics lane's own spend
+        // (ADR-1103 decision 4 step 4): a log lane spending a second full
+        // budget would let a query with both selector kinds cost twice what
+        // `EngineConfig` bounds it to.
+        let samples_so_far: usize = source.series.iter().map(|s| s.samples.len()).sum::<usize>()
+            + source
+                .histogram_series
+                .iter()
+                .map(|s| s.samples.len())
+                .sum::<usize>();
+        let series_so_far = source.series.len() + source.histogram_series.len();
+        let mut samples_remaining = self.config.max_samples.saturating_sub(samples_so_far);
+        let mut series_remaining = self.config.max_series.saturating_sub(series_so_far);
+
+        let scanned_so_far = stats.phase_accounting.pooled().total_s3_bytes();
+        let bytes_remaining = match self.config.max_bytes_scanned {
+            ByteLimit::Bounded(max) => ByteLimit::Bounded(max.saturating_sub(scanned_so_far)),
+            ByteLimit::Unlimited => ByteLimit::Unlimited,
+        };
+        let requests_so_far = stats.phase_accounting.pooled().total_s3_requests();
+        let requests_remaining = match self.config.max_s3_requests {
+            RequestLimit::Bounded(max) => {
+                RequestLimit::Bounded(max.saturating_sub(requests_so_far))
+            }
+            RequestLimit::Unlimited => RequestLimit::Unlimited,
+        };
+
+        // `bytes_remaining`/`requests_remaining` are the absolute ceiling for
+        // the WHOLE log lane (every log plan below shares `log_accounting`,
+        // so `fetch_log_series`'s own per-segment check sees each plan's
+        // predecessor's spend too and naturally enforces the combined
+        // budget). `samples_remaining`/`series_remaining` are plain counts
+        // with no shared live accounting behind them, so they are reduced by
+        // hand after each plan below -- otherwise two log selectors would
+        // each see, and could each spend, the full remaining budget.
+        let mut log_series_out: Vec<SeriesData> = Vec::new();
+        let mut log_segments_fetched: u64 = 0;
+        let mut fed_metric_names: Vec<&'static str> = Vec::new();
+        for plan in &log_plans {
+            // `log_plans` was filtered by `log_metric_of(...).is_some()`
+            // above, so this is always `Some`; the `continue` never fires but
+            // keeps this loop panic-free rather than relying on that
+            // invariant holding across future edits to the filter above.
+            let Some(metric) = log_series::log_metric_of(&plan.matchers) else {
+                continue;
+            };
+            let req = log_series::LogSeriesRequest {
+                metric,
+                matchers: &plan.matchers,
+                window: log_padded,
+                erasure: &erasure,
+                max_samples: samples_remaining,
+                max_series: series_remaining,
+                max_bytes_scanned: bytes_remaining,
+                max_s3_requests: requests_remaining,
+                deadline: Some(Instant::now() + self.config.deadline),
+            };
+            let out = log_series::fetch_log_series(
+                &self.log_fetcher,
+                tenant_hash,
+                &log_snapshot.segments,
+                &req,
+                &log_accounting,
+            )
+            .await
+            .map_err(|err| self.map_log_series_error(err))?;
+            let out_samples: usize = out.series.iter().map(|s| s.samples.len()).sum();
+            samples_remaining = samples_remaining.saturating_sub(out_samples);
+            series_remaining = series_remaining.saturating_sub(out.series.len());
+            log_segments_fetched = log_segments_fetched.max(out.segments_fetched as u64);
+            log_series_out.extend(out.series);
+            if !fed_metric_names.contains(&metric.name()) {
+                fed_metric_names.push(metric.name());
+            }
+        }
+
+        source.log_series = log_series_out;
+        stats.segments_fetched += log_segments_fetched;
+        stats.segments_pruned += log_snapshot.segments_pruned;
+        stats.phase_accounting =
+            combine_phase_accounting(&stats.phase_accounting, &log_accounting.snapshot());
+        stats.accounting = stats.phase_accounting.pooled();
+
+        // ADR-1103 decision 5: a federated query answers a log selector
+        // locally only, never fanning it to a remote cluster; the client is
+        // told so via the same `warnings` channel `federate_scalar` already
+        // populates for a skipped remote.
+        if self.federation.is_some() {
+            for name in fed_metric_names {
+                stats.warnings.push(format!(
+                    "{name} is answered by this cluster only; log series are not federated"
+                ));
+            }
+        }
+
+        Ok((source, stats))
+    }
+
+    /// Prefetches every metrics selector `plan_selectors` reported: one
+    /// shared snapshot resolved against the union of every selector's own
+    /// fetch window (`padded_range`, docs/query-engine.md), then one
+    /// concurrency-bounded, independently budget-checked fetch+merge per
+    /// selector's own matchers against that snapshot. A selector's fetch
+    /// only prunes by its own matchers server-side; a later
+    /// `SeriesSource::query` call still clips to its own window, so
+    /// combining every selector's already-merged series into one flat
+    /// source is correct regardless of how widely the selectors' windows
+    /// or matchers differ. An empty plan list (no metrics selector in the
+    /// query -- a bare scalar/string literal, or a query naming only log
+    /// metrics) skips storage entirely and issues zero `Signal::Metrics`
+    /// resolves.
+    async fn prefetch_metric_plans(
+        &self,
+        tenant_hash: TenantHash,
+        plans: &[SelectorPlan],
+        eval_window: &EvalWindow,
+        min_tokens: &[CommitToken],
+        now_ns: i64,
+    ) -> Result<(MergedSource, QueryStats), QueryError> {
+        if plans.is_empty() {
+            return Ok((
+                MergedSource {
+                    series: Vec::new(),
+                    histogram_series: Vec::new(),
+                    log_series: Vec::new(),
                     precomputed_count: None,
                 },
                 QueryStats::default(),
@@ -1202,6 +1514,10 @@ impl QueryEngine {
                     MergedSource {
                         series,
                         histogram_series,
+                        // Task #6 (log-plan partitioning) fills this in from
+                        // the log lane's own fetch, run outside this
+                        // `attempt` closure.
+                        log_series: Vec::new(),
                         precomputed_count,
                     },
                     fed_warnings,
@@ -1214,6 +1530,7 @@ impl QueryEngine {
         let ((source, warnings, partial), mut stats) = self
             .resolve_snapshot_with_retry(
                 tenant_hash,
+                Signal::Metrics,
                 padded,
                 min_tokens,
                 now_ns,
@@ -1236,6 +1553,7 @@ impl QueryEngine {
     async fn resolve_snapshot_with_retry<T, F, Fut>(
         &self,
         tenant_hash: TenantHash,
+        signal: Signal,
         window: TimeRange,
         min_tokens: &[CommitToken],
         now_ns: i64,
@@ -1262,6 +1580,7 @@ impl QueryEngine {
         let (first, first_generations) = self
             .resolve_bounded(
                 tenant_hash,
+                signal,
                 window,
                 min_tokens,
                 now_ns,
@@ -1281,6 +1600,7 @@ impl QueryEngine {
                 let (second, second_generations) = self
                     .resolve_bounded(
                         tenant_hash,
+                        signal,
                         window,
                         min_tokens,
                         now_ns,
@@ -1329,9 +1649,11 @@ impl QueryEngine {
     // `resolve_pruned_with_accounting` directly and never reaches this wrapper
     // (ADR-0044 decision 5). Instrumenting here too would span a
     // resolve reached through ravel-query twice.
+    #[allow(clippy::too_many_arguments)]
     async fn resolve_bounded(
         &self,
         tenant_hash: TenantHash,
+        signal: Signal,
         window: TimeRange,
         min_tokens: &[CommitToken],
         now_ns: i64,
@@ -1347,7 +1669,7 @@ impl QueryEngine {
             .catalog
             .resolve_pruned_with_generations(
                 &tenant_hash,
-                Signal::Metrics,
+                signal,
                 window,
                 min_tokens,
                 now_ns,
@@ -1361,6 +1683,60 @@ impl QueryEngine {
         // checked incrementally during fetch, below.
         segment_admission::admit(&snapshot, &origins, &self.config)?;
         Ok((snapshot, generations))
+    }
+
+    /// Maps a log lane failure onto the same [`QueryError`] variants the
+    /// metrics fetch path returns, so the HTTP layer's status mapping and
+    /// object-key redaction (`http/error.rs`) apply unchanged to a log
+    /// selector. `Corrupt`/`Decode`/`UnknownStream` have no structurally
+    /// matching `FetchError` variant available from this crate (adding one
+    /// would touch `fetcher.rs`, out of this task's scope), so all three
+    /// coarsen to `FetchError::Store` with a `StoreError::Corrupted` cause --
+    /// the client-visible message becomes "unavailable" rather than
+    /// "corrupt" for exactly those three cases, a deliberate scope trade-off
+    /// flagged in the task report, not a silent behavior change.
+    fn map_log_series_error(&self, err: log_series::LogSeriesError) -> QueryError {
+        match err {
+            log_series::LogSeriesError::SamplesExceeded { count, max } => {
+                QueryError::TooManySamples { count, max }
+            }
+            log_series::LogSeriesError::SeriesExceeded { count, max } => {
+                QueryError::TooManySeries { count, max }
+            }
+            log_series::LogSeriesError::BytesScannedExceeded { scanned, max } => {
+                QueryError::TooManyBytesScanned { scanned, max }
+            }
+            log_series::LogSeriesError::RequestsExceeded { requests, max } => {
+                QueryError::RequestBudgetExceeded { requests, max }
+            }
+            log_series::LogSeriesError::DeadlineExceeded => QueryError::DeadlineExceeded {
+                deadline: self.config.deadline,
+            },
+            log_series::LogSeriesError::Fetch(LogFetchError::Store { key, source }) => {
+                QueryError::Fetch(FetchError::Store { key, source })
+            }
+            log_series::LogSeriesError::Fetch(LogFetchError::EtagChanged { key }) => {
+                QueryError::Fetch(FetchError::EtagChanged { key })
+            }
+            log_series::LogSeriesError::Fetch(LogFetchError::Corrupt { key, source }) => {
+                QueryError::Fetch(FetchError::Store {
+                    key,
+                    source: StoreError::Corrupted(source.to_string()),
+                })
+            }
+            log_series::LogSeriesError::Decode(source) => QueryError::Fetch(FetchError::Store {
+                key: String::new(),
+                source: StoreError::Corrupted(source.to_string()),
+            }),
+            log_series::LogSeriesError::UnknownStream { stream_id } => {
+                QueryError::Fetch(FetchError::Store {
+                    key: format!("stream:{stream_id:?}"),
+                    source: StoreError::Corrupted(format!(
+                        "record's stream {stream_id:?} is not present in its segment's STREAM_DIR"
+                    )),
+                })
+            }
+        }
     }
 
     /// Fetches every matched series from each snapshot segment in a single
@@ -1777,6 +2153,54 @@ impl QueryEngine {
 /// (`services/ravel-server/src/distrib.rs`) re-exports and calls it.
 pub fn snapshot_erasure_predicates(snapshot: &Snapshot) -> Vec<ErasurePredicate> {
     crate::erasure::snapshot_pending_erasure_predicates(snapshot)
+}
+
+/// Field-wise sums two independently-tracked [`PhaseAccountingSnapshot`]s
+/// (ADR-1103 decision 4 step 4): `prefetch`'s log lane runs its own
+/// [`PhaseAccounting`] handle rather than sharing the metrics lane's live
+/// handle, so the two lanes' costs are combined only once, at snapshot time,
+/// for the query-wide total the caller reports.
+fn combine_phase_accounting(
+    a: &PhaseAccountingSnapshot,
+    b: &PhaseAccountingSnapshot,
+) -> PhaseAccountingSnapshot {
+    PhaseAccountingSnapshot {
+        resolve: a.resolve.saturating_add(&b.resolve),
+        plan: a.plan.saturating_add(&b.plan),
+        probe: a.probe.saturating_add(&b.probe),
+        scan: a.scan.saturating_add(&b.scan),
+    }
+}
+
+/// A locally-scoped series identity for a log-derived series returned from
+/// a discovery endpoint (`/api/v1/series`, `/api/v1/labels`,
+/// `/api/v1/label/{name}/values`). Log series carry no persisted
+/// `SeriesId` -- ADR-1103 derives them at query time, never at ingest --
+/// and query-time code holds only a `TenantHash`, not the `TenantId`
+/// `SeriesId::compute`'s canonical encoding requires. This hash is used
+/// only to dedupe within one `resolve_log_series_inner` call (always
+/// scoped to a single tenant) and is discarded before the label set
+/// reaches the client (`series_to_json`), so it need not be canonical,
+/// persistent, or stable across calls -- unlike `SeriesId::compute`, whose
+/// doc comment marks its encoding a persistent contract.
+fn log_series_discovery_id(labels: &LabelSet) -> SeriesId {
+    let mut sorted: Vec<(&str, &str)> = labels
+        .iter()
+        .map(|l| (l.name.as_str(), l.value.as_str()))
+        .collect();
+    sorted.sort_unstable();
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"ravel-log-series-discovery-v1\0");
+    for (name, value) in sorted {
+        hasher.update(&(name.len() as u32).to_le_bytes());
+        hasher.update(name.as_bytes());
+        hasher.update(&(value.len() as u32).to_le_bytes());
+        hasher.update(value.as_bytes());
+    }
+    let hash = hasher.finalize();
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&hash.as_bytes()[..16]);
+    SeriesId(bytes)
 }
 
 /// Builds a `series_id -> labels` map incrementally, rejecting the moment a
@@ -3188,6 +3612,12 @@ struct PrecomputedCount {
 struct MergedSource {
     series: Vec<SeriesData>,
     histogram_series: Vec<HistogramSeriesData>,
+    /// ADR-1103 log-derived series (`ravel_log_lines`/`ravel_log_bytes`),
+    /// merged in by `prefetch`'s log lane. Consulted by `query` only when
+    /// the matcher set names a log metric (`log_series::log_metric_of`);
+    /// never by `query_histograms` or `query_precomputed_count`, which
+    /// have no log-signal counterpart.
+    log_series: Vec<SeriesData>,
     /// ADR-0103 collected pushdown count table. Written by `prefetch` and read
     /// by `query_precomputed_count` (this impl) on the T4b fast path.
     precomputed_count: Option<PrecomputedCount>,
@@ -3199,10 +3629,29 @@ impl SeriesSource for MergedSource {
         matchers: &[LabelMatcher],
         window: TimeRange,
     ) -> Result<Vec<SeriesData>, SourceError> {
-        Ok(self
-            .series
+        let is_log_pool = log_series::log_metric_of(matchers).is_some();
+        let pool = if is_log_pool {
+            &self.log_series
+        } else {
+            &self.series
+        };
+        // `fetch_log_series` already applied every `__body__` matcher per
+        // record (ADR-1103 decision 3: `__body__` is a per-record pseudo-label,
+        // never a member of a log series' `LabelSet`). Re-checking it here
+        // against `s.labels` would hit matchers.rs's absent-label-as-empty-
+        // string rule and wrongly drop every series for a non-empty-matching
+        // `__body__` matcher.
+        let label_matchers: Vec<&LabelMatcher> = if is_log_pool {
+            matchers
+                .iter()
+                .filter(|m| m.name != log_series::BODY_MATCHER_LABEL)
+                .collect()
+        } else {
+            matchers.iter().collect()
+        };
+        Ok(pool
             .iter()
-            .filter(|s| matches_series(matchers, &s.labels))
+            .filter(|s| label_matchers.iter().all(|m| m.is_match(&s.labels)))
             .map(|s| SeriesData {
                 labels: s.labels.clone(),
                 samples: s
@@ -4818,6 +5267,7 @@ mod histogram_source_tests {
         MergedSource {
             series: Vec::new(),
             histogram_series,
+            log_series: Vec::new(),
             precomputed_count: None,
         }
     }
@@ -5897,6 +6347,7 @@ mod prefetch_tests {
         let source = MergedSource {
             series: Vec::new(),
             histogram_series: Vec::new(),
+            log_series: Vec::new(),
             precomputed_count: Some(PrecomputedCount {
                 matchers: matchers.clone(),
                 start_ns: 100,

--- a/crates/ravel-query/src/http/compat.rs
+++ b/crates/ravel-query/src/http/compat.rs
@@ -24,11 +24,12 @@ use axum::routing::get;
 use axum::{Json, Router};
 use serde::Serialize;
 
-use ravel_catalog::MetricKind;
+use ravel_catalog::{MetricKind, MetricMetadataEntry};
 
 use crate::http::json::ApiResponse;
 use crate::http::params::Params;
 use crate::http::{AppState, MetadataSnapshot};
+use crate::log_series::{LOG_BYTES_METRIC, LOG_LINES_METRIC};
 
 /// Git revision of the build, when the build environment provided one.
 ///
@@ -151,8 +152,41 @@ async fn metadata(State(state): State<AppState>, req: Request) -> Response {
         .and_then(|raw| raw.parse::<usize>().ok());
 
     let snapshot: MetadataSnapshot = cache.get(tenant.hash()).await;
-    let data = project(&snapshot, metric_filter.as_deref(), limit);
+    let mut entries: Vec<MetricMetadataEntry> = snapshot.to_vec();
+    entries.extend(log_metric_entries());
+    let data = project(&entries, metric_filter.as_deref(), limit);
     Json(ApiResponse::success(data)).into_response()
+}
+
+/// The two reserved log metric names' metadata (ADR-1103), synthesized
+/// here rather than ever stored in the cache: they are query-time derived
+/// series, not an ingested family, so no ingest sink ever writes a
+/// `MetricMetadataEntry` for them. Always present on the normal path
+/// (a tenant that resolves and has a cache attached), subject to the same
+/// `metric`/`limit` projection as any cached entry. `updated_unix_ns` plays
+/// no part in `project`'s output, so `0` is fine here.
+fn log_metric_entries() -> [MetricMetadataEntry; 2] {
+    [
+        MetricMetadataEntry {
+            family_name: LOG_LINES_METRIC.to_string(),
+            kind: MetricKind::Gauge,
+            help: "One sample per log line, value 1, derived from the logs \
+                   signal at query time (ADR-1103); count_over_time counts \
+                   lines."
+                .to_string(),
+            unit: String::new(),
+            updated_unix_ns: 0,
+        },
+        MetricMetadataEntry {
+            family_name: LOG_BYTES_METRIC.to_string(),
+            kind: MetricKind::Gauge,
+            help: "One sample per log line whose value is the line body's \
+                   length in bytes (ADR-1103); sum_over_time sums bytes."
+                .to_string(),
+            unit: "bytes".to_string(),
+            updated_unix_ns: 0,
+        },
+    ]
 }
 
 /// Project a cached record into Prometheus' `data` map: one length-1 array per
@@ -416,7 +450,11 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::OK);
         let data = json["data"].as_object().expect("data object");
-        assert_eq!(data.len(), 3);
+        // 3 seeded families plus the 2 reserved log metrics (ADR-1103),
+        // always present alongside whatever the cache holds.
+        assert_eq!(data.len(), 5);
+        assert!(data.contains_key("ravel_log_lines"));
+        assert!(data.contains_key("ravel_log_bytes"));
         assert_eq!(json["data"]["bbb_bytes"][0]["type"], "gauge");
         assert_eq!(json["data"]["bbb_bytes"][0]["unit"], "bytes");
         assert_eq!(json["data"]["ccc_seconds"][0]["help"], "c help");

--- a/crates/ravel-query/src/http/handlers.rs
+++ b/crates/ravel-query/src/http/handlers.rs
@@ -10,7 +10,7 @@ use axum::{Json, body::Body};
 use ravel_maintain::{QueryStatus, query_audit_event};
 use ravel_promql::LabelMatcher;
 use ravel_types::accounting::{CostEstimate, QueryAccountingSnapshot, QueryWorkloadClass};
-use ravel_types::{LabelSet, SeriesId, TenantHash, TimeRange};
+use ravel_types::{LabelSet, METRIC_NAME_LABEL, SeriesId, TenantHash, TimeRange};
 
 use crate::Coverage;
 use crate::engine::parse_match_selector;
@@ -23,6 +23,7 @@ use crate::http::params::{
     Params, decode_commit_tokens, parse_allow_partial, parse_deadline, parse_timestamp_ms,
 };
 use crate::http::{AppState, ONE_HOUR_NS};
+use crate::log_series;
 
 /// Caps the size of a request body read into memory. There is no
 /// Prometheus-mandated limit; this is a defensive bound for a JSON-free,
@@ -444,7 +445,32 @@ async fn handle_label_values(
             values.insert(v.to_string());
         }
     }
+    // ADR-1103: the two reserved log metric names never appear in any
+    // stored postings, so they only surface here explicitly. A request
+    // whose match[] selectors name metrics only asks about the metrics
+    // signal specifically and gets metrics names only.
+    if name == METRIC_NAME_LABEL && include_log_metric_names(&params)? {
+        values.insert(log_series::LOG_LINES_METRIC.to_string());
+        values.insert(log_series::LOG_BYTES_METRIC.to_string());
+    }
     Ok((values.into_iter().collect(), partial, warnings))
+}
+
+/// Whether `label/__name__/values` should include the two reserved log
+/// metric names (ADR-1103): true when the request carries no `match[]` at
+/// all, or when at least one `match[]` selector is a log selector.
+fn include_log_metric_names(params: &Params) -> Result<bool, ApiError> {
+    let selectors = params.all("match[]");
+    if selectors.is_empty() {
+        return Ok(true);
+    }
+    for selector in selectors {
+        let matchers = parse_match_selector(selector)?;
+        if log_series::log_metric_of(&matchers).is_some() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 pub async fn series(State(state): State<AppState>, req: Request<Body>) -> Response {

--- a/crates/ravel-query/src/log_series.rs
+++ b/crates/ravel-query/src/log_series.rs
@@ -39,7 +39,7 @@ use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL, Sample, TenantHash, TimeRa
 
 use crate::erasure::ErasurePredicate;
 use crate::phase_accounting::PhaseAccounting;
-use crate::{ByteLimit, LogFetchError, LogQuery, LogSegmentFetcher};
+use crate::{ByteLimit, LogFetchError, LogQuery, LogSegmentFetcher, RequestLimit};
 
 /// Reserved metric name for the log-lines series (ADR-1103 decision 1): one
 /// sample per matching log record, value `1.0`.
@@ -290,6 +290,9 @@ pub struct LogSeriesRequest<'a> {
     /// change to the read path itself (checking before or during a segment's
     /// fetch, not only after), which nothing here implements.
     pub max_bytes_scanned: ByteLimit,
+    /// Checked once per fetched segment, alongside `max_bytes_scanned`
+    /// (same per-segment-granularity caveat).
+    pub max_s3_requests: RequestLimit,
     pub deadline: Option<Instant>,
 }
 
@@ -312,6 +315,8 @@ pub enum LogSeriesError {
     SeriesExceeded { count: usize, max: usize },
     #[error("query scanned {scanned} bytes, exceeding the budget of {max}")]
     BytesScannedExceeded { scanned: u64, max: u64 },
+    #[error("query issued {requests} S3 requests, exceeding the budget of {max}")]
+    RequestsExceeded { requests: u64, max: u64 },
     #[error("query exceeded its deadline")]
     DeadlineExceeded,
     #[error(transparent)]
@@ -398,6 +403,15 @@ fn bytes_scanned_exceeded(scanned: u64, max: ByteLimit) -> Option<LogSeriesError
     match max {
         ByteLimit::Bounded(max) if scanned > max => {
             Some(LogSeriesError::BytesScannedExceeded { scanned, max })
+        }
+        _ => None,
+    }
+}
+
+fn requests_exceeded(requests: u64, max: RequestLimit) -> Option<LogSeriesError> {
+    match max {
+        RequestLimit::Bounded(max) if requests > max => {
+            Some(LogSeriesError::RequestsExceeded { requests, max })
         }
         _ => None,
     }
@@ -592,12 +606,18 @@ pub async fn fetch_log_series(
         if let Some(err) = bytes_scanned_exceeded(scanned, req.max_bytes_scanned) {
             return Err(err);
         }
+        let requests = accounting.snapshot().pooled().total_s3_requests();
+        if let Some(err) = requests_exceeded(requests, req.max_s3_requests) {
+            return Err(err);
+        }
     }
 
     let mut out: Vec<(Vec<u8>, LabelSet, Vec<Sample>)> = series
         .into_iter()
         .map(|(key, (labels, mut samples))| {
-            samples.sort_by_key(|s| s.ts_ns);
+            // ADR-1103 decision 1: samples sharing a timestamp within a
+            // series order by value bits ascending, not input order.
+            samples.sort_by_key(|s| (s.ts_ns, s.value.to_bits()));
             (key, labels, samples)
         })
         .collect();

--- a/crates/ravel-query/tests/log_series.rs
+++ b/crates/ravel-query/tests/log_series.rs
@@ -582,7 +582,7 @@ async fn log_series_request_budget_trips_exactly() {
     let mem = Arc::new(MemoryStore::new());
     let (ref_a, _ref_b) = two_objects(&mem).await;
     let counting = Arc::new(CountingStore::new(mem));
-    let fetcher = LogSegmentFetcher::new(counting as Arc<dyn ObjectStoreBackend>)
+    let fetcher = LogSegmentFetcher::new(counting.clone() as Arc<dyn ObjectStoreBackend>)
         .with_block_range_threshold(0)
         .with_suffix_len(300);
 
@@ -610,6 +610,11 @@ async fn log_series_request_budget_trips_exactly() {
         }
         other => panic!("expected RequestsExceeded, got {other:?}"),
     }
+    assert_eq!(
+        counting.get_count(),
+        8,
+        "accounted request count must equal the store's real GET count"
+    );
 }
 
 /// A deadline already in the past is caught before the first segment's Plan

--- a/crates/ravel-query/tests/log_series.rs
+++ b/crates/ravel-query/tests/log_series.rs
@@ -30,7 +30,7 @@ use ravel_query::log_series::{
     BODY_MATCHER_LABEL, LOG_BYTES_METRIC, LOG_LINES_METRIC, LogMetric, LogSeriesError,
     LogSeriesRequest, SEVERITY_LABEL, fetch_log_series,
 };
-use ravel_query::{ByteLimit, LogSegmentFetcher, PhaseAccounting, QueryPhase};
+use ravel_query::{ByteLimit, LogSegmentFetcher, PhaseAccounting, QueryPhase, RequestLimit};
 use ravel_types::accounting::AccountedOp;
 use ravel_types::{METRIC_NAME_LABEL, TenantHash, TimeRange};
 use uuid::Uuid;
@@ -333,6 +333,7 @@ fn lines_request<'a>(matchers: &'a [LabelMatcher], window: TimeRange) -> LogSeri
         max_samples: 1_000,
         max_series: 1_000,
         max_bytes_scanned: ByteLimit::Unlimited,
+        max_s3_requests: RequestLimit::Unlimited,
         deadline: None,
     }
 }
@@ -568,6 +569,46 @@ async fn log_series_samples_budget_trips_exactly() {
             assert_eq!(max, 5);
         }
         other => panic!("expected SamplesExceeded, got {other:?}"),
+    }
+}
+
+/// `max_s3_requests` trips at the exact request count `log_series_fetch_counts_lines_and_bytes_exactly`
+/// pins for this same fixture and window (2 Plan GETs + 6 Scan GETs = 8 for
+/// object A's one segment): `Bounded(7)` is one under that total, so the
+/// check after the segment completes must fail with the exact count, never
+/// silently truncate or round down to the budget.
+#[tokio::test]
+async fn log_series_request_budget_trips_exactly() {
+    let mem = Arc::new(MemoryStore::new());
+    let (ref_a, _ref_b) = two_objects(&mem).await;
+    let counting = Arc::new(CountingStore::new(mem));
+    let fetcher = LogSegmentFetcher::new(counting as Arc<dyn ObjectStoreBackend>)
+        .with_block_range_threshold(0)
+        .with_suffix_len(300);
+
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_LINES_METRIC),
+        LabelMatcher::equal("job", "pay/api"),
+    ];
+    let window = TimeRange {
+        start_ns: 90,
+        end_ns: 120,
+    };
+    let req = LogSeriesRequest {
+        max_s3_requests: RequestLimit::Bounded(7),
+        ..lines_request(&matchers, window)
+    };
+    let accounting = PhaseAccounting::new();
+
+    let err = fetch_log_series(&fetcher, TENANT, &[ref_a], &req, &accounting)
+        .await
+        .expect_err("8 requests exceed max_s3_requests=7");
+    match err {
+        LogSeriesError::RequestsExceeded { requests, max } => {
+            assert_eq!(requests, 8);
+            assert_eq!(max, 7);
+        }
+        other => panic!("expected RequestsExceeded, got {other:?}"),
     }
 }
 
@@ -1274,12 +1315,12 @@ async fn log_series_body_matcher_review_probe_ok_ok_boom_request_timeout() {
 /// `RlogWriter::finish` sorts every object's own rows by `(stream_ref, ts)`
 /// (crates/ravel-logseg/src/writer.rs), so within one object the scan already
 /// comes back ts-ascending regardless of push order: a single-object fixture
-/// cannot exercise `fetch_log_series`'s own
-/// `samples.sort_by_key(|s| s.ts_ns)`. Two objects for the same stream can:
-/// each object is internally sorted, but the segment loop pushes object A's
-/// records before object B's, so the per-series `Vec<Sample>` accumulates
-/// [50, 60] then [10, 20] before the final sort reorders it. Flip
-/// `samples.sort_by_key(|s| s.ts_ns)` to a no-op and this test fails: the
+/// cannot exercise `fetch_log_series`'s own final
+/// `samples.sort_by_key(|s| (s.ts_ns, s.value.to_bits()))`. Two objects for
+/// the same stream can: each object is internally sorted, but the segment
+/// loop pushes object A's records before object B's, so the per-series
+/// `Vec<Sample>` accumulates [50, 60] then [10, 20] before the final sort
+/// reorders it. Flip the sort key to a no-op and this test fails: the
 /// samples come back in segment-scan order, [50, 60, 10, 20].
 #[tokio::test]
 async fn log_series_samples_come_back_ts_sorted_across_segments() {
@@ -1317,5 +1358,96 @@ async fn log_series_samples_come_back_ts_sorted_across_segments() {
         tss,
         vec![10, 20, 50, 60],
         "ascending, even though segment A (later timestamps) is scanned before segment B"
+    );
+}
+
+/// ADR-1103 decision 1: samples sharing a timestamp within a series order by
+/// value bits ascending, never by scan/insertion order. Two `ravel_log_bytes`
+/// records at the identical timestamp with different body lengths (so
+/// different values), written in both orders, must come back in the same
+/// ascending-by-value sequence [1.0, 5.0] regardless of which order they were
+/// written and scanned in. Flip the final sort key from
+/// `(s.ts_ns, s.value.to_bits())` back to bare `s.ts_ns` and the
+/// long-then-short fixture returns [5.0, 1.0] instead, failing this test
+/// (`sort_by_key` is stable, so a tie keeps push/scan order).
+#[tokio::test]
+async fn log_series_equal_timestamp_samples_order_by_value_bits() {
+    let matchers = [
+        LabelMatcher::equal(METRIC_NAME_LABEL, LOG_BYTES_METRIC),
+        LabelMatcher::equal("job", "tiecheck"),
+    ];
+    let window = TimeRange {
+        start_ns: 0,
+        end_ns: 100,
+    };
+
+    let short_then_long = vec![
+        resource_record(
+            &[("service.name", AttrValue::Str("tiecheck".to_string()))],
+            50,
+            "INFO",
+            "a",
+            &[],
+        ),
+        resource_record(
+            &[("service.name", AttrValue::Str("tiecheck".to_string()))],
+            50,
+            "INFO",
+            "bbbbb",
+            &[],
+        ),
+    ];
+    let mem_a = Arc::new(MemoryStore::new());
+    let ref_a = write_object(&mem_a, "logs/tie-a.rlog", &short_then_long).await;
+    let fetcher_a = LogSegmentFetcher::new(mem_a as Arc<dyn ObjectStoreBackend>);
+    let req_a = LogSeriesRequest {
+        metric: LogMetric::Bytes,
+        ..lines_request(&matchers, window)
+    };
+    let accounting_a = PhaseAccounting::new();
+    let out_a = fetch_log_series(&fetcher_a, TENANT, &[ref_a], &req_a, &accounting_a)
+        .await
+        .expect("fetch_log_series");
+    assert_eq!(out_a.series.len(), 1);
+    let values_a: Vec<f64> = out_a.series[0].samples.iter().map(|s| s.value).collect();
+    assert_eq!(
+        values_a,
+        vec![1.0, 5.0],
+        "short body (1 byte) sorts before long body (5 bytes) at the shared timestamp"
+    );
+
+    let long_then_short = vec![
+        resource_record(
+            &[("service.name", AttrValue::Str("tiecheck".to_string()))],
+            50,
+            "INFO",
+            "bbbbb",
+            &[],
+        ),
+        resource_record(
+            &[("service.name", AttrValue::Str("tiecheck".to_string()))],
+            50,
+            "INFO",
+            "a",
+            &[],
+        ),
+    ];
+    let mem_b = Arc::new(MemoryStore::new());
+    let ref_b = write_object(&mem_b, "logs/tie-b.rlog", &long_then_short).await;
+    let fetcher_b = LogSegmentFetcher::new(mem_b as Arc<dyn ObjectStoreBackend>);
+    let req_b = LogSeriesRequest {
+        metric: LogMetric::Bytes,
+        ..lines_request(&matchers, window)
+    };
+    let accounting_b = PhaseAccounting::new();
+    let out_b = fetch_log_series(&fetcher_b, TENANT, &[ref_b], &req_b, &accounting_b)
+        .await
+        .expect("fetch_log_series");
+    assert_eq!(out_b.series.len(), 1);
+    let values_b: Vec<f64> = out_b.series[0].samples.iter().map(|s| s.value).collect();
+    assert_eq!(
+        values_b,
+        vec![1.0, 5.0],
+        "same ascending order even though the write/scan order was reversed"
     );
 }

--- a/crates/ravel-query/tests/log_series_engine.rs
+++ b/crates/ravel-query/tests/log_series_engine.rs
@@ -1,0 +1,1115 @@
+//! Acceptance tests proving the log-derived series source (issue #1106,
+//! `ravel_query::log_series`) is fully wired into the query engine and the
+//! Prometheus-compatible HTTP handlers (issue #1108, ADR-1103 task T3): a
+//! PromQL query naming `ravel_log_lines`/`ravel_log_bytes` is answered end to
+//! end from real RLOG objects published as real `Signal::Logs` commit
+//! records, through the same `Catalog`/`QueryEngine`/HTTP-router stack
+//! `tests/e2e.rs` and `tests/erasure_e2e.rs` already drive for metrics.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::too_many_arguments)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use ravel_catalog::{Catalog, CatalogConfig};
+use ravel_commit::publish::RetryPolicy;
+use ravel_commit::record::NewCommitRecord;
+use ravel_commit::{erasure, keys, publish, record, signal};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_promql::{InstantSample, LabelMatcher, Value};
+use ravel_proto::commit::v1::{ErasurePredicateMatcher, ErasureRequest};
+use ravel_query::distrib::client::{DistribError, SliceFetcher, SliceResponse};
+use ravel_query::distrib::{Federation, RemoteCluster};
+use ravel_query::http::{AppState, StaticBearerTokenResolver, router};
+use ravel_query::{EngineConfig, QueryEngine, QueryError, RequestLimit};
+use ravel_types::{Signal, TenantHash, TenantId, TimeRange};
+use serde_json::Value as JsonValue;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const NS: i64 = 1_000_000_000;
+const NS_PER_HOUR: i64 = 3_600 * NS;
+/// A fixed base far enough past the epoch that every test's fixture windows
+/// (a few tens of seconds around it) sit comfortably inside `i64` ranges on
+/// both the ts and ms axes, and past enough that `min_event_ts_ns`-based
+/// sealing/pruning logic never mistakes it for "now".
+const BASE: i64 = 1_700_000_000 * NS;
+/// `now_ns` handed to every engine call: far enough past every fixture
+/// timestamp that no staleness/lookback rule in the evaluator excludes a
+/// sample, without depending on the wall clock (forbidden in workflow
+/// scripts, and unnecessary here: the fixture is self-contained).
+const NOW_NS: i64 = BASE + 3_600 * NS;
+const DEADLINE: Duration = Duration::from_secs(5);
+
+fn tenant(name: &str) -> TenantId {
+    TenantId::new(name.to_string())
+}
+
+fn ms(ts_ns: i64) -> i64 {
+    ts_ns / 1_000_000
+}
+
+/// The HTTP API's `time`/`start`/`end` params are Prometheus-style unix
+/// seconds (`parse_timestamp_ms` treats a bare number as seconds and
+/// converts to milliseconds internally), unlike the engine's direct
+/// `instant`/`range` methods, which take milliseconds directly.
+fn secs(ts_ns: i64) -> i64 {
+    ts_ns / 1_000_000_000
+}
+
+fn identity(tenant_hash: TenantHash, seq: u64) -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: tenant_hash.0,
+        shard: 0,
+        writer_id: [3u8; 16],
+        writer_epoch: 1,
+        writer_seq: seq,
+    }
+}
+
+/// A log record on the stream identified by `resource`, with the given
+/// severity, body, and record-level attributes (used by the erasure test to
+/// carry a `user.id` attribute matching a pending erasure predicate).
+fn record(
+    resource: &[(&str, AttrValue)],
+    ts: i64,
+    severity: &str,
+    body: &str,
+    record_attrs: &[(&str, &str)],
+) -> LogRecord {
+    let resource: Vec<(String, AttrValue)> = resource
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect();
+    let attrs: Vec<(String, AttrValue)> = record_attrs
+        .iter()
+        .map(|(k, v)| (k.to_string(), AttrValue::Str(v.to_string())))
+        .collect();
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: severity.into(),
+        body: body.into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs,
+    }
+}
+
+/// Writes one real RLOG object (via `RlogWriter`) and publishes a real
+/// `Signal::Logs` commit record for it onto `store`, computing every commit
+/// field by hand from `records` exactly as an ingest sink would (mirrors
+/// `services/ravel-cli/tests/catalog_signal.rs`'s `publish_rlog`,
+/// generalized to a caller-supplied record set spanning multiple streams).
+async fn publish_log_segment(
+    store: &MemoryStore,
+    tenant_hash: TenantHash,
+    seq: u64,
+    records: &[LogRecord],
+) {
+    let mut writer = RlogWriter::new(RlogConfig::default(), identity(tenant_hash, seq));
+    for r in records {
+        writer.push(r.clone()).expect("push log record");
+    }
+    let object = bytes::Bytes::from(writer.finish().expect("finish rlog"));
+    let content_hash = *blake3::hash(&object).as_bytes();
+
+    let min_ts = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max_ts = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    let min_observed = records
+        .iter()
+        .map(|r| r.observed_ts_ns)
+        .min()
+        .expect("nonempty");
+    let max_observed = records
+        .iter()
+        .map(|r| r.observed_ts_ns)
+        .max()
+        .expect("nonempty");
+    let series_count = records
+        .iter()
+        .map(|r| r.stream_id)
+        .collect::<std::collections::HashSet<_>>()
+        .len() as u64;
+
+    let commit = record::build(NewCommitRecord {
+        tenant_hash,
+        signal: Signal::Logs,
+        shard: 0,
+        writer_id: Uuid::from_bytes([3u8; 16]),
+        writer_epoch: 1,
+        writer_seq: seq,
+        object_size: object.len() as u64,
+        content_hash,
+        sample_count: records.len() as u64,
+        series_count,
+        min_event_ts_ns: min_ts,
+        max_event_ts_ns: max_ts,
+        min_ingest_ts_ns: min_observed,
+        max_ingest_ts_ns: max_observed,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        created_unix_ns: max_observed,
+        ingest_hour_bucket: u32::try_from(max_observed / NS_PER_HOUR).expect("fits u32"),
+    })
+    .expect("valid logs commit record");
+    let data_key = keys::reconstruct_data_key(&commit).expect("data key");
+    publish::put_data_object(store, &data_key, object)
+        .await
+        .expect("put rlog data object");
+    publish::publish(store, &commit, &RetryPolicy::default())
+        .await
+        .expect("publish logs commit record");
+}
+
+/// The two-stream, two-object fixture every test in this file builds on.
+///
+/// Object 1 (`fixture-a`): stream `s1` (`service.name=api`) with 5 ERROR
+/// records at ts `BASE+0..=BASE+3*NS` (`BASE+2*NS` shared by two records) and
+/// 3 INFO records at `BASE+4*NS..=BASE+6*NS`; the first two ERROR records
+/// carry `user.id=u1` (for the pending-erasure test) and bodies "abc"/"de"
+/// (regex fixture bodies, 3 and 2 bytes); the rest are 1-byte bodies "x".
+/// Object 2 (`fixture-b`): stream `s2` (`service.name=worker`) with 4 ERROR
+/// records at `BASE+7*NS..=BASE+10*NS`, each a 1-byte body "y".
+///
+/// `s1`/ERROR byte total: 3 + 2 + 1 + 1 + 1 = 8. `s1`/INFO byte total: 3.
+/// `s2`/ERROR byte total: 4. `job="api"` total lines: 8. `job="worker"` total
+/// lines: 4.
+async fn fixture(store: &MemoryStore, tenant_hash: TenantHash) {
+    let s1 = [("service.name", AttrValue::Str("api".to_string()))];
+    let s2 = [("service.name", AttrValue::Str("worker".to_string()))];
+
+    let a = vec![
+        record(&s1, BASE, "ERROR", "abc", &[("user.id", "u1")]),
+        record(&s1, BASE + NS, "ERROR", "de", &[("user.id", "u1")]),
+        record(&s1, BASE + 2 * NS, "ERROR", "x", &[]),
+        record(&s1, BASE + 2 * NS, "ERROR", "x", &[]),
+        record(&s1, BASE + 3 * NS, "ERROR", "x", &[]),
+        record(&s1, BASE + 4 * NS, "INFO", "x", &[]),
+        record(&s1, BASE + 5 * NS, "INFO", "x", &[]),
+        record(&s1, BASE + 6 * NS, "INFO", "x", &[]),
+    ];
+    let b = vec![
+        record(&s2, BASE + 7 * NS, "ERROR", "y", &[]),
+        record(&s2, BASE + 8 * NS, "ERROR", "y", &[]),
+        record(&s2, BASE + 9 * NS, "ERROR", "y", &[]),
+        record(&s2, BASE + 10 * NS, "ERROR", "y", &[]),
+    ];
+    publish_log_segment(store, tenant_hash, 0, &a).await;
+    publish_log_segment(store, tenant_hash, 1, &b).await;
+}
+
+/// Publishes one RSEG segment carrying `target_rps{job="api"}` = `value` at
+/// `ts`, for the log/metrics binop test. Mirrors `tests/e2e.rs`'s
+/// `publish_segment`/`series_input`.
+async fn publish_metric(
+    store: &MemoryStore,
+    tenant_id: &TenantId,
+    tenant_hash: TenantHash,
+    ts: i64,
+    value: f64,
+) {
+    use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
+    use ravel_types::{Label, LabelSet, Sample, SeriesId};
+
+    let labels = LabelSet::new(vec![
+        Label {
+            name: "__name__".to_string(),
+            value: "target_rps".to_string(),
+        },
+        Label {
+            name: "job".to_string(),
+            value: "api".to_string(),
+        },
+    ])
+    .expect("valid labels");
+    let series_id = SeriesId::compute(tenant_id, "target_rps", &labels).expect("series id");
+    let input = SeriesInput {
+        series_id,
+        labels,
+        samples: vec![Sample { ts_ns: ts, value }],
+    };
+    let seg_identity = SegmentIdentity {
+        tenant_hash: tenant_hash.0,
+        shard: 0,
+        writer_id: Uuid::from_bytes([4u8; 16]).to_string(),
+        writer_epoch: 1,
+        writer_seq: 0,
+    };
+    let written = SegmentWriter::write(
+        vec![input],
+        seg_identity,
+        IngestBounds {
+            min_ingest_ts_ns: 0,
+            max_ingest_ts_ns: 0,
+        },
+    )
+    .expect("write segment");
+    let rec = record::build(NewCommitRecord {
+        tenant_hash,
+        signal: Signal::Metrics,
+        shard: 0,
+        writer_id: Uuid::from_bytes([4u8; 16]),
+        writer_epoch: 1,
+        writer_seq: 0,
+        object_size: written.bytes.len() as u64,
+        content_hash: written.summary.blake3,
+        sample_count: written.summary.sample_count,
+        series_count: written.summary.series_count,
+        min_event_ts_ns: written.summary.min_event_ts_ns,
+        max_event_ts_ns: written.summary.max_event_ts_ns,
+        min_ingest_ts_ns: written.summary.min_event_ts_ns,
+        max_ingest_ts_ns: written.summary.max_event_ts_ns,
+        segment_format_version: 1,
+        created_unix_ns: ts,
+        ingest_hour_bucket: u32::try_from(ts / NS_PER_HOUR).expect("fits u32"),
+    })
+    .expect("valid commit record");
+    let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+    publish::put_data_object(store, &data_key, written.bytes)
+        .await
+        .expect("put data object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish");
+}
+
+fn build_engine(store: Arc<MemoryStore>, config: EngineConfig) -> (QueryEngine, TenantId) {
+    let tid = tenant("tenant-a");
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let catalog =
+        Arc::new(Catalog::new(backend.clone(), CatalogConfig::default()).expect("catalog"));
+    (QueryEngine::new(catalog, backend, config), tid)
+}
+
+fn build_router(store: Arc<MemoryStore>, config: EngineConfig, tenant_id: &TenantId) -> Router {
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let catalog =
+        Arc::new(Catalog::new(backend.clone(), CatalogConfig::default()).expect("catalog"));
+    let engine = Arc::new(QueryEngine::new(catalog, backend, config));
+    let mut tokens = HashMap::new();
+    tokens.insert("secret-a".to_string(), tenant_id.clone());
+    let state = AppState::new(engine, Arc::new(StaticBearerTokenResolver::new(tokens)));
+    router(state)
+}
+
+fn encode_query_param(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+async fn call(app: &Router, uri: &str, auth: Option<&str>) -> (StatusCode, JsonValue) {
+    let mut builder = Request::builder().method("GET").uri(uri);
+    if let Some(token) = auth {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    let request = builder.body(Body::empty()).expect("build request");
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("oneshot is infallible");
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let json: JsonValue = serde_json::from_slice(&body).expect("parse response json");
+    (status, json)
+}
+
+fn vector_results(body: &JsonValue) -> &Vec<JsonValue> {
+    body["data"]["result"]
+        .as_array()
+        .expect("vector result array")
+}
+
+fn label<'a>(sample: &'a InstantSample, name: &str) -> Option<&'a str> {
+    sample.labels.get(name)
+}
+
+async fn put_dreq(
+    store: &MemoryStore,
+    tenant_hash: TenantHash,
+    matchers: &[(&str, &str)],
+    window_start_ns: i64,
+    window_end_ns: i64,
+) {
+    let request_id = Uuid::new_v4();
+    let request = ErasureRequest {
+        format_version: 1,
+        tenant_hash: tenant_hash.0.to_vec(),
+        signal: signal::to_proto(Signal::Logs) as i32,
+        request_id: request_id.to_string(),
+        created_unix_ns: 1,
+        predicate: matchers
+            .iter()
+            .map(|(k, v)| ErasurePredicateMatcher {
+                key: (*k).to_string(),
+                value: (*v).to_string(),
+            })
+            .collect(),
+        window_start_ns,
+        window_end_ns,
+        reason: String::new(),
+    };
+    let key = keys::erasure_request_key(&tenant_hash, Signal::Logs, request_id).expect("dreq key");
+    store
+        .put(
+            &key,
+            erasure::encode_request(&request),
+            PutOptions::create_if_absent(),
+        )
+        .await
+        .expect("put dreq");
+}
+
+// ---------------------------------------------------------------------------
+// Core value contract: lines, bytes, range, regex.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn log_lines_aggregated_by_job_matches_the_fixture_totals() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+
+    let (value, _coverage) = engine
+        .instant(
+            th,
+            "sum by (job) (count_over_time(ravel_log_lines[1h]))",
+            ms(BASE + 20 * NS),
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+    let Value::Vector(vector) = value else {
+        panic!("expected vector");
+    };
+    let mut totals: Vec<(String, f64)> = vector
+        .iter()
+        .map(|s| (label(s, "job").expect("job label").to_string(), s.value))
+        .collect();
+    totals.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(
+        totals,
+        vec![("api".to_string(), 8.0), ("worker".to_string(), 4.0)]
+    );
+}
+
+#[tokio::test]
+async fn log_bytes_summed_across_severities_matches_the_fixture_total() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+
+    // `job="api"` splits into two series by `severity_text` (ERROR: 5
+    // records, bytes 3+2+1+1+1=8; INFO: 3 records, bytes 1+1+1=3), so the
+    // outer `sum` is required to see the combined 11-byte total across both.
+    let (value, _coverage) = engine
+        .instant(
+            th,
+            r#"sum(sum_over_time(ravel_log_bytes{job="api"}[1h]))"#,
+            ms(BASE + 20 * NS),
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+    let Value::Vector(vector) = value else {
+        panic!("expected vector");
+    };
+    assert_eq!(vector.len(), 1);
+    assert!(
+        (vector[0].value - 11.0).abs() < 1e-9,
+        "expected 11 bytes total, got {}",
+        vector[0].value
+    );
+}
+
+#[tokio::test]
+async fn body_regex_matcher_selects_only_matching_lines() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+
+    // Only "abc" and "de" (the two `user.id=u1` records) match `^[a-e]+$`;
+    // the other three ERROR bodies are all "x".
+    let (value, _coverage) = engine
+        .instant(
+            th,
+            r#"count_over_time(ravel_log_lines{job="api",severity_text="ERROR",__body__=~"^[a-e]+$"}[1h])"#,
+            ms(BASE + 20 * NS),
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+    let Value::Vector(vector) = value else {
+        panic!("expected vector");
+    };
+    assert_eq!(vector.len(), 1);
+    assert!((vector[0].value - 2.0).abs() < 1e-9);
+}
+
+#[tokio::test]
+async fn range_query_straddling_a_shared_timestamp_counts_both_records_at_it() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+
+    // `s1`/ERROR carries records at BASE+0,1,2,2,3 (ts=BASE+2*NS shared by
+    // two distinct records). A `[4s]` window straddling that shared
+    // timestamp must count both copies, not collapse them to one: at
+    // t=BASE+2s the window (t-4s, t] holds ts 0,1,2,2 (4 samples); at
+    // t=BASE+3s it holds ts 0,1,2,2,3 (5 samples) -- the shared timestamp's
+    // second copy is counted at both steps, proving it was never
+    // deduplicated away.
+    let (value, _coverage) = engine
+        .range(
+            th,
+            r#"count_over_time(ravel_log_lines{job="api",severity_text="ERROR"}[4s])"#,
+            ms(BASE + 2 * NS),
+            ms(BASE + 3 * NS),
+            1_000,
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+    let Value::Matrix(matrix) = value else {
+        panic!("expected matrix");
+    };
+    assert_eq!(matrix.len(), 1);
+    let samples = &matrix[0].1;
+    let values: Vec<f64> = samples.iter().map(|s| s.value).collect();
+    assert_eq!(values, vec![4.0, 5.0]);
+}
+
+// ---------------------------------------------------------------------------
+// Binop between a log series and a published metrics series.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn binop_between_aggregated_log_series_and_a_metrics_series() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    publish_metric(&store, &tid, th, BASE + 2 * NS, 3.0).await;
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+
+    let (value, _coverage) = engine
+        .instant(
+            th,
+            r#"sum by (job) (count_over_time(ravel_log_lines{job="api"}[1h])) - target_rps{job="api"}"#,
+            ms(BASE + 20 * NS),
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+    let Value::Vector(vector) = value else {
+        panic!("expected vector");
+    };
+    assert_eq!(vector.len(), 1);
+    assert!(
+        (vector[0].value - 5.0).abs() < 1e-9,
+        "8 log lines - 3 rps = 5"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Nameless selectors and ordinary metric queries never touch Signal::Logs.
+// ---------------------------------------------------------------------------
+
+/// Wraps `inner` so every `get`/`list`/`list_delimited`/`head` touching a
+/// `Signal::Logs` catalog or data key panics -- a hard, provable "never
+/// called" rather than a counter a test could forget to assert on.
+struct PanicsOnLogsTouch {
+    inner: Arc<MemoryStore>,
+}
+
+fn touches_logs(key: &str) -> bool {
+    key.contains(&format!("/{}/", Signal::Logs.key_prefix())) || key.contains(".rlog")
+}
+
+#[async_trait]
+impl ObjectStoreBackend for PanicsOnLogsTouch {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<ravel_object_store::PutOutcome, ravel_object_store::StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: ravel_object_store::GetRange,
+    ) -> Result<ravel_object_store::GetOutcome, ravel_object_store::StoreError> {
+        assert!(!touches_logs(key), "unexpected GET of a logs key: {key}");
+        self.inner.get(key, range).await
+    }
+
+    async fn head(
+        &self,
+        key: &str,
+    ) -> Result<ravel_object_store::ObjectMeta, ravel_object_store::StoreError> {
+        assert!(!touches_logs(key), "unexpected HEAD of a logs key: {key}");
+        self.inner.head(key).await
+    }
+
+    async fn list(
+        &self,
+        prefix: &str,
+        page: Option<ravel_object_store::PageToken>,
+    ) -> Result<ravel_object_store::ListPage, ravel_object_store::StoreError> {
+        assert!(
+            !touches_logs(prefix),
+            "unexpected LIST of a logs prefix: {prefix}"
+        );
+        self.inner.list(prefix, page).await
+    }
+
+    async fn list_delimited(
+        &self,
+        prefix: &str,
+    ) -> Result<ravel_object_store::DelimitedList, ravel_object_store::StoreError> {
+        assert!(
+            !touches_logs(prefix),
+            "unexpected delimited LIST of a logs prefix: {prefix}"
+        );
+        self.inner.list_delimited(prefix).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ravel_object_store::StoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn capabilities(&self) -> ravel_object_store::Capabilities {
+        self.inner.capabilities()
+    }
+}
+
+#[tokio::test]
+async fn nameless_selector_returns_only_metrics_series_and_never_touches_logs() {
+    let mem = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&mem, th).await;
+    publish_metric(&mem, &tid, th, BASE + 2 * NS, 3.0).await;
+
+    let guarded: Arc<dyn ObjectStoreBackend> = Arc::new(PanicsOnLogsTouch { inner: mem });
+    let catalog =
+        Arc::new(Catalog::new(guarded.clone(), CatalogConfig::default()).expect("catalog"));
+    let engine = QueryEngine::new(catalog, guarded, EngineConfig::default());
+
+    let (series, _coverage) = engine
+        .resolve_series(
+            th,
+            &[LabelMatcher::equal("job", "api")],
+            TimeRange {
+                start_ns: BASE - NS,
+                end_ns: BASE + 20 * NS,
+            },
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("resolve succeeds");
+    assert_eq!(series.len(), 1, "only the metrics series should match");
+    assert_eq!(series[0].1.get("__name__"), Some("target_rps"));
+}
+
+#[tokio::test]
+async fn ordinary_named_metric_query_never_resolves_signal_logs() {
+    let mem = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&mem, th).await;
+    publish_metric(&mem, &tid, th, BASE + 2 * NS, 3.0).await;
+
+    let guarded: Arc<dyn ObjectStoreBackend> = Arc::new(PanicsOnLogsTouch { inner: mem });
+    let tokens = {
+        let mut m = HashMap::new();
+        m.insert("secret-a".to_string(), tid.clone());
+        m
+    };
+    let catalog =
+        Arc::new(Catalog::new(guarded.clone(), CatalogConfig::default()).expect("catalog"));
+    let engine = Arc::new(QueryEngine::new(catalog, guarded, EngineConfig::default()));
+    let state = AppState::new(engine, Arc::new(StaticBearerTokenResolver::new(tokens)));
+    let app = router(state);
+
+    let uri = format!(
+        "/api/v1/query?query={}&time={}",
+        encode_query_param(r#"target_rps{job="api"}"#),
+        secs(BASE + 20 * NS)
+    );
+    let (status, body) = call(&app, &uri, Some("secret-a")).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(vector_results(&body).len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Budgets: max_samples / max_series -> HTTP 422.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn exceeding_max_samples_budget_for_a_log_selector_returns_422() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let config = EngineConfig {
+        max_samples: 3,
+        ..EngineConfig::default()
+    };
+    let app = build_router(store, config, &tid);
+
+    let uri = format!(
+        "/api/v1/query?query={}&time={}",
+        encode_query_param(r#"ravel_log_lines{job="api"}"#),
+        secs(BASE + 20 * NS)
+    );
+    let (status, body) = call(&app, &uri, Some("secret-a")).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "body: {body}");
+    assert_eq!(body["errorType"], "execution");
+}
+
+#[tokio::test]
+async fn exceeding_max_series_budget_for_a_log_selector_returns_422() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    // `job="api"` splits into 2 series (ERROR, INFO); a cap of 1 must trip.
+    let config = EngineConfig {
+        max_series: 1,
+        ..EngineConfig::default()
+    };
+    let app = build_router(store, config, &tid);
+
+    let uri = format!(
+        "/api/v1/query?query={}&time={}",
+        encode_query_param(r#"ravel_log_lines{job="api"}"#),
+        secs(BASE + 20 * NS)
+    );
+    let (status, body) = call(&app, &uri, Some("secret-a")).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "body: {body}");
+    assert_eq!(body["errorType"], "execution");
+}
+
+// ---------------------------------------------------------------------------
+// Query-wide shared budget across two log selectors (ADR-1103 decision 4
+// step 4): the same `PhaseAccounting` handle is threaded through every log
+// plan's `fetch_log_series` call, so the second selector's segments are
+// checked against the ceiling with the first selector's spend already
+// counted.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn two_log_selectors_share_one_request_budget() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+
+    // One selector alone (one object, one stream) fits comfortably under 3
+    // requests (plan + scan, at most a couple of blocks); two selectors
+    // together each touch a distinct object, so the combined request count
+    // must exceed a budget sized for one.
+    let config = EngineConfig {
+        max_s3_requests: RequestLimit::Bounded(3),
+        ..EngineConfig::default()
+    };
+    let (engine, _tid) = build_engine(store, config);
+
+    // `or` is PromQL's set operator: it unions the two vectors regardless of
+    // label-set compatibility, so this exercises both log selectors without
+    // a vector-matching error masking the budget outcome.
+    let query = r#"count_over_time(ravel_log_lines{job="api"}[1h]) or count_over_time(ravel_log_lines{job="worker"}[1h])"#;
+    let err = engine
+        .instant(th, query, ms(BASE + 20 * NS), &[], NOW_NS, DEADLINE)
+        .await
+        .expect_err("combined budget must be exceeded");
+    assert!(
+        matches!(err, QueryError::RequestBudgetExceeded { .. }),
+        "expected RequestBudgetExceeded, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Federation: log series are never fanned out to a remote cluster, only
+// flagged with a warning. A `SliceFetcher` whose `fetch` panics if called is
+// a hard proof, not a counter a test could forget to assert on.
+// ---------------------------------------------------------------------------
+
+struct PanicsIfFetched;
+
+#[async_trait]
+impl SliceFetcher for PanicsIfFetched {
+    async fn fetch(
+        &self,
+        _request: ravel_proto::queryfrag::v1::FetchRequest,
+    ) -> Result<SliceResponse, DistribError> {
+        panic!("a log-only query must never fan out to a remote cluster");
+    }
+}
+
+#[tokio::test]
+async fn log_only_query_warns_instead_of_federating() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+    let federation = Arc::new(Federation::new(vec![RemoteCluster {
+        name: "remote-1".to_string(),
+        fetcher: Arc::new(PanicsIfFetched),
+        skip_unavailable: false,
+        soft_timeout: Duration::from_secs(1),
+    }]));
+    let engine = engine.with_federation(federation);
+
+    let (_value, stats) = engine
+        .instant_with_stats(
+            th,
+            r#"count_over_time(ravel_log_lines{job="api"}[1h])"#,
+            ms(BASE + 20 * NS),
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds without ever calling the remote fetcher");
+    assert_eq!(
+        stats.warnings,
+        vec![
+            "ravel_log_lines is answered by this cluster only; log series are not federated"
+                .to_string()
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Pending erasure applies to log series through the engine, exactly as it
+// does for metrics (tests/erasure_e2e.rs's pattern, `Signal::Logs` swapped
+// in for `Signal::Metrics`).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pending_erasure_excludes_matching_log_records() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+
+    let (value_before, _c) = {
+        let (engine, _tid) = build_engine(store.clone(), EngineConfig::default());
+        engine
+            .instant(
+                th,
+                r#"count_over_time(ravel_log_lines{job="api",severity_text="ERROR"}[1h])"#,
+                ms(BASE + 20 * NS),
+                &[],
+                NOW_NS,
+                DEADLINE,
+            )
+            .await
+            .expect("query succeeds")
+    };
+    let Value::Vector(before) = value_before else {
+        panic!("expected vector");
+    };
+    assert!(
+        (before[0].value - 5.0).abs() < 1e-9,
+        "5 ERROR records before erasure"
+    );
+
+    // The two `user.id=u1` records (ts BASE, BASE+NS) fall inside this
+    // window and must be excluded from the next resolve.
+    put_dreq(&store, th, &[("user.id", "u1")], BASE - NS, BASE + 20 * NS).await;
+
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+    let (value_after, _c) = engine
+        .instant(
+            th,
+            r#"count_over_time(ravel_log_lines{job="api",severity_text="ERROR"}[1h])"#,
+            ms(BASE + 20 * NS),
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+    let Value::Vector(after) = value_after else {
+        panic!("expected vector");
+    };
+    assert_eq!(after.len(), 1);
+    assert!(
+        (after[0].value - 3.0).abs() < 1e-9,
+        "2 of 5 ERROR records erased, expected 3 remaining, got {}",
+        after[0].value
+    );
+}
+
+// ---------------------------------------------------------------------------
+// /api/v1/series, /api/v1/labels, /api/v1/label/__name__/values,
+// /api/v1/metadata for a log selector.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn series_endpoint_lists_log_series_for_a_log_selector() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let app = build_router(store, EngineConfig::default(), &tid);
+
+    let matcher = encode_query_param(r#"ravel_log_lines{job="api"}"#);
+    let window = format!("start={}&end={}", secs(BASE - NS), secs(NOW_NS));
+    let uri = format!("/api/v1/series?match%5B%5D={matcher}&{window}");
+    let (status, body) = call(&app, &uri, Some("secret-a")).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let results = body["data"].as_array().expect("series result array");
+    assert_eq!(
+        results.len(),
+        2,
+        "job=api splits into ERROR and INFO series"
+    );
+    let mut severities: Vec<&str> = results
+        .iter()
+        .map(|s| s["severity_text"].as_str().expect("severity_text label"))
+        .collect();
+    severities.sort_unstable();
+    assert_eq!(severities, vec!["ERROR", "INFO"]);
+    for s in results {
+        assert_eq!(s["__name__"], "ravel_log_lines");
+        assert_eq!(s["job"], "api");
+    }
+
+    let (status, body) = call(
+        &app,
+        &format!("/api/v1/labels?match%5B%5D={matcher}&{window}"),
+        Some("secret-a"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let mut names: Vec<&str> = body["data"]
+        .as_array()
+        .expect("labels array")
+        .iter()
+        .map(|v| v.as_str().expect("label name string"))
+        .collect();
+    names.sort_unstable();
+    assert_eq!(
+        names,
+        vec![
+            "__name__",
+            "job",
+            "otel_scope_name",
+            "otel_scope_version",
+            "severity_text"
+        ]
+    );
+
+    let (status, body) = call(
+        &app,
+        &format!("/api/v1/label/__name__/values?match%5B%5D={matcher}&{window}"),
+        Some("secret-a"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let mut values: Vec<&str> = body["data"]
+        .as_array()
+        .expect("values array")
+        .iter()
+        .map(|v| v.as_str().expect("value string"))
+        .collect();
+    values.sort_unstable();
+    // ADR-1103: a match[] selector naming a log metric brings in both
+    // reserved names, not only the one the selector matched.
+    assert_eq!(values, vec!["ravel_log_bytes", "ravel_log_lines"]);
+
+    // No match[] at all: `__name__` values must include both reserved log
+    // metric names even though nothing else in the request names them.
+    let (status, body) = call(
+        &app,
+        &format!("/api/v1/label/__name__/values?{window}"),
+        Some("secret-a"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let mut values: Vec<&str> = body["data"]
+        .as_array()
+        .expect("values array")
+        .iter()
+        .map(|v| v.as_str().expect("value string"))
+        .collect();
+    values.sort_unstable();
+    assert!(values.contains(&"ravel_log_lines"));
+    assert!(values.contains(&"ravel_log_bytes"));
+    let _ = &mut values;
+}
+
+#[tokio::test]
+async fn metadata_endpoint_always_includes_the_two_reserved_log_metrics() {
+    use ravel_cache::SystemClock;
+    use ravel_query::http::{MetadataCache, MetadataCacheConfig};
+
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let catalog =
+        Arc::new(Catalog::new(backend.clone(), CatalogConfig::default()).expect("catalog"));
+    let engine = Arc::new(QueryEngine::new(
+        catalog,
+        backend.clone(),
+        EngineConfig::default(),
+    ));
+    let cache = Arc::new(MetadataCache::new(
+        backend,
+        MetadataCacheConfig::default(),
+        Arc::new(SystemClock),
+    ));
+    let mut tokens = HashMap::new();
+    tokens
+        .insert("secret-a".to_string(), th)
+        .into_iter()
+        .for_each(drop);
+    let mut tok = HashMap::new();
+    tok.insert("secret-a".to_string(), tid);
+    let state = AppState::new(engine, Arc::new(StaticBearerTokenResolver::new(tok)))
+        .with_metadata_cache(cache);
+    let app = router(state);
+    let _ = &mut tokens;
+
+    let (status, body) = call(&app, "/api/v1/metadata", Some("secret-a")).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["data"]["ravel_log_lines"][0]["type"], "gauge");
+    assert_eq!(
+        body["data"]["ravel_log_lines"][0]["help"],
+        "One sample per log line, value 1, derived from the logs signal at query time (ADR-1103); count_over_time counts lines."
+    );
+    assert_eq!(body["data"]["ravel_log_lines"][0]["unit"], "");
+    assert_eq!(body["data"]["ravel_log_bytes"][0]["type"], "gauge");
+    assert_eq!(
+        body["data"]["ravel_log_bytes"][0]["help"],
+        "One sample per log line whose value is the line body's length in bytes (ADR-1103); sum_over_time sums bytes."
+    );
+    assert_eq!(body["data"]["ravel_log_bytes"][0]["unit"], "bytes");
+}
+
+// ---------------------------------------------------------------------------
+// Exact per-phase GET counts (pinned against observed behavior, matching
+// tests/log_series.rs's own established convention for this kind of
+// assertion: block layout, suffix length, and threshold config make the
+// number infeasible to hand-derive from first principles).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn phase_accounting_reports_exact_get_counts_for_a_log_query() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+
+    let (_value, stats) = engine
+        .instant_with_stats(
+            th,
+            r#"count_over_time(ravel_log_lines{job="api"}[1h])"#,
+            ms(BASE + 20 * NS),
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+    use ravel_query::QueryPhase;
+    use ravel_types::accounting::AccountedOp;
+    let pooled = stats.phase_accounting.pooled();
+    // Pinned against observed behavior (tests/log_series.rs's own convention:
+    // block layout and catalog round trips are infeasible to hand-derive).
+    // Resolve: the Signal::Logs catalog snapshot resolve, generic per-query
+    // overhead shared with a metrics query, not log-series-specific. Plan:
+    // one footer probe GET plus one STREAM_DIR range GET for object A (the
+    // only object `job="api"` matches; object B is pruned by stream before
+    // any GET). Scan: one BLOCKS range read for object A's 8 records, which
+    // fit a single block at this fixture's size.
+    assert_eq!(
+        stats
+            .phase_accounting
+            .phase(QueryPhase::Resolve)
+            .s3_requests(AccountedOp::Get),
+        3,
+        "catalog snapshot resolve"
+    );
+    assert_eq!(
+        stats
+            .phase_accounting
+            .phase(QueryPhase::Plan)
+            .s3_requests(AccountedOp::Get),
+        2,
+        "one footer probe GET, one STREAM_DIR section GET"
+    );
+    assert_eq!(
+        stats
+            .phase_accounting
+            .phase(QueryPhase::Probe)
+            .s3_requests(AccountedOp::Get),
+        0,
+        "log fetch has no separate segment-catalog probe phase"
+    );
+    assert_eq!(
+        stats
+            .phase_accounting
+            .phase(QueryPhase::Scan)
+            .s3_requests(AccountedOp::Get),
+        1,
+        "one BLOCKS range read for object A's single block"
+    );
+    assert_eq!(
+        pooled.s3_requests(AccountedOp::Get),
+        6,
+        "every GET this query issues is charged to exactly one phase"
+    );
+}

--- a/crates/ravel-query/tests/log_series_engine.rs
+++ b/crates/ravel-query/tests/log_series_engine.rs
@@ -1071,10 +1071,12 @@ async fn phase_accounting_reports_exact_get_counts_for_a_log_query() {
     // block layout and catalog round trips are infeasible to hand-derive).
     // Resolve: the Signal::Logs catalog snapshot resolve, generic per-query
     // overhead shared with a metrics query, not log-series-specific. Plan:
-    // one footer probe GET plus one STREAM_DIR range GET for object A (the
-    // only object `job="api"` matches; object B is pruned by stream before
-    // any GET). Scan: one BLOCKS range read for object A's 8 records, which
-    // fit a single block at this fixture's size.
+    // two GETs, one per candidate object, because stream discovery reads
+    // every candidate's directory before any of them can be excluded:
+    // object A's footer probe and object B's STREAM_DIR read. Only A matches
+    // `job="api"`; B is pruned out of the scan by that read, not before it.
+    // Scan: one BLOCKS range read for object A's 8 records, which fit a
+    // single block at this fixture's size.
     assert_eq!(
         stats
             .phase_accounting

--- a/crates/ravel-query/tests/log_series_engine.rs
+++ b/crates/ravel-query/tests/log_series_engine.rs
@@ -985,7 +985,6 @@ async fn series_endpoint_lists_log_series_for_a_log_selector() {
     values.sort_unstable();
     assert!(values.contains(&"ravel_log_lines"));
     assert!(values.contains(&"ravel_log_bytes"));
-    let _ = &mut values;
 }
 
 #[tokio::test]
@@ -1010,17 +1009,11 @@ async fn metadata_endpoint_always_includes_the_two_reserved_log_metrics() {
         MetadataCacheConfig::default(),
         Arc::new(SystemClock),
     ));
-    let mut tokens = HashMap::new();
-    tokens
-        .insert("secret-a".to_string(), th)
-        .into_iter()
-        .for_each(drop);
     let mut tok = HashMap::new();
     tok.insert("secret-a".to_string(), tid);
     let state = AppState::new(engine, Arc::new(StaticBearerTokenResolver::new(tok)))
         .with_metadata_cache(cache);
     let app = router(state);
-    let _ = &mut tokens;
 
     let (status, body) = call(&app, "/api/v1/metadata", Some("secret-a")).await;
     assert_eq!(status, StatusCode::OK, "body: {body}");

--- a/docs/adrs/0039-prometheus-http-api-compat.md
+++ b/docs/adrs/0039-prometheus-http-api-compat.md
@@ -98,3 +98,15 @@ additive only, no existing route changed:
   degraded, documented in docs/query-engine.md.
 - The native-histogram subquery gap stays open, tracked separately, and
   does not block the "Grafana works day one" acceptance bar.
+
+## Amendment (ADR-1103)
+
+ADR-1103 decision 4 supersedes decision 2's empty-`data` claim for exactly
+two reserved family names, `ravel_log_lines` and `ravel_log_bytes`:
+`/api/v1/metadata` now always includes them for a request whose tenant
+resolves and whose cache is attached, alongside any real captured metadata.
+These are definitions Ravel itself implements (query-time derived series
+over the logs signal), not guessed OTLP descriptors, so the "no inferred
+placeholder metadata" rejection above still holds for every other name.
+An unresolved tenant (no/bad bearer, or no cache attached) still gets the
+empty object.

--- a/docs/adrs/0039-prometheus-http-api-compat.md
+++ b/docs/adrs/0039-prometheus-http-api-compat.md
@@ -103,8 +103,11 @@ additive only, no existing route changed:
 
 ADR-1103 decision 4 supersedes decision 2's empty-`data` claim for exactly
 two reserved family names, `ravel_log_lines` and `ravel_log_bytes`:
-`/api/v1/metadata` now always includes them for a request whose tenant
-resolves and whose cache is attached, alongside any real captured metadata.
+for a request whose tenant resolves and whose cache is attached, the
+*unfiltered* result now always includes them, alongside any real captured
+metadata, before the endpoint's `metric` and `limit` request filters are
+applied; a request that filters them out (e.g. `metric=does_not_exist`, or
+a `limit` too small to reach them) still excludes them from the response.
 These are definitions Ravel itself implements (query-time derived series
 over the logs signal), not guessed OTLP descriptors, so the "no inferred
 placeholder metadata" rejection above still holds for every other name.

--- a/services/ravel-server/tests/metadata_e2e.rs
+++ b/services/ravel-server/tests/metadata_e2e.rs
@@ -354,7 +354,10 @@ async fn otlp_counter_is_suffixed_and_metadata_visible_over_http() {
 }
 
 /// The read side degrades gracefully with no metadata yet: a tenant that has
-/// ingested nothing gets a `200` with an empty `data` object, not an error.
+/// ingested nothing gets a `200` back, and `data` carries only the two
+/// reserved log-derived families (`ravel_log_lines`, `ravel_log_bytes`) that
+/// ADR-1103 decision 4 synthesizes on every resolved-tenant request; no
+/// other, fabricated entry is present.
 #[tokio::test]
 async fn metadata_for_tenant_with_no_ingest_is_empty_not_an_error() {
     let running = start_test_server().await;
@@ -370,11 +373,29 @@ async fn metadata_for_tenant_with_no_ingest_is_empty_not_an_error() {
     assert_eq!(response.status(), 200, "an empty tenant is still a 200");
     let body: serde_json::Value = response.json().await.expect("metadata JSON");
     assert_eq!(body["status"], "success");
+    let data = body["data"].as_object().expect("data is an object");
     assert_eq!(
-        body["data"],
-        serde_json::json!({}),
-        "no metadata ingested yet -> empty data object, no error"
+        data.keys().collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from([
+            &"ravel_log_lines".to_string(),
+            &"ravel_log_bytes".to_string()
+        ]),
+        "no ingest yet -> only the two reserved log families, no fabricated entry: {body}"
     );
+    assert_eq!(data["ravel_log_lines"][0]["type"], "gauge");
+    assert_eq!(
+        data["ravel_log_lines"][0]["help"],
+        "One sample per log line, value 1, derived from the logs signal at \
+         query time (ADR-1103); count_over_time counts lines."
+    );
+    assert_eq!(data["ravel_log_lines"][0]["unit"], "");
+    assert_eq!(data["ravel_log_bytes"][0]["type"], "gauge");
+    assert_eq!(
+        data["ravel_log_bytes"][0]["help"],
+        "One sample per log line whose value is the line body's length in \
+         bytes (ADR-1103); sum_over_time sums bytes."
+    );
+    assert_eq!(data["ravel_log_bytes"][0]["unit"], "bytes");
 
     running.shutdown().await.expect("graceful shutdown");
 }


### PR DESCRIPTION
ADR-1103's log-derived series source landed in #1106 with no caller. This
wires it into the query engine and the Prometheus-compatible HTTP
handlers, so a selector naming ravel_log_lines or ravel_log_bytes is
answered from the logs signal end to end.

prefetch partitions selector plans by reserved metric name. A log plan
resolves a Signal::Logs snapshot through resolve_bounded, which now takes
the signal explicitly, applies the snapshot's pending erasure, and reads
each candidate object's stream directory before a projected scan. Its
samples reach the evaluator through a separate lane on MergedSource that
only a log selector consults, so a nameless selector still sees metrics
alone. Every budget stays the query's single context: samples, series,
segments, bytes scanned and object-store requests are shared across all
selectors, so two log selectors cannot each spend a full allowance. The
series, labels, label-values and metadata endpoints answer log selectors
on the same terms, and a configured federation returns local results with
a warning rather than sending log selectors to a remote.

Two defects surfaced and are fixed here. MergedSource post-filtered log
results against the __body__ pseudo-label, which is never part of a log
series label set, so the absent-label rule silently dropped every result
for a body matcher the scan had already applied correctly. And samples
sharing a timestamp are now ordered by value bits, which ADR-1103
requires so that order-sensitive functions like last_over_time are
deterministic.

Part of epic #1103 (wave 2, task T3).

Fixes: #1108
