### PR TITLE
test(maintain): pin eight lifecycle and catalog claims the TLA+ suite named

### DIFF
--- a/crates/ravel-maintain/tests/compact_token_query.rs
+++ b/crates/ravel-maintain/tests/compact_token_query.rs
@@ -1,0 +1,113 @@
+//! #1113 traceability (commit row 6, SupersedeRecord): a commit-token query
+//! for an L0 flush a real compaction has superseded.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::*;
+use ravel_maintain::{Clock, CompactionOutcome, CompactorConfig, FixedClock, compact_bucket};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use ravel_types::{CommitToken, Signal, TimeRange};
+use uuid::Uuid;
+
+fn cfg() -> CompactorConfig {
+    CompactorConfig::default()
+}
+
+/// SupersedeRecord (commit traceability row 6): a commit-token query for an
+/// L0 flush a real compaction has superseded must answer superseded, served
+/// from the compaction record's parts, not a plain miss. The raw commit
+/// record is removed the way the superseded-input sweep eventually leaves it
+/// (that sweep is a separate traceability row; this row names
+/// `compact_bucket`, not the sweep), so the resolver's exact-key GET
+/// genuinely misses and the fallback's compaction-record branch is the one
+/// that must serve the answer.
+///
+/// To watch this FAIL, make `resolve_min_token_fallback` treat every
+/// compaction record's `covers` check as false (as if no compaction record
+/// ever names the token's identity): the resolve call then returns
+/// `CatalogError::UnsatisfiableToken` instead of a snapshot naming the L1
+/// parts, and the `.expect(...)` below panics.
+#[tokio::test]
+async fn superseded_record_token_query_reports_superseded() {
+    let store = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+
+    let kept = InputSpec::new(
+        Uuid::from_u128(0x81),
+        1,
+        1,
+        vec![raw_series("m", &[("k", "a")], &[(1_000, 1.0)])],
+    );
+    let superseded = InputSpec::new(
+        Uuid::from_u128(0x82),
+        2,
+        1,
+        vec![raw_series("m", &[("k", "b")], &[(2_000, 2.0)])],
+    );
+    seed_input(store.as_ref(), &kept).await;
+    let superseded_key = seed_input(store.as_ref(), &superseded).await;
+
+    let config = cfg();
+    let compacted = compact_bucket(store.as_ref(), &clock, &config, &bucket())
+        .await
+        .expect("compact");
+    assert!(matches!(compacted, CompactionOutcome::Compacted { .. }));
+
+    // The raw L0 input the superseded-input sweep would eventually delete:
+    // remove it directly so the token query's exact-key GET genuinely misses,
+    // isolating the fallback's compaction-record branch from the sweep that
+    // (in production) produces the same precondition.
+    store
+        .delete(&superseded_key)
+        .await
+        .expect("delete raw L0 record");
+
+    let token = CommitToken {
+        shard: SHARD,
+        writer_id: superseded.writer_id,
+        epoch: superseded.epoch,
+        seq: superseded.seq,
+        ingest_hour_bucket: HOUR,
+    };
+    let dyn_store: Arc<dyn ObjectStoreBackend> = store.clone();
+    let catalog = ravel_catalog::Catalog::new(
+        dyn_store,
+        ravel_catalog::CatalogConfig {
+            shard_count: SHARD + 1,
+            ..Default::default()
+        },
+    )
+    .expect("catalog");
+    let range = TimeRange {
+        start_ns: i64::from(HOUR) * NS_PER_HOUR,
+        end_ns: (i64::from(HOUR) + 1) * NS_PER_HOUR,
+    };
+    let snapshot = catalog
+        .resolve(
+            &tenant_hash(),
+            Signal::Metrics,
+            range,
+            &[token],
+            clock.now_ns(),
+        )
+        .await
+        .expect(
+            "a superseded token resolves through the compaction record, not UnsatisfiableToken",
+        );
+    assert!(
+        !snapshot.segments.is_empty(),
+        "the superseded flush is served from the compaction record's parts, not zero segments"
+    );
+    assert!(
+        snapshot
+            .segments
+            .iter()
+            .all(|s| s.ingest_hour_bucket == HOUR),
+        "served segments belong to the compacted bucket's hour"
+    );
+}

--- a/crates/ravel-maintain/tests/erasure_sweep.rs
+++ b/crates/ravel-maintain/tests/erasure_sweep.rs
@@ -21,11 +21,13 @@ use common::*;
 use prost::Message;
 use ravel_commit::keys::{self, BucketEntry};
 use ravel_commit::{erasure, signal};
+use ravel_maintain::config::DEFAULT_MAX_INGEST_LAG_NS;
 use ravel_maintain::{
     Bucket, CompactionOutcome, CompactorConfig, ErasureRewriteOutcome, FixedClock, LeaseCheck,
-    LegalHoldCheck, MaintainMemo, NoLeases, PendingErasureRequest, SupersededSweepOutcome,
-    compact_bucket, erasure_rewrite_bucket, shard_hold_scopes, sweep_erasure_requests,
-    sweep_superseded, write_hold_set,
+    LegalHoldCheck, MaintainMemo, NoLeases, PendingErasureRequest, RetentionConfig,
+    RetentionOutcome, RetentionPolicy, SupersededSweepOutcome, bucket_erasure_completion,
+    compact_bucket, erasure_rewrite_bucket, retention_sweep_bucket, shard_hold_scopes,
+    sweep_erasure_requests, sweep_superseded, write_hold_set,
 };
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions, list_all};
@@ -549,6 +551,91 @@ async fn held_dreq_survives_past_horizon() {
     );
 }
 
+/// DreqSweep / DreqSweepRespectsLegalHold (lifecycle traceability row 27): a
+/// `.dreq` past its own horizon, with a valid `.done`, and never itself
+/// protected by any hold, is still kept when the rewrite's own superseded
+/// input chain is legally held -- distinct from [`held_dreq_survives_past_horizon`]
+/// above, where the hold covers the `del/` key directly. Here the hold covers
+/// only the shard's data/commit/L1 prefixes ([`shard_hold_scopes`]), which
+/// never overlap `del/`, so `lease.is_protected(dreq_key)` is false and the
+/// only path that can keep the request is rule 6 observing rule 2's own
+/// chain-level hold (`chain_groups_held_by_legal_hold`) through
+/// `held_by_superseded_inputs`.
+///
+/// Flip-line proof: in `sweep_erasure_requests_inner`, replace `let held =
+/// holds.request_ids.contains(&request_id_s) || !holds.truncated_buckets.is_empty();`
+/// with `let held = false;`: the held case then deletes the `.dreq` exactly
+/// like the control, failing `assert_eq!(held_out.deleted, 0, ...)` below.
+#[tokio::test]
+async fn dreq_sweep_keeps_request_markers_whose_chain_is_legally_held() {
+    let created = sealed_now_ns();
+    let b = bucket();
+
+    // Control: no hold anywhere. The rewrite's superseded chain is freely
+    // clearable, so rule 6 deletes the completed, past-horizon `.dreq`.
+    let control = MemoryStore::new();
+    let clock = FixedClock::new(created);
+    for spec in metrics_specs() {
+        seed_input(&control, &spec).await;
+    }
+    run_rewrite(&control, &clock).await;
+    let (control_dreq_key, _) = seed_dreq_done(&control, 42, Some(created)).await;
+    let control_out = sweep_dreq(&control, past_horizon(created), &NoLeases).await;
+    assert_eq!(
+        control_out.deleted, 1,
+        "control: nothing holds the chain, the marker is removed"
+    );
+    assert_eq!(control_out.held_by_superseded_inputs, 0);
+    assert!(!present(&control, &control_dreq_key).await);
+
+    // Held: a legal hold over the shard's real key prefixes (not `del/`)
+    // holds the whole supersession chain the rewrite produced. The `.dreq`'s
+    // own key is untouched by the hold, its `.done` is valid, and it is well
+    // past its horizon -- every rule-6 gate other than the chain-hold
+    // observation says "delete this."
+    let held = MemoryStore::new();
+    let clock = FixedClock::new(created);
+    for spec in metrics_specs() {
+        seed_input(&held, &spec).await;
+    }
+    run_rewrite(&held, &clock).await;
+    let (held_dreq_key, _) = seed_dreq_done(&held, 42, Some(created)).await;
+    for (i, scope) in shard_hold_scopes(&b.tenant_hash, b.signal, b.shard)
+        .unwrap()
+        .iter()
+        .enumerate()
+    {
+        write_hold_set(
+            &held,
+            &b.tenant_hash,
+            Uuid::from_u128(300 + i as u128),
+            created,
+            scope,
+            "litigation hold",
+        )
+        .await
+        .unwrap();
+    }
+    let lease = LegalHoldCheck::refresh(&held, &b.tenant_hash)
+        .await
+        .unwrap();
+    assert!(
+        !lease.is_protected(&held_dreq_key),
+        "shard_hold_scopes never covers del/, so the dreq key itself is not held"
+    );
+
+    let held_out = sweep_dreq(&held, past_horizon(created), &lease).await;
+    assert_eq!(
+        held_out.deleted, 0,
+        "the held chain keeps the marker even though the dreq key itself is unheld"
+    );
+    assert_eq!(
+        held_out.held_by_superseded_inputs, 1,
+        "held specifically via the chain observation, not the dreq-key-held path"
+    );
+    assert!(present(&held, &held_dreq_key).await, ".dreq survives");
+}
+
 /// A completion with a zero `completed_unix_ns` is a fail-safe keep: a zero
 /// anchor would collapse the horizon gate to always-past.
 ///
@@ -562,4 +649,189 @@ async fn zero_completion_timestamp_keeps_dreq() {
     let out = sweep_dreq(&store, i64::MAX / 2, &NoLeases).await;
     assert_eq!(out.deleted, 0, "zero completion anchor is not a valid gate");
     assert!(present(&store, &dreq_key).await);
+}
+
+/// CompleteErasure / CompletionRespectsLegalHold (lifecycle traceability row
+/// 25): a legal hold covering the bucket blocks `bucket_erasure_completion`
+/// unconditionally, checked before the served-set read. Isolated from the
+/// served-set branch: the seeded input's event-time window does not overlap
+/// the pending request's window at all, so without a hold the served-set
+/// check alone already reports the bucket complete (`blocked` empty,
+/// `unresolved` false); the flip to `unresolved: true` under the hold is
+/// caused solely by the legal-hold gate, not by anything the served-set
+/// branch would have found.
+///
+/// Flip-line proof: in `bucket_erasure_completion`, delete the `if
+/// bucket_is_held(&listing, lease) { out.unresolved = true; return Ok(out); }`
+/// block. Completion then falls through to the served-set check, which (given
+/// the non-overlapping window) reports `unresolved: false`, failing
+/// `assert!(held.unresolved, ...)` below.
+#[tokio::test]
+async fn erasure_completion_refuses_while_a_legal_hold_covers_the_bucket() {
+    let store = MemoryStore::new();
+    let spec = InputSpec::new(
+        Uuid::from_u128(0x51),
+        1,
+        1,
+        vec![raw_series(
+            "victim",
+            &[("k", "a")],
+            &[(1_000, 1.0), (2_000, 2.0)],
+        )],
+    );
+    seed_input(&store, &spec).await;
+
+    let request_id = Uuid::from_u128(0x52);
+    let request = ErasureRequest {
+        format_version: 1,
+        tenant_hash: tenant_hash().0.to_vec(),
+        signal: signal::to_proto(Signal::Metrics) as i32,
+        request_id: request_id.to_string(),
+        created_unix_ns: 0,
+        predicate: vec![ErasurePredicateMatcher {
+            key: "__name__".to_string(),
+            value: "victim".to_string(),
+        }],
+        // Strictly after the seeded input's [1_000, 2_000] event-time range,
+        // so `bucket_may_overlap` is false regardless of the hold.
+        window_start_ns: 1_000_000,
+        window_end_ns: 2_000_000,
+        reason: String::new(),
+    };
+    let pending = vec![PendingErasureRequest {
+        request_key: keys::erasure_request_key(&tenant_hash(), Signal::Metrics, request_id)
+            .expect("dreq key"),
+        request,
+    }];
+
+    let clock = FixedClock::new(sealed_now_ns());
+    let config = cfg();
+
+    // Control: with no hold, the non-overlapping window alone already means
+    // the served-set check reports the bucket complete.
+    let control =
+        bucket_erasure_completion(&store, &clock, &config, &NoLeases, &bucket(), &pending)
+            .await
+            .expect("completion without hold");
+    assert!(
+        control.blocked.is_empty(),
+        "the request window does not overlap the seeded input"
+    );
+    assert!(
+        !control.unresolved,
+        "control: the served-set check alone would allow completion"
+    );
+
+    let scopes = shard_hold_scopes(&tenant_hash(), Signal::Metrics, SHARD).expect("shard scopes");
+    for (i, scope) in scopes.iter().enumerate() {
+        write_hold_set(
+            &store,
+            &tenant_hash(),
+            Uuid::from_u128(200 + i as u128),
+            0,
+            scope,
+            "litigation hold",
+        )
+        .await
+        .expect("set hold");
+    }
+    let lease = LegalHoldCheck::refresh(&store, &tenant_hash())
+        .await
+        .expect("refresh");
+
+    let held = bucket_erasure_completion(&store, &clock, &config, &lease, &bucket(), &pending)
+        .await
+        .expect("completion under hold");
+    assert!(
+        held.blocked.is_empty(),
+        "the hold gate returns before the served-set check ever populates blocked"
+    );
+    assert!(
+        held.unresolved,
+        "a bucket under legal hold stays unresolved regardless of the served-set outcome"
+    );
+}
+
+/// A retention config whose window for the test tenant is exactly the floor,
+/// so the tiny-timestamp fixtures (events at ts 1_000-3_000, `now` at
+/// [`sealed_now_ns`]) are always expired.
+fn retention_at_floor(config: &CompactorConfig) -> RetentionConfig {
+    let floor = config.retention_floor_ns(DEFAULT_MAX_INGEST_LAG_NS);
+    RetentionConfig::from_policy(
+        RetentionPolicy {
+            default: None,
+            tenants: vec![(TENANT.to_string(), floor)],
+        },
+        config,
+        DEFAULT_MAX_INGEST_LAG_NS,
+    )
+    .expect("valid retention config")
+}
+
+/// PerformRewrite / tombstone guard (lifecycle traceability row 29): once a
+/// bucket carries a retention tombstone, `erasure_rewrite_bucket` refuses to
+/// run at all -- checked against a fresh listing at rewrite time, not a
+/// cached decision. Isolated from the other refusal outcomes: the control
+/// runs the identical seeded bucket and pending request with no tombstone and
+/// gets `Rewritten`, so the flip to `Tombstoned` is caused solely by the
+/// tombstone-listing check, not by `NotSealed`/`NoApplicableRequests`/`Held`.
+///
+/// Flip-line proof: in `erasure_rewrite_bucket`, delete the `if
+/// listing.tombstone_key.is_some() { return Ok(ErasureRewriteOutcome::Tombstoned); }`
+/// block. The tombstoned case then falls through to the live-input resolution
+/// and rewrites the (physically already-swept) bucket instead of refusing,
+/// failing the `matches!(outcome, ErasureRewriteOutcome::Tombstoned)` assertion
+/// below.
+#[tokio::test]
+async fn erasure_rewrite_refuses_a_tombstoned_bucket_with_the_tombstoned_outcome() {
+    let created = sealed_now_ns();
+    let config = cfg();
+
+    // Control: the same seeded bucket and pending request, no tombstone. The
+    // rewrite proceeds normally, proving the fixture is otherwise rewritable.
+    let control = MemoryStore::new();
+    let clock = FixedClock::new(created);
+    for spec in metrics_specs() {
+        seed_input(&control, &spec).await;
+    }
+    let control_outcome = run_rewrite(&control, &clock).await;
+    assert!(
+        matches!(control_outcome, ErasureRewriteOutcome::Rewritten { .. }),
+        "control: an untombstoned bucket rewrites normally, got {control_outcome:?}"
+    );
+
+    // Tombstoned: retention expires and tombstones the bucket before the
+    // rewrite pass ever runs.
+    let store = MemoryStore::new();
+    for spec in metrics_specs() {
+        seed_input(&store, &spec).await;
+    }
+    let b = bucket();
+    let retention = retention_at_floor(&config);
+    let retention_outcome =
+        retention_sweep_bucket(&store, &clock, &config, &retention, &NoLeases, &b)
+            .await
+            .expect("retention pass");
+    assert_eq!(
+        retention_outcome,
+        RetentionOutcome::Tombstoned,
+        "the tiny-timestamp fixture is expired under the floor window"
+    );
+
+    let mut memo = MaintainMemo::with_default_interval();
+    let outcome = erasure_rewrite_bucket(
+        &store,
+        &clock,
+        &config,
+        &NoLeases,
+        &b,
+        &[pending_request(42, "victim")],
+        &mut memo,
+    )
+    .await
+    .expect("rewrite over a tombstoned bucket");
+    assert!(
+        matches!(outcome, ErasureRewriteOutcome::Tombstoned),
+        "a tombstoned bucket refuses the rewrite entirely, got {outcome:?}"
+    );
 }

--- a/crates/ravel-maintain/tests/legal_hold.rs
+++ b/crates/ravel-maintain/tests/legal_hold.rs
@@ -10,11 +10,14 @@ mod common;
 use common::*;
 use ravel_commit::keys;
 use ravel_maintain::{
-    Bucket, CompactionOutcome, CompactorConfig, FixedClock, LeaseCheck, LegalHoldCheck, NoLeases,
-    SweepReport, compact_bucket, shard_hold_scopes, sweep_shard, write_hold_clear, write_hold_set,
+    AUDIT_HOLD_SHARD, Bucket, CompactionOutcome, CompactorConfig, FixedClock, LeaseCheck,
+    LegalHoldCheck, NoLeases, SweepReport, compact_bucket, shard_hold_scopes, sweep_shard,
+    write_hold_clear, write_hold_set,
 };
+use ravel_object_store::fault::{FaultKind, FaultPlan, FaultStore, Op, Rule, ScriptedFault};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, list_all};
+use ravel_types::Signal;
 use uuid::Uuid;
 
 fn cfg() -> CompactorConfig {
@@ -345,6 +348,91 @@ async fn empty_scope_is_rejected_before_any_write() {
         before,
         "no object written for a rejected clear"
     );
+}
+
+/// The tick a real caller composes: refresh the hold snapshot, then sweep
+/// under it. Plain `?` propagation means a failed refresh never reaches the
+/// sweep call at all. No production symbol performs this composition yet
+/// (lifecycle traceability row 22 names the fallible `refresh` alone, not a
+/// tick that wraps it), so the tick is local to this test.
+async fn tick(
+    store: &dyn ObjectStoreBackend,
+    clock: &FixedClock,
+    bucket: &Bucket,
+) -> ravel_maintain::Result<SweepReport> {
+    let lease = LegalHoldCheck::refresh(store, &bucket.tenant_hash).await?;
+    sweep_shard(
+        store,
+        clock,
+        &cfg(),
+        &lease,
+        &bucket.tenant_hash,
+        bucket.signal,
+        bucket.shard,
+    )
+    .await
+}
+
+/// SetRefresh / RefreshFailureNeverSweeps (lifecycle traceability row 22): a
+/// legal-hold refresh that fails must fail closed for a tick composing it with
+/// a sweep - the error stops the tick before the sweep call, deleting nothing,
+/// rather than the tick treating a failed refresh as "no holds" and sweeping
+/// anyway.
+///
+/// To watch this FAIL, change `tick` above to swallow a refresh error and
+/// fall back to `NoLeases` (the shape a careless tick could take) instead of
+/// propagating it with `?`: the sweep then runs unheld, the superseded L0
+/// inputs and their commit records are deleted, and the post-tick
+/// `l0_data_count`/`commit_record_count` assertions below fail.
+#[tokio::test]
+async fn refresh_failure_skips_the_sweep_tick_and_deletes_nothing() {
+    let mem = MemoryStore::new();
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let bucket = seed_and_compact(&mem, &clock).await;
+    let data_before = l0_data_count(&mem, &bucket).await;
+    let records_before = commit_record_count(&mem, &bucket).await;
+    assert!(data_before > 0, "fixture seeds superseded L0 data");
+    assert!(records_before > 0, "fixture seeds commit records");
+
+    let hold_shard_prefix =
+        keys::commit_shard_prefix(&bucket.tenant_hash, Signal::Audit, AUDIT_HOLD_SHARD)
+            .expect("hold shard prefix");
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::List, ScriptedFault::Timeout).with_key_contains(hold_shard_prefix))
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout));
+    let store = FaultStore::new(mem, plan);
+
+    clock.set(past_horizon(created));
+    let err = tick(&store, &clock, &bucket)
+        .await
+        .expect_err("a failed refresh must fail the tick, not sweep unheld");
+    assert!(
+        matches!(err, ravel_maintain::MaintainError::Store(_)),
+        "the refresh's own LIST failure surfaces as a store error: {err:?}"
+    );
+
+    assert_eq!(
+        store.fault_count(Op::List, FaultKind::Timeout),
+        1,
+        "exactly one LIST of the hold shard, and it was the one that failed"
+    );
+    assert_eq!(
+        store.fault_count(Op::Delete, FaultKind::Timeout),
+        0,
+        "the tick never reached the sweep, so it issued zero deletes"
+    );
+    assert_eq!(
+        l0_data_count(&store, &bucket).await,
+        data_before,
+        "superseded data survives a tick whose refresh failed"
+    );
+    assert_eq!(
+        commit_record_count(&store, &bucket).await,
+        records_before,
+        "and so do the commit records"
+    );
+    assert_l1_intact(&store, &bucket).await;
 }
 
 /// Every object key under the tenant prefix, sorted.

--- a/crates/ravel-maintain/tests/retention.rs
+++ b/crates/ravel-maintain/tests/retention.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 
 use bytes::Bytes;
 use ravel_maintain::Clock;
-use ravel_types::{Signal, TimeRange};
+use ravel_types::{CommitToken, Signal, TimeRange};
 
 #[derive(Debug, Clone, Copy)]
 enum Sig {
@@ -1708,4 +1708,102 @@ async fn scan_reports_blocked_by_unreadable_head_counter() {
         "the fail-closed unreadable-HEAD block is counted distinctly"
     );
     assert_eq!(r2.blocked_by_snapshot, 0);
+}
+
+// --- #1113 traceability: TombstoneBucket / commit-token query --------------
+
+/// TombstoneBucket (commit traceability row 5): a commit-token query for a
+/// flush whose bucket was tombstoned through the real `write_tombstone`
+/// production path must answer tombstoned -- satisfied with zero segments --
+/// not a plain miss. The tombstone is reached by faulting the tombstone's own
+/// delete during the physical sweep (mirrors `partial_sweep_crash_then_
+/// converges`), so the commit record is already gone while the tombstone
+/// object still stands: exactly the state a client holding a stale token can
+/// observe.
+///
+/// To watch this FAIL, change `resolve_min_token_fallback` to ignore a
+/// tombstone match on the listed bucket (treat it the same as finding
+/// nothing): the `catalog.resolve` call then returns
+/// `CatalogError::UnsatisfiableToken` instead of a snapshot, so the
+/// `.expect("a tombstoned token resolves...")` panics.
+#[tokio::test]
+async fn tombstoned_bucket_token_query_reports_tombstoned() {
+    let inner = Arc::new(MemoryStore::new());
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(Op::Delete, ScriptedFault::Timeout)
+            .with_key_contains("retire.tmb")
+            .with_occurrence(Occurrence::Nth(1)),
+    );
+    let store = FaultStore::new(inner.clone(), plan);
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let writer_id = Uuid::from_u128(0x70);
+    let spec = InputSpec::new(
+        writer_id,
+        3,
+        1,
+        vec![raw_series("m", &[("k", "a")], &[(1_000, 1.0)])],
+    );
+    seed_input(&store, &spec).await;
+    let bucket = bucket();
+    let config = cfg();
+    let retention = retention_at_floor(&config);
+
+    let tombstoned =
+        retention_sweep_bucket(&store, &clock, &config, &retention, &NoLeases, &bucket)
+            .await
+            .expect("tombstone pass");
+    assert_eq!(tombstoned, RetentionOutcome::Tombstoned);
+
+    // Past the horizon: the physical sweep deletes the commit record and
+    // data, then the tombstone's own delete faults, leaving the tombstone in
+    // place with the record already gone.
+    clock.set(created + config.protection_horizon_ns + 1);
+    let err = retention_sweep_bucket(&store, &clock, &config, &retention, &NoLeases, &bucket).await;
+    assert!(err.is_err(), "the tombstone delete fault aborts the sweep");
+    assert_eq!(store.fault_count(Op::Delete, FaultKind::Timeout), 1);
+    assert!(
+        has_tombstone(inner.as_ref(), &bucket).await,
+        "tombstone survives the crash, so exclusion still holds"
+    );
+    assert_eq!(
+        count_commit_records(inner.as_ref(), &bucket).await,
+        0,
+        "the commit record is already gone: the exact-key GET must miss"
+    );
+
+    let token = CommitToken {
+        shard: SHARD,
+        writer_id,
+        epoch: spec.epoch,
+        seq: spec.seq,
+        ingest_hour_bucket: HOUR,
+    };
+    let dyn_store: Arc<dyn ObjectStoreBackend> = inner.clone();
+    let catalog = ravel_catalog::Catalog::new(
+        dyn_store,
+        ravel_catalog::CatalogConfig {
+            shard_count: SHARD + 1,
+            ..Default::default()
+        },
+    )
+    .expect("catalog");
+    let range = TimeRange {
+        start_ns: i64::from(HOUR) * NS_PER_HOUR,
+        end_ns: (i64::from(HOUR) + 1) * NS_PER_HOUR,
+    };
+    let snapshot = catalog
+        .resolve(
+            &tenant_hash(),
+            Signal::Metrics,
+            range,
+            &[token],
+            clock.now_ns(),
+        )
+        .await
+        .expect("a tombstoned token resolves, not UnsatisfiableToken");
+    assert!(
+        snapshot.segments.is_empty(),
+        "the tombstoned flush is satisfied with zero segments, not served stale data"
+    );
 }

--- a/crates/ravel-maintain/tests/superseded_head_gate.rs
+++ b/crates/ravel-maintain/tests/superseded_head_gate.rs
@@ -2141,6 +2141,211 @@ async fn a_part_reference_that_excludes_its_own_entries_blocks_fail_closed() {
     }
 }
 
+// --- (k2) a covering part that cannot be read back intact --------------------
+
+/// DoSweepSuperseded covering-part guard (catalog traceability row 29): a
+/// snapshot part HEAD names by an intact reference (matching hash, matching
+/// bounds) but whose bytes come back corrupted blocks the sweep fail-closed,
+/// distinct from both an unreadable HEAD and the bounds-mismatch reference
+/// case above. There the HEAD-level reference itself was edited; here the
+/// reference is untouched and only the part object's own bytes are corrupted
+/// at read time, so this exercises `ensure_part`'s own decode/hash-mismatch
+/// arm rather than its bounds-mismatch arm or `ensure_head`.
+///
+/// Flip-line proof: in `ensure_part`, change the blake3-mismatch and
+/// decode-failure arms to fall through to `Ok(part)` as if the corrupted
+/// bytes had decoded cleanly: the gate then clears on unproven data, all four
+/// objects are deleted, the `Op::Delete` fault fires, and the sweep's
+/// `.expect` panics.
+#[tokio::test]
+async fn an_unreadable_covering_part_blocks_the_superseded_sweep_fail_closed() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+
+    fold_head(&mem, created, 1, None).await;
+    run_rewrite(mem.as_ref(), &clock).await;
+    fold_head(&mem, created + 3 * NS_PER_HOUR, 2, None).await;
+    assert_eq!(
+        head_named_data_keys(mem.as_ref(), OLD_HOUR).await,
+        input_data_keys,
+        "the part names exactly the two pre-rewrite inputs"
+    );
+
+    let head_bytes = get_full(mem.as_ref(), &head_key()).await;
+    let head = ravel_catalog::decode_head(head_bytes.as_ref()).expect("HEAD decodes");
+    assert_eq!(head.parts.len(), 1, "single-part HEAD on this fixture");
+    let part_key = head.parts[0].key.clone();
+
+    // The HEAD-level reference is never touched: its hash and bounds still
+    // match what is on disk. Only the GET of the part's own bytes is
+    // corrupted, so `ensure_part` reads something present but unreadable.
+    let plan = FaultPlan::empty()
+        .with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout))
+        .with_rule(Rule::new(Op::Get, ScriptedFault::CorruptRange).with_key_contains(part_key));
+    let store = FaultStore::new(mem.clone(), plan);
+
+    clock.set(past_horizon(created));
+    let out = sweep(&store, &clock)
+        .await
+        .expect("an unreadable covering part holds, it does not error the pass");
+    assert_eq!((out.records_deleted, out.data_deleted), (0, 0));
+    assert_eq!(
+        out.held_by_unreadable_head, 4,
+        "all four objects held under the Unreadable reason"
+    );
+    assert_eq!(
+        out.held_by_snapshot, 0,
+        "not the Named reason: the part could not be decoded to check names"
+    );
+    assert_eq!(
+        store.fault_count(Op::Get, FaultKind::CorruptRange),
+        1,
+        "exactly one GET of the covering part, and it was corrupted"
+    );
+    assert_eq!(
+        store.fault_count(Op::Delete, FaultKind::Timeout),
+        0,
+        "the sweep issued exactly zero deletes"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &input_data_keys).await,
+        input_data_keys,
+        "both inputs the unreadable part would have named survive"
+    );
+    for key in &commit_keys {
+        assert!(mem.head(key).await.is_ok(), "and both their commit records");
+    }
+}
+
+// --- (k3) a covering entry whose identity does not fit the shape a fold writes
+
+/// DoSweepSuperseded entry-identity guard (catalog traceability row 30): a
+/// covering part that decodes cleanly (right hash, right bounds) can still
+/// carry one entry whose identity fields do not fit the shape a fold writes.
+/// Here the reconciled hour's snapshot names only the rewrite's single level-1
+/// output entry; that entry's `writer_epoch` slot (which the frozen
+/// `SnapshotEntry` overloads for the level-1 `part_index`) is set past
+/// `u32::MAX`, which `snapshot_object` cannot read back into a `part_index`.
+/// The part and the HEAD-level reference around it are otherwise untouched
+/// and mutually consistent, so this exercises `snapshot_object`'s own
+/// fail-closed `None`, distinct from `ensure_part` finding the part itself
+/// unreadable.
+///
+/// Flip-line proof: in `snapshot_object`, change the level-1 arm's
+/// `u32::try_from(entry.writer_epoch).ok()?` to `entry.writer_epoch as u32`
+/// (a silent truncating cast instead of a fail-closed `None`): the corrupted
+/// entry then decodes to some arbitrary `part_index` instead of blocking, the
+/// gate does not recognize it as unreadable, the two superseded inputs are
+/// deleted, the `Op::Delete` fault fires, and the sweep's `.expect` panics.
+#[tokio::test]
+async fn an_undecodable_covering_entry_blocks_the_superseded_sweep_fail_closed() {
+    let mem = Arc::new(MemoryStore::new());
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let commit_keys = seed_two_hours(mem.as_ref()).await;
+    let input_data_keys = seeded_input_data_keys(mem.as_ref(), &commit_keys).await;
+
+    fold_head(&mem, created, 1, None).await;
+    run_rewrite(mem.as_ref(), &clock).await;
+    // A reconcile window wide enough to reach 100 hours back: the fold now
+    // observes the rewrite and republishes the hour naming only its output.
+    fold_head(&mem, created + 3 * NS_PER_HOUR, 2, Some(200)).await;
+
+    let named = head_named_data_keys(mem.as_ref(), OLD_HOUR).await;
+    assert!(
+        named.is_disjoint(&input_data_keys),
+        "the reconciled snapshot names none of the pre-rewrite inputs"
+    );
+
+    let head_bytes = get_full(mem.as_ref(), &head_key()).await;
+    let mut head = ravel_catalog::decode_head(head_bytes.as_ref()).expect("HEAD decodes");
+    assert_eq!(head.parts.len(), 1, "single-part HEAD on this fixture");
+    let part_key = head.parts[0].key.clone();
+    let part_bytes = get_full(mem.as_ref(), &part_key).await;
+    let limits = ravel_catalog::PartLimits {
+        max_snapshot_part_bytes: ravel_catalog::DEFAULT_MAX_SNAPSHOT_PART_BYTES,
+    };
+    let part = ravel_catalog::decode_part(part_bytes.as_ref(), &limits).expect("part decodes");
+    let mut entries = part.entries.clone();
+    let old_hour_entry_idx = entries
+        .iter()
+        .position(|e| e.level == 1 && e.ingest_hour_bucket == OLD_HOUR)
+        .expect("the rewrite's level-1 output entry covers the old hour");
+    // Past u32::MAX: snapshot_object's `u32::try_from(entry.writer_epoch)`
+    // on the level-1 arm cannot read this back as a part_index.
+    entries[old_hour_entry_idx].writer_epoch = u64::from(u32::MAX) + 1;
+
+    let tenant_hash_bytes: [u8; 16] = part
+        .header
+        .tenant_hash
+        .as_slice()
+        .try_into()
+        .expect("16-byte tenant hash");
+    let corrupted_part = ravel_catalog::encode_part(
+        tenant_hash_bytes,
+        part.header.signal,
+        part.header.shard_count,
+        part.header.watermark_hour,
+        &entries,
+    )
+    .expect("validate_entries does not range-check writer_epoch, so this still encodes");
+    // Re-decodes cleanly too: the corruption is in the identity's meaning,
+    // not in the envelope, which is exactly why `ensure_part` alone cannot
+    // catch it.
+    ravel_catalog::decode_part(&corrupted_part, &limits).expect("the corrupted part still decodes");
+
+    mem.put(
+        &part_key,
+        bytes::Bytes::from(corrupted_part.clone()),
+        PutOptions::default(),
+    )
+    .await
+    .expect("republish the part");
+    head.parts[0].blake3 = blake3::hash(&corrupted_part).as_bytes().to_vec();
+    head.parts[0].size = corrupted_part.len() as u64;
+    let encoded_head = ravel_catalog::encode_head(&head).expect("HEAD still encodes");
+    mem.put(
+        &head_key(),
+        bytes::Bytes::from(encoded_head),
+        PutOptions::default(),
+    )
+    .await
+    .expect("republish HEAD");
+
+    let plan = FaultPlan::empty().with_rule(Rule::new(Op::Delete, ScriptedFault::Timeout));
+    let store = FaultStore::new(mem.clone(), plan);
+
+    clock.set(past_horizon(created));
+    let out = sweep(&store, &clock)
+        .await
+        .expect("an undecodable covering entry holds, it does not error the pass");
+    assert_eq!((out.records_deleted, out.data_deleted), (0, 0));
+    assert_eq!(
+        out.held_by_unreadable_head, 4,
+        "all four objects held under the Unreadable reason"
+    );
+    assert_eq!(
+        out.held_by_snapshot, 0,
+        "not the Named reason: the entry's identity could not be read to compare"
+    );
+    assert_eq!(
+        store.fault_count(Op::Delete, FaultKind::Timeout),
+        0,
+        "the sweep issued exactly zero deletes"
+    );
+    assert_eq!(
+        present_keys(mem.as_ref(), &input_data_keys).await,
+        input_data_keys,
+        "both inputs the undecodable entry would have named survive"
+    );
+    for key in &commit_keys {
+        assert!(mem.head(key).await.is_ok(), "and both their commit records");
+    }
+}
+
 // --- (l) observing the holds is never gated on age --------------------------
 //
 // Two filters decide whether a chain is collectable YET: the protection


### PR DESCRIPTION
The lifecycle, catalog and commit TLA+ traceability tables named eight
claims about ravel-maintain that no Rust test pinned. This adds them as
integration tests, without touching production code.

A commit-token query through a retention tombstone answers tombstoned,
and through a compaction answers superseded, not merely not found. An
unreadable covering part and an undecodable covering entry each block
the superseded sweep on their own, separately from the HEAD-unreadable
trigger the existing tests already cover. A failed legal-hold refresh
skips the sweep tick and deletes nothing. The legal-hold branch of
erasure completion is isolated from the served-set branch, the legal-hold
branch of the request-marker sweep from the horizon and reachability
branch, and the tombstoned-bucket refusal of the erasure rewrite from its
other refusal outcomes: each test constructs a state where only the
branch under test can produce the outcome.

Every test was run against a deliberately broken production path first
and failed on the assertion that names its claim, then passed once the
path was restored; the commit bodies record the failing lines. No test
exposed a defect, so none is ignored.

Refs: #1113
