### PR TITLE
feat(server,cache): expose per-subsystem process memory diagnostics

### DIFF
--- a/crates/ravel-cache/src/tiered.rs
+++ b/crates/ravel-cache/src/tiered.rs
@@ -409,6 +409,35 @@ where
         self.disk.insert(key, &value);
     }
 
+    /// Current number of resident entries in the **RAM tier**.
+    ///
+    /// Live, not cumulative: this is [`Cache::len`], which tracks the S3-FIFO
+    /// queues' actual occupancy and falls when an entry is evicted. It answers
+    /// "how many entries does this tier hold right now," a question
+    /// [`ram_metrics`](Self::ram_metrics)'s counters cannot answer -- they only
+    /// ever grow, so nothing nets an eviction against an earlier admission.
+    pub fn ram_len(&self) -> usize {
+        self.ram.len()
+    }
+
+    /// Current total payload bytes resident in the **RAM tier**, by the same
+    /// live-vs-cumulative distinction [`ram_len`](Self::ram_len) documents.
+    pub fn ram_total_bytes(&self) -> u64 {
+        self.ram.total_bytes()
+    }
+
+    /// Current number of resident entries in the **disk tier**, live rather
+    /// than cumulative -- see [`ram_len`](Self::ram_len).
+    pub fn disk_len(&self) -> usize {
+        self.disk.len()
+    }
+
+    /// Current total payload bytes resident in the **disk tier**, live rather
+    /// than cumulative -- see [`ram_len`](Self::ram_len).
+    pub fn disk_total_bytes(&self) -> u64 {
+        self.disk.total_bytes()
+    }
+
     /// Whether the **RAM tier** holds no resident entry.
     ///
     /// "Empty" is defined as the RAM tier alone, not both tiers, because every
@@ -1157,5 +1186,66 @@ mod tests {
             served, ram_corrupted,
             "a disk-served hit must be corrupted exactly like a RAM hit"
         );
+    }
+
+    /// Live residency accounting for [`TieredCache::ram_len`],
+    /// [`TieredCache::ram_total_bytes`], [`TieredCache::disk_len`], and
+    /// [`TieredCache::disk_total_bytes`] (#1170): each answers "how many
+    /// bytes/entries are resident right now," which a cumulative
+    /// [`CacheMetrics`] counter (`bytes_admitted`, `evictions`) cannot --
+    /// those only ever grow, with no per-eviction byte accounting to net
+    /// against admissions. This test insists on exact counts and bytes at
+    /// every step, never `> 0`: four sequential inserts with no `get` in
+    /// between all land in the small (probation) queue with `freq == 0`, so
+    /// eviction is deterministic FIFO (oldest-admitted first) once the byte
+    /// bound is exceeded.
+    ///
+    /// FLIP (magnitude, non-vacuity): in `TieredCache::ram_total_bytes`,
+    /// change `self.ram.total_bytes()` to `self.ram.total_bytes() / 2`. The
+    /// `assert_eq!(tiered.ram_total_bytes(), 300)` below then reads 150 and
+    /// fails.
+    #[tokio::test]
+    async fn tiered_cache_residency_tracks_exact_bytes_and_entries_across_eviction() {
+        let tmp = TempDir::new().unwrap();
+        let limits = CacheLimits::new(300, 10_000, 1_000);
+        let disk = DiskCache::new(tmp.path().to_path_buf(), limits);
+        let ram: Cache<&'static str> = Cache::new(limits);
+        let tiered = TieredCache::new(ram, disk);
+
+        let payload = |n: u8| Bytes::from(vec![n; 100]);
+
+        tiered.insert(test_key(1, 100), payload(1));
+        tiered.insert(test_key(2, 100), payload(2));
+        tiered.insert(test_key(3, 100), payload(3));
+
+        assert_eq!(
+            tiered.ram_len(),
+            3,
+            "three 100-byte entries, no eviction yet"
+        );
+        assert_eq!(tiered.ram_total_bytes(), 300);
+        assert_eq!(tiered.disk_len(), 3);
+        assert_eq!(tiered.disk_total_bytes(), 300);
+
+        // A fourth 100-byte entry pushes total resident bytes to 400, over
+        // the 300-byte limit: the oldest entry (key 1) is evicted from both
+        // tiers' independent S3-FIFO instances, deterministically, since
+        // none of the four keys was ever `get`-touched (freq stays 0, so
+        // eviction is FIFO from the front of the small queue).
+        tiered.insert(test_key(4, 100), payload(4));
+
+        assert_eq!(
+            tiered.ram_len(),
+            3,
+            "the byte bound evicted exactly one entry to make room"
+        );
+        assert_eq!(
+            tiered.ram_total_bytes(),
+            300,
+            "resident bytes fall by exactly the evicted entry's size (100), \
+             not merely 'less than before'"
+        );
+        assert_eq!(tiered.disk_len(), 3);
+        assert_eq!(tiered.disk_total_bytes(), 300);
     }
 }

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -174,12 +174,13 @@ arrow-flight = { workspace = true, optional = true }
 # src/main.rs, a binary root, never in a library crate.
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true }
-
-[target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
-# Honest runtime check that the binary is actually running under jemalloc: the
-# smoke test in main.rs reads jemalloc's own allocated-bytes stat. Pinned
-# directly (not via [workspace.dependencies]) matching this crate's convention
-# for deps the single authorized root line does not cover.
+# Reads jemalloc's own allocated/active/resident stats at runtime (#1170): the
+# `/metrics` allocator gauges (`src/mem_stats.rs`) and the smoke test in
+# main.rs both call this. Pinned directly (not via [workspace.dependencies]),
+# matching this crate's convention for deps the single authorized root line
+# does not cover. Promoted from a dev-dependency (issue #972's original
+# jemalloc-is-configured smoke test) to a regular dependency because the
+# `/metrics` handler now reads these stats in production, not only in tests.
 tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
 
 [features]

--- a/services/ravel-server/src/distrib.rs
+++ b/services/ravel-server/src/distrib.rs
@@ -2590,6 +2590,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
         assert!(
             body.contains("ravel_distrib_quarantine_marks_total{mode=\"query\"} 1"),

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -31,6 +31,7 @@ pub mod ingest_concurrency;
 pub mod lifecycle_refresh;
 pub mod logs_ingest;
 pub mod maintain;
+pub mod mem_stats;
 pub mod metadata_sink_task;
 pub mod metrics;
 #[cfg(feature = "otap")]
@@ -1161,6 +1162,9 @@ pub async fn start(
         cache_disk_metrics: cache.as_ref().and_then(|c| c.disk_metrics()),
         catalog_cache_metrics: catalog.byte_cache_metrics(),
         catalog_cache_disk_metrics: catalog.byte_cache_disk_metrics(),
+        cache: cache.clone(),
+        cache_max_bytes: config.cache_max_bytes,
+        catalog_cache_max_bytes: config.catalog_cache_max_bytes,
         admission: admission.clone(),
         metrics_tenant_labels: config.metrics_tenant_labels,
         query_accounting: query_accounting.clone(),

--- a/services/ravel-server/src/mem_stats.rs
+++ b/services/ravel-server/src/mem_stats.rs
@@ -1,0 +1,90 @@
+//! Process allocator figures for the `/metrics` endpoint (#1170): a whole-
+//! process RSS number cannot say which subsystem grew (the ClickBench OOM
+//! this module exists to make attributable retracted two published memory
+//! claims for exactly that reason), so this reports the allocator's own
+//! breakdown instead. `main.rs` compiles jemalloc in as the global allocator
+//! on every target this repo builds for (`#[cfg(not(target_env = "msvc"))]`,
+//! and this repo does not target msvc); this module names that fact plainly
+//! rather than silently formatting zeros for an allocator that is not
+//! actually configured.
+
+/// The three jemalloc-native figures (`stats.allocated`/`active`/`resident`)
+/// on a build where jemalloc is the global allocator, or an explicit marker
+/// naming whichever allocator this process actually uses instead. There is
+/// no all-zeros case: a non-jemalloc build says so by name rather than
+/// reporting jemalloc figures it does not have.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllocatorStats {
+    Jemalloc {
+        allocated: u64,
+        active: u64,
+        resident: u64,
+    },
+    Other {
+        name: &'static str,
+    },
+}
+
+/// Reads the live figures from whichever allocator this binary actually
+/// links. On every target this repo builds, `main.rs` sets
+/// `#[global_allocator]` to jemalloc, so this is a real mallctl read of the
+/// process's own allocator at call time, not a cached or startup-time
+/// snapshot: `epoch::advance` refreshes jemalloc's cached stats immediately
+/// before each read.
+#[cfg(not(target_env = "msvc"))]
+pub fn read() -> AllocatorStats {
+    use tikv_jemalloc_ctl::{epoch, stats};
+
+    // A refresh or read failure here is a diagnostic-path degradation, not a
+    // correctness path: fall back to 0 for that one figure rather than
+    // panicking a scrape over a mallctl hiccup. This is distinct from "not
+    // running under jemalloc," which this function never claims via a zero --
+    // that state is reported by the `Other` variant below, on msvc only.
+    let _ = epoch::advance();
+    AllocatorStats::Jemalloc {
+        allocated: stats::allocated::read().unwrap_or(0) as u64,
+        active: stats::active::read().unwrap_or(0) as u64,
+        resident: stats::resident::read().unwrap_or(0) as u64,
+    }
+}
+
+/// msvc has no jemalloc global allocator (`tikv-jemallocator`'s own
+/// documented unsupported target, `main.rs`'s `#[global_allocator]` is
+/// `#[cfg]`-absent here), so this process runs under Rust's default `System`
+/// allocator instead.
+#[cfg(target_env = "msvc")]
+pub fn read() -> AllocatorStats {
+    AllocatorStats::Other { name: "system" }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Non-vacuity: on every target this repo actually builds for, `read`
+    /// must report the `Jemalloc` variant, and by the time any test runs this
+    /// process has allocated well past zero, so each figure must be nonzero.
+    /// This is a smoke check, not a magnitude assertion -- jemalloc's own
+    /// allocated-bytes accounting under a real allocation delta is exercised
+    /// by `main.rs`'s `binary_runs_under_jemalloc`, the regression gate for
+    /// "is jemalloc actually linked as the global allocator."
+    #[cfg(not(target_env = "msvc"))]
+    #[test]
+    fn read_reports_jemalloc_with_nonzero_figures() {
+        match read() {
+            AllocatorStats::Jemalloc {
+                allocated,
+                active,
+                resident,
+            } => {
+                assert!(allocated > 0, "a running process has allocated bytes");
+                assert!(active > 0, "a running process has active bytes");
+                assert!(resident > 0, "a running process has resident bytes");
+            }
+            AllocatorStats::Other { name } => {
+                panic!("expected Jemalloc on a non-msvc target, got Other({name})");
+            }
+        }
+    }
+}

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -230,6 +230,13 @@ pub enum Label {
     Cache(CacheFamily),
     CacheTier(CacheTier),
     MergeMemoryKind(MergeMemoryKind),
+    /// The allocator this process runs under (#1170): `"jemalloc"` on every
+    /// target this repo builds, or whatever [`crate::mem_stats::read`] names
+    /// otherwise. A bare `&'static str` rather than a closed enum because the
+    /// value is compile-time-fixed per target (never derived from request or
+    /// tenant input), so there is no cardinality this label could blow up.
+    Allocator(&'static str),
+    AllocatorStat(AllocatorStat),
 }
 
 /// Which high-water mark a `ravel_maintain_rlog_merge_peak_bytes` sample is
@@ -296,6 +303,30 @@ impl CacheTier {
     }
 }
 
+/// Which jemalloc-reported figure a `ravel_process_allocator_bytes` sample is
+/// (#1170): `allocated` is bytes the application requested, `active` adds
+/// page-rounding and thread-cache slop, `resident` additionally counts pages
+/// jemalloc has not yet returned to the OS. Three separate series, not one
+/// number, because a single process-RSS figure cannot say which of these --
+/// or which subsystem's cache -- grew, the exact ambiguity that forced two
+/// published ClickBench memory claims to be retracted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllocatorStat {
+    Allocated,
+    Active,
+    Resident,
+}
+
+impl AllocatorStat {
+    fn name(self) -> &'static str {
+        match self {
+            AllocatorStat::Allocated => "allocated",
+            AllocatorStat::Active => "active",
+            AllocatorStat::Resident => "resident",
+        }
+    }
+}
+
 impl Label {
     fn key(&self) -> &'static str {
         match self {
@@ -311,6 +342,8 @@ impl Label {
             Label::Cache(_) => "cache",
             Label::CacheTier(_) => "tier",
             Label::MergeMemoryKind(_) => "kind",
+            Label::Allocator(_) => "allocator",
+            Label::AllocatorStat(_) => "stat",
         }
     }
 
@@ -328,6 +361,8 @@ impl Label {
             Label::Cache(family) => family.name().to_string(),
             Label::CacheTier(tier) => tier.name().to_string(),
             Label::MergeMemoryKind(kind) => kind.name().to_string(),
+            Label::Allocator(name) => name.to_string(),
+            Label::AllocatorStat(stat) => stat.name().to_string(),
         }
     }
 }
@@ -2363,6 +2398,164 @@ fn render_cache_family(
     );
 }
 
+/// Live (not cumulative) resident bytes and entry count for the ADR-0046
+/// fetcher read cache's tiers, plus each cache's resolved startup byte
+/// ceiling, so an operator can compare held-vs-budgeted (#1170) without
+/// deriving it from a cumulative counter that cannot answer "what is
+/// resident right now" -- [`render_cache_family`] above renders that other,
+/// cumulative half of the picture (hits, misses, evictions).
+///
+/// The catalog byte cache's own live residency is deliberately NOT rendered
+/// here: reaching it requires a `pub` accessor on `crates/ravel-catalog`,
+/// outside this task's declared scope (`services/ravel-server` and
+/// `crates/ravel-cache` only). Only its resolved ceiling is exposed, under
+/// `cache="catalog"`, so the gap is a missing residency row, not a missing
+/// cache row.
+fn render_cache_residency_family(
+    out: &mut String,
+    mode: Mode,
+    fetch_ram: Option<(usize, u64)>,
+    fetch_disk: Option<(usize, u64)>,
+    fetch_max_bytes: Option<u64>,
+    catalog_max_bytes: Option<u64>,
+) {
+    // Same disk-tier-present-or-not label discipline `render_cache_family`
+    // uses: with no disk tier, the RAM sample carries only `cache=`; with one,
+    // the RAM sample gains `tier="ram"` and the disk sample carries
+    // `tier="disk"`.
+    let mut emit_tier = |name: &str, help: &str, ram: Option<u64>, disk: Option<u64>| {
+        write_header(out, name, help, "gauge");
+        if let Some(value) = ram {
+            if disk.is_some() {
+                write_sample(
+                    out,
+                    name,
+                    &[
+                        Label::Mode(mode),
+                        Label::Cache(CacheFamily::Fetch),
+                        Label::CacheTier(CacheTier::Ram),
+                    ],
+                    value,
+                );
+            } else {
+                write_sample(
+                    out,
+                    name,
+                    &[Label::Mode(mode), Label::Cache(CacheFamily::Fetch)],
+                    value,
+                );
+            }
+        }
+        if let Some(value) = disk {
+            write_sample(
+                out,
+                name,
+                &[
+                    Label::Mode(mode),
+                    Label::Cache(CacheFamily::Fetch),
+                    Label::CacheTier(CacheTier::Disk),
+                ],
+                value,
+            );
+        }
+    };
+
+    emit_tier(
+        "ravel_cache_resident_entries",
+        "Entries currently held in this read-cache tier (ADR-0046), live rather than cumulative.",
+        fetch_ram.map(|(len, _)| len as u64),
+        fetch_disk.map(|(len, _)| len as u64),
+    );
+    emit_tier(
+        "ravel_cache_resident_bytes",
+        "Payload bytes currently held in this read-cache tier (ADR-0046), live rather than cumulative.",
+        fetch_ram.map(|(_, bytes)| bytes),
+        fetch_disk.map(|(_, bytes)| bytes),
+    );
+
+    write_header(
+        out,
+        "ravel_cache_max_bytes",
+        "The resolved startup byte ceiling for this cache, shared by its RAM and disk tiers, for \
+         comparing held-vs-budgeted.",
+        "gauge",
+    );
+    if let Some(max_bytes) = fetch_max_bytes {
+        write_sample(
+            out,
+            "ravel_cache_max_bytes",
+            &[Label::Mode(mode), Label::Cache(CacheFamily::Fetch)],
+            max_bytes,
+        );
+    }
+    if let Some(max_bytes) = catalog_max_bytes {
+        write_sample(
+            out,
+            "ravel_cache_max_bytes",
+            &[Label::Mode(mode), Label::Cache(CacheFamily::Catalog)],
+            max_bytes,
+        );
+    }
+}
+
+/// This process's own allocator-reported figures (#1170), read live at
+/// scrape time via [`crate::mem_stats::read`]: a whole-process RSS number
+/// cannot say which subsystem grew, so this surfaces the allocator's own
+/// breakdown -- or names the allocator plainly when it is not jemalloc,
+/// rather than reporting zeros for stats an allocator that isn't jemalloc
+/// does not expose.
+fn render_allocator_family(
+    out: &mut String,
+    mode: Mode,
+    allocator: crate::mem_stats::AllocatorStats,
+) {
+    match allocator {
+        crate::mem_stats::AllocatorStats::Jemalloc {
+            allocated,
+            active,
+            resident,
+        } => {
+            write_header(
+                out,
+                "ravel_process_allocator_bytes",
+                "This process's jemalloc-reported byte figures, split by stat= (allocated/active/resident).",
+                "gauge",
+            );
+            for (stat, value) in [
+                (AllocatorStat::Allocated, allocated),
+                (AllocatorStat::Active, active),
+                (AllocatorStat::Resident, resident),
+            ] {
+                write_sample(
+                    out,
+                    "ravel_process_allocator_bytes",
+                    &[
+                        Label::Mode(mode),
+                        Label::Allocator("jemalloc"),
+                        Label::AllocatorStat(stat),
+                    ],
+                    value,
+                );
+            }
+        }
+        crate::mem_stats::AllocatorStats::Other { name } => {
+            write_header(
+                out,
+                "ravel_process_allocator_info",
+                "Which allocator this process runs under, when it is not jemalloc: a 1-valued info series \
+                 naming it, never a stand-in zero for figures this allocator does not expose.",
+                "gauge",
+            );
+            write_sample(
+                out,
+                "ravel_process_allocator_info",
+                &[Label::Mode(mode), Label::Allocator(name)],
+                1,
+            );
+        }
+    }
+}
+
 /// The per-(tenant, signal) admission counters (ADR-0051 section 6), read
 /// from [`AdmissionController::usage_snapshot`] at scrape time and paired with
 /// the `--metrics-tenant-labels` decision, matching every other family's
@@ -3388,8 +3581,14 @@ pub fn render(
     durable_auth: Option<&DurableAuthCountersSnapshot>,
     attribution: &[TenantAttributionRow],
     metadata_cache: Option<&MetadataCacheCounters>,
+    allocator: crate::mem_stats::AllocatorStats,
+    cache_ram_residency: Option<(usize, u64)>,
+    cache_disk_residency: Option<(usize, u64)>,
+    cache_max_bytes: Option<u64>,
+    catalog_cache_max_bytes: Option<u64>,
 ) -> String {
     let mut out = String::new();
+    render_allocator_family(&mut out, mode, allocator);
     render_store_family(&mut out, mode, store);
     if !ingest.is_empty() {
         render_ingest_family(&mut out, mode, ingest);
@@ -3464,6 +3663,20 @@ pub fn render(
     if let Some(snapshot) = distrib {
         render_distrib_family(&mut out, mode, snapshot);
     }
+    if cache_ram_residency.is_some()
+        || cache_disk_residency.is_some()
+        || cache_max_bytes.is_some()
+        || catalog_cache_max_bytes.is_some()
+    {
+        render_cache_residency_family(
+            &mut out,
+            mode,
+            cache_ram_residency,
+            cache_disk_residency,
+            cache_max_bytes,
+            catalog_cache_max_bytes,
+        );
+    }
     out
 }
 
@@ -3528,6 +3741,26 @@ pub struct MetricsState {
     /// disabled. Rendered under `cache="catalog",tier="disk"`. Sourced from
     /// [`ravel_catalog::Catalog::byte_cache_disk_metrics`].
     pub catalog_cache_disk_metrics: Option<Arc<ravel_cache::CacheMetrics>>,
+    /// The fetcher cache handle itself (as distinct from `cache_metrics`'s
+    /// cumulative counters), for the live resident-bytes/entry-count gauges
+    /// (#1170): `Cache::len`/`total_bytes` or, tiered, `TieredCache::ram_len`/
+    /// `ram_total_bytes`/`disk_len`/`disk_total_bytes`. `None` under exactly
+    /// the same condition as `cache_metrics` (`--disable-cache`).
+    pub cache: Option<ravel_query::ReadCache>,
+    /// The resolved startup byte ceiling for the fetcher cache
+    /// (`ravel_server::store::build_cache`'s `cache_max_bytes`), rendered
+    /// under `cache="fetch"` alongside the live residency gauges above so an
+    /// operator can compare held-vs-budgeted. Meaningful only when
+    /// `cache_metrics` is `Some`; the value is otherwise whatever
+    /// `ServerConfig` resolved regardless of use.
+    pub cache_max_bytes: u64,
+    /// The resolved startup byte ceiling for the catalog byte cache
+    /// (`ravel_server::query::build_catalog`'s `cache_max_bytes`, a SEPARATE
+    /// ceiling from `cache_max_bytes` above), rendered under
+    /// `cache="catalog"`. Meaningful only when `catalog_cache_metrics` is
+    /// `Some`. The catalog cache's live residency is not rendered (see
+    /// [`render_cache_residency_family`]'s doc comment for the scope gap).
+    pub catalog_cache_max_bytes: u64,
     /// The one process-wide admission controller (ADR-0051), shared with every
     /// ingest path. Always present (built in every mode); in a mode that
     /// serves no ingest its `usage_snapshot` is simply empty, so the admission
@@ -3681,6 +3914,34 @@ async fn metrics_handler(State(state): State<MetricsState>) -> impl IntoResponse
         .as_ref()
         .map(|metrics| metrics.snapshot());
 
+    // Live (not cumulative) resident bytes/entries for the fetcher cache's
+    // tiers (#1170), read straight off the S3-FIFO structures via
+    // `ravel_query::ReadCache`'s two variants rather than `cache_metrics`'s
+    // cumulative counters, which cannot answer "what is resident right now."
+    let cache_ram_residency = state.cache.as_ref().map(|cache| match cache {
+        ravel_query::ReadCache::Ram(ram) => (ram.len(), ram.total_bytes()),
+        ravel_query::ReadCache::Tiered(tiered) => (tiered.ram_len(), tiered.ram_total_bytes()),
+    });
+    let cache_disk_residency = state.cache.as_ref().and_then(|cache| match cache {
+        ravel_query::ReadCache::Ram(_) => None,
+        ravel_query::ReadCache::Tiered(tiered) => {
+            Some((tiered.disk_len(), tiered.disk_total_bytes()))
+        }
+    });
+    let cache_max_bytes = state
+        .cache_metrics
+        .is_some()
+        .then_some(state.cache_max_bytes);
+    let catalog_cache_max_bytes = state
+        .catalog_cache_metrics
+        .is_some()
+        .then_some(state.catalog_cache_max_bytes);
+
+    // This process's own allocator figures (#1170), read live via mallctl
+    // (or named plainly when the allocator is not jemalloc) rather than
+    // relying on whole-process RSS to say which subsystem grew.
+    let allocator_stats = crate::mem_stats::read();
+
     // Read the admission counters at scrape time (a lock-and-copy, no
     // `.await`), like every other family, rather than baking a snapshot in at
     // construction.
@@ -3774,6 +4035,11 @@ async fn metrics_handler(State(state): State<MetricsState>) -> impl IntoResponse
         durable_auth_snapshot.as_ref(),
         &attribution,
         metadata_cache_snapshot.as_ref(),
+        allocator_stats,
+        cache_ram_residency,
+        cache_disk_residency,
+        cache_max_bytes,
+        catalog_cache_max_bytes,
     );
     (
         StatusCode::OK,
@@ -3851,6 +4117,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         assert!(
@@ -3896,7 +4167,8 @@ mod tests {
         // the fetcher and catalog byte caches; `kind` is the tenth, added by
         // ADR-0065 decision 4 for the RLOG merge-memory gauge; `tier` is the
         // eleventh, added by #97 to split each read cache into its RAM and
-        // local-disk tiers.
+        // local-disk tiers; `allocator` and `stat` are the twelfth and
+        // thirteenth, added by #1170 for the process allocator gauges.
         let one_of_each = [
             Label::TenantHash(TenantHashLabel::Other),
             Label::Signal(Signal::Metrics),
@@ -3910,6 +4182,8 @@ mod tests {
             Label::Cache(CacheFamily::Fetch),
             Label::CacheTier(CacheTier::Ram),
             Label::MergeMemoryKind(MergeMemoryKind::Transient),
+            Label::Allocator("jemalloc"),
+            Label::AllocatorStat(AllocatorStat::Allocated),
         ];
         let keys: Vec<&'static str> = one_of_each
             .iter()
@@ -3926,6 +4200,8 @@ mod tests {
                 Label::Cache(_) => "cache",
                 Label::CacheTier(_) => "tier",
                 Label::MergeMemoryKind(_) => "kind",
+                Label::Allocator(_) => "allocator",
+                Label::AllocatorStat(_) => "stat",
             })
             .collect();
         assert_eq!(
@@ -3946,15 +4222,18 @@ mod tests {
                 "cache",
                 "tier",
                 "kind",
+                "allocator",
+                "stat",
             ],
             "ADR-0044 section 4's allowlist plus ADR-0051 section 6's `reason` (also reused by \
              ADR-0059 section 2's scrub seal-divergence family), the `cache` label, #97's `tier` \
-             label, and ADR-0065 decision 4's `kind`; `shard` must never appear here"
+             label, ADR-0065 decision 4's `kind`, and #1170's `allocator`/`stat`; `shard` must \
+             never appear here"
         );
         assert_eq!(
             one_of_each.len(),
-            12,
-            "exactly 12 label variants, 11 distinct keys"
+            14,
+            "exactly 14 label variants, 13 distinct keys"
         );
     }
 
@@ -4000,6 +4279,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
 
@@ -4079,6 +4363,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
 
@@ -4213,6 +4502,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
 
@@ -4388,6 +4682,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         assert!(body.contains(
@@ -4454,6 +4753,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
 
@@ -4523,6 +4827,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         assert!(
@@ -4580,6 +4889,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
 
@@ -4681,6 +4995,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         assert!(
@@ -4730,6 +5049,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         assert!(
@@ -4761,6 +5085,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
 
@@ -4826,6 +5155,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         assert!(
@@ -4876,6 +5210,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         assert!(
@@ -4917,6 +5256,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
         // Default reachability is healthy (1); the process runs no probe here.
@@ -5018,6 +5362,11 @@ mod tests {
             Some(&snapshot),
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         // All three counters appear, mode-labeled, carrying the driven value.
@@ -5066,6 +5415,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
         assert!(
@@ -5119,6 +5473,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
 
@@ -5208,6 +5567,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         for expected in [
@@ -5279,6 +5643,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
         assert!(
             !off.contains("ravel_distrib_"),
@@ -5329,6 +5698,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
 
@@ -5413,6 +5787,11 @@ mod tests {
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
         assert!(
             !body.contains("ravel_scrub_"),
@@ -5463,6 +5842,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
 
@@ -5541,6 +5925,11 @@ mod tests {
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         );
 
@@ -5766,6 +6155,11 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
         assert!(
             body.contains("ravel_cache_hits_total{mode=\"gateway\",cache=\"catalog\"} 7"),
@@ -5803,6 +6197,11 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         assert!(
@@ -5810,6 +6209,107 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             "a server run with --disable-cache must not render any cache \
              family at all, neither fetch nor catalog:\n{body}"
         );
+    }
+
+    /// Exact figures (#1170), not `> 0`: on a jemalloc build the three stats
+    /// render as three distinct samples under their own `stat=` label, with
+    /// the values passed straight through, and the allocator-name info series
+    /// does not also render.
+    #[test]
+    fn allocator_family_renders_jemalloc_exact_figures() {
+        let mut out = String::new();
+        render_allocator_family(
+            &mut out,
+            Mode::Query,
+            crate::mem_stats::AllocatorStats::Jemalloc {
+                allocated: 111,
+                active: 222,
+                resident: 333,
+            },
+        );
+        assert!(out.contains(
+            "ravel_process_allocator_bytes{mode=\"query\",allocator=\"jemalloc\",stat=\"allocated\"} 111"
+        ));
+        assert!(out.contains(
+            "ravel_process_allocator_bytes{mode=\"query\",allocator=\"jemalloc\",stat=\"active\"} 222"
+        ));
+        assert!(out.contains(
+            "ravel_process_allocator_bytes{mode=\"query\",allocator=\"jemalloc\",stat=\"resident\"} 333"
+        ));
+        assert!(
+            !out.contains("ravel_process_allocator_info"),
+            "a jemalloc build renders the byte figures, never the named-allocator \
+             fallback series:\n{out}"
+        );
+    }
+
+    /// On a non-jemalloc build there are no allocated/active/resident figures
+    /// to report: the fallback is a single 1-valued info series naming the
+    /// allocator, never a stand-in zero for stats jemalloc alone exposes.
+    #[test]
+    fn allocator_family_renders_named_allocator_when_not_jemalloc() {
+        let mut out = String::new();
+        render_allocator_family(
+            &mut out,
+            Mode::Query,
+            crate::mem_stats::AllocatorStats::Other { name: "system" },
+        );
+        assert!(
+            out.contains("ravel_process_allocator_info{mode=\"query\",allocator=\"system\"} 1")
+        );
+        assert!(
+            !out.contains("ravel_process_allocator_bytes"),
+            "a non-jemalloc build must never report the jemalloc-only byte \
+             figures:\n{out}"
+        );
+    }
+
+    /// An empty fetcher cache (no tiered disk cache attached) must report
+    /// valid zeros, not omit the family: a reader scraping right after
+    /// startup needs to see `0`, not a missing series it cannot distinguish
+    /// from a scrape error.
+    #[test]
+    fn cache_residency_family_reports_valid_zeros_on_empty_cache() {
+        let mut out = String::new();
+        render_cache_residency_family(&mut out, Mode::Query, Some((0, 0)), None, Some(1000), None);
+        assert!(out.contains("ravel_cache_resident_entries{mode=\"query\",cache=\"fetch\"} 0"));
+        assert!(out.contains("ravel_cache_resident_bytes{mode=\"query\",cache=\"fetch\"} 0"));
+        assert!(out.contains("ravel_cache_max_bytes{mode=\"query\",cache=\"fetch\"} 1000"));
+        assert!(
+            !out.contains("tier="),
+            "a RAM-only cache (no disk tier) must render without a tier label:\n{out}"
+        );
+    }
+
+    /// A tiered cache with both tiers populated renders each tier's exact
+    /// entry count and byte total under its own `tier=` label, plus each
+    /// cache's resolved ceiling -- the held-vs-budgeted comparison this
+    /// family exists for.
+    #[test]
+    fn cache_residency_family_reports_exact_figures_for_both_tiers() {
+        let mut out = String::new();
+        render_cache_residency_family(
+            &mut out,
+            Mode::Query,
+            Some((3, 300)),
+            Some((5, 500)),
+            Some(1_000),
+            Some(2_000),
+        );
+        assert!(out.contains(
+            "ravel_cache_resident_entries{mode=\"query\",cache=\"fetch\",tier=\"ram\"} 3"
+        ));
+        assert!(out.contains(
+            "ravel_cache_resident_bytes{mode=\"query\",cache=\"fetch\",tier=\"ram\"} 300"
+        ));
+        assert!(out.contains(
+            "ravel_cache_resident_entries{mode=\"query\",cache=\"fetch\",tier=\"disk\"} 5"
+        ));
+        assert!(out.contains(
+            "ravel_cache_resident_bytes{mode=\"query\",cache=\"fetch\",tier=\"disk\"} 500"
+        ));
+        assert!(out.contains("ravel_cache_max_bytes{mode=\"query\",cache=\"fetch\"} 1000"));
+        assert!(out.contains("ravel_cache_max_bytes{mode=\"query\",cache=\"catalog\"} 2000"));
     }
 
     fn tenant_usage(tenant: &str, signal: Signal) -> TenantUsage {
@@ -5892,6 +6392,11 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         assert_eq!(
@@ -5969,6 +6474,11 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
 
         let rendered = admission_tenant_hashes(&body);
@@ -6045,6 +6555,11 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             None,
             &[],
             None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         );
         assert!(
             body.contains(&format!(
@@ -6096,6 +6611,11 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             None,
             None,
             &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
             None,
         )
     }
@@ -6313,6 +6833,11 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             None,
             &[],
             metadata_cache,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
         )
     }
 

--- a/services/ravel-server/src/tests.rs
+++ b/services/ravel-server/src/tests.rs
@@ -201,6 +201,9 @@ fn harness(store: Arc<dyn ObjectStoreBackend>, configured: HashSet<TenantHash>) 
             crate::ingest_byte_metrics::IngestByteMetrics::new(),
         ),
         metadata_cache: None,
+        cache: None,
+        cache_max_bytes: 0,
+        catalog_cache_max_bytes: 0,
     });
 
     Harness {

--- a/services/ravel-server/tests/query_cost_surfaces.rs
+++ b/services/ravel-server/tests/query_cost_surfaces.rs
@@ -211,6 +211,9 @@ fn surfaces(store: Arc<dyn ObjectStoreBackend>, tenant: &TenantId) -> Surfaces {
             ravel_server::ingest_byte_metrics::IngestByteMetrics::new(),
         ),
         metadata_cache: None,
+        cache: None,
+        cache_max_bytes: 0,
+        catalog_cache_max_bytes: 0,
     });
 
     Surfaces {
@@ -615,6 +618,9 @@ mod flight {
                 ravel_server::ingest_byte_metrics::IngestByteMetrics::new(),
             ),
             metadata_cache: None,
+            cache: None,
+            cache_max_bytes: 0,
+            catalog_cache_max_bytes: 0,
         });
         let scrape = scrape(&metrics).await;
         let expected = vec![


### PR DESCRIPTION
feat(server,cache): expose per-subsystem process memory diagnostics

Whole-process RSS cannot say which subsystem grew. Two memory attributions were
published from a ClickBench OOM this week and both had to be retracted: a 19.4 GB
peak that also contained the read cache holding up to 11.24 GB of corpus, and a
31.1 GB figure that was a kernel kill point rather than a peak.

This reports the figures that make an attribution possible at the moment they are
asked for: the allocator's own accounting, the payload bytes and entry count held
live by the fetcher cache and the catalog byte cache separately, and the ceilings
resolved at startup so what is held can be compared against what was budgeted.

The cache side reports bytes currently resident rather than a cumulative total. A
cumulative counter answers a different question than "what is held now", and
confusing the two is the error this change exists to prevent.

Why it matters now: the ClickBench concurrency phase drives the server into a
repeated OOM loop under its mandated 10 connections, at stock defaults, after
about four minutes of sustained load (see #1185). Diagnosing that needs
per-subsystem figures over time, not a kill point.

Local gates were not run: this machine had 15 GB free against the 54-70 GB a cold
workspace gate needs, so PR CI is the gate for this branch. The executor's own
gate run was green, which is not a substitute and is not being treated as one.

Refs: #1170
