### PR TITLE
docs: split the fetch epic into two decidable ADRs

### DIFF
--- a/docs/adrs/1195-unbundle-fetch-concurrency.md
+++ b/docs/adrs/1195-unbundle-fetch-concurrency.md
@@ -101,7 +101,7 @@ the process, which this ADR does not propose.
 three. Supplying it together with any of the new flags is a **startup error**
 naming both, not a silent precedence rule.
 
-**Compatibility changes are named, not denied.** Two behaviours change for
+**Compatibility changes are named, not denied.** Three behaviours change for
 existing deployments:
 
 - **RSEG fetchers are raised and then shared.** They move from the compiled
@@ -115,7 +115,7 @@ existing deployments:
 - The distributed fragment path stops being able to exceed the node limit by
   constructing a fetcher per fragment.
 
-Both are the point of the change. Neither is invisible, so the release notes say
+All three are the point of the change. None is invisible, so the release notes say
 so rather than claiming no deployment is affected.
 
 ## Rejected alternatives

--- a/docs/adrs/1195-unbundle-fetch-concurrency.md
+++ b/docs/adrs/1195-unbundle-fetch-concurrency.md
@@ -1,0 +1,131 @@
+# ADR-1195: Unbundle `--fetch-concurrency`, and make GET concurrency a process-wide limit
+
+- Status: Proposed
+- Date: 2026-09-03
+- Refs: #1195, #1191, #1170, #1185, ADR-0087, ADR-0088, ADR-0107
+
+## Context
+
+`--fetch-concurrency` is one flag driving four consumers:
+
+```
+crates/ravel-query/src/engine.rs:358, :369        with_max_concurrent_gets()  RLOG GET semaphore
+services/ravel-server/src/query.rs:333            with_max_concurrent_gets()  RLOG GET semaphore
+crates/ravel-sql/src/session.rs:540               with_target_partitions()    DataFusion partitions
+crates/ravel-query/src/engine.rs:1366,1784,2092   buffer_unordered()          PromQL fan-out
+```
+
+This coupling is documented, not accidental: `docs/reference/ravel-server-flags.md:39`
+names all three effects, and ADR-0088's amendment records the derived default
+`max(8, 2 x cores)` while noting "it also sets the SQL scan partition count".
+This ADR supersedes that part of ADR-0088's decision.
+
+Two defects sit behind the one name.
+
+**The GET-concurrency half never reaches two of the three fetchers.** The RSEG
+`SegmentFetcher` is constructed bare at every site, so it keeps the compiled
+`DEFAULT_MAX_CONCURRENT_GETS = 16` (`crates/ravel-query/src/fetcher.rs:127`)
+whatever the operator sets: `crates/ravel-query/src/engine.rs:374`,
+`services/ravel-server/src/query.rs:306`,
+`services/ravel-server/src/distrib.rs:796`,
+`services/ravel-server/src/cache_warm.rs:99`. `SpanSegmentFetcher` has no
+semaphore at all (`crates/ravel-query/src/span_fetcher.rs:169-193`). PromQL and
+the SQL metrics path therefore ignore the knob that documents itself as governing
+their GET concurrency.
+
+**A permit count is not a node limit.** `get_semaphore` is a field on each
+fetcher instance (`crates/ravel-query/src/fetcher.rs:579`), and fetchers are
+constructed independently per query engine, per SQL executor, and — in the
+distributed path — per fragment request (`distrib.rs:796`). Giving each one N
+permits admits a multiple of N concurrent GETs against the store, with no
+process-level ceiling anywhere.
+
+The performance case for raising GET concurrency on the whole-object path does
+not survive scrutiny and is deliberately not claimed here. Stock at concurrency
+32 against 256 measured 525.0 s against 486.0 s, but the implied per-statement
+fixed cost differs by 1.1 s between those runs and the byte volume differs by
+3.2%, so the 7.4% is not attributable to concurrency (#1185). This ADR is a
+correctness and reachability fix. The configuration where concurrency
+demonstrably matters is the ranged path (596.3 s of transfer at 32 against
+171.0 s at 256), and selecting that path is ADR-1196's decision, not this one.
+
+```mermaid
+flowchart LR
+    F["--fetch-concurrency"] --> G["GET concurrency"]
+    F --> P["SQL partitions"]
+    F --> Q["PromQL fan-out"]
+    G --> S["one process-owned limiter"]
+    S --> R1["RLOG fetchers"]
+    S --> R2["RSEG fetchers<br/>(today: unreached, pinned 16)"]
+    S --> R3["RSPAN fetcher<br/>(today: no semaphore)"]
+    style R2 fill:#fdd,stroke:#900
+    style R3 fill:#fdd,stroke:#900
+```
+
+## Decision
+
+**Three named knobs**, each with its own flag and its own derived default:
+
+| Knob | Governs | Derived default |
+|---|---|---|
+| store GET concurrency | permits against the object store | `max(8, 2 x cores)`, unchanged from today's derived value |
+| SQL partition count | DataFusion `target_partitions` | today's derived value, unchanged |
+| PromQL fan-out | `buffer_unordered` width | today's derived value, unchanged |
+
+No default moves. The SQL partition default in particular stays where it is:
+`crates/ravel-sql/src/session.rs:540-544` sets `target_partitions` immediately
+above `with_repartition_aggregations`, which ADR-0094 and ADR-0954 depend on, and
+moving it silently would put those in scope.
+
+**GET concurrency becomes one process-owned limiter**, an `Arc` constructed once
+and shared by every query-side fetcher, replacing the per-fetcher semaphore. The
+RSEG `SegmentFetcher` and `SpanSegmentFetcher` are wired to it at every
+construction site. The flag then means what it says: a node-wide ceiling on
+concurrent store GETs.
+
+**Legacy precedence is explicit.** `--fetch-concurrency` remains, setting all
+three. Supplying it together with any of the new flags is a **startup error**
+naming both, not a silent precedence rule.
+
+**Compatibility changes are named, not denied.** Two behaviours change for
+existing deployments:
+
+- RSEG and RSPAN fetchers begin honouring the GET limit. On a 16-core host that
+  raises their effective concurrency from the compiled 16 to 32, and it makes
+  them subject to a shared ceiling they previously escaped.
+- The distributed fragment path stops being able to exceed the node limit by
+  constructing a fetcher per fragment.
+
+Both are the point of the change. Neither is invisible, so the release notes say
+so rather than claiming no deployment is affected.
+
+## Rejected alternatives
+
+**Leave the flag bundled and document it better.** It is already documented
+(`ravel-server-flags.md:39`); documentation is not the defect. The defects are
+that two fetchers ignore the knob and that no ceiling is process-wide.
+
+**Keep the per-fetcher semaphore and just wire it everywhere.** Simpler, and it
+fixes reachability. Rejected because it leaves the multiplication: the
+distributed path constructs a fetcher per fragment, so per-fetcher permits give
+no node-level bound at all, which is the property an operator setting this flag
+believes they are buying.
+
+**Move the SQL partition default at the same time.** Tempting, since 256
+partitions cost roughly 19 GB of process peak in measurement. Rejected: that
+number is a whole-process peak that also contains the read cache and up to
+11.24 GB of cached corpus, so it does not isolate the partition cost, and
+changing that default pulls ADR-0094's aggregation gate into scope.
+
+## Consequences
+
+- The knob an operator sets for GET concurrency starts governing every fetcher
+  and the process as a whole.
+- ADR-0088's amendment is superseded in the part that records `fetch_concurrency`
+  as the single knob for both scan fan-out and GET concurrency. ADR-0107 ties the
+  RLOG pool sizing to the same flag and needs re-reading against the split before
+  this lands.
+- Three flags where there was one, plus a deprecated alias. The reference doc and
+  the derived-defaults table both change.
+- No performance claim. If a benchmark moves on this change alone, that is a
+  finding to investigate, not the expected outcome.

--- a/docs/adrs/1195-unbundle-fetch-concurrency.md
+++ b/docs/adrs/1195-unbundle-fetch-concurrency.md
@@ -8,7 +8,7 @@
 
 `--fetch-concurrency` is one flag driving four consumers:
 
-```
+```text
 crates/ravel-query/src/engine.rs:358, :369        with_max_concurrent_gets()  RLOG GET semaphore
 services/ravel-server/src/query.rs:333            with_max_concurrent_gets()  RLOG GET semaphore
 crates/ravel-sql/src/session.rs:540               with_target_partitions()    DataFusion partitions
@@ -72,7 +72,13 @@ flowchart LR
 | `--sql-partition-count` | count of partitions | DataFusion `target_partitions` (`crates/ravel-sql/src/session.rs:540`) | `max(8, 2 x cores)` |
 | `--promql-fetch-fanout` | count of in-flight futures | `buffer_unordered` width (`crates/ravel-query/src/engine.rs:1366,1784,2092`) | `max(8, 2 x cores)` |
 
-Every unit is a positive integer count; zero is rejected at startup. All three
+Every unit is a positive integer count. Zero is rejected during configuration
+resolution, before any fetcher or SQL session is constructed, and
+`EngineConfig::validate` gains the same check for direct construction. Today
+nothing rejects it: `with_max_concurrent_gets` silently converts zero to one
+and the SQL session applies `.max(1)` to the partition count, so an operator
+who sets zero gets one without being told. A refused startup is the honest
+answer to a value that has no meaning. All three
 formulas are today's single derived default, so **no default moves**: the split
 changes which knob an operator turns, not what an untouched deployment does. The
 `max(8, ...)` floor and the `2 x cores` factor come from
@@ -104,9 +110,15 @@ naming both, not a silent precedence rule.
 **Compatibility changes are named, not denied.** Three behaviours change for
 existing deployments:
 
-- **RSEG fetchers are raised and then shared.** They move from the compiled
+- **RSEG fetchers start honouring the limit, and are shared.** For a
+  deployment with no explicit legacy value they move from the compiled
   `DEFAULT_MAX_CONCURRENT_GETS = 16` to the derived default, 32 on a 16-core
-  host, and become subject to a shared ceiling they previously escaped.
+  host. For a deployment that set `--fetch-concurrency` explicitly, the
+  alias now reaches RSEG too, so RSEG moves to THAT value: a deployment on
+  `--fetch-concurrency=8` takes RSEG from 16 down to 8, and one on `64`
+  raises it to 64. Either way RSEG becomes subject to a shared ceiling it
+  previously escaped, and either way the change is a consequence of the
+  operator's existing setting finally applying where it was documented to.
 - **RSPAN fetchers are constrained for the first time.** `SpanSegmentFetcher`
   has no semaphore today, so its GET concurrency is bounded only by its caller.
   Wiring it to the limiter is a restriction, not a raise, and it is the one

--- a/docs/adrs/1195-unbundle-fetch-concurrency.md
+++ b/docs/adrs/1195-unbundle-fetch-concurrency.md
@@ -64,13 +64,21 @@ flowchart LR
 
 ## Decision
 
-**Three named knobs**, each with its own flag and its own derived default:
+**Three named knobs**, each with its own flag, unit and derived default:
 
-| Knob | Governs | Derived default |
-|---|---|---|
-| store GET concurrency | permits against the object store | `max(8, 2 x cores)`, unchanged from today's derived value |
-| SQL partition count | DataFusion `target_partitions` | today's derived value, unchanged |
-| PromQL fan-out | `buffer_unordered` width | today's derived value, unchanged |
+| Flag | Unit | Governs | Derived default |
+|---|---|---|---|
+| `--store-get-concurrency` | count of permits | concurrent GETs against the object store, process-wide | `max(8, 2 x cores)` |
+| `--sql-partition-count` | count of partitions | DataFusion `target_partitions` (`crates/ravel-sql/src/session.rs:540`) | `max(8, 2 x cores)` |
+| `--promql-fetch-fanout` | count of in-flight futures | `buffer_unordered` width (`crates/ravel-query/src/engine.rs:1366,1784,2092`) | `max(8, 2 x cores)` |
+
+Every unit is a positive integer count; zero is rejected at startup. All three
+formulas are today's single derived default, so **no default moves**: the split
+changes which knob an operator turns, not what an untouched deployment does. The
+`max(8, ...)` floor and the `2 x cores` factor come from
+`MIN_DERIVED_FETCH_CONCURRENCY` and `FETCH_CONCURRENCY_PER_CORE`
+(`services/ravel-server/src/config.rs:1548-1553`) and are carried over unchanged
+so that the three can diverge later, deliberately, rather than by accident here.
 
 No default moves. The SQL partition default in particular stays where it is:
 `crates/ravel-sql/src/session.rs:540-544` sets `target_partitions` immediately
@@ -80,8 +88,14 @@ moving it silently would put those in scope.
 **GET concurrency becomes one process-owned limiter**, an `Arc` constructed once
 and shared by every query-side fetcher, replacing the per-fetcher semaphore. The
 RSEG `SegmentFetcher` and `SpanSegmentFetcher` are wired to it at every
-construction site. The flag then means what it says: a node-wide ceiling on
-concurrent store GETs.
+construction site. The flag then means what it says: a **process-wide** ceiling
+on concurrent store GETs.
+
+Process-wide, not node-wide: an `Arc` coordinates the fetchers inside one server
+process and cannot see a second process on the same host. A node running two
+`ravel-server` processes can still issue twice this number of concurrent GETs,
+and nothing here changes that. A node-wide bound would need a mechanism outside
+the process, which this ADR does not propose.
 
 **Legacy precedence is explicit.** `--fetch-concurrency` remains, setting all
 three. Supplying it together with any of the new flags is a **startup error**
@@ -90,9 +104,14 @@ naming both, not a silent precedence rule.
 **Compatibility changes are named, not denied.** Two behaviours change for
 existing deployments:
 
-- RSEG and RSPAN fetchers begin honouring the GET limit. On a 16-core host that
-  raises their effective concurrency from the compiled 16 to 32, and it makes
-  them subject to a shared ceiling they previously escaped.
+- **RSEG fetchers are raised and then shared.** They move from the compiled
+  `DEFAULT_MAX_CONCURRENT_GETS = 16` to the derived default, 32 on a 16-core
+  host, and become subject to a shared ceiling they previously escaped.
+- **RSPAN fetchers are constrained for the first time.** `SpanSegmentFetcher`
+  has no semaphore today, so its GET concurrency is bounded only by its caller.
+  Wiring it to the limiter is a restriction, not a raise, and it is the one
+  change here that can make a workload slower. Span-heavy deployments should be
+  told so in the release notes rather than discovering it.
 - The distributed fragment path stops being able to exceed the node limit by
   constructing a fetcher per fragment.
 
@@ -122,9 +141,13 @@ changing that default pulls ADR-0094's aggregation gate into scope.
 - The knob an operator sets for GET concurrency starts governing every fetcher
   and the process as a whole.
 - ADR-0088's amendment is superseded in the part that records `fetch_concurrency`
-  as the single knob for both scan fan-out and GET concurrency. ADR-0107 ties the
-  RLOG pool sizing to the same flag and needs re-reading against the split before
-  this lands.
+  as the single knob for both scan fan-out and GET concurrency. That supersession
+  takes effect when this ADR is accepted and implemented; while it is `Proposed`,
+  ADR-0088 and the production wiring are unchanged and remain authoritative.
+- ADR-0107 sizes the RLOG fetch pool from the same flag and is **not** reconciled
+  here. Implementation must decide which of the three new knobs that sizing
+  follows, and record the answer in ADR-0107, before the split lands. Until then
+  ADR-0107 stands as written.
 - Three flags where there was one, plus a deprecated alias. The reference doc and
   the derived-defaults table both change.
 - No performance claim. If a benchmark moves on this change alone, that is a

--- a/docs/adrs/1196-fetch-objective-cost-first-default-latency-first-policy.md
+++ b/docs/adrs/1196-fetch-objective-cost-first-default-latency-first-policy.md
@@ -1,0 +1,126 @@
+# ADR-1196: Keep the cost-first fetch default, add a latency-first policy
+
+- Status: Proposed
+- Date: 2026-09-03
+- Refs: #1196, #1191, #1170, #1007, #1185, ADR-0904, ADR-0996, ADR-0046
+
+## Context
+
+The fetch objective decides, for every logs scan, whether to read an object whole
+or to range-read the blocks a projection needs. Today that decision is made
+purely on money.
+
+`resolve_logs_fetch` derives a byte scalar from the active `StoreCostProfile`
+(`crates/ravel-query/src/config.rs:255-324`). ADR-0904 defines the unit as a pure
+price ratio: "`price_per_request / price_per_byte` has units of bytes, so a byte
+value expresses every dollar preference exactly." The only shipped profile,
+`s3-intra-region-2026`, prices transfer and retrieval at zero
+(`crates/ravel-types/src/cost_profile.rs:149-156`), so `resolve_cost_based_rate`
+returns `u64::MAX` (`config.rs:301-309`) and whole-object reads always win.
+Nothing in the model expresses time.
+
+Measured on the reference machine, true cold, 42 statements, 2,617 objects /
+11.24 GB (#1185):
+
+| Configuration | Bytes | Time | GET requests |
+|---|---|---|---|
+| `cost-based` (stock) @ concurrency 256 | 463.79 GB | 486.0 s | 104,780 |
+| `byte-minimal` @ concurrency 256 | 150.28 GB | **285.8 s** | 570,752 |
+
+**The money-minimising objective selects the slower plan, by 41%.** That is the
+finding this ADR exists to answer. It is not an argument that the objective is
+wrong: intra-region bytes really are free, so cost-based is right about the bill.
+It is an argument that the bill is not the only thing an operator may be
+optimising, and that today they cannot say so.
+
+Two things this ADR does not claim, both refuted earlier in the investigation:
+
+- That `DEFAULT_LOG_REQUEST_COST_BYTES` is mispriced by ~27x at high concurrency.
+  Both `byte-minimal` rows used that same scalar and issued identical requests
+  and identical bytes, so it was never the variable between the losing and
+  winning runs.
+- That raising concurrency alone delivers the win. On the whole-object path it
+  measured 7.4%, which does not survive the per-statement floor discrepancy in
+  the same data. Concurrency is what makes the ranged path viable (596.3 s of
+  transfer at 32 against 171.0 s at 256), not a win in itself. ADR-1195 covers
+  the knob.
+
+## Decision
+
+**Cost-first remains the default.** `cost-based` at the reference profile keeps
+resolving to whole-object reads. A deployment that has not asked for anything
+else keeps the cheaper S3 bill, and the published stock ClickBench entry
+continues to reflect it.
+
+**Add `latency-first` as a named policy.** Selected explicitly by the operator,
+it prefers the plan that finishes sooner where the two objectives disagree,
+which in practice means ranged reads for narrow projections. It is an intent, not
+a tuning constant: it says "spend requests to save wall time", and the engine
+decides how.
+
+The trade is stated in the flag's own documentation, not buried: **5.45x the GET
+requests** (570,752 against 104,780 over one pass) for **41% less cold time**.
+Intra-region transfer is free and requests are billed, so this is money for time
+at a rate the operator, not Ravel, should choose.
+
+**`latency-first` carries a memory precondition, and says so.** At the
+concurrency it needs to pay off, the ranged path is not currently survivable: one
+long-lived server running the same statements was OOM-killed where the
+whole-object server completed (#1185, #1170). Until in-flight fetch memory is
+bounded, the policy ships with its supported concurrency documented as bounded,
+and the flag's docs point at #1170 and #1007. Shipping it silently at a setting
+that kills the process would be worse than not shipping it.
+
+**Both ClickBench entries get published**, labelled: a stock entry on default
+settings, and a tuned entry naming `latency-first` and the concurrency it uses.
+Upstream accepts labelled tuned entries, so the default stays honest about the
+bill while the benchmark shows what the engine can do.
+
+## Rejected alternatives
+
+**Make `byte-minimal` the default.** It is the fast configuration and it needs no
+new policy name. Rejected twice over: at the default concurrency it measured
+712.4 s against 525.0 s, 36% *worse*, so as a default it is a regression for
+anyone who does not also raise concurrency; and at the concurrency where it wins
+it OOMs a long-lived server. A default must be safe at its own defaults.
+
+**Give `cost-based` a time term, so one policy balances both.** The intellectually
+tidier answer, and the direction a future ADR may take. Rejected for now because
+the model has no live time input: bandwidth and latency are properties of the
+instance, not of the store, and `StoreCostProfile` is explicitly "this
+deployment's object-store prices" (`crates/ravel-types/src/cost_profile.rs:110-140`).
+Putting NIC bandwidth into a profile named `s3-intra-region-2026`, shared across
+every instance type, is a category error. A named policy expresses the operator's
+intent without pretending to have measured their hardware.
+
+**Set a non-zero `transfer_nanodollars_per_gib` so `cost-based` stops
+saturating.** One line, no new fields. Rejected because it lies about the bill to
+obtain a behaviour, and the number required has no defensible value in dollars.
+
+**Tune `--logs-request-cost-bytes` and add no policy.** The flag exists, wins over
+policy (`crates/ravel-query/src/config.rs:263-267`), and reaches the same routing
+today. It stays the right escape hatch for an operator experimenting. Rejected as
+the answer because it asks operators to express an intent as a magic byte count,
+and it does not make the resulting configuration safe.
+
+## Consequences
+
+- An operator can ask for latency and get it, at a stated price in requests.
+- The default S3 bill does not change for anyone who does not opt in.
+- Two ClickBench entries to maintain, and the tuned one cannot be published until
+  the memory work makes its configuration survivable. That ordering is the point:
+  the tuned entry is a claim about what the engine does, and it must not be a
+  claim about a configuration that dies at statement 31.
+- Cost-regression bands move on the tuned lane only. `[data_gets]`
+  (`crates/ravel-bench/cost_regression_bands.toml:38`, `kind = "exact"`) and the
+  two-sided `[modeled_request_cost]` (`:56-58`) both fail on a 5.45x request
+  change and must be re-banded per lane. `[bytes]` is one-sided and a reduction
+  passes it (`:6-10`), so it does not.
+- `[peak_memory]` is `expected = false` in that file, so the memory property this
+  policy depends on has no gate today. It should become an emitted and enforced
+  figure in the tuned lane before that lane is published.
+- The tests pinning cost-based's present resolution stay green and unmodified:
+  `policy_to_rate_mapping_table_is_pinned` and
+  `cost_based_high_saturation_boundary_is_pinned`
+  (`crates/ravel-query/src/config.rs:483,708`). This ADR adds a policy; it does
+  not alter the existing ones.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -143,3 +143,5 @@ the reservation commit that used to work around it.
 | [1101](1101-alerts-and-audit-sql-tables.md) | Register the `alerts` and `audit` SQL tables | Accepted (2026-09-03) |
 | [1103](1103-promql-over-logs.md) | PromQL over logs: `ravel_log_lines` and `ravel_log_bytes` | Accepted |
 | [1113](1113-tla-verification-suite.md) | TLA+ verification suite for the commit, catalog, lifecycle, resharding, and maintenance protocols | Proposed |
+| [1195](1195-unbundle-fetch-concurrency.md) | Unbundle `--fetch-concurrency`, and make GET concurrency a process-wide limit | Proposed |
+| [1196](1196-fetch-objective-cost-first-default-latency-first-policy.md) | Keep the cost-first fetch default, add a latency-first policy | Proposed |


### PR DESCRIPTION
docs: split the fetch epic into two decidable ADRs

Three rounds of adversarial review blocked a single combined ADR. The blocking
gap was structural rather than editorial: the draft claimed a measured 46% cold
improvement while rejecting or withdrawing every decision that would select the
path producing it, and its memory-governance design did not survive contact with
the two fetch paths it had to govern.

ADR-1195 takes the part that is a correctness fix and nothing else.
--fetch-concurrency drives GET concurrency, DataFusion's partition count and the
PromQL fan-out from one number; the GET half never reaches the RSEG or RSPAN
fetchers, and the semaphore is per-fetcher while fetchers are constructed per
engine, per executor and per distributed fragment, so the flag is not a node
limit. Three named knobs, every derived default unchanged, one process-owned
limiter. It makes no performance claim, because the 7.4% previously credited to
concurrency does not survive the per-statement floor discrepancy in the same
data.

ADR-1196 takes the part that is a product decision. The money-minimising
objective selects the slower plan by 41% on this corpus. Cost-first stays the
default so an unchanged deployment keeps the cheaper bill; latency-first becomes
a named policy stating its price, 5.45x the GET requests, and carrying an
explicit memory precondition because the ranged path at the concurrency it needs
is not yet survivable. Both ClickBench entries get published, stock and tuned.

The memory governor is deliberately absent. Reservations have to follow
allocation ownership rather than request lifetime, the minimum-progress unit is
not knowable at admission, and the existing join_all paths cannot degrade without
a scheduler rewrite. It returns as its own ADR once those are designed and the
12 GB attribution is isolated by measurement rather than inferred.

Refs: #1191, #1170, #1007
