### PR TITLE
fix(cli): refuse writes to a marker-less bucket, add tenancy resolve

### DIFF
--- a/docs/reference/ravel-cli-flags.md
+++ b/docs/reference/ravel-cli-flags.md
@@ -345,6 +345,14 @@ Print the bucket's `sys/tenancy` marker: its scheme and, for a keyed bucket, the
 | --- | --- | --- | --- |
 | `--tenant-hash-key-file` |  |  | Optional 32-byte deployment key file (64 hex chars or 32 raw bytes) to verify against the marker's fingerprint |
 
+### tenancy resolve
+
+Hash a tenant id under the bucket's resolved scheme and print its object-store prefix (`t/<hash>/`) on stdout and nothing else (issue #1180): the one entry point for turning a tenant id into the prefix a bytes-summed total, a lifecycle rule, or an erasure check needs, instead of scraping it off a failure message. Exits nonzero if the bucket's scheme needs a key that was not supplied via the global `--tenant-hash-key-file` / `--tenant-hash-unkeyed`
+
+| Flag | Environment variable | Default | Help |
+| --- | --- | --- | --- |
+| `<TENANT>` |  |  | Tenant id to resolve (hashed under the bucket's pinned scheme) |
+
 ## provision
 
 Manage the durable shard_count provisioning record (ADR-0050 section 5)

--- a/docs/reference/ravel-cli-flags.md
+++ b/docs/reference/ravel-cli-flags.md
@@ -347,7 +347,7 @@ Print the bucket's `sys/tenancy` marker: its scheme and, for a keyed bucket, the
 
 ### tenancy resolve
 
-Hash a tenant id under the bucket's resolved scheme and print its object-store prefix (`t/<hash>/`) on stdout and nothing else (issue #1180): the one entry point for turning a tenant id into the prefix a bytes-summed total, a lifecycle rule, or an erasure check needs, instead of scraping it off a failure message. Exits nonzero if the bucket's scheme needs a key that was not supplied via the global `--tenant-hash-key-file` / `--tenant-hash-unkeyed`
+Hash a tenant id under the bucket's resolved scheme and print its object-store prefix (`t/<hash>/`) on stdout and nothing else (issue #1180): the one entry point for turning a tenant id into the prefix a bytes-summed total, a lifecycle rule, or an erasure check needs, instead of scraping it off a failure message. Exits nonzero when the bucket's marker is `v2-keyed` and the global `--tenant-hash-key-file` was not given: that flag supplies the key the derivation needs. The global `--tenant-hash-unkeyed` is not an alternative way to satisfy a keyed marker: it selects the `v1-unkeyed` derivation, and is itself rejected against a keyed bucket
 
 | Flag | Environment variable | Default | Help |
 | --- | --- | --- | --- |

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -113,6 +113,10 @@ fn command_hashes_tenant(command: &Command) -> bool {
         | Command::Rspan { .. }
         | Command::Store { .. }
         | Command::Idem { .. }
+        // `tenancy show` decodes the marker itself and takes no `--tenant`;
+        // `tenancy resolve` (issue #1180) resolves the scheme itself inline
+        // (mirroring `show`), rather than going through this shared gate, so
+        // its dispatch arm stays self-contained and directly testable.
         | Command::Tenancy { .. }
         // sys/gc is a bucket-root object, not under any tenant prefix, so
         // gc-config never hashes a tenant. sys/auth (ADR-0072 decision 4) is
@@ -123,6 +127,36 @@ fn command_hashes_tenant(command: &Command) -> bool {
         // `cache reclaim-legacy` operates on a local directory, not object
         // storage: no tenant prefix, no store built.
         | Command::Cache { .. } => false,
+    }
+}
+
+/// Whether `command` writes to the object store (issue #1184). Used ahead of
+/// dispatch to require the bucket's `sys/tenancy` marker (or an explicit
+/// `--tenant-hash-key-file` / `--tenant-hash-unkeyed`) before the first write,
+/// rather than the lenient absent-marker default [`tenancy::resolve_scheme`]
+/// gives read-only commands: a fresh bucket defaults to keyed on the server,
+/// so a write there under the silent v1-unkeyed fallback lands under a prefix
+/// nothing addresses once the bucket is eventually bootstrapped keyed.
+///
+/// `catalog fold`, `maintain compact-bucket`/`compact-tenant`, and `commit
+/// reconstruct` also write and hash a tenant, but are out of this fix's scope
+/// (see the final report): they are left on the lenient default.
+fn command_is_write(command: &Command) -> bool {
+    match command {
+        Command::Load { .. } => true,
+        // Both `provision` shapes write a durable record (or, for `adopt`, a
+        // control record and audit entry via `reshard`); neither has a
+        // read-only variant.
+        Command::Provision { .. } => true,
+        Command::TypedAttrColumn { command } => {
+            matches!(command, TypedAttrColumnCommand::Set { .. })
+        }
+        Command::Hold { command } => {
+            matches!(command, HoldCommand::Set { .. } | HoldCommand::Clear { .. })
+        }
+        Command::Erase { command } => matches!(command, EraseCommand::Submit { .. }),
+        Command::GcConfig { command } => matches!(command, GcConfigCommand::Set { .. }),
+        _ => false,
     }
 }
 
@@ -727,6 +761,17 @@ enum TenancyCommand {
         #[arg(long, value_name = "PATH")]
         tenant_hash_key_file: Option<std::path::PathBuf>,
     },
+    /// Hash a tenant id under the bucket's resolved scheme and print its
+    /// object-store prefix (`t/<hash>/`) on stdout and nothing else (issue
+    /// #1180): the one entry point for turning a tenant id into the prefix a
+    /// bytes-summed total, a lifecycle rule, or an erasure check needs,
+    /// instead of scraping it off a failure message. Exits nonzero if the
+    /// bucket's scheme needs a key that was not supplied via the global
+    /// `--tenant-hash-key-file` / `--tenant-hash-unkeyed`.
+    Resolve {
+        /// Tenant id to resolve (hashed under the bucket's pinned scheme).
+        tenant: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -1080,9 +1125,25 @@ async fn main() -> anyhow::Result<()> {
             cli.tenancy.tenant_hash_key_file.as_deref(),
             cli.tenancy.tenant_hash_unkeyed,
         )?;
-        let scheme = tenancy::resolve_scheme(store.as_ref(), configured).await?;
+        let scheme = if command_is_write(&cli.command) {
+            tenancy::resolve_scheme_for_write(store.as_ref(), configured).await?
+        } else {
+            tenancy::resolve_scheme(store.as_ref(), configured).await?
+        };
         ravel_types::install_tenant_hash_scheme(scheme)
             .map_err(|_| anyhow::anyhow!("tenant-hash scheme was already installed"))?;
+    } else if command_is_write(&cli.command) {
+        // A writing command that does not hash a tenant (`gc-config set`:
+        // `sys/gc` is a bucket-root object) still writes into the same
+        // bucket the server must accept at startup, so it clears the same
+        // fail-closed gate even though it needs no `TenantHashScheme`
+        // installed (issue #1184).
+        let store = store::build_store(&cli.store)?;
+        let configured = tenancy::configured_scheme_from_flags(
+            cli.tenancy.tenant_hash_key_file.as_deref(),
+            cli.tenancy.tenant_hash_unkeyed,
+        )?;
+        tenancy::resolve_scheme_for_write(store.as_ref(), configured).await?;
     }
 
     match cli.command {
@@ -1458,6 +1519,19 @@ async fn main() -> anyhow::Result<()> {
             )
             .await?;
             print!("{report}");
+            Ok(())
+        }
+        Command::Tenancy {
+            command: TenancyCommand::Resolve { tenant },
+        } => {
+            let configured = tenancy::configured_scheme_from_flags(
+                cli.tenancy.tenant_hash_key_file.as_deref(),
+                cli.tenancy.tenant_hash_unkeyed,
+            )?;
+            let scheme =
+                tenancy::resolve_scheme(store::build_store(&cli.store)?.as_ref(), configured)
+                    .await?;
+            println!("{}", tenancy::resolve(&scheme, &tenant));
             Ok(())
         }
         Command::Provision {
@@ -2517,7 +2591,7 @@ mod tests {
     use clap::Parser;
 
     use super::rspan_status_mask_names;
-    use super::{Cli, Command};
+    use super::{Cli, Command, tenancy};
     use ravel_rspan::skip_index::{STATUS_BIT_ERROR, STATUS_BIT_OK, STATUS_BIT_UNSET};
 
     /// This unit test binary is built from this binary root, so it links the
@@ -2636,6 +2710,253 @@ mod tests {
             max_flush_delay,
             Some(std::time::Duration::from_secs(600)),
             "--max-flush-delay 10m reaches the field as 600s"
+        );
+    }
+
+    /// Issue #1184's classification: exactly `load`, `typed-attr-column set`,
+    /// `hold set`/`clear`, `erase submit`, `provision adopt`/`reshard`, and
+    /// `gc-config set` write; their `show`/`list`/`status` siblings, and every
+    /// other command, do not.
+    #[test]
+    fn command_is_write_classifies_the_named_shapes() {
+        let cases: &[(&[&str], bool)] = &[
+            (
+                &[
+                    "ravel",
+                    "load",
+                    "--parquet",
+                    "h.parquet",
+                    "--tenant",
+                    "t",
+                    "--mapping",
+                    "m.toml",
+                ],
+                true,
+            ),
+            (&["ravel", "typed-attr-column", "set", "t", "k:str"], true),
+            (&["ravel", "typed-attr-column", "show", "t"], false),
+            (
+                &["ravel", "hold", "set", "--tenant", "t", "--scope", "t/x/"],
+                true,
+            ),
+            (
+                &["ravel", "hold", "clear", "--tenant", "t", "--scope", "t/x/"],
+                true,
+            ),
+            (&["ravel", "hold", "list", "--tenant", "t"], false),
+            (
+                &[
+                    "ravel",
+                    "erase",
+                    "submit",
+                    "--tenant",
+                    "t",
+                    "--signal",
+                    "logs",
+                    "--matcher",
+                    "k=v",
+                ],
+                true,
+            ),
+            (
+                &[
+                    "ravel", "erase", "status", "--tenant", "t", "--signal", "logs",
+                ],
+                false,
+            ),
+            (
+                &[
+                    "ravel",
+                    "provision",
+                    "adopt",
+                    "--tenant",
+                    "t",
+                    "--shards",
+                    "4",
+                ],
+                true,
+            ),
+            (
+                &[
+                    "ravel",
+                    "provision",
+                    "reshard",
+                    "--tenant",
+                    "t",
+                    "--signal",
+                    "logs",
+                    "--shard-count",
+                    "8",
+                ],
+                true,
+            ),
+            (
+                &[
+                    "ravel",
+                    "gc-config",
+                    "set",
+                    "--protection-horizon",
+                    "25h",
+                    "--grace",
+                    "24h",
+                    "--max-query-duration",
+                    "1h",
+                    "--max-flush-lifetime",
+                    "1h",
+                ],
+                true,
+            ),
+            (&["ravel", "gc-config", "show"], false),
+            (&["ravel", "tenancy", "show"], false),
+            (&["ravel", "tenancy", "resolve", "t"], false),
+        ];
+        for (args, expect_write) in cases {
+            let cli =
+                Cli::try_parse_from(*args).unwrap_or_else(|e| panic!("{args:?} must parse: {e}"));
+            assert_eq!(
+                super::command_is_write(&cli.command),
+                *expect_write,
+                "{args:?} classified as write={}, expected {}",
+                super::command_is_write(&cli.command),
+                expect_write
+            );
+        }
+    }
+
+    /// Issue #1184, end to end against the exact gate `main` runs before
+    /// dispatch: `hold set` (a writing shape that hashes a tenant) against a
+    /// fresh, marker-less bucket with no scheme flag refuses with the
+    /// server's own `FreshBucketNeedsKey` wording, and the store holds zero
+    /// objects both before and after the attempt -- proving the refusal
+    /// happens before any write, not just that an error was raised.
+    ///
+    /// Non-vacuity: before this fix, `command_is_write` did not exist and
+    /// every tenant-hashing command (write or not) called plain
+    /// `resolve_scheme`, whose `Unspecified` arm returns
+    /// `Ok(TenantHashScheme::V1Unkeyed)`. Reverting the `if
+    /// super::command_is_write(&cli.command) { resolve_scheme_for_write }
+    /// else { resolve_scheme }` branch below to always call `resolve_scheme`
+    /// turns this test's `expect_err` into a panic on `Ok`.
+    #[tokio::test]
+    async fn hold_set_refuses_and_writes_nothing_on_marker_less_bucket() {
+        use ravel_object_store::ObjectStoreBackend;
+        use ravel_object_store::memory::MemoryStore;
+
+        let cli = Cli::try_parse_from([
+            "ravel", "hold", "set", "--tenant", "acme", "--scope", "t/x/",
+        ])
+        .expect("hold set parses");
+        let store: std::sync::Arc<dyn ObjectStoreBackend> = std::sync::Arc::new(MemoryStore::new());
+
+        let objects_before = store
+            .list("", None)
+            .await
+            .expect("list succeeds on an empty store")
+            .objects
+            .len();
+        assert_eq!(objects_before, 0);
+
+        let configured = tenancy::configured_scheme_from_flags(None, false)
+            .expect("no scheme flags is a valid configuration");
+        let gate = if super::command_is_write(&cli.command) {
+            tenancy::resolve_scheme_for_write(store.as_ref(), configured).await
+        } else {
+            tenancy::resolve_scheme(store.as_ref(), configured).await
+        };
+        let err = gate.expect_err("hold set on a fresh bucket with no scheme flag must refuse");
+        assert!(
+            err.to_string().contains(
+                "this is a fresh bucket and the tenant hash is keyed by default, but no \
+                 --tenant-hash-key-file was configured"
+            ),
+            "err: {err}"
+        );
+
+        let objects_after = store
+            .list("", None)
+            .await
+            .expect("list still succeeds")
+            .objects
+            .len();
+        assert_eq!(
+            objects_after, 0,
+            "the refused hold set must not have written any object"
+        );
+    }
+
+    /// The read-only sibling in the same command group, `hold list`, keeps
+    /// working against the same marker-less bucket with no scheme flag
+    /// (issue #1184's explicit requirement): `command_is_write` is false for
+    /// it, so it takes the lenient `resolve_scheme` path and gets the
+    /// v1-unkeyed default rather than a refusal.
+    #[tokio::test]
+    async fn hold_list_still_succeeds_on_marker_less_bucket() {
+        use ravel_object_store::ObjectStoreBackend;
+        use ravel_object_store::memory::MemoryStore;
+
+        let cli = Cli::try_parse_from(["ravel", "hold", "list", "--tenant", "acme"])
+            .expect("hold list parses");
+        assert!(!super::command_is_write(&cli.command));
+
+        let store: std::sync::Arc<dyn ObjectStoreBackend> = std::sync::Arc::new(MemoryStore::new());
+        let configured = tenancy::configured_scheme_from_flags(None, false)
+            .expect("no scheme flags is a valid configuration");
+        tenancy::resolve_scheme(store.as_ref(), configured)
+            .await
+            .expect("a read-only command must keep working on a fresh, marker-less bucket");
+    }
+
+    /// `gc-config set` writes `sys/gc`, a bucket-root object with no tenant
+    /// prefix, so it never reaches the tenant-hashing gate above; it still
+    /// must clear the write gate on its own (the `else if
+    /// command_is_write(&cli.command)` arm in `main`), since the invariant
+    /// is "does the server accept this bucket", not "does this command hash
+    /// a tenant".
+    #[tokio::test]
+    async fn gc_config_set_refuses_on_marker_less_bucket() {
+        use ravel_object_store::ObjectStoreBackend;
+        use ravel_object_store::memory::MemoryStore;
+
+        let cli = Cli::try_parse_from([
+            "ravel",
+            "gc-config",
+            "set",
+            "--protection-horizon",
+            "25h",
+            "--grace",
+            "24h",
+            "--max-query-duration",
+            "1h",
+            "--max-flush-lifetime",
+            "1h",
+        ])
+        .expect("gc-config set parses");
+        assert!(!super::command_hashes_tenant(&cli.command));
+        assert!(super::command_is_write(&cli.command));
+
+        let store: std::sync::Arc<dyn ObjectStoreBackend> = std::sync::Arc::new(MemoryStore::new());
+        let configured = tenancy::configured_scheme_from_flags(None, false)
+            .expect("no scheme flags is a valid configuration");
+        let err = tenancy::resolve_scheme_for_write(store.as_ref(), configured)
+            .await
+            .expect_err("gc-config set on a fresh bucket with no scheme flag must refuse");
+        assert!(
+            err.to_string().contains(
+                "this is a fresh bucket and the tenant hash is keyed by default, but no \
+                 --tenant-hash-key-file was configured"
+            ),
+            "err: {err}"
+        );
+
+        let objects_after = store
+            .list("", None)
+            .await
+            .expect("list succeeds")
+            .objects
+            .len();
+        assert_eq!(
+            objects_after, 0,
+            "the refused gc-config set must not have written sys/gc"
         );
     }
 

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -838,9 +838,12 @@ enum TenancyCommand {
     /// object-store prefix (`t/<hash>/`) on stdout and nothing else (issue
     /// #1180): the one entry point for turning a tenant id into the prefix a
     /// bytes-summed total, a lifecycle rule, or an erasure check needs,
-    /// instead of scraping it off a failure message. Exits nonzero if the
-    /// bucket's scheme needs a key that was not supplied via the global
-    /// `--tenant-hash-key-file` / `--tenant-hash-unkeyed`.
+    /// instead of scraping it off a failure message. Exits nonzero when the
+    /// bucket's marker is `v2-keyed` and the global `--tenant-hash-key-file`
+    /// was not given: that flag supplies the key the derivation needs. The
+    /// global `--tenant-hash-unkeyed` is not an alternative way to satisfy a
+    /// keyed marker: it selects the `v1-unkeyed` derivation, and is itself
+    /// rejected against a keyed bucket.
     Resolve {
         /// Tenant id to resolve (hashed under the bucket's pinned scheme).
         tenant: String,

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -185,11 +185,16 @@ fn command_is_write(command: &Command) -> bool {
         },
         Command::Maintain { command } => match command {
             // Writes L1 segment objects and a compaction record under
-            // `t/<tenant_hash>/<signal>/<shard>/...`.
-            MaintainCommand::CompactBucket { .. } | MaintainCommand::CompactTenant { .. } => true,
+            // `t/<tenant_hash>/<signal>/<shard>/...`, EXCEPT under `--dry-run`,
+            // which only reports the plan it would run. Gating a dry run would
+            // stop an operator inspecting that plan on a marker-less bucket,
+            // which is the one case where they most need to look before acting.
+            MaintainCommand::CompactBucket { dry_run, .. }
+            | MaintainCommand::CompactTenant { dry_run, .. } => !dry_run,
             // Deletes orphaned/superseded/unreferenced segment objects under
-            // `t/<tenant_hash>/<signal>/<shard>/...`.
-            MaintainCommand::Sweep { .. } => true,
+            // `t/<tenant_hash>/<signal>/<shard>/...`; `--dry-run` only lists
+            // what it would delete.
+            MaintainCommand::Sweep { dry_run, .. } => !dry_run,
             // Rewrites objects to the target format version and raises the
             // recorded format floor under `t/<tenant_hash>/...`.
             MaintainCommand::Migrate { .. } => true,
@@ -2903,6 +2908,29 @@ mod tests {
                     "0",
                 ],
                 true,
+            ),
+            // `--dry-run` reports the plan and mutates nothing, so it is a read
+            // even on the commands whose non-dry form writes. Gating it would
+            // stop an operator inspecting the plan on a marker-less bucket.
+            (
+                &[
+                    "ravel", "maintain", "sweep", "--tenant", "t", "--signal", "logs", "--shard",
+                    "0", "--dry-run",
+                ],
+                false,
+            ),
+            (
+                &[
+                    "ravel",
+                    "maintain",
+                    "compact-tenant",
+                    "--tenant",
+                    "t",
+                    "--signal",
+                    "logs",
+                    "--dry-run",
+                ],
+                false,
             ),
             (
                 &[

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -2914,8 +2914,16 @@ mod tests {
             // stop an operator inspecting the plan on a marker-less bucket.
             (
                 &[
-                    "ravel", "maintain", "sweep", "--tenant", "t", "--signal", "logs", "--shard",
-                    "0", "--dry-run",
+                    "ravel",
+                    "maintain",
+                    "sweep",
+                    "--tenant",
+                    "t",
+                    "--signal",
+                    "logs",
+                    "--shard",
+                    "0",
+                    "--dry-run",
                 ],
                 false,
             ),

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -138,9 +138,11 @@ fn command_hashes_tenant(command: &Command) -> bool {
 /// so a write there under the silent v1-unkeyed fallback lands under a prefix
 /// nothing addresses once the bucket is eventually bootstrapped keyed.
 ///
-/// `catalog fold`, `maintain compact-bucket`/`compact-tenant`, and `commit
-/// reconstruct` also write and hash a tenant, but are out of this fix's scope
-/// (see the final report): they are left on the lenient default.
+/// Exhaustive match, no catch-all: adding a `Command` variant must fail to
+/// compile here until someone classifies it, so the gate fails closed on
+/// future commands instead of silently treating them as reads (this is the
+/// hole issue #1184's original `_ => false` left open). Mirrors
+/// `command_hashes_tenant` above: every group names why it is a write or not.
 fn command_is_write(command: &Command) -> bool {
     match command {
         Command::Load { .. } => true,
@@ -155,8 +157,74 @@ fn command_is_write(command: &Command) -> bool {
             matches!(command, HoldCommand::Set { .. } | HoldCommand::Clear { .. })
         }
         Command::Erase { command } => matches!(command, EraseCommand::Submit { .. }),
+        // sys/gc is a bucket-root object (see `command_hashes_tenant`), but
+        // `gc-config set` still clears this same write gate: see
+        // `gc_config_set_refuses_on_marker_less_bucket` and the final report
+        // for the tension this raises with deliverable 3 of issue #1184's
+        // follow-up (closing the `command_is_write` catch-all).
         Command::GcConfig { command } => matches!(command, GcConfigCommand::Set { .. }),
-        _ => false,
+        Command::Commit { command } => match command {
+            // Decode-only shapes never write, only read an existing record.
+            CommitCommand::Decode { .. }
+            | CommitCommand::DecodeCompaction { .. }
+            | CommitCommand::DecodeTombstone { .. } => false,
+            // Writes CreateIfAbsent-only commit records under
+            // `t/<tenant_hash>/<signal>/<shard>/...`, computed from
+            // `--tenant` (see `command_hashes_tenant`).
+            CommitCommand::Reconstruct { .. } => true,
+        },
+        Command::Catalog { command } => match command {
+            // `list`/`inspect`/`verify` only read the catalog and commit
+            // records; they never publish a snapshot.
+            CatalogCommand::List { .. }
+            | CatalogCommand::Inspect { .. }
+            | CatalogCommand::Verify { .. } => false,
+            // Publishes a new snapshot HEAD and part objects under
+            // `t/<tenant_hash>/<signal>/...`.
+            CatalogCommand::Fold { .. } => true,
+        },
+        Command::Maintain { command } => match command {
+            // Writes L1 segment objects and a compaction record under
+            // `t/<tenant_hash>/<signal>/<shard>/...`.
+            MaintainCommand::CompactBucket { .. } | MaintainCommand::CompactTenant { .. } => true,
+            // Deletes orphaned/superseded/unreferenced segment objects under
+            // `t/<tenant_hash>/<signal>/<shard>/...`.
+            MaintainCommand::Sweep { .. } => true,
+            // Rewrites objects to the target format version and raises the
+            // recorded format floor under `t/<tenant_hash>/...`.
+            MaintainCommand::Migrate { .. } => true,
+            // Read-only inspection/reporting: `status` reports maintenance
+            // state, `audit-versions` audits live format versions, and
+            // `verify-custody` re-verifies the content-addressed chain; none
+            // writes or deletes.
+            MaintainCommand::Status { .. }
+            | MaintainCommand::AuditVersions { .. }
+            | MaintainCommand::VerifyCustody { .. } => false,
+        },
+        // `store qualify` writes `sys/qualification`, a bucket-root object,
+        // never under `t/<tenant_hash>/`; gating it would also break the
+        // documented bootstrap order (it runs before the first server start,
+        // which is what writes `sys/tenancy` in the first place).
+        Command::Store { .. } => false,
+        Command::Tenant { command } => match command {
+            TenantCommand::Token { command } => match command {
+                // `list` only reads `sys/auth`.
+                TenantTokenCommand::List { .. } => false,
+                // `upsert`/`revoke` write `sys/auth`, a bucket-root object,
+                // never under `t/<tenant_hash>/`.
+                TenantTokenCommand::Upsert { .. } | TenantTokenCommand::Revoke { .. } => false,
+            },
+        },
+        // Pure inspection commands that take an explicit key/path or decode a
+        // marker directly (`tenancy show`/`resolve` resolve the scheme
+        // inline rather than through this gate, per `command_hashes_tenant`),
+        // plus `cache reclaim-legacy`, which never touches object storage.
+        Command::Segment { .. }
+        | Command::Rlog { .. }
+        | Command::Rspan { .. }
+        | Command::Idem { .. }
+        | Command::Tenancy { .. }
+        | Command::Cache { .. } => false,
     }
 }
 
@@ -2713,10 +2781,13 @@ mod tests {
         );
     }
 
-    /// Issue #1184's classification: exactly `load`, `typed-attr-column set`,
-    /// `hold set`/`clear`, `erase submit`, `provision adopt`/`reshard`, and
-    /// `gc-config set` write; their `show`/`list`/`status` siblings, and every
-    /// other command, do not.
+    /// Issue #1184's classification: `load`, `typed-attr-column set`, `hold
+    /// set`/`clear`, `erase submit`, `provision adopt`/`reshard`, `gc-config
+    /// set`, `commit reconstruct`, `catalog fold`, and the mutating `maintain`
+    /// subcommands write; their `show`/`list`/`status`/`decode`/`inspect`
+    /// siblings do not, and neither do the bucket-root writers `store
+    /// qualify` and `tenant token upsert`/`revoke` (see `command_is_write`'s
+    /// comments for why the latter two are deliberately left ungated).
     #[test]
     fn command_is_write_classifies_the_named_shapes() {
         let cases: &[(&[&str], bool)] = &[
@@ -2809,6 +2880,64 @@ mod tests {
             (&["ravel", "gc-config", "show"], false),
             (&["ravel", "tenancy", "show"], false),
             (&["ravel", "tenancy", "resolve", "t"], false),
+            (
+                &[
+                    "ravel",
+                    "commit",
+                    "reconstruct",
+                    "--tenant",
+                    "t",
+                    "--signal",
+                    "logs",
+                    "--shard",
+                    "0",
+                ],
+                true,
+            ),
+            (&["ravel", "commit", "decode", "some-key"], false),
+            (&["ravel", "catalog", "fold", "--tenant", "t"], true),
+            (&["ravel", "catalog", "list", "--tenant", "t"], false),
+            (
+                &[
+                    "ravel", "maintain", "sweep", "--tenant", "t", "--signal", "logs", "--shard",
+                    "0",
+                ],
+                true,
+            ),
+            (
+                &[
+                    "ravel", "maintain", "status", "--tenant", "t", "--signal", "logs", "--shard",
+                    "0", "--hour", "0",
+                ],
+                false,
+            ),
+            (&["ravel", "store", "qualify"], false),
+            (
+                &[
+                    "ravel",
+                    "tenant",
+                    "token",
+                    "upsert",
+                    "--deployment-key-file",
+                    "k",
+                    "--token",
+                    "tok",
+                    "--tenant",
+                    "t",
+                ],
+                false,
+            ),
+            (
+                &[
+                    "ravel",
+                    "tenant",
+                    "token",
+                    "list",
+                    "--deployment-key-file",
+                    "k",
+                ],
+                false,
+            ),
         ];
         for (args, expect_write) in cases {
             let cli =

--- a/services/ravel-cli/src/tenancy.rs
+++ b/services/ravel-cli/src/tenancy.rs
@@ -51,6 +51,14 @@ pub fn configured_scheme_from_flags(
     Ok(ConfiguredScheme::Unspecified)
 }
 
+/// Exact wording of ravel-server's `TenancyError::FreshBucketNeedsKey`
+/// (services/ravel-server/src/tenancy.rs), reused verbatim so a writing CLI
+/// command refuses in the same words the server would refuse to start with
+/// (issue #1184).
+const FRESH_BUCKET_NEEDS_KEY: &str = "this is a fresh bucket and the tenant hash is keyed by \
+     default, but no --tenant-hash-key-file was configured: pass --tenant-hash-key-file to key \
+     the bucket, or --tenant-hash-unkeyed to opt out permanently";
+
 /// Resolve the tenant-hash scheme the CLI must hash tenants under, reading the
 /// bucket's real `sys/tenancy` marker and validating the configured scheme
 /// against it through the same fail-closed decision the server uses at startup
@@ -64,9 +72,39 @@ pub fn configured_scheme_from_flags(
 /// bucket with no marker is refused (the bucket is not pinned to that key),
 /// while an unkeyed or unspecified config falls back to the v1 derivation (the
 /// only scheme a pre-ADR, not-yet-adopted bucket ever used).
+///
+/// This lenient absent-marker default is only safe for a command that never
+/// writes: use [`resolve_scheme_for_write`] ahead of any write, since a fresh
+/// bucket defaults to keyed on the server and this fallback would otherwise
+/// write under the wrong (unkeyed) prefix silently (issue #1184).
 pub async fn resolve_scheme(
     store: &dyn ObjectStoreBackend,
     configured: ConfiguredScheme,
+) -> anyhow::Result<TenantHashScheme> {
+    resolve_scheme_inner(store, configured, false).await
+}
+
+/// The scheme resolution a writing subcommand must use ahead of its first
+/// write (issue #1184). Identical to [`resolve_scheme`] except that an absent
+/// marker with no scheme flag given (`ConfiguredScheme::Unspecified`) refuses
+/// with the same [`FRESH_BUCKET_NEEDS_KEY`] message the server's own startup
+/// refusal uses, instead of silently defaulting to the v1-unkeyed derivation.
+/// A bucket in that state is one the server itself refuses to start against
+/// (it defaults to keyed and has no key configured), so a CLI write there
+/// writes data under a prefix nothing will ever address once the bucket is
+/// eventually bootstrapped keyed. `--tenant-hash-unkeyed` remains a valid
+/// explicit opt-out: only the flag-less default is refused.
+pub async fn resolve_scheme_for_write(
+    store: &dyn ObjectStoreBackend,
+    configured: ConfiguredScheme,
+) -> anyhow::Result<TenantHashScheme> {
+    resolve_scheme_inner(store, configured, true).await
+}
+
+async fn resolve_scheme_inner(
+    store: &dyn ObjectStoreBackend,
+    configured: ConfiguredScheme,
+    refuse_unspecified_on_fresh_bucket: bool,
 ) -> anyhow::Result<TenantHashScheme> {
     let outcome = match store.get("sys/tenancy", GetRange::Full).await {
         Ok(outcome) => outcome,
@@ -78,6 +116,9 @@ pub async fn resolve_scheme(
                      refusing to hash tenants under a key this bucket is not pinned to. Drop the \
                      key file to inspect it unkeyed."
                 ),
+                ConfiguredScheme::Unspecified if refuse_unspecified_on_fresh_bucket => {
+                    anyhow::bail!(FRESH_BUCKET_NEEDS_KEY)
+                }
                 ConfiguredScheme::Unkeyed | ConfiguredScheme::Unspecified => {
                     Ok(TenantHashScheme::V1Unkeyed)
                 }
@@ -110,6 +151,16 @@ pub async fn resolve_scheme(
     };
     resolve_scheme_against_marker(marker_scheme, &marker.key_fingerprint, &configured)
         .map_err(|err| anyhow::anyhow!("{err}"))
+}
+
+/// `tenancy resolve` (issue #1180): hash `tenant` under an already-resolved
+/// `scheme` and return its object-store prefix. `scheme` comes from the same
+/// [`resolve_scheme`] call and [`TenantHashScheme::hash`] method every other
+/// tenant-hashing subcommand uses, so the prefix cannot drift from what the
+/// rest of the CLI, or the server, would derive for the same tenant.
+pub fn resolve(scheme: &TenantHashScheme, tenant: &str) -> String {
+    let hash = scheme.hash(&ravel_types::TenantId::new(tenant));
+    format!("t/{}/", hash.to_hex())
 }
 
 /// `tenancy show`: GET `sys/tenancy`, decode it, and render the scheme and (for
@@ -375,5 +426,98 @@ mod tests {
         let err = configured_scheme_from_flags(Some(Path::new("/some/key")), true)
             .expect_err("both flags must be rejected");
         assert!(err.to_string().contains("mutually exclusive"), "err: {err}");
+    }
+
+    /// Issue #1184: a writing subcommand's scheme resolution refuses a fresh
+    /// (marker-less) bucket when no scheme flag was given, with the exact
+    /// wording of the server's own `TenancyError::FreshBucketNeedsKey`
+    /// startup refusal. Before this fix, [`resolve_scheme`] was the only
+    /// resolution a writing subcommand had, and its `Unspecified` arm
+    /// returned `Ok(TenantHashScheme::V1Unkeyed)` here instead: flipping
+    /// `resolve_scheme_for_write` back to call plain `resolve_scheme`
+    /// reproduces that pre-fix behavior and turns this `expect_err` into a
+    /// panic on `Ok(V1Unkeyed)`.
+    #[tokio::test]
+    async fn write_resolution_refuses_unspecified_config_on_fresh_bucket() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let configured = configured_scheme_from_flags(None, false).expect("no flags is valid");
+        let err = resolve_scheme_for_write(store.as_ref(), configured)
+            .await
+            .expect_err("a fresh bucket with no scheme flag must refuse, not default to unkeyed");
+        assert_eq!(err.to_string(), FRESH_BUCKET_NEEDS_KEY);
+    }
+
+    /// The explicit `--tenant-hash-unkeyed` opt-out still works against a
+    /// fresh bucket: only the flag-less default is refused.
+    #[tokio::test]
+    async fn write_resolution_allows_explicit_unkeyed_on_fresh_bucket() {
+        use ravel_types::TenantId;
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let configured = configured_scheme_from_flags(None, true).expect("valid flags");
+        let scheme = resolve_scheme_for_write(store.as_ref(), configured)
+            .await
+            .expect("explicit --tenant-hash-unkeyed must still be honored");
+        let tenant = TenantId::new("acme");
+        assert_eq!(
+            scheme.hash(&tenant),
+            TenantHashScheme::V1Unkeyed.hash(&tenant)
+        );
+    }
+
+    /// `--tenant-hash-key-file` against a fresh bucket still refuses under
+    /// write resolution too, same as it already does for [`resolve_scheme`].
+    #[tokio::test]
+    async fn write_resolution_still_refuses_keyed_config_on_fresh_bucket() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let configured = ConfiguredScheme::Keyed(Box::new([0x55u8; 32]));
+        let err = resolve_scheme_for_write(store.as_ref(), configured)
+            .await
+            .expect_err("a keyed config against a marker-less bucket must refuse");
+        assert!(
+            err.to_string().contains("no sys/tenancy marker"),
+            "err: {err}"
+        );
+    }
+
+    /// Read-only resolution is unchanged by the write-path fix: it still
+    /// falls back to v1-unkeyed on a fresh bucket with no scheme flag, so a
+    /// read-only command keeps working exactly as before (issue #1184's
+    /// requirement that read-only subcommands keep working).
+    #[tokio::test]
+    async fn read_resolution_still_defaults_unspecified_on_fresh_bucket() {
+        use ravel_types::TenantId;
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let configured = configured_scheme_from_flags(None, false).expect("no flags is valid");
+        let scheme = resolve_scheme(store.as_ref(), configured)
+            .await
+            .expect("read-only resolution still defaults rather than refuses");
+        let tenant = TenantId::new("acme");
+        assert_eq!(
+            scheme.hash(&tenant),
+            TenantHashScheme::V1Unkeyed.hash(&tenant)
+        );
+    }
+
+    /// Issue #1180: `tenancy resolve` prints exactly `t/<hash>/`, computed
+    /// through the same [`TenantHashScheme::hash`] every other subcommand
+    /// calls, so a change to the derivation on either side fails this test.
+    #[test]
+    fn resolve_prints_exact_prefix_for_known_tenant_and_scheme() {
+        use ravel_types::TenantId;
+
+        let scheme = TenantHashScheme::V1Unkeyed;
+        let expected = format!("t/{}/", scheme.hash(&TenantId::new("acme")).to_hex());
+        assert_eq!(resolve(&scheme, "acme"), expected);
+
+        let key = [0x66u8; 32];
+        let keyed_scheme = TenantHashScheme::v2_from_deployment_key(&key);
+        let expected_keyed = format!("t/{}/", keyed_scheme.hash(&TenantId::new("acme")).to_hex());
+        assert_eq!(resolve(&keyed_scheme, "acme"), expected_keyed);
+        assert_ne!(
+            expected, expected_keyed,
+            "the two schemes must resolve different prefixes for the same tenant"
+        );
     }
 }


### PR DESCRIPTION
fix(cli): refuse writes to a marker-less bucket, add tenancy resolve

A bucket with no `sys/tenancy` marker is bootstrapped by the first SERVER start,
and the server's default is the keyed derivation, so it refuses to start without
a key file. `ravel-cli` against that same unmarked bucket did not refuse: it
computed a prefix and wrote. `ravel-cli load` reaches the same path, so a full
dataset could land in a bucket whose server then will not start, and if the
bucket were later bootstrapped keyed, those objects would sit under a prefix
nothing addresses, with no error at any point.

Writing subcommands now refuse a marker-less bucket with the same message and the
same two flags the server offers. Read-only subcommands are unaffected. The CLI
does not bootstrap the marker: the server owns that, and two writers of one
marker would be a worse bug than the one being fixed.

Adds `ravel-cli tenancy resolve <TENANT>`, which prints `t/<hash>/` and nothing
else. Nothing could previously answer that question: the only route was scraping
a failure message, and the success path printed nothing to scrape. Summing a
tenant's stored bytes, scoping a lifecycle rule, or checking what an erasure
removed all need it.

Found while running the ClickBench entry against a new bucket, where the load
step would have written the whole dataset before the first server start reported
the bucket unusable.

Fixes: #1184
Fixes: #1180
