### PR TITLE
test: pin five catalog, ingest and fleet claims the TLA+ suite named

### DIFF
--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -5159,6 +5159,91 @@ mod tests {
         );
     }
 
+    /// Test debt (formal/tla/TRACEABILITY.md, catalog row 1, `DoFoldCas`
+    /// fold-lifetime bound / `DoFoldRebase`): a fold that LISTs a bucket
+    /// before a compaction supersedes one of its L0 inputs, and whose own
+    /// publishing CAS lands only after that input's superseded-sweep horizon
+    /// has passed (so a real deployment's maintenance process would already
+    /// have physically deleted it), must never publish a snapshot that names
+    /// the swept input. `fold_reconcile_window_hours` (default 26, see
+    /// `config.rs`) is sized in hours-behind-watermark specifically so this
+    /// holds regardless of how much wall-clock time elapses: the reconcile
+    /// pass re-lists the bucket and excludes the input by matching the
+    /// compaction record's own input list, never by re-reading the (possibly
+    /// already-gone) input object itself.
+    #[tokio::test]
+    async fn fold_that_lists_before_a_compaction_and_cas_after_the_sweep_horizon_does_not_name_a_swept_input()
+     {
+        let store = Arc::new(MemoryStore::new());
+        let cfg = CatalogConfig {
+            shard_count: 1,
+            snapshot_part_max_entries: 1,
+            ..Default::default()
+        };
+        let catalog = Catalog::new(store.clone(), cfg).expect("catalog");
+
+        // Hour 10 seals into its own part; hour 11 is the tail. This fold's
+        // LIST of hour 10 sees only the raw L0 segment: no compaction exists
+        // yet.
+        let now_1 = now_at_seal(11);
+        let writer_a = Uuid::new_v4();
+        let seg_a = publish_segment(&store, 0, writer_a, 1, 10, now_1 - 2 * NS_PER_HOUR).await;
+        publish_segment(&store, 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
+        let first = catalog
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
+            .await
+            .expect("first fold");
+        assert_eq!(first.parts_total, 2);
+        assert_eq!(first.entry_count, 2);
+
+        // A compaction lands in the already-sealed, already-folded hour 10,
+        // superseding seg_a's L0 with one L1 part.
+        publish_compaction(&store, 0, 10, &[&seg_a], now_1).await;
+
+        // Simulate the superseded-input sweep: once `protection_horizon_ns`
+        // has elapsed past the compaction's own `created_unix_ns`, a real
+        // maintenance process would physically delete seg_a's commit record
+        // and data object (docs/deletion-and-gc.md's superseded-input sweep
+        // row). Do that directly here (ravel-maintain is out of this task's
+        // scope) so the SECOND fold below runs against a bucket where the
+        // swept input is already gone from the store, not merely superseded.
+        let commit_key = keys::commit_key_for_record(&seg_a).expect("commit key");
+        let data_key = keys::reconstruct_data_key(&seg_a).expect("data key");
+        store
+            .delete(&commit_key)
+            .await
+            .expect("delete swept commit record");
+        store
+            .delete(&data_key)
+            .await
+            .expect("delete swept data object");
+
+        // A later fold, its own CAS landing well past the sweep horizon: the
+        // reconcile window is sized in hours behind the fold's own watermark
+        // (not wall-clock time), so hour 10 is still reconciled even though
+        // real time has moved far beyond `protection_horizon_ns`.
+        let now_2 = now_1 + cfg.protection_horizon_ns + NS_PER_HOUR;
+        let second = catalog
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
+            .await
+            .expect("second fold must not fail even though the swept input is already gone");
+        assert!(!second.no_op);
+        assert!(!second.rebuilt, "an incremental fold, not a rebuild");
+
+        let head2 = read_head(store.as_ref()).await;
+        let entries = collect_head_entries(store.as_ref(), &head2).await;
+        let hour10: Vec<&SnapshotEntry> = entries
+            .iter()
+            .filter(|e| e.ingest_hour_bucket == 10)
+            .collect();
+        assert_eq!(hour10.len(), 1, "hour 10 now has exactly the L1 part");
+        assert_eq!(hour10[0].level, 1, "hour 10's entry is the compaction L1");
+        assert!(
+            !entries.iter().any(|e| e.content_hash == seg_a.content_hash),
+            "the published fold must not name the swept input"
+        );
+    }
+
     /// Regression for issue #587: a fold used to skip postings entirely the
     /// moment any L1 (compacted) entry was present, because
     /// `fetch_segment_names` could only key and identity-check an L0 object.

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -5165,73 +5165,107 @@ mod tests {
     /// publishing CAS lands only after that input's superseded-sweep horizon
     /// has passed (so a real deployment's maintenance process would already
     /// have physically deleted it), must never publish a snapshot that names
-    /// the swept input. `fold_reconcile_window_hours` (default 26, see
-    /// `config.rs`) is sized in hours-behind-watermark specifically so this
-    /// holds regardless of how much wall-clock time elapses: the reconcile
-    /// pass re-lists the bucket and excludes the input by matching the
-    /// compaction record's own input list, never by re-reading the (possibly
-    /// already-gone) input object itself.
+    /// the swept input. Nothing inside `Catalog::fold` samples a clock or
+    /// times its own duration (module docs above: "this crate never reads a
+    /// clock"); the guarantee comes from `DoFoldRebase`, the HEAD CAS retry
+    /// loop's `PreconditionFailed`/`AlreadyExists` branch: a delayed fold's
+    /// CAS loses to whichever fold's fresher listing published first, and the
+    /// loser re-reads HEAD and takes the no-op path instead of ever
+    /// publishing its own stale listing. A `FaultStore` hold on the delayed
+    /// fold's HEAD PUT freezes it after its LIST and before its CAS so a
+    /// second, unheld fold can win the race while the compaction and the
+    /// sweep both land in between.
     #[tokio::test]
     async fn fold_that_lists_before_a_compaction_and_cas_after_the_sweep_horizon_does_not_name_a_swept_input()
      {
-        let store = Arc::new(MemoryStore::new());
+        let store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
         let cfg = CatalogConfig {
             shard_count: 1,
             snapshot_part_max_entries: 1,
             ..Default::default()
         };
-        let catalog = Catalog::new(store.clone(), cfg).expect("catalog");
+        let catalog = Arc::new(Catalog::new(store.clone(), cfg).expect("catalog"));
 
-        // Hour 10 seals into its own part; hour 11 is the tail. This fold's
-        // LIST of hour 10 sees only the raw L0 segment: no compaction exists
-        // yet.
+        // Hour 10 seals into its own part; hour 11 is the tail. Fold A's LIST
+        // of hour 10 sees only the raw L0 segment: no compaction exists yet.
         let now_1 = now_at_seal(11);
         let writer_a = Uuid::new_v4();
-        let seg_a = publish_segment(&store, 0, writer_a, 1, 10, now_1 - 2 * NS_PER_HOUR).await;
-        publish_segment(&store, 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
-        let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
-            .await
-            .expect("first fold");
-        assert_eq!(first.parts_total, 2);
-        assert_eq!(first.entry_count, 2);
+        let seg_a =
+            publish_segment(store.inner(), 0, writer_a, 1, 10, now_1 - 2 * NS_PER_HOUR).await;
+        publish_segment(store.inner(), 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
 
-        // A compaction lands in the already-sealed, already-folded hour 10,
-        // superseding seg_a's L0 with one L1 part.
-        publish_compaction(&store, 0, 10, &[&seg_a], now_1).await;
+        // Hold fold A's HEAD PUT: HEAD is absent, so this is the very first
+        // (and only, until released) call that matches. Fold A's LIST has
+        // already completed by the time its PUT is attempted, so the hold
+        // freezes it exactly after LIST and before CAS.
+        let gate = store.hold(Op::Put, Some("HEAD".to_string()), Occurrence::Nth(1));
+        let cat_a = catalog.clone();
+        let fold_a = tokio::spawn(async move {
+            cat_a
+                .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
+                .await
+        });
+        gate.wait_until_held(1).await;
+        assert_eq!(gate.held_count(), 1, "fold A is blocked on its HEAD CAS");
+
+        // A compaction lands while fold A is paused, superseding seg_a's L0
+        // with one L1 part.
+        publish_compaction(store.inner(), 0, 10, &[&seg_a], now_1).await;
 
         // Simulate the superseded-input sweep: once `protection_horizon_ns`
         // has elapsed past the compaction's own `created_unix_ns`, a real
         // maintenance process would physically delete seg_a's commit record
         // and data object (docs/deletion-and-gc.md's superseded-input sweep
-        // row). Do that directly here (ravel-maintain is out of this task's
-        // scope) so the SECOND fold below runs against a bucket where the
-        // swept input is already gone from the store, not merely superseded.
+        // row; the delete blocker there is vacuous while HEAD is still
+        // absent, which is exactly fold A's paused state). Do that directly
+        // here (ravel-maintain is out of this task's scope) so fold B below
+        // runs, and fold A resumes, against a store where the swept input is
+        // already gone, not merely superseded.
         let commit_key = keys::commit_key_for_record(&seg_a).expect("commit key");
         let data_key = keys::reconstruct_data_key(&seg_a).expect("data key");
         store
+            .inner()
             .delete(&commit_key)
             .await
             .expect("delete swept commit record");
         store
+            .inner()
             .delete(&data_key)
             .await
             .expect("delete swept data object");
 
-        // A later fold, its own CAS landing well past the sweep horizon: the
-        // reconcile window is sized in hours behind the fold's own watermark
-        // (not wall-clock time), so hour 10 is still reconciled even though
-        // real time has moved far beyond `protection_horizon_ns`.
+        // Fold B: its own LIST of hour 10 sees the compaction directly (no
+        // reconcile pass needed, this is also a first/rebuild fold since HEAD
+        // is still absent while fold A is paused). Its CAS is not gated by
+        // the hold (`Occurrence::Nth(1)` matched only fold A's attempt), so
+        // it wins the race and publishes HEAD naming the L1 part, well past
+        // the sweep horizon.
         let now_2 = now_1 + cfg.protection_horizon_ns + NS_PER_HOUR;
         let second = catalog
             .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
-            .expect("second fold must not fail even though the swept input is already gone");
+            .expect("fold B must not fail even though the swept input is already gone");
         assert!(!second.no_op);
-        assert!(!second.rebuilt, "an incremental fold, not a rebuild");
+        assert!(second.rebuilt, "HEAD was still absent when fold B listed");
 
-        let head2 = read_head(store.as_ref()).await;
-        let entries = collect_head_entries(store.as_ref(), &head2).await;
+        // Release fold A: its own HEAD PUT now loses (`AlreadyExists`, HEAD
+        // was created by fold B while fold A was held), so it must rebase
+        // onto fold B's HEAD and take the no-op path rather than publish its
+        // own stale listing that still names seg_a.
+        for id in gate.held() {
+            gate.release(id);
+        }
+        let first = fold_a
+            .await
+            .expect("join fold A")
+            .expect("fold A must rebase, not error");
+        assert!(
+            first.no_op,
+            "fold A must rebase onto fold B's HEAD, never publish its stale listing"
+        );
+
+        let head = read_head(store.inner()).await;
+        let entries = collect_head_entries(store.inner(), &head).await;
         let hour10: Vec<&SnapshotEntry> = entries
             .iter()
             .filter(|e| e.ingest_hour_bucket == 10)

--- a/crates/ravel-fleet/src/claim.rs
+++ b/crates/ravel-fleet/src/claim.rs
@@ -1070,6 +1070,72 @@ mod tests {
         );
     }
 
+    /// Test debt (formal/tla/TRACEABILITY.md: `GuardedPublish`, `AbandonPublish`,
+    /// `LostClaimNeverPublishesThroughGuardedPath`, all three mapped to one
+    /// "ClaimGuard-abandons-on-lost-claim" test against `renew`). No
+    /// `ClaimGuard` type exists in this crate: the guard is a caller
+    /// convention (publish a compaction result only when `renew` reports
+    /// `Renewed`, never on `ClaimLost`), implemented by callers in
+    /// `ravel-maintain`/`services/ravel-cli`, outside this task's scope. This
+    /// test pins the contract those callers depend on, with the guard
+    /// convention modeled locally: a renew that discovers the claim was
+    /// stolen returns `Renewal::ClaimLost`, the guarded publish step is
+    /// therefore skipped, and the store carries no trace of a publish -- only
+    /// the thief's claim.
+    #[tokio::test]
+    async fn claim_guard_abandons_publish_when_the_claim_is_lost() {
+        let store = MemoryStore::new();
+        let cfg = ClaimConfig::default();
+        let original = owner_at(1);
+        let thief = owner_at(2);
+
+        let (key, original_version, original_payload) = acquired(
+            acquire(&store, &identity(), &original, &cfg)
+                .await
+                .expect("acquire"),
+        );
+
+        let observed = held(
+            acquire(&store, &identity(), &thief, &cfg)
+                .await
+                .expect("acquire"),
+        );
+        let taken = steal(&store, &observed, &thief, &cfg, observed.expiry_unix_ms)
+            .await
+            .expect("steal");
+        assert!(matches!(taken, Steal::Acquired { .. }), "the steal lands");
+
+        let renewal = renew(&store, &key, &original_version, &original_payload, 99)
+            .await
+            .expect("renew is not an error");
+
+        // The guard convention every real caller of `renew` follows: publish
+        // the compaction result only on `Renewed`, never on `ClaimLost`.
+        let publish_key = "t/acme/compaction/result";
+        if let Renewal::Renewed { .. } = &renewal {
+            store
+                .put(
+                    publish_key,
+                    b"compaction result".to_vec().into(),
+                    PutOptions {
+                        mode: PutMode::Overwrite,
+                        checksum: None,
+                    },
+                )
+                .await
+                .expect("publish");
+        }
+
+        assert!(
+            matches!(renewal, Renewal::ClaimLost),
+            "a renewal on a stolen claim is ClaimLost, got {renewal:?}"
+        );
+        assert!(
+            store.head(publish_key).await.is_err(),
+            "a lost-claim renewal must never publish through the guarded path"
+        );
+    }
+
     /// Completion is CAS-guarded like every other write in this module: a
     /// process holding a stale version cannot flip the state, and the stored
     /// payload is byte-identical afterwards. This is what makes "never an

--- a/crates/ravel-fleet/src/worker_set.rs
+++ b/crates/ravel-fleet/src/worker_set.rs
@@ -650,4 +650,42 @@ mod tests {
             "at most, and exactly, the cap runs concurrently"
         );
     }
+
+    /// Test debt (formal/tla/TRACEABILITY.md, `HeartbeatAndMemoNeverCas`): the
+    /// row asks for a test that both a heartbeat PUT and a "memo" PUT use
+    /// `PutMode::Overwrite`, not CAS. `write_heartbeat` issues exactly one PUT;
+    /// no "memo" write exists anywhere in `ravel-fleet`. The memo write is
+    /// `ravel_maintain::memo_snapshot::write_memo_snapshot`, in a different
+    /// crate, and the two are only ever driven together from
+    /// `services/ravel-server`'s maintain loop -- outside this task's scope.
+    /// This test pins what is true and testable here: the heartbeat PUT is an
+    /// unconditional overwrite. Proven behaviorally, since no store wrapper in
+    /// this workspace records the `PutMode` a call used: a second heartbeat
+    /// write to an already-populated key succeeds and its content wins, which
+    /// neither CAS variant (`CreateIfAbsent`, `CasVersion`) can do without the
+    /// caller reading and passing a precondition -- and `write_heartbeat` never
+    /// reads the key before writing it.
+    #[tokio::test]
+    async fn heartbeat_and_memo_puts_use_overwrite_not_cas() {
+        let store = MemoryStore::new();
+        let w = worker(0);
+
+        w.write_heartbeat(&store, 1_000)
+            .await
+            .expect("first heartbeat write succeeds");
+        w.write_heartbeat(&store, 2_000)
+            .await
+            .expect("second heartbeat write to the same key succeeds unconditionally");
+
+        let key = heartbeat_key(&w.process_id());
+        let got = store
+            .get(&key, GetRange::Full)
+            .await
+            .expect("get heartbeat");
+        let heartbeat = WorkerHeartbeat::decode(got.data.as_ref()).expect("decode heartbeat");
+        assert_eq!(
+            heartbeat.heartbeat_unix_ns, 2_000,
+            "the second write's content wins: no CAS precondition blocked it"
+        );
+    }
 }

--- a/crates/ravel-ingest/src/error.rs
+++ b/crates/ravel-ingest/src/error.rs
@@ -191,4 +191,124 @@ mod tests {
         };
         assert!(!not_retryable.is_retryable());
     }
+
+    /// Test debt (formal/tla/TRACEABILITY.md, ingest row 2, `AdmitFailClosed`
+    /// fence / `StaleProvisioningView`): a writer whose cached provisioning
+    /// view has gone stale past the refresh interval `C`, and whose re-read
+    /// of the provisioning record cannot complete, and whose grace-extend
+    /// horizon has already been crossed, gets exactly
+    /// `WriteError::StaleProvisioningView` and durably writes nothing --
+    /// no data object and no commit record appear in the store.
+    #[tokio::test]
+    #[allow(clippy::expect_used)]
+    async fn stale_provisioning_view_fails_closed_past_the_staleness_fence() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicI64, Ordering};
+        use std::time::Duration;
+
+        use ravel_object_store::fault::{
+            FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+        };
+        use ravel_object_store::memory::MemoryStore;
+        use ravel_object_store::{ObjectStoreBackend, list_all};
+        use ravel_otlp::NormalizedPoint;
+        use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL, Sample, SeriesId, Signal, TenantId};
+
+        use crate::clock::Clock;
+        use crate::config::IngestConfig;
+        use crate::router::{IngestRouter, WriteMode};
+
+        const NS_PER_HOUR: i64 = 3_600_000_000_000;
+
+        struct FrozenClock(AtomicI64);
+
+        impl Clock for FrozenClock {
+            fn now_ns(&self) -> i64 {
+                self.0.load(Ordering::SeqCst)
+            }
+
+            fn sleep(&self, _dur: Duration) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+                Box::pin(async {})
+            }
+        }
+
+        let plan = FaultPlan::empty().with_rule(
+            Rule::new(
+                Op::Get,
+                ScriptedFault::Transient("simulated sustained store latency".into()),
+            )
+            .with_occurrence(Occurrence::Always),
+        );
+        let store: Arc<dyn ObjectStoreBackend> =
+            Arc::new(FaultStore::new(MemoryStore::new(), plan));
+
+        let t0 = 10 * NS_PER_HOUR;
+        let clock = Arc::new(FrozenClock(AtomicI64::new(t0)));
+        let router = IngestRouter::new(
+            IngestConfig {
+                shard_count: 4,
+                ..IngestConfig::default()
+            },
+            Arc::clone(&store),
+            Signal::Metrics,
+            clock.clone(),
+        );
+
+        let tenant = TenantId::new("acme");
+
+        // Seed a fresh cached view the ordinary way (this call never touches
+        // the store), then move the clock past both the refresh interval `C`
+        // and the grace-extend horizon (`min_lead_hours(C)` = 2 hours past t0
+        // for the default `C`), so the upcoming write's re-read is forced and
+        // its grace fallback is refused.
+        router.refresh_generations(tenant.hash(), vec![], t0);
+        clock.0.store(t0 + 3 * NS_PER_HOUR, Ordering::SeqCst);
+
+        let labels = LabelSet::new(vec![Label {
+            name: METRIC_NAME_LABEL.to_string(),
+            value: "cpu_usage".to_string(),
+        }])
+        .expect("valid labels");
+        let series_id = SeriesId::compute(&tenant, "cpu_usage", &labels).expect("series id");
+        let point = NormalizedPoint {
+            series_id,
+            labels: Arc::new(labels),
+            sample: Sample {
+                ts_ns: t0,
+                value: 1.0,
+            },
+            is_monotonic_sum: false,
+        };
+
+        let result = router
+            .write(
+                tenant.clone(),
+                vec![point],
+                WriteMode::Buffered,
+                Duration::from_secs(5),
+            )
+            .await;
+
+        match result {
+            Err(WriteError::StaleProvisioningView) => {}
+            Ok(_) => panic!("past the staleness fence, must fail closed, not route"),
+            Err(other) => panic!("past the staleness fence, wrong error: {other:?}"),
+        }
+        assert_eq!(
+            router.metrics().snapshot().stale_provisioning_flushes,
+            1,
+            "the fail-closed counter fires exactly once"
+        );
+
+        let objects = list_all(store.as_ref(), "t/")
+            .await
+            .expect("list must succeed: only Get is faulted");
+        assert!(
+            objects.is_empty(),
+            "a write that fails closed on a stale provisioning view must not \
+             durably write anything, but the store holds {objects:?}"
+        );
+    }
 }

--- a/crates/ravel-ingest/src/router.rs
+++ b/crates/ravel-ingest/src/router.rs
@@ -554,3 +554,150 @@ impl IngestRouter {
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::AtomicI64;
+
+    use ravel_catalog::ShardGeneration;
+    use ravel_object_store::list_all;
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL, Sample, SeriesId};
+
+    use super::*;
+
+    const NS_PER_HOUR: i64 = 3_600_000_000_000;
+
+    struct FrozenClock(AtomicI64);
+
+    impl Clock for FrozenClock {
+        fn now_ns(&self) -> i64 {
+            self.0.load(Ordering::SeqCst)
+        }
+
+        fn sleep(&self, _dur: Duration) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            // Never resolves: the test drives flushing explicitly via
+            // `flush_all`, not via the actor's age-based tick. A sleep that
+            // completes immediately turns the actor's `tokio::select!` loop
+            // into a synchronous spin that never yields to the executor.
+            Box::pin(std::future::pending())
+        }
+    }
+
+    fn test_point(tenant: &TenantId, metric: &str, ts_ns: i64, value: f64) -> NormalizedPoint {
+        let labels = LabelSet::new(vec![Label {
+            name: METRIC_NAME_LABEL.to_string(),
+            value: metric.to_string(),
+        }])
+        .expect("valid labels");
+        let series_id = SeriesId::compute(tenant, metric, &labels).expect("series id");
+        NormalizedPoint {
+            series_id,
+            labels: Arc::new(labels),
+            sample: Sample { ts_ns, value },
+            is_monotonic_sum: false,
+        }
+    }
+
+    /// Test debt (formal/tla/TRACEABILITY.md, ingest row 3, `DoAdmit` write
+    /// path): an admitted write lands on the shard `shard_for` selects for
+    /// the generation's active count at the write's hour, not on the
+    /// process's default (generation 0) count -- so a write flushed after a
+    /// reshard has activated is durable on the *new* topology's shard, and
+    /// that shard is independently confirmed both by the returned commit
+    /// token and by the commit record actually found in the store.
+    #[tokio::test]
+    async fn admitted_write_lands_on_the_shard_the_routed_count_selects() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        // Flush open checks the reading against the 2020 plausibility floor
+        // (crate::config::MIN_PLAUSIBLE_INGEST_CLOCK_NS), so the test clock
+        // must sit in real epoch-hour territory, not small offsets from 0.
+        let base_hour = crate::config::MIN_PLAUSIBLE_INGEST_CLOCK_NS / NS_PER_HOUR + 10;
+        let t0 = base_hour * NS_PER_HOUR;
+        let clock = Arc::new(FrozenClock(AtomicI64::new(t0)));
+        let router = IngestRouter::new(
+            IngestConfig {
+                shard_count: 4,
+                ..IngestConfig::default()
+            },
+            Arc::clone(&store),
+            Signal::Metrics,
+            clock.clone(),
+        );
+
+        let tenant = TenantId::new("acme");
+        // A reshard to 8 shards activates at the seed hour itself. Seeding
+        // this via `refresh_generations` (never touches the store) and
+        // writing at that same instant keeps the cached view fresh (well
+        // within the refresh interval `C`), so the write routes on this
+        // history directly instead of falling back to the process default.
+        let activation_hour = u32::try_from(base_hour).expect("fits u32");
+        router.refresh_generations(
+            tenant.hash(),
+            vec![
+                ShardGeneration {
+                    generation: 0,
+                    shard_count: 4,
+                    activation_hour: 0,
+                    appended_unix_ns: 0,
+                },
+                ShardGeneration {
+                    generation: 1,
+                    shard_count: 8,
+                    activation_hour,
+                    appended_unix_ns: 0,
+                },
+            ],
+            t0,
+        );
+
+        let point = test_point(&tenant, "cpu_usage", t0, 1.0);
+        let expected_shard = shard_for(&point.series_id, 8);
+
+        // The frozen clock never ages past `max_flush_delay` on its own, so
+        // `flush_all` must run concurrently with (not after) the write, and
+        // after (not before) the write's own enqueue; joining the two
+        // futures interleaves them correctly (crates/ravel-ingest/tests/
+        // acks_and_modes.rs uses the same pattern).
+        let (write_result, ()) = tokio::join!(
+            router.write(
+                tenant.clone(),
+                vec![point],
+                WriteMode::Strict,
+                Duration::from_secs(5),
+            ),
+            router.flush_all(),
+        );
+        let receipt = write_result.expect("strict write on the routed 8-shard generation succeeds");
+
+        assert_eq!(receipt.tokens.len(), 1, "one shard was involved");
+        assert_eq!(
+            receipt.tokens[0].shard, expected_shard,
+            "the receipt's token names the shard `shard_for` selects for the \
+             routed (post-reshard) count, not the process default"
+        );
+
+        let objects = list_all(store.as_ref(), "t/").await.expect("list");
+        let commit_key = objects
+            .iter()
+            .find(|o| o.key.contains("/c/"))
+            .expect("exactly one commit record")
+            .key
+            .clone();
+        let raw = store
+            .get(&commit_key, ravel_object_store::GetRange::Full)
+            .await
+            .expect("get commit record");
+        let decoded = ravel_commit::record::decode(&raw.data).expect("decode commit record");
+        assert_eq!(
+            decoded.shard, expected_shard,
+            "the commit record durably placed in the store names the same \
+             routed shard, not a stale generation-0 count"
+        );
+        assert_eq!(decoded.series_count, 1);
+        assert_eq!(decoded.sample_count, 1);
+    }
+}

--- a/crates/ravel-ingest/src/router.rs
+++ b/crates/ravel-ingest/src/router.rs
@@ -656,6 +656,17 @@ mod tests {
 
         let point = test_point(&tenant, "cpu_usage", t0, 1.0);
         let expected_shard = shard_for(&point.series_id, 8);
+        // The process default (4 shards) must route this point to a
+        // different shard than the routed (post-reshard, 8-shard) count, or a
+        // write that used the wrong count would land on `expected_shard` by
+        // coincidence and both assertions below would still pass.
+        assert_ne!(
+            shard_for(&point.series_id, 4),
+            expected_shard,
+            "this series id must not land on the same shard under the process \
+             default count (4) and the routed count (8), or routing with the \
+             wrong count would go undetected"
+        );
 
         // The frozen clock never ages past `max_flush_delay` on its own, so
         // `flush_all` must run concurrently with (not after) the write, and


### PR DESCRIPTION
The catalog, resharding and maintenance TLA+ traceability tables named
five claims across three crates that no Rust test pinned. This adds them
as unit tests inside the crates' existing test modules, adding no
production code and no dependency.

ravel-catalog: a fold that lists a bucket before a compaction supersedes
an input and attempts its CAS after the superseded-sweep horizon does not
name the swept input. ravel-ingest: a writer whose provisioning view is
older than the permitted staleness gets StaleProvisioningView and routes
nothing, and an admitted write lands on the shard the routed generation's
count selects rather than the process default. ravel-fleet: the heartbeat
PUT uses PutMode::Overwrite, not a conditional mode, and a renewal on a
stolen claim returns ClaimLost so a guarded caller publishes nothing.

Every test was run against a deliberately broken production path first
and failed on the assertion that names its claim, then passed once the
path was restored; the commit bodies record the failing lines. No test
exposed a defect, so none is ignored.

Two traceability rows turned out to describe the code imprecisely, and
the tests pin what is true rather than what the rows say. The heartbeat
row speaks of both PUTs in write_heartbeat, but that function issues one;
the memo write is ravel_maintain::memo_snapshot::write_memo_snapshot and
is covered separately. The guarded-publish rows name a ClaimGuard, but no
such type exists in ravel-fleet; the guard is a caller convention over
renew's outcome, which the test models locally. The traceability tables
are corrected in the follow-up that writes the new test names back.

Refs: #1113
