### PR TITLE
docs(lifecycle): label fenced code blocks with language identifiers

### DIFF
--- a/formal/tla/lifecycle/counterexamples/absent-head-delete-probes.md
+++ b/formal/tla/lifecycle/counterexamples/absent-head-delete-probes.md
@@ -16,7 +16,7 @@ A scratch module under `/tmp`, `EXTENDS MCLifecycleGC`, checked with
 `SPECIFICATION Spec`, `VIEW View`, `INVARIANT TypeOK` plus one probe at a
 time, `smoke.cfg`'s constants.
 
-```
+```tla
 ProbeReachesRetentionDeleteUnderAbsentHead ==
     ~(headState = "absent" /\ lastGc.rule = "retention")
 

--- a/formal/tla/lifecycle/counterexamples/candidate-1133.md
+++ b/formal/tla/lifecycle/counterexamples/candidate-1133.md
@@ -15,7 +15,7 @@ Invariant checked: `NoDeleteInsideProtectionWindow`. Result: violated, TLC exit
 
 Exact TLC line:
 
-```
+```text
 Error: Invariant NoDeleteInsideProtectionWindow is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/complete-ignores-served-set.md
+++ b/formal/tla/lifecycle/counterexamples/complete-ignores-served-set.md
@@ -6,7 +6,7 @@ subject). All other switches at base.
 
 Target invariant: `CompletionImpliesNoPreRewriteExposure`. TLC exit 12.
 
-```
+```text
 Error: Invariant CompletionImpliesNoPreRewriteExposure is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/completion-ignores-legal-hold-mutant.md
+++ b/formal/tla/lifecycle/counterexamples/completion-ignores-legal-hold-mutant.md
@@ -9,7 +9,7 @@ serves the erased subject, which `CompletionRespectsLegalHold` then catches.
 Behaviour edit (not a switch), applied to a scratch copy under `/tmp`. The
 unconditional gate is deleted from `CompleteErasure`:
 
-```
+```tla
      /\ (CompleteIgnoresServedSet \/ ~ServesNow("s1"))
 -    /\ ~HeldInputServes("s1")
      /\ clock > 0
@@ -23,7 +23,7 @@ has no switch of its own in either the model or the code).
 
 TLC exit 12. Exact line:
 
-```
+```text
 Error: Invariant CompletionRespectsLegalHold is violated.
 ```
 
@@ -43,7 +43,7 @@ Re-applied the same one-line removal to the post-finding-2 model (`DataObjects`,
 no `ServesSubject` conjunct; see `rewrite-output-hold-probe.md`) against the
 same base `smoke.cfg`. TLC exit 12. Exact line:
 
-```
+```text
 Error: Invariant CompletionRespectsLegalHold is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/delete-before-horizon.md
+++ b/formal/tla/lifecycle/counterexamples/delete-before-horizon.md
@@ -5,7 +5,7 @@ Switch: `DeleteBeforeHorizon = TRUE` (drops the retention horizon gate
 
 Target invariant: `NoDeleteInsideProtectionWindow`. TLC exit 12.
 
-```
+```text
 Error: Invariant NoDeleteInsideProtectionWindow is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/dreq-ignores-held-inputs.md
+++ b/formal/tla/lifecycle/counterexamples/dreq-ignores-held-inputs.md
@@ -12,7 +12,7 @@ fire the invariant that names that clause, not the unrelated
 reachability and never claimed anything about a held-but-unreachable input).
 TLC exit 12.
 
-```
+```text
 Error: Invariant DreqSweepRespectsLegalHold is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/dreq-removal-pinned-reader-mutant.md
+++ b/formal/tla/lifecycle/counterexamples/dreq-removal-pinned-reader-mutant.md
@@ -14,7 +14,7 @@ specifically instead of whichever invariant a full-list run reports first).
 Behaviour edit (not a switch), applied to a scratch copy under `/tmp`. The
 unconditional live-reachability gate is deleted from `DreqSweep`:
 
-```
+```tla
      /\ clock >= dreqHorizon
 -    /\ ~ServesAny("s1")
      /\ (DreqIgnoresHeldInputs \/ ~HeldInputServes("s1"))
@@ -28,7 +28,7 @@ except the invariant list is narrowed to `TypeOK` plus
 
 TLC exit 12. Exact line:
 
-```
+```text
 Error: Invariant DreqRemovalCannotResurrect is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/erased-subject-mutant.md
+++ b/formal/tla/lifecycle/counterexamples/erased-subject-mutant.md
@@ -10,7 +10,7 @@ Behaviour edit (not a switch), applied to a scratch copy under `/tmp`. The
 erasure request stops writing its `.dreq` marker, so the read-time erasure
 filter `~PresentObj("dreqR1")` never engages:
 
-```
+```tla
 -    /\ S!PutCreateIfAbsent("dreqR1", "dat")
 +    /\ UNCHANGED storeVars
 ```
@@ -22,7 +22,7 @@ fires. The run used the base `smoke.cfg`.
 
 TLC exit 12. Exact line:
 
-```
+```text
 Error: Invariant ErasedSubjectNeverServedAfterRequest is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/held-object-mutant.md
+++ b/formal/tla/lifecycle/counterexamples/held-object-mutant.md
@@ -8,7 +8,7 @@ held object exists and the invariant catches it.
 Behaviour edit (not a switch), applied to a scratch copy under `/tmp`. The
 legal-hold gate is removed from the sweep bodies:
 
-```
+```tla
 -    /\ ~HeldObject(o, heldBuckets)
 ```
 
@@ -19,7 +19,7 @@ the run used the base `smoke.cfg` with every switch at its shipped value.
 
 TLC exit 12. Exact line:
 
-```
+```text
 Error: Invariant HeldObjectNeverDeleted is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/perform-rewrite-completion-guard-probe.md
+++ b/formal/tla/lifecycle/counterexamples/perform-rewrite-completion-guard-probe.md
@@ -14,7 +14,7 @@ after which the old guard set still permitted `PerformRewrite`.
 
 A scratch module under `/tmp`, `EXTENDS MCLifecycleGC`, adding:
 
-```
+```tla
 ProbeNoRewriteAfterCompletion ==
     PresentObj("doneR1") => ~(ENABLED PerformRewrite)
 ```
@@ -27,7 +27,7 @@ View`, every switch at `smoke.cfg`'s shipped value, `MaxClock = 2`.
 `PerformRewrite` with only its pre-existing three conjuncts (no
 `~PresentObj("doneR1")`). TLC exit 12:
 
-```
+```text
 Error: Invariant ProbeNoRewriteAfterCompletion is violated.
 ```
 
@@ -41,7 +41,7 @@ generated, 1052 distinct, run stopped at the first violation).
 `PerformRewrite` gated additionally on `~PresentObj("doneR1")`. TLC exit 0.
 Exact line:
 
-```
+```text
 Model checking completed. No error has been found.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/perform-rewrite-predecessor-presence-probe.md
+++ b/formal/tla/lifecycle/counterexamples/perform-rewrite-predecessor-presence-probe.md
@@ -15,7 +15,7 @@ derive `rwA`'s content from an input no longer in the store.
 
 A scratch module under `/tmp`, `EXTENDS MCLifecycleGC`, adding:
 
-```
+```tla
 ProbeNoRewriteWithMissingPredecessor ==
     (\E i \in Predecessors("rwA") : ~PresentObj(i)) => ~(ENABLED PerformRewrite)
 ```
@@ -28,7 +28,7 @@ View`, every switch at `smoke.cfg`'s shipped value, `MaxClock = 2`.
 `PerformRewrite` with `~PresentObj("doneR1")` present but no predecessor
 presence conjunct. TLC exit 12:
 
-```
+```text
 Error: Invariant ProbeNoRewriteWithMissingPredecessor is violated.
 ```
 
@@ -43,7 +43,7 @@ the first violation).
 `PerformRewrite` gated additionally on `\A i \in Predecessors("rwA") :
 PresentObj(i)`. TLC exit 0. Exact line:
 
-```
+```text
 Model checking completed. No error has been found.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/perform-rewrite-reachable-probe.md
+++ b/formal/tla/lifecycle/counterexamples/perform-rewrite-reachable-probe.md
@@ -16,7 +16,7 @@ A scratch module under `/tmp`, `EXTENDS MCLifecycleGC`, checked with
 `SPECIFICATION Spec`, `VIEW View`, `INVARIANT TypeOK` plus the probe,
 `smoke.cfg`'s constants.
 
-```
+```tla
 ProbeReachesPerformRewrite ==
     ~(PresentObj("rwA") /\ RawInputs \subseteq superseded)
 ```

--- a/formal/tla/lifecycle/counterexamples/perform-rewrite-still-reachable-after-guards-probe.md
+++ b/formal/tla/lifecycle/counterexamples/perform-rewrite-still-reachable-after-guards-probe.md
@@ -9,7 +9,7 @@ conjuncts (`~PresentObj("doneR1")`, predecessor presence) are in place.
 A scratch module under `/tmp`, `EXTENDS MCLifecycleGC`, adding the same
 formula as `reachability-probes.md`'s `ProbeReachesRewriteSupersession`:
 
-```
+```tla
 ProbeReachesPerformRewrite ==
     ~(PresentObj("rwA") /\ RawInputs \subseteq superseded)
 ```
@@ -22,7 +22,7 @@ value, `MaxClock = 2`.
 
 TLC exit 12:
 
-```
+```text
 Error: Invariant ProbeReachesPerformRewrite is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/perform-rewrite-tombstone-guard-probe.md
+++ b/formal/tla/lifecycle/counterexamples/perform-rewrite-tombstone-guard-probe.md
@@ -14,7 +14,7 @@ so `tombB1` can be present while every one of those conjuncts still holds.
 
 A scratch module under `/tmp`, `EXTENDS MCLifecycleGC`, adding:
 
-```
+```tla
 ProbeNoRewriteOverTombstonedBucket ==
     PresentObj("tombB1") => ~(ENABLED PerformRewrite)
 
@@ -31,7 +31,7 @@ value, `MaxClock = 2`.
 `PerformRewrite` with only its pre-existing five conjuncts (no
 `~PresentObj("tombB1")`), `ProbeNoRewriteOverTombstonedBucket`. TLC exit 12:
 
-```
+```text
 Error: Invariant ProbeNoRewriteOverTombstonedBucket is violated.
 ```
 
@@ -45,7 +45,7 @@ the old guard set's `ENABLED PerformRewrite` is still true there.
 `PerformRewrite` gated additionally on `~PresentObj("tombB1")`,
 `ProbeNoRewriteOverTombstonedBucket`. TLC exit 0:
 
-```
+```text
 Model checking completed. No error has been found.
 ```
 
@@ -56,7 +56,7 @@ Model checking completed. No error has been found.
 
 Same fixed model, `ProbeReachesPerformRewrite`. TLC exit 12:
 
-```
+```text
 Error: Invariant ProbeReachesPerformRewrite is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/raw-input-immutable-mutant.md
+++ b/formal/tla/lifecycle/counterexamples/raw-input-immutable-mutant.md
@@ -9,7 +9,7 @@ it, even though no such behaviour is part of the shipped `Next`.
 Behaviour edit (not a switch), applied to a scratch copy under `/tmp`. A new
 action is added and disjuncted into `Next`:
 
-```
+```tla
 MutateRawInput ==
     /\ PresentObj("raw1")
     /\ objContent["raw1"] # {}
@@ -29,7 +29,7 @@ its shipped value and the full smoke invariant list, including
 
 TLC exit 12 at depth 4. Exact line:
 
-```
+```text
 Error: Invariant RawInputContentAssumedImmutable is violated.
 ```
 
@@ -41,7 +41,7 @@ to `{}`, so `objContent["raw1"] = InitContent("raw1")` fails immediately.
 The unmutated model (no `MutateRawInput` action, same `smoke.cfg`) passes
 with `RawInputContentAssumedImmutable` in the invariant list:
 
-```
+```text
 check-tla: lifecycle/MCLifecycleGC smoke: PASS  states=276015 distinct=50102 depth=21 3s
 ```
 

--- a/formal/tla/lifecycle/counterexamples/reachability-probes.md
+++ b/formal/tla/lifecycle/counterexamples/reachability-probes.md
@@ -15,7 +15,7 @@ time, `exhaustive.cfg`'s constants (`MaxClock = 3`, every switch at its
 shipped value). Each probe is checked alone so its own violation is
 unambiguous.
 
-```
+```tla
 ProbeReachesRewriteSupersession ==
     ~(PresentObj("rwA") /\ RawInputs \subseteq superseded)
 

--- a/formal/tla/lifecycle/counterexamples/refresh-failure-is-no-hold.md
+++ b/formal/tla/lifecycle/counterexamples/refresh-failure-is-no-hold.md
@@ -6,7 +6,7 @@ All other switches at base.
 
 Target invariant: `RefreshFailureNeverSweeps`. TLC exit 12.
 
-```
+```text
 Error: Invariant RefreshFailureNeverSweeps is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/rewrite-identity-omits-requests.md
+++ b/formal/tla/lifecycle/counterexamples/rewrite-identity-omits-requests.md
@@ -6,7 +6,7 @@ applied requests hash to the same key). All other switches at base.
 
 Target invariant: `IdenticalInputSetsDoNotCollide`. TLC exit 12.
 
-```
+```text
 Error: Invariant IdenticalInputSetsDoNotCollide is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/rewrite-keeps-erased-records.md
+++ b/formal/tla/lifecycle/counterexamples/rewrite-keeps-erased-records.md
@@ -6,7 +6,7 @@ switches at base.
 
 Target invariant: `RewriteOutputsAreInputsMinusErased`. TLC exit 12.
 
-```
+```text
 Error: Invariant RewriteOutputsAreInputsMinusErased is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/rewrite-output-hold-probe.md
+++ b/formal/tla/lifecycle/counterexamples/rewrite-output-hold-probe.md
@@ -9,7 +9,7 @@ subject.
 
 A scratch module under `/tmp`, `EXTENDS MCLifecycleGC`, adding:
 
-```
+```tla
 ProbeNoCompletionUnderBucketHold ==
     ("b1" \in heldBuckets /\ (\E o \in DataObjects : Bucket(o) = "b1" /\ PresentObj(o)))
         => ~(ENABLED CompleteErasure)
@@ -31,7 +31,7 @@ predicate was therefore already equivalent to a content-blind "held and
 present" check for `raw1`, by coincidence, while the same requirement made a
 held `rwA` invisible to the gate. TLC exit 12 with this scope-only widening:
 
-```
+```text
 Error: Invariant ProbeNoCompletionUnderBucketHold is violated.
 ```
 
@@ -48,7 +48,7 @@ generated, 7234 distinct states found).
 `bucket_is_held`'s and `chain_groups_held_by_legal_hold`'s own content-blind,
 per-live-key gating. TLC exit 0. Exact line:
 
-```
+```text
 Model checking completed. No error has been found.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/rewrite-output-surviving-record-mutant.md
+++ b/formal/tla/lifecycle/counterexamples/rewrite-output-surviving-record-mutant.md
@@ -14,7 +14,7 @@ Behaviour edit (not a switch), applied to a scratch copy under `/tmp`. The
 rewrite output drops the surviving record outright, regardless of the
 `RewriteKeepsErasedRecords` switch:
 
-```
+```tla
 -    IN IF RewriteKeepsErasedRecords
 -           THEN inRecs
 -           ELSE { r \in inRecs : RecordSubject(r) \notin ErasedBy(AppliedReqs("rwA")) }
@@ -30,7 +30,7 @@ its shipped value.
 
 TLC exit 12. Exact line:
 
-```
+```text
 Error: Invariant RewriteOutputsAreInputsMinusErased is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/superseded-sweep-ungated.md
+++ b/formal/tla/lifecycle/counterexamples/superseded-sweep-ungated.md
@@ -6,7 +6,7 @@ switches at base.
 
 Target invariant: `HeadNamedObjectNeverDeletedBySupersededSweep`. TLC exit 12.
 
-```
+```text
 Error: Invariant HeadNamedObjectNeverDeletedBySupersededSweep is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/sweep-tombstone-empty-bucket-mutant.md
+++ b/formal/tla/lifecycle/counterexamples/sweep-tombstone-empty-bucket-mutant.md
@@ -9,7 +9,7 @@ object is reachable and the invariant catches it.
 Behaviour edit (not a switch), applied to a scratch copy under `/tmp`. The
 bucket-empty precondition is removed from `SweepTombstone`:
 
-```
+```tla
 -    /\ \A o \in DataObjects : Bucket(o) = "b1" => ~PresentObj(o)
 ```
 
@@ -20,7 +20,7 @@ at its shipped value.
 
 TLC exit 12. Exact line:
 
-```
+```text
 Error: Invariant TombstoneNotDeletedBeforeBucketEmpty is violated.
 ```
 

--- a/formal/tla/lifecycle/counterexamples/sweep-tombstone-reachable-probe.md
+++ b/formal/tla/lifecycle/counterexamples/sweep-tombstone-reachable-probe.md
@@ -12,7 +12,7 @@ A scratch module under `/tmp`, `EXTENDS MCLifecycleGC`, checked with
 `SPECIFICATION Spec`, `VIEW View`, `INVARIANT TypeOK` plus the probe,
 `smoke.cfg`'s constants.
 
-```
+```tla
 ProbeReachesSweepTombstone ==
     lastGc.rule # "tombstone"
 ```

--- a/formal/tla/lifecycle/counterexamples/tombstone-mutant.md
+++ b/formal/tla/lifecycle/counterexamples/tombstone-mutant.md
@@ -8,7 +8,7 @@ that runs before its tombstone exists is reachable and the invariant catches it.
 Behaviour edit (not a switch), applied to a scratch copy under `/tmp`. The
 tombstone-present precondition is removed from both sweep-enabling actions:
 
-```
+```tla
 -    /\ PresentObj("tombB1")
 ```
 
@@ -25,7 +25,7 @@ clause are untouched. The run used the base `smoke.cfg`.
 
 TLC exit 12. Exact line:
 
-```
+```text
 Error: Invariant TombstoneExcludesBeforeDelete is violated.
 ```
 

--- a/formal/tla/lifecycle/results.md
+++ b/formal/tla/lifecycle/results.md
@@ -883,14 +883,14 @@ Non-vacuity: a scratch mutant (`counterexamples/raw-input-immutable-mutant.md`)
 adds a `MutateRawInput` action, disjuncted into `Next`, that clears
 `objContent["raw1"]`. Against `smoke.cfg` with the new invariant in the list:
 
-```
+```text
 Error: Invariant RawInputContentAssumedImmutable is violated.
 ```
 
 (TLC exit 12, depth 4, 6 states generated / 6 distinct.) The unmutated model
 passes clean with the same invariant list:
 
-```
+```text
 check-tla: lifecycle/MCLifecycleGC smoke: PASS  states=276015 distinct=50102 depth=21 3s
 ```
 


### PR DESCRIPTION
markdownlint MD040 flagged fenced blocks without a language in the
lifecycle GC model's counterexample notes and results. The review that
filed it counted nine in three files; the full sweep of
formal/tla/lifecycle found forty-seven across twenty-six files. Each
opening fence now carries tla for TLA+ definitions and diff snippets or
text for TLC output. No content inside any block changed, and the diff is
forty-seven fence lines and nothing else.

Fixes: #1222
Refs: #1113, #1122
