### PR TITLE
docs: mark ADR-1101 accepted

### DIFF
--- a/docs/adrs/1101-alerts-and-audit-sql-tables.md
+++ b/docs/adrs/1101-alerts-and-audit-sql-tables.md
@@ -1,6 +1,6 @@
 # ADR-1101: Register the `alerts` and `audit` SQL tables
 
-Status: Proposed
+Status: Accepted (2026-09-03)
 
 ## Context
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -140,6 +140,6 @@ the reservation commit that used to work around it.
 | [0996](0996-request-cost-aware-fetching.md) | request-cost-aware fetching and the S3 request ledger | Proposed |
 | [1029](1029-advisory-compaction-claims.md) | advisory compaction claims over object-store CAS | Proposed |
 | [1040](1040-documentation-architecture.md) | Documentation architecture, canonical vocabulary, and a docs gate | Proposed |
-| [1101](1101-alerts-and-audit-sql-tables.md) | Register the `alerts` and `audit` SQL tables | Proposed |
+| [1101](1101-alerts-and-audit-sql-tables.md) | Register the `alerts` and `audit` SQL tables | Accepted (2026-09-03) |
 | [1103](1103-promql-over-logs.md) | PromQL over logs: `ravel_log_lines` and `ravel_log_bytes` | Accepted |
 | [1113](1113-tla-verification-suite.md) | TLA+ verification suite for the commit, catalog, lifecycle, resharding, and maintenance protocols | Proposed |


### PR DESCRIPTION
Both decisions are implemented and on main: #1186 registered the `alerts` and `audit` tables on both SQL transports, and #1163 added the read-side shard floor. Flip the status and the index row to Accepted.

Refs: #1101