### PR TITLE
test(server): prove PromQL over logs end to end, and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ management service (SSE-KMS), legal hold, and admission limits.
 
 - No downsampled or pre-aggregated rollups. A wide-range metrics query reads
   every raw hour it covers.
-- Logs and traces are queryable over SQL only, as the `logs` and `spans` tables.
-  There is no LogQL, no PromQL surface for logs, no TraceQL, no trace-by-ID
-  endpoint, and no Jaeger or Tempo API.
+- Traces are queryable over SQL only, as the `spans` table. Logs are queryable
+  over SQL, as the `logs` table, and over PromQL, through the reserved
+  `ravel_log_lines` and `ravel_log_bytes` metric names (see
+  [PromQL over logs](docs/guides/query.md#promql-over-logs)). Neither surface
+  gets you LogQL, TraceQL, a trace-by-ID endpoint, or a Jaeger or Tempo API.
 - Profiles are a reserved object-key prefix only. No ingest, no query.
 - Exemplars are stored from the OpenTelemetry Protocol (OTLP) only. Remote Write
   and OTAP decode exemplars and then discard them.
@@ -72,10 +74,13 @@ management service (SSE-KMS), legal hold, and admission limits.
 
 **Who should wait.** If your dashboards range over months of high-cardinality
 metrics, the missing downsampled storage will cost you on every panel. If your
-logs or traces workflow depends on LogQL, TraceQL, or the Jaeger UI, there is
-nothing here to point them at. If you need write acknowledgement in single-digit
-milliseconds, strict mode
-pays an object-store round trip and buffered mode gives up the crash guarantee
+logs workflow depends on LogQL's line-pipeline browsing style, or your traces
+workflow depends on TraceQL or the Jaeger UI, there is nothing here to point
+them at; a Grafana Prometheus datasource can already chart log volume and
+error rate against Ravel through PromQL, and filter the lines it counts by
+body text, but it cannot browse the lines themselves. Reading log lines is
+SQL's job. If you need write acknowledgement in single-digit milliseconds, strict
+mode pays an object-store round trip and buffered mode gives up the crash guarantee
 above. Ravel is pre-1.0: the persistent formats are versioned contracts, and the
 surfaces around them still move.
 
@@ -92,7 +97,7 @@ matrix says which.
 | OTLP ingest, HTTP and gRPC | metrics, logs, traces | `none` | yes |
 | Prometheus Remote Write 1.0 and 2.0 ingest | metrics | `none` | yes |
 | OTAP ingest, gRPC | metrics | `otap` | yes |
-| PromQL HTTP API | metrics | `none` | yes |
+| PromQL HTTP API | metrics, logs as `ravel_log_lines` and `ravel_log_bytes` | `none` | yes |
 | SQL over `POST /api/v1/sql` | metrics as `samples`, logs as `logs`, traces as `spans`, alert history as `alerts`, audit records as `audit` | `sql` | yes |
 | Flight SQL | the same five tables | `flight-sql` | yes |
 
@@ -109,7 +114,9 @@ ingest is registered only when the process is started with `--otap`
 surfaces by passing the same `--features` list to cargo.
 
 Exactly five SQL tables are registered: `samples`, `logs`, `spans`, `alerts`,
-and `audit`. SQL is the only way to query logs and traces.
+and `audit`. SQL is the only way to query traces, alerts, and audit records.
+Logs are also queryable over PromQL, as `ravel_log_lines` and
+`ravel_log_bytes`.
 
 Also live:
 
@@ -158,6 +165,16 @@ demo bearer token, exactly as a real deployment needs a real one:
 ```sh
 curl -s -H "Authorization: Bearer demo-token" \
   'http://127.0.0.1:4318/api/v1/query?query=system_cpu_load_average_1m'
+```
+
+Logs answer the same PromQL API, through the reserved `ravel_log_lines` and
+`ravel_log_bytes` metric names ([details](docs/guides/query.md#promql-over-logs)):
+
+<!-- ravel:run status=200; json:.data.resultType=vector -->
+```sh
+curl -s -H "Authorization: Bearer demo-token" \
+  --data-urlencode 'query=sum by (job) (count_over_time(ravel_log_lines[5m]))' \
+  'http://127.0.0.1:4318/api/v1/query'
 ```
 
 The published image carries the `sql` feature, so `POST /api/v1/sql` answers

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,9 +36,14 @@ process never compacts or deletes anything.
 The ingest surfaces are OTLP over HTTP and gRPC, Prometheus Remote Write,
 and OTAP behind a cargo feature. The query surfaces are the
 Prometheus-compatible `/api/v1/*` routes, `POST /api/v1/sql`, Flight SQL
-behind a cargo feature, and `POST /api/v1/analytics`. The ingest protocols
-share one pipeline: Remote Write payloads normalise to the shape OTLP
-produces and enter the same router call, so there is no second flush or
+behind a cargo feature, and `POST /api/v1/analytics`. The
+Prometheus-compatible routes also serve the logs signal: a selector with
+exact `__name__` equality on the reserved `ravel_log_lines` or
+`ravel_log_bytes` metric name is answered from log data, evaluated locally
+by the query coordinator rather than federated (ADR-1103; see
+[docs/guides/query.md](guides/query.md#promql-over-logs)). The ingest
+protocols share one pipeline: Remote Write payloads normalise to the shape
+OTLP produces and enter the same router call, so there is no second flush or
 commit path to hold correct.
 
 Two capabilities that the decision records discuss do not exist in the

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -311,12 +311,14 @@ that flushed, exactly like a metrics export. An unresolvable tenant returns
 pipeline cannot accept returns `503`.
 
 Log records are durable in RLOG objects under the tenant's `l` keyspace after
-the strict ack returns. **Logs are queryable over SQL**: the `logs` table is
-registered on the `POST /api/v1/sql` endpoint, and
-[query.md](query.md#sql-over-samples-logs-and-spans) documents its schema and usage.
-PromQL does not query logs, so log data is reachable only through SQL. You can
-also read a log object back directly with `ravel-cli rlog inspect`
-([inspecting-data.md](inspecting-data.md)).
+the strict ack returns. **Logs are queryable two ways**: over SQL, where the
+`logs` table is registered on the `POST /api/v1/sql` endpoint
+([query.md](query.md#sql-over-samples-logs-and-spans) documents its schema
+and usage), and over PromQL, through the reserved `ravel_log_lines` and
+`ravel_log_bytes` metric names
+([query.md](query.md#promql-over-logs) documents the label mapping and
+routing rule). You can also read a log object back directly with
+`ravel-cli rlog inspect` ([inspecting-data.md](inspecting-data.md)).
 
 ### Log admission limits
 

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -218,6 +218,170 @@ Selector details that hold for a bare vector selector:
   exactly 5 minutes old is not used. A series with no sample in that window
   is omitted from the result entirely, not reported as absent or zero.
 
+## PromQL over logs
+
+The `logs` signal is also reachable through the PromQL HTTP API, via two
+reserved metric names (see Background below):
+
+- `ravel_log_lines` -- one sample per log line, value `1`. `count_over_time`
+  counts lines.
+- `ravel_log_bytes` -- one sample per log line, value the line's `body`
+  length in bytes. `sum_over_time` sums bytes.
+
+No new endpoint and no new query language. `/api/v1/query`,
+`/api/v1/query_range` and `/api/v1/metadata` serve these two names exactly
+as they serve any other metric name, and the discovery endpoints treat a
+log selector in `match[]` exactly as they treat a metrics one:
+`/api/v1/series` returns its matching label sets, `/api/v1/labels` returns
+the label names those sets carry, and `/api/v1/label/{name}/values` returns
+that label's values, which for `__name__` includes the two reserved names.
+
+### Routing: a selector is a log selector only on exact `__name__` equality
+
+A vector selector is answered from the logs signal only when its `__name__`
+matcher is an exact `=` equality on `ravel_log_lines` or `ravel_log_bytes`
+(`ravel_log_lines{job="api"}`, never `{__name__=~"ravel_log_.*"}` and never
+`!=`). Every other selector, including one that merely resembles a reserved
+name, resolves against the metrics signal as it always has.
+
+### Label mapping
+
+A log record becomes one sample whose label set is built in this precedence
+order, first writer wins on a key collision:
+
+1. `__name__` -- `ravel_log_lines` or `ravel_log_bytes`, from the selector.
+2. `job` and `instance` -- the same derivation ingest already uses for
+   metrics (see [the ingest guide](ingest.md)).
+3. `otel_scope_name` and `otel_scope_version` when non-empty, and
+   `otel_scope_<attr>` for each scope attribute.
+4. Every remaining resource attribute, sanitized to a label name. Unlike
+   metrics ingest, there is **no allowlist**: every resource attribute the
+   record's stream carries becomes a label, not just a fixed set.
+5. `severity_text` when non-empty -- the one per-record (not per-stream)
+   field promoted to a label.
+
+Only scalar attributes become labels. A string is used as it stands, and an
+integer, double or boolean is rendered the way the SQL `attrs` map renders
+it; a byte string, list or map is skipped, since none has a faithful single
+label value. An attribute whose value is empty is skipped as well, so an
+empty attribute never differs from an absent one.
+
+Sanitizing a name for use as a label rewrites the first character to
+`[A-Za-z_]` and every later character to `[A-Za-z0-9_]` in place (so
+`k8s.pod.name` becomes `k8s_pod_name`), the same rule
+`ravel_otlp::normalize::sanitize_label_name` already applies to metrics.
+The `__`-prefixed namespace is reserved: an attribute whose sanitized name
+lands there is dropped rather than becoming a label. The only `__` label on a
+log-derived series is the `__name__` the mapping itself sets to the reserved
+metric name.
+
+A **stream** is a resource-and-scope attribute set; it is not the same thing
+as a query-time series. Two streams whose resource, scope, and per-record
+`severity_text` map to the identical label set merge into one series: their
+samples interleave and none are dropped. Conversely, one stream's records
+with different `severity_text` values (say, `ERROR` and `INFO` from the same
+pod) split into distinct series, since `severity_text` is part of the label
+set.
+
+Two records at the exact same timestamp in the same series are never
+deduplicated or merged; both remain distinct samples, ordered by ascending
+`value.to_bits()` (so `ravel_log_lines`, always `1`, has no defined order
+between same-timestamp lines beyond that bit-pattern tie-break).
+
+### `__body__`: a matcher-only pseudo-label
+
+`__body__` matches a log record's body, either by whole-body equality
+(`__body__="exact text"`) or a fully-anchored regex
+(`__body__=~".*timeout.*"`). It is a matcher, not a label: it never appears
+in a returned label set, and it plays no part in series identity or the
+merge/split rules above. Multiple `__body__` matchers in one selector AND
+together.
+
+### `rate()` is not redefined for log series
+
+There is no log-specific meaning for `rate()`. The PromQL spelling of "lines
+per second" over a log selector is division by the window's seconds, exactly
+as it would be for any counter-shaped `count_over_time`:
+
+```promql
+count_over_time(ravel_log_lines{job="api"}[5m]) / 300
+```
+
+### Budgets, `series`/`labels`/`label-values`, and `metadata`
+
+A log selector draws on the same [query budgets](#query-budgets) as a
+metrics selector, in the same query: `max_samples`, `max_series`,
+`max_segments`, `max_bytes_scanned`, and `max_s3_requests` are shared totals
+across every selector a query contains, metrics and log alike. Exceeding any
+of them is the same typed `422` a metrics-only query gets.
+
+`/api/v1/series` with a log selector in `match[]` resolves that selector's
+matching log streams into label sets, same as for metrics. `/api/v1/labels`
+and `/api/v1/label/{name}/values` behave the same way when a log selector is
+present in `match[]`.
+
+`/api/v1/label/__name__/values` includes both `ravel_log_lines` and
+`ravel_log_bytes` when the request carries no `match[]`, and when at least
+one `match[]` selector is a log selector; a request whose selectors name only
+metrics gets metrics names only. The names are listed even on a tenant that
+has never ingested a log, since they exist independently of the data. A
+`match[]` naming one reserved name currently returns both of them.
+`/api/v1/metadata` always includes both reserved names too, each with a
+fixed `type`, `help`, and `unit`, subject to the same `metric` and `limit`
+filters a metrics request uses; neither entry depends on any log data having
+been ingested.
+
+### Local evaluation only in this release
+
+A log selector is answered by the query coordinator directly against
+object storage; it does not fan out over `--distributed-query` federation
+the way a metrics selector does (see Background below). A federated deployment
+still answers a log selector, just from the coordinator's own local view, not
+a cluster-wide merge; wiring log selectors into federation is unscheduled
+follow-up work.
+
+### Examples
+
+Error lines per job over the last 5 minutes:
+
+```sh
+curl -G http://127.0.0.1:4318/api/v1/query \
+  -H "Authorization: Bearer devtoken" \
+  --data-urlencode 'query=sum by (job) (count_over_time(ravel_log_lines{severity_text="ERROR"}[5m]))'
+```
+
+```json
+{
+  "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {"metric": {"job": "api"}, "value": [1732400000, "128"]}
+    ]
+  }
+}
+```
+
+Log volume in bytes for lines whose body mentions a timeout:
+
+```sh
+curl -G http://127.0.0.1:4318/api/v1/query \
+  -H "Authorization: Bearer devtoken" \
+  --data-urlencode 'query=sum(sum_over_time(ravel_log_bytes{job="api", __body__=~".*timeout.*"}[1h]))'
+```
+
+```json
+{
+  "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {"metric": {}, "value": [1732400000, "5312"]}
+    ]
+  }
+}
+```
+
 ## `min_commit_token`
 
 Pass a commit token from an ingest response's `x-ravel-commit-token`
@@ -242,6 +406,8 @@ truncation:
 | Concurrent segment fetches | derived: `max(8, 2 x cores)` (`--fetch-concurrency`) | (not user-visible; throughput knob only) |
 | Wall-clock deadline | fixed: 11m (`--gc-max-query-duration`) | `query exceeded its deadline of {deadline}` |
 | Catalog list requests | 100,000 | `query window too wide: it would issue an estimated {estimate} catalog list requests, over the limit of {limit}; narrow the query time range and retry` |
+| Bytes scanned | unlimited (opt in via `query_defaults.max_bytes_scanned`) | `query scanned {scanned} bytes, exceeding the budget of {max}` |
+| Object-store requests | derived from the deployment's shard count and flush cadence | `query issued {requests} S3 requests, exceeding the budget of {max}` |
 
 `timeout` (Prometheus duration syntax like `30s`/`5m`, or bare float
 seconds) lowers the deadline per request. It cannot raise it above the
@@ -546,7 +712,13 @@ the modes that evaluate it, and the sinks are in the
 | 200 | n/a | Success. |
 | 400 | `bad_data` | Bad or missing parameter, PromQL parse error, invalid time range, step <= 0. |
 | 401 | `unauthorized` | Tenant authentication failed or was not provided. |
-| 422 | `execution` | An intentionally rejected PromQL construct (the set listed under PromQL support: `histogram_stddev`/`histogram_stdvar` over native histograms, an or-grouped label matcher, vector-matching fill values, a subquery over native histograms, or the experimental `limitk`/`limit_ratio` operators), or a query budget (segments/series/samples, the catalog-list window ceiling, or the SQL memory pool) exceeded. |
+| 422 | `execution` | An intentionally rejected PromQL construct (the set listed under PromQL support: `histogram_stddev`/`histogram_stdvar` over native histograms, an or-grouped label matcher, vector-matching fill values, a subquery over native histograms, or the experimental `limitk`/`limit_ratio` operators), or a query budget (segments/series/samples, bytes scanned, object-store requests, the catalog-list window ceiling, or the SQL memory pool) exceeded. |
 | 500 | `internal` | Permanent data corruption: a corrupt catalog record, segment, field, or key, or a non-monotonic sample sequence. The message is a fixed internal-error string; the storage-layer detail is redacted and logged server-side. |
 | 503 | `unavailable` | Transient catalog or segment fetch failure, an unresolvable `min_commit_token`, or a snapshot invalidated by concurrent GC/compaction. |
 | 504 | `timeout` | Query exceeded its deadline. |
+
+## Background
+
+PromQL over logs, the two reserved metric names, the label mapping, and the
+coordinator-local (non-federated) evaluation are
+[ADR-1103](../adrs/1103-promql-over-logs.md).

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -77,6 +77,21 @@ HTTP /api/v1/query, /query_range, /labels, /label/{name}/values, /series
      histogram monotonicity fixup is an info.)
 ```
 
+### Log selectors
+
+A log selector -- exact `__name__` equality on `ravel_log_lines` or
+`ravel_log_bytes` (ADR-1103) -- is planned by the same `plan_selectors` walk
+above and shares the query's total budgets with every metrics selector in
+the same query, but resolves against the tenant's log catalog instead of the
+metrics one, and only against this coordinator's own local view: log
+selectors are never federated (ADR-1103 decision 5), so a
+`--distributed-query` deployment still answers one from local segments only,
+never a cluster-wide merge. Its decoded per-record samples (one
+`ravel_log_lines`/`ravel_log_bytes` sample per log line, labels derived per
+[query.md](guides/query.md#promql-over-logs)) join the same query-wide
+pooled merge a metrics selector's runs join, so a query mixing a metrics and
+a log selector still evaluates over one merged, sorted series set.
+
 `padded_range`: the union, over every selector `plan_selectors` reports, of
 that selector's own fetch window (its lookback or matrix range, plus its
 own offset, anchored per `PlanAnchor::Window`/`Pinned`), so lookback never
@@ -973,9 +988,13 @@ absence-of-output-sample contract the raw path already has.
 This is the engine-level (queryfrag) fetch, merge, and federation machinery for
 all five signals, shipped and covered by the per-signal differential, erasure,
 skew, and federation tests. The coordinator caller that actually dispatches a
-Logs/Alerts/Audit/Spans distributed *search* is the SQL surface (log and trace
-search runs through the `logs`/`alerts`/`audit`/`spans` tables, not PromQL); the
-PromQL engine's own fetch/federation flow drives `Signal::Metrics` only today.
+Alerts/Audit/Spans distributed *search* is the SQL surface (trace search runs
+through the `alerts`/`audit`/`spans` tables, not PromQL); logs are reachable
+both ways, through the `logs` SQL table and, since ADR-1103, through the
+PromQL engine's own fetch flow (see "Log selectors" above) -- but that PromQL
+log lane is coordinator-local only. The PromQL engine's federation half still
+drives `Signal::Metrics` only today: a log selector is never federated
+(ADR-1103 decision 5).
 The SQL-lane distributed scan that drives that log and trace search is a
 separate step, and it exists only in a `flight-sql` build, which the published
 image is; see "The SQL-lane distributed scan" below.

--- a/services/ravel-server/tests/promql_logs_e2e.rs
+++ b/services/ravel-server/tests/promql_logs_e2e.rs
@@ -1,0 +1,777 @@
+//! End-to-end coverage for ADR-1103 (PromQL over logs, issue #1109): a real
+//! OTLP logs export against an in-process server, read back through the
+//! Prometheus-compatible HTTP API's `ravel_log_lines`/`ravel_log_bytes`
+//! reserved metric names, exactly as a Grafana Prometheus datasource would.
+//!
+//! Every figure below is a named constant computed from the fixture bodies
+//! below, not a magic number, so the arithmetic behind each assertion is
+//! auditable.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValueVariant;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope, KeyValue};
+use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs, SeverityNumber};
+use opentelemetry_proto::tonic::metrics::v1::metric::Data as MetricData;
+use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+use opentelemetry_proto::tonic::metrics::v1::{
+    Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics,
+};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use prost::Message;
+use ravel_object_store::memory::MemoryStore;
+use ravel_server::{FoldTaskConfig, Mode, ServerConfig};
+use ravel_types::TenantId;
+use serde_json::Value as JsonValue;
+
+const TOKEN: &str = "testtoken";
+const TENANT: &str = "acme";
+
+/// One second in nanoseconds; every fixture record's timestamp is `BASE`
+/// plus a whole multiple of this, so second-granularity HTTP `time`/`start`/
+/// `end` params (`secs`, below) land exactly, with no truncation ambiguity.
+const NS: i64 = 1_000_000_000;
+
+// ---------------------------------------------------------------------------
+// Fixture bodies, api resource (`service.name=api`, `k8s.pod.name=p1`).
+// Byte lengths are `str::len()` on ASCII text, so they equal both the char
+// count and what `wc -c` reports; each is spelled out here rather than
+// computed at test time so the expected totals below are auditable against
+// the literal bodies.
+// ---------------------------------------------------------------------------
+
+/// Shares its timestamp with `API_ERR_2_BODY` (the "shared timestamp" the
+/// range-query test straddles). Contains "timeout" (one of the two
+/// `__body__=~".*timeout.*"` matches).
+const API_ERR_1_BODY: &str = "request failed with timeout";
+const API_ERR_1_LEN: usize = 27;
+/// Shares `API_ERR_1_BODY`'s timestamp.
+const API_ERR_2_BODY: &str = "upstream unavailable";
+const API_ERR_2_LEN: usize = 20;
+/// Contains "timeout" (the second `__body__=~".*timeout.*"` match).
+const API_ERR_3_BODY: &str = "disk write timeout occurred";
+const API_ERR_3_LEN: usize = 27;
+const API_ERR_4_BODY: &str = "connection reset by peer";
+const API_ERR_4_LEN: usize = 24;
+const API_ERR_5_BODY: &str = "null pointer dereference";
+const API_ERR_5_LEN: usize = 24;
+
+const API_INFO_1_BODY: &str = "request completed";
+const API_INFO_1_LEN: usize = 17;
+const API_INFO_2_BODY: &str = "cache warmed";
+const API_INFO_2_LEN: usize = 12;
+const API_INFO_3_BODY: &str = "health check ok";
+const API_INFO_3_LEN: usize = 15;
+
+/// api's 5 ERROR lines.
+const API_ERROR_LINES: usize = 5;
+/// api's 3 INFO lines.
+const API_INFO_LINES: usize = 3;
+/// api's 8 lines total (`job="api"` line count).
+const API_TOTAL_LINES: usize = API_ERROR_LINES + API_INFO_LINES;
+/// Byte total of api's 5 ERROR bodies.
+const API_ERROR_BYTES: usize =
+    API_ERR_1_LEN + API_ERR_2_LEN + API_ERR_3_LEN + API_ERR_4_LEN + API_ERR_5_LEN;
+/// Byte total of api's 3 INFO bodies.
+const API_INFO_BYTES: usize = API_INFO_1_LEN + API_INFO_2_LEN + API_INFO_3_LEN;
+/// Byte total of all 8 api bodies (`sum(sum_over_time(ravel_log_bytes{job="api"}[1h]))`).
+const API_TOTAL_BYTES: usize = API_ERROR_BYTES + API_INFO_BYTES;
+/// Lines whose body contains "timeout": `API_ERR_1_BODY` and `API_ERR_3_BODY`.
+const API_TIMEOUT_LINES: usize = 2;
+
+// ---------------------------------------------------------------------------
+// Fixture bodies, worker resource (`service.name=worker`, no other resource
+// attributes, so no `instance` and no attribute-derived label beyond `job`).
+// ---------------------------------------------------------------------------
+
+const WORKER_ERR_1_BODY: &str = "job failed";
+const WORKER_ERR_1_LEN: usize = 10;
+const WORKER_ERR_2_BODY: &str = "job retrying";
+const WORKER_ERR_2_LEN: usize = 12;
+const WORKER_ERR_3_BODY: &str = "job failed permanently";
+const WORKER_ERR_3_LEN: usize = 22;
+const WORKER_ERR_4_BODY: &str = "queue backlog critical";
+const WORKER_ERR_4_LEN: usize = 22;
+
+/// worker's 4 ERROR lines (worker carries no INFO lines).
+const WORKER_ERROR_LINES: usize = 4;
+/// Byte total of worker's 4 bodies; not directly asserted over HTTP, kept
+/// here so the fixture sanity check below exercises every body constant.
+const WORKER_TOTAL_BYTES: usize =
+    WORKER_ERR_1_LEN + WORKER_ERR_2_LEN + WORKER_ERR_3_LEN + WORKER_ERR_4_LEN;
+
+fn now_ns() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_nanos() as i64
+}
+
+/// The HTTP API's `time`/`start`/`end` params are Prometheus-style unix
+/// seconds. Every fixture timestamp is `base_ns + k * NS` for an integer
+/// `k`, so `secs` divides out exactly: `(a + k*NS) / NS == a/NS + k` for any
+/// remainder `a` has against `NS`, with no rounding ambiguity between
+/// adjacent fixture timestamps.
+fn secs(ts_ns: i64) -> i64 {
+    ts_ns / NS
+}
+
+fn string_kv(key: &str, value: &str) -> KeyValue {
+    KeyValue {
+        key: key.to_string(),
+        value: Some(AnyValue {
+            value: Some(AnyValueVariant::StringValue(value.to_string())),
+        }),
+        ..Default::default()
+    }
+}
+
+fn log_record(
+    ts_ns: i64,
+    severity_number: SeverityNumber,
+    severity_text: &str,
+    body: &str,
+) -> LogRecord {
+    LogRecord {
+        time_unix_nano: ts_ns as u64,
+        observed_time_unix_nano: ts_ns as u64,
+        severity_number: severity_number as i32,
+        severity_text: severity_text.to_string(),
+        body: Some(AnyValue {
+            value: Some(AnyValueVariant::StringValue(body.to_string())),
+        }),
+        ..Default::default()
+    }
+}
+
+fn scope() -> Option<InstrumentationScope> {
+    Some(InstrumentationScope {
+        name: "scope".to_string(),
+        version: "1.0".to_string(),
+        ..Default::default()
+    })
+}
+
+/// One OTLP logs export carrying both resources described in issue #1109:
+/// `api` (with `k8s.pod.name=p1`, 5 ERROR + 3 INFO lines, two ERROR lines
+/// sharing `base_ns`) and `worker` (no extra resource attributes, 4 ERROR
+/// lines).
+fn logs_export_request(base_ns: i64) -> ExportLogsServiceRequest {
+    let api_resource = Resource {
+        attributes: vec![
+            string_kv("service.name", "api"),
+            string_kv("k8s.pod.name", "p1"),
+        ],
+        ..Default::default()
+    };
+    let api_records = vec![
+        log_record(base_ns, SeverityNumber::Error, "ERROR", API_ERR_1_BODY),
+        log_record(base_ns, SeverityNumber::Error, "ERROR", API_ERR_2_BODY),
+        log_record(base_ns + NS, SeverityNumber::Error, "ERROR", API_ERR_3_BODY),
+        log_record(
+            base_ns + 2 * NS,
+            SeverityNumber::Error,
+            "ERROR",
+            API_ERR_4_BODY,
+        ),
+        log_record(
+            base_ns + 3 * NS,
+            SeverityNumber::Error,
+            "ERROR",
+            API_ERR_5_BODY,
+        ),
+        log_record(
+            base_ns + 4 * NS,
+            SeverityNumber::Info,
+            "INFO",
+            API_INFO_1_BODY,
+        ),
+        log_record(
+            base_ns + 5 * NS,
+            SeverityNumber::Info,
+            "INFO",
+            API_INFO_2_BODY,
+        ),
+        log_record(
+            base_ns + 6 * NS,
+            SeverityNumber::Info,
+            "INFO",
+            API_INFO_3_BODY,
+        ),
+    ];
+
+    let worker_resource = Resource {
+        attributes: vec![string_kv("service.name", "worker")],
+        ..Default::default()
+    };
+    let worker_records = vec![
+        log_record(
+            base_ns + 7 * NS,
+            SeverityNumber::Error,
+            "ERROR",
+            WORKER_ERR_1_BODY,
+        ),
+        log_record(
+            base_ns + 8 * NS,
+            SeverityNumber::Error,
+            "ERROR",
+            WORKER_ERR_2_BODY,
+        ),
+        log_record(
+            base_ns + 9 * NS,
+            SeverityNumber::Error,
+            "ERROR",
+            WORKER_ERR_3_BODY,
+        ),
+        log_record(
+            base_ns + 10 * NS,
+            SeverityNumber::Error,
+            "ERROR",
+            WORKER_ERR_4_BODY,
+        ),
+    ];
+
+    ExportLogsServiceRequest {
+        resource_logs: vec![
+            ResourceLogs {
+                resource: Some(api_resource),
+                scope_logs: vec![ScopeLogs {
+                    scope: scope(),
+                    log_records: api_records,
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            },
+            ResourceLogs {
+                resource: Some(worker_resource),
+                scope_logs: vec![ScopeLogs {
+                    scope: scope(),
+                    log_records: worker_records,
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            },
+        ],
+    }
+}
+
+fn metrics_export_request(
+    metric_name: &str,
+    job: &str,
+    value: f64,
+    ts_ns: i64,
+) -> ExportMetricsServiceRequest {
+    ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            resource: Some(Resource {
+                attributes: vec![string_kv("service.name", job)],
+                ..Default::default()
+            }),
+            scope_metrics: vec![ScopeMetrics {
+                metrics: vec![Metric {
+                    name: metric_name.to_string(),
+                    data: Some(MetricData::Gauge(Gauge {
+                        data_points: vec![NumberDataPoint {
+                            time_unix_nano: ts_ns as u64,
+                            value: Some(NumberValue::AsDouble(value)),
+                            ..Default::default()
+                        }],
+                    })),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    }
+}
+
+async fn start_test_server() -> ravel_server::Running {
+    let mut tokens = HashMap::new();
+    tokens.insert(TOKEN.to_string(), TenantId::new(TENANT));
+    let tenant_resolver = ravel_server::tenant::build_resolver(tokens, false);
+    let store = Arc::new(MemoryStore::new());
+    let config = ServerConfig {
+        query_budgets: Default::default(),
+        max_inflight_flushes: 1,
+        adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
+        mode: Mode::All,
+        listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
+        listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
+        shard_count: 1,
+        tenant_resolver,
+        mtls_listener: None,
+        fold_tenants: Vec::new(),
+        fold: FoldTaskConfig {
+            enabled: false,
+            ..FoldTaskConfig::default()
+        },
+        maintain: ravel_server::MaintenanceTaskConfig::default(),
+        alerting: ravel_server::AlertEvalConfig::default(),
+        oidc_refresh: None,
+        otap: false,
+        metrics_tenant_labels: false,
+        limits: ravel_server::LimitsConfig::default(),
+        deployment_key: None,
+        gc: ravel_maintain::GcConfigValues::maintain_defaults(),
+        query_deadline: ravel_query::EngineConfig::default().deadline,
+        store_probe_interval: ravel_server::store_probe::DEFAULT_STORE_PROBE_INTERVAL,
+        admission_reconcile_interval: ravel_ingest::DEFAULT_ADMISSION_RECONCILE_INTERVAL,
+        query_concurrency_limit: ravel_query::QueryConcurrencyLimit::Unlimited,
+        max_s3_requests: ravel_query::EngineConfig::default().max_s3_requests,
+        scrub_period: std::time::Duration::from_secs(7 * 86_400),
+        indexed_fields: Default::default(),
+        typed_attr_columns: Default::default(),
+        disable_cache: false,
+        cache_max_bytes: 256 * 1024 * 1024,
+        catalog_cache_max_bytes: 256 * 1024 * 1024,
+        cache_dir: None,
+        ingest_buffer_budget_limit: ravel_server::IngestByteBudgetLimit::Unlimited,
+        idle_tenant_state_ttl: std::time::Duration::from_secs(3600),
+        distrib: None,
+        remote_clusters: Vec::new(),
+        ingest_concurrency_limit: ravel_server::ingest_concurrency::IngestConcurrencyLimit::Bounded(
+            1024,
+        ),
+    };
+    ravel_server::start(
+        config,
+        store.clone(),
+        store.clone(),
+        Arc::new(ravel_object_store::StoreMetrics::default()),
+        None,
+    )
+    .await
+    .expect("server starts")
+}
+
+async fn get_json(
+    client: &reqwest::Client,
+    url: &str,
+    params: &[(&str, &str)],
+) -> (reqwest::StatusCode, JsonValue) {
+    let response = client
+        .get(url)
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .query(params)
+        .send()
+        .await
+        .expect("query request succeeds");
+    let status = response.status();
+    let json: JsonValue = response.json().await.expect("query response is JSON");
+    (status, json)
+}
+
+fn vector_results(body: &JsonValue) -> &Vec<JsonValue> {
+    assert_eq!(body["status"], "success", "unexpected response: {body}");
+    assert_eq!(body["data"]["resultType"], "vector", "body: {body}");
+    body["data"]["result"]
+        .as_array()
+        .expect("result is an array")
+}
+
+fn instant_value(sample: &JsonValue) -> f64 {
+    sample["value"][1]
+        .as_str()
+        .expect("value is a string")
+        .parse()
+        .expect("value parses as f64")
+}
+
+/// Finds the one vector entry whose `metric` map is exactly `want` (same
+/// keys, same values, nothing extra), panicking with the full result set
+/// otherwise -- an exact match, not a "contains" check.
+fn find_exact_series<'a>(results: &'a [JsonValue], want: &[(&str, &str)]) -> &'a JsonValue {
+    let matches: Vec<&JsonValue> = results
+        .iter()
+        .filter(|entry| {
+            let metric = entry["metric"].as_object().expect("metric is an object");
+            metric.len() == want.len()
+                && want
+                    .iter()
+                    .all(|(k, v)| metric.get(*k).and_then(JsonValue::as_str) == Some(*v))
+        })
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one series with metric == {want:?}, found {}: {results:?}",
+        matches.len()
+    );
+    matches[0]
+}
+
+#[tokio::test]
+async fn otlp_logs_are_queryable_through_promql_over_http() {
+    let running = start_test_server().await;
+    let base = format!("http://{}", running.http_addr);
+    let client = reqwest::Client::new();
+
+    // Whole-second aligned: a sub-second remainder would push each record's
+    // true `time_unix_nano` just past its nominal integer-second grid
+    // boundary, since `secs()` truncates it away when building query params,
+    // silently shifting every count_over_time grid point below by one step.
+    let base_ns = secs(now_ns()) * NS;
+
+    // --- Ingest: one OTLP logs export, two resources, twelve records. ---
+    let logs_request = logs_export_request(base_ns);
+    let response = client
+        .post(format!("{base}/v1/logs"))
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .header("content-type", "application/x-protobuf")
+        .body(logs_request.encode_to_vec())
+        .send()
+        .await
+        .expect("logs export request succeeds");
+    assert_eq!(response.status(), 200, "logs export should succeed");
+    let logs_commit_token = response
+        .headers()
+        .get("x-ravel-commit-token")
+        .expect("commit token header present")
+        .to_str()
+        .expect("commit token header is ascii")
+        .to_string();
+
+    // --- Ingest: one OTLP metric, to prove the logs export left the
+    // metrics lane untouched. ---
+    const METRIC_VALUE: f64 = 99.5;
+    let metrics_request =
+        metrics_export_request("demo_requests_total", "checkout", METRIC_VALUE, base_ns);
+    let response = client
+        .post(format!("{base}/v1/metrics"))
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .header("content-type", "application/x-protobuf")
+        .body(metrics_request.encode_to_vec())
+        .send()
+        .await
+        .expect("metrics export request succeeds");
+    assert_eq!(response.status(), 200, "metrics export should succeed");
+    let metrics_commit_token = response
+        .headers()
+        .get("x-ravel-commit-token")
+        .expect("commit token header present")
+        .to_str()
+        .expect("commit token header is ascii")
+        .to_string();
+
+    let query_url = format!("{base}/api/v1/query");
+    let query_range_url = format!("{base}/api/v1/query_range");
+    let series_url = format!("{base}/api/v1/series");
+    let name_values_url = format!("{base}/api/v1/label/__name__/values");
+    let metadata_url = format!("{base}/api/v1/metadata");
+
+    // Well past every fixture timestamp (base_ns + 10*NS is the last one),
+    // but inside every window used below.
+    let eval_time = secs(base_ns + 20 * NS).to_string();
+
+    // --- sum by (job) (count_over_time(ravel_log_lines{severity_text="ERROR"}[1h])) ---
+    let (status, body) = get_json(
+        &client,
+        &query_url,
+        &[
+            (
+                "query",
+                r#"sum by (job) (count_over_time(ravel_log_lines{severity_text="ERROR"}[1h]))"#,
+            ),
+            ("time", &eval_time),
+            ("min_commit_token", &logs_commit_token),
+        ],
+    )
+    .await;
+    assert_eq!(status, 200, "body: {body}");
+    let results = vector_results(&body);
+    assert_eq!(results.len(), 2, "expected api and worker: {results:?}");
+    let api_series = find_exact_series(results, &[("job", "api")]);
+    assert!(
+        (instant_value(api_series) - API_ERROR_LINES as f64).abs() < f64::EPSILON,
+        "job=api ERROR count: {api_series}"
+    );
+    let worker_series = find_exact_series(results, &[("job", "worker")]);
+    assert!(
+        (instant_value(worker_series) - WORKER_ERROR_LINES as f64).abs() < f64::EPSILON,
+        "job=worker ERROR count: {worker_series}"
+    );
+
+    // --- sum(sum_over_time(ravel_log_bytes{job="api"}[1h])) ---
+    // (`ravel_log_bytes{job="api"}` alone matches two series -- ERROR and
+    // INFO differ by `severity_text` -- so the outer `sum` is what turns
+    // "per-series byte totals" into "the byte total of api's 8 bodies".)
+    let (status, body) = get_json(
+        &client,
+        &query_url,
+        &[
+            (
+                "query",
+                r#"sum(sum_over_time(ravel_log_bytes{job="api"}[1h]))"#,
+            ),
+            ("time", &eval_time),
+            ("min_commit_token", &logs_commit_token),
+        ],
+    )
+    .await;
+    assert_eq!(status, 200, "body: {body}");
+    let results = vector_results(&body);
+    assert_eq!(
+        results.len(),
+        1,
+        "expected one aggregated series: {results:?}"
+    );
+    assert!(
+        (instant_value(&results[0]) - API_TOTAL_BYTES as f64).abs() < f64::EPSILON,
+        "job=api byte total: {}, want {API_TOTAL_BYTES}",
+        results[0]
+    );
+
+    // --- count_over_time(ravel_log_lines{job="api", __body__=~".*timeout.*"}[1h]) ---
+    let (status, body) = get_json(
+        &client,
+        &query_url,
+        &[
+            (
+                "query",
+                r#"count_over_time(ravel_log_lines{job="api", __body__=~".*timeout.*"}[1h])"#,
+            ),
+            ("time", &eval_time),
+            ("min_commit_token", &logs_commit_token),
+        ],
+    )
+    .await;
+    assert_eq!(status, 200, "body: {body}");
+    let results = vector_results(&body);
+    assert_eq!(
+        results.len(),
+        1,
+        "expected one matching series: {results:?}"
+    );
+    assert!(
+        (instant_value(&results[0]) - API_TIMEOUT_LINES as f64).abs() < f64::EPSILON,
+        "timeout line count: {}, want {API_TIMEOUT_LINES}",
+        results[0]
+    );
+    let metric = results[0]["metric"]
+        .as_object()
+        .expect("metric is an object");
+    assert!(
+        !metric.contains_key("__body__"),
+        "__body__ must never appear in a returned label set: {metric:?}"
+    );
+
+    // --- query_range: sum(count_over_time(ravel_log_lines{job="api"}[10m])) ---
+    // straddling the shared timestamp at base_ns. The window (600s) is far
+    // wider than the fixture's ~10s spread, so each step's count is the
+    // cumulative line count up to that step. A range-vector selector with no
+    // samples in a step's window contributes no point at all (not a 0), so
+    // the series starts at base_ns with value 2, not before it with 0; that
+    // first value being 2 (not 1) proves both same-timestamp ERROR records
+    // survive the step (neither dropped nor merged into one). The window
+    // keeps counting 8 for one extra step (base_ns + 7s) after the last
+    // write, proving cumulative counts persist rather than expiring the
+    // instant no new line arrives.
+    let range_start = secs(base_ns - NS).to_string();
+    let range_end = secs(base_ns + 7 * NS).to_string();
+    let (status, body) = get_json(
+        &client,
+        &query_range_url,
+        &[
+            (
+                "query",
+                r#"sum(count_over_time(ravel_log_lines{job="api"}[10m]))"#,
+            ),
+            ("start", &range_start),
+            ("end", &range_end),
+            ("step", "1s"),
+            ("min_commit_token", &logs_commit_token),
+        ],
+    )
+    .await;
+    assert_eq!(status, 200, "body: {body}");
+    assert_eq!(body["status"], "success", "body: {body}");
+    assert_eq!(body["data"]["resultType"], "matrix", "body: {body}");
+    let matrix = body["data"]["result"]
+        .as_array()
+        .expect("matrix result array");
+    assert_eq!(
+        matrix.len(),
+        1,
+        "expected one aggregated series: {matrix:?}"
+    );
+    let values: Vec<f64> = matrix[0]["values"]
+        .as_array()
+        .expect("values array")
+        .iter()
+        .map(|pair| {
+            pair[1]
+                .as_str()
+                .expect("value is a string")
+                .parse::<f64>()
+                .expect("value parses as f64")
+        })
+        .collect();
+    assert_eq!(
+        values,
+        vec![2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 8.0],
+        "per-step cumulative api line count: {matrix:?}"
+    );
+
+    // --- /api/v1/series?match[]=ravel_log_lines{job="api"} ---
+    let window_start = secs(base_ns - NS).to_string();
+    let window_end = secs(base_ns + 20 * NS).to_string();
+    let (status, body) = get_json(
+        &client,
+        &series_url,
+        &[
+            ("match[]", r#"ravel_log_lines{job="api"}"#),
+            ("start", &window_start),
+            ("end", &window_end),
+            ("min_commit_token", &logs_commit_token),
+        ],
+    )
+    .await;
+    assert_eq!(status, 200, "body: {body}");
+    let series = body["data"].as_array().expect("series result array");
+    assert_eq!(
+        series.len(),
+        2,
+        "job=api must split into an ERROR series and an INFO series: {series:?}"
+    );
+    let mut severities: Vec<&str> = series
+        .iter()
+        .map(|s| {
+            s.as_object()
+                .expect("label set is an object")
+                .get("severity_text")
+                .and_then(JsonValue::as_str)
+                .expect("severity_text label present")
+        })
+        .collect();
+    severities.sort_unstable();
+    assert_eq!(severities, vec!["ERROR", "INFO"], "series: {series:?}");
+    for label_set in series {
+        let obj = label_set.as_object().expect("label set is an object");
+        assert_eq!(
+            obj.get("__name__").and_then(JsonValue::as_str),
+            Some("ravel_log_lines")
+        );
+        assert_eq!(obj.get("job").and_then(JsonValue::as_str), Some("api"));
+        assert_eq!(
+            obj.get("k8s_pod_name").and_then(JsonValue::as_str),
+            Some("p1")
+        );
+        assert_eq!(
+            obj.get("otel_scope_name").and_then(JsonValue::as_str),
+            Some("scope")
+        );
+        assert_eq!(
+            obj.get("otel_scope_version").and_then(JsonValue::as_str),
+            Some("1.0")
+        );
+        assert!(
+            obj.get("severity_text")
+                .and_then(JsonValue::as_str)
+                .is_some(),
+            "label set: {obj:?}"
+        );
+        assert!(
+            !obj.contains_key("instance"),
+            "fixture sets no service.instance.id, so no series may carry `instance`: {obj:?}"
+        );
+        assert_eq!(
+            obj.len(),
+            6,
+            "expected exactly __name__, job, k8s_pod_name, otel_scope_name, \
+             otel_scope_version, severity_text: {obj:?}"
+        );
+    }
+
+    // --- /api/v1/label/__name__/values ---
+    // No `match[]`, so `resolve_matched_series` resolves the metrics catalog
+    // only (`log_metric_of` never sees a selector to recognize); the two
+    // reserved names are added afterward, unconditionally, by
+    // `include_log_metric_names` rather than through any log-catalog read.
+    // `min_commit_token` must therefore be a token the metrics catalog can
+    // satisfy, not `logs_commit_token`.
+    let (status, body) = get_json(
+        &client,
+        &name_values_url,
+        &[
+            ("start", &window_start),
+            ("end", &window_end),
+            ("min_commit_token", &metrics_commit_token),
+        ],
+    )
+    .await;
+    assert_eq!(status, 200, "body: {body}");
+    let values: Vec<&str> = body["data"]
+        .as_array()
+        .expect("values array")
+        .iter()
+        .map(|v| v.as_str().expect("value is a string"))
+        .collect();
+    assert!(
+        values.contains(&"ravel_log_lines"),
+        "__name__ values must contain ravel_log_lines: {values:?}"
+    );
+    assert!(
+        values.contains(&"ravel_log_bytes"),
+        "__name__ values must contain ravel_log_bytes: {values:?}"
+    );
+
+    // --- /api/v1/metadata ---
+    let (status, body) = get_json(&client, &metadata_url, &[]).await;
+    assert_eq!(status, 200, "body: {body}");
+    assert_eq!(body["data"]["ravel_log_lines"][0]["type"], "gauge");
+    assert_eq!(
+        body["data"]["ravel_log_lines"][0]["help"],
+        "One sample per log line, value 1, derived from the logs signal at query \
+         time (ADR-1103); count_over_time counts lines."
+    );
+    assert_eq!(body["data"]["ravel_log_lines"][0]["unit"], "");
+    assert_eq!(body["data"]["ravel_log_bytes"][0]["type"], "gauge");
+    assert_eq!(
+        body["data"]["ravel_log_bytes"][0]["help"],
+        "One sample per log line whose value is the line body's length in bytes \
+         (ADR-1103); sum_over_time sums bytes."
+    );
+    assert_eq!(body["data"]["ravel_log_bytes"][0]["unit"], "bytes");
+
+    // --- The metrics lane is unaffected by the logs export: querying the
+    // metric ingested above returns exactly what it would with no logs
+    // present at all. ---
+    let (status, body) = get_json(
+        &client,
+        &query_url,
+        &[
+            ("query", "demo_requests_total"),
+            ("time", &eval_time),
+            ("min_commit_token", &metrics_commit_token),
+        ],
+    )
+    .await;
+    assert_eq!(status, 200, "body: {body}");
+    let results = vector_results(&body);
+    assert_eq!(results.len(), 1, "expected exactly one series: {results:?}");
+    assert_eq!(results[0]["metric"]["__name__"], "demo_requests_total");
+    assert_eq!(results[0]["metric"]["job"], "checkout");
+    assert!(
+        (instant_value(&results[0]) - METRIC_VALUE).abs() < f64::EPSILON,
+        "metric value: {}",
+        results[0]
+    );
+    // Total lines/bytes fixture sanity: named constants, not restated
+    // literals, so a change to a body above is caught here rather than
+    // silently drifting the assertions that use the totals.
+    assert_eq!(API_TOTAL_LINES, 8);
+    assert_eq!(API_TOTAL_BYTES, 166);
+    assert_eq!(WORKER_TOTAL_BYTES, 66);
+
+    running.shutdown().await.expect("graceful shutdown");
+}


### PR DESCRIPTION
The engine and HTTP wiring landed with no proof that a real server
answers a log selector from real ingest, and the documentation still told
readers the surface did not exist.

This adds a server-level test that exports one OTLP logs payload over
HTTP, reads the commit token back, and queries the running router with
that token: aggregated line counts per job, a byte total, a body-matcher
count, a range query whose steps straddle a shared timestamp, the series
and label-values endpoints, and the metadata entries, each asserted
against named constants rather than loose comparisons. A metrics query on
the same server is asserted unchanged.

The docs now describe what ships. The README no longer says logs have no
PromQL surface, its support matrix lists the two reserved names, and the
sentence claiming SQL is the only way to query logs is corrected. The
query guide gains a section covering the metric definitions, the label
mapping, the body matcher, the routing rule, the ordering of samples
sharing a timestamp, and the shared query budgets. The ingest guide, the
query-engine flow, and the architecture overview name the log lane.

Two mistakes in the test itself were found and fixed while writing it: an
unaligned base timestamp shifted every range step under right-inclusive
window semantics, and the label-values endpoint resolves against the
metrics catalog, so passing a logs commit token there is unsatisfiable.
Neither was an engine defect.

Part of epic #1103 (wave 3, task T4).

Fixes: #1109
