### PR TITLE
test(object-store): pin four contract claims the TLA+ suite named

### DIFF
--- a/crates/ravel-object-store/src/conformance.rs
+++ b/crates/ravel-object-store/src/conformance.rs
@@ -1385,4 +1385,62 @@ mod tests {
         assert_eq!(listing.versions.len(), 1);
         assert_eq!(listing.versions[0].version_id, "v-prior-1");
     }
+
+    /// `PutOverwriteLostResponse / LostResponseEffectApplied`
+    /// (formal/tla/common/traceability.md): a lost-response write still
+    /// applies its durable effect even though the caller observes a
+    /// failure, modeled here by `FaultKind::DuplicateDelivery` on `Put`
+    /// (`FaultStore` calls the wrapped `put` for real, then returns
+    /// `Transient`, per its module doc). This proves only the
+    /// memory-oracle half of the row; the backend half stays an
+    /// assumption until a probe exists against a real S3-compatible
+    /// endpoint.
+    #[tokio::test]
+    async fn lost_ack_after_successful_put_leaves_object_visible() {
+        let key = "lost-ack/k";
+        let plan =
+            FaultPlan::empty().with_rule(Rule::new(Op::Put, ScriptedFault::DuplicateDelivery));
+        let store = FaultStore::new(MemoryStore::new(), plan);
+
+        let err = store
+            .put(key, Bytes::from_static(b"v1"), PutOptions::default())
+            .await
+            .expect_err("a lost-response PUT must surface an error to the caller");
+        assert!(matches!(err, StoreError::Transient(_)), "got {err:?}");
+        assert_eq!(store.fault_count(Op::Put, FaultKind::DuplicateDelivery), 1);
+
+        let got = store
+            .get(key, GetRange::Full)
+            .await
+            .expect("the object must be visible even though the caller saw a failure");
+        assert_eq!(&got.data[..], b"v1");
+    }
+
+    /// `TransientFailure / TransientLeavesNothing`
+    /// (formal/tla/common/traceability.md): a transient failure applies
+    /// nothing, modeled here by `FaultKind::Transient` on `Put`
+    /// (`FaultStore` never calls the wrapped backend for that kind, per
+    /// its module doc). This proves only the memory-oracle half of the
+    /// row; the backend half stays an assumption until a probe exists
+    /// against a real S3-compatible endpoint.
+    #[tokio::test]
+    async fn failed_put_leaves_no_object() {
+        let key = "transient-put/k";
+        let plan = FaultPlan::empty()
+            .with_rule(Rule::new(Op::Put, ScriptedFault::Transient("blip".into())));
+        let store = FaultStore::new(MemoryStore::new(), plan);
+
+        let err = store
+            .put(key, Bytes::from_static(b"v1"), PutOptions::default())
+            .await
+            .expect_err("the transient fault must surface as an error");
+        assert!(matches!(err, StoreError::Transient(_)), "got {err:?}");
+        assert_eq!(store.fault_count(Op::Put, FaultKind::Transient), 1);
+
+        let err = store
+            .head(key)
+            .await
+            .expect_err("a failed PUT must leave no object, partial or otherwise");
+        assert!(matches!(err, StoreError::NotFound), "got {err:?}");
+    }
 }

--- a/crates/ravel-object-store/tests/contract.rs
+++ b/crates/ravel-object-store/tests/contract.rs
@@ -1052,6 +1052,78 @@ impl ObjectStoreBackend for RefusingMultipartStore {
     }
 }
 
+/// `PutCasVersion / CasOutcomeMatchesEffect` (formal/tla/common/traceability.md):
+/// a `CasVersion` put against a key that has never existed has no current
+/// version to match, so it must fail `PreconditionFailed`, the same outcome
+/// as a stale version against a present key, and apply nothing.
+#[tokio::test]
+async fn cas_version_on_absent_key_is_precondition_failed() {
+    let store = MemoryStore::new();
+    let key = "cas-absent/k";
+
+    // A well-formed but wrong version token: a real version issued for a
+    // different object, not a hand-rolled string (see
+    // `assert_cas_version_semantics` above for why this matters).
+    let other = store
+        .put(
+            "cas-absent/other",
+            Bytes::from_static(b"unrelated"),
+            PutOptions::default(),
+        )
+        .await
+        .expect("unrelated put for a well-formed-but-wrong version token");
+
+    let err = store
+        .put(
+            key,
+            Bytes::from_static(b"v1"),
+            PutOptions {
+                mode: PutMode::CasVersion(other.version),
+                checksum: None,
+            },
+        )
+        .await
+        .expect_err("CasVersion against an absent key must fail without applying");
+    assert!(matches!(err, StoreError::PreconditionFailed), "got {err:?}");
+    assert!(
+        matches!(store.head(key).await, Err(StoreError::NotFound)),
+        "losing CAS must not have created the key"
+    );
+}
+
+/// `Delete / VersionsNeverReused` (formal/tla/common/traceability.md): the
+/// version counter (`MemoryStore::next_id`) is never reset by a delete, so
+/// create/delete/create mints a fresh version and a CAS holding the
+/// pre-delete version fails against the recreated object.
+#[tokio::test]
+async fn cas_with_pre_delete_version_fails_after_recreate() {
+    let store = MemoryStore::new();
+    let key = "cas-pre-delete/k";
+
+    let put1 = store
+        .put(key, Bytes::from_static(b"v1"), PutOptions::default())
+        .await
+        .expect("initial create");
+    store.delete(key).await.expect("delete");
+    store
+        .put(key, Bytes::from_static(b"v2"), PutOptions::default())
+        .await
+        .expect("recreate after delete");
+
+    let err = store
+        .put(
+            key,
+            Bytes::from_static(b"v3"),
+            PutOptions {
+                mode: PutMode::CasVersion(put1.version),
+                checksum: None,
+            },
+        )
+        .await
+        .expect_err("CAS with the pre-delete version must fail after recreate");
+    assert!(matches!(err, StoreError::PreconditionFailed), "got {err:?}");
+}
+
 #[tokio::test]
 async fn memory_store_contract() {
     let store = MemoryStore::new();


### PR DESCRIPTION
The object-store TLA+ module's traceability table named four contract
claims that no Rust test pinned. This adds them, in the files the table
names, without changing any store behaviour.

In tests/contract.rs: a CasVersion put against an absent key returns
PreconditionFailed and applies nothing, and after create, delete and
create again a CasVersion with the first version fails, because versions
are never reused across a delete. In src/conformance.rs, two probes run
through FaultStore against MemoryStore: a put whose response is dropped
after it took effect leaves the object readable, and a put that fails
transiently leaves no object behind, partial or otherwise. Both probes
say in their doc comment that the backend half of each claim remains an
assumption until a real backend runs the conformance suite.

Each test was run against a deliberately broken store first and failed
on the assertion that names its claim, then passed once the behaviour
was restored; the commit bodies record the failing lines. No new fault
kind was needed: DuplicateDelivery and Transient already carry the
semantics the two probes need.

Refs: #1113
