### PR TITLE
feat(ravel-query): record and report a query's I/O dependency shape

### DIFF
--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -1225,12 +1225,36 @@ impl QueryEngine {
         stats.accounting = stats.phase_accounting.pooled();
 
         // Fold the log lane's own io_shape contribution into the metrics
-        // lane's, mirroring the `combine_phase_accounting` fold above.
-        // Unlike that fold, `dependency_depth`/`list_page_depth`/
-        // `service_batches` are "longest chain wins" (`IoShapeCounts`'s own
-        // max-based semantics), not sums: two lanes' chains ran alongside
-        // each other, not one after the other. `unfolded_segments_resolved`
-        // IS additive (an exact total count across both lanes' resolves).
+        // lane's, mirroring the `combine_phase_accounting` fold above. The
+        // two lanes run STRICTLY SERIALLY, never alongside each other (see
+        // the comment above `resolve_bounded` at the top of this function:
+        // the log lane's resolve is only reached after the metrics lane's
+        // `prefetch_metric_plans` call has already been awaited to
+        // completion). That seriality is exactly why the fields below
+        // combine differently from each other, not the same way:
+        // - `list_page_depth` counts serial LIST pages. Because the two
+        //   lanes' resolves run one after another in wall-clock time, their
+        //   page counts ADD: a query whose metrics lane paginated 4 LIST
+        //   pages and whose log lane paginated 2 more genuinely waited
+        //   through 6 serial pages, not 4.
+        // - `dependency_depth` stays max-based, but not because of
+        //   concurrency (there is none here): the log lane's fetch chain
+        //   has no DATA dependency on the metrics lane's bytes -- it does
+        //   not need any byte the metrics lane fetched to know its own
+        //   segment keys, so the two chains are independent chains that
+        //   happen to run one after the other. The reported figure is the
+        //   longest independent chain, matching `dependency_depth`'s own
+        //   definition ("the longest chain... where a stage needs a
+        //   previous stage's bytes to know its own keys"), which a serial
+        //   but data-independent pair of chains does not satisfy across
+        //   lanes.
+        // - `service_batches` stays max-based for the same data-independence
+        //   reason: each lane's fan-out is bounded by its own concurrency
+        //   permit independently of the other lane's batch count.
+        // `unfolded_segments_resolved` IS additive (an exact total count
+        // across both lanes' resolves, with no ambiguity about how the two
+        // lanes' costs compose).
+        //
         // The log lane's `whole_object_threshold` is not reachable from
         // here (`BlockRangeFetcher::effective_whole_object_threshold` is
         // private and, unlike `SegmentFetcher`'s fixed field, scales
@@ -1240,7 +1264,7 @@ impl QueryEngine {
         // dependency_depth here.
         let mut log_counts = IoShapeCounts {
             dependency_depth: stats.io_shape.dependency_depth,
-            list_page_depth: stats.io_shape.list_page_depth,
+            list_page_depth: 0,
             service_batches: stats.io_shape.service_batches,
         };
         let log_depth = log_snapshot
@@ -1264,11 +1288,25 @@ impl QueryEngine {
             .snapshot()
             .s3_requests(AccountedOp::List);
         log_counts.record_list_pages(log_list_requests.min(u64::from(u32::MAX)) as u32);
-        let log_plan_class = if log_snapshot.segments_pruned > 0 {
-            PlanClass::SelectiveIndexed
-        } else {
-            PlanClass::ExhaustiveScan
-        };
+        log_counts.list_page_depth = stats
+            .io_shape
+            .list_page_depth
+            .saturating_add(log_counts.list_page_depth);
+        // The log lane's `resolve_bounded` call above always passes
+        // `name_filter: None` (ADR-1103's log discovery has no name-postings
+        // filter to prune against), so `Snapshot::segments_pruned` is
+        // structurally always 0 for this lane regardless of how narrow the
+        // resolved window actually is: `postings_ordinals_for_filter`'s
+        // first line returns `None` immediately when there is no name
+        // filter, so the pruning-count increment in
+        // `SnapshotWindow::extract_into` is unreachable here. Reporting
+        // `ExhaustiveScan` on that basis would be fabricated severity this
+        // lane cannot actually back up, and letting it through
+        // `merge_plan_class` would wrongly outrank a metrics lane that DID
+        // classify itself correctly. `Unclassified` says plainly that this
+        // crate cannot tell, for this lane, whether the fetch was pruned or
+        // exhaustive.
+        let log_plan_class = PlanClass::Unclassified;
         stats.io_shape = log_counts.into_shape(
             stats.io_shape.unfolded_segments_resolved + log_unfolded,
             crate::io_shape::merge_plan_class(stats.io_shape.plan_class, log_plan_class),
@@ -1720,6 +1758,7 @@ impl QueryEngine {
             metadata_only,
             whole_object_threshold,
             concurrency,
+            fetch_multiplier,
             &first_accounting,
             first_unfolded,
         );
@@ -1748,6 +1787,7 @@ impl QueryEngine {
                     metadata_only,
                     whole_object_threshold,
                     concurrency,
+                    fetch_multiplier,
                     &second_accounting,
                     second_unfolded,
                 );
@@ -2330,6 +2370,17 @@ fn combine_phase_accounting(
 /// two shards' LIST pages ran concurrently with each other), and the
 /// already-computed exact unfolded-segment count and plan-class decision.
 ///
+/// `fetch_multiplier` is the same per-distinct-selector fan-out factor
+/// `estimate_cost` scales its own request estimate by (`plans.len()` in
+/// `prefetch_metric_plans`): the metrics fetch reopens this resolve's
+/// segment set once per distinct plan, all contending for one shared
+/// `fetch_concurrency` semaphore, so the batch count this query's fetch is
+/// actually forced into is `service_batches(segments * fetch_multiplier,
+/// concurrency)`, not `service_batches(segments, concurrency)`. Omitting the
+/// multiplier here (while `estimate_cost` already applies it) made
+/// `stats.io` and `stats.estimate` disagree by construction for any query
+/// with more than one distinct selector.
+///
 /// Deliberately does NOT thread any new instrumentation into the per-segment
 /// fetch loops (`fetch_all_samples_and_histograms`/`fetch_all_series`):
 /// every figure here is a pure function of the resolved `Snapshot` and the
@@ -2340,6 +2391,7 @@ fn io_shape_for_resolve(
     metadata_only: bool,
     whole_object_threshold: u64,
     concurrency: u64,
+    fetch_multiplier: u64,
     accounting: &PhaseAccounting,
     unfolded_segments_resolved: u64,
 ) -> QueryIoShape {
@@ -2352,7 +2404,7 @@ fn io_shape_for_resolve(
         .unwrap_or(0);
     counts.record_dependency_chain(depth);
     counts.record_service_batches(crate::io_shape::service_batches(
-        snapshot.segments.len() as u64,
+        snapshot.segments.len() as u64 * fetch_multiplier,
         concurrency,
     ));
     let resolve_list_requests = accounting

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -19,7 +19,9 @@ use ravel_promql::{
 };
 use ravel_proto::queryfrag::v1 as pb;
 use ravel_segment::ReaderLimits;
-use ravel_types::accounting::{AccountedOp, CostEstimate, QueryAccounting, QueryAccountingSnapshot};
+use ravel_types::accounting::{
+    AccountedOp, CostEstimate, QueryAccounting, QueryAccountingSnapshot,
+};
 use ravel_types::{
     CommitToken, LabelSet, METRIC_NAME_LABEL, Sample, SeriesId, Signal, TenantHash, TimeRange,
 };
@@ -1227,7 +1229,7 @@ impl QueryEngine {
         // Unlike that fold, `dependency_depth`/`list_page_depth`/
         // `service_batches` are "longest chain wins" (`IoShapeCounts`'s own
         // max-based semantics), not sums: two lanes' chains ran alongside
-        // each other, not one after the other. `unfolded_records_resolved`
+        // each other, not one after the other. `unfolded_segments_resolved`
         // IS additive (an exact total count across both lanes' resolves).
         // The log lane's `whole_object_threshold` is not reachable from
         // here (`BlockRangeFetcher::effective_whole_object_threshold` is
@@ -1244,7 +1246,12 @@ impl QueryEngine {
         let log_depth = log_snapshot
             .segments
             .iter()
-            .map(|seg| crate::io_shape::depth_for_object(seg.object_size, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD))
+            .map(|seg| {
+                crate::io_shape::depth_for_object(
+                    seg.object_size,
+                    DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+                )
+            })
             .max()
             .unwrap_or(0);
         log_counts.record_dependency_chain(log_depth);
@@ -1252,7 +1259,10 @@ impl QueryEngine {
             log_snapshot.segments.len() as u64,
             self.config.fetch_concurrency.max(1) as u64,
         ));
-        let log_list_requests = log_accounting.resolve().snapshot().s3_requests(AccountedOp::List);
+        let log_list_requests = log_accounting
+            .resolve()
+            .snapshot()
+            .s3_requests(AccountedOp::List);
         log_counts.record_list_pages(log_list_requests.min(u64::from(u32::MAX)) as u32);
         let log_plan_class = if log_snapshot.segments_pruned > 0 {
             PlanClass::SelectiveIndexed
@@ -1260,7 +1270,7 @@ impl QueryEngine {
             PlanClass::ExhaustiveScan
         };
         stats.io_shape = log_counts.into_shape(
-            stats.io_shape.unfolded_records_resolved + log_unfolded,
+            stats.io_shape.unfolded_segments_resolved + log_unfolded,
             crate::io_shape::merge_plan_class(stats.io_shape.plan_class, log_plan_class),
         );
 
@@ -1816,11 +1826,11 @@ impl QueryEngine {
         segment_admission::admit(&snapshot, &origins, &self.config)?;
         // Exact count of segments this resolve took from the recent
         // (unfolded) listing path rather than a folded snapshot part
-        // (`QueryIoShape::unfolded_records_resolved`, issue #1214): gates a
+        // (`QueryIoShape::unfolded_segments_resolved`, issue #1214): gates a
         // downstream fold-benefit decision, so this must be the real count,
         // never an estimate.
-        let unfolded_records_resolved = crate::io_shape::count_unfolded_records(&origins.origins);
-        Ok((snapshot, generations, unfolded_records_resolved))
+        let unfolded_segments_resolved = crate::io_shape::count_unfolded_segments(&origins.origins);
+        Ok((snapshot, generations, unfolded_segments_resolved))
     }
 
     /// Maps a log lane failure onto the same [`QueryError`] variants the
@@ -2318,7 +2328,7 @@ fn combine_phase_accounting(
 /// LIST request count (`list_page_depth`, an upper-bound serial depth --
 /// see `crate::io_shape` module docs for why this crate cannot see whether
 /// two shards' LIST pages ran concurrently with each other), and the
-/// already-computed exact unfolded-record count and plan-class decision.
+/// already-computed exact unfolded-segment count and plan-class decision.
 ///
 /// Deliberately does NOT thread any new instrumentation into the per-segment
 /// fetch loops (`fetch_all_samples_and_histograms`/`fetch_all_series`):
@@ -2331,7 +2341,7 @@ fn io_shape_for_resolve(
     whole_object_threshold: u64,
     concurrency: u64,
     accounting: &PhaseAccounting,
-    unfolded_records_resolved: u64,
+    unfolded_segments_resolved: u64,
 ) -> QueryIoShape {
     let mut counts = IoShapeCounts::default();
     let depth = snapshot
@@ -2357,7 +2367,7 @@ fn io_shape_for_resolve(
     } else {
         PlanClass::ExhaustiveScan
     };
-    counts.into_shape(unfolded_records_resolved, plan_class)
+    counts.into_shape(unfolded_segments_resolved, plan_class)
 }
 
 /// A locally-scoped series identity for a log-derived series returned from

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -1763,8 +1763,15 @@ impl QueryEngine {
         // attempts: `window` and `now_ns` do not change on retry, only the
         // snapshot resolve's outcome does.
         let catalog_requests = self.catalog.estimated_catalog_requests(window, now_ns);
-        let concurrency = self.config.fetch_concurrency.max(1) as u64;
+        // The two bounds `io_shape`'s `service_batches` divides by: the
+        // `buffer_unordered` width the fetch streams below are built with
+        // (`promql_fetch_fanout`, ADR-1195) and the permit count of the one
+        // `GetLimiter` every fetcher this engine owns draws from. Reading the
+        // permits off the engine's own limiter rather than off a fetcher
+        // keeps one source of truth for it under `with_get_limiter`.
+        let concurrency = self.config.promql_fetch_fanout().max(1) as u64;
         let whole_object_threshold = self.fetcher.whole_object_threshold();
+        let shared_get_permits = self.get_limiter.permits() as u64;
         // Fresh handle per attempt, created before `resolve_bounded` runs so
         // the same handle that goes on to fetch segments also receives
         // resolve's own catalog-side counters (ADR-0044 decision 1: "created
@@ -1793,6 +1800,7 @@ impl QueryEngine {
             whole_object_threshold,
             concurrency,
             service_fetch_multiplier,
+            shared_get_permits,
             &first_accounting,
             first_unfolded,
         );
@@ -1822,6 +1830,7 @@ impl QueryEngine {
                     whole_object_threshold,
                     concurrency,
                     service_fetch_multiplier,
+                    shared_get_permits,
                     &second_accounting,
                     second_unfolded,
                 );
@@ -2411,39 +2420,63 @@ fn combine_phase_accounting(
 /// plan count `estimate_cost` scales by: that estimate is a deliberate
 /// upper envelope, but `service_batches` documents itself as the batches the
 /// fan-out was FORCED into, a factual figure that must not carry the
-/// envelope's slop. The fan-out itself is a nested `buffer_unordered`
-/// (`futures::stream`): one `buffer_unordered(fetch_concurrency)` over
-/// distinct plans (`prefetch_metric_plans`'s `attempt` closure), each of
-/// which runs its own `buffer_unordered(fetch_concurrency)` over that plan's
-/// segments (`fetch_all_samples_and_histograms`). Neither level shares a
-/// single semaphore across plans: `fetch_concurrency` (`EngineConfig`,
-/// default 8) only bounds each `buffer_unordered` call's own concurrent
-/// future count. The one pool actually shared by every concurrent segment
-/// fetch in a query is `SegmentFetcher::get_semaphore`
-/// (`fetcher.rs`), sized `DEFAULT_MAX_CONCURRENT_GETS` (16) for the metrics
-/// fetcher -- `QueryEngine::new` calls `with_max_concurrent_gets` on the log
-/// fetcher only, never on `self.fetcher`. So the batch count this query's
-/// fetch is actually forced into (at the `buffer_unordered` level
-/// `service_batches` models) is `service_batches(segments *
-/// service_fetch_multiplier, fetch_concurrency)`, not
-/// `service_batches(segments, fetch_concurrency)`; the 8-vs-16 mismatch
-/// between that `buffer_unordered` bound and the get-semaphore's real
-/// capacity is a separate, pre-existing gap this field does not attempt to
-/// close. Omitting the multiplier here (while `estimate_cost` already
-/// applies its own) made `stats.io` and `stats.estimate` disagree by
-/// construction for any query with more than one distinct selector.
+/// envelope's slop.
+///
+/// The fan-out itself is a NESTED `buffer_unordered` (`futures::stream`):
+/// one `buffer_unordered(promql_fetch_fanout)` over distinct plans
+/// (`prefetch_metric_plans`'s `attempt` closure, `distinct_plans_by_matcher`
+/// in `engine.rs`), each of which runs its own
+/// `buffer_unordered(promql_fetch_fanout)` over that plan's segments
+/// (`fetch_all_samples_and_histograms`). Neither level's own
+/// `buffer_unordered` bound is the binding concurrency for the whole query,
+/// because those inner streams do not get independent budgets: every GET
+/// from every plan passes through the one `GetLimiter` this engine wired to
+/// every fetcher it owns (ADR-1195, `limiter.rs`), whose permit count is
+/// `shared_get_permits` here (`GetLimiter::permits`, resolved from
+/// `EngineConfig::store_get_concurrency`, which falls back to
+/// `fetch_concurrency` when unset). So the real binding concurrency is
+/// `min(service_fetch_multiplier * promql_fetch_fanout,
+/// shared_get_permits)`: the outer `buffer_unordered` can never have more
+/// than `service_fetch_multiplier * promql_fetch_fanout` plan/segment
+/// fetches in flight at once even with an unbounded limiter, and the shared
+/// limiter can never let more than `shared_get_permits` GETs run at once
+/// even with an unbounded outer fan-out -- whichever bound is smaller is the
+/// one the query actually waits on. The work this fan-out issues is
+/// `segments * service_fetch_multiplier` GETs, so the batch count this
+/// query's fetch is actually forced into is `service_batches(segments *
+/// service_fetch_multiplier, min(service_fetch_multiplier *
+/// promql_fetch_fanout, shared_get_permits))`, not
+/// `service_batches(segments * service_fetch_multiplier,
+/// promql_fetch_fanout)`: dividing the
+/// plan-multiplied numerator by the un-multiplied fan-out width alone
+/// double-counts the plan fan-out, since raising the numerator by
+/// `service_fetch_multiplier` without ever raising the denominator to match
+/// double counts the plans (2 distinct matcher sets, 64 segments,
+/// `promql_fetch_fanout` 8, `shared_get_permits` 16: 128 GETs at binding
+/// concurrency `min(16, 16) = 16` is 8 batches, not the 16 the unscaled
+/// divisor reports).
+///
+/// A single-plan query (`service_fetch_multiplier == 1`) reduces to
+/// `service_batches(segments, promql_fetch_fanout)` whenever the limiter's
+/// pool is at least as large as one plan's own `buffer_unordered` bound,
+/// which is every config that leaves ADR-1195's knobs unset (both resolve to
+/// `fetch_concurrency`). An operator who sets `--store-get-concurrency`
+/// below `--promql-fetch-fanout` makes the limiter the binding bound even
+/// for one plan, and this figure follows that.
 ///
 /// Deliberately does NOT thread any new instrumentation into the per-segment
 /// fetch loops (`fetch_all_samples_and_histograms`/`fetch_all_series`):
 /// every figure here is a pure function of the resolved `Snapshot` and the
 /// query's own configuration, computable before a single segment fetch
 /// starts.
+#[allow(clippy::too_many_arguments)]
 fn io_shape_for_resolve(
     snapshot: &Snapshot,
     metadata_only: bool,
     whole_object_threshold: u64,
     concurrency: u64,
     service_fetch_multiplier: u64,
+    shared_get_permits: u64,
     accounting: &PhaseAccounting,
     unfolded_segments_resolved: u64,
 ) -> QueryIoShape {
@@ -2455,9 +2488,12 @@ fn io_shape_for_resolve(
         .max()
         .unwrap_or(0);
     counts.record_dependency_chain(depth);
+    let binding_concurrency = concurrency
+        .saturating_mul(service_fetch_multiplier)
+        .min(shared_get_permits);
     counts.record_service_batches(crate::io_shape::service_batches(
         (snapshot.segments.len() as u64).saturating_mul(service_fetch_multiplier),
-        concurrency,
+        binding_concurrency,
     ));
     let resolve_list_requests = accounting
         .resolve()
@@ -7211,6 +7247,204 @@ mod prefetch_tests {
             "every resolve issues one bounded shard LIST plus one \
              unconditional pending-erasure `del/` LIST (ravel-catalog, \
              ADR-0064 decision 2), regardless of plan count: 2 total"
+        );
+    }
+
+    /// Regression for issue #1214's worked acceptance case: a multi-selector
+    /// metrics query's `service_batches` must divide by the BINDING
+    /// concurrency (`min(distinct_matcher_sets * promql_fetch_fanout,
+    /// shared_get_permits)`), not by the fan-out width alone. Two distinct
+    /// matcher sets (`binding_metric_a`, `binding_metric_b`, no shared
+    /// `__name__` filter so the resolve prunes nothing and the padded window
+    /// resolves all 64 published segments), the default `promql_fetch_fanout`
+    /// (8, resolving to `fetch_concurrency`), and a shared `GetLimiter`
+    /// (ADR-1195) built with exactly 16 permits: 128 GETs (64 segments * 2
+    /// distinct matcher sets) at binding concurrency `min(2 * 8, 16) == 16`
+    /// is 8 batches. The limiter is wired explicitly rather than left at the
+    /// resolved default so the expectation is pinned by the test, not by
+    /// whatever `store_get_concurrency` resolves to on the host. Before the
+    /// fix, `io_shape_for_resolve` divided the plan-multiplied numerator by
+    /// the fan-out width alone -- `ceil(64 * 2 / 8) == 16`, double the real
+    /// figure. Flip `binding_concurrency` in `io_shape_for_resolve` back to
+    /// plain `concurrency` to watch the assertion below fail: it would then
+    /// read 16, not 8.
+    #[tokio::test]
+    async fn service_batches_divides_by_binding_concurrency_not_fetch_concurrency_alone() {
+        const WIDE_RANGE_NS: i64 = 70 * NS_PER_MIN;
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        for seq in 1..=64u64 {
+            let ts = BASE_NS - (65 - seq as i64) * NS_PER_MIN;
+            let metric = if seq % 2 == 0 {
+                "binding_metric_a"
+            } else {
+                "binding_metric_b"
+            };
+            publish_metric(&store, tenant_hash, seq, metric, ts, seq as f64).await;
+        }
+
+        let eng = engine(store).with_get_limiter(Arc::new(
+            crate::GetLimiter::new(16).expect("16 permits is valid"),
+        ));
+        let plans = vec![
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("binding_metric_a")
+            },
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("binding_metric_b")
+            },
+        ];
+        let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
+        let (_source, stats) = eng
+            .prefetch(tenant_hash, &plans, &eval_window, &[], BASE_NS)
+            .await
+            .expect("prefetch two-distinct-matcher-set query");
+
+        assert_eq!(
+            stats.estimate.segments, 64,
+            "expected the padded window to resolve exactly the 64 published \
+             segments (no shared name filter to prune by), got {}",
+            stats.estimate.segments
+        );
+        assert_eq!(
+            stats.io_shape.service_batches, 8,
+            "64 segments * 2 distinct matcher sets = 128 GETs at binding \
+             concurrency min(2 * 8, 16) == 16 is 8 batches, not \
+             ceil(64 * 2 / 8) == 16"
+        );
+    }
+
+    /// Regression for issue #1214: exercises `min()` in the OTHER direction
+    /// from the worked acceptance case above -- here the outer plan fan-out
+    /// (`distinct_matcher_sets * promql_fetch_fanout`), not the shared
+    /// limiter, is the binding constraint, so the pre-fix and post-fix
+    /// formulas disagree on a case where the limiter was never close to
+    /// full. `fetch_concurrency` is lowered to 4 (`EngineConfig`, and
+    /// `promql_fetch_fanout` resolves to it), so 2 distinct matcher sets give
+    /// a plan fan-out bound of `2 * 4 == 8`, strictly under the 16 permits
+    /// the shared `GetLimiter` is built with here: `min(8, 16) == 8` is bound
+    /// by the plan fan-out, not the limiter. 20 segments * 2 matcher sets =
+    /// 40 GETs at that binding concurrency is `ceil(40 / 8) == 5`. The
+    /// limiter is wired explicitly (rather than left at the resolved
+    /// `store_get_concurrency`, which would follow `fetch_concurrency` down
+    /// to 4 and make the limiter bind after all) so this case keeps testing
+    /// the direction it names. The pre-fix formula (dividing by the fan-out
+    /// width alone, ignoring the multiplier entirely) would have read
+    /// `ceil(20 * 2 / 4) == 10`, twice the correct figure -- a different
+    /// wrong answer than the worked acceptance case's, because here the
+    /// multiplier's own contribution to the divisor was never capped by the
+    /// limiter.
+    #[tokio::test]
+    async fn service_batches_binds_on_plan_fanout_when_semaphore_has_headroom() {
+        const WIDE_RANGE_NS: i64 = 25 * NS_PER_MIN;
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        for seq in 1..=20u64 {
+            let ts = BASE_NS - (21 - seq as i64) * NS_PER_MIN;
+            let metric = if seq % 2 == 0 {
+                "fanout_metric_a"
+            } else {
+                "fanout_metric_b"
+            };
+            publish_metric(&store, tenant_hash, seq, metric, ts, seq as f64).await;
+        }
+
+        let config = EngineConfig {
+            fetch_concurrency: 4,
+            ..EngineConfig::default()
+        };
+        let eng = engine_with_config(store, config).with_get_limiter(Arc::new(
+            crate::GetLimiter::new(16).expect("16 permits is valid"),
+        ));
+        let plans = vec![
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("fanout_metric_a")
+            },
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("fanout_metric_b")
+            },
+        ];
+        let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
+        let (_source, stats) = eng
+            .prefetch(tenant_hash, &plans, &eval_window, &[], BASE_NS)
+            .await
+            .expect("prefetch plan-fanout-bound query");
+
+        assert_eq!(
+            stats.estimate.segments, 20,
+            "expected the padded window to resolve exactly the 20 published \
+             segments (no shared name filter to prune by), got {}",
+            stats.estimate.segments
+        );
+        assert_eq!(
+            stats.io_shape.service_batches, 5,
+            "plan fan-out binds here, not the shared limiter: min(2 distinct \
+             matcher sets * 4 promql_fetch_fanout, 16 shared permits) == 8, \
+             so 20 segments * 2 matcher sets = 40 GETs is ceil(40 / 8) == 5"
+        );
+    }
+
+    /// Pins WHERE the shared permit count comes from after ADR-1195: the
+    /// `GetLimiter` this engine wired to the fetchers it owns, not a
+    /// fetcher-local default. Same shape as the two cases above (2 distinct
+    /// matcher sets, default `promql_fetch_fanout` of 8), but the engine's
+    /// limiter is replaced with a 4-permit one, well under the plan fan-out
+    /// bound of `2 * 8 == 16`: `min(16, 4) == 4`, so 20 segments * 2 matcher
+    /// sets = 40 GETs is `ceil(40 / 4) == 10`. Reading the permit count from
+    /// the fetcher module's `DEFAULT_MAX_CONCURRENT_GETS` (16) instead --
+    /// which is what the pre-ADR-1195 `SegmentFetcher::max_concurrent_gets`
+    /// accessor reported for a fetcher nobody had overridden -- would give
+    /// `min(16, 16) == 16` and report `ceil(40 / 16) == 3`.
+    #[tokio::test]
+    async fn service_batches_reads_permits_from_the_engines_shared_limiter() {
+        const WIDE_RANGE_NS: i64 = 25 * NS_PER_MIN;
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        for seq in 1..=20u64 {
+            let ts = BASE_NS - (21 - seq as i64) * NS_PER_MIN;
+            let metric = if seq % 2 == 0 {
+                "limiter_metric_a"
+            } else {
+                "limiter_metric_b"
+            };
+            publish_metric(&store, tenant_hash, seq, metric, ts, seq as f64).await;
+        }
+
+        let eng = engine(store).with_get_limiter(Arc::new(
+            crate::GetLimiter::new(4).expect("4 permits is valid"),
+        ));
+        let plans = vec![
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("limiter_metric_a")
+            },
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("limiter_metric_b")
+            },
+        ];
+        let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
+        let (_source, stats) = eng
+            .prefetch(tenant_hash, &plans, &eval_window, &[], BASE_NS)
+            .await
+            .expect("prefetch limiter-bound query");
+
+        assert_eq!(
+            stats.estimate.segments, 20,
+            "expected the padded window to resolve exactly the 20 published \
+             segments (no shared name filter to prune by), got {}",
+            stats.estimate.segments
+        );
+        assert_eq!(
+            stats.io_shape.service_batches, 10,
+            "the shared limiter binds here: min(2 distinct matcher sets * 8 \
+             promql_fetch_fanout, 4 shared permits) == 4, so 20 segments * 2 \
+             matcher sets = 40 GETs is ceil(40 / 4) == 10, not the 3 a \
+             16-permit fetcher default would report"
         );
     }
 

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -879,6 +879,7 @@ impl QueryEngine {
                 now_ns,
                 name_filter.as_deref(),
                 1,
+                1,
                 true, // metadata_only: discovery never fetches pages.
                 attempt,
             )
@@ -955,6 +956,7 @@ impl QueryEngine {
                 min_tokens,
                 now_ns,
                 None,
+                1,
                 1,
                 true, // metadata_only: log discovery never fetches pages.
                 attempt,
@@ -1230,27 +1232,30 @@ impl QueryEngine {
         // the comment above `resolve_bounded` at the top of this function:
         // the log lane's resolve is only reached after the metrics lane's
         // `prefetch_metric_plans` call has already been awaited to
-        // completion). That seriality is exactly why the fields below
-        // combine differently from each other, not the same way:
-        // - `list_page_depth` counts serial LIST pages. Because the two
-        //   lanes' resolves run one after another in wall-clock time, their
-        //   page counts ADD: a query whose metrics lane paginated 4 LIST
-        //   pages and whose log lane paginated 2 more genuinely waited
-        //   through 6 serial pages, not 4.
-        // - `dependency_depth` stays max-based, but not because of
-        //   concurrency (there is none here): the log lane's fetch chain
-        //   has no DATA dependency on the metrics lane's bytes -- it does
-        //   not need any byte the metrics lane fetched to know its own
-        //   segment keys, so the two chains are independent chains that
-        //   happen to run one after the other. The reported figure is the
-        //   longest independent chain, matching `dependency_depth`'s own
-        //   definition ("the longest chain... where a stage needs a
-        //   previous stage's bytes to know its own keys"), which a serial
-        //   but data-independent pair of chains does not satisfy across
-        //   lanes.
-        // - `service_batches` stays max-based for the same data-independence
-        //   reason: each lane's fan-out is bounded by its own concurrency
-        //   permit independently of the other lane's batch count.
+        // completion). Each field's combining rule follows from ONE
+        // criterion, stated once so the three do not silently drift onto
+        // three different unstated rules:
+        // - `list_page_depth` and `service_batches` are both
+        //   SERIALIZATION-ROUND counts: the number of sequential rounds a
+        //   lane's own fan-out actually waited through (LIST pages one
+        //   lane's resolve issued; concurrency-permit batches one lane's
+        //   fetch was forced into). Because the two lanes run one after the
+        //   other in wall-clock time with no overlap, the rounds a query
+        //   waits through end-to-end are the metrics lane's rounds followed
+        //   by the log lane's rounds -- genuinely additive, not a max: a
+        //   query whose metrics lane paginated 4 LIST pages and whose log
+        //   lane paginated 2 more waited through 6 serial pages, not 4, and
+        //   the same reasoning applies unchanged to `service_batches`'s
+        //   fetch-concurrency rounds.
+        // - `dependency_depth` uses a DIFFERENT criterion: DATA
+        //   independence, not serialization order. It measures the longest
+        //   chain of stages where a later stage needs an earlier stage's
+        //   bytes to know its own keys. The log lane's fetch chain needs no
+        //   byte the metrics lane fetched to know its own segment keys, so
+        //   the two chains are independent chains that merely happen to run
+        //   one after the other -- across lanes this stays max-based,
+        //   matching `dependency_depth`'s own definition, which a serial but
+        //   data-independent pair of chains does not satisfy.
         // `unfolded_segments_resolved` IS additive (an exact total count
         // across both lanes' resolves, with no ambiguity about how the two
         // lanes' costs compose).
@@ -1265,7 +1270,7 @@ impl QueryEngine {
         let mut log_counts = IoShapeCounts {
             dependency_depth: stats.io_shape.dependency_depth,
             list_page_depth: 0,
-            service_batches: stats.io_shape.service_batches,
+            service_batches: 0,
         };
         let log_depth = log_snapshot
             .segments
@@ -1283,6 +1288,10 @@ impl QueryEngine {
             log_snapshot.segments.len() as u64,
             self.config.fetch_concurrency.max(1) as u64,
         ));
+        log_counts.service_batches = stats
+            .io_shape
+            .service_batches
+            .saturating_add(log_counts.service_batches);
         let log_list_requests = log_accounting
             .resolve()
             .snapshot()
@@ -1384,9 +1393,24 @@ impl QueryEngine {
             .saturating_add(i64::try_from(self.config.deadline.as_nanos()).unwrap_or(i64::MAX));
         // One independent fetch per selector against the same snapshot
         // (below): an N-selector query re-opens every snapshot segment up to
-        // N times, so the pre-fetch cost estimate must scale by this same
-        // factor to stay a genuine upper bound.
+        // N times in the worst case (no shared matcher set), so the
+        // pre-fetch cost estimate must scale by this same factor to stay a
+        // genuine upper bound. Deliberately NOT deduplicated by matcher
+        // equality: `estimate_cost` is an upper envelope (like every other
+        // term it computes), so over-counting a query whose plans happen to
+        // share a matcher set is a legitimate conservative slop, not a bug.
         let fetch_multiplier = plans.len() as u64;
+        // The fan-out `service_batches` actually measures (`io_shape.rs`'s
+        // doc comment: "batches this query's per-segment fan-out was forced
+        // into") is real, not an envelope: the `attempt` closure below fetches
+        // exactly one distinct matcher set's segments per pass
+        // (`distinct_plans_by_matcher`, same dedup the closure's own
+        // `distinct_plans` uses), so `up + up offset 5m` -- two plans, one
+        // distinct matcher set -- is forced into ONE fetch pass over the
+        // snapshot, not two. Using `fetch_multiplier` here as well (the
+        // upper-envelope, undeduplicated count) would report a batch count
+        // the fan-out was never actually forced into.
+        let service_fetch_multiplier = distinct_plans_by_matcher(plans).len() as u64;
         // Captured by reference (like `plans`), so the `FnMut` attempt copies
         // the reference on each retry rather than moving the owned `Vec` out of
         // its environment. The per-plan futures below build owned pairs from it.
@@ -1422,17 +1446,12 @@ impl QueryEngine {
             // would otherwise pay for -- and account -- the same segment
             // fetch once per plan even though a cache/single-flight layer
             // underneath never re-hits the store for the repeat. Dedup by
-            // matcher equality (`LabelMatcher` has no `Hash`, only a
-            // structural `Eq`, hence a linear scan rather than a set; a
-            // query's selector count is small enough that this stays cheap)
-            // so each distinct matcher set is fetched, decoded, and counted
-            // exactly once, however many plans reference it.
-            let mut distinct_plans: Vec<SelectorPlan> = Vec::with_capacity(plans.len());
-            for plan in plans {
-                if !distinct_plans.iter().any(|p| p.matchers == plan.matchers) {
-                    distinct_plans.push(plan.clone());
-                }
-            }
+            // matcher equality so each distinct matcher set is fetched,
+            // decoded, and counted exactly once, however many plans
+            // reference it -- `distinct_plans_by_matcher` is the same
+            // dedup `service_fetch_multiplier` below was sized from, so the
+            // two never drift onto two different notions of "distinct".
+            let distinct_plans = distinct_plans_by_matcher(plans);
             // ADR-0103 eligibility gate, evaluated ONCE per query over the whole
             // resolved snapshot's segment set and the generation history THIS
             // resolve produced (never a per-matcher-set subset, never a
@@ -1688,6 +1707,7 @@ impl QueryEngine {
                 now_ns,
                 name_filter.as_deref(),
                 fetch_multiplier,
+                service_fetch_multiplier,
                 false, // metadata_only: this path fetches scalar/histogram pages.
                 attempt,
             )
@@ -1711,7 +1731,21 @@ impl QueryEngine {
         min_tokens: &[CommitToken],
         now_ns: i64,
         name_filter: Option<&str>,
+        // Upper-envelope selector fan-out factor for `estimate_cost`
+        // (`plans.len()`, undeduplicated -- see the comment above its
+        // assignment in `prefetch_metric_plans`): legitimately over-counts
+        // a query whose plans share a matcher set, since `estimate_cost` is
+        // an upper bound by design.
         fetch_multiplier: u64,
+        // The real per-distinct-matcher-set fan-out factor `io_shape`'s
+        // `service_batches` scales by: the count of distinct matcher sets
+        // the fetch fan-out actually issues one pass per
+        // (`distinct_plans_by_matcher`), never larger than `fetch_multiplier`
+        // and strictly smaller whenever two plans share a matcher set (`up +
+        // up offset 5m`). `service_batches` documents itself as the batches
+        // the fan-out was FORCED into, a factual figure, so it must use this
+        // deduplicated count rather than the upper-envelope one.
+        service_fetch_multiplier: u64,
         // `QueryIoShape::plan_class` is decided before any segment is opened
         // (issue #1214): `true` for a discovery-only caller
         // (`resolve_series_inner`/`resolve_log_series_inner`, neither of
@@ -1758,7 +1792,7 @@ impl QueryEngine {
             metadata_only,
             whole_object_threshold,
             concurrency,
-            fetch_multiplier,
+            service_fetch_multiplier,
             &first_accounting,
             first_unfolded,
         );
@@ -1787,7 +1821,7 @@ impl QueryEngine {
                     metadata_only,
                     whole_object_threshold,
                     concurrency,
-                    fetch_multiplier,
+                    service_fetch_multiplier,
                     &second_accounting,
                     second_unfolded,
                 );
@@ -2370,16 +2404,34 @@ fn combine_phase_accounting(
 /// two shards' LIST pages ran concurrently with each other), and the
 /// already-computed exact unfolded-segment count and plan-class decision.
 ///
-/// `fetch_multiplier` is the same per-distinct-selector fan-out factor
-/// `estimate_cost` scales its own request estimate by (`plans.len()` in
-/// `prefetch_metric_plans`): the metrics fetch reopens this resolve's
-/// segment set once per distinct plan, all contending for one shared
-/// `fetch_concurrency` semaphore, so the batch count this query's fetch is
-/// actually forced into is `service_batches(segments * fetch_multiplier,
-/// concurrency)`, not `service_batches(segments, concurrency)`. Omitting the
-/// multiplier here (while `estimate_cost` already applies it) made
-/// `stats.io` and `stats.estimate` disagree by construction for any query
-/// with more than one distinct selector.
+/// `service_fetch_multiplier` is the count of DISTINCT matcher sets the
+/// metrics fetch fan-out actually issues one pass per
+/// (`distinct_plans_by_matcher` in `prefetch_metric_plans`, e.g. `up + up
+/// offset 5m` -- two plans, one distinct matcher set, one pass), not the raw
+/// plan count `estimate_cost` scales by: that estimate is a deliberate
+/// upper envelope, but `service_batches` documents itself as the batches the
+/// fan-out was FORCED into, a factual figure that must not carry the
+/// envelope's slop. The fan-out itself is a nested `buffer_unordered`
+/// (`futures::stream`): one `buffer_unordered(fetch_concurrency)` over
+/// distinct plans (`prefetch_metric_plans`'s `attempt` closure), each of
+/// which runs its own `buffer_unordered(fetch_concurrency)` over that plan's
+/// segments (`fetch_all_samples_and_histograms`). Neither level shares a
+/// single semaphore across plans: `fetch_concurrency` (`EngineConfig`,
+/// default 8) only bounds each `buffer_unordered` call's own concurrent
+/// future count. The one pool actually shared by every concurrent segment
+/// fetch in a query is `SegmentFetcher::get_semaphore`
+/// (`fetcher.rs`), sized `DEFAULT_MAX_CONCURRENT_GETS` (16) for the metrics
+/// fetcher -- `QueryEngine::new` calls `with_max_concurrent_gets` on the log
+/// fetcher only, never on `self.fetcher`. So the batch count this query's
+/// fetch is actually forced into (at the `buffer_unordered` level
+/// `service_batches` models) is `service_batches(segments *
+/// service_fetch_multiplier, fetch_concurrency)`, not
+/// `service_batches(segments, fetch_concurrency)`; the 8-vs-16 mismatch
+/// between that `buffer_unordered` bound and the get-semaphore's real
+/// capacity is a separate, pre-existing gap this field does not attempt to
+/// close. Omitting the multiplier here (while `estimate_cost` already
+/// applies its own) made `stats.io` and `stats.estimate` disagree by
+/// construction for any query with more than one distinct selector.
 ///
 /// Deliberately does NOT thread any new instrumentation into the per-segment
 /// fetch loops (`fetch_all_samples_and_histograms`/`fetch_all_series`):
@@ -2391,7 +2443,7 @@ fn io_shape_for_resolve(
     metadata_only: bool,
     whole_object_threshold: u64,
     concurrency: u64,
-    fetch_multiplier: u64,
+    service_fetch_multiplier: u64,
     accounting: &PhaseAccounting,
     unfolded_segments_resolved: u64,
 ) -> QueryIoShape {
@@ -2404,7 +2456,7 @@ fn io_shape_for_resolve(
         .unwrap_or(0);
     counts.record_dependency_chain(depth);
     counts.record_service_batches(crate::io_shape::service_batches(
-        snapshot.segments.len() as u64 * fetch_multiplier,
+        (snapshot.segments.len() as u64).saturating_mul(service_fetch_multiplier),
         concurrency,
     ));
     let resolve_list_requests = accounting
@@ -2847,6 +2899,28 @@ fn shared_equality_name_filter<'a>(plans: &'a [SelectorPlan]) -> Option<Cow<'a, 
         }
     }
     shared
+}
+
+/// Deduplicates `plans` by matcher equality, keeping the first plan seen for
+/// each distinct matcher set. The single source of truth for what
+/// `prefetch_metric_plans`'s per-attempt fetch fan-out (`engine.rs`, the
+/// `distinct_plans` loop inside its `attempt` closure) actually fetches:
+/// `LabelMatcher` has no `Hash`, only a structural `Eq`, hence a linear scan
+/// rather than a set, which stays cheap for the small selector counts a
+/// query carries. Called twice per query attempt against the same `plans`
+/// slice (once here to size the metrics fetch fan-out's `service_batches`
+/// contribution before any segment is opened, once inside the fetch closure
+/// to build the actual per-matcher-set future list) rather than threaded
+/// through as a value, so the two call sites can never drift onto two
+/// different notions of "distinct".
+fn distinct_plans_by_matcher(plans: &[SelectorPlan]) -> Vec<SelectorPlan> {
+    let mut distinct: Vec<SelectorPlan> = Vec::with_capacity(plans.len());
+    for plan in plans {
+        if !distinct.iter().any(|p| p.matchers == plan.matchers) {
+            distinct.push(plan.clone());
+        }
+    }
+    distinct
 }
 
 #[cfg(test)]
@@ -5817,6 +5891,18 @@ mod prefetch_tests {
         }
     }
 
+    /// Same matcher set as `window_plan`, a different `offset_ns`: two plans
+    /// built this way carry identical `matchers` (a query like `up + up
+    /// offset 5m`) and so collapse to one distinct matcher set under
+    /// `distinct_plans_by_matcher`, despite being two separate `SelectorPlan`
+    /// entries.
+    fn window_plan_with_offset(metric: &str, offset_ns: i64) -> SelectorPlan {
+        SelectorPlan {
+            offset_ns,
+            ..window_plan(metric)
+        }
+    }
+
     /// Writes one real RSEG segment (one series per metric) and publishes
     /// its commit record, mirroring `tests/e2e.rs`'s own helper.
     async fn publish_metric(
@@ -7075,6 +7161,57 @@ mod prefetch_tests {
             stats.estimate.segments
         );
         assert_estimate_covers_actual("multi-segment query", &stats);
+    }
+
+    /// Regression for issue #1214's second review round, Finding 1: a real
+    /// `up + up offset 5m`-shaped query (two `SelectorPlan`s sharing one
+    /// matcher set, `window_plan` plus `window_plan_with_offset`) run through
+    /// a real `QueryEngine` must report `service_batches` from the
+    /// DEDUPLICATED matcher-set count, not the raw plan count. 5 segments
+    /// under the default `fetch_concurrency` of 8: the fixed
+    /// `service_fetch_multiplier` (1 distinct matcher set) gives
+    /// `ceil(5 * 1 / 8) == 1`; the pre-fix `fetch_multiplier` (2, the raw
+    /// plan count) would have given `ceil(5 * 2 / 8) == 2`. Flip
+    /// `service_fetch_multiplier` back to `fetch_multiplier` at its
+    /// `resolve_snapshot_with_retry` call site (`prefetch_metric_plans`) to
+    /// watch the `service_batches` assertion below fail: it would then read
+    /// 2, not 1.
+    #[tokio::test]
+    async fn real_query_with_shared_matcher_plans_reports_deduplicated_service_batches() {
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        for seq in 1..=5u64 {
+            let ts = BASE_NS - (6 - seq as i64) * NS_PER_MIN;
+            publish_metric(&store, tenant_hash, seq, "dedup_metric", ts, seq as f64).await;
+        }
+
+        let eng = engine(store);
+        let plans = vec![
+            window_plan("dedup_metric"),
+            window_plan_with_offset("dedup_metric", 5 * 60 * NS_PER_SEC),
+        ];
+        let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
+        let (_source, stats) = eng
+            .prefetch(tenant_hash, &plans, &eval_window, &[], BASE_NS)
+            .await
+            .expect("prefetch shared-matcher query");
+
+        assert!(
+            stats.estimate.segments >= 5,
+            "expected the snapshot to span at least the 5 published segments, got {}",
+            stats.estimate.segments
+        );
+        assert_eq!(
+            stats.io_shape.service_batches, 1,
+            "two plans sharing one matcher set must fetch as one distinct pass: \
+             ceil(5 segments * 1 distinct matcher set / 8 concurrency) == 1"
+        );
+        assert_eq!(
+            stats.io_shape.list_page_depth, 2,
+            "every resolve issues one bounded shard LIST plus one \
+             unconditional pending-erasure `del/` LIST (ravel-catalog, \
+             ADR-0064 decision 2), regardless of plan count: 2 total"
+        );
     }
 
     /// Native-histogram fixture (ADR-0044 finding 2): a 200-bucket sample's

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -19,7 +19,7 @@ use ravel_promql::{
 };
 use ravel_proto::queryfrag::v1 as pb;
 use ravel_segment::ReaderLimits;
-use ravel_types::accounting::{CostEstimate, QueryAccounting, QueryAccountingSnapshot};
+use ravel_types::accounting::{AccountedOp, CostEstimate, QueryAccounting, QueryAccountingSnapshot};
 use ravel_types::{
     CommitToken, LabelSet, METRIC_NAME_LABEL, Sample, SeriesId, Signal, TenantHash, TimeRange,
 };
@@ -31,8 +31,9 @@ use crate::fetcher::{
     FetchError, FetchStats, FetchedHistogramSeries, FetchedSeriesSoa, ReadCache, SamplePriority,
     SegmentFetcher,
 };
+use crate::io_shape::{IoShapeCounts, PlanClass, QueryIoShape};
 use crate::limiter::GetLimiter;
-use crate::log_fetcher::{LogFetchError, LogSegmentFetcher};
+use crate::log_fetcher::{DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LogFetchError, LogSegmentFetcher};
 use crate::log_series;
 use crate::phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot};
 use crate::segment_admission;
@@ -105,15 +106,23 @@ pub struct QueryStats {
     /// healthy. Surfaced into the query response's `warnings` array alongside
     /// the evaluator's own [`Annotations`] warnings.
     pub warnings: Vec<String>,
+    /// The query's I/O dependency shape (issue #1214): chain depth, LIST
+    /// pagination, concurrency-forced batching, exact unfolded-record count,
+    /// and pre-execution plan class. See `crate::io_shape` module docs for
+    /// what each figure means, and how it differs from `phase_accounting`'s
+    /// request/byte cost split above.
+    pub io_shape: QueryIoShape,
 }
 
 impl QueryStats {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         segments_fetched: u64,
         segments_pruned: u64,
         page_stats: FetchStats,
         phase_accounting: PhaseAccountingSnapshot,
         estimate: CostEstimate,
+        io_shape: QueryIoShape,
     ) -> Self {
         QueryStats {
             segments_fetched,
@@ -124,6 +133,7 @@ impl QueryStats {
             estimate,
             partial: false,
             warnings: Vec::new(),
+            io_shape,
         }
     }
 }
@@ -142,6 +152,7 @@ impl Default for QueryStats {
             estimate: CostEstimate::new(0, 0, 0, 0, 0),
             partial: false,
             warnings: Vec::new(),
+            io_shape: QueryIoShape::default(),
         }
     }
 }
@@ -866,6 +877,7 @@ impl QueryEngine {
                 now_ns,
                 name_filter.as_deref(),
                 1,
+                true, // metadata_only: discovery never fetches pages.
                 attempt,
             )
             .await?;
@@ -942,6 +954,7 @@ impl QueryEngine {
                 now_ns,
                 None,
                 1,
+                true, // metadata_only: log discovery never fetches pages.
                 attempt,
             )
             .await?;
@@ -1096,7 +1109,7 @@ impl QueryEngine {
         // second attempt exists to paper over, not a case worth duplicating
         // that machinery for.
         let log_accounting = PhaseAccounting::new();
-        let (log_snapshot, _log_generations) = self
+        let (log_snapshot, _log_generations, log_unfolded) = self
             .resolve_bounded(
                 tenant_hash,
                 Signal::Logs,
@@ -1208,6 +1221,48 @@ impl QueryEngine {
         stats.phase_accounting =
             combine_phase_accounting(&stats.phase_accounting, &log_accounting.snapshot());
         stats.accounting = stats.phase_accounting.pooled();
+
+        // Fold the log lane's own io_shape contribution into the metrics
+        // lane's, mirroring the `combine_phase_accounting` fold above.
+        // Unlike that fold, `dependency_depth`/`list_page_depth`/
+        // `service_batches` are "longest chain wins" (`IoShapeCounts`'s own
+        // max-based semantics), not sums: two lanes' chains ran alongside
+        // each other, not one after the other. `unfolded_records_resolved`
+        // IS additive (an exact total count across both lanes' resolves).
+        // The log lane's `whole_object_threshold` is not reachable from
+        // here (`BlockRangeFetcher::effective_whole_object_threshold` is
+        // private and, unlike `SegmentFetcher`'s fixed field, scales
+        // dynamically with `request_cost_bytes`); `DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`
+        // is used as a structural approximation, so a log fetcher configured
+        // with a non-default override can misclassify a segment's
+        // dependency_depth here.
+        let mut log_counts = IoShapeCounts {
+            dependency_depth: stats.io_shape.dependency_depth,
+            list_page_depth: stats.io_shape.list_page_depth,
+            service_batches: stats.io_shape.service_batches,
+        };
+        let log_depth = log_snapshot
+            .segments
+            .iter()
+            .map(|seg| crate::io_shape::depth_for_object(seg.object_size, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD))
+            .max()
+            .unwrap_or(0);
+        log_counts.record_dependency_chain(log_depth);
+        log_counts.record_service_batches(crate::io_shape::service_batches(
+            log_snapshot.segments.len() as u64,
+            self.config.fetch_concurrency.max(1) as u64,
+        ));
+        let log_list_requests = log_accounting.resolve().snapshot().s3_requests(AccountedOp::List);
+        log_counts.record_list_pages(log_list_requests.min(u64::from(u32::MAX)) as u32);
+        let log_plan_class = if log_snapshot.segments_pruned > 0 {
+            PlanClass::SelectiveIndexed
+        } else {
+            PlanClass::ExhaustiveScan
+        };
+        stats.io_shape = log_counts.into_shape(
+            stats.io_shape.unfolded_records_resolved + log_unfolded,
+            crate::io_shape::merge_plan_class(stats.io_shape.plan_class, log_plan_class),
+        );
 
         // ADR-1103 decision 5: a federated query answers a log selector
         // locally only, never fanning it to a remote cluster; the client is
@@ -1585,6 +1640,7 @@ impl QueryEngine {
                 now_ns,
                 name_filter.as_deref(),
                 fetch_multiplier,
+                false, // metadata_only: this path fetches scalar/histogram pages.
                 attempt,
             )
             .await?;
@@ -1608,6 +1664,13 @@ impl QueryEngine {
         now_ns: i64,
         name_filter: Option<&str>,
         fetch_multiplier: u64,
+        // `QueryIoShape::plan_class` is decided before any segment is opened
+        // (issue #1214): `true` for a discovery-only caller
+        // (`resolve_series_inner`/`resolve_log_series_inner`, neither of
+        // which reaches `fetch_scalar_pages`/`fetch_histogram_pages`),
+        // `false` for the metrics evaluation path, which then classifies by
+        // the resolve's own pruning outcome below.
+        metadata_only: bool,
         mut attempt: F,
     ) -> Result<(T, QueryStats), QueryError>
     where
@@ -1618,6 +1681,8 @@ impl QueryEngine {
         // attempts: `window` and `now_ns` do not change on retry, only the
         // snapshot resolve's outcome does.
         let catalog_requests = self.catalog.estimated_catalog_requests(window, now_ns);
+        let concurrency = self.config.fetch_concurrency.max(1) as u64;
+        let whole_object_threshold = self.fetcher.whole_object_threshold();
         // Fresh handle per attempt, created before `resolve_bounded` runs so
         // the same handle that goes on to fetch segments also receives
         // resolve's own catalog-side counters (ADR-0044 decision 1: "created
@@ -1626,7 +1691,7 @@ impl QueryEngine {
         // discarded first attempt's in-flight counts must not bleed into the
         // attempt that actually produced the result.
         let first_accounting = PhaseAccounting::new();
-        let (first, first_generations) = self
+        let (first, first_generations, first_unfolded) = self
             .resolve_bounded(
                 tenant_hash,
                 signal,
@@ -1640,13 +1705,21 @@ impl QueryEngine {
         let first_estimate = estimate_cost(&first, fetch_multiplier, catalog_requests);
         let first_segments = first.segments.len() as u64;
         let first_pruned = first.segments_pruned;
+        let first_io_shape = io_shape_for_resolve(
+            &first,
+            metadata_only,
+            whole_object_threshold,
+            concurrency,
+            &first_accounting,
+            first_unfolded,
+        );
         match attempt(first, first_generations, first_accounting.clone()).await {
             Err(QueryError::Fetch(FetchError::Store {
                 source: StoreError::NotFound,
                 ..
             })) => {
                 let second_accounting = PhaseAccounting::new();
-                let (second, second_generations) = self
+                let (second, second_generations, second_unfolded) = self
                     .resolve_bounded(
                         tenant_hash,
                         signal,
@@ -1660,6 +1733,14 @@ impl QueryEngine {
                 let second_estimate = estimate_cost(&second, fetch_multiplier, catalog_requests);
                 let second_segments = second.segments.len() as u64;
                 let second_pruned = second.segments_pruned;
+                let second_io_shape = io_shape_for_resolve(
+                    &second,
+                    metadata_only,
+                    whole_object_threshold,
+                    concurrency,
+                    &second_accounting,
+                    second_unfolded,
+                );
                 match attempt(second, second_generations, second_accounting.clone()).await {
                     Err(QueryError::Fetch(FetchError::Store {
                         source: StoreError::NotFound,
@@ -1673,6 +1754,7 @@ impl QueryEngine {
                             page_stats,
                             second_accounting.snapshot(),
                             second_estimate,
+                            second_io_shape,
                         ),
                     )),
                     Err(other) => Err(other),
@@ -1686,6 +1768,7 @@ impl QueryEngine {
                     page_stats,
                     first_accounting.snapshot(),
                     first_estimate,
+                    first_io_shape,
                 ),
             )),
             Err(other) => Err(other),
@@ -1708,7 +1791,7 @@ impl QueryEngine {
         now_ns: i64,
         name_filter: Option<&str>,
         accounting: &QueryAccounting,
-    ) -> Result<(Snapshot, Vec<ShardGeneration>), QueryError> {
+    ) -> Result<(Snapshot, Vec<ShardGeneration>, u64), QueryError> {
         // `resolve_pruned_with_generations` returns the shard-generation history
         // THIS resolve computed its scan set from (ADR-0103 decision 1(b)): the
         // pushdown eligibility gate reads exactly this copy, never a separately
@@ -1731,7 +1814,13 @@ impl QueryEngine {
         // 2). Their cost is bounded separately by the request budget
         // checked incrementally during fetch, below.
         segment_admission::admit(&snapshot, &origins, &self.config)?;
-        Ok((snapshot, generations))
+        // Exact count of segments this resolve took from the recent
+        // (unfolded) listing path rather than a folded snapshot part
+        // (`QueryIoShape::unfolded_records_resolved`, issue #1214): gates a
+        // downstream fold-benefit decision, so this must be the real count,
+        // never an estimate.
+        let unfolded_records_resolved = crate::io_shape::count_unfolded_records(&origins.origins);
+        Ok((snapshot, generations, unfolded_records_resolved))
     }
 
     /// Maps a log lane failure onto the same [`QueryError`] variants the
@@ -2219,6 +2308,56 @@ fn combine_phase_accounting(
         probe: a.probe.saturating_add(&b.probe),
         scan: a.scan.saturating_add(&b.scan),
     }
+}
+
+/// Builds one resolve attempt's [`QueryIoShape`] (issue #1214) entirely from
+/// values already produced by that attempt's resolve: the segment set's own
+/// `object_size`s (structural `dependency_depth`, see
+/// `io_shape::depth_for_object`), the resolved segment count against this
+/// query's concurrency permit (`service_batches`), the resolve phase's own
+/// LIST request count (`list_page_depth`, an upper-bound serial depth --
+/// see `crate::io_shape` module docs for why this crate cannot see whether
+/// two shards' LIST pages ran concurrently with each other), and the
+/// already-computed exact unfolded-record count and plan-class decision.
+///
+/// Deliberately does NOT thread any new instrumentation into the per-segment
+/// fetch loops (`fetch_all_samples_and_histograms`/`fetch_all_series`):
+/// every figure here is a pure function of the resolved `Snapshot` and the
+/// query's own configuration, computable before a single segment fetch
+/// starts.
+fn io_shape_for_resolve(
+    snapshot: &Snapshot,
+    metadata_only: bool,
+    whole_object_threshold: u64,
+    concurrency: u64,
+    accounting: &PhaseAccounting,
+    unfolded_records_resolved: u64,
+) -> QueryIoShape {
+    let mut counts = IoShapeCounts::default();
+    let depth = snapshot
+        .segments
+        .iter()
+        .map(|seg| crate::io_shape::depth_for_object(seg.object_size, whole_object_threshold))
+        .max()
+        .unwrap_or(0);
+    counts.record_dependency_chain(depth);
+    counts.record_service_batches(crate::io_shape::service_batches(
+        snapshot.segments.len() as u64,
+        concurrency,
+    ));
+    let resolve_list_requests = accounting
+        .resolve()
+        .snapshot()
+        .s3_requests(AccountedOp::List);
+    counts.record_list_pages(resolve_list_requests.min(u64::from(u32::MAX)) as u32);
+    let plan_class = if metadata_only {
+        PlanClass::MetadataOnly
+    } else if snapshot.segments_pruned > 0 {
+        PlanClass::SelectiveIndexed
+    } else {
+        PlanClass::ExhaustiveScan
+    };
+    counts.into_shape(unfolded_records_resolved, plan_class)
 }
 
 /// A locally-scoped series identity for a log-derived series returned from

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -2427,34 +2427,46 @@ fn combine_phase_accounting(
 /// (`prefetch_metric_plans`'s `attempt` closure, `distinct_plans_by_matcher`
 /// in `engine.rs`), each of which runs its own
 /// `buffer_unordered(promql_fetch_fanout)` over that plan's segments
-/// (`fetch_all_samples_and_histograms`). Neither level's own
-/// `buffer_unordered` bound is the binding concurrency for the whole query,
-/// because those inner streams do not get independent budgets: every GET
-/// from every plan passes through the one `GetLimiter` this engine wired to
+/// (`fetch_all_samples_and_histograms`). The OUTER `buffer_unordered` admits
+/// at most `promql_fetch_fanout` plans at once, however many distinct
+/// matcher sets the query has, so plan capacity is `promql_fetch_fanout *
+/// min(service_fetch_multiplier, promql_fetch_fanout)`, not
+/// `promql_fetch_fanout * service_fetch_multiplier` -- that would assume
+/// every distinct plan runs concurrently, true only when
+/// `service_fetch_multiplier <= promql_fetch_fanout`. Neither this level nor
+/// the inner one gets an independent budget on top of that: every GET from
+/// every plan also passes through the one `GetLimiter` this engine wired to
 /// every fetcher it owns (ADR-1195, `limiter.rs`), whose permit count is
 /// `shared_get_permits` here (`GetLimiter::permits`, resolved from
 /// `EngineConfig::store_get_concurrency`, which falls back to
 /// `fetch_concurrency` when unset). So the real binding concurrency is
-/// `min(service_fetch_multiplier * promql_fetch_fanout,
-/// shared_get_permits)`: the outer `buffer_unordered` can never have more
-/// than `service_fetch_multiplier * promql_fetch_fanout` plan/segment
-/// fetches in flight at once even with an unbounded limiter, and the shared
-/// limiter can never let more than `shared_get_permits` GETs run at once
-/// even with an unbounded outer fan-out -- whichever bound is smaller is the
-/// one the query actually waits on. The work this fan-out issues is
-/// `segments * service_fetch_multiplier` GETs, so the batch count this
-/// query's fetch is actually forced into is `service_batches(segments *
-/// service_fetch_multiplier, min(service_fetch_multiplier *
-/// promql_fetch_fanout, shared_get_permits))`, not
-/// `service_batches(segments * service_fetch_multiplier,
-/// promql_fetch_fanout)`: dividing the
+/// `min(promql_fetch_fanout * min(service_fetch_multiplier,
+/// promql_fetch_fanout), shared_get_permits)`: the outer `buffer_unordered`
+/// can never have more than `promql_fetch_fanout * min(service_fetch_multiplier,
+/// promql_fetch_fanout)` plan/segment fetches in flight at once even with an
+/// unbounded limiter, and the shared limiter can never let more than
+/// `shared_get_permits` GETs run at once even with an unbounded outer
+/// fan-out -- whichever bound is smaller is the one the query actually waits
+/// on. The work this fan-out issues is `segments * service_fetch_multiplier`
+/// GETs (uncapped -- every distinct matcher set still issues its own GETs,
+/// just not all of them concurrently), so the batch count this query's
+/// fetch is actually forced into is `service_batches(segments *
+/// service_fetch_multiplier, min(promql_fetch_fanout *
+/// min(service_fetch_multiplier, promql_fetch_fanout),
+/// shared_get_permits))`, not `service_batches(segments *
+/// service_fetch_multiplier, promql_fetch_fanout)`: dividing the
 /// plan-multiplied numerator by the un-multiplied fan-out width alone
-/// double-counts the plan fan-out, since raising the numerator by
-/// `service_fetch_multiplier` without ever raising the denominator to match
-/// double counts the plans (2 distinct matcher sets, 64 segments,
+/// double-counts the plan fan-out (2 distinct matcher sets, 64 segments,
 /// `promql_fetch_fanout` 8, `shared_get_permits` 16: 128 GETs at binding
-/// concurrency `min(16, 16) = 16` is 8 batches, not the 16 the unscaled
-/// divisor reports).
+/// concurrency `min(8 * min(2, 8), 16) = min(16, 16) = 16` is 8 batches, not
+/// the 16 the unscaled divisor reports); and capping the multiplier by
+/// `shared_get_permits` alone, without also capping it by
+/// `promql_fetch_fanout`, overstates plan capacity when there are more
+/// distinct matcher sets than `promql_fetch_fanout` (`promql_fetch_fanout`
+/// 1, 3 distinct matcher sets, 20 segments, `shared_get_permits` 1000: only
+/// one plan's segments are ever in flight, so binding concurrency is
+/// `min(1 * min(3, 1), 1000) = 1`, i.e. 60 batches, not the 20 an uncapped
+/// `1 * 3` capacity term would report).
 ///
 /// A single-plan query (`service_fetch_multiplier == 1`) reduces to
 /// `service_batches(segments, promql_fetch_fanout)` whenever the limiter's
@@ -2489,7 +2501,7 @@ fn io_shape_for_resolve(
         .unwrap_or(0);
     counts.record_dependency_chain(depth);
     let binding_concurrency = concurrency
-        .saturating_mul(service_fetch_multiplier)
+        .saturating_mul(service_fetch_multiplier.min(concurrency))
         .min(shared_get_permits);
     counts.record_service_batches(crate::io_shape::service_batches(
         (snapshot.segments.len() as u64).saturating_mul(service_fetch_multiplier),
@@ -7445,6 +7457,84 @@ mod prefetch_tests {
              promql_fetch_fanout, 4 shared permits) == 4, so 20 segments * 2 \
              matcher sets = 40 GETs is ceil(40 / 4) == 10, not the 3 a \
              16-permit fetcher default would report"
+        );
+    }
+
+    /// Regression for issue #1214's second review round, Finding 2: the
+    /// OUTER `buffer_unordered(promql_fetch_fanout)` over distinct plans
+    /// admits at most `promql_fetch_fanout` plans at once, so plan capacity
+    /// is `promql_fetch_fanout * min(distinct_plans, promql_fetch_fanout)`,
+    /// not `promql_fetch_fanout * distinct_plans` -- that formula assumes
+    /// every distinct plan runs concurrently, which is only true when
+    /// `distinct_plans <= promql_fetch_fanout`. Here `promql_fetch_fanout`
+    /// is 1 (`fetch_concurrency` lowered to 1) with THREE distinct matcher
+    /// sets, so only one plan's segments are ever in flight: plan capacity
+    /// is `1 * min(3, 1) == 1`. The shared `GetLimiter` is built with a
+    /// large permit count so the semaphore never binds and the plan-capacity
+    /// term is what's under test. 20 segments * 3 distinct matcher sets = 60
+    /// GETs at binding concurrency `min(1, 1000) == 1` is 60 batches. The
+    /// pre-fix formula (`concurrency * distinct_plans`, uncapped by
+    /// `concurrency` itself) would have computed binding concurrency
+    /// `min(1 * 3, 1000) == 3` and reported `ceil(60 / 3) == 20`, the raw
+    /// segment count, silently dropping the fact that only one plan's
+    /// segments ever fetch at a time. Flip `service_fetch_multiplier.min(concurrency)`
+    /// in `io_shape_for_resolve` back to plain `service_fetch_multiplier` to
+    /// watch the assertion below fail: it would then read 20, not 60.
+    #[tokio::test]
+    async fn service_batches_caps_plan_capacity_at_outer_fanout_width() {
+        const WIDE_RANGE_NS: i64 = 25 * NS_PER_MIN;
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        for seq in 1..=20u64 {
+            let ts = BASE_NS - (21 - seq as i64) * NS_PER_MIN;
+            let metric = match seq % 3 {
+                0 => "capacity_metric_a",
+                1 => "capacity_metric_b",
+                _ => "capacity_metric_c",
+            };
+            publish_metric(&store, tenant_hash, seq, metric, ts, seq as f64).await;
+        }
+
+        let config = EngineConfig {
+            fetch_concurrency: 1,
+            ..EngineConfig::default()
+        };
+        let eng = engine_with_config(store, config).with_get_limiter(Arc::new(
+            crate::GetLimiter::new(1000).expect("1000 permits is valid"),
+        ));
+        let plans = vec![
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("capacity_metric_a")
+            },
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("capacity_metric_b")
+            },
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("capacity_metric_c")
+            },
+        ];
+        let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
+        let (_source, stats) = eng
+            .prefetch(tenant_hash, &plans, &eval_window, &[], BASE_NS)
+            .await
+            .expect("prefetch three-distinct-matcher-set query");
+
+        assert_eq!(
+            stats.estimate.segments, 20,
+            "expected the padded window to resolve exactly the 20 published \
+             segments (no shared name filter to prune by), got {}",
+            stats.estimate.segments
+        );
+        assert_eq!(
+            stats.io_shape.service_batches, 60,
+            "outer plan admission binds here, not the shared limiter: \
+             min(1 promql_fetch_fanout * min(3 distinct matcher sets, 1 \
+             promql_fetch_fanout), 1000 shared permits) == 1, so 20 \
+             segments * 3 matcher sets = 60 GETs is ceil(60 / 1) == 60, \
+             not the 20 an uncapped plan-capacity term would report"
         );
     }
 

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -1401,15 +1401,15 @@ impl QueryEngine {
         // share a matcher set is a legitimate conservative slop, not a bug.
         let fetch_multiplier = plans.len() as u64;
         // The fan-out `service_batches` actually measures (`io_shape.rs`'s
-        // doc comment: "batches this query's per-segment fan-out was forced
-        // into") is real, not an envelope: the `attempt` closure below fetches
-        // exactly one distinct matcher set's segments per pass
-        // (`distinct_plans_by_matcher`, same dedup the closure's own
-        // `distinct_plans` uses), so `up + up offset 5m` -- two plans, one
-        // distinct matcher set -- is forced into ONE fetch pass over the
-        // snapshot, not two. Using `fetch_multiplier` here as well (the
-        // upper-envelope, undeduplicated count) would report a batch count
-        // the fan-out was never actually forced into.
+        // doc comment: "a LOWER bound on the serial service rounds this
+        // query's per-segment fan-out needed") is real, not an envelope: the
+        // `attempt` closure below fetches exactly one distinct matcher set's
+        // segments per pass (`distinct_plans_by_matcher`, same dedup the
+        // closure's own `distinct_plans` uses), so `up + up offset 5m` --
+        // two plans, one distinct matcher set -- runs as ONE fetch pass over
+        // the snapshot, not two. Using `fetch_multiplier` here as well (the
+        // upper-envelope, undeduplicated count) would report a round count
+        // the fan-out never actually needed.
         let service_fetch_multiplier = distinct_plans_by_matcher(plans).len() as u64;
         // Captured by reference (like `plans`), so the `FnMut` attempt copies
         // the reference on each retry rather than moving the owned `Vec` out of
@@ -1742,9 +1742,9 @@ impl QueryEngine {
         // the fetch fan-out actually issues one pass per
         // (`distinct_plans_by_matcher`), never larger than `fetch_multiplier`
         // and strictly smaller whenever two plans share a matcher set (`up +
-        // up offset 5m`). `service_batches` documents itself as the batches
-        // the fan-out was FORCED into, a factual figure, so it must use this
-        // deduplicated count rather than the upper-envelope one.
+        // up offset 5m`). `service_batches` documents itself as a lower
+        // bound on the serial rounds the fan-out actually needed, so it must
+        // use this deduplicated count rather than the upper-envelope one.
         service_fetch_multiplier: u64,
         // `QueryIoShape::plan_class` is decided before any segment is opened
         // (issue #1214): `true` for a discovery-only caller
@@ -2418,9 +2418,11 @@ fn combine_phase_accounting(
 /// (`distinct_plans_by_matcher` in `prefetch_metric_plans`, e.g. `up + up
 /// offset 5m` -- two plans, one distinct matcher set, one pass), not the raw
 /// plan count `estimate_cost` scales by: that estimate is a deliberate
-/// upper envelope, but `service_batches` documents itself as the batches the
-/// fan-out was FORCED into, a factual figure that must not carry the
-/// envelope's slop.
+/// upper envelope, but `service_batches` is a LOWER bound on serial rounds
+/// under a wave-synchronous model of the fan-out (see
+/// `crate::io_shape::service_batches_over_plan_waves` and the module docs'
+/// `service_batches` entry for why this is a lower, not an upper or exact,
+/// bound), and must not carry the envelope's slop either.
 ///
 /// The fan-out itself is a NESTED `buffer_unordered` (`futures::stream`):
 /// one `buffer_unordered(promql_fetch_fanout)` over distinct plans
@@ -2429,52 +2431,52 @@ fn combine_phase_accounting(
 /// `buffer_unordered(promql_fetch_fanout)` over that plan's segments
 /// (`fetch_all_samples_and_histograms`). The OUTER `buffer_unordered` admits
 /// at most `promql_fetch_fanout` plans at once, however many distinct
-/// matcher sets the query has, so plan capacity is `promql_fetch_fanout *
-/// min(service_fetch_multiplier, promql_fetch_fanout)`, not
-/// `promql_fetch_fanout * service_fetch_multiplier` -- that would assume
-/// every distinct plan runs concurrently, true only when
-/// `service_fetch_multiplier <= promql_fetch_fanout`. Neither this level nor
-/// the inner one gets an independent budget on top of that: every GET from
-/// every plan also passes through the one `GetLimiter` this engine wired to
-/// every fetcher it owns (ADR-1195, `limiter.rs`), whose permit count is
+/// matcher sets the query has, and it is a SLIDING window, not a
+/// wave-synchronous one: as soon as one admitted plan finishes, the next
+/// plan is admitted, without waiting for its siblings. Modeling it as
+/// wave-synchronous anyway -- computing one binding concurrency
+/// (`min(promql_fetch_fanout * min(service_fetch_multiplier,
+/// promql_fetch_fanout), shared_get_permits)`) and dividing the total work
+/// (`segments * service_fetch_multiplier` GETs) by it in one division --
+/// UNDERCOUNTS whenever the outer window is not full for the query's whole
+/// duration: 3 distinct plans, 1 segment each, `promql_fetch_fanout` 2, and
+/// `shared_get_permits` 1000 gives peak capacity `min(2 * 2, 1000) = 4`, so
+/// that single division reports `ceil(3 / 4) = 1` round, but plans 1 and 2
+/// admit together in the first round and plan 3 only after one of them
+/// finishes, in a second round -- 2 rounds, not 1. Every GET from every
+/// plan also passes through the one `GetLimiter` this engine wired to every
+/// fetcher it owns (ADR-1195, `limiter.rs`), whose permit count is
 /// `shared_get_permits` here (`GetLimiter::permits`, resolved from
 /// `EngineConfig::store_get_concurrency`, which falls back to
-/// `fetch_concurrency` when unset). So the real binding concurrency is
-/// `min(promql_fetch_fanout * min(service_fetch_multiplier,
-/// promql_fetch_fanout), shared_get_permits)`: the outer `buffer_unordered`
-/// can never have more than `promql_fetch_fanout * min(service_fetch_multiplier,
-/// promql_fetch_fanout)` plan/segment fetches in flight at once even with an
-/// unbounded limiter, and the shared limiter can never let more than
-/// `shared_get_permits` GETs run at once even with an unbounded outer
-/// fan-out -- whichever bound is smaller is the one the query actually waits
-/// on. The work this fan-out issues is `segments * service_fetch_multiplier`
-/// GETs (uncapped -- every distinct matcher set still issues its own GETs,
-/// just not all of them concurrently), so the batch count this query's
-/// fetch is actually forced into is `service_batches(segments *
-/// service_fetch_multiplier, min(promql_fetch_fanout *
-/// min(service_fetch_multiplier, promql_fetch_fanout),
-/// shared_get_permits))`, not `service_batches(segments *
-/// service_fetch_multiplier, promql_fetch_fanout)`: dividing the
-/// plan-multiplied numerator by the un-multiplied fan-out width alone
-/// double-counts the plan fan-out (2 distinct matcher sets, 64 segments,
-/// `promql_fetch_fanout` 8, `shared_get_permits` 16: 128 GETs at binding
-/// concurrency `min(8 * min(2, 8), 16) = min(16, 16) = 16` is 8 batches, not
-/// the 16 the unscaled divisor reports); and capping the multiplier by
-/// `shared_get_permits` alone, without also capping it by
-/// `promql_fetch_fanout`, overstates plan capacity when there are more
-/// distinct matcher sets than `promql_fetch_fanout` (`promql_fetch_fanout`
-/// 1, 3 distinct matcher sets, 20 segments, `shared_get_permits` 1000: only
-/// one plan's segments are ever in flight, so binding concurrency is
-/// `min(1 * min(3, 1), 1000) = 1`, i.e. 60 batches, not the 20 an uncapped
-/// `1 * 3` capacity term would report).
+/// `fetch_concurrency` when unset).
 ///
-/// A single-plan query (`service_fetch_multiplier == 1`) reduces to
-/// `service_batches(segments, promql_fetch_fanout)` whenever the limiter's
-/// pool is at least as large as one plan's own `buffer_unordered` bound,
-/// which is every config that leaves ADR-1195's knobs unset (both resolve to
-/// `fetch_concurrency`). An operator who sets `--store-get-concurrency`
-/// below `--promql-fetch-fanout` makes the limiter the binding bound even
-/// for one plan, and this figure follows that.
+/// So this figure is computed per WAVE of the outer fan-out
+/// (`crate::io_shape::service_batches_over_plan_waves`): `waves =
+/// ceil(service_fetch_multiplier / promql_fetch_fanout)`; for 0-based wave
+/// `w`, `active_w = min(promql_fetch_fanout, service_fetch_multiplier - w *
+/// promql_fetch_fanout)` plans are admitted, `capacity_w =
+/// min(promql_fetch_fanout * active_w, shared_get_permits)` is that wave's
+/// binding concurrency, and `batches_w = service_batches(segments *
+/// active_w, capacity_w)` is its own serial round count; `service_batches`
+/// is the sum of `batches_w` over every wave. This is still a lower bound,
+/// not an exact count: the sliding window can only pack work at least as
+/// tightly as the wave-synchronous model assumes, never more loosely, so
+/// the real scheduler takes at least this many rounds. 2 distinct matcher
+/// sets, 64 segments, `promql_fetch_fanout` 8, `shared_get_permits` 16: one
+/// wave, `active_0 = 2`, `capacity_0 = min(16, 16) = 16`, `batches_0 =
+/// ceil(128 / 16) = 8`. `promql_fetch_fanout` 1, 3 distinct matcher sets, 20
+/// segments, `shared_get_permits` 1000: three waves, each `active_w = 1`,
+/// `capacity_w = min(1, 1000) = 1`, `batches_w = ceil(20 / 1) = 20`, summing
+/// to 60 -- not the 20 a single `min(1 * 3, 1000) = 3`-capacity division
+/// would report, which would silently assume all 3 plans ran at once when
+/// the outer stream never admits more than 1.
+///
+/// A single-plan query (`service_fetch_multiplier == 1`) always has exactly
+/// one wave with `active_0 = 1`, reducing to `service_batches(segments,
+/// min(promql_fetch_fanout, shared_get_permits))`. An operator who sets
+/// `--store-get-concurrency` below `--promql-fetch-fanout` makes the
+/// limiter the binding bound even for one plan, and this figure follows
+/// that.
 ///
 /// Deliberately does NOT thread any new instrumentation into the per-segment
 /// fetch loops (`fetch_all_samples_and_histograms`/`fetch_all_series`):
@@ -2500,12 +2502,11 @@ fn io_shape_for_resolve(
         .max()
         .unwrap_or(0);
     counts.record_dependency_chain(depth);
-    let binding_concurrency = concurrency
-        .saturating_mul(service_fetch_multiplier.min(concurrency))
-        .min(shared_get_permits);
-    counts.record_service_batches(crate::io_shape::service_batches(
-        (snapshot.segments.len() as u64).saturating_mul(service_fetch_multiplier),
-        binding_concurrency,
+    counts.record_service_batches(crate::io_shape::service_batches_over_plan_waves(
+        snapshot.segments.len() as u64,
+        service_fetch_multiplier,
+        concurrency,
+        shared_get_permits,
     ));
     let resolve_list_requests = accounting
         .resolve()
@@ -7535,6 +7536,88 @@ mod prefetch_tests {
              promql_fetch_fanout), 1000 shared permits) == 1, so 20 \
              segments * 3 matcher sets = 60 GETs is ceil(60 / 1) == 60, \
              not the 20 an uncapped plan-capacity term would report"
+        );
+    }
+
+    /// Regression for issue #1214 (defect found in review of this PR):
+    /// dividing TOTAL work by PEAK capacity in one division undercounts
+    /// whenever the outer plan fan-out window is not full for the query's
+    /// whole duration. Reviewer's case: 3 distinct matcher plans, 1
+    /// resolved segment, `promql_fetch_fanout` 2, and a 1000-permit shared
+    /// limiter (`GetLimiter::new(1000)`, wired explicitly so the expectation
+    /// does not depend on whatever `store_get_concurrency` resolves to on
+    /// the host). The pre-fix formula computed one binding concurrency
+    /// `min(2 * min(3, 2), 1000) = min(4, 1000) = 4` and divided the total
+    /// work (`1 segment * 3 distinct matcher sets = 3` GETs) by it in one
+    /// shot: `ceil(3 / 4) == 1`. The real outer `buffer_unordered(2)` admits
+    /// only 2 of the 3 plans in its first wave; the third plan is admitted
+    /// only after one of the first two finishes, in a second wave -- 2
+    /// serial rounds, not 1. The wave-accounted fix computes 2 waves: wave 0
+    /// (`active_0 = min(2, 3) = 2`, `capacity_0 = min(2 * 2, 1000) = 4`,
+    /// `batches_0 = ceil(1 * 2 / 4) = 1`) and wave 1 (`active_1 = min(2, 1)
+    /// = 1`, `capacity_1 = min(2 * 1, 1000) = 2`, `batches_1 = ceil(1 * 1 /
+    /// 2) = 1`), summing to 2. Flip `io_shape_for_resolve`'s call site back
+    /// to a single `service_batches(segments * service_fetch_multiplier,
+    /// min(concurrency * service_fetch_multiplier.min(concurrency),
+    /// shared_get_permits))` division to watch the assertion below fail: it
+    /// would then read 1, not 2.
+    #[tokio::test]
+    async fn service_batches_accounts_for_outer_fanout_waves_not_peak_capacity() {
+        const WIDE_RANGE_NS: i64 = 25 * NS_PER_MIN;
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        publish_metric(
+            &store,
+            tenant_hash,
+            1,
+            "wave_metric_a",
+            BASE_NS - NS_PER_MIN,
+            1.0,
+        )
+        .await;
+
+        let config = EngineConfig {
+            promql_fetch_fanout: Some(2),
+            ..EngineConfig::default()
+        };
+        let eng = engine_with_config(store, config).with_get_limiter(Arc::new(
+            crate::GetLimiter::new(1000).expect("1000 permits is valid"),
+        ));
+        let plans = vec![
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("wave_metric_a")
+            },
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("wave_metric_b")
+            },
+            SelectorPlan {
+                range_ns: WIDE_RANGE_NS,
+                ..window_plan("wave_metric_c")
+            },
+        ];
+        let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
+        let (_source, stats) = eng
+            .prefetch(tenant_hash, &plans, &eval_window, &[], BASE_NS)
+            .await
+            .expect("prefetch three-distinct-matcher-set single-segment query");
+
+        assert_eq!(
+            stats.estimate.segments, 1,
+            "expected the padded window to resolve exactly the 1 published \
+             segment (no shared name filter to prune by, since the 3 plans \
+             name 3 different metrics), got {}",
+            stats.estimate.segments
+        );
+        assert_eq!(
+            stats.io_shape.service_batches, 2,
+            "3 distinct matcher plans over a promql_fetch_fanout of 2 admit \
+             in 2 waves (2 plans, then 1); wave 0 is ceil(1 * 2 / min(4, \
+             1000)) == 1 batch and wave 1 is ceil(1 * 1 / min(2, 1000)) == \
+             1 batch, summing to 2 -- not the 1 a single peak-capacity \
+             division (ceil(3 / min(4, 1000)) == ceil(3 / 4) == 1) would \
+             report"
         );
     }
 

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -700,6 +700,15 @@ impl SegmentFetcher {
         self
     }
 
+    /// The whole-object threshold this fetcher opens segments with (see
+    /// [`Self::with_whole_object_threshold`]). Read-only counterpart used by
+    /// `io_shape`'s structural `dependency_depth` classification, which needs
+    /// the same size cutoff `open_segment` branches on without duplicating or
+    /// re-deriving it.
+    pub fn whole_object_threshold(&self) -> u64 {
+        self.whole_object_threshold
+    }
+
     /// Sets the in-flight byte-range GET bound by building a new private
     /// limiter. Shared across this fetcher's clones; not shared with any
     /// other fetcher unless [`Self::with_get_limiter`] is used instead.

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -4486,6 +4486,146 @@ mod tests {
         }
     }
 
+    /// `crate::io_shape::depth_for_object` (issue #1214) mirrors the real
+    /// branches `open_segment` takes, not just two of its three. A small
+    /// object (`object_size` in `(0, threshold]`) resolves footer, catalog,
+    /// and pages from one GET: zero dependent stages, depth 1. Every other
+    /// case takes the footer-tail path, which is always followed by a
+    /// dependent page fetch (`decode_selected`'s own doc comment: "page
+    /// bytes are fetched afterwards by the caller from regions") -- a
+    /// second stage on top of the footer stage(s) -- and the footer stage
+    /// itself is either 1 GET (the tail guess covers the real footer) or 2
+    /// (a `FooterOutcome::NeedRange` chase), so the real chain is 2 or 3
+    /// stages. The pre-fix `depth_for_object` tested only
+    /// `object_size <= whole_object_threshold`, which is vacuously true for
+    /// `object_size == 0` against any non-negative threshold, and so wrongly
+    /// reported depth 1 -- the whole-object depth -- for a segment that
+    /// `open_segment` actually routes down the footer-tail path.
+    ///
+    /// Verified against real `open_segment` GET counts via `QueryAccounting`,
+    /// not hardcoded constants: `real_footer_gets + 1` (the dependent page
+    /// stage) must never exceed the predicted upper bound of 3, and must
+    /// equal it exactly in the forced-`NeedRange` case. Flip the
+    /// `object_size != 0 &&` guard back off in `depth_for_object` to watch
+    /// the `object_size == 0` assertion below fail: it would then predict 1,
+    /// not 3.
+    #[tokio::test]
+    async fn depth_for_object_upper_bounds_the_real_footer_and_page_chain() {
+        use crate::io_shape::depth_for_object;
+
+        // (a) Whole-object path: resolves everything from the single first
+        // GET, zero dependent stages.
+        {
+            let (mem, tenant_hash, seg_ref) = write_test_segment().await;
+            let bytes = mem
+                .get(&seg_ref.data_object_key, GetRange::Full)
+                .await
+                .expect("get bytes")
+                .data;
+            let size = seg_ref.object_size;
+            let store = counting_store(bytes, &seg_ref.data_object_key).await;
+            let backend: Arc<dyn ObjectStoreBackend> = store.clone();
+            SegmentFetcher::new(backend)
+                .with_whole_object_threshold(size + 1)
+                .fetch(tenant_hash, &seg_ref, &[])
+                .await
+                .expect("whole-object fetch");
+            let real_chain = store.sequence_progress(0);
+            assert_eq!(
+                real_chain, 1,
+                "whole-object path resolves footer, catalog, and pages from one GET"
+            );
+            assert_eq!(
+                depth_for_object(size, size + 1),
+                1,
+                "predicted depth must match the real single-GET chain exactly"
+            );
+        }
+
+        // (b) Forced footer-tail path with a `NeedRange` chase (`suffix_len`
+        // too small to cover the footer): 2 footer-stage GETs plus the
+        // dependent page stage is 3, matching the upper bound exactly.
+        {
+            let (mem, tenant_hash, seg_ref) = write_test_segment().await;
+            let bytes = mem
+                .get(&seg_ref.data_object_key, GetRange::Full)
+                .await
+                .expect("get bytes")
+                .data;
+            let store = store_from_bytes(&seg_ref.data_object_key, bytes).await;
+            let backend: Arc<dyn ObjectStoreBackend> = store;
+            let fetcher = SegmentFetcher::new(backend)
+                .with_whole_object_threshold(0)
+                .with_suffix_len(16);
+            let acct = QueryAccounting::new();
+            fetcher
+                .open_segment(tenant_hash, &seg_ref, &acct)
+                .await
+                .expect("forced NeedRange chase open");
+            let footer_gets = acct.snapshot().s3_requests(AccountedOp::Get);
+            assert_eq!(
+                footer_gets, 2,
+                "a 16-byte suffix_len is too small to cover the footer, forcing a \
+                 NeedRange chase: exactly 2 footer-stage GETs"
+            );
+            let real_chain = footer_gets + 1; // + the dependent page fetch stage
+            assert_eq!(
+                real_chain, 3,
+                "2 footer GETs plus the dependent page fetch is a 3-stage chain"
+            );
+            assert_eq!(
+                depth_for_object(seg_ref.object_size, 0),
+                3,
+                "predicted upper bound must equal the real chain exactly in the \
+                 worst case"
+            );
+        }
+
+        // (c) `object_size == 0` (unknown size): takes the SAME footer-tail
+        // path as (b), not the whole-object path, even though the pre-fix
+        // code's `object_size <= whole_object_threshold` test was vacuously
+        // true for 0 against any non-negative threshold. The generous
+        // default `suffix_len` covers this small segment's footer in one
+        // GET, so the real chain is 2 (1 footer GET + 1 page stage) -- more
+        // than the pre-fix code's wrongly-predicted 1, and safely within the
+        // fixed code's upper bound of 3.
+        {
+            let (mem, tenant_hash, seg_ref) = write_test_segment().await;
+            let bytes = mem
+                .get(&seg_ref.data_object_key, GetRange::Full)
+                .await
+                .expect("get bytes")
+                .data;
+            let mut sizeless = seg_ref.clone();
+            sizeless.object_size = 0;
+            let store = store_from_bytes(&seg_ref.data_object_key, bytes).await;
+            let backend: Arc<dyn ObjectStoreBackend> = store;
+            let fetcher = SegmentFetcher::new(backend).with_whole_object_threshold(1_000_000);
+            let acct = QueryAccounting::new();
+            fetcher
+                .open_segment(tenant_hash, &sizeless, &acct)
+                .await
+                .expect("sizeless open");
+            let footer_gets = acct.snapshot().s3_requests(AccountedOp::Get);
+            assert_eq!(
+                footer_gets, 1,
+                "the default suffix_len covers this small segment's footer in one GET"
+            );
+            let real_chain = footer_gets + 1;
+            assert!(
+                real_chain <= 3,
+                "real chain ({real_chain}) must not exceed the predicted upper bound"
+            );
+            assert_eq!(
+                depth_for_object(0, 1_000_000),
+                3,
+                "object_size == 0 must take the footer-tail upper bound, not the \
+                 whole-object depth of 1, even though 0 <= any non-negative \
+                 threshold"
+            );
+        }
+    }
+
     /// End-to-end guard for issue #811 over a full `fetch_soa` (footer +
     /// catalog + pages), not just `open_segment`: a cold query with a cache
     /// attached must succeed, and a second identical query must issue zero

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -4487,28 +4487,28 @@ mod tests {
     }
 
     /// `crate::io_shape::depth_for_object` (issue #1214) mirrors the real
-    /// branches `open_segment` takes, not just two of its three. A small
-    /// object (`object_size` in `(0, threshold]`) resolves footer, catalog,
-    /// and pages from one GET: zero dependent stages, depth 1. Every other
-    /// case takes the footer-tail path, which is always followed by a
-    /// dependent page fetch (`decode_selected`'s own doc comment: "page
-    /// bytes are fetched afterwards by the caller from regions") -- a
-    /// second stage on top of the footer stage(s) -- and the footer stage
-    /// itself is either 1 GET (the tail guess covers the real footer) or 2
-    /// (a `FooterOutcome::NeedRange` chase), so the real chain is 2 or 3
-    /// stages. The pre-fix `depth_for_object` tested only
-    /// `object_size <= whole_object_threshold`, which is vacuously true for
-    /// `object_size == 0` against any non-negative threshold, and so wrongly
-    /// reported depth 1 -- the whole-object depth -- for a segment that
-    /// `open_segment` actually routes down the footer-tail path.
+    /// branches `open_segment` -> `decode_selected` -> `fetch_scalar_pages`
+    /// takes, not just the footer stage. A small object (`object_size` in
+    /// `(0, threshold]`) resolves footer, catalog, and pages from one GET:
+    /// zero dependent stages, depth 1. Every other case takes the
+    /// footer-tail path, whose footer stage is either 1 GET (the tail guess
+    /// covers the real footer) or 2 (a `FooterOutcome::NeedRange` chase),
+    /// followed by a dependent catalog `ensure_ranges` GET (LABEL_DICT /
+    /// SERIES_IDS / SERIES_META, at the object front, never inside the
+    /// footer-tail bytes) and a dependent page `ensure_ranges` GET (the run
+    /// ranges the catalog just named): up to 4 stages total. The pre-fix
+    /// `depth_for_object` tested only `object_size <= whole_object_threshold`,
+    /// which is vacuously true for `object_size == 0` against any
+    /// non-negative threshold, and so wrongly reported depth 1 -- the
+    /// whole-object depth -- for a segment that `open_segment` actually
+    /// routes down the footer-tail path.
     ///
-    /// Verified against real `open_segment` GET counts via `QueryAccounting`,
-    /// not hardcoded constants: `real_footer_gets + 1` (the dependent page
-    /// stage) must never exceed the predicted upper bound of 3, and must
-    /// equal it exactly in the forced-`NeedRange` case. Flip the
-    /// `object_size != 0 &&` guard back off in `depth_for_object` to watch
-    /// the `object_size == 0` assertion below fail: it would then predict 1,
-    /// not 3.
+    /// Every case below drives the real GET count through a full `.fetch()`
+    /// call against a counting store (`FaultStore`'s `sequence_progress`),
+    /// not a recomputation from a partial call (`open_segment` alone) that
+    /// cannot see the catalog or page stages. Flip the `object_size != 0 &&`
+    /// guard back off in `depth_for_object` to watch the `object_size == 0`
+    /// assertion in (c) fail: it would then predict 1, not 4.
     #[tokio::test]
     async fn depth_for_object_upper_bounds_the_real_footer_and_page_chain() {
         use crate::io_shape::depth_for_object;
@@ -4543,8 +4543,10 @@ mod tests {
         }
 
         // (b) Forced footer-tail path with a `NeedRange` chase (`suffix_len`
-        // too small to cover the footer): 2 footer-stage GETs plus the
-        // dependent page stage is 3, matching the upper bound exactly.
+        // too small to cover the footer): the real chain runs the whole
+        // pipeline (footer tail, NeedRange chase, catalog fetch, page
+        // fetch), counted from a full `.fetch()` against a counting store,
+        // not recomputed from `open_segment` alone.
         {
             let (mem, tenant_hash, seg_ref) = write_test_segment().await;
             let bytes = mem
@@ -4552,30 +4554,25 @@ mod tests {
                 .await
                 .expect("get bytes")
                 .data;
-            let store = store_from_bytes(&seg_ref.data_object_key, bytes).await;
-            let backend: Arc<dyn ObjectStoreBackend> = store;
-            let fetcher = SegmentFetcher::new(backend)
+            let store = counting_store(bytes, &seg_ref.data_object_key).await;
+            let backend: Arc<dyn ObjectStoreBackend> = store.clone();
+            SegmentFetcher::new(backend)
                 .with_whole_object_threshold(0)
-                .with_suffix_len(16);
-            let acct = QueryAccounting::new();
-            fetcher
-                .open_segment(tenant_hash, &seg_ref, &acct)
+                .with_suffix_len(16)
+                .fetch(tenant_hash, &seg_ref, &[])
                 .await
-                .expect("forced NeedRange chase open");
-            let footer_gets = acct.snapshot().s3_requests(AccountedOp::Get);
+                .expect("forced NeedRange chase fetch");
+            let real_chain = store.sequence_progress(0);
             assert_eq!(
-                footer_gets, 2,
+                real_chain, 4,
                 "a 16-byte suffix_len is too small to cover the footer, forcing a \
-                 NeedRange chase: exactly 2 footer-stage GETs"
-            );
-            let real_chain = footer_gets + 1; // + the dependent page fetch stage
-            assert_eq!(
-                real_chain, 3,
-                "2 footer GETs plus the dependent page fetch is a 3-stage chain"
+                 NeedRange chase, and this segment's catalog and page sections sit \
+                 outside the footer-tail bytes: footer tail + NeedRange chase + \
+                 catalog fetch + page fetch is a 4-GET chain"
             );
             assert_eq!(
                 depth_for_object(seg_ref.object_size, 0),
-                3,
+                4,
                 "predicted upper bound must equal the real chain exactly in the \
                  worst case"
             );
@@ -4584,11 +4581,11 @@ mod tests {
         // (c) `object_size == 0` (unknown size): takes the SAME footer-tail
         // path as (b), not the whole-object path, even though the pre-fix
         // code's `object_size <= whole_object_threshold` test was vacuously
-        // true for 0 against any non-negative threshold. The generous
-        // default `suffix_len` covers this small segment's footer in one
-        // GET, so the real chain is 2 (1 footer GET + 1 page stage) -- more
-        // than the pre-fix code's wrongly-predicted 1, and safely within the
-        // fixed code's upper bound of 3.
+        // true for 0 against any non-negative threshold. A 250-byte
+        // `suffix_len` covers this segment's footer in a single GET (no
+        // `NeedRange` chase) without reaching far enough back to also cover
+        // the catalog or page sections, so the real chain is 3 (footer +
+        // catalog + page), safely within the upper bound of 4.
         {
             let (mem, tenant_hash, seg_ref) = write_test_segment().await;
             let bytes = mem
@@ -4598,27 +4595,24 @@ mod tests {
                 .data;
             let mut sizeless = seg_ref.clone();
             sizeless.object_size = 0;
-            let store = store_from_bytes(&seg_ref.data_object_key, bytes).await;
-            let backend: Arc<dyn ObjectStoreBackend> = store;
-            let fetcher = SegmentFetcher::new(backend).with_whole_object_threshold(1_000_000);
-            let acct = QueryAccounting::new();
-            fetcher
-                .open_segment(tenant_hash, &sizeless, &acct)
+            let store = counting_store(bytes, &seg_ref.data_object_key).await;
+            let backend: Arc<dyn ObjectStoreBackend> = store.clone();
+            SegmentFetcher::new(backend)
+                .with_whole_object_threshold(1_000_000)
+                .with_suffix_len(250)
+                .fetch(tenant_hash, &sizeless, &[])
                 .await
-                .expect("sizeless open");
-            let footer_gets = acct.snapshot().s3_requests(AccountedOp::Get);
+                .expect("sizeless fetch");
+            let real_chain = store.sequence_progress(0);
             assert_eq!(
-                footer_gets, 1,
-                "the default suffix_len covers this small segment's footer in one GET"
-            );
-            let real_chain = footer_gets + 1;
-            assert!(
-                real_chain <= 3,
-                "real chain ({real_chain}) must not exceed the predicted upper bound"
+                real_chain, 3,
+                "a 250-byte suffix_len covers the footer without a NeedRange chase \
+                 and without reaching the catalog or page sections: footer + \
+                 catalog + page is a 3-GET chain"
             );
             assert_eq!(
                 depth_for_object(0, 1_000_000),
-                3,
+                4,
                 "object_size == 0 must take the footer-tail upper bound, not the \
                  whole-object depth of 1, even though 0 <= any non-negative \
                  threshold"

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -353,8 +353,11 @@ fn phase_costs(snapshot: &PhaseAccountingSnapshot) -> Vec<PhaseCostJson> {
 pub struct IoShapeJson {
     /// The longest chain of object-store stages, across every segment this
     /// query opened, where a stage needed a previous stage's bytes to know
-    /// its own keys. Four independent segment GETs report depth 1; a footer
-    /// read followed by a dependent page fetch reports depth 2.
+    /// its own keys. Four independent segment GETs report depth 1; a
+    /// segment whose footer read is followed by a dependent catalog fetch
+    /// and a dependent page fetch reports depth 4, an upper bound covering
+    /// a possible footer-range chase this crate cannot rule out from
+    /// `object_size` alone.
     #[serde(rename = "dependencyDepth")]
     pub dependency_depth: u32,
     /// Serial LIST pages, recorded independently of `dependencyDepth`

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -113,6 +113,15 @@ pub struct QueryStatsJson {
     /// count cannot say whether a query spent its requests resolving the
     /// catalog snapshot or scanning pages.
     pub phases: Vec<PhaseCostJson>,
+    /// The query's I/O dependency shape (issue #1214, `crate::io_shape`):
+    /// how many object-store stages had to run one after another versus in
+    /// one round, kept separate from `phases`' request/byte cost split.
+    /// Additive beside `phases`, never a replacement for it: `phases` answers
+    /// how much a query's requests cost, `io` answers how their requests
+    /// depended on each other. A cheap-by-`phases` query can still be slow
+    /// because of a deep `io.dependencyDepth`, and an expensive-by-`phases`
+    /// query can still be fast because every request in it ran at depth 1.
+    pub io: IoShapeJson,
     pub estimate: CostEstimateJson,
     /// True when at least one federated remote cluster was skipped because it
     /// was unavailable and its `skip_unavailable` opt-in was set
@@ -137,6 +146,7 @@ impl From<crate::QueryStats> for QueryStatsJson {
             segments_pruned: stats.segments_pruned,
             accounting: QueryAccountingJson::from_snapshot(&stats.accounting, &stats.page_stats),
             phases: phase_costs(&stats.phase_accounting),
+            io: stats.io_shape.into(),
             estimate: stats.estimate.into(),
             partial: stats.partial,
             warnings: stats.warnings.clone(),
@@ -331,6 +341,51 @@ fn phase_costs(snapshot: &PhaseAccountingSnapshot) -> Vec<PhaseCostJson> {
             }
         })
         .collect()
+}
+
+/// A query's I/O dependency shape (issue #1214), rendered under `stats.io`.
+/// See `crate::io_shape`'s module docs for what each figure means, what is
+/// and is not knowable from this crate, and why `dependencyDepth` and the
+/// `phases` cost split are different dimensions. Carries no object keys,
+/// field values, predicates, or index terms: every figure here is a
+/// structural count.
+#[derive(Debug, Serialize)]
+pub struct IoShapeJson {
+    /// The longest chain of object-store stages, across every segment this
+    /// query opened, where a stage needed a previous stage's bytes to know
+    /// its own keys. Four independent segment GETs report depth 1; a footer
+    /// read followed by a dependent page fetch reports depth 2.
+    #[serde(rename = "dependencyDepth")]
+    pub dependency_depth: u32,
+    /// Serial LIST pages, recorded independently of `dependencyDepth`
+    /// because pagination and the GET dependency chain are different
+    /// object-store mechanisms with different causes.
+    #[serde(rename = "listPageDepth")]
+    pub list_page_depth: u32,
+    /// Batches this query's per-segment fan-out was forced into by its
+    /// concurrency permit: `ceil(segment_count / fetch_concurrency)`.
+    #[serde(rename = "serviceBatches")]
+    pub service_batches: u32,
+    /// EXACT count of commit records this query's resolve took from the
+    /// recent (unfolded) listing path rather than a folded snapshot part.
+    #[serde(rename = "unfoldedRecordsResolved")]
+    pub unfolded_records_resolved: u64,
+    /// Pre-execution access-pattern classification: `metadata_only`,
+    /// `selective_indexed`, or `exhaustive_scan` (`crate::io_shape::PlanClass::name`).
+    #[serde(rename = "planClass")]
+    pub plan_class: &'static str,
+}
+
+impl From<crate::io_shape::QueryIoShape> for IoShapeJson {
+    fn from(shape: crate::io_shape::QueryIoShape) -> Self {
+        IoShapeJson {
+            dependency_depth: shape.dependency_depth,
+            list_page_depth: shape.list_page_depth,
+            service_batches: shape.service_batches,
+            unfolded_records_resolved: shape.unfolded_records_resolved,
+            plan_class: shape.plan_class.name(),
+        }
+    }
 }
 
 /// Upper-envelope cost estimate (ADR-0044 decision 3), rendered under
@@ -1294,6 +1349,54 @@ mod tests {
         assert!(
             value.get("estimate").is_some(),
             "estimate must not be removed"
+        );
+    }
+
+    #[test]
+    fn stats_json_carries_io_shape_with_every_figure_exactly_once() {
+        // ACCEPTANCE TEST (issue #1214). `io` sits beside `phases` in the
+        // stats object and must carry every `QueryIoShape` figure exactly
+        // once, under its own key, distinct from the per-phase cost split.
+        //
+        // Flip-line proof: replace `io: stats.io_shape.into()` with
+        // `io: IoShapeJson::from(crate::io_shape::QueryIoShape::default())`
+        // in `QueryStatsJson`'s `From<crate::QueryStats>` impl (severing the
+        // wire from the real `stats.io_shape`) and `io["dependencyDepth"]`
+        // reads `0`, not `2`.
+        let shape = crate::io_shape::QueryIoShape {
+            dependency_depth: 2,
+            list_page_depth: 13,
+            service_batches: 4,
+            unfolded_records_resolved: 2_500,
+            plan_class: crate::io_shape::PlanClass::SelectiveIndexed,
+        };
+        let stats = crate::QueryStats {
+            io_shape: shape,
+            ..Default::default()
+        };
+        let json = QueryStatsJson::from(stats);
+        let value = serde_json::to_value(&json).expect("serializes");
+
+        let io = value.get("io").expect("io object present beside phases");
+        assert_eq!(io["dependencyDepth"], serde_json::json!(2));
+        assert_eq!(io["listPageDepth"], serde_json::json!(13));
+        assert_eq!(io["serviceBatches"], serde_json::json!(4));
+        assert_eq!(io["unfoldedRecordsResolved"], serde_json::json!(2_500));
+        assert_eq!(io["planClass"], serde_json::json!("selective_indexed"));
+
+        // Every figure exactly once: no duplicate key, and no field beyond
+        // the five `QueryIoShape` carries (an object key, field value,
+        // predicate, or index term would show up here as an extra field).
+        let obj = io.as_object().expect("io is a JSON object");
+        assert_eq!(
+            obj.len(),
+            5,
+            "io carries exactly the five QueryIoShape figures, no more"
+        );
+
+        assert!(
+            value.get("phases").is_some(),
+            "io is additive beside phases, not a replacement for it"
         );
     }
 

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -366,10 +366,14 @@ pub struct IoShapeJson {
     /// concurrency permit: `ceil(segment_count / fetch_concurrency)`.
     #[serde(rename = "serviceBatches")]
     pub service_batches: u32,
-    /// EXACT count of commit records this query's resolve took from the
-    /// recent (unfolded) listing path rather than a folded snapshot part.
-    #[serde(rename = "unfoldedRecordsResolved")]
-    pub unfolded_records_resolved: u64,
+    /// EXACT count of SEGMENTS (`SegmentOrigin::Recent` entries, one per
+    /// resolved `SegmentRef`) this query's resolve took from the recent
+    /// (unfolded) listing path rather than a folded snapshot part. Not a
+    /// commit-record count: a multi-part L1 compaction record contributes
+    /// one entry per part, so this figure can exceed the number of
+    /// underlying records (`crate::io_shape` module docs).
+    #[serde(rename = "unfoldedSegmentsResolved")]
+    pub unfolded_segments_resolved: u64,
     /// Pre-execution access-pattern classification: `metadata_only`,
     /// `selective_indexed`, or `exhaustive_scan` (`crate::io_shape::PlanClass::name`).
     #[serde(rename = "planClass")]
@@ -382,7 +386,7 @@ impl From<crate::io_shape::QueryIoShape> for IoShapeJson {
             dependency_depth: shape.dependency_depth,
             list_page_depth: shape.list_page_depth,
             service_batches: shape.service_batches,
-            unfolded_records_resolved: shape.unfolded_records_resolved,
+            unfolded_segments_resolved: shape.unfolded_segments_resolved,
             plan_class: shape.plan_class.name(),
         }
     }
@@ -1367,7 +1371,7 @@ mod tests {
             dependency_depth: 2,
             list_page_depth: 13,
             service_batches: 4,
-            unfolded_records_resolved: 2_500,
+            unfolded_segments_resolved: 2_500,
             plan_class: crate::io_shape::PlanClass::SelectiveIndexed,
         };
         let stats = crate::QueryStats {
@@ -1381,7 +1385,7 @@ mod tests {
         assert_eq!(io["dependencyDepth"], serde_json::json!(2));
         assert_eq!(io["listPageDepth"], serde_json::json!(13));
         assert_eq!(io["serviceBatches"], serde_json::json!(4));
-        assert_eq!(io["unfoldedRecordsResolved"], serde_json::json!(2_500));
+        assert_eq!(io["unfoldedSegmentsResolved"], serde_json::json!(2_500));
         assert_eq!(io["planClass"], serde_json::json!("selective_indexed"));
 
         // Every figure exactly once: no duplicate key, and no field beyond
@@ -1398,6 +1402,66 @@ mod tests {
             value.get("phases").is_some(),
             "io is additive beside phases, not a replacement for it"
         );
+    }
+
+    #[test]
+    fn stats_json_io_object_has_each_figure_present_exactly_once_in_the_wire_text() {
+        // Deliberately distinct from `stats_json_carries_io_shape_with_every_figure_exactly_once`
+        // above: that test parses the wire text into a `serde_json::Value`
+        // first, and a `serde_json::Map` COLLAPSES a duplicate key on
+        // insert (last write wins), so a `Serialize` impl that emits one
+        // `QueryIoShape` figure twice under the same key would still show
+        // `obj.len() == 5` there -- present-or-more, not present-and-once.
+        // This test instead counts key occurrences in the raw serialized
+        // JSON TEXT, before any parser has a chance to collapse anything, so
+        // a figure emitted twice is caught as 2 occurrences and a figure
+        // dropped is caught as 0.
+        //
+        // Flip-line proof: in `IoShapeJson`, duplicate the `service_batches`
+        // field under its own `#[serde(rename = "serviceBatches")]` tag
+        // (two struct fields serializing to the same wire key) and populate
+        // both in the `From<QueryIoShape>` impl. `occurrences("serviceBatches")`
+        // then reads 2, not 1, and the assertion below fails.
+        let shape = crate::io_shape::QueryIoShape {
+            dependency_depth: 2,
+            list_page_depth: 13,
+            service_batches: 4,
+            unfolded_segments_resolved: 2_500,
+            plan_class: crate::io_shape::PlanClass::SelectiveIndexed,
+        };
+        let stats = crate::QueryStats {
+            io_shape: shape,
+            ..Default::default()
+        };
+        let json = QueryStatsJson::from(stats);
+        let text = serde_json::to_string(&json).expect("serializes");
+
+        // `io` renders no nested objects (every figure is a flat number or
+        // string), so the first `}` after `"io":{` is the io object's own
+        // close brace: slicing there scopes the occurrence count to `io`
+        // alone, not the whole envelope (which could otherwise hide a
+        // dropped `io` figure behind an unrelated same-named field
+        // elsewhere in `QueryStatsJson`).
+        let io_start = text
+            .find("\"io\":{")
+            .expect("io object present in wire text");
+        let io_rest = &text[io_start..];
+        let io_end = io_rest.find('}').map(|i| i + 1).expect("io object closes");
+        let io_text = &io_rest[..io_end];
+
+        for key in [
+            "\"dependencyDepth\"",
+            "\"listPageDepth\"",
+            "\"serviceBatches\"",
+            "\"unfoldedSegmentsResolved\"",
+            "\"planClass\"",
+        ] {
+            let occurrences = io_text.matches(key).count();
+            assert_eq!(
+                occurrences, 1,
+                "io.{key} must be present exactly once in the wire text, found {occurrences}"
+            );
+        }
     }
 
     #[test]

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -375,7 +375,10 @@ pub struct IoShapeJson {
     #[serde(rename = "unfoldedSegmentsResolved")]
     pub unfolded_segments_resolved: u64,
     /// Pre-execution access-pattern classification: `metadata_only`,
-    /// `selective_indexed`, or `exhaustive_scan` (`crate::io_shape::PlanClass::name`).
+    /// `selective_indexed`, `exhaustive_scan`, or `unclassified` (a lane,
+    /// such as the log lane, whose own resolve carries no signal this crate
+    /// can use to tell a pruned fetch from a full scan --
+    /// `crate::io_shape::PlanClass::name`).
     #[serde(rename = "planClass")]
     pub plan_class: &'static str,
 }

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -17,7 +17,8 @@
 //! [`dependency_depth`](QueryIoShape::dependency_depth) reflects it: whether a
 //! segment resolves in one whole-object GET (depth 1) or needs a
 //! footer-tail-then-dependent-fetch sequence, reported as an upper bound of
-//! depth 3 to cover a possible footer-range chase (`depth_for_object` below),
+//! depth 4 to cover a possible footer-range chase plus the catalog and page
+//! fetch stages (`depth_for_object` below),
 //! classified structurally from `SegmentRef::object_size` against
 //! `SegmentFetcher::whole_object_threshold`, the same size test `open_segment`
 //! itself branches on. This mirrors `CostEstimate`'s existing convention: an
@@ -47,9 +48,9 @@
 //!   stage needs a previous stage's bytes to know its own keys. Four
 //!   independent segment GETs report depth 1 (they run concurrently, none
 //!   depends on another); a segment whose footer read is followed by a
-//!   dependent page fetch reports depth 3, an upper bound covering a
-//!   possible footer-range chase this crate cannot rule out from
-//!   `object_size` alone (see `depth_for_object`).
+//!   dependent catalog fetch and a dependent page fetch reports depth 4, an
+//!   upper bound covering a possible footer-range chase this crate cannot
+//!   rule out from `object_size` alone (see `depth_for_object`).
 //! - [`list_page_depth`](QueryIoShape::list_page_depth): serial LIST pages,
 //!   recorded separately from `dependency_depth` because pagination
 //!   (`Catalog::list_shard_hours`) and the GET dependency chain are different
@@ -189,26 +190,35 @@ pub fn merge_plan_class(a: PlanClass, b: PlanClass) -> PlanClass {
 /// everything (footer, catalog, pages) from its first GET: depth 1, no later
 /// stage depends on this one's output to name its own keys.
 ///
-/// Every other case reports depth 3, as an upper bound rather than a single
+/// Every other case reports depth 4, as an upper bound rather than a single
 /// true value, because this function only has `(object_size,
-/// whole_object_threshold)` to go on and `open_segment`'s real chain length
-/// past the whole-object branch depends on state this crate cannot see from
-/// those two numbers alone:
-/// - `object_size == 0` (size unknown ahead of the fetch) takes a
-///   `GetRange::Suffix` read (a footer-tail guess, not a whole-object read),
-///   which is then followed by dependent page GETs: at least 2 stages, and a
-///   `FooterOutcome::NeedRange` on that suffix guess (the tail didn't reach
-///   far enough back to cover the real footer) inserts one more dependent
-///   footer-range GET before the page fetch, making 3.
-/// - `object_size > whole_object_threshold` takes the same footer-tail path
-///   and is subject to the same possible `NeedRange` chase, for the same
-///   2-or-3 range.
+/// whole_object_threshold)` to go on and `open_segment`'s real chain past
+/// the whole-object branch can stack up to four dependent stages, each
+/// needing the previous stage's bytes to know its own keys
+/// (`crate::fetcher`):
+/// 1. **Footer tail**: a `GetRange::Suffix` (size unknown) or a tail
+///    `GetRange::Range` (size known but over threshold) guess at the
+///    footer (`SegmentFetcher::open_segment`).
+/// 2. **`FooterOutcome::NeedRange` chase**: only when the tail guess didn't
+///    reach far enough back to cover the real footer, a second dependent
+///    GET at the exact offset the first GET's bytes revealed
+///    (`open_segment`).
+/// 3. **Catalog `ensure_ranges`**: `decode_selected` fetches LABEL_DICT /
+///    SERIES_IDS / SERIES_META (or the sparse SERIES_IDX / chunked variant)
+///    from the offsets the footer named; these sections sit at the object
+///    front, never inside the footer-tail bytes already in hand, so this is
+///    a separate dependent GET whenever the footer stage's regions don't
+///    already cover them.
+/// 4. **Page `ensure_ranges`**: `fetch_scalar_pages` /
+///    `fetch_histogram_pages` fetch the run page ranges the catalog decode
+///    just named; same reasoning, a separate dependent GET unless already
+///    covered.
 ///
-/// Neither branch can be resolved to an exact depth here: whether the tail
-/// guess (`SegmentFetcher`'s private `suffix_len`) covers a given segment's
-/// real footer size is not observable from this function's inputs, and no
-/// public accessor exposes it. Reporting the upper bound (3) rather than the
-/// optimistic case (2) matches the module's existing "never underestimate"
+/// Stage 1 always runs; stages 2-4 are each conditional on whether an
+/// earlier GET's bytes happen to already cover the next stage's ranges
+/// (`FetchedRegions::covers`), which this function cannot observe from
+/// `object_size` alone. Reporting the upper bound (4) rather than an
+/// optimistic count matches the module's existing "never underestimate"
 /// convention (see `CostEstimate`'s upper envelope): a chain this function
 /// undercounts would silently understate how serial a query's fetch plan
 /// is, which is the failure mode this field exists to surface.
@@ -220,7 +230,7 @@ pub fn depth_for_object(object_size: u64, whole_object_threshold: u64) -> u32 {
     if object_size != 0 && object_size <= whole_object_threshold {
         1
     } else {
-        3
+        4
     }
 }
 
@@ -405,12 +415,13 @@ mod tests {
         );
         assert_eq!(
             depth_for_object(2_001, 2_000),
-            3,
-            "above threshold: footer tail, upper-bounded for a possible NeedRange chase"
+            4,
+            "above threshold: footer tail, upper-bounded for a possible NeedRange \
+             chase plus the catalog and page fetch stages"
         );
         assert_eq!(
             depth_for_object(0, 2_000),
-            3,
+            4,
             "unknown size takes the suffix footer-tail path, not whole-object, \
              even though 0 <= threshold"
         );
@@ -446,23 +457,31 @@ mod tests {
         assert_eq!(count_unfolded_segments(&origins), 1);
     }
 
-    /// Pins the segments-versus-records divergence the field name and doc
-    /// comment now spell out explicitly, against REAL `ravel-catalog` types
-    /// rather than a bare `Vec<SegmentOrigin>` with no `Snapshot` behind it:
-    /// a `Snapshot` holding one L0 `SegmentRef` plus a 3-part L1 compaction
-    /// (`SegmentLevel::L1` at `part_index` 0, 1, 2, sharing one
+    /// Pins `count_unfolded_segments`'s arithmetic against a realistic
+    /// segment shape: a `Snapshot` holding one L0 `SegmentRef` plus a 3-part
+    /// L1 compaction (`SegmentLevel::L1` at `part_index` 0, 1, 2, sharing one
     /// `input_set_hash` -- the real shape one compaction record fans out
-    /// into) has 4 `segments` entries from only 2 underlying commit/
-    /// compaction records. `SegmentOrigins::origins` is built parallel to
-    /// `snapshot.segments` (same length, same order, all `Recent`, matching
-    /// how a real live-listing resolve populates both), and the assertion
-    /// checks that parallelism explicitly before checking the count, so a
-    /// carriage bug that let the two vectors drift out of sync would fail
-    /// here even before the count assertion. Flip the L1 fixture down to 1
-    /// part (drop two of the three `part_index` entries and their origins)
-    /// to watch the count assertion fail: it would then read 2, not 4.
+    /// into) has 4 `segments` entries. This test builds `origins` itself
+    /// (one `SegmentOrigin::Recent` per `snapshot.segments` entry, by
+    /// construction), so it does NOT demonstrate that a real resolve
+    /// actually produces one `Recent` origin per L1 part rather than one per
+    /// compaction record -- that invariant is `ravel-catalog`'s own, made in
+    /// its per-listed-key insert (`origin_by_key.insert(key.clone(),
+    /// SegmentOrigin::Recent)` inside the listing loop,
+    /// `crates/ravel-catalog/src/catalog.rs:1687`, where `key` is one listed
+    /// segment object -- one entry per L1 part, not per compaction record),
+    /// which is out of this crate's scope to prove. What this test DOES pin
+    /// is that `count_unfolded_segments` counts every `Recent` entry in a
+    /// same-length `origins` slice exactly, including when that slice came
+    /// from a 4-segment/2-record snapshot shape rather than a flatter one.
+    /// The parallelism assertion below (`origins.origins.len() ==
+    /// snapshot.segments.len()`) checks the fixture is well-formed before
+    /// the count assertion runs, so a fixture bug would fail there first.
+    /// Flip the L1 fixture down to 1 part (drop two of the three
+    /// `part_index` entries and their origins) to watch the count assertion
+    /// fail: it would then read 2, not 4.
     #[test]
-    fn unfolded_segments_resolved_counts_compaction_parts_not_records() {
+    fn count_unfolded_segments_counts_recent_origins_over_an_l0_plus_l1_parts_snapshot() {
         fn segment_ref(level: SegmentLevel) -> SegmentRef {
             SegmentRef {
                 data_object_key: "irrelevant".to_string(),

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -55,16 +55,30 @@
 //!   recorded separately from `dependency_depth` because pagination
 //!   (`Catalog::list_shard_hours`) and the GET dependency chain are different
 //!   object-store mechanisms with different causes.
-//! - [`service_batches`](QueryIoShape::service_batches): batches this query's
-//!   per-segment fan-out was forced into by its concurrency permit
-//!   (`ceil(segment_count / fetch_concurrency)`): 64 segments under 8
-//!   concurrent permits (`fetch_concurrency`'s default,
-//!   `DEFAULT_FETCH_CONCURRENCY`) is 8 batches at whatever depth those
-//!   segments' fetches classify at. For the metrics lane this is scaled by
-//!   `service_fetch_multiplier`, the count of distinct matcher sets the
-//!   fetch fan-out issues one pass per (`distinct_plans_by_matcher` in
-//!   `crates/ravel-query/src/engine.rs`): 64 segments under 8 permits with
-//!   two distinct matcher sets reports 16 batches, not 8.
+//! - [`service_batches`](QueryIoShape::service_batches): batches this
+//!   query's per-segment fan-out was forced into by the binding concurrency
+//!   it actually ran under. The metrics fetch is a NESTED fan-out
+//!   (`crates/ravel-query/src/engine.rs`): one
+//!   `buffer_unordered(promql_fetch_fanout)` over distinct matcher plans
+//!   (`distinct_plans_by_matcher`), each running its own
+//!   `buffer_unordered(promql_fetch_fanout)` over that plan's segments.
+//!   Those inner streams do not get independent budgets -- every GET from
+//!   every plan passes through the one [`crate::GetLimiter`] the engine
+//!   shares across the fetchers it owns (ADR-1195), sized by the resolved
+//!   `EngineConfig::store_get_concurrency` (see "GET concurrency" in
+//!   docs/query-engine.md). So the binding concurrency is
+//!   `min(service_fetch_multiplier * promql_fetch_fanout,
+//!   shared_get_permits)`, and the work is `segment_count *
+//!   service_fetch_multiplier` GETs: 64 segments, `promql_fetch_fanout` 8, 2
+//!   distinct matcher sets, and 16 shared permits gives 128 GETs at binding
+//!   concurrency `min(16, 16) = 16`, i.e. 8 batches, not
+//!   `ceil(64 * 2 / 8) = 16` -- dividing the plan-multiplied numerator by
+//!   the un-multiplied fan-out width alone double-counts the plan fan-out. A
+//!   single-plan query (`service_fetch_multiplier == 1`) reduces to
+//!   `ceil(segment_count / promql_fetch_fanout)`, since
+//!   `min(promql_fetch_fanout, shared_get_permits)` is the fan-out width
+//!   whenever the shared pool is at least as large as one plan's own
+//!   fan-out bound, as it is for any config leaving both knobs unset.
 //! - [`unfolded_segments_resolved`](QueryIoShape::unfolded_segments_resolved):
 //!   the EXACT count of segments this query's resolve took from the recent
 //!   (unfolded) listing path (`SegmentOrigin::Recent`) rather than a folded

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -55,11 +55,11 @@
 //!   recorded separately from `dependency_depth` because pagination
 //!   (`Catalog::list_shard_hours`) and the GET dependency chain are different
 //!   object-store mechanisms with different causes.
-//! - [`service_batches`](QueryIoShape::service_batches): batches this
-//!   query's per-segment fan-out was forced into by the binding concurrency
-//!   it actually ran under. The metrics fetch is a NESTED fan-out
+//! - [`service_batches`](QueryIoShape::service_batches): a LOWER bound on
+//!   the serial service rounds this query's per-segment fan-out needed,
+//!   under a wave-synchronous model of the nested fan-out
 //!   (`crates/ravel-query/src/engine.rs`) with three levels of admission,
-//!   all of which bound the batch count:
+//!   all of which bound the round count:
 //!   1. the OUTER `buffer_unordered(promql_fetch_fanout)` over distinct
 //!      matcher plans (`distinct_plans_by_matcher`), which admits at most
 //!      `promql_fetch_fanout` plans at once -- never
@@ -73,33 +73,53 @@
 //!      docs/query-engine.md), which every GET from every plan passes
 //!      through regardless of which plan or segment issued it.
 //!
-//!   Levels 1 and 2 do not multiply freely: plan capacity is
-//!   `promql_fetch_fanout * min(service_fetch_multiplier,
-//!   promql_fetch_fanout)`, not `promql_fetch_fanout *
-//!   service_fetch_multiplier` -- the outer stream can never have more than
-//!   `promql_fetch_fanout` plans in flight even when there are more distinct
-//!   matcher sets than that. The binding concurrency is that plan capacity
-//!   capped by the shared limiter:
-//!   `min(promql_fetch_fanout * min(service_fetch_multiplier,
-//!   promql_fetch_fanout), shared_get_permits)`, and the work is
-//!   `segment_count * service_fetch_multiplier` GETs (the multiplier is not
-//!   capped there -- every distinct matcher set still issues its own GETs,
-//!   just not all at once): 64 segments, `promql_fetch_fanout` 8, 2 distinct
-//!   matcher sets, and 16 shared permits gives 128 GETs at binding
-//!   concurrency `min(8 * min(2, 8), 16) = min(16, 16) = 16`, i.e. 8
-//!   batches, not `ceil(64 * 2 / 8) = 16` -- dividing the plan-multiplied
-//!   numerator by the un-multiplied fan-out width alone double-counts the
-//!   plan fan-out. Conversely, `promql_fetch_fanout` 1 with 3 distinct
-//!   matcher sets and 20 segments gives binding concurrency
-//!   `min(1 * min(3, 1), 1000) = 1`, i.e. 60 batches (60 GETs, one at a
-//!   time) -- capping the multiplier by `shared_get_permits` alone, without
-//!   also capping it by `promql_fetch_fanout`, would have reported 20,
-//!   silently assuming all 3 plans ran at once when the outer stream never
-//!   admits more than 1. A single-plan query (`service_fetch_multiplier ==
-//!   1`) reduces to `ceil(segment_count / promql_fetch_fanout)`, since
-//!   `min(promql_fetch_fanout, shared_get_permits)` is the fan-out width
-//!   whenever the shared pool is at least as large as one plan's own
-//!   fan-out bound, as it is for any config leaving both knobs unset.
+//!   It is a lower bound, never an upper bound or an exact count, because
+//!   the OUTER `buffer_unordered` is a SLIDING window, not a wave-synchronous
+//!   one: as soon as one admitted plan finishes, the next plan is admitted
+//!   immediately, without waiting for its siblings. A model that assumed the
+//!   whole outer window empties and refills together (`ceil(segment_count *
+//!   service_fetch_multiplier / min(promql_fetch_fanout *
+//!   min(service_fetch_multiplier, promql_fetch_fanout),
+//!   shared_get_permits))`, dividing TOTAL work by PEAK capacity) undercounts
+//!   whenever the outer window is not full for the query's entire duration:
+//!   3 distinct plans, 1 segment each, `promql_fetch_fanout` 2, and a
+//!   1000-permit limiter gives peak capacity `min(2 * 2, 1000) = 4`, so that
+//!   model reports `ceil(3 / 4) = 1` round -- but plans 1 and 2 admit
+//!   together in the first round, and plan 3 is only admitted after one of
+//!   them finishes, in a second round: the real scheduler takes at least 2
+//!   rounds, never fewer than the wave-synchronous model computes, because a
+//!   sliding window can only pack work as tightly as a synchronized one, not
+//!   more loosely.
+//!
+//!   So this figure is computed per WAVE of the outer fan-out instead of
+//!   once over the total: `waves = ceil(service_fetch_multiplier /
+//!   promql_fetch_fanout)`. For 0-based wave `w`, `active_w =
+//!   min(promql_fetch_fanout, service_fetch_multiplier - w *
+//!   promql_fetch_fanout)` is the count of distinct plans admitted in that
+//!   wave, `capacity_w = min(promql_fetch_fanout * active_w,
+//!   shared_get_permits)` is that wave's binding concurrency, and `batches_w
+//!   = ceil(segment_count * active_w / capacity_w)` is the serial rounds
+//!   that wave alone needs. `service_batches` sums `batches_w` over every
+//!   wave: because the outer stream never admits a plan from wave `w + 1`
+//!   until wave `w`'s plans have all been admitted (though not necessarily
+//!   finished -- see the sliding-window caveat above, which is exactly why
+//!   this sum is a lower rather than an exact bound), the waves are at least
+//!   this serial, and their round counts add.
+//!
+//!   Reviewer's case above: 2 waves. Wave 0: `active_0 = min(2, 3) = 2`,
+//!   `capacity_0 = min(2 * 2, 1000) = 4`, `batches_0 = ceil(1 * 2 / 4) = 1`.
+//!   Wave 1: `active_1 = min(2, 1) = 1`, `capacity_1 = min(2 * 1, 1000) =
+//!   2`, `batches_1 = ceil(1 * 1 / 2) = 1`. Sum: 2, matching the real
+//!   schedule. 64 segments, `promql_fetch_fanout` 8, 2 distinct matcher
+//!   sets, and 16 shared permits: one wave (`ceil(2 / 8) = 1`), `active_0 =
+//!   2`, `capacity_0 = min(16, 16) = 16`, `batches_0 = ceil(128 / 16) = 8`.
+//!   `promql_fetch_fanout` 1 with 3 distinct matcher sets, 20 segments, and
+//!   1000 permits: three waves (`ceil(3 / 1) = 3`), each `active_w = 1`,
+//!   `capacity_w = min(1, 1000) = 1`, `batches_w = ceil(20 / 1) = 20`, sum
+//!   60. A single-plan query (`service_fetch_multiplier == 1`) always has
+//!   exactly one wave with `active_0 = 1`, so it reduces to
+//!   `ceil(segment_count / min(promql_fetch_fanout, shared_get_permits))`,
+//!   the same figure the un-waved formula already gave for that case.
 //! - [`unfolded_segments_resolved`](QueryIoShape::unfolded_segments_resolved):
 //!   the EXACT count of segments this query's resolve took from the recent
 //!   (unfolded) listing path (`SegmentOrigin::Recent`) rather than a folded
@@ -309,6 +329,43 @@ pub fn count_unfolded_segments(origins: &[SegmentOrigin]) -> u64 {
 pub fn service_batches(item_count: u64, concurrency: u64) -> u32 {
     let concurrency = concurrency.max(1);
     item_count.div_ceil(concurrency).min(u64::from(u32::MAX)) as u32
+}
+
+/// A LOWER bound on the serial service rounds a nested plan/segment fan-out
+/// needs, computed per wave of the OUTER `buffer_unordered(fanout)` over
+/// `distinct_plans` distinct matcher plans rather than once over the total
+/// work -- see the module docs' `service_batches` entry for why a single
+/// total-work-over-peak-capacity division undercounts, and for the worked
+/// examples this function's wave loop reproduces exactly.
+///
+/// `waves = ceil(distinct_plans / fanout)`. For 0-based wave `w`, `active_w
+/// = min(fanout, distinct_plans - w * fanout)` distinct plans are admitted,
+/// `capacity_w = min(fanout * active_w, shared_permits)` is that wave's
+/// binding concurrency, and `batches_w = service_batches(segments *
+/// active_w, capacity_w)` is the wave's own serial round count. The result
+/// is the sum of `batches_w` across every wave, saturating throughout and
+/// clamped to `u32::MAX` like [`service_batches`]. `fanout` and
+/// `distinct_plans` are each clamped to at least 1, matching
+/// [`service_batches`]'s own concurrency clamp, so this never divides by
+/// zero and never iterates zero waves.
+pub fn service_batches_over_plan_waves(
+    segments: u64,
+    distinct_plans: u64,
+    fanout: u64,
+    shared_permits: u64,
+) -> u32 {
+    let fanout = fanout.max(1);
+    let distinct_plans = distinct_plans.max(1);
+    let waves = distinct_plans.div_ceil(fanout);
+    let mut total: u64 = 0;
+    for w in 0..waves {
+        let admitted_before = w.saturating_mul(fanout);
+        let active = fanout.min(distinct_plans.saturating_sub(admitted_before));
+        let capacity = fanout.saturating_mul(active).min(shared_permits);
+        let batches = service_batches(segments.saturating_mul(active), capacity);
+        total = total.saturating_add(u64::from(batches));
+    }
+    total.min(u64::from(u32::MAX)) as u32
 }
 
 /// Accumulates the three fan-out-shaped `QueryIoShape` fields

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -16,14 +16,15 @@
 //! / `fetch_histogram_pages`, `crate::fetcher`) is visible here, so
 //! [`dependency_depth`](QueryIoShape::dependency_depth) reflects it: whether a
 //! segment resolves in one whole-object GET (depth 1) or needs a
-//! footer-tail-then-dependent-fetch sequence (depth 2), classified structurally
-//! from `SegmentRef::object_size` against `SegmentFetcher::whole_object_threshold`
-//! (`depth_for_object` below), the same size test `open_segment` itself
-//! branches on. This mirrors `CostEstimate`'s existing convention: an upper
-//! envelope, not a per-request trace, because tracing the real request graph
-//! would require instrumenting every private call inside the fetch pipeline
-//! for a benefit this structural classification already gets from a field
-//! the snapshot already carries.
+//! footer-tail-then-dependent-fetch sequence, reported as an upper bound of
+//! depth 3 to cover a possible footer-range chase (`depth_for_object` below),
+//! classified structurally from `SegmentRef::object_size` against
+//! `SegmentFetcher::whole_object_threshold`, the same size test `open_segment`
+//! itself branches on. This mirrors `CostEstimate`'s existing convention: an
+//! upper envelope, not a per-request trace, because tracing the real request
+//! graph would require instrumenting every private call inside the fetch
+//! pipeline for a benefit this structural classification already gets from a
+//! field the snapshot already carries.
 //!
 //! What is NOT knowable from this crate: the catalog snapshot resolve's own
 //! internal dependency chain (`Catalog::resolve_pruned_with_generations` and
@@ -46,7 +47,9 @@
 //!   stage needs a previous stage's bytes to know its own keys. Four
 //!   independent segment GETs report depth 1 (they run concurrently, none
 //!   depends on another); a segment whose footer read is followed by a
-//!   dependent page fetch reports depth 2.
+//!   dependent page fetch reports depth 3, an upper bound covering a
+//!   possible footer-range chase this crate cannot rule out from
+//!   `object_size` alone (see `depth_for_object`).
 //! - [`list_page_depth`](QueryIoShape::list_page_depth): serial LIST pages,
 //!   recorded separately from `dependency_depth` because pagination
 //!   (`Catalog::list_shard_hours`) and the GET dependency chain are different
@@ -76,7 +79,7 @@
 //! # Tests
 //!
 //! Unit tests live in this module (`tests` submodule below) and exercise
-//! [`IoShapeRecorder`] directly: they construct chained versus parallel
+//! [`IoShapeCounts`] directly: they construct chained versus parallel
 //! recording sequences and assert on the resulting [`IoShapeCounts`], with no
 //! dependency on a live catalog or object store.
 
@@ -97,6 +100,16 @@ pub enum PlanClass {
     /// Every listed segment in the resolved window is opened: no pruning
     /// narrowed the set (or none was possible for this query shape).
     ExhaustiveScan,
+    /// The lane's own resolve carries no signal this crate can use to tell
+    /// a pruned fetch from a full scan (the log lane's `resolve_bounded`
+    /// call always passes `name_filter: None`, so `Snapshot::segments_pruned`
+    /// is structurally always 0 for it, regardless of whether the resolved
+    /// window is actually narrow). Reporting `ExhaustiveScan` here would be
+    /// fabricated: this lane genuinely does not know, and the honest
+    /// classification says so rather than defaulting to the most severe
+    /// value. See [`merge_plan_class`] for how this ranks against a lane
+    /// that DOES know.
+    Unclassified,
 }
 
 impl PlanClass {
@@ -107,6 +120,7 @@ impl PlanClass {
             PlanClass::MetadataOnly => "metadata_only",
             PlanClass::SelectiveIndexed => "selective_indexed",
             PlanClass::ExhaustiveScan => "exhaustive_scan",
+            PlanClass::Unclassified => "unclassified",
         }
     }
 }
@@ -145,18 +159,25 @@ impl Default for QueryIoShape {
 
 /// Combines two lanes' plan classes (a federated query can run a metrics
 /// lane and a log lane, each independently classified) into the single
-/// value `QueryIoShape` reports. Ranked by scan severity, most severe wins:
-/// `ExhaustiveScan` outranks `SelectiveIndexed`, which outranks
-/// `MetadataOnly`. This is the same conservative direction as
-/// `CostEstimate`'s upper-envelope convention -- if either lane touched an
-/// unpruned full window, the combined figure says so rather than averaging
-/// it away against a lane that pruned well.
+/// value `QueryIoShape` reports. Ranked: `MetadataOnly` (0) < `Unclassified`
+/// (1) < `SelectiveIndexed` (2) < `ExhaustiveScan` (3), most severe wins.
+/// `Unclassified` sits strictly between the never-ran identity and either
+/// real scan classification: a lane that genuinely resolved segments but
+/// cannot say whether pruning narrowed them is worse than a lane that never
+/// touched storage, but merging it against a lane that DID classify itself
+/// must never silently promote a real `SelectiveIndexed` result up to
+/// `ExhaustiveScan` -- that would be exactly the fabrication this value
+/// exists to avoid. This is the same conservative direction as
+/// `CostEstimate`'s upper-envelope convention otherwise: if either lane
+/// touched an unpruned full window, the combined figure says so rather than
+/// averaging it away against a lane that pruned well.
 pub fn merge_plan_class(a: PlanClass, b: PlanClass) -> PlanClass {
     fn rank(c: PlanClass) -> u8 {
         match c {
             PlanClass::MetadataOnly => 0,
-            PlanClass::SelectiveIndexed => 1,
-            PlanClass::ExhaustiveScan => 2,
+            PlanClass::Unclassified => 1,
+            PlanClass::SelectiveIndexed => 2,
+            PlanClass::ExhaustiveScan => 3,
         }
     }
     if rank(a) >= rank(b) { a } else { b }
@@ -164,21 +185,42 @@ pub fn merge_plan_class(a: PlanClass, b: PlanClass) -> PlanClass {
 
 /// Structural `dependency_depth` classification for one segment's fetch
 /// pipeline, from the same size test `SegmentFetcher::open_segment` branches
-/// on. A segment at or below the whole-object threshold resolves everything
-/// (footer, catalog, pages) from its first GET: depth 1, no later stage
-/// depends on this one's output to name its own keys. A larger segment reads
-/// only a footer tail first, and a page fetch that needs byte ranges the
-/// footer/catalog decode had to name is a second, dependent stage: depth 2.
+/// on. A segment strictly between 0 and the whole-object threshold resolves
+/// everything (footer, catalog, pages) from its first GET: depth 1, no later
+/// stage depends on this one's output to name its own keys.
 ///
-/// This ignores in-memory region reuse and cache warmth by design (same
-/// upper-envelope convention as `CostEstimate`): a fully-cached large segment
-/// still reports depth 2, because the *plan* has two dependent stages even
-/// when a cache absorbs the second one.
+/// Every other case reports depth 3, as an upper bound rather than a single
+/// true value, because this function only has `(object_size,
+/// whole_object_threshold)` to go on and `open_segment`'s real chain length
+/// past the whole-object branch depends on state this crate cannot see from
+/// those two numbers alone:
+/// - `object_size == 0` (size unknown ahead of the fetch) takes a
+///   `GetRange::Suffix` read (a footer-tail guess, not a whole-object read),
+///   which is then followed by dependent page GETs: at least 2 stages, and a
+///   `FooterOutcome::NeedRange` on that suffix guess (the tail didn't reach
+///   far enough back to cover the real footer) inserts one more dependent
+///   footer-range GET before the page fetch, making 3.
+/// - `object_size > whole_object_threshold` takes the same footer-tail path
+///   and is subject to the same possible `NeedRange` chase, for the same
+///   2-or-3 range.
+///
+/// Neither branch can be resolved to an exact depth here: whether the tail
+/// guess (`SegmentFetcher`'s private `suffix_len`) covers a given segment's
+/// real footer size is not observable from this function's inputs, and no
+/// public accessor exposes it. Reporting the upper bound (3) rather than the
+/// optimistic case (2) matches the module's existing "never underestimate"
+/// convention (see `CostEstimate`'s upper envelope): a chain this function
+/// undercounts would silently understate how serial a query's fetch plan
+/// is, which is the failure mode this field exists to surface.
+///
+/// This also ignores in-memory region reuse and cache warmth by design: a
+/// fully-cached large segment still reports its structural depth, because
+/// the *plan* has that many dependent stages even when a cache absorbs one.
 pub fn depth_for_object(object_size: u64, whole_object_threshold: u64) -> u32 {
-    if object_size <= whole_object_threshold {
+    if object_size != 0 && object_size <= whole_object_threshold {
         1
     } else {
-        2
+        3
     }
 }
 
@@ -272,6 +314,8 @@ impl IoShapeCounts {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ravel_catalog::{DeclaredColumnStats, SegmentLevel, SegmentOrigins, SegmentRef, Snapshot};
+    use uuid::Uuid;
 
     /// A chained stage sequence (a HEAD-shaped stage whose bytes name the
     /// next stage's keys, repeated) must report a strictly greater
@@ -337,15 +381,22 @@ mod tests {
     }
 
     /// `depth_for_object` classifies structurally from the same size test
-    /// `SegmentFetcher::open_segment` branches on: at or below the
-    /// threshold is a whole-object read (depth 1), above it is a
-    /// footer-tail-then-dependent-fetch sequence (depth 2).
+    /// `SegmentFetcher::open_segment` branches on: strictly between 0 and
+    /// the threshold is a whole-object read (depth 1); every other case --
+    /// including `object_size == 0`, which `open_segment` sends down the
+    /// `GetRange::Suffix` footer-tail path, not the whole-object path --
+    /// reports the upper bound 3, because a `FooterOutcome::NeedRange` chase
+    /// on the tail guess is a real third stage this function cannot rule
+    /// out from `object_size` alone. Flip the `object_size != 0 &&` guard
+    /// off (restoring the old `object_size <= threshold` test alone) to
+    /// watch the `object_size == 0` case fail: it would wrongly report 1
+    /// instead of 3.
     #[test]
     fn depth_for_object_matches_whole_object_threshold_branch() {
         assert_eq!(
             depth_for_object(1_000, 2_000),
             1,
-            "at or below: whole object"
+            "strictly between 0 and threshold: whole object"
         );
         assert_eq!(
             depth_for_object(2_000, 2_000),
@@ -354,8 +405,14 @@ mod tests {
         );
         assert_eq!(
             depth_for_object(2_001, 2_000),
-            2,
-            "above threshold: footer tail then dependent fetch"
+            3,
+            "above threshold: footer tail, upper-bounded for a possible NeedRange chase"
+        );
+        assert_eq!(
+            depth_for_object(0, 2_000),
+            3,
+            "unknown size takes the suffix footer-tail path, not whole-object, \
+             even though 0 <= threshold"
         );
     }
 
@@ -390,28 +447,79 @@ mod tests {
     }
 
     /// Pins the segments-versus-records divergence the field name and doc
-    /// comment now spell out explicitly: `origins` is parallel to
-    /// `Snapshot::segments`, one entry per resolved `SegmentRef`, so a single
-    /// L1 compaction record that fans out into several parts contributes one
-    /// `Recent` origin PER PART, not one per underlying record. A fixture
-    /// standing in for one compaction record with 3 parts (all `Recent`)
-    /// plus one L0 record (also `Recent`, one segment) has 2 underlying
-    /// records but must report 4 -- the segment count, never the record
-    /// count `ravel-query` cannot see from `SegmentOrigin` alone.
+    /// comment now spell out explicitly, against REAL `ravel-catalog` types
+    /// rather than a bare `Vec<SegmentOrigin>` with no `Snapshot` behind it:
+    /// a `Snapshot` holding one L0 `SegmentRef` plus a 3-part L1 compaction
+    /// (`SegmentLevel::L1` at `part_index` 0, 1, 2, sharing one
+    /// `input_set_hash` -- the real shape one compaction record fans out
+    /// into) has 4 `segments` entries from only 2 underlying commit/
+    /// compaction records. `SegmentOrigins::origins` is built parallel to
+    /// `snapshot.segments` (same length, same order, all `Recent`, matching
+    /// how a real live-listing resolve populates both), and the assertion
+    /// checks that parallelism explicitly before checking the count, so a
+    /// carriage bug that let the two vectors drift out of sync would fail
+    /// here even before the count assertion. Flip the L1 fixture down to 1
+    /// part (drop two of the three `part_index` entries and their origins)
+    /// to watch the count assertion fail: it would then read 2, not 4.
     #[test]
     fn unfolded_segments_resolved_counts_compaction_parts_not_records() {
-        let origins = vec![
-            // 1 underlying L0 commit record -> 1 segment.
-            SegmentOrigin::Recent,
-            // 1 underlying L1 compaction record, fanned out into 3 parts
-            // (`SegmentLevel::L1`'s `part_index` 0, 1, 2) -> 3 segments.
-            SegmentOrigin::Recent,
-            SegmentOrigin::Recent,
-            SegmentOrigin::Recent,
-        ];
+        fn segment_ref(level: SegmentLevel) -> SegmentRef {
+            SegmentRef {
+                data_object_key: "irrelevant".to_string(),
+                object_size: 4_096,
+                min_event_ts_ns: 0,
+                max_event_ts_ns: 1,
+                ingest_hour_bucket: 0,
+                sample_count: 1,
+                series_count: 1,
+                shard: 0,
+                content_hash: [0u8; 32],
+                writer_id: Uuid::nil(),
+                writer_epoch: 0,
+                writer_seq: 0,
+                created_unix_ns: 0,
+                level,
+                segment_format_version: 1,
+                declared_column_stats: DeclaredColumnStats::default(),
+            }
+        }
+
+        let input_set_hash = [7u8; 32];
+        let snapshot = Snapshot {
+            segments: vec![
+                // 1 underlying L0 commit record -> 1 segment.
+                segment_ref(SegmentLevel::L0),
+                // 1 underlying L1 compaction record, fanned out into 3
+                // parts -> 3 segments.
+                segment_ref(SegmentLevel::L1 {
+                    input_set_hash,
+                    part_index: 0,
+                }),
+                segment_ref(SegmentLevel::L1 {
+                    input_set_hash,
+                    part_index: 1,
+                }),
+                segment_ref(SegmentLevel::L1 {
+                    input_set_hash,
+                    part_index: 2,
+                }),
+            ],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+
+        let mut origins = SegmentOrigins::default();
+        for _ in &snapshot.segments {
+            origins.push(SegmentOrigin::Recent);
+        }
 
         assert_eq!(
-            count_unfolded_segments(&origins),
+            origins.origins.len(),
+            snapshot.segments.len(),
+            "origins must stay parallel to snapshot.segments"
+        );
+        assert_eq!(
+            count_unfolded_segments(&origins.origins),
             4,
             "4 segments (1 L0 + 3 L1 parts) from only 2 underlying commit/compaction records"
         );

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -57,9 +57,14 @@
 //!   object-store mechanisms with different causes.
 //! - [`service_batches`](QueryIoShape::service_batches): batches this query's
 //!   per-segment fan-out was forced into by its concurrency permit
-//!   (`ceil(segment_count / fetch_concurrency)`): 64 segments under 16
-//!   concurrent permits is 4 batches at whatever depth those segments'
-//!   fetches classify at.
+//!   (`ceil(segment_count / fetch_concurrency)`): 64 segments under 8
+//!   concurrent permits (`fetch_concurrency`'s default,
+//!   `DEFAULT_FETCH_CONCURRENCY`) is 8 batches at whatever depth those
+//!   segments' fetches classify at. For the metrics lane this is scaled by
+//!   `service_fetch_multiplier`, the count of distinct matcher sets the
+//!   fetch fan-out issues one pass per (`distinct_plans_by_matcher` in
+//!   `crates/ravel-query/src/engine.rs`): 64 segments under 8 permits with
+//!   two distinct matcher sets reports 16 batches, not 8.
 //! - [`unfolded_segments_resolved`](QueryIoShape::unfolded_segments_resolved):
 //!   the EXACT count of segments this query's resolve took from the recent
 //!   (unfolded) listing path (`SegmentOrigin::Recent`) rather than a folded
@@ -395,12 +400,12 @@ mod tests {
     /// the threshold is a whole-object read (depth 1); every other case --
     /// including `object_size == 0`, which `open_segment` sends down the
     /// `GetRange::Suffix` footer-tail path, not the whole-object path --
-    /// reports the upper bound 3, because a `FooterOutcome::NeedRange` chase
-    /// on the tail guess is a real third stage this function cannot rule
-    /// out from `object_size` alone. Flip the `object_size != 0 &&` guard
-    /// off (restoring the old `object_size <= threshold` test alone) to
-    /// watch the `object_size == 0` case fail: it would wrongly report 1
-    /// instead of 3.
+    /// reports the upper bound 4, because a `FooterOutcome::NeedRange` chase
+    /// on the tail guess, plus the catalog and page fetch stages, are real
+    /// further stages this function cannot rule out from `object_size`
+    /// alone. Flip the `object_size != 0 &&` guard off (restoring the old
+    /// `object_size <= threshold` test alone) to watch the `object_size ==
+    /// 0` case fail: it would wrongly report 1 instead of 4.
     #[test]
     fn depth_for_object_matches_whole_object_threshold_branch() {
         assert_eq!(

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -56,11 +56,20 @@
 //!   (`ceil(segment_count / fetch_concurrency)`): 64 segments under 16
 //!   concurrent permits is 4 batches at whatever depth those segments'
 //!   fetches classify at.
-//! - [`unfolded_records_resolved`](QueryIoShape::unfolded_records_resolved):
+//! - [`unfolded_segments_resolved`](QueryIoShape::unfolded_segments_resolved):
 //!   the EXACT count of segments this query's resolve took from the recent
 //!   (unfolded) listing path (`SegmentOrigin::Recent`) rather than a folded
 //!   snapshot part. Exact, not estimated, because it gates a downstream
-//!   fold-benefit decision that an approximation would silently corrupt.
+//!   fold-benefit decision that an approximation would silently corrupt. A
+//!   SEGMENT count, not a commit-record count: `SegmentOrigin` is parallel to
+//!   `Snapshot::segments` (one entry per resolved `SegmentRef`), and one L1
+//!   compaction record can produce several `SegmentRef` parts
+//!   (`SegmentLevel::L1`'s `part_index`s) that all inherit that record's
+//!   `Recent` origin. The two counts coincide for L0 (one commit record names
+//!   one segment) and diverge for a multi-part L1 compaction, where this
+//!   figure counts every part. `ravel-query` cannot recover the underlying
+//!   record count from `SegmentOrigin` alone -- the field is named, and
+//!   documented, for the quantity it actually counts.
 //! - [`plan_class`](QueryIoShape::plan_class): decided before any segment is
 //!   opened, from the query's shape and the resolve's own pruning outcome.
 //!
@@ -111,7 +120,7 @@ pub struct QueryIoShape {
     pub dependency_depth: u32,
     pub list_page_depth: u32,
     pub service_batches: u32,
-    pub unfolded_records_resolved: u64,
+    pub unfolded_segments_resolved: u64,
     pub plan_class: PlanClass,
 }
 
@@ -128,7 +137,7 @@ impl Default for QueryIoShape {
             dependency_depth: 0,
             list_page_depth: 0,
             service_batches: 0,
-            unfolded_records_resolved: 0,
+            unfolded_segments_resolved: 0,
             plan_class: PlanClass::MetadataOnly,
         }
     }
@@ -175,11 +184,25 @@ pub fn depth_for_object(object_size: u64, whole_object_threshold: u64) -> u32 {
 
 /// Counts `SegmentOrigin::Recent` entries: segments this resolve took from
 /// the recent (unfolded) listing path rather than a folded snapshot part.
-/// Deliberately excludes `SegmentOrigin::TokenResolved` (an explicit
-/// read-your-write token match, not a listing outcome) and
-/// `SegmentOrigin::SealedBelowWatermark` (already folded). An exact count
-/// over the full `origins` slice, never an estimate.
-pub fn count_unfolded_records(origins: &[SegmentOrigin]) -> u64 {
+/// `origins` is parallel to `Snapshot::segments` (one entry per resolved
+/// `SegmentRef`), so this counts SEGMENTS, not commit records -- see the
+/// module docs' `unfolded_segments_resolved` entry for when a segment and its
+/// underlying record diverge (a multi-part L1 compaction).
+///
+/// Deliberately excludes `SegmentOrigin::SealedBelowWatermark` (already
+/// folded: the quantity this figure gates is unfolded exposure, and a sealed
+/// segment carries none) and `SegmentOrigin::TokenResolved`. The
+/// `TokenResolved` exclusion is a deliberate cost-shape decision, not merely
+/// "not a listing outcome": a token-resolved segment costs exactly one GET by
+/// its explicit `min_commit_token` key (`Catalog::resolve_min_token`)
+/// regardless of whether a fold has run, so folding can never remove that
+/// GET. Counting it here would overstate the fold-benefit figure with a cost
+/// no fold could ever recover. A `Recent` segment's cost is different: it is
+/// discovered by the listing path specifically because no fold covers it
+/// yet, so folding it into a snapshot part is exactly the benefit this
+/// figure gates. An exact count over the full `origins` slice, never an
+/// estimate.
+pub fn count_unfolded_segments(origins: &[SegmentOrigin]) -> u64 {
     origins
         .iter()
         .filter(|o| matches!(o, SegmentOrigin::Recent))
@@ -233,14 +256,14 @@ impl IoShapeCounts {
     /// [`QueryIoShape`].
     pub fn into_shape(
         self,
-        unfolded_records_resolved: u64,
+        unfolded_segments_resolved: u64,
         plan_class: PlanClass,
     ) -> QueryIoShape {
         QueryIoShape {
             dependency_depth: self.dependency_depth,
             list_page_depth: self.list_page_depth,
             service_batches: self.service_batches,
-            unfolded_records_resolved,
+            unfolded_segments_resolved,
             plan_class,
         }
     }
@@ -319,19 +342,31 @@ mod tests {
     /// footer-tail-then-dependent-fetch sequence (depth 2).
     #[test]
     fn depth_for_object_matches_whole_object_threshold_branch() {
-        assert_eq!(depth_for_object(1_000, 2_000), 1, "at or below: whole object");
-        assert_eq!(depth_for_object(2_000, 2_000), 1, "exactly at threshold: whole object");
-        assert_eq!(depth_for_object(2_001, 2_000), 2, "above threshold: footer tail then dependent fetch");
+        assert_eq!(
+            depth_for_object(1_000, 2_000),
+            1,
+            "at or below: whole object"
+        );
+        assert_eq!(
+            depth_for_object(2_000, 2_000),
+            1,
+            "exactly at threshold: whole object"
+        );
+        assert_eq!(
+            depth_for_object(2_001, 2_000),
+            2,
+            "above threshold: footer tail then dependent fetch"
+        );
     }
 
-    /// `count_unfolded_records` counts `Recent` origins EXACTLY, excluding
-    /// both `SealedBelowWatermark` (already folded) and `TokenResolved`
-    /// (an explicit read-your-write match, not a listing outcome). Pinned to
-    /// an exact figure, not `> 0`: this count gates a downstream fold-benefit
-    /// decision that a merely-nonzero check would not catch an
+    /// `count_unfolded_segments` counts `Recent` origins EXACTLY, excluding
+    /// both `SealedBelowWatermark` (already folded) and `TokenResolved` (its
+    /// GET cost survives a fold, so it is not fold-benefit exposure). Pinned
+    /// to an exact figure, not `> 0`: this count gates a downstream
+    /// fold-benefit decision that a merely-nonzero check would not catch an
     /// under-count on.
     #[test]
-    fn unfolded_records_resolved_counts_recent_origins_exactly() {
+    fn unfolded_segments_resolved_counts_recent_origins_exactly() {
         let origins = vec![
             SegmentOrigin::SealedBelowWatermark,
             SegmentOrigin::Recent,
@@ -340,7 +375,7 @@ mod tests {
             SegmentOrigin::Recent,
             SegmentOrigin::SealedBelowWatermark,
         ];
-        assert_eq!(count_unfolded_records(&origins), 3);
+        assert_eq!(count_unfolded_segments(&origins), 3);
     }
 
     /// A deliberate under-count: folding `TokenResolved` into the `Recent`
@@ -349,16 +384,52 @@ mod tests {
     /// pins the exact figure so that regression is visible, not just "some
     /// segments counted."
     #[test]
-    fn unfolded_records_resolved_excludes_token_resolved() {
+    fn unfolded_segments_resolved_excludes_token_resolved() {
         let origins = vec![SegmentOrigin::TokenResolved, SegmentOrigin::Recent];
-        assert_eq!(count_unfolded_records(&origins), 1);
+        assert_eq!(count_unfolded_segments(&origins), 1);
+    }
+
+    /// Pins the segments-versus-records divergence the field name and doc
+    /// comment now spell out explicitly: `origins` is parallel to
+    /// `Snapshot::segments`, one entry per resolved `SegmentRef`, so a single
+    /// L1 compaction record that fans out into several parts contributes one
+    /// `Recent` origin PER PART, not one per underlying record. A fixture
+    /// standing in for one compaction record with 3 parts (all `Recent`)
+    /// plus one L0 record (also `Recent`, one segment) has 2 underlying
+    /// records but must report 4 -- the segment count, never the record
+    /// count `ravel-query` cannot see from `SegmentOrigin` alone.
+    #[test]
+    fn unfolded_segments_resolved_counts_compaction_parts_not_records() {
+        let origins = vec![
+            // 1 underlying L0 commit record -> 1 segment.
+            SegmentOrigin::Recent,
+            // 1 underlying L1 compaction record, fanned out into 3 parts
+            // (`SegmentLevel::L1`'s `part_index` 0, 1, 2) -> 3 segments.
+            SegmentOrigin::Recent,
+            SegmentOrigin::Recent,
+            SegmentOrigin::Recent,
+        ];
+
+        assert_eq!(
+            count_unfolded_segments(&origins),
+            4,
+            "4 segments (1 L0 + 3 L1 parts) from only 2 underlying commit/compaction records"
+        );
     }
 
     #[test]
     fn service_batches_rounds_up_and_clamps_concurrency() {
         assert_eq!(service_batches(64, 16), 4);
-        assert_eq!(service_batches(65, 16), 5, "one leftover item forces another batch");
-        assert_eq!(service_batches(4, 0), 4, "zero concurrency clamps to 1 permit");
+        assert_eq!(
+            service_batches(65, 16),
+            5,
+            "one leftover item forces another batch"
+        );
+        assert_eq!(
+            service_batches(4, 0),
+            4,
+            "zero concurrency clamps to 1 permit"
+        );
     }
 
     /// `merge_plan_class` picks the more severe scan class, in either

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -58,24 +58,45 @@
 //! - [`service_batches`](QueryIoShape::service_batches): batches this
 //!   query's per-segment fan-out was forced into by the binding concurrency
 //!   it actually ran under. The metrics fetch is a NESTED fan-out
-//!   (`crates/ravel-query/src/engine.rs`): one
-//!   `buffer_unordered(promql_fetch_fanout)` over distinct matcher plans
-//!   (`distinct_plans_by_matcher`), each running its own
-//!   `buffer_unordered(promql_fetch_fanout)` over that plan's segments.
-//!   Those inner streams do not get independent budgets -- every GET from
-//!   every plan passes through the one [`crate::GetLimiter`] the engine
-//!   shares across the fetchers it owns (ADR-1195), sized by the resolved
-//!   `EngineConfig::store_get_concurrency` (see "GET concurrency" in
-//!   docs/query-engine.md). So the binding concurrency is
-//!   `min(service_fetch_multiplier * promql_fetch_fanout,
-//!   shared_get_permits)`, and the work is `segment_count *
-//!   service_fetch_multiplier` GETs: 64 segments, `promql_fetch_fanout` 8, 2
-//!   distinct matcher sets, and 16 shared permits gives 128 GETs at binding
-//!   concurrency `min(16, 16) = 16`, i.e. 8 batches, not
-//!   `ceil(64 * 2 / 8) = 16` -- dividing the plan-multiplied numerator by
-//!   the un-multiplied fan-out width alone double-counts the plan fan-out. A
-//!   single-plan query (`service_fetch_multiplier == 1`) reduces to
-//!   `ceil(segment_count / promql_fetch_fanout)`, since
+//!   (`crates/ravel-query/src/engine.rs`) with three levels of admission,
+//!   all of which bound the batch count:
+//!   1. the OUTER `buffer_unordered(promql_fetch_fanout)` over distinct
+//!      matcher plans (`distinct_plans_by_matcher`), which admits at most
+//!      `promql_fetch_fanout` plans at once -- never
+//!      `service_fetch_multiplier` plans, however many distinct matcher sets
+//!      the query has;
+//!   2. each admitted plan's own INNER
+//!      `buffer_unordered(promql_fetch_fanout)` over that plan's segments;
+//!   3. the one [`crate::GetLimiter`] the engine shares across every fetcher
+//!      it owns (ADR-1195), sized by the resolved
+//!      `EngineConfig::store_get_concurrency` (see "GET concurrency" in
+//!      docs/query-engine.md), which every GET from every plan passes
+//!      through regardless of which plan or segment issued it.
+//!
+//!   Levels 1 and 2 do not multiply freely: plan capacity is
+//!   `promql_fetch_fanout * min(service_fetch_multiplier,
+//!   promql_fetch_fanout)`, not `promql_fetch_fanout *
+//!   service_fetch_multiplier` -- the outer stream can never have more than
+//!   `promql_fetch_fanout` plans in flight even when there are more distinct
+//!   matcher sets than that. The binding concurrency is that plan capacity
+//!   capped by the shared limiter:
+//!   `min(promql_fetch_fanout * min(service_fetch_multiplier,
+//!   promql_fetch_fanout), shared_get_permits)`, and the work is
+//!   `segment_count * service_fetch_multiplier` GETs (the multiplier is not
+//!   capped there -- every distinct matcher set still issues its own GETs,
+//!   just not all at once): 64 segments, `promql_fetch_fanout` 8, 2 distinct
+//!   matcher sets, and 16 shared permits gives 128 GETs at binding
+//!   concurrency `min(8 * min(2, 8), 16) = min(16, 16) = 16`, i.e. 8
+//!   batches, not `ceil(64 * 2 / 8) = 16` -- dividing the plan-multiplied
+//!   numerator by the un-multiplied fan-out width alone double-counts the
+//!   plan fan-out. Conversely, `promql_fetch_fanout` 1 with 3 distinct
+//!   matcher sets and 20 segments gives binding concurrency
+//!   `min(1 * min(3, 1), 1000) = 1`, i.e. 60 batches (60 GETs, one at a
+//!   time) -- capping the multiplier by `shared_get_permits` alone, without
+//!   also capping it by `promql_fetch_fanout`, would have reported 20,
+//!   silently assuming all 3 plans ran at once when the outer stream never
+//!   admits more than 1. A single-plan query (`service_fetch_multiplier ==
+//!   1`) reduces to `ceil(segment_count / promql_fetch_fanout)`, since
 //!   `min(promql_fetch_fanout, shared_get_permits)` is the fan-out width
 //!   whenever the shared pool is at least as large as one plan's own
 //!   fan-out bound, as it is for any config leaving both knobs unset.

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -1,0 +1,386 @@
+//! Per-query I/O shape (issue #1214): the dependency structure between a
+//! query's object-store stages, kept separate from `phase_accounting`'s cost
+//! split. `phase_accounting` answers "how many requests and bytes did each
+//! phase spend"; this module answers "how many of those requests had to run
+//! one after another because a later stage needed an earlier stage's bytes
+//! to know its own keys." A query can be cheap by [`crate::phase_accounting`]
+//! (few requests, few bytes) and still be slow because its requests chain,
+//! or expensive by request count and still be fast because every request
+//! runs in one parallel round. Neither dimension predicts the other, which is
+//! exactly why both are reported.
+//!
+//! # What is knowable from `ravel-query`, and what is not
+//!
+//! The per-segment fetch pipeline this crate owns
+//! (`SegmentFetcher::open_segment` -> `decode_selected` -> `fetch_scalar_pages`
+//! / `fetch_histogram_pages`, `crate::fetcher`) is visible here, so
+//! [`dependency_depth`](QueryIoShape::dependency_depth) reflects it: whether a
+//! segment resolves in one whole-object GET (depth 1) or needs a
+//! footer-tail-then-dependent-fetch sequence (depth 2), classified structurally
+//! from `SegmentRef::object_size` against `SegmentFetcher::whole_object_threshold`
+//! (`depth_for_object` below), the same size test `open_segment` itself
+//! branches on. This mirrors `CostEstimate`'s existing convention: an upper
+//! envelope, not a per-request trace, because tracing the real request graph
+//! would require instrumenting every private call inside the fetch pipeline
+//! for a benefit this structural classification already gets from a field
+//! the snapshot already carries.
+//!
+//! What is NOT knowable from this crate: the catalog snapshot resolve's own
+//! internal dependency chain (`Catalog::resolve_pruned_with_generations` and
+//! the snapshot-window HEAD-then-part-GET sequence it can take) lives
+//! entirely inside `ravel-catalog`, which this task's scope excludes editing.
+//! [`dependency_depth`] therefore reports only the segment-fetch chain's
+//! depth; the true end-to-end depth (resolve's own chain, however deep,
+//! prefixed to the segment-fetch chain) can only be equal to or greater than
+//! what is reported here. Likewise LIST pagination is entirely internal to
+//! `ravel-catalog`'s per-shard bounded listing (`Catalog::list_shard_hours`):
+//! [`list_page_depth`](QueryIoShape::list_page_depth) reports the resolve
+//! phase's total LIST request count as an upper-bound serial depth, because
+//! this crate cannot see whether two shards' LIST pages actually ran
+//! concurrently with each other or serially -- only that they happened.
+//!
+//! # Fields
+//!
+//! - [`dependency_depth`](QueryIoShape::dependency_depth): the longest chain
+//!   of object-store stages, across every segment this query opened, where a
+//!   stage needs a previous stage's bytes to know its own keys. Four
+//!   independent segment GETs report depth 1 (they run concurrently, none
+//!   depends on another); a segment whose footer read is followed by a
+//!   dependent page fetch reports depth 2.
+//! - [`list_page_depth`](QueryIoShape::list_page_depth): serial LIST pages,
+//!   recorded separately from `dependency_depth` because pagination
+//!   (`Catalog::list_shard_hours`) and the GET dependency chain are different
+//!   object-store mechanisms with different causes.
+//! - [`service_batches`](QueryIoShape::service_batches): batches this query's
+//!   per-segment fan-out was forced into by its concurrency permit
+//!   (`ceil(segment_count / fetch_concurrency)`): 64 segments under 16
+//!   concurrent permits is 4 batches at whatever depth those segments'
+//!   fetches classify at.
+//! - [`unfolded_records_resolved`](QueryIoShape::unfolded_records_resolved):
+//!   the EXACT count of segments this query's resolve took from the recent
+//!   (unfolded) listing path (`SegmentOrigin::Recent`) rather than a folded
+//!   snapshot part. Exact, not estimated, because it gates a downstream
+//!   fold-benefit decision that an approximation would silently corrupt.
+//! - [`plan_class`](QueryIoShape::plan_class): decided before any segment is
+//!   opened, from the query's shape and the resolve's own pruning outcome.
+//!
+//! # Tests
+//!
+//! Unit tests live in this module (`tests` submodule below) and exercise
+//! [`IoShapeRecorder`] directly: they construct chained versus parallel
+//! recording sequences and assert on the resulting [`IoShapeCounts`], with no
+//! dependency on a live catalog or object store.
+
+use ravel_catalog::SegmentOrigin;
+
+/// Coarse pre-execution classification of a query's expected access pattern,
+/// decided once, before any segment is opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanClass {
+    /// No page fetch: a labels/label-values/series discovery query, which
+    /// opens and catalog-decodes segments but never reaches
+    /// `fetch_scalar_pages`/`fetch_histogram_pages`.
+    MetadataOnly,
+    /// The resolve's postings-based pruning excluded at least one
+    /// snapshot-sourced segment (`Snapshot::segments_pruned > 0`): the fetch
+    /// touches a strict subset of the window's listed segments.
+    SelectiveIndexed,
+    /// Every listed segment in the resolved window is opened: no pruning
+    /// narrowed the set (or none was possible for this query shape).
+    ExhaustiveScan,
+}
+
+impl PlanClass {
+    /// Stable lowercase-snake-case name, matching `QueryPhase::name`'s
+    /// rendering convention for the JSON surface.
+    pub fn name(self) -> &'static str {
+        match self {
+            PlanClass::MetadataOnly => "metadata_only",
+            PlanClass::SelectiveIndexed => "selective_indexed",
+            PlanClass::ExhaustiveScan => "exhaustive_scan",
+        }
+    }
+}
+
+/// Recorded per query: the dependency shape of its object-store I/O,
+/// alongside (never instead of) `phase_accounting`'s request/byte cost split.
+/// See the module docs above for what each field means and its known
+/// limitations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryIoShape {
+    pub dependency_depth: u32,
+    pub list_page_depth: u32,
+    pub service_batches: u32,
+    pub unfolded_records_resolved: u64,
+    pub plan_class: PlanClass,
+}
+
+impl Default for QueryIoShape {
+    /// `PlanClass` has no natural zero value, but `Default` is also what a
+    /// lane that never ran (no metric selector in a log-only query, or vice
+    /// versa) contributes before [`merge_plan_class`] combines it with the
+    /// lane that did run. `MetadataOnly` is the correct identity for that
+    /// merge -- it never outranks a real lane's classification -- whereas
+    /// `ExhaustiveScan` would wrongly force every literal-only query (no
+    /// storage touched at all) to report the plan class of a full scan.
+    fn default() -> Self {
+        QueryIoShape {
+            dependency_depth: 0,
+            list_page_depth: 0,
+            service_batches: 0,
+            unfolded_records_resolved: 0,
+            plan_class: PlanClass::MetadataOnly,
+        }
+    }
+}
+
+/// Combines two lanes' plan classes (a federated query can run a metrics
+/// lane and a log lane, each independently classified) into the single
+/// value `QueryIoShape` reports. Ranked by scan severity, most severe wins:
+/// `ExhaustiveScan` outranks `SelectiveIndexed`, which outranks
+/// `MetadataOnly`. This is the same conservative direction as
+/// `CostEstimate`'s upper-envelope convention -- if either lane touched an
+/// unpruned full window, the combined figure says so rather than averaging
+/// it away against a lane that pruned well.
+pub fn merge_plan_class(a: PlanClass, b: PlanClass) -> PlanClass {
+    fn rank(c: PlanClass) -> u8 {
+        match c {
+            PlanClass::MetadataOnly => 0,
+            PlanClass::SelectiveIndexed => 1,
+            PlanClass::ExhaustiveScan => 2,
+        }
+    }
+    if rank(a) >= rank(b) { a } else { b }
+}
+
+/// Structural `dependency_depth` classification for one segment's fetch
+/// pipeline, from the same size test `SegmentFetcher::open_segment` branches
+/// on. A segment at or below the whole-object threshold resolves everything
+/// (footer, catalog, pages) from its first GET: depth 1, no later stage
+/// depends on this one's output to name its own keys. A larger segment reads
+/// only a footer tail first, and a page fetch that needs byte ranges the
+/// footer/catalog decode had to name is a second, dependent stage: depth 2.
+///
+/// This ignores in-memory region reuse and cache warmth by design (same
+/// upper-envelope convention as `CostEstimate`): a fully-cached large segment
+/// still reports depth 2, because the *plan* has two dependent stages even
+/// when a cache absorbs the second one.
+pub fn depth_for_object(object_size: u64, whole_object_threshold: u64) -> u32 {
+    if object_size <= whole_object_threshold {
+        1
+    } else {
+        2
+    }
+}
+
+/// Counts `SegmentOrigin::Recent` entries: segments this resolve took from
+/// the recent (unfolded) listing path rather than a folded snapshot part.
+/// Deliberately excludes `SegmentOrigin::TokenResolved` (an explicit
+/// read-your-write token match, not a listing outcome) and
+/// `SegmentOrigin::SealedBelowWatermark` (already folded). An exact count
+/// over the full `origins` slice, never an estimate.
+pub fn count_unfolded_records(origins: &[SegmentOrigin]) -> u64 {
+    origins
+        .iter()
+        .filter(|o| matches!(o, SegmentOrigin::Recent))
+        .count() as u64
+}
+
+/// Batches one concurrency-bounded fan-out over `item_count` items is forced
+/// into under `concurrency` simultaneous permits: `ceil(item_count /
+/// concurrency)`. `concurrency` is clamped to at least 1 (mirrors every fetch
+/// call site's own `self.config.fetch_concurrency.max(1)`), so this never
+/// divides by zero.
+pub fn service_batches(item_count: u64, concurrency: u64) -> u32 {
+    let concurrency = concurrency.max(1);
+    item_count.div_ceil(concurrency).min(u64::from(u32::MAX)) as u32
+}
+
+/// Accumulates the three fan-out-shaped `QueryIoShape` fields
+/// (`dependency_depth`, `list_page_depth`, `service_batches`) across however
+/// many independent stage chains and fan-out rounds one query's resolve and
+/// fetch produce. Each field takes the MAXIMUM ever recorded, never a sum: a
+/// query's `dependency_depth` is the length of its single longest chain, not
+/// the total number of stages across every chain that ran (most of which ran
+/// concurrently with each other, not after each other).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct IoShapeCounts {
+    pub dependency_depth: u32,
+    pub list_page_depth: u32,
+    pub service_batches: u32,
+}
+
+impl IoShapeCounts {
+    /// Folds in one independent stage chain's depth: keeps the larger of the
+    /// current recorded depth and `depth`.
+    pub fn record_dependency_chain(&mut self, depth: u32) {
+        self.dependency_depth = self.dependency_depth.max(depth);
+    }
+
+    /// Folds in one LIST call's serial page count, independently of
+    /// `dependency_depth`.
+    pub fn record_list_pages(&mut self, pages: u32) {
+        self.list_page_depth = self.list_page_depth.max(pages);
+    }
+
+    /// Folds in one concurrency-bounded fan-out's forced batch count.
+    pub fn record_service_batches(&mut self, batches: u32) {
+        self.service_batches = self.service_batches.max(batches);
+    }
+
+    /// Combines these fan-out-shaped counts with the two values only
+    /// knowable directly at the resolve call site into a complete
+    /// [`QueryIoShape`].
+    pub fn into_shape(
+        self,
+        unfolded_records_resolved: u64,
+        plan_class: PlanClass,
+    ) -> QueryIoShape {
+        QueryIoShape {
+            dependency_depth: self.dependency_depth,
+            list_page_depth: self.list_page_depth,
+            service_batches: self.service_batches,
+            unfolded_records_resolved,
+            plan_class,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A chained stage sequence (a HEAD-shaped stage whose bytes name the
+    /// next stage's keys, repeated) must report a strictly greater
+    /// `dependency_depth` than a parallel fan-out issuing the same total
+    /// request count, because `IoShapeCounts` takes the max of recorded
+    /// chain depths, never a sum. Flip `.max(depth)` in
+    /// `record_dependency_chain` to `+= depth` to watch this fail: both
+    /// counts land in the same bucket and the assertion that chained must
+    /// exceed parallel breaks (parallel: 1+1+1+1=4, chained: 1+2+3+4=10, so a
+    /// summing bug would even invert which one this test expects to be
+    /// larger were the chain shorter than the fan-out -- the `assert_eq!`
+    /// pins on the exact depth, not just an inequality, so a `+=` bug is
+    /// caught either way).
+    #[test]
+    fn depth_counts_chained_stages_not_parallel_batches() {
+        let mut parallel = IoShapeCounts::default();
+        // Four independent segment GETs: none depends on another, so each
+        // chain recorded is depth 1.
+        for _ in 0..4 {
+            parallel.record_dependency_chain(1);
+        }
+
+        let mut chained = IoShapeCounts::default();
+        // One chain of four dependent stages (e.g. a footer read, then three
+        // successively-dependent page fetches): depths 1, 2, 3, 4 recorded
+        // as the chain grows, same total request count as `parallel`.
+        for depth in 1..=4 {
+            chained.record_dependency_chain(depth);
+        }
+
+        assert_eq!(parallel.dependency_depth, 1, "independent GETs never chain");
+        assert_eq!(
+            chained.dependency_depth, 4,
+            "the chain's own longest depth survives"
+        );
+        assert!(
+            chained.dependency_depth > parallel.dependency_depth,
+            "a chained stage sequence must report strictly greater dependency_depth \
+             than a parallel fan-out issuing the same number of requests"
+        );
+    }
+
+    /// `list_page_depth` must be reported independently of
+    /// `dependency_depth`: a query with several serial LIST pages and a flat
+    /// (unchained) GET fan-out reports high `list_page_depth` and low
+    /// `dependency_depth`. Flip `record_list_pages` to update
+    /// `self.dependency_depth` instead of `self.list_page_depth` to watch
+    /// this fail: `dependency_depth` would then read 13, not 1.
+    #[test]
+    fn list_page_depth_reported_independently_of_dependency_depth() {
+        let mut counts = IoShapeCounts::default();
+        // 13 serial LIST pages (the reference S3 run this task investigates:
+        // 4 shards paginated at 1000 records/page plus one pending-erasure
+        // LIST), against a flat 4-way parallel GET fan-out.
+        counts.record_list_pages(13);
+        for _ in 0..4 {
+            counts.record_dependency_chain(1);
+        }
+
+        assert_eq!(counts.list_page_depth, 13);
+        assert_eq!(counts.dependency_depth, 1);
+        assert!(counts.list_page_depth > counts.dependency_depth);
+    }
+
+    /// `depth_for_object` classifies structurally from the same size test
+    /// `SegmentFetcher::open_segment` branches on: at or below the
+    /// threshold is a whole-object read (depth 1), above it is a
+    /// footer-tail-then-dependent-fetch sequence (depth 2).
+    #[test]
+    fn depth_for_object_matches_whole_object_threshold_branch() {
+        assert_eq!(depth_for_object(1_000, 2_000), 1, "at or below: whole object");
+        assert_eq!(depth_for_object(2_000, 2_000), 1, "exactly at threshold: whole object");
+        assert_eq!(depth_for_object(2_001, 2_000), 2, "above threshold: footer tail then dependent fetch");
+    }
+
+    /// `count_unfolded_records` counts `Recent` origins EXACTLY, excluding
+    /// both `SealedBelowWatermark` (already folded) and `TokenResolved`
+    /// (an explicit read-your-write match, not a listing outcome). Pinned to
+    /// an exact figure, not `> 0`: this count gates a downstream fold-benefit
+    /// decision that a merely-nonzero check would not catch an
+    /// under-count on.
+    #[test]
+    fn unfolded_records_resolved_counts_recent_origins_exactly() {
+        let origins = vec![
+            SegmentOrigin::SealedBelowWatermark,
+            SegmentOrigin::Recent,
+            SegmentOrigin::Recent,
+            SegmentOrigin::TokenResolved,
+            SegmentOrigin::Recent,
+            SegmentOrigin::SealedBelowWatermark,
+        ];
+        assert_eq!(count_unfolded_records(&origins), 3);
+    }
+
+    /// A deliberate under-count: folding `TokenResolved` into the `Recent`
+    /// tally too (as if the filter were `!= SealedBelowWatermark` instead of
+    /// `== Recent`) would report 4, not 3, on the same fixture -- this test
+    /// pins the exact figure so that regression is visible, not just "some
+    /// segments counted."
+    #[test]
+    fn unfolded_records_resolved_excludes_token_resolved() {
+        let origins = vec![SegmentOrigin::TokenResolved, SegmentOrigin::Recent];
+        assert_eq!(count_unfolded_records(&origins), 1);
+    }
+
+    #[test]
+    fn service_batches_rounds_up_and_clamps_concurrency() {
+        assert_eq!(service_batches(64, 16), 4);
+        assert_eq!(service_batches(65, 16), 5, "one leftover item forces another batch");
+        assert_eq!(service_batches(4, 0), 4, "zero concurrency clamps to 1 permit");
+    }
+
+    /// `merge_plan_class` picks the more severe scan class, in either
+    /// argument order, and a lane that never ran (`MetadataOnly`, the
+    /// `Default`) never outranks a lane that actually scanned.
+    #[test]
+    fn merge_plan_class_picks_more_severe_scan() {
+        assert_eq!(
+            merge_plan_class(PlanClass::MetadataOnly, PlanClass::SelectiveIndexed),
+            PlanClass::SelectiveIndexed
+        );
+        assert_eq!(
+            merge_plan_class(PlanClass::ExhaustiveScan, PlanClass::SelectiveIndexed),
+            PlanClass::ExhaustiveScan
+        );
+        assert_eq!(
+            merge_plan_class(PlanClass::SelectiveIndexed, PlanClass::ExhaustiveScan),
+            PlanClass::ExhaustiveScan
+        );
+        assert_eq!(
+            merge_plan_class(PlanClass::MetadataOnly, PlanClass::MetadataOnly),
+            PlanClass::MetadataOnly
+        );
+    }
+}

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -10,6 +10,7 @@ pub mod erasure;
 mod error;
 mod fetcher;
 pub mod http;
+pub mod io_shape;
 mod limiter;
 mod log_fetcher;
 pub mod log_series;

--- a/crates/ravel-query/tests/log_series_engine.rs
+++ b/crates/ravel-query/tests/log_series_engine.rs
@@ -15,7 +15,10 @@ use async_trait::async_trait;
 use axum::Router;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use ravel_catalog::{Catalog, CatalogConfig};
+use ravel_catalog::{
+    Catalog, CatalogConfig, DEFAULT_CLOCK_SKEW_ALLOWANCE_NS, DEFAULT_FOLD_SAFETY_MARGIN_NS,
+    DEFAULT_MAX_FLUSH_LIFETIME_NS,
+};
 use ravel_commit::publish::RetryPolicy;
 use ravel_commit::record::NewCommitRecord;
 use ravel_commit::{erasure, keys, publish, record, signal};
@@ -219,13 +222,32 @@ async fn publish_metric(
     ts: i64,
     value: f64,
 ) {
+    publish_metric_named(store, tenant_id, tenant_hash, "target_rps", 0, ts, value).await;
+}
+
+/// Same as `publish_metric`, naming the metric explicitly and taking an
+/// explicit `writer_seq`: used to publish a second, unrelated series so a
+/// postings-pruned resolve has something real to prune (issue #1214 finding
+/// 1's plan-class test needs the metrics lane to resolve as
+/// `SelectiveIndexed`, not `ExhaustiveScan`). Distinct `writer_seq` values
+/// keep each call's `SegmentIdentity`/`NewCommitRecord` from colliding when
+/// two segments share the same writer id.
+async fn publish_metric_named(
+    store: &MemoryStore,
+    tenant_id: &TenantId,
+    tenant_hash: TenantHash,
+    metric: &str,
+    writer_seq: u64,
+    ts: i64,
+    value: f64,
+) {
     use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
     use ravel_types::{Label, LabelSet, Sample, SeriesId};
 
     let labels = LabelSet::new(vec![
         Label {
             name: "__name__".to_string(),
-            value: "target_rps".to_string(),
+            value: metric.to_string(),
         },
         Label {
             name: "job".to_string(),
@@ -233,7 +255,7 @@ async fn publish_metric(
         },
     ])
     .expect("valid labels");
-    let series_id = SeriesId::compute(tenant_id, "target_rps", &labels).expect("series id");
+    let series_id = SeriesId::compute(tenant_id, metric, &labels).expect("series id");
     let input = SeriesInput {
         series_id,
         labels,
@@ -244,7 +266,7 @@ async fn publish_metric(
         shard: 0,
         writer_id: Uuid::from_bytes([4u8; 16]).to_string(),
         writer_epoch: 1,
-        writer_seq: 0,
+        writer_seq,
     };
     let written = SegmentWriter::write(
         vec![input],
@@ -261,7 +283,7 @@ async fn publish_metric(
         shard: 0,
         writer_id: Uuid::from_bytes([4u8; 16]),
         writer_epoch: 1,
-        writer_seq: 0,
+        writer_seq,
         object_size: written.bytes.len() as u64,
         content_hash: written.summary.blake3,
         sample_count: written.summary.sample_count,
@@ -547,6 +569,77 @@ async fn binop_between_aggregated_log_series_and_a_metrics_series() {
     assert!(
         (vector[0].value - 5.0).abs() < 1e-9,
         "8 log lines - 3 rps = 5"
+    );
+}
+
+/// The same log/metrics binop as
+/// `binop_between_aggregated_log_series_and_a_metrics_series`, but with a
+/// second, unrelated metric segment and postings built for `Signal::Metrics`
+/// so the metrics lane resolves with real pruning (`segments_pruned > 0`,
+/// `PlanClass::SelectiveIndexed`). Issue #1214 finding 1's bug was that the
+/// log lane unconditionally reported `PlanClass::ExhaustiveScan` regardless
+/// of what it itself resolved -- the log lane's `resolve_bounded` call
+/// always passes `name_filter: None`, so its own `segments_pruned` is
+/// structurally always 0 and it has no basis to claim any class at all, let
+/// alone the most severe one -- which would have dragged this query's
+/// overall `plan_class` from `SelectiveIndexed` up to `ExhaustiveScan` by
+/// `merge_plan_class`'s most-severe-wins rule, even though the log lane
+/// resolved its own segments outside of any selector-based pruning. The fix
+/// reports the log lane's contribution as `Unclassified`, which ranks below
+/// `SelectiveIndexed`, so the metrics lane's real classification survives
+/// the merge unharmed.
+#[tokio::test]
+async fn log_lane_never_escalates_a_selectively_indexed_metrics_lane_to_exhaustive_scan() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    publish_metric(&store, &tid, th, BASE + 2 * NS, 3.0).await;
+    // Unrelated metric segment: pruned for the `target_rps` selector once
+    // postings are built, fetched for a selector that names it instead.
+    publish_metric_named(&store, &tid, th, "other_metric", 1, BASE + 2 * NS, 99.0).await;
+
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let catalog = Catalog::new(backend.clone(), CatalogConfig::default()).expect("catalog");
+
+    let hour = u32::try_from(BASE / NS_PER_HOUR).expect("hour fits u32");
+    let fold_now_ns = (i64::from(hour) + 1) * NS_PER_HOUR
+        + DEFAULT_MAX_FLUSH_LIFETIME_NS
+        + DEFAULT_CLOCK_SKEW_ALLOWANCE_NS
+        + DEFAULT_FOLD_SAFETY_MARGIN_NS;
+    let report = catalog
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), fold_now_ns, &[], None)
+        .await
+        .expect("fold");
+    assert!(
+        report.postings_built,
+        "postings must build for this test to exercise pruning at all"
+    );
+
+    let engine = QueryEngine::new(Arc::new(catalog), backend, EngineConfig::default());
+
+    let (_value, stats) = engine
+        .instant_with_stats(
+            th,
+            r#"sum by (job) (count_over_time(ravel_log_lines{job="api"}[1h])) - target_rps{job="api"}"#,
+            ms(BASE + 20 * NS),
+            &[],
+            fold_now_ns,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+
+    assert_eq!(
+        stats.segments_pruned, 1,
+        "the unrelated metric segment must actually be pruned for this test to be meaningful"
+    );
+    assert_eq!(
+        stats.io_shape.plan_class,
+        ravel_query::io_shape::PlanClass::SelectiveIndexed,
+        "the log lane resolved zero segments of its own choosing (name_filter: None never \
+         prunes), and must not escalate the metrics lane's real SelectiveIndexed class to \
+         ExhaustiveScan"
     );
 }
 

--- a/crates/ravel-query/tests/postings_pruning.rs
+++ b/crates/ravel-query/tests/postings_pruning.rs
@@ -240,6 +240,97 @@ async fn pruned_and_bypassed_queries_are_bit_identical_across_formats_and_duplic
     assert_eq!(vector_bits(&bypassed_value), expected);
 }
 
+/// The same equality-vs-regex pair as
+/// `pruned_and_bypassed_queries_are_bit_identical_across_formats_and_duplicates`,
+/// but asserting on `stats.io_shape.plan_class` (issue #1214 finding 1): a
+/// real pruned resolve (seg C excluded, `segments_pruned == 1`) must report
+/// `SelectiveIndexed`, and a real exhaustive resolve of the SAME snapshot
+/// under a regex matcher that bypasses pruning (`segments_pruned == 0`, all
+/// three segments fetched) must report `ExhaustiveScan`. Before this fix
+/// both cases fell through `merge_plan_class`'s old two-way rank unchanged,
+/// so this pair already differed; the regression this pins is that
+/// `plan_class` tracks the metrics lane's OWN resolve outcome, not a
+/// constant for the query class.
+#[tokio::test]
+async fn differently_pruned_queries_report_different_plan_class() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tid = tenant("acme");
+    let th = tid.hash();
+    let hour = 5_010u32;
+    let now = now_at_seal(hour);
+    let ts = i64::from(hour) * NS_PER_HOUR + 30 * 60 * NS_PER_SEC;
+    let t_ms = ts / 1_000_000;
+
+    publish_segment(
+        store.as_ref(),
+        th,
+        Uuid::new_v4(),
+        1,
+        hour,
+        false,
+        vec![series_input(&tid, "target_metric", ts, 1.0)],
+    )
+    .await;
+    // Seg B: unrelated metric only. Pruned for the equality query, fetched
+    // for the regex-bypassed one.
+    publish_segment(
+        store.as_ref(),
+        th,
+        Uuid::new_v4(),
+        1,
+        hour,
+        false,
+        vec![series_input(&tid, "other_metric", ts, 99.0)],
+    )
+    .await;
+
+    let catalog = catalog(store.clone());
+    let report = catalog
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
+        .await
+        .expect("fold");
+    assert!(
+        report.postings_built,
+        "postings must build for this test to exercise pruning at all"
+    );
+
+    let engine = QueryEngine::new(Arc::new(catalog), store, EngineConfig::default());
+
+    let (_pruned_value, pruned_stats) = engine
+        .instant_with_stats(th, "target_metric", t_ms, &[], now, Duration::from_secs(5))
+        .await
+        .expect("equality query");
+    assert_eq!(pruned_stats.segments_pruned, 1, "seg B pruned");
+    assert_eq!(
+        pruned_stats.io_shape.plan_class,
+        ravel_query::io_shape::PlanClass::SelectiveIndexed,
+        "a resolve that actually pruned a segment must report SelectiveIndexed"
+    );
+
+    let (_bypassed_value, bypassed_stats) = engine
+        .instant_with_stats(
+            th,
+            "{__name__=~\"target_metric\"}",
+            t_ms,
+            &[],
+            now,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("regex-bypassed query");
+    assert_eq!(bypassed_stats.segments_pruned, 0);
+    assert_eq!(
+        bypassed_stats.io_shape.plan_class,
+        ravel_query::io_shape::PlanClass::ExhaustiveScan,
+        "a resolve that fetched every segment with no pruning must report ExhaustiveScan"
+    );
+
+    assert_ne!(
+        pruned_stats.io_shape.plan_class, bypassed_stats.io_shape.plan_class,
+        "two queries with different real pruning outcomes must report different plan_class"
+    );
+}
+
 /// A negative `__name__` matcher must bypass pruning entirely, even though
 /// a segment lacking the compared-against name legitimately exists (so
 /// pruning-by-absence could otherwise seem to "work" here by accident).

--- a/crates/ravel-query/tests/postings_pruning.rs
+++ b/crates/ravel-query/tests/postings_pruning.rs
@@ -240,13 +240,13 @@ async fn pruned_and_bypassed_queries_are_bit_identical_across_formats_and_duplic
     assert_eq!(vector_bits(&bypassed_value), expected);
 }
 
-/// The same equality-vs-regex pair as
+/// The same equality-vs-regex shape as
 /// `pruned_and_bypassed_queries_are_bit_identical_across_formats_and_duplicates`,
 /// but asserting on `stats.io_shape.plan_class` (issue #1214 finding 1): a
-/// real pruned resolve (seg C excluded, `segments_pruned == 1`) must report
+/// real pruned resolve (seg B excluded, `segments_pruned == 1`) must report
 /// `SelectiveIndexed`, and a real exhaustive resolve of the SAME snapshot
-/// under a regex matcher that bypasses pruning (`segments_pruned == 0`, all
-/// three segments fetched) must report `ExhaustiveScan`. Before this fix
+/// under a regex matcher that bypasses pruning (`segments_pruned == 0`, both
+/// segments fetched) must report `ExhaustiveScan`. Before this fix
 /// both cases fell through `merge_plan_class`'s old two-way rank unchanged,
 /// so this pair already differed; the regression this pins is that
 /// `plan_class` tracks the metrics lane's OWN resolve outcome, not a

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1670,12 +1670,13 @@ and rendered as `stats.io`, additive beside `stats.phases`:
 - `dependencyDepth`: the longest chain of object-store stages, across every
   segment the query opened, where a stage needed a previous stage's bytes to
   know its own keys. Four independent segment GETs report depth 1; a
-  footer-tail read that may need a dependent page fetch reports depth 3, an
-  upper bound, not a single true value: this crate cannot tell from
-  `object_size` alone whether the footer-tail guess covered the real footer
-  in one GET or needed a `FooterOutcome::NeedRange` chase for another GET
-  before the dependent page fetch, so it reports the worse of the two rather
-  than risk understating the chain. Classified structurally from each
+  footer-tail read that may need a dependent catalog fetch and a dependent
+  page fetch reports depth 4, an upper bound, not a single true value: this
+  crate cannot tell from `object_size` alone whether the footer-tail guess
+  covered the real footer in one GET or needed a `FooterOutcome::NeedRange`
+  chase for another GET before the dependent catalog and page fetches, so it
+  reports the worst case rather than risk understating the chain. Classified
+  structurally from each
   segment's `object_size` against the fetcher's whole-object threshold (the
   same size test `SegmentFetcher::open_segment` itself branches on), not
   from a live per-request trace, matching `CostEstimate`'s existing
@@ -1694,14 +1695,25 @@ and rendered as `stats.io`, additive beside `stats.phases`:
   task's scope to change).
 - `serviceBatches`: batches this query's per-segment fan-out was forced into
   by its concurrency permit: `ceil(segment_count / fetch_concurrency)`. 64
-  segments under 16 concurrent permits is 4 batches at whatever depth those
-  segments' fetches classify at. For the metrics lane this is scaled by the
-  same per-distinct-selector fan-out multiplier `stats.estimate` already
-  applies (`fetch_multiplier`, one resolve reopened once per distinct plan,
-  all contending for the same concurrency permit): a query naming two
-  distinct metrics selectors over 64 segments under 16 permits reports 8
-  batches, not 4, matching the cost estimate's own scaling instead of
-  disagreeing with it.
+  segments under 8 concurrent permits (`fetch_concurrency`'s default) is 8
+  batches at whatever depth those segments' fetches classify at. For the
+  metrics lane this is scaled by the count of DISTINCT matcher sets the
+  fetch fan-out actually issues one pass per (`distinct_plans_by_matcher` in
+  `crates/ravel-query/src/engine.rs`), not the raw plan count
+  `stats.estimate` scales by: a query naming two `SelectorPlan`s that share
+  one matcher set (`up + up offset 5m`) is fetched in one pass, so its
+  `serviceBatches` does not double, while a query naming two plans with two
+  distinct matcher sets over 64 segments under 8 permits reports 16
+  batches, not 8. This deliberately does NOT claim every plan's segment
+  fetches contend for one shared semaphore: the fan-out is a nested
+  `buffer_unordered(fetch_concurrency)` over distinct plans, each running
+  its own `buffer_unordered(fetch_concurrency)` over that plan's segments
+  (`prefetch_metric_plans`/`fetch_all_samples_and_histograms`), and the one
+  pool genuinely shared across every concurrent segment fetch in a query is
+  `SegmentFetcher::get_semaphore`, sized `DEFAULT_MAX_CONCURRENT_GETS` (16)
+  for the metrics fetcher -- a different, larger number than
+  `fetch_concurrency` (8), and a pre-existing mismatch this field does not
+  attempt to close.
 - `unfoldedSegmentsResolved`: the EXACT (never estimated) count of segments
   this query's resolve took from the recent (unfolded) listing path rather
   than a folded snapshot part (`SegmentOrigin::Recent`, ADR-0073 decision 1).
@@ -1743,17 +1755,23 @@ segment-fetch chain) can only be equal to or greater than what is reported.
 A federated query (a metrics lane and a log lane) folds both lanes'
 contributions together. The two lanes run STRICTLY SERIALLY -- the log
 lane's resolve is only reached after the metrics lane has already been
-awaited to completion, never alongside it -- and that seriality is why the
-fields below do not all combine the same way:
-`listPageDepth` ADDS across lanes (two serial phases' page counts sum: a
-query whose metrics lane paginated 4 LIST pages and whose log lane
-paginated 2 more waited through 6 serial pages, not 4).
-`dependencyDepth`/`serviceBatches` still take the max across lanes, but not
-because the lanes run concurrently (they do not): the log lane's fetch
-chain has no DATA dependency on the metrics lane's bytes, so the two chains
-are independent chains that happen to run one after the other, and the
-reported figure is the longest (or most-batched) independent chain, not
-their sum.
+awaited to completion, never alongside it -- and each field's combining
+rule follows from one criterion, not from the same criterion applied
+loosely three times:
+`listPageDepth` and `serviceBatches` are both SERIALIZATION-ROUND counts
+(the number of sequential rounds a lane's own fan-out actually waited
+through), and ADD across lanes for that reason: because the lanes never
+overlap, the rounds a query waits through end-to-end are one lane's rounds
+followed by the other's. A query whose metrics lane paginated 4 LIST pages
+and whose log lane paginated 2 more waited through 6 serial pages, not 4,
+and a query whose metrics fetch was forced into 3 concurrency-permit
+batches and whose log fetch needed 2 more waited through 5 serial batches,
+not `max(3, 2)`.
+`dependencyDepth` uses a DIFFERENT criterion -- DATA independence, not
+serialization order -- and stays max-based across lanes: the log lane's
+fetch chain has no DATA dependency on the metrics lane's bytes, so the two
+chains are independent chains that happen to run one after the other, and
+the reported figure is the longest independent chain, not their sum.
 `unfoldedSegmentsResolved` sums across lanes (an exact total count, with no
 ambiguity about how the two lanes' costs compose), and `planClass` takes
 the more severe of the two (`exhaustive_scan` outranks `selective_indexed`

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1693,14 +1693,14 @@ and rendered as `stats.io`, additive beside `stats.phases`:
   shards' LIST pages ran concurrently with each other or one after another,
   only that they happened (`ravel-catalog` owns that fan-out; out of this
   task's scope to change).
-- `serviceBatches`: batches this query's per-segment fan-out was forced into
-  by the binding concurrency it actually ran under. The metrics fetch is a
-  NESTED fan-out with three levels of admission, all of which bound the
-  batch count: an OUTER `buffer_unordered(promql_fetch_fanout)` over
-  distinct matcher plans (`distinct_plans_by_matcher` in
-  `crates/ravel-query/src/engine.rs`), which admits at most
-  `promql_fetch_fanout` plans at once, however many distinct matcher sets
-  the query has; each admitted plan's own INNER
+- `serviceBatches`: a LOWER bound on the serial service rounds this query's
+  per-segment fan-out needed, under a wave-synchronous model of the nested
+  fan-out. The metrics fetch is a NESTED fan-out with three levels of
+  admission, all of which bound the round count: an OUTER
+  `buffer_unordered(promql_fetch_fanout)` over distinct matcher plans
+  (`distinct_plans_by_matcher` in `crates/ravel-query/src/engine.rs`), which
+  admits at most `promql_fetch_fanout` plans at once, however many distinct
+  matcher sets the query has; each admitted plan's own INNER
   `buffer_unordered(promql_fetch_fanout)` over that plan's segments
   (`prefetch_metric_plans`/`fetch_all_samples_and_histograms`); and the one
   shared `GetLimiter` described under "GET concurrency (ADR-1195)" above,
@@ -1710,29 +1710,44 @@ and rendered as `stats.io`, additive beside `stats.phases`:
   figure models: it says nothing about GETs another engine in the same
   process issues, and nothing about the RLOG whole-object funnel, which
   takes no permit at all.
-  The outer and inner levels do not multiply freely: plan capacity is
-  `promql_fetch_fanout * min(distinctMatcherSets, promql_fetch_fanout)`, not
-  `promql_fetch_fanout * distinctMatcherSets` -- the outer stream can never
-  have more than `promql_fetch_fanout` plans in flight even when there are
-  more distinct matcher sets than that. So the binding concurrency is
-  `min(promql_fetch_fanout * min(distinctMatcherSets, promql_fetch_fanout),
-  sharedGetPermits)`, and the work this fan-out issues is `segment_count *
-  distinctMatcherSets` GETs, uncapped (distinct matcher sets, not the raw
-  plan count `stats.estimate` scales by -- a query naming two `SelectorPlan`s
+  It is a lower bound, never an upper bound or an exact count, because the
+  OUTER `buffer_unordered` is a SLIDING window, not a wave-synchronous one:
+  as soon as one admitted plan finishes, the next plan is admitted
+  immediately, without waiting for its siblings. Modeling it as
+  wave-synchronous anyway -- one binding concurrency
+  (`min(promql_fetch_fanout * min(distinctMatcherSets,
+  promql_fetch_fanout), sharedGetPermits)`) dividing the total work
+  (`segment_count * distinctMatcherSets` GETs) in a single division --
+  undercounts whenever the outer window is not full for the query's whole
+  duration: 3 distinct matcher sets, 1 segment each, `promql_fetch_fanout`
+  2, and 1000 shared permits gives peak capacity `min(2 * 2, 1000) = 4`, so
+  that single division reports `ceil(3 / 4) = 1` round, but plans 1 and 2
+  admit together in the first round and plan 3 only after one of them
+  finishes, in a second round -- the real schedule needs at least 2 rounds,
+  not 1.
+  So this figure is computed per WAVE of the outer fan-out instead: `waves
+  = ceil(distinctMatcherSets / promql_fetch_fanout)`; for 0-based wave `w`,
+  `active_w = min(promql_fetch_fanout, distinctMatcherSets - w *
+  promql_fetch_fanout)` plans are admitted, `capacity_w =
+  min(promql_fetch_fanout * active_w, sharedGetPermits)` is that wave's
+  binding concurrency, and `batches_w = ceil(segment_count * active_w /
+  capacity_w)` is its own serial round count; `serviceBatches` sums
+  `batches_w` over every wave (distinct matcher sets, not the raw plan
+  count `stats.estimate` scales by -- a query naming two `SelectorPlan`s
   that share one matcher set, `up + up offset 5m`, is fetched in one pass,
-  so its `serviceBatches` does not double; every distinct matcher set still
-  issues its own GETs, just not all of them concurrently). 64 segments,
-  `promql_fetch_fanout` 8, two distinct matcher sets, and 16 shared permits
-  gives 128 GETs at binding concurrency `min(8 * min(2, 8), 16) = min(16,
-  16) = 16`, i.e. 8 batches, not `ceil(64 * 2 / 8) = 16`: dividing the
-  plan-multiplied numerator by the un-multiplied fan-out width alone
-  double-counts the plan fan-out. Conversely, `promql_fetch_fanout` 1 with
-  three distinct matcher sets, 20 segments, and 1000 shared permits gives
-  binding concurrency `min(1 * min(3, 1), 1000) = 1`, i.e. 60 batches (60
-  GETs one at a time) -- capping the multiplier by `sharedGetPermits` alone,
-  without also capping it by `promql_fetch_fanout`, would have reported 20,
-  silently assuming all 3 plans ran at once when the outer stream never
-  admits more than 1. A single-plan query reduces to
+  so its `serviceBatches` does not double). This sum is still a lower
+  bound, never exact: the sliding window can only pack work at least as
+  tightly as the wave-synchronous model assumes, never more loosely, so the
+  real scheduler takes at least this many rounds. 64 segments,
+  `promql_fetch_fanout` 8, two distinct matcher sets, and 16 shared permits:
+  one wave, `active_0 = 2`, `capacity_0 = min(16, 16) = 16`, `batches_0 =
+  ceil(128 / 16) = 8`. `promql_fetch_fanout` 1 with three distinct matcher
+  sets, 20 segments, and 1000 shared permits: three waves, each `active_w =
+  1`, `capacity_w = min(1, 1000) = 1`, `batches_w = ceil(20 / 1) = 20`,
+  summing to 60 -- not the 20 a single `min(1 * 3, 1000) = 3`-capacity
+  division would report, which would silently assume all 3 plans ran at
+  once when the outer stream never admits more than 1. A single-plan query
+  always has exactly one wave with `active_0 = 1`, reducing to
   `ceil(segment_count / promql_fetch_fanout)`, since `min(promql_fetch_fanout,
   sharedGetPermits)` is the fan-out width whenever the shared pool is at
   least as large as one plan's own fan-out bound, as it is for any config

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1670,14 +1670,20 @@ and rendered as `stats.io`, additive beside `stats.phases`:
 - `dependencyDepth`: the longest chain of object-store stages, across every
   segment the query opened, where a stage needed a previous stage's bytes to
   know its own keys. Four independent segment GETs report depth 1; a
-  footer-tail read whose bytes name a page's byte range, followed by that
-  page's dependent GET, reports depth 2. Classified structurally from each
+  footer-tail read that may need a dependent page fetch reports depth 3, an
+  upper bound, not a single true value: this crate cannot tell from
+  `object_size` alone whether the footer-tail guess covered the real footer
+  in one GET or needed a `FooterOutcome::NeedRange` chase for another GET
+  before the dependent page fetch, so it reports the worse of the two rather
+  than risk understating the chain. Classified structurally from each
   segment's `object_size` against the fetcher's whole-object threshold (the
   same size test `SegmentFetcher::open_segment` itself branches on), not
   from a live per-request trace, matching `CostEstimate`'s existing
-  upper-envelope convention: a fully-cached large segment still reports
-  depth 2, because the plan has two dependent stages even when a cache
-  absorbs the second one.
+  upper-envelope convention: a fully-cached large segment still reports its
+  structural depth, because the plan has that many dependent stages even
+  when a cache absorbs one. A segment with unknown size (`object_size == 0`)
+  also takes the footer-tail path, not the whole-object path, and reports
+  the same upper bound.
 - `listPageDepth`: serial LIST pages, recorded independently of
   `dependencyDepth` because pagination (`Catalog::list_shard_hours`) and the
   GET dependency chain are different object-store mechanisms with different
@@ -1689,7 +1695,13 @@ and rendered as `stats.io`, additive beside `stats.phases`:
 - `serviceBatches`: batches this query's per-segment fan-out was forced into
   by its concurrency permit: `ceil(segment_count / fetch_concurrency)`. 64
   segments under 16 concurrent permits is 4 batches at whatever depth those
-  segments' fetches classify at.
+  segments' fetches classify at. For the metrics lane this is scaled by the
+  same per-distinct-selector fan-out multiplier `stats.estimate` already
+  applies (`fetch_multiplier`, one resolve reopened once per distinct plan,
+  all contending for the same concurrency permit): a query naming two
+  distinct metrics selectors over 64 segments under 16 permits reports 8
+  batches, not 4, matching the cost estimate's own scaling instead of
+  disagreeing with it.
 - `unfoldedSegmentsResolved`: the EXACT (never estimated) count of segments
   this query's resolve took from the recent (unfolded) listing path rather
   than a folded snapshot part (`SegmentOrigin::Recent`, ADR-0073 decision 1).
@@ -1706,10 +1718,18 @@ and rendered as `stats.io`, additive beside `stats.phases`:
   counting it here would overstate the fold benefit.
 - `planClass`: `metadata_only` (a labels/label-values/series discovery query
   that never reaches a page fetch), `selective_indexed` (the resolve's
-  postings-based pruning excluded at least one snapshot-sourced segment), or
+  postings-based pruning excluded at least one snapshot-sourced segment),
   `exhaustive_scan` (every listed segment in the resolved window was
-  opened). Decided before any segment is opened, from the query's shape and
-  the resolve's own pruning outcome, not from the fetch's actual cost.
+  opened), or `unclassified` (the lane's own resolve carries no signal this
+  crate can use to tell a pruned fetch from a full scan). The log lane
+  always reports `unclassified`: `resolve_bounded` always resolves
+  `Signal::Logs` with `name_filter: None` (ADR-1103's log discovery has no
+  name-postings filter to prune against), so `Snapshot::segments_pruned` is
+  structurally always 0 for that lane no matter how narrow the resolved
+  window actually is, and reporting `exhaustive_scan` on that basis alone
+  would be a fabricated severity this crate cannot back up. Decided before
+  any segment is opened, from the query's shape and the resolve's own
+  pruning outcome, not from the fetch's actual cost.
 
 What is knowable from `ravel-query`, and what is not: the per-segment fetch
 pipeline this crate owns is visible here, so `dependencyDepth` reflects it
@@ -1720,14 +1740,27 @@ sequence it takes) lives entirely inside `ravel-catalog`; `dependencyDepth`
 therefore reports only the segment-fetch chain's depth, and the true
 end-to-end depth (resolve's own chain, however deep, prefixed to the
 segment-fetch chain) can only be equal to or greater than what is reported.
-A federated query (a metrics lane and a log lane, prefetched independently)
-folds both lanes' contributions together: `dependencyDepth`/
-`listPageDepth`/`serviceBatches` take the max across lanes (the longer
-chain wins, since the two lanes' chains ran alongside each other, not one
-after the other), `unfoldedSegmentsResolved` sums across lanes (an exact
-total count), and `planClass` takes the more severe of the two
-(`exhaustive_scan` outranks `selective_indexed` outranks `metadata_only`),
-so a lane that never ran cannot understate a lane that did.
+A federated query (a metrics lane and a log lane) folds both lanes'
+contributions together. The two lanes run STRICTLY SERIALLY -- the log
+lane's resolve is only reached after the metrics lane has already been
+awaited to completion, never alongside it -- and that seriality is why the
+fields below do not all combine the same way:
+`listPageDepth` ADDS across lanes (two serial phases' page counts sum: a
+query whose metrics lane paginated 4 LIST pages and whose log lane
+paginated 2 more waited through 6 serial pages, not 4).
+`dependencyDepth`/`serviceBatches` still take the max across lanes, but not
+because the lanes run concurrently (they do not): the log lane's fetch
+chain has no DATA dependency on the metrics lane's bytes, so the two chains
+are independent chains that happen to run one after the other, and the
+reported figure is the longest (or most-batched) independent chain, not
+their sum.
+`unfoldedSegmentsResolved` sums across lanes (an exact total count, with no
+ambiguity about how the two lanes' costs compose), and `planClass` takes
+the more severe of the two (`exhaustive_scan` outranks `selective_indexed`
+outranks `unclassified` outranks `metadata_only`), so a lane that never ran
+cannot understate a lane that did, and the log lane's `unclassified` result
+cannot fabricate a worse classification than a metrics lane that pruned
+correctly.
 
 `stats.io` carries no object keys, field values, predicates, or index
 terms: every figure is a structural count.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1694,26 +1694,36 @@ and rendered as `stats.io`, additive beside `stats.phases`:
   only that they happened (`ravel-catalog` owns that fan-out; out of this
   task's scope to change).
 - `serviceBatches`: batches this query's per-segment fan-out was forced into
-  by its concurrency permit: `ceil(segment_count / fetch_concurrency)`. 64
-  segments under 8 concurrent permits (`fetch_concurrency`'s default) is 8
-  batches at whatever depth those segments' fetches classify at. For the
-  metrics lane this is scaled by the count of DISTINCT matcher sets the
-  fetch fan-out actually issues one pass per (`distinct_plans_by_matcher` in
-  `crates/ravel-query/src/engine.rs`), not the raw plan count
-  `stats.estimate` scales by: a query naming two `SelectorPlan`s that share
-  one matcher set (`up + up offset 5m`) is fetched in one pass, so its
-  `serviceBatches` does not double, while a query naming two plans with two
-  distinct matcher sets over 64 segments under 8 permits reports 16
-  batches, not 8. This deliberately does NOT claim every plan's segment
-  fetches contend for one shared semaphore: the fan-out is a nested
-  `buffer_unordered(fetch_concurrency)` over distinct plans, each running
-  its own `buffer_unordered(fetch_concurrency)` over that plan's segments
-  (`prefetch_metric_plans`/`fetch_all_samples_and_histograms`), and the one
-  pool genuinely shared across every concurrent segment fetch in a query is
-  `SegmentFetcher::get_semaphore`, sized `DEFAULT_MAX_CONCURRENT_GETS` (16)
-  for the metrics fetcher -- a different, larger number than
-  `fetch_concurrency` (8), and a pre-existing mismatch this field does not
-  attempt to close.
+  by the binding concurrency it actually ran under. The metrics fetch is a
+  NESTED fan-out: one `buffer_unordered(promql_fetch_fanout)` over distinct
+  matcher plans (`distinct_plans_by_matcher` in
+  `crates/ravel-query/src/engine.rs`), each running its own
+  `buffer_unordered(promql_fetch_fanout)` over that plan's segments
+  (`prefetch_metric_plans`/`fetch_all_samples_and_histograms`). Those inner
+  streams do not get independent budgets: every GET from every plan passes
+  through the one shared `GetLimiter` described under "GET concurrency
+  (ADR-1195)" above, whose permit count is the resolved
+  `store_get_concurrency`. That limiter is shared inside one `QueryEngine`,
+  which is the scope this figure models: it says nothing about GETs another
+  engine in the same process issues, and nothing about the RLOG
+  whole-object funnel, which takes no permit at all. So the binding
+  concurrency is `min(distinctMatcherSets * promql_fetch_fanout,
+  sharedGetPermits)`, and the work this fan-out issues is
+  `segment_count * distinctMatcherSets` GETs (distinct matcher sets, not the
+  raw plan count `stats.estimate` scales by -- a query naming two
+  `SelectorPlan`s that share one matcher set, `up + up offset 5m`, is
+  fetched in one pass, so its `serviceBatches` does not double). 64 segments,
+  `promql_fetch_fanout` 8, two distinct matcher sets, and 16 shared permits
+  gives 128 GETs at binding concurrency `min(16, 16) = 16`, i.e. 8 batches,
+  not `ceil(64 * 2 / 8) = 16`: dividing the plan-multiplied numerator by the
+  un-multiplied fan-out width alone double-counts the plan fan-out. A
+  single-plan query reduces to `ceil(segment_count / promql_fetch_fanout)`,
+  since `min(promql_fetch_fanout, sharedGetPermits)` is the fan-out width
+  whenever the shared pool is at least as large as one plan's own fan-out
+  bound, as it is for any config that leaves both ADR-1195 knobs unset (both
+  then resolve to `fetch_concurrency`). Lower `--store-get-concurrency`
+  below `--promql-fetch-fanout` and the limiter binds instead, for a
+  single-plan query too; this figure follows whichever bound is smaller.
 - `unfoldedSegmentsResolved`: the EXACT (never estimated) count of segments
   this query's resolve took from the recent (unfolded) listing path rather
   than a folded snapshot part (`SegmentOrigin::Recent`, ADR-0073 decision 1).

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1652,6 +1652,77 @@ cost fields alongside the existing `segmentsFetched`/`segmentsPruned`:
   `s3HeadRequests`/`s3HeadBytes`, `s3ListBytes`, and
   `peakIntermediateBytes` (SQL executor only).
 
+### I/O dependency shape (issue #1214)
+
+`stats.phases` above answers "how many requests and bytes did each phase
+spend." It cannot answer a different question: how many of those requests
+had to run one after another because a later stage needed an earlier
+stage's bytes to know its own keys, versus how many ran in one concurrent
+round. **Dependency depth and phase cost are different dimensions**: a
+query can be cheap by `stats.phases` (few requests, few bytes) and still be
+slow because its requests chain, and a query can be expensive by request
+count and still be fast because every request ran at depth 1. Neither
+number predicts the other.
+
+`crates/ravel-query/src/io_shape.rs`'s `QueryIoShape` is recorded per query
+and rendered as `stats.io`, additive beside `stats.phases`:
+
+- `dependencyDepth`: the longest chain of object-store stages, across every
+  segment the query opened, where a stage needed a previous stage's bytes to
+  know its own keys. Four independent segment GETs report depth 1; a
+  footer-tail read whose bytes name a page's byte range, followed by that
+  page's dependent GET, reports depth 2. Classified structurally from each
+  segment's `object_size` against the fetcher's whole-object threshold (the
+  same size test `SegmentFetcher::open_segment` itself branches on), not
+  from a live per-request trace, matching `CostEstimate`'s existing
+  upper-envelope convention: a fully-cached large segment still reports
+  depth 2, because the plan has two dependent stages even when a cache
+  absorbs the second one.
+- `listPageDepth`: serial LIST pages, recorded independently of
+  `dependencyDepth` because pagination (`Catalog::list_shard_hours`) and the
+  GET dependency chain are different object-store mechanisms with different
+  causes. Reported as the resolve phase's total LIST request count, an
+  upper-bound serial depth: this crate cannot see from here whether two
+  shards' LIST pages ran concurrently with each other or one after another,
+  only that they happened (`ravel-catalog` owns that fan-out; out of this
+  task's scope to change).
+- `serviceBatches`: batches this query's per-segment fan-out was forced into
+  by its concurrency permit: `ceil(segment_count / fetch_concurrency)`. 64
+  segments under 16 concurrent permits is 4 batches at whatever depth those
+  segments' fetches classify at.
+- `unfoldedRecordsResolved`: the EXACT (never estimated) count of commit
+  records this query's resolve took from the recent (unfolded) listing path
+  rather than a folded snapshot part (`SegmentOrigin::Recent`, ADR-0073
+  decision 1). Exact because it gates a downstream fold-benefit decision an
+  approximation would silently corrupt.
+- `planClass`: `metadata_only` (a labels/label-values/series discovery query
+  that never reaches a page fetch), `selective_indexed` (the resolve's
+  postings-based pruning excluded at least one snapshot-sourced segment), or
+  `exhaustive_scan` (every listed segment in the resolved window was
+  opened). Decided before any segment is opened, from the query's shape and
+  the resolve's own pruning outcome, not from the fetch's actual cost.
+
+What is knowable from `ravel-query`, and what is not: the per-segment fetch
+pipeline this crate owns is visible here, so `dependencyDepth` reflects it
+directly. What is NOT knowable from this crate: the catalog snapshot
+resolve's own internal dependency chain
+(`Catalog::resolve_pruned_with_generations` and any HEAD-then-part-GET
+sequence it takes) lives entirely inside `ravel-catalog`; `dependencyDepth`
+therefore reports only the segment-fetch chain's depth, and the true
+end-to-end depth (resolve's own chain, however deep, prefixed to the
+segment-fetch chain) can only be equal to or greater than what is reported.
+A federated query (a metrics lane and a log lane, prefetched independently)
+folds both lanes' contributions together: `dependencyDepth`/
+`listPageDepth`/`serviceBatches` take the max across lanes (the longer
+chain wins, since the two lanes' chains ran alongside each other, not one
+after the other), `unfoldedRecordsResolved` sums across lanes (an exact
+total count), and `planClass` takes the more severe of the two
+(`exhaustive_scan` outranks `selective_indexed` outranks `metadata_only`),
+so a lane that never ran cannot understate a lane that did.
+
+`stats.io` carries no object keys, field values, predicates, or index
+terms: every figure is a structural count.
+
 ## PromQL conformance (ADR-0035)
 
 What Ravel supports, what it deliberately refuses, and what is merely

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1652,7 +1652,7 @@ cost fields alongside the existing `segmentsFetched`/`segmentsPruned`:
   `s3HeadRequests`/`s3HeadBytes`, `s3ListBytes`, and
   `peakIntermediateBytes` (SQL executor only).
 
-### I/O dependency shape (issue #1214)
+### I/O dependency shape
 
 `stats.phases` above answers "how many requests and bytes did each phase
 spend." It cannot answer a different question: how many of those requests

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1695,35 +1695,51 @@ and rendered as `stats.io`, additive beside `stats.phases`:
   task's scope to change).
 - `serviceBatches`: batches this query's per-segment fan-out was forced into
   by the binding concurrency it actually ran under. The metrics fetch is a
-  NESTED fan-out: one `buffer_unordered(promql_fetch_fanout)` over distinct
-  matcher plans (`distinct_plans_by_matcher` in
-  `crates/ravel-query/src/engine.rs`), each running its own
+  NESTED fan-out with three levels of admission, all of which bound the
+  batch count: an OUTER `buffer_unordered(promql_fetch_fanout)` over
+  distinct matcher plans (`distinct_plans_by_matcher` in
+  `crates/ravel-query/src/engine.rs`), which admits at most
+  `promql_fetch_fanout` plans at once, however many distinct matcher sets
+  the query has; each admitted plan's own INNER
   `buffer_unordered(promql_fetch_fanout)` over that plan's segments
-  (`prefetch_metric_plans`/`fetch_all_samples_and_histograms`). Those inner
-  streams do not get independent budgets: every GET from every plan passes
-  through the one shared `GetLimiter` described under "GET concurrency
-  (ADR-1195)" above, whose permit count is the resolved
-  `store_get_concurrency`. That limiter is shared inside one `QueryEngine`,
-  which is the scope this figure models: it says nothing about GETs another
-  engine in the same process issues, and nothing about the RLOG
-  whole-object funnel, which takes no permit at all. So the binding
-  concurrency is `min(distinctMatcherSets * promql_fetch_fanout,
-  sharedGetPermits)`, and the work this fan-out issues is
-  `segment_count * distinctMatcherSets` GETs (distinct matcher sets, not the
-  raw plan count `stats.estimate` scales by -- a query naming two
-  `SelectorPlan`s that share one matcher set, `up + up offset 5m`, is
-  fetched in one pass, so its `serviceBatches` does not double). 64 segments,
+  (`prefetch_metric_plans`/`fetch_all_samples_and_histograms`); and the one
+  shared `GetLimiter` described under "GET concurrency (ADR-1195)" above,
+  whose permit count is the resolved `store_get_concurrency` and which every
+  GET from every plan passes through regardless of which level admitted it.
+  That limiter is shared inside one `QueryEngine`, which is the scope this
+  figure models: it says nothing about GETs another engine in the same
+  process issues, and nothing about the RLOG whole-object funnel, which
+  takes no permit at all.
+  The outer and inner levels do not multiply freely: plan capacity is
+  `promql_fetch_fanout * min(distinctMatcherSets, promql_fetch_fanout)`, not
+  `promql_fetch_fanout * distinctMatcherSets` -- the outer stream can never
+  have more than `promql_fetch_fanout` plans in flight even when there are
+  more distinct matcher sets than that. So the binding concurrency is
+  `min(promql_fetch_fanout * min(distinctMatcherSets, promql_fetch_fanout),
+  sharedGetPermits)`, and the work this fan-out issues is `segment_count *
+  distinctMatcherSets` GETs, uncapped (distinct matcher sets, not the raw
+  plan count `stats.estimate` scales by -- a query naming two `SelectorPlan`s
+  that share one matcher set, `up + up offset 5m`, is fetched in one pass,
+  so its `serviceBatches` does not double; every distinct matcher set still
+  issues its own GETs, just not all of them concurrently). 64 segments,
   `promql_fetch_fanout` 8, two distinct matcher sets, and 16 shared permits
-  gives 128 GETs at binding concurrency `min(16, 16) = 16`, i.e. 8 batches,
-  not `ceil(64 * 2 / 8) = 16`: dividing the plan-multiplied numerator by the
-  un-multiplied fan-out width alone double-counts the plan fan-out. A
-  single-plan query reduces to `ceil(segment_count / promql_fetch_fanout)`,
-  since `min(promql_fetch_fanout, sharedGetPermits)` is the fan-out width
-  whenever the shared pool is at least as large as one plan's own fan-out
-  bound, as it is for any config that leaves both ADR-1195 knobs unset (both
-  then resolve to `fetch_concurrency`). Lower `--store-get-concurrency`
-  below `--promql-fetch-fanout` and the limiter binds instead, for a
-  single-plan query too; this figure follows whichever bound is smaller.
+  gives 128 GETs at binding concurrency `min(8 * min(2, 8), 16) = min(16,
+  16) = 16`, i.e. 8 batches, not `ceil(64 * 2 / 8) = 16`: dividing the
+  plan-multiplied numerator by the un-multiplied fan-out width alone
+  double-counts the plan fan-out. Conversely, `promql_fetch_fanout` 1 with
+  three distinct matcher sets, 20 segments, and 1000 shared permits gives
+  binding concurrency `min(1 * min(3, 1), 1000) = 1`, i.e. 60 batches (60
+  GETs one at a time) -- capping the multiplier by `sharedGetPermits` alone,
+  without also capping it by `promql_fetch_fanout`, would have reported 20,
+  silently assuming all 3 plans ran at once when the outer stream never
+  admits more than 1. A single-plan query reduces to
+  `ceil(segment_count / promql_fetch_fanout)`, since `min(promql_fetch_fanout,
+  sharedGetPermits)` is the fan-out width whenever the shared pool is at
+  least as large as one plan's own fan-out bound, as it is for any config
+  that leaves both ADR-1195 knobs unset (both then resolve to
+  `fetch_concurrency`). Lower `--store-get-concurrency` below
+  `--promql-fetch-fanout` and the limiter binds instead, for a single-plan
+  query too; this figure follows whichever bound is smaller.
 - `unfoldedSegmentsResolved`: the EXACT (never estimated) count of segments
   this query's resolve took from the recent (unfolded) listing path rather
   than a folded snapshot part (`SegmentOrigin::Recent`, ADR-0073 decision 1).

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1690,11 +1690,20 @@ and rendered as `stats.io`, additive beside `stats.phases`:
   by its concurrency permit: `ceil(segment_count / fetch_concurrency)`. 64
   segments under 16 concurrent permits is 4 batches at whatever depth those
   segments' fetches classify at.
-- `unfoldedRecordsResolved`: the EXACT (never estimated) count of commit
-  records this query's resolve took from the recent (unfolded) listing path
-  rather than a folded snapshot part (`SegmentOrigin::Recent`, ADR-0073
-  decision 1). Exact because it gates a downstream fold-benefit decision an
-  approximation would silently corrupt.
+- `unfoldedSegmentsResolved`: the EXACT (never estimated) count of segments
+  this query's resolve took from the recent (unfolded) listing path rather
+  than a folded snapshot part (`SegmentOrigin::Recent`, ADR-0073 decision 1).
+  Exact because it gates a downstream fold-benefit decision an approximation
+  would silently corrupt. A SEGMENT count, not a commit-record count:
+  `SegmentOrigin` is parallel to `Snapshot::segments` (one entry per resolved
+  `SegmentRef`), and a multi-part L1 compaction record contributes one
+  `Recent` entry per part, so this figure counts every part, not the single
+  underlying compaction record. `ravel-query` cannot recover the record
+  count from `SegmentOrigin` alone, so the field is named for the quantity
+  it actually counts. Excludes `SegmentOrigin::TokenResolved`: a
+  read-your-write token match always costs its own GET by explicit key,
+  whether or not a fold has run, so folding can never remove that cost and
+  counting it here would overstate the fold benefit.
 - `planClass`: `metadata_only` (a labels/label-values/series discovery query
   that never reaches a page fetch), `selective_indexed` (the resolve's
   postings-based pruning excluded at least one snapshot-sourced segment), or
@@ -1715,7 +1724,7 @@ A federated query (a metrics lane and a log lane, prefetched independently)
 folds both lanes' contributions together: `dependencyDepth`/
 `listPageDepth`/`serviceBatches` take the max across lanes (the longer
 chain wins, since the two lanes' chains ran alongside each other, not one
-after the other), `unfoldedRecordsResolved` sums across lanes (an exact
+after the other), `unfoldedSegmentsResolved` sums across lanes (an exact
 total count), and `planClass` takes the more severe of the two
 (`exhaustive_scan` outranks `selective_indexed` outranks `metadata_only`),
 so a lane that never ran cannot understate a lane that did.


### PR DESCRIPTION
`PhaseAccounting` answers which phase spent a request. It cannot answer how
many dependent network waits were on the critical path: four parallel GETs and
four chained ones produce the same counter, which is what lets a change improve
request count while latency stays flat.

This adds an orthogonal per-query model, rendered as an additive `io` object in
query stats beside the existing `phases` array:

- `dependency_depth`, the longest chain of object-store stages where a stage
  needs a previous stage's bytes to know its own keys.
- `list_page_depth`, serial LIST pages, separate because page n+1 needs page
  n's continuation token.
- `service_batches`, the batches a concurrency permit forces a fan-out into.
- `unfolded_segments_resolved`, segments taken from the recent listing path
  rather than a folded snapshot part.
- `plan_class`: metadata_only, unclassified, selective_indexed or
  exhaustive_scan.

All of it is observation-only. Nothing reads these figures to decide what to
fetch or return, and nothing fails a query on them; the existing request, byte,
memory and deadline budgets remain the only things that do.

Not exposed as SQL. `crates/ravel-sql/src/validate.rs` rejects every `EXPLAIN`
form before planning under security invariant 1, and this does not change that.

Three adversarial review rounds shaped what the figures mean, and two claims
made in the intermediate commit messages on this branch did not survive them.
Both are retracted here, since those messages land on main under rebase-merge:

- `ed5125fe` says the branch pins the segments-versus-records distinction with
  a fixture where the two diverge. It does not. `count_unfolded_segments` takes
  a `&[SegmentOrigin]` slice and structurally cannot tell a segment from a
  record; that property belongs to ravel-catalog's construction of
  `SegmentOrigins` (`catalog.rs:1687`), which this crate cites rather than
  proves. The test is now named for the arithmetic it can actually fail on.
- `ce5cd476` says the metrics plans all share one concurrency semaphore. They
  do not. The metrics fan-out is a nested `buffer_unordered` over plans times
  segments, and the only shared pool is `SegmentFetcher::get_semaphore`, sized
  `DEFAULT_MAX_CONCURRENT_GETS` rather than `fetch_concurrency`.

Two findings from those reviews are reported and not fixed here: the 8-versus-16
divisor mismatch between `fetch_concurrency` and the shared GET semaphore, and
the logs lane discarding its own real `segments_pruned` (#1228), which is why
the log lane reports `unclassified` rather than a computed class.

Refs: #1214
Refs: #1199
