### PR TITLE
fix(tla): enforce the TLC wall-clock budget with GNU timeout(1)

### DIFF
--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -47,9 +47,14 @@ Requires Java 17 or newer (Temurin 21 is what CI uses). The harness resolves
 Java from `RAVEL_TLA_JAVA` if set, else `java` on `PATH`, and exits 2 if none
 is usable. It needs network access on first run only to fetch the TLC jar,
 unless you supply one with `RAVEL_TLA_TOOLS_JAR` (see below). The per-model
-wall-clock ceiling needs coreutils `timeout` (`gtimeout` from Homebrew
-coreutils on macOS); without either the run proceeds unbounded and the harness
-says so once. CI and the fleet executors always have `timeout`.
+wall-clock ceiling prefers coreutils `timeout` (`gtimeout` from Homebrew
+coreutils on macOS). Without either, a pure-shell watchdog enforces the same
+budget: it runs TLC in its own process group, and on expiry records the
+timeout and terminates the whole group, so an over-budget run is reported as
+a timeout rather than left running. The verdict follows whether the watchdog
+killed the run, not a clock reading, so a run that finishes on its own keeps
+its own exit status. CI and the fleet executors have `timeout` and take the
+first path.
 
 ```sh
 scripts/check-tla.sh smoke            # fast safety, every area (budget 300s/cfg)

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -71,7 +71,8 @@ scripts/check-tla.sh smoke -a common  # scope any subcommand to one area
 
 `ci` and `all` record every model under a single run id, so `last-run.tsv` is
 one coherent run rather than a config's rows overwriting the previous config's.
-Exit codes: `0` pass, `1` a check failed, `2` no usable Java. A subcommand or
+Exit codes: `0` pass, `1` a check failed, `2` no usable Java or GNU
+timeout(1) unavailable. A subcommand or
 `-a` area that does not exist, and `-a` with no value, fail immediately.
 
 ### The TLC jar

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -46,15 +46,18 @@ config. New areas planned by ADR-1113:
 Requires Java 17 or newer (Temurin 21 is what CI uses). The harness resolves
 Java from `RAVEL_TLA_JAVA` if set, else `java` on `PATH`, and exits 2 if none
 is usable. It needs network access on first run only to fetch the TLC jar,
-unless you supply one with `RAVEL_TLA_TOOLS_JAR` (see below). The per-model
-wall-clock ceiling prefers coreutils `timeout` (`gtimeout` from Homebrew
-coreutils on macOS). Without either, a pure-shell watchdog enforces the same
-budget: it runs TLC in its own process group, and on expiry records the
-timeout and terminates the whole group, so an over-budget run is reported as
-a timeout rather than left running. The verdict follows whether the watchdog
-killed the run, not a clock reading, so a run that finishes on its own keeps
-its own exit status. CI and the fleet executors have `timeout` and take the
-first path.
+unless you supply one with `RAVEL_TLA_TOOLS_JAR` (see below).
+
+The per-model wall-clock ceiling requires GNU `timeout(1)`. Linux ships it as
+`timeout`; on macOS install it with `brew install coreutils`, which provides
+it as `gtimeout`. The harness resolves the binary once at startup, before
+any model runs, and exits 2 with a one-line refusal if neither is GNU
+coreutils' `timeout` (a look-alike that doesn't support `--kill-after` is
+rejected the same as no binary at all). Every TLC invocation runs under
+`timeout --kill-after=30 <budget>`: TERM at the budget, KILL 30 seconds
+later if TERM was ignored. Either way the run is reported as a timeout, not
+left running and not read as a pass. CI runs on Ubuntu, which ships GNU
+`timeout`, so it needs no extra setup.
 
 ```sh
 scripts/check-tla.sh smoke            # fast safety, every area (budget 300s/cfg)

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -46,7 +46,8 @@ config. New areas planned by ADR-1113:
 Requires Java 17 or newer (Temurin 21 is what CI uses). The harness resolves
 Java from `RAVEL_TLA_JAVA` if set, else `java` on `PATH`, and exits 2 if none
 is usable. It needs network access on first run only to fetch the TLC jar,
-unless you supply one with `RAVEL_TLA_TOOLS_JAR` (see below).
+unless you supply one with `RAVEL_TLA_TOOLS_JAR` (see below). The
+traceability lane runs no TLC and needs no Java at all.
 
 The per-model wall-clock ceiling requires GNU `timeout(1)`. Linux ships it as
 `timeout`; on macOS install it with `brew install coreutils`, which provides

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -14,7 +14,8 @@
 #   ci           [-a AREA]   smoke + negative + traceability under one run id
 #   all          [-a AREA]   ci, then exhaustive, under one run id
 #
-# Exit codes: 0 pass; 1 a check failed; 2 toolchain missing (no usable Java).
+# Exit codes: 0 pass; 1 a check failed; 2 toolchain missing (no usable Java
+# or no GNU timeout(1)).
 #
 # The TLC jar is resolved once and checksum-pinned. Set RAVEL_TLA_TOOLS_JAR to
 # an operator-supplied jar (verified against the pin, never downloaded); else it
@@ -29,6 +30,9 @@ TLA_JAR_URL="https://github.com/tlaplus/tlaplus/releases/download/v${TLA_VERSION
 
 SMOKE_BUDGET=300
 EXHAUSTIVE_BUDGET=3600
+TIMEOUT_KILL_AFTER=30
+
+TIMEOUT_BIN=""
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 FORMAL_DIR="$REPO_ROOT/formal/tla"
@@ -61,6 +65,28 @@ resolve_java() {
     fi
     JAVA="$java"
     note "java: $java (version $ver)"
+}
+
+# resolve_timeout: pick GNU timeout(1) once, before any lane launches
+# anything, so a run that would otherwise start unbounded refuses instead.
+# Only GNU coreutils' timeout supports --kill-after, which is the mechanism
+# every budget in this script relies on; BSD/macOS ship no `timeout` at all,
+# so the coreutils one arrives as `gtimeout` there (Homebrew). A `timeout`
+# on PATH that isn't GNU coreutils (some minimal containers ship a look-alike)
+# is rejected the same as no binary at all: it silently drops --kill-after
+# and turns a hang into an unbounded run instead of a report.
+resolve_timeout() {
+    local candidate
+    for candidate in timeout gtimeout; do
+        if command -v "$candidate" >/dev/null 2>&1 \
+            && "$candidate" --version 2>/dev/null | grep -qi 'GNU coreutils'; then
+            TIMEOUT_BIN="$candidate"
+            note "timeout: $candidate (GNU coreutils)"
+            return 0
+        fi
+    done
+    note "GNU timeout(1) not found; on macOS run: brew install coreutils"
+    exit 2
 }
 
 # sha256 of a file: coreutils sha256sum where present, else the shasum that
@@ -168,108 +194,18 @@ record_row() {
         "$RUN_ID" "$1" "$2" "$3" "$4" "$5" "$6" "$7" >> "$LAST_RUN"
 }
 
-# run_with_deadline <budget-seconds> <logfile> <cwd> <cmd...>
-# Pure-shell fallback for timeout(1)/gtimeout(1) when neither is on PATH.
-# Runs <cmd...> in <cwd> as a backgrounded job under job control, which gives
-# it its own process group, so a JVM's own children can't survive the
-# wrapper the way they would from a plain `kill $pid`. Returns 124 on
-# expiry, matching timeout(1)'s convention, so callers already keyed off
-# that exit code work unchanged.
-#
-# The deadline is enforced by a timer running alongside the job, not by
-# polling: a poll interval can't tell "exited just before the deadline"
-# from "exited just after it" apart, since both look identical between two
-# polls. The timer fires once at exactly the budget, checks the job is
-# still alive right there, and only then kills it and records the timeout
-# (in that order, so a job that finishes in the same instant the timer
-# expires is checked before, not after, the kill). The verdict is keyed on
-# whether that record was made, never on a clock reading: still alive at
-# the deadline is always killed and always 124, exited on its own before
-# the timer acts is always its own status.
-run_with_deadline() {
-    local budget="$1" logfile="$2" cwd="$3"
-    shift 3
-    local flag
-    flag="$(mktemp -u "${TMPDIR:-/tmp}/check-tla-deadline.XXXXXX")" || return 1
-    (
-        set -m
-        cd "$cwd" && "$@" > "$logfile" 2>&1 &
-        local pid=$!
-        local timer_pid=""
-
-        terminate_group() {
-            kill -TERM -"$pid" 2>/dev/null
-            sleep 1
-            kill -KILL -"$pid" 2>/dev/null
-            wait "$pid" 2>/dev/null
-        }
-        cancel_timer() {
-            [ -n "$timer_pid" ] || return 0
-            kill -TERM -"$timer_pid" 2>/dev/null
-            wait "$timer_pid" 2>/dev/null
-        }
-        on_term() { terminate_group; cancel_timer; exit 143; }
-        on_int()  { terminate_group; cancel_timer; exit 130; }
-        on_hup()  { terminate_group; cancel_timer; exit 129; }
-        trap on_term TERM
-        trap on_int INT
-        trap on_hup HUP
-
-        # The timer job: its `sleep` and the `if` after it share the timer
-        # process's own group (set -m puts every backgrounded job in its
-        # own group), so killing that one pid's group from cancel_timer
-        # reaps the sleep too and nothing outlives this function.
-        ( sleep "$budget"
-          if kill -0 "$pid" 2>/dev/null; then
-              : > "$flag"
-              terminate_group
-          fi
-        ) &
-        timer_pid=$!
-
-        local code=0
-        wait "$pid" || code=$?
-        cancel_timer
-
-        if [ -f "$flag" ]; then
-            exit 124
-        fi
-        exit "$code"
-    ) &
-    local watchdog_pid=$!
-    # The watchdog subshell keeps our own process group; only the TLC job it
-    # backgrounds under `set -m` gets a group of its own. So a plain
-    # `kill <our-pid>` from outside (a terminal interrupt, or a harness
-    # killing this script) never reaches the subshell on its own. Forward
-    # the signal to it directly so its own trap, where TLC's pid is in
-    # scope, actually runs and can tear down TLC's group.
-    trap 'kill -TERM "$watchdog_pid" 2>/dev/null' TERM
-    trap 'kill -INT  "$watchdog_pid" 2>/dev/null' INT
-    trap 'kill -HUP  "$watchdog_pid" 2>/dev/null' HUP
-    # A forwarded signal interrupts this wait before the watchdog has
-    # actually torn down TLC's group: bash returns wait early with
-    # 128+signum right when the trap runs, not when watchdog_pid exits.
-    # Keep waiting on the same pid (valid until it's reaped) so this
-    # function can't return, and rm the flag, while that teardown is
-    # still in flight. Once wait completes without the pid still being
-    # alive, its exit status is the watchdog's real one, which for a
-    # forwarded signal is already the conventional 128+signum from the
-    # watchdog's own on_term/on_int/on_hup handler.
-    local code=0
-    while :; do
-        code=0
-        wait "$watchdog_pid" || code=$?
-        kill -0 "$watchdog_pid" 2>/dev/null || break
-    done
-    trap - TERM INT HUP
-    rm -f "$flag"
-    return "$code"
-}
-
 # --- TLC invocation ---------------------------------------------------------
 # Runs TLC on one cfg. Echoes the log path. Returns TLC's exit code.
 # CHECK_DEADLOCK FALSE in a cfg means the model has intentional stutter/terminal
 # states, so pass -deadlock (TLC's flag that DISABLES the deadlock check).
+#
+# The wall-clock ceiling is GNU timeout(1), resolved once into $TIMEOUT_BIN
+# by resolve_timeout before any area runs. `--kill-after=$TIMEOUT_KILL_AFTER`
+# sends TERM at the budget and, if the JVM ignores it, KILL after the grace
+# period: that turns "ignores TERM" from an unbounded hang into a bounded
+# one instead of needing a second layer to catch it. timeout(1) exits 124 on
+# its own TERM, and 137 (128+9) when it had to escalate to KILL; both are
+# mapped to 124 here so callers keyed off that one code work either way.
 run_tlc() {
     local area="$1" module="$2" cfg="$3" budget="$4" logfile="$5"
     local area_dir="$FORMAL_DIR/$area"
@@ -279,32 +215,17 @@ run_tlc() {
     fi
     local metadir="$CACHE_DIR/meta/$area"
     mkdir -p "$metadir"
-    # The wall-clock ceiling prefers coreutils timeout (gtimeout from Homebrew
-    # coreutils on macOS); without either, run_with_deadline enforces it with
-    # a pure-shell watchdog instead of leaving the run unbounded.
-    local -a wrap=()
-    if [ -z "${TIMEOUT_BIN+x}" ]; then
-        if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN=timeout
-        elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN=gtimeout
-        else
-            TIMEOUT_BIN=""
-            note "neither timeout nor gtimeout on PATH: using shell watchdog for wall-clock ceiling"
-        fi
-    fi
-    if [ -n "$TIMEOUT_BIN" ]; then wrap=("$TIMEOUT_BIN" "$budget"); fi
     # The library path carries the shared common/ module first, then the area
     # dir, so any area can EXTEND or INSTANCE RavelObjectStore. The area dir
     # comes second so a same-named module in the area still wins locally.
     local libpath="$FORMAL_DIR/common:$area_dir"
     local code=0
-    if [ -n "$TIMEOUT_BIN" ]; then
-        ( cd "$area_dir" && "${wrap[@]}" "$JAVA" -XX:+UseParallelGC \
-            -DTLA-Library="$libpath" -cp "$JAR" tlc2.TLC \
-            -config "$cfg" -metadir "$metadir" -workers auto $deadlock "$module" ) > "$logfile" 2>&1 || code=$?
-    else
-        run_with_deadline "$budget" "$logfile" "$area_dir" \
-            "$JAVA" -XX:+UseParallelGC -DTLA-Library="$libpath" -cp "$JAR" tlc2.TLC \
-            -config "$cfg" -metadir "$metadir" -workers auto $deadlock "$module" || code=$?
+    ( cd "$area_dir" && "$TIMEOUT_BIN" "--kill-after=$TIMEOUT_KILL_AFTER" "$budget" \
+        "$JAVA" -XX:+UseParallelGC -DTLA-Library="$libpath" -cp "$JAR" tlc2.TLC \
+        -config "$cfg" -metadir "$metadir" -workers auto $deadlock "$module" ) > "$logfile" 2>&1 || code=$?
+    if [ "$code" -eq 137 ]; then
+        note "$area/$module: ignored TERM at the ${budget}s budget, needed the ${TIMEOUT_KILL_AFTER}s kill-after grace period"
+        code=124
     fi
     return $code
 }
@@ -643,6 +564,14 @@ main() {
     esac
 
     resolve_java
+    # Resolved once, before any lane launches anything, and even for a lane
+    # that discovers zero configs to run: a developer without GNU coreutils
+    # must hear about it on the first invocation, not on the first slow run.
+    # traceability enforces no budget and needs no timeout binary at all.
+    case "$cmd" in
+        traceability) : ;;
+        *) resolve_timeout ;;
+    esac
 
     local areas
     if [ -n "$only_area" ]; then

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -563,15 +563,18 @@ main() {
         *) die "unknown subcommand: $cmd" ;;
     esac
 
-    resolve_java
-    # Resolved once, before any lane launches anything, and even for a lane
-    # that discovers zero configs to run: a developer without GNU coreutils
-    # must hear about it on the first invocation, not on the first slow run.
-    # traceability enforces no budget and needs no timeout binary at all.
+    # resolve_timeout runs before resolve_java: resolve_java's -version probe
+    # spawns java, so on a host without GNU timeout(1) that probe must never
+    # happen. Resolved once, before any lane launches anything, and even for
+    # a lane that discovers zero configs to run: a developer without GNU
+    # coreutils must hear about it on the first invocation, not on the first
+    # slow run. traceability enforces no budget and needs no timeout binary
+    # at all.
     case "$cmd" in
         traceability) : ;;
         *) resolve_timeout ;;
     esac
+    resolve_java
 
     local areas
     if [ -n "$only_area" ]; then

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -171,19 +171,31 @@ record_row() {
 # run_with_deadline <budget-seconds> <logfile> <cwd> <cmd...>
 # Pure-shell fallback for timeout(1)/gtimeout(1) when neither is on PATH.
 # Runs <cmd...> in <cwd> as a backgrounded job under job control, which gives
-# it its own process group, then polls its liveness. On expiry it kills the
-# whole group (not just the job leader), so a JVM's own children can't
-# survive the wrapper the way they would from a plain `kill $pid`. Returns
-# 124 on expiry, matching timeout(1)'s convention, so callers already keyed
-# off that exit code work unchanged.
+# it its own process group, so a JVM's own children can't survive the
+# wrapper the way they would from a plain `kill $pid`. Returns 124 on
+# expiry, matching timeout(1)'s convention, so callers already keyed off
+# that exit code work unchanged.
+#
+# The deadline is enforced by a timer running alongside the job, not by
+# polling: a poll interval can't tell "exited just before the deadline"
+# from "exited just after it" apart, since both look identical between two
+# polls. The timer fires once at exactly the budget, checks the job is
+# still alive right there, and only then kills it and records the timeout
+# (in that order, so a job that finishes in the same instant the timer
+# expires is checked before, not after, the kill). The verdict is keyed on
+# whether that record was made, never on a clock reading: still alive at
+# the deadline is always killed and always 124, exited on its own before
+# the timer acts is always its own status.
 run_with_deadline() {
     local budget="$1" logfile="$2" cwd="$3"
     shift 3
+    local flag
+    flag="$(mktemp -u "${TMPDIR:-/tmp}/check-tla-deadline.XXXXXX")" || return 1
     (
         set -m
         cd "$cwd" && "$@" > "$logfile" 2>&1 &
         local pid=$!
-        local deadline=$((SECONDS + budget))
+        local timer_pid=""
 
         terminate_group() {
             kill -TERM -"$pid" 2>/dev/null
@@ -191,29 +203,37 @@ run_with_deadline() {
             kill -KILL -"$pid" 2>/dev/null
             wait "$pid" 2>/dev/null
         }
-        on_term() { terminate_group; exit 143; }
-        on_int()  { terminate_group; exit 130; }
-        on_hup()  { terminate_group; exit 129; }
+        cancel_timer() {
+            [ -n "$timer_pid" ] || return 0
+            kill -TERM -"$timer_pid" 2>/dev/null
+            wait "$timer_pid" 2>/dev/null
+        }
+        on_term() { terminate_group; cancel_timer; exit 143; }
+        on_int()  { terminate_group; cancel_timer; exit 130; }
+        on_hup()  { terminate_group; cancel_timer; exit 129; }
         trap on_term TERM
         trap on_int INT
         trap on_hup HUP
 
-        while kill -0 "$pid" 2>/dev/null; do
-            if [ "$SECONDS" -ge "$deadline" ]; then
-                terminate_group
-                exit 124
-            fi
-            sleep 1
-        done
-        # The loop above is the only place that kills the job, and it exits
-        # 124 there. So reaching here means the job exited on its own, and
-        # the verdict is its own status. Keying on the kill event rather
-        # than on the clock is what makes that right in both directions:
-        # still running at the deadline is always killed and always 124,
-        # exited on its own is always its own status. The one second poll
-        # bounds how far past the deadline a self-exit can go unobserved.
+        # The timer job: its `sleep` and the `if` after it share the timer
+        # process's own group (set -m puts every backgrounded job in its
+        # own group), so killing that one pid's group from cancel_timer
+        # reaps the sleep too and nothing outlives this function.
+        ( sleep "$budget"
+          if kill -0 "$pid" 2>/dev/null; then
+              : > "$flag"
+              terminate_group
+          fi
+        ) &
+        timer_pid=$!
+
         local code=0
         wait "$pid" || code=$?
+        cancel_timer
+
+        if [ -f "$flag" ]; then
+            exit 124
+        fi
         exit "$code"
     ) &
     local watchdog_pid=$!
@@ -229,6 +249,7 @@ run_with_deadline() {
     local code=0
     wait "$watchdog_pid" || code=$?
     trap - TERM INT HUP
+    rm -f "$flag"
     return "$code"
 }
 

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -168,6 +168,36 @@ record_row() {
         "$RUN_ID" "$1" "$2" "$3" "$4" "$5" "$6" "$7" >> "$LAST_RUN"
 }
 
+# run_with_deadline <budget-seconds> <logfile> <cwd> <cmd...>
+# Pure-shell fallback for timeout(1)/gtimeout(1) when neither is on PATH.
+# Runs <cmd...> in <cwd> as a backgrounded job under job control, which gives
+# it its own process group, then polls its liveness. On expiry it kills the
+# whole group (not just the job leader), so a JVM's own children can't
+# survive the wrapper the way they would from a plain `kill $pid`. Returns
+# 124 on expiry, matching timeout(1)'s convention, so callers already keyed
+# off that exit code work unchanged.
+run_with_deadline() {
+    local budget="$1" logfile="$2" cwd="$3"
+    shift 3
+    (
+        set -m
+        cd "$cwd" && "$@" > "$logfile" 2>&1 &
+        local pid=$!
+        local deadline=$((SECONDS + budget))
+        while kill -0 "$pid" 2>/dev/null; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+                kill -TERM -"$pid" 2>/dev/null
+                sleep 1
+                kill -KILL -"$pid" 2>/dev/null
+                wait "$pid" 2>/dev/null
+                exit 124
+            fi
+            sleep 2
+        done
+        wait "$pid"
+    )
+}
+
 # --- TLC invocation ---------------------------------------------------------
 # Runs TLC on one cfg. Echoes the log path. Returns TLC's exit code.
 # CHECK_DEADLOCK FALSE in a cfg means the model has intentional stutter/terminal
@@ -181,16 +211,16 @@ run_tlc() {
     fi
     local metadir="$CACHE_DIR/meta/$area"
     mkdir -p "$metadir"
-    # The wall-clock ceiling needs coreutils timeout (gtimeout from Homebrew
-    # coreutils on macOS). Without either the run is unbounded, announced once;
-    # CI and the fleet executors are Linux and always have timeout.
+    # The wall-clock ceiling prefers coreutils timeout (gtimeout from Homebrew
+    # coreutils on macOS); without either, run_with_deadline enforces it with
+    # a pure-shell watchdog instead of leaving the run unbounded.
     local -a wrap=()
     if [ -z "${TIMEOUT_BIN+x}" ]; then
         if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN=timeout
         elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN=gtimeout
         else
             TIMEOUT_BIN=""
-            note "neither timeout nor gtimeout on PATH: running TLC without a wall-clock ceiling"
+            note "neither timeout nor gtimeout on PATH: using shell watchdog for wall-clock ceiling"
         fi
     fi
     if [ -n "$TIMEOUT_BIN" ]; then wrap=("$TIMEOUT_BIN" "$budget"); fi
@@ -199,10 +229,15 @@ run_tlc() {
     # comes second so a same-named module in the area still wins locally.
     local libpath="$FORMAL_DIR/common:$area_dir"
     local code=0
-    # ${wrap[@]+...}: an empty array is "unbound" under set -u on bash 3.2.
-    ( cd "$area_dir" && ${wrap[@]+"${wrap[@]}"} "$JAVA" -XX:+UseParallelGC \
-        -DTLA-Library="$libpath" -cp "$JAR" tlc2.TLC \
-        -config "$cfg" -metadir "$metadir" -workers auto $deadlock "$module" ) > "$logfile" 2>&1 || code=$?
+    if [ -n "$TIMEOUT_BIN" ]; then
+        ( cd "$area_dir" && "${wrap[@]}" "$JAVA" -XX:+UseParallelGC \
+            -DTLA-Library="$libpath" -cp "$JAR" tlc2.TLC \
+            -config "$cfg" -metadir "$metadir" -workers auto $deadlock "$module" ) > "$logfile" 2>&1 || code=$?
+    else
+        run_with_deadline "$budget" "$logfile" "$area_dir" \
+            "$JAVA" -XX:+UseParallelGC -DTLA-Library="$libpath" -cp "$JAR" tlc2.TLC \
+            -config "$cfg" -metadir "$metadir" -workers auto $deadlock "$module" || code=$?
+    fi
     return $code
 }
 

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -79,7 +79,8 @@ resolve_timeout() {
     local candidate
     for candidate in timeout gtimeout; do
         if command -v "$candidate" >/dev/null 2>&1 \
-            && "$candidate" --version 2>/dev/null | grep -qi 'GNU coreutils'; then
+            && "$candidate" --version 2>/dev/null | grep -qi 'GNU coreutils' \
+            && "$candidate" --kill-after=1 1 true >/dev/null 2>&1; then
             TIMEOUT_BIN="$candidate"
             note "timeout: $candidate (GNU coreutils)"
             return 0
@@ -572,9 +573,8 @@ main() {
     # at all.
     case "$cmd" in
         traceability) : ;;
-        *) resolve_timeout ;;
+        *) resolve_timeout; resolve_java ;;
     esac
-    resolve_java
 
     local areas
     if [ -n "$only_area" ]; then

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -246,8 +246,21 @@ run_with_deadline() {
     trap 'kill -TERM "$watchdog_pid" 2>/dev/null' TERM
     trap 'kill -INT  "$watchdog_pid" 2>/dev/null' INT
     trap 'kill -HUP  "$watchdog_pid" 2>/dev/null' HUP
+    # A forwarded signal interrupts this wait before the watchdog has
+    # actually torn down TLC's group: bash returns wait early with
+    # 128+signum right when the trap runs, not when watchdog_pid exits.
+    # Keep waiting on the same pid (valid until it's reaped) so this
+    # function can't return, and rm the flag, while that teardown is
+    # still in flight. Once wait completes without the pid still being
+    # alive, its exit status is the watchdog's real one, which for a
+    # forwarded signal is already the conventional 128+signum from the
+    # watchdog's own on_term/on_int/on_hup handler.
     local code=0
-    wait "$watchdog_pid" || code=$?
+    while :; do
+        code=0
+        wait "$watchdog_pid" || code=$?
+        kill -0 "$watchdog_pid" 2>/dev/null || break
+    done
     trap - TERM INT HUP
     rm -f "$flag"
     return "$code"

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -184,18 +184,52 @@ run_with_deadline() {
         cd "$cwd" && "$@" > "$logfile" 2>&1 &
         local pid=$!
         local deadline=$((SECONDS + budget))
+
+        terminate_group() {
+            kill -TERM -"$pid" 2>/dev/null
+            sleep 1
+            kill -KILL -"$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
+        }
+        on_term() { terminate_group; exit 143; }
+        on_int()  { terminate_group; exit 130; }
+        on_hup()  { terminate_group; exit 129; }
+        trap on_term TERM
+        trap on_int INT
+        trap on_hup HUP
+
         while kill -0 "$pid" 2>/dev/null; do
             if [ "$SECONDS" -ge "$deadline" ]; then
-                kill -TERM -"$pid" 2>/dev/null
-                sleep 1
-                kill -KILL -"$pid" 2>/dev/null
-                wait "$pid" 2>/dev/null
+                terminate_group
                 exit 124
             fi
             sleep 2
         done
-        wait "$pid"
-    )
+        # TLC may exit during the sleep, after the deadline already passed:
+        # kill -0 goes false without the loop ever re-checking SECONDS, so
+        # `wait` alone would report TLC's own success as the verdict. Decide
+        # the verdict from the deadline, not from which side of that race won.
+        local code=0
+        wait "$pid" || code=$?
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            exit 124
+        fi
+        exit "$code"
+    ) &
+    local watchdog_pid=$!
+    # The watchdog subshell keeps our own process group; only the TLC job it
+    # backgrounds under `set -m` gets a group of its own. So a plain
+    # `kill <our-pid>` from outside (a terminal interrupt, or a harness
+    # killing this script) never reaches the subshell on its own. Forward
+    # the signal to it directly so its own trap, where TLC's pid is in
+    # scope, actually runs and can tear down TLC's group.
+    trap 'kill -TERM "$watchdog_pid" 2>/dev/null' TERM
+    trap 'kill -INT  "$watchdog_pid" 2>/dev/null' INT
+    trap 'kill -HUP  "$watchdog_pid" 2>/dev/null' HUP
+    local code=0
+    wait "$watchdog_pid" || code=$?
+    trap - TERM INT HUP
+    return "$code"
 }
 
 # --- TLC invocation ---------------------------------------------------------

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -203,17 +203,17 @@ run_with_deadline() {
                 terminate_group
                 exit 124
             fi
-            sleep 2
+            sleep 1
         done
-        # TLC may exit during the sleep, after the deadline already passed:
-        # kill -0 goes false without the loop ever re-checking SECONDS, so
-        # `wait` alone would report TLC's own success as the verdict. Decide
-        # the verdict from the deadline, not from which side of that race won.
+        # The loop above is the only place that kills the job, and it exits
+        # 124 there. So reaching here means the job exited on its own, and
+        # the verdict is its own status. Keying on the kill event rather
+        # than on the clock is what makes that right in both directions:
+        # still running at the deadline is always killed and always 124,
+        # exited on its own is always its own status. The one second poll
+        # bounds how far past the deadline a self-exit can go unobserved.
         local code=0
         wait "$pid" || code=$?
-        if [ "$SECONDS" -ge "$deadline" ]; then
-            exit 124
-        fi
         exit "$code"
     ) &
     local watchdog_pid=$!

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -114,7 +114,11 @@ done
 javashim="$bdir/java"
 cat > "$javashim" <<EOF
 #!/usr/bin/env bash
-touch "$marker"
+# ':' and '>' are shell builtins/syntax, not external commands: the
+# restricted PATH built above deliberately carries no 'touch', so an
+# external touch here would fail silently and the marker would never
+# land regardless of whether java was actually invoked.
+: > "$marker"
 case "\$1" in
     -version) echo 'openjdk version "21.0.4" 2024-07-16' >&2; exit 0 ;;
 esac

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Proofs for issue #1192: check-tla.sh must enforce its TLC wall-clock
-# budget via GNU timeout(1), never report a timed-out run as a pass, and
-# refuse outright when no GNU timeout is available. Run:
+# budget via GNU timeout(1), never report a timed-out run as a pass, refuse
+# outright when no GNU timeout is available or when one accepts the banner
+# check but rejects --kill-after, and never require Java for the
+# traceability lane. Run:
 #   bash scripts/check-tla.test.sh
 set -uo pipefail
 
@@ -142,6 +144,79 @@ else
     ok
 fi
 rm -rf "$bdir"
+
+# --- (d) refusal when timeout's banner lies about --kill-after -------------
+# A candidate that prints the GNU coreutils --version banner but rejects
+# --kill-after must be refused at startup, before java ever runs: accepting
+# it on the banner alone would only fail once a lane is already mid-run.
+echo "--- (d) timeout shim: real banner, --kill-after rejected: expect exit 2, refusal, java never launched"
+ddir="$(mktemp -d)"
+dmarker="$ddir/java-was-invoked"
+for tool in bash git basename dirname date mktemp grep sed awk cat tr sha256sum mkdir rm cut wc head tail printf env sh; do
+    real="$(command -v "$tool" 2>/dev/null)" || continue
+    ln -sf "$real" "$ddir/$tool"
+done
+timeoutshim="$ddir/timeout"
+cat > "$timeoutshim" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    --version) echo 'timeout (GNU coreutils) 9.4'; exit 0 ;;
+esac
+for a in "$@"; do
+    case "$a" in
+        --kill-after*) exit 125 ;;
+    esac
+done
+exit 0
+EOF
+chmod +x "$timeoutshim"
+javashim_d="$ddir/java"
+cat > "$javashim_d" <<EOF
+#!/usr/bin/env bash
+: > "$dmarker"
+case "\$1" in
+    -version) echo 'openjdk version "21.0.4" 2024-07-16' >&2; exit 0 ;;
+esac
+exit 0
+EOF
+chmod +x "$javashim_d"
+
+out=""
+out="$(env -i PATH="$ddir" HOME="$HOME" RAVEL_TLA_JAVA="$javashim_d" "$SCRIPT" smoke 2>&1)"
+code=$?
+
+if [ "$code" -eq 2 ]; then ok; else bad "d: expected exit 2, got $code"; fi
+if printf '%s' "$out" | grep -qF 'GNU timeout(1) not found'; then
+    ok
+else
+    bad "d: refusal line not printed; got: $out"
+fi
+if [ -e "$dmarker" ]; then
+    bad "d: java shim was invoked despite the --kill-after refusal"
+else
+    ok
+fi
+rm -rf "$ddir"
+
+# --- (e) traceability needs no Java -----------------------------------------
+# main used to call resolve_java before dispatching on the subcommand, so
+# traceability (pure filesystem, no TLC) refused with "no Java found" on a
+# host with no JDK. Restrict PATH to what traceability actually needs (git,
+# basename, dirname, date, mktemp, grep, sed, awk, cat, tr, mkdir, rm, cut,
+# wc, head, tail, printf, env, sh) and give it no java and no shim.
+echo "--- (e) no java, no shim on PATH: traceability must exit 0"
+edir="$(mktemp -d)"
+for tool in bash git basename dirname date mktemp grep sed awk cat tr mkdir rm cut wc head tail printf env sh; do
+    real="$(command -v "$tool" 2>/dev/null)" || continue
+    ln -sf "$real" "$edir/$tool"
+done
+
+out=""
+out="$(env -i PATH="$edir" HOME="$HOME" "$SCRIPT" traceability 2>&1)"
+code=$?
+
+if [ "$code" -eq 0 ]; then ok; else bad "e: expected exit 0, got $code; output: $out"; fi
+rm -rf "$edir"
 
 # --- (c) normal operation is unchanged (see report; needs the real TLC jar
 # and a JDK, so it is not run unpiped here) ----------------------------------

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -114,10 +114,10 @@ done
 javashim="$bdir/java"
 cat > "$javashim" <<EOF
 #!/usr/bin/env bash
+touch "$marker"
 case "\$1" in
     -version) echo 'openjdk version "21.0.4" 2024-07-16' >&2; exit 0 ;;
 esac
-touch "$marker"
 exit 0
 EOF
 chmod +x "$javashim"

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Proofs for issue #1192: check-tla.sh must enforce its TLC wall-clock
+# budget via GNU timeout(1), never report a timed-out run as a pass, and
+# refuse outright when no GNU timeout is available. Run:
+#   bash scripts/check-tla.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-tla.sh"
+
+pass=0
+fail=0
+
+ok()   { pass=$((pass + 1)); }
+bad()  { printf 'FAIL  %s\n' "$1"; fail=$((fail + 1)); }
+
+# --- (a) timeout fires and nothing survives ---------------------------------
+# Source check-tla.sh's function definitions (everything but its unconditional
+# `main "$@"` call on the last line) so run_tlc can be driven directly,
+# against a throwaway FORMAL_DIR/CACHE_DIR, without needing the real TLC jar
+# or network access.
+source_lib() {
+    local tmp_src
+    tmp_src="$(mktemp)"
+    sed '$d' "$SCRIPT" > "$tmp_src"
+    # shellcheck disable=SC1090
+    source "$tmp_src"
+    rm -f "$tmp_src"
+}
+source_lib
+
+run_tlc_case() {
+    # run_tlc_case <shim-body-file> <budget> -> sets CASE_CODE, CASE_ELAPSED,
+    # CASE_SHIM (the shim path, for the post-mortem pgrep check).
+    local shim_body="$1" budget="$2"
+    local tmp area_dir shim logfile start end
+    tmp="$(mktemp -d)"
+    area_dir="$tmp/area"
+    mkdir -p "$area_dir"
+    : > "$area_dir/smoke.cfg"
+    shim="$tmp/java"
+    cp "$shim_body" "$shim"
+    chmod +x "$shim"
+
+    FORMAL_DIR="$tmp"
+    CACHE_DIR="$tmp/cache"
+    mkdir -p "$CACHE_DIR"
+    JAVA="$shim"
+    JAR="/dev/null"
+    resolve_timeout
+
+    logfile="$tmp/tlc.log"
+    start=$(date +%s)
+    run_tlc area module "$area_dir/smoke.cfg" "$budget" "$logfile"
+    CASE_CODE=$?
+    end=$(date +%s)
+    CASE_ELAPSED=$((end - start))
+    CASE_SHIM="$shim"
+    CASE_TMP="$tmp"
+}
+
+shim_sleeps_60="$(mktemp)"
+cat > "$shim_sleeps_60" <<'EOF'
+#!/usr/bin/env bash
+exec sleep 60
+EOF
+
+shim_ignores_term="$(mktemp)"
+cat > "$shim_ignores_term" <<'EOF'
+#!/usr/bin/env bash
+trap '' TERM
+while :; do :; done
+EOF
+
+echo "--- (a1) budget 2s, shim obeys TERM: expect 124 in ~2s, nothing survives"
+run_tlc_case "$shim_sleeps_60" 2
+echo "    measured: exit=$CASE_CODE elapsed=${CASE_ELAPSED}s"
+if [ "$CASE_CODE" -eq 124 ]; then ok; else bad "a1: expected exit 124, got $CASE_CODE"; fi
+if [ "$CASE_ELAPSED" -ge 1 ] && [ "$CASE_ELAPSED" -le 8 ]; then ok; else bad "a1: expected ~2s, got ${CASE_ELAPSED}s"; fi
+if pgrep -f "$CASE_SHIM" >/dev/null 2>&1; then
+    bad "a1: shim process still alive after run_tlc returned"
+else
+    ok
+fi
+rm -rf "$CASE_TMP"
+
+echo "--- (a2) budget 2s, shim ignores TERM: expect timeout verdict in ~32s, nothing survives"
+run_tlc_case "$shim_ignores_term" 2
+echo "    measured: exit=$CASE_CODE elapsed=${CASE_ELAPSED}s"
+if [ "$CASE_CODE" -eq 124 ]; then ok; else bad "a2: expected mapped exit 124 (raw 137), got $CASE_CODE"; fi
+if [ "$CASE_ELAPSED" -ge 25 ] && [ "$CASE_ELAPSED" -le 45 ]; then ok; else bad "a2: expected ~32s (2s budget + 30s kill-after), got ${CASE_ELAPSED}s"; fi
+if pgrep -f "$CASE_SHIM" >/dev/null 2>&1; then
+    bad "a2: shim process still alive after run_tlc returned (kill-after failed to reap it)"
+else
+    ok
+fi
+rm -rf "$CASE_TMP"
+
+rm -f "$shim_sleeps_60" "$shim_ignores_term"
+
+# --- (b) refusal without GNU timeout on PATH --------------------------------
+# Build a minimal PATH: a bindir holding only bash plus symlinks to the
+# coreutils check-tla.sh actually calls before it would reach a lane (git,
+# basename, dirname, date, mktemp, grep, sed, awk, cat, tr, sha256sum, mkdir,
+# rm, cut, wc), and a `java` shim that only proves it was never invoked. No
+# timeout, no gtimeout.
+echo "--- (b) no GNU timeout on PATH: expect exit 2, refusal, java never launched"
+bdir="$(mktemp -d)"
+marker="$bdir/java-was-invoked"
+for tool in bash git basename dirname date mktemp grep sed awk cat tr sha256sum mkdir rm cut wc head tail printf env sh; do
+    real="$(command -v "$tool" 2>/dev/null)" || continue
+    ln -sf "$real" "$bdir/$tool"
+done
+javashim="$bdir/java"
+cat > "$javashim" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+    -version) echo 'openjdk version "21.0.4" 2024-07-16' >&2; exit 0 ;;
+esac
+touch "$marker"
+exit 0
+EOF
+chmod +x "$javashim"
+
+out=""
+out="$(env -i PATH="$bdir" HOME="$HOME" RAVEL_TLA_JAVA="$javashim" "$SCRIPT" smoke 2>&1)"
+code=$?
+
+if [ "$code" -eq 2 ]; then ok; else bad "b: expected exit 2, got $code"; fi
+if printf '%s' "$out" | grep -qF 'GNU timeout(1) not found'; then
+    ok
+else
+    bad "b: refusal line not printed; got: $out"
+fi
+if [ -e "$marker" ]; then
+    bad "b: java shim was invoked despite the missing-timeout refusal"
+else
+    ok
+fi
+rm -rf "$bdir"
+
+# --- (c) normal operation is unchanged (see report; needs the real TLC jar
+# and a JDK, so it is not run unpiped here) ----------------------------------
+echo "(c) is proved manually and reported, not replayed here: it needs the" \
+     "real TLC jar, network on first fetch, and a JDK, none of which this" \
+     "unit test provisions."
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
The TLC harness enforced its wall-clock budget with a pure-bash watchdog: a job group under set -m, a timer subshell, a flag file and traps at two levels. Six review rounds each found a new race in it (a timer firing on an already-reaped child, kill -0 succeeding on a zombie, the flag written after the verdict was read), and the seventh attempt was tuning an mkdir lock against spinner processes. A budget enforcer that needs that much care in shell is the wrong tool.

This replaces the watchdog with a requirement on GNU coreutils timeout(1). The harness resolves the binary once at startup, for every lane that enforces a budget, accepting timeout or gtimeout only when --version reports GNU coreutils, because --kill-after is the mechanism and look-alike binaries drop it silently. Without it the harness refuses with exit 2 and the one-line fix (brew install coreutils on macOS) before launching anything, so a developer without coreutils learns on the first invocation and not on the first slow run. Every TLC invocation runs under timeout --kill-after=30 <budget>; exit 124 is the timeout verdict, and 137 (killed after the grace period) maps to the same verdict with a note. Exit codes 12 and 13 pass through unchanged.

Three proofs are recorded as real assertions in the new scripts/check-tla.test.sh, which exits non-zero when any fails: a shim java that obeys TERM is dead after about 3 seconds at a 2 second budget; a shim that ignores TERM is dead after about 32 seconds and the lane still reports 124; a PATH holding coreutils minus timeout makes the harness exit 2 without ever invoking java (a marker the shim would have written is asserted absent). Normal operation is unchanged: the common area's smoke lane exits 0 with its elapsed-time line intact.

CI needs no change: both the tla job in ci.yml and tla-nightly.yml run on ubuntu-latest, which ships GNU coreutils.

Fixes: #1192
Refs: #1113, #1119
