### PR TITLE
docs: correct two statements the TLA+ reconnaissance found false

### DIFF
--- a/crates/ravel-ingest/src/idempotency.rs
+++ b/crates/ravel-ingest/src/idempotency.rs
@@ -157,10 +157,11 @@ fn marker_prefix(tenant_id: &TenantId, signal: Signal, client_key: &[u8]) -> Str
 
 /// Build the exact marker key for a pinned ingest-hour bucket
 /// (`t/<tenant_hash>/<signal>/idem/<keyhash32>.<ingest_hour>.idm`).
-/// [`write_marker`] always knows this hour (pinned at flush open, the same
-/// convention as the commit-record key); [`read_marker`] does not, because a
-/// retry's flush can land in a different hour than the original, which is
-/// why lookup instead LISTs [`marker_prefix`] over a window.
+/// [`write_marker`] always knows this hour (pinned at request receive, from
+/// the receiver's admission-time clock, not the commit record's flush-open
+/// hour); [`read_marker`] does not, because a retry's request can land in a
+/// different hour than the original, which is why lookup instead LISTs
+/// [`marker_prefix`] over a window.
 pub fn marker_key(
     tenant_id: &TenantId,
     signal: Signal,

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -106,11 +106,15 @@ most a rescan of the affected units, never correctness (the ADR-0003
 HEAD-pointer precedent). Nothing deletes these snapshots (staleness detection
 replaces a sweep; a bounded cleanup sweep is a future step if it ever matters).
 
-`sys/maintain/claims/compaction/<work_id_hex>` (ADR-1029 §1) is the maintain
-role's advisory work-claim keyspace, the third root-level prefix beside the
-heartbeat and memo prefixes above. One small mutable object per unit of
-expensive merge work, so two processes do not both pay for compacting the same
-sealed bucket. `work_id` is
+`sys/maintain/claims/compaction/<work_id_hex>` (ADR-1029 §1, Proposed) is the
+maintain role's advisory work-claim keyspace, the third root-level prefix
+beside the heartbeat and memo prefixes above. The primitive is landed in
+`ravel_fleet::claim` (`acquire`, `renew`, `steal`, `mark_completed`) but has
+no callers today: nothing in the compaction path acquires this key, so two
+processes can still both pay for compacting the same sealed bucket until a
+caller is wired in. The rest of this section describes the mechanism as
+designed, for when that lands. One small mutable object per unit of
+expensive merge work is meant to stop that double payment. `work_id` is
 `blake3::derive_key("ravel-compaction-claim-v1", tenant_hash || signal ||
 shard || ingest_hour_bucket)`, hex-encoded, where `tenant_hash` is the raw 16
 bytes, `signal` is the one-byte signal key prefix (`l`, `m`, `s`, ...), and


### PR DESCRIPTION
Building the verification suite surfaced places where a normative document
disagreed with the shipped code. Three of the five turned out to be
already correct on main and are left alone; the two that were wrong are
fixed here.

The marker_key doc comment said the marker's hour is pinned at flush open,
the same convention as the commit-record key. It is not: the caller chain
derives it from the request-receive timestamp before any flush, through
request_ingest_hour_bucket.

docs/catalog-and-mvcc.md described the compaction-claim keyspace in the
present tense, as though compactors already used it to avoid duplicate
work. The primitive is landed in ravel_fleet::claim and has no callers,
and ADR-1029 is Proposed, so nothing currently prevents duplicate
compaction. The section now says so and is framed as the design rather
than as current behaviour.

Fixes: #1126
