### PR TITLE
feat(ravel-query): share one GET limiter across an engine's fetchers

### DIFF
--- a/crates/ravel-query/src/config.rs
+++ b/crates/ravel-query/src/config.rs
@@ -335,6 +335,24 @@ pub enum EngineConfigError {
         "logs_max_fetch_run_bytes must be non-zero: the segmented covering fallback divides by it"
     )]
     ZeroFetchBound,
+    /// [`EngineConfig::fetch_concurrency`] was zero (ADR-1195: "zero is
+    /// rejected during configuration resolution").
+    #[error("fetch_concurrency must be at least 1")]
+    ZeroFetchConcurrency,
+    /// A [`GetLimiter`](crate::GetLimiter) was built with, or
+    /// [`EngineConfig::store_get_concurrency`] resolved to, zero permits
+    /// (ADR-1195's `--store-get-concurrency`): a zero-permit limiter can
+    /// never issue a GET.
+    #[error("store GET concurrency must be at least 1")]
+    ZeroGetLimiterPermits,
+    /// [`EngineConfig::sql_partition_count`] resolved to zero (ADR-1195's
+    /// `--sql-partition-count`).
+    #[error("sql_partition_count must be at least 1")]
+    ZeroSqlPartitionCount,
+    /// [`EngineConfig::promql_fetch_fanout`] resolved to zero (ADR-1195's
+    /// `--promql-fetch-fanout`).
+    #[error("promql_fetch_fanout must be at least 1")]
+    ZeroPromqlFetchFanout,
 }
 
 /// [`crate::QueryEngine`] resource limits and concurrency. Every limit is
@@ -412,15 +430,65 @@ pub struct EngineConfig {
     /// ([`Self::validate`]): the segmented fallback divides by it. Defaults to
     /// [`DEFAULT_LOG_MAX_FETCH_RUN_BYTES`] (64 MiB).
     pub logs_max_fetch_run_bytes: u64,
+    /// Explicit override for concurrent object-store GETs, process-wide
+    /// (ADR-1195's `--store-get-concurrency`), fed to the one shared
+    /// [`crate::GetLimiter`] every query-side fetcher honours. `None` falls
+    /// back to [`Self::fetch_concurrency`] (no default moves): use
+    /// [`Self::store_get_concurrency`] to read the resolved value.
+    pub store_get_concurrency: Option<usize>,
+    /// Explicit override for DataFusion `target_partitions`
+    /// (ADR-1195's `--sql-partition-count`); wired into
+    /// `crates/ravel-sql/src/session.rs` by a follow-up task. `None` falls
+    /// back to [`Self::fetch_concurrency`]: use
+    /// [`Self::sql_partition_count`] to read the resolved value.
+    pub sql_partition_count: Option<usize>,
+    /// Explicit override for PromQL `buffer_unordered` fan-out width
+    /// (ADR-1195's `--promql-fetch-fanout`). `None` falls back to
+    /// [`Self::fetch_concurrency`]: use [`Self::promql_fetch_fanout`] to read
+    /// the resolved value.
+    pub promql_fetch_fanout: Option<usize>,
 }
 
 impl EngineConfig {
+    /// The resolved concurrent-GET permit count: the explicit
+    /// [`Self::store_get_concurrency`] override if set, else the legacy
+    /// [`Self::fetch_concurrency`] (ADR-1195: no default moves).
+    pub fn store_get_concurrency(&self) -> usize {
+        self.store_get_concurrency.unwrap_or(self.fetch_concurrency)
+    }
+
+    /// The resolved DataFusion partition count: the explicit
+    /// [`Self::sql_partition_count`] override if set, else the legacy
+    /// [`Self::fetch_concurrency`] (ADR-1195: no default moves).
+    pub fn sql_partition_count(&self) -> usize {
+        self.sql_partition_count.unwrap_or(self.fetch_concurrency)
+    }
+
+    /// The resolved PromQL fan-out width: the explicit
+    /// [`Self::promql_fetch_fanout`] override if set, else the legacy
+    /// [`Self::fetch_concurrency`] (ADR-1195: no default moves).
+    pub fn promql_fetch_fanout(&self) -> usize {
+        self.promql_fetch_fanout.unwrap_or(self.fetch_concurrency)
+    }
+
     /// Refuse a configuration the fetch layer cannot run on (ADR-0996 decision
     /// 2). Called at startup resolution; a bad value is a typed
     /// [`EngineConfigError`], never a silent clamp.
     pub fn validate(&self) -> Result<(), EngineConfigError> {
         if self.logs_max_fetch_run_bytes == 0 {
             return Err(EngineConfigError::ZeroFetchBound);
+        }
+        if self.fetch_concurrency == 0 {
+            return Err(EngineConfigError::ZeroFetchConcurrency);
+        }
+        if self.store_get_concurrency() == 0 {
+            return Err(EngineConfigError::ZeroGetLimiterPermits);
+        }
+        if self.sql_partition_count() == 0 {
+            return Err(EngineConfigError::ZeroSqlPartitionCount);
+        }
+        if self.promql_fetch_fanout() == 0 {
+            return Err(EngineConfigError::ZeroPromqlFetchFanout);
         }
         Ok(())
     }
@@ -444,6 +512,9 @@ impl Default for EngineConfig {
             logs_request_cost_bytes: crate::DEFAULT_LOG_REQUEST_COST_BYTES,
             logs_fetch_policy: LogsFetchPolicy::default(),
             logs_max_fetch_run_bytes: DEFAULT_LOG_MAX_FETCH_RUN_BYTES,
+            store_get_concurrency: None,
+            sql_partition_count: None,
+            promql_fetch_fanout: None,
         }
     }
 }
@@ -800,5 +871,86 @@ mod tests {
         assert_eq!(cfg.validate(), Ok(()));
         cfg.logs_max_fetch_run_bytes = 0;
         assert_eq!(cfg.validate(), Err(EngineConfigError::ZeroFetchBound));
+    }
+
+    #[test]
+    fn zero_fetch_concurrency_is_refused_with_a_typed_error() {
+        let cfg = EngineConfig {
+            fetch_concurrency: 0,
+            ..EngineConfig::default()
+        };
+        assert_eq!(cfg.validate(), Err(EngineConfigError::ZeroFetchConcurrency));
+    }
+
+    /// ADR-1195: each of the three split knobs is validated on its RESOLVED
+    /// value, so a zero override is rejected even though `fetch_concurrency`
+    /// itself stays nonzero -- an operator turning one knob to 0 must not
+    /// silently fall back to the legacy value.
+    #[test]
+    fn zero_store_get_concurrency_override_is_refused_with_a_typed_error() {
+        let cfg = EngineConfig {
+            store_get_concurrency: Some(0),
+            ..EngineConfig::default()
+        };
+        assert_eq!(
+            cfg.validate(),
+            Err(EngineConfigError::ZeroGetLimiterPermits)
+        );
+    }
+
+    #[test]
+    fn zero_sql_partition_count_override_is_refused_with_a_typed_error() {
+        let cfg = EngineConfig {
+            sql_partition_count: Some(0),
+            ..EngineConfig::default()
+        };
+        assert_eq!(
+            cfg.validate(),
+            Err(EngineConfigError::ZeroSqlPartitionCount)
+        );
+    }
+
+    #[test]
+    fn zero_promql_fetch_fanout_override_is_refused_with_a_typed_error() {
+        let cfg = EngineConfig {
+            promql_fetch_fanout: Some(0),
+            ..EngineConfig::default()
+        };
+        assert_eq!(
+            cfg.validate(),
+            Err(EngineConfigError::ZeroPromqlFetchFanout)
+        );
+    }
+
+    /// ADR-1195: no default moves. With all three knobs unset, every
+    /// accessor must return the legacy `fetch_concurrency` value, not some
+    /// new independent default.
+    #[test]
+    fn unset_knobs_all_resolve_to_fetch_concurrency() {
+        let cfg = EngineConfig {
+            fetch_concurrency: 8,
+            ..EngineConfig::default()
+        };
+        assert_eq!(cfg.validate(), Ok(()));
+        assert_eq!(cfg.store_get_concurrency(), 8);
+        assert_eq!(cfg.sql_partition_count(), 8);
+        assert_eq!(cfg.promql_fetch_fanout(), 8);
+    }
+
+    /// Setting one knob overrides only that knob's accessor; the other two
+    /// still fall back to `fetch_concurrency` (ADR-1195: splitting the knob
+    /// changes which lever an operator turns, not what an untouched knob
+    /// resolves to).
+    #[test]
+    fn one_explicit_knob_overrides_only_its_own_accessor() {
+        let cfg = EngineConfig {
+            fetch_concurrency: 8,
+            promql_fetch_fanout: Some(3),
+            ..EngineConfig::default()
+        };
+        assert_eq!(cfg.validate(), Ok(()));
+        assert_eq!(cfg.promql_fetch_fanout(), 3);
+        assert_eq!(cfg.store_get_concurrency(), 8);
+        assert_eq!(cfg.sql_partition_count(), 8);
     }
 }

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -31,6 +31,7 @@ use crate::fetcher::{
     FetchError, FetchStats, FetchedHistogramSeries, FetchedSeriesSoa, ReadCache, SamplePriority,
     SegmentFetcher,
 };
+use crate::limiter::GetLimiter;
 use crate::log_fetcher::{LogFetchError, LogSegmentFetcher};
 use crate::log_series;
 use crate::phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot};
@@ -324,6 +325,12 @@ pub struct QueryEngine {
     /// selectors (ADR-1103). Built from the same store as `fetcher`,
     /// with the logs-specific fetch bounds from `config`.
     log_fetcher: LogSegmentFetcher,
+    /// The one process-shareable GET limiter (ADR-1195) this engine's
+    /// `fetcher` and `log_fetcher` were built to share. Kept so
+    /// [`Self::with_get_limiter`] can hand out the SAME `Arc` a caller
+    /// later wants a second engine (or a directly-constructed fetcher) to
+    /// also draw permits from.
+    get_limiter: Arc<GetLimiter>,
     config: EngineConfig,
     /// ADR-0071 distributed read fan-out. `None` is the default:
     /// the engine runs the local fetch path untouched. `Some` opts this engine
@@ -353,9 +360,18 @@ impl QueryEngine {
         } else {
             config.logs_max_fetch_run_bytes
         };
+        // One process-owned limiter shared by every fetcher this engine owns
+        // (ADR-1195), built from `store_get_concurrency` rather than the
+        // legacy `fetch_concurrency` the two `with_max_concurrent_gets` calls
+        // below used before this change -- `store_get_concurrency()` resolves
+        // to `fetch_concurrency` itself when unset, so an untouched
+        // deployment is unaffected.
+        let get_limiter = Arc::new(GetLimiter::new_unchecked(
+            config.store_get_concurrency().max(1),
+        ));
         let log_fetcher = LogSegmentFetcher::new(store.clone())
             .with_block_range_threshold(config.logs_block_range_threshold)
-            .with_max_concurrent_gets(config.fetch_concurrency)
+            .with_get_limiter(get_limiter.clone())
             .with_request_cost_bytes(config.logs_request_cost_bytes)
             .with_max_fetch_run_bytes(fetch_run_bytes)
             .unwrap_or_else(|err| {
@@ -366,13 +382,14 @@ impl QueryEngine {
                 );
                 LogSegmentFetcher::new(store.clone())
                     .with_block_range_threshold(config.logs_block_range_threshold)
-                    .with_max_concurrent_gets(config.fetch_concurrency)
+                    .with_get_limiter(get_limiter.clone())
                     .with_request_cost_bytes(config.logs_request_cost_bytes)
             });
         QueryEngine {
             catalog,
-            fetcher: SegmentFetcher::new(store),
+            fetcher: SegmentFetcher::new(store).with_get_limiter(get_limiter.clone()),
             log_fetcher,
+            get_limiter,
             config,
             distributed: None,
             federation: None,
@@ -419,8 +436,32 @@ impl QueryEngine {
         self
     }
 
+    /// Replaces the limiter on every fetcher this engine owns (`fetcher` and
+    /// `log_fetcher`) with `limiter`, so a process can share one
+    /// [`GetLimiter`] -- and so one process-wide GET ceiling -- across several
+    /// `QueryEngine`s (ADR-1195). `QueryEngine::new` already builds one
+    /// private limiter from `store_get_concurrency` and wires both fetchers to
+    /// it; this is the seam a caller uses to replace that private limiter with
+    /// a shared one after construction, mirroring [`Self::with_cache`].
+    #[must_use]
+    pub fn with_get_limiter(mut self, limiter: Arc<GetLimiter>) -> Self {
+        self.fetcher = self.fetcher.with_get_limiter(limiter.clone());
+        self.log_fetcher = self.log_fetcher.with_get_limiter(limiter.clone());
+        self.get_limiter = limiter;
+        self
+    }
+
     pub fn config(&self) -> &EngineConfig {
         &self.config
+    }
+
+    /// The [`GetLimiter`] this engine's `fetcher` and `log_fetcher` currently
+    /// share. Test-only: production code has no reason to reach behind the
+    /// engine at its fetchers' shared limiter, only to replace it wholesale
+    /// via [`Self::with_get_limiter`].
+    #[cfg(test)]
+    fn get_limiter_for_test(&self) -> &Arc<GetLimiter> {
+        &self.get_limiter
     }
 
     /// Evaluates `query` as an instant query, returning its value paired with
@@ -1221,7 +1262,7 @@ impl QueryEngine {
         let max_samples = self.config.max_samples;
         let max_bytes_scanned = self.config.max_bytes_scanned;
         let max_s3_requests = self.config.max_s3_requests;
-        let concurrency = self.config.fetch_concurrency.max(1);
+        let concurrency = self.config.promql_fetch_fanout().max(1);
         // The query's absolute deadline in unix nanoseconds, from the injected
         // `now_ns` and the configured engine deadline. Threaded into the
         // distributed fan-out (ADR-0071 amendment, decision 2) so the coordinator
@@ -1763,7 +1804,7 @@ impl QueryEngine {
         ),
         QueryError,
     > {
-        let concurrency = self.config.fetch_concurrency.max(1);
+        let concurrency = self.config.promql_fetch_fanout().max(1);
         let matchers: Arc<Vec<LabelMatcher>> = Arc::new(matchers.to_vec());
         let mut stream = stream::iter(snapshot.segments.iter().cloned())
             .map(|seg_ref| {
@@ -2071,7 +2112,7 @@ impl QueryEngine {
         max_bytes_scanned: ByteLimit,
         max_s3_requests: RequestLimit,
     ) -> Result<Vec<Vec<ravel_segment::SeriesEntry>>, QueryError> {
-        let concurrency = self.config.fetch_concurrency.max(1);
+        let concurrency = self.config.promql_fetch_fanout().max(1);
         let matchers: Arc<Vec<LabelMatcher>> = Arc::new(matchers.to_vec());
         let mut stream = stream::iter(snapshot.segments.iter().cloned())
             .map(|seg_ref| {
@@ -7462,5 +7503,67 @@ mod coverage_wrapper_tests {
     #[tokio::test]
     async fn resolve_series_reports_partial_coverage_matching_its_stats() {
         assert_resolve_series_parity(false).await;
+    }
+}
+
+/// ADR-1195: `QueryEngine::new` builds one process-shareable `GetLimiter` and
+/// wires it to every fetcher it owns; `with_get_limiter` replaces it on all of
+/// them at once, for a process sharing one limiter across engines.
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod get_limiter_tests {
+    use ravel_catalog::{Catalog, CatalogConfig};
+    use ravel_object_store::memory::MemoryStore;
+
+    use super::*;
+
+    fn engine(store: Arc<MemoryStore>) -> QueryEngine {
+        let backend: Arc<dyn ObjectStoreBackend> = store;
+        let catalog =
+            Catalog::new(Arc::clone(&backend), CatalogConfig::default()).expect("catalog");
+        QueryEngine::new(Arc::new(catalog), backend, EngineConfig::default())
+    }
+
+    /// `QueryEngine::new` must wire the SAME limiter `Arc` to both fetchers it
+    /// owns, not two equal-but-distinct ones: two independent limiters would
+    /// let each fetcher exhaust its own pool while the other sits idle, which
+    /// is exactly the multiplication ADR-1195 exists to close.
+    #[test]
+    fn new_wires_one_shared_limiter_to_both_owned_fetchers() {
+        let engine = engine(Arc::new(MemoryStore::new()));
+        assert!(Arc::ptr_eq(
+            engine.fetcher.get_limiter_for_test(),
+            engine.log_fetcher.get_limiter_for_test()
+        ));
+        assert!(Arc::ptr_eq(
+            engine.fetcher.get_limiter_for_test(),
+            engine.get_limiter_for_test()
+        ));
+    }
+
+    /// `with_get_limiter` must replace the limiter on every fetcher the engine
+    /// owns, and record the new `Arc` as the engine's own, so a later
+    /// `with_get_limiter` call (or another engine sharing this one) still sees
+    /// the current limiter rather than the one `new` built privately.
+    #[test]
+    fn with_get_limiter_replaces_every_owned_fetcher() {
+        let engine = engine(Arc::new(MemoryStore::new()));
+        let original = engine.get_limiter_for_test().clone();
+        let replacement = Arc::new(GetLimiter::new(4).expect("4 permits is valid"));
+        let engine = engine.with_get_limiter(replacement.clone());
+
+        assert!(Arc::ptr_eq(engine.get_limiter_for_test(), &replacement));
+        assert!(Arc::ptr_eq(
+            engine.fetcher.get_limiter_for_test(),
+            &replacement
+        ));
+        assert!(Arc::ptr_eq(
+            engine.log_fetcher.get_limiter_for_test(),
+            &replacement
+        ));
+        assert!(!Arc::ptr_eq(
+            engine.fetcher.get_limiter_for_test(),
+            &original
+        ));
     }
 }

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -366,6 +366,14 @@ impl QueryEngine {
         // below used before this change -- `store_get_concurrency()` resolves
         // to `fetch_concurrency` itself when unset, so an untouched
         // deployment is unaffected.
+        //
+        // The permit bounds GETs in flight, not tasks in flight: an RLOG
+        // block-range read builds its `ObjectAssembler` (charged to the
+        // assembly pool) before its first extent reaches `store_get_pinned`
+        // and waits for a permit, so with `promql_fetch_fanout` (or the SQL
+        // partition count) above `store_get_concurrency` up to that many
+        // object-sized assemblies can sit queued behind the limiter at once.
+        // Peak assembly memory scales with the fan-out, not with this count.
         let get_limiter = Arc::new(GetLimiter::new_unchecked(
             config.store_get_concurrency().max(1),
         ));

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -570,13 +570,14 @@ pub struct SegmentFetcher {
     /// instead of a footer suffix.
     whole_object_threshold: u64,
     limits: ReaderLimits,
-    /// Bounds the byte-range GETs kept in flight. Shared across `clone`s (it
-    /// is an `Arc`), so every concurrent segment fetch in one query draws
-    /// from the same permit pool rather than each opening its own unbounded
-    /// fan-out. It is only ever held around a single leaf
-    /// `store.get`, never across a scope that acquires another permit, so no
-    /// fetch can deadlock waiting on permits it already holds.
-    get_semaphore: std::sync::Arc<tokio::sync::Semaphore>,
+    /// Bounds the byte-range GETs kept in flight. Shared across `clone`s and,
+    /// via [`Self::with_get_limiter`], across every other fetcher and engine
+    /// holding the same `Arc` (ADR-1195): every concurrent segment fetch in
+    /// the process draws from the same permit pool rather than each fetcher
+    /// opening its own unbounded fan-out. It is only ever held around a
+    /// single leaf `store.get`, never across a scope that acquires another
+    /// permit, so no fetch can deadlock waiting on permits it already holds.
+    get_limiter: std::sync::Arc<crate::GetLimiter>,
     /// ADR-0046's read cache, consulted by `guarded_get` for every
     /// byte-range (and whole-object) GET. `None` -- the default from
     /// `new` -- reproduces exactly the pre-cache behavior: every GET goes
@@ -620,7 +621,7 @@ impl SegmentFetcher {
             coalesce_gap: DEFAULT_COALESCE_GAP,
             whole_object_threshold: DEFAULT_WHOLE_OBJECT_THRESHOLD,
             limits: ReaderLimits::default(),
-            get_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(
+            get_limiter: std::sync::Arc::new(crate::GetLimiter::new_unchecked(
                 DEFAULT_MAX_CONCURRENT_GETS,
             )),
             cache: None,
@@ -699,15 +700,34 @@ impl SegmentFetcher {
         self
     }
 
-    /// Sets the in-flight byte-range GET bound. Shared across
-    /// this fetcher's clones.
+    /// Sets the in-flight byte-range GET bound by building a new private
+    /// limiter. Shared across this fetcher's clones; not shared with any
+    /// other fetcher unless [`Self::with_get_limiter`] is used instead.
     #[must_use]
     pub fn with_max_concurrent_gets(mut self, n: usize) -> Self {
-        self.get_semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(n.max(1)));
+        self.get_limiter = std::sync::Arc::new(crate::GetLimiter::new_unchecked(n.max(1)));
         self
     }
 
-    /// One store GET, bounded by the shared in-flight semaphore. The permit
+    /// Wires this fetcher to a caller-owned [`crate::GetLimiter`] (ADR-1195),
+    /// so it draws GET permits from the same pool as every other fetcher (and,
+    /// via [`crate::QueryEngine::with_get_limiter`], every other engine)
+    /// holding the same `Arc`.
+    #[must_use]
+    pub fn with_get_limiter(mut self, limiter: std::sync::Arc<crate::GetLimiter>) -> Self {
+        self.get_limiter = limiter;
+        self
+    }
+
+    /// This fetcher's current limiter, for a test to `Arc::ptr_eq` against
+    /// another fetcher's or an engine's, proving two fetchers actually share
+    /// one `GetLimiter` rather than each holding an equal-but-distinct one.
+    #[cfg(test)]
+    pub(crate) fn get_limiter_for_test(&self) -> &std::sync::Arc<crate::GetLimiter> {
+        &self.get_limiter
+    }
+
+    /// One store GET, bounded by the shared in-flight limiter. The permit
     /// is released the moment the GET resolves; callers must
     /// never hold the returned future's permit across another
     /// `guarded_get`/`ensure_ranges` call, or a query whose in-flight GETs
@@ -726,10 +746,7 @@ impl SegmentFetcher {
         range: GetRange,
         accounting: &QueryAccounting,
     ) -> Result<GetOutcome, StoreError> {
-        let _permit =
-            self.get_semaphore.acquire().await.map_err(|_| {
-                StoreError::Transient("fetch concurrency semaphore closed".to_string())
-            })?;
+        let _permit = self.get_limiter.acquire().await;
         accounting.record_s3_request(AccountedOp::Get);
         let got = self.store.get(key, range).await?;
         accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
@@ -3388,6 +3405,151 @@ mod tests {
             object_bytes.len() as u64,
             "the whole-object GET charges exactly the object's byte length at completion"
         );
+    }
+
+    /// ADR-1195: two `SegmentFetcher`s sharing one `GetLimiter::new(1)` must
+    /// never let both their GETs reach the store concurrently. The gate
+    /// observes the store's own in-flight GET count directly, so this pins
+    /// the process-wide bound rather than trusting the fetchers' bookkeeping.
+    #[tokio::test]
+    async fn shared_get_limiter_bounds_peak_concurrent_gets_to_one() {
+        use ravel_object_store::fault::{GateHandle, Occurrence};
+
+        let (source, tenant_hash, seg_ref) = write_test_segment().await;
+        let object_bytes = source
+            .get(&seg_ref.data_object_key, GetRange::Full)
+            .await
+            .expect("read back test segment")
+            .data;
+        let memory = MemoryStore::new();
+        memory
+            .put(
+                &seg_ref.data_object_key,
+                object_bytes.clone(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put segment object");
+        let fault = Arc::new(FaultStore::new(memory, FaultPlan::default()));
+        let gate: GateHandle = fault.hold(Op::Get, None, Occurrence::Always);
+        let backend: Arc<dyn ObjectStoreBackend> = fault;
+
+        let shared = Arc::new(crate::GetLimiter::new(1).expect("1 permit is valid"));
+        let fetcher_a = SegmentFetcher::new(backend.clone()).with_get_limiter(shared.clone());
+        let fetcher_b = SegmentFetcher::new(backend).with_get_limiter(shared);
+
+        let seg_a = seg_ref.clone();
+        let handle_a = tokio::spawn(async move { fetcher_a.fetch(tenant_hash, &seg_a, &[]).await });
+        let seg_b = seg_ref.clone();
+        let handle_b = tokio::spawn(async move { fetcher_b.fetch(tenant_hash, &seg_b, &[]).await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(1))
+            .await
+            .expect("one of the two fetches issues its GET within 30 s");
+
+        // Give the other fetch's task every chance to also reach the store: if
+        // the shared limiter did not actually bound concurrency, its GET would
+        // land here too and `held_count` would climb to 2 well within this
+        // window.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert_eq!(
+            gate.held_count(),
+            1,
+            "one shared permit must cap in-flight GETs at exactly 1, \
+             not merely at more than 0"
+        );
+
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(1))
+            .await
+            .expect("releasing the first permit lets the second GET proceed within 30 s");
+        assert_eq!(
+            gate.held_count(),
+            1,
+            "the second GET must be the only one held once the first releases"
+        );
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+
+        let a = tokio::time::timeout(std::time::Duration::from_secs(30), handle_a)
+            .await
+            .expect("fetch a completes within 30 s")
+            .expect("join fetch a")
+            .expect("fetch a");
+        let b = tokio::time::timeout(std::time::Duration::from_secs(30), handle_b)
+            .await
+            .expect("fetch b completes within 30 s")
+            .expect("join fetch b")
+            .expect("fetch b");
+        assert_eq!(a.len(), 2);
+        assert_eq!(b.len(), 2);
+    }
+
+    /// Control for [`shared_get_limiter_bounds_peak_concurrent_gets_to_one`]:
+    /// the same two fetchers, but each with its OWN private limiter of 1
+    /// permit rather than a shared one. Private pools do not add, so both
+    /// GETs reach the store at once and peak in-flight is exactly 2 --
+    /// proving the shared test's bound of 1 comes from sharing, not from some
+    /// other serialization (object identity, a single-flight cache, tokio
+    /// scheduling).
+    #[tokio::test]
+    async fn private_get_limiters_do_not_share_a_bound() {
+        use ravel_object_store::fault::{GateHandle, Occurrence};
+
+        let (source, tenant_hash, seg_ref) = write_test_segment().await;
+        let object_bytes = source
+            .get(&seg_ref.data_object_key, GetRange::Full)
+            .await
+            .expect("read back test segment")
+            .data;
+        let memory = MemoryStore::new();
+        memory
+            .put(
+                &seg_ref.data_object_key,
+                object_bytes.clone(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put segment object");
+        let fault = Arc::new(FaultStore::new(memory, FaultPlan::default()));
+        let gate: GateHandle = fault.hold(Op::Get, None, Occurrence::Always);
+        let backend: Arc<dyn ObjectStoreBackend> = fault;
+
+        let fetcher_a = SegmentFetcher::new(backend.clone()).with_max_concurrent_gets(1);
+        let fetcher_b = SegmentFetcher::new(backend).with_max_concurrent_gets(1);
+
+        let seg_a = seg_ref.clone();
+        let handle_a = tokio::spawn(async move { fetcher_a.fetch(tenant_hash, &seg_a, &[]).await });
+        let seg_b = seg_ref.clone();
+        let handle_b = tokio::spawn(async move { fetcher_b.fetch(tenant_hash, &seg_b, &[]).await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(2))
+            .await
+            .expect("two independently-limited fetchers both reach the store within 30 s");
+        assert_eq!(
+            gate.held_count(),
+            2,
+            "two private 1-permit limiters admit exactly 2 concurrent GETs, not 1"
+        );
+
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+        let a = tokio::time::timeout(std::time::Duration::from_secs(30), handle_a)
+            .await
+            .expect("fetch a completes within 30 s")
+            .expect("join fetch a")
+            .expect("fetch a");
+        let b = tokio::time::timeout(std::time::Duration::from_secs(30), handle_b)
+            .await
+            .expect("fetch b completes within 30 s")
+            .expect("join fetch b")
+            .expect("fetch b");
+        assert_eq!(a.len(), 2);
+        assert_eq!(b.len(), 2);
     }
 
     /// ADR-0044: accounting must be pure observation. The accounted and

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -10,6 +10,7 @@ pub mod erasure;
 mod error;
 mod fetcher;
 pub mod http;
+mod limiter;
 mod log_fetcher;
 pub mod log_series;
 mod phase_accounting;
@@ -31,6 +32,7 @@ pub use fetcher::{
     CacheFetchError, FetchError, FetchStats, FetchedSeries, FetchedSeriesSoa, ReadCache,
     SamplePriority, SegmentFetcher,
 };
+pub use limiter::GetLimiter;
 pub use log_fetcher::{
     AssemblyBufferStats, BlockRangeFetcher, BlockRangeStats, BlockStatsReport, CarriedFooter,
     ColumnarBlockOutcome, DEFAULT_LOG_COALESCE_GAP, DEFAULT_LOG_COVERAGE_THRESHOLD,

--- a/crates/ravel-query/src/limiter.rs
+++ b/crates/ravel-query/src/limiter.rs
@@ -1,0 +1,112 @@
+//! Process-shareable GET concurrency limiter (ADR-1195).
+//!
+//! Before this, each fetcher held a private `Arc<Semaphore>`, so concurrent
+//! segment fetches within one fetcher were bounded, but two fetchers (the
+//! RSEG and RLOG paths inside one engine, or two engines in one process)
+//! never shared a bound at all: their permits multiplied instead of adding.
+//! `GetLimiter` is the same shape, `Arc`-wrapped so several fetchers -- and,
+//! via [`crate::QueryEngine::with_get_limiter`], several engines -- can hold
+//! the same instance and draw from one pool of permits.
+
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::config::EngineConfigError;
+
+/// A bound on concurrent object-store GETs, shareable across fetchers and
+/// engines by cloning the `Arc` it is always held behind.
+pub struct GetLimiter {
+    semaphore: Arc<Semaphore>,
+    permits: usize,
+}
+
+impl GetLimiter {
+    /// Rejects zero: a zero-permit limiter can never issue a GET, which is
+    /// never a meaningful configuration (ADR-1195 "zero is rejected during
+    /// configuration resolution").
+    pub fn new(permits: usize) -> Result<GetLimiter, EngineConfigError> {
+        if permits == 0 {
+            return Err(EngineConfigError::ZeroGetLimiterPermits);
+        }
+        Ok(GetLimiter::new_unchecked(permits))
+    }
+
+    /// Builds a limiter with no zero check, for the fetcher builders
+    /// (`with_max_concurrent_gets`) that keep their pre-ADR-1195
+    /// clamp-zero-to-one behaviour rather than erroring: the caller has
+    /// already clamped `permits` to at least 1.
+    pub(crate) fn new_unchecked(permits: usize) -> GetLimiter {
+        GetLimiter {
+            semaphore: Arc::new(Semaphore::new(permits)),
+            permits,
+        }
+    }
+
+    /// The permit count this limiter was built with.
+    pub fn permits(&self) -> usize {
+        self.permits
+    }
+
+    /// Acquires one owned permit. Owned rather than borrowed so a fetcher can
+    /// hold it across an `.await` on the store GET itself without borrowing
+    /// this limiter; drop the permit to release it back to the pool.
+    pub fn acquire(&self) -> impl Future<Output = OwnedSemaphorePermit> {
+        let semaphore = Arc::clone(&self.semaphore);
+        async move {
+            match semaphore.acquire_owned().await {
+                Ok(permit) => permit,
+                // A `Semaphore` only closes when `close()` is called on it,
+                // and no fetcher or engine ever reaches this `Arc` to do
+                // so: it is private to `GetLimiter`, which exposes no
+                // `close`. This arm is therefore unreachable, not merely
+                // rare.
+                Err(_) => unreachable!("GetLimiter's semaphore is never closed"),
+            }
+        }
+    }
+}
+
+impl fmt::Debug for GetLimiter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GetLimiter")
+            .field("permits", &self.permits)
+            .field("available_permits", &self.semaphore.available_permits())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_permits_is_rejected() {
+        assert_eq!(
+            GetLimiter::new(0).err(),
+            Some(EngineConfigError::ZeroGetLimiterPermits)
+        );
+    }
+
+    #[test]
+    fn nonzero_permits_reports_itself() {
+        let limiter = GetLimiter::new(4).expect("4 permits is valid");
+        assert_eq!(limiter.permits(), 4);
+        assert_eq!(
+            format!("{limiter:?}"),
+            "GetLimiter { permits: 4, available_permits: 4 }"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_yields_an_owned_permit_and_releases_on_drop() {
+        let limiter = GetLimiter::new(1).expect("1 permit is valid");
+        let permit = limiter.acquire().await;
+        assert_eq!(limiter.semaphore.available_permits(), 0);
+        drop(permit);
+        assert_eq!(limiter.semaphore.available_permits(), 1);
+    }
+}

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -72,7 +72,6 @@ use ravel_object_store::{Etag, GetOutcome, GetRange, ObjectStoreBackend, StoreEr
 use ravel_types::TenantHash;
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
 use ravel_types::logstream::canonical_attr_bytes;
-use tokio::sync::Semaphore;
 use tracing::Instrument;
 
 /// Upper bound on STREAM_DIR entries accepted when decoding the directory out
@@ -657,6 +656,25 @@ impl LogSegmentFetcher {
     pub fn with_max_concurrent_gets(mut self, n: usize) -> Self {
         self.block_range = self.block_range.with_max_concurrent_gets(n);
         self
+    }
+
+    /// Wires the block-range path to a caller-owned [`crate::GetLimiter`]
+    /// (ADR-1195), so it draws GET permits from the same pool as every other
+    /// fetcher (and, via [`crate::QueryEngine::with_get_limiter`], every
+    /// other engine) holding the same `Arc`.
+    #[must_use]
+    pub fn with_get_limiter(mut self, limiter: std::sync::Arc<crate::GetLimiter>) -> Self {
+        self.block_range = self.block_range.with_get_limiter(limiter);
+        self
+    }
+
+    /// The block-range path's current limiter, for a test to `Arc::ptr_eq`
+    /// against another fetcher's or an engine's, proving two fetchers
+    /// actually share one `GetLimiter` rather than each holding an
+    /// equal-but-distinct one.
+    #[cfg(test)]
+    pub(crate) fn get_limiter_for_test(&self) -> &std::sync::Arc<crate::GetLimiter> {
+        self.block_range.get_limiter_for_test()
     }
 
     /// Pins the block-range fetcher's suffix-probe length
@@ -3099,11 +3117,13 @@ pub struct BlockRangeFetcher {
     /// on [`Self::covering_read`] (issue #1007): this field only ever reports
     /// the wire side.
     peak_fetch_run: Arc<AtomicU64>,
-    /// Bounds in-flight byte-range GETs. Its own instance, never shared with
-    /// `SegmentFetcher`'s RSEG semaphore (ADR-0107 decision 1).
-    get_semaphore: Arc<Semaphore>,
+    /// Bounds in-flight byte-range GETs. By default its own private instance
+    /// (ADR-0107 decision 1); [`Self::with_get_limiter`] wires it to the one
+    /// process-shared limiter every query-side fetcher can hold instead
+    /// (ADR-1195).
+    get_limiter: Arc<crate::GetLimiter>,
     /// Reusable object-sized assembly buffers (issue #894), shared by every
-    /// clone of this fetcher the way `get_semaphore` is, so the one production
+    /// clone of this fetcher the way `get_limiter` is, so the one production
     /// `LogSegmentFetcher` pools across every read of the process rather than
     /// per query.
     assembly_pool: Arc<AssemblyBufferPool>,
@@ -3128,7 +3148,9 @@ impl BlockRangeFetcher {
             request_cost_bytes: DEFAULT_LOG_REQUEST_COST_BYTES,
             max_fetch_run_bytes: crate::DEFAULT_LOG_MAX_FETCH_RUN_BYTES,
             peak_fetch_run: Arc::new(AtomicU64::new(0)),
-            get_semaphore: Arc::new(Semaphore::new(DEFAULT_LOG_MAX_CONCURRENT_GETS)),
+            get_limiter: Arc::new(crate::GetLimiter::new_unchecked(
+                DEFAULT_LOG_MAX_CONCURRENT_GETS,
+            )),
             assembly_pool: Arc::new(AssemblyBufferPool::default()),
             wire_bytes: PhaseWireByteCounter::new(),
         }
@@ -3436,8 +3458,25 @@ impl BlockRangeFetcher {
 
     #[must_use]
     pub fn with_max_concurrent_gets(mut self, n: usize) -> Self {
-        self.get_semaphore = Arc::new(Semaphore::new(n.max(1)));
+        self.get_limiter = Arc::new(crate::GetLimiter::new_unchecked(n.max(1)));
         self
+    }
+
+    /// Wires this fetcher to a caller-owned [`crate::GetLimiter`] (ADR-1195),
+    /// so it draws GET permits from the same pool as every other fetcher (and,
+    /// via [`crate::QueryEngine::with_get_limiter`], every other engine)
+    /// holding the same `Arc`.
+    #[must_use]
+    pub fn with_get_limiter(mut self, limiter: Arc<crate::GetLimiter>) -> Self {
+        self.get_limiter = limiter;
+        self
+    }
+
+    /// This fetcher's current limiter, for a test to `Arc::ptr_eq` against
+    /// another fetcher's or an engine's.
+    #[cfg(test)]
+    pub(crate) fn get_limiter_for_test(&self) -> &Arc<crate::GetLimiter> {
+        &self.get_limiter
     }
 
     /// Whether ADR-0046's read cache is wired into this fetcher. Every GET the
@@ -3467,14 +3506,7 @@ impl BlockRangeFetcher {
         phase: QueryPhase,
         accounting: &QueryAccounting,
     ) -> Result<GetOutcome, LogFetchError> {
-        let _permit = self
-            .get_semaphore
-            .acquire()
-            .await
-            .map_err(|_| LogFetchError::Store {
-                key: key.to_string(),
-                source: StoreError::Transient("fetch concurrency semaphore closed".to_string()),
-            })?;
+        let _permit = self.get_limiter.acquire().await;
         let got = self
             .store
             .get(key, range)
@@ -5202,7 +5234,7 @@ impl BlockRangeFetcher {
 
         // Every coalesced run concurrently, not one await at a time (mirrors
         // `crate::fetcher::SegmentFetcher::ensure_ranges`' `join_all`). Awaiting
-        // the runs in series made `get_semaphore` inert: a sequential loop never
+        // the runs in series made `get_limiter` inert: a sequential loop never
         // has more than one GET in flight to bound.
         let runs = coalesce_extents(&missing, self.effective_coalesce_gap());
         let outcomes = futures::future::join_all(runs.iter().map(|run| {

--- a/crates/ravel-query/src/span_fetcher.rs
+++ b/crates/ravel-query/src/span_fetcher.rs
@@ -181,6 +181,14 @@ pub struct SpanSegmentFetcher {
     /// builds the RAM or RAM-over-disk variant the same way the metric and log
     /// fetchers do.
     cache: Option<ReadCache>,
+    /// Bounds in-flight object-store GETs (ADR-1195). This is this fetcher's
+    /// FIRST-EVER concurrency bound: before ADR-1195, `SpanSegmentFetcher` held
+    /// no semaphore at all and its GET concurrency was limited only by its
+    /// caller. `new` gives it a private limiter at
+    /// [`crate::fetcher::DEFAULT_MAX_CONCURRENT_GETS`]; [`Self::with_get_limiter`]
+    /// wires it to the one process-shared limiter every query-side fetcher can
+    /// hold instead.
+    get_limiter: Arc<crate::GetLimiter>,
 }
 
 impl SpanSegmentFetcher {
@@ -189,7 +197,29 @@ impl SpanSegmentFetcher {
             store,
             cfg: RspanConfig::default(),
             cache: None,
+            get_limiter: Arc::new(crate::GetLimiter::new_unchecked(
+                crate::fetcher::DEFAULT_MAX_CONCURRENT_GETS,
+            )),
         }
+    }
+
+    /// Sets the in-flight GET bound by building a new private limiter. Shared
+    /// across this fetcher's clones; not shared with any other fetcher unless
+    /// [`Self::with_get_limiter`] is used instead.
+    #[must_use]
+    pub fn with_max_concurrent_gets(mut self, n: usize) -> Self {
+        self.get_limiter = Arc::new(crate::GetLimiter::new_unchecked(n.max(1)));
+        self
+    }
+
+    /// Wires this fetcher to a caller-owned [`crate::GetLimiter`] (ADR-1195),
+    /// so it draws GET permits from the same pool as every other fetcher (and,
+    /// via [`crate::QueryEngine::with_get_limiter`], every other engine)
+    /// holding the same `Arc`.
+    #[must_use]
+    pub fn with_get_limiter(mut self, limiter: Arc<crate::GetLimiter>) -> Self {
+        self.get_limiter = limiter;
+        self
     }
 
     /// Overrides the [`RspanConfig`] used for section-size caps when decoding.
@@ -282,6 +312,7 @@ impl SpanSegmentFetcher {
         }
 
         let key = &seg_ref.data_object_key;
+        let _permit = self.get_limiter.acquire().await;
         let got = self
             .store
             .get(key, GetRange::Full)
@@ -510,6 +541,7 @@ impl SpanSegmentFetcher {
         let key = &seg_ref.data_object_key;
 
         let Some(cache) = &self.cache else {
+            let _permit = self.get_limiter.acquire().await;
             let got = self
                 .store
                 .get(key, GetRange::Full)
@@ -529,6 +561,7 @@ impl SpanSegmentFetcher {
         // tiered tier (see `ReadCache::get_or_fetch`).
         let (bytes, source) = cache
             .get_or_fetch(cache_key, || async move {
+                let _permit = self.get_limiter.acquire().await;
                 let got = self.store.get(key, GetRange::Full).await?;
                 accounting.record_s3_request(AccountedOp::Get);
                 accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
@@ -1586,5 +1619,79 @@ mod tests {
             row_out.records.len(),
             "both exits select the identical surviving-row multiset under a trace filter"
         );
+    }
+
+    /// ADR-1195: `SpanSegmentFetcher` had no GET concurrency bound at all
+    /// before this change. `with_max_concurrent_gets(1)` must cap in-flight
+    /// GETs at exactly 1 -- proven the same way as the RSEG/RLOG shared-bound
+    /// tests (`crate::fetcher`'s `shared_get_limiter_bounds_peak_concurrent_gets_to_one`):
+    /// a `FaultStore` hold gate observes the store's own in-flight GET count
+    /// directly, so this pins the fetcher's own bookkeeping against the
+    /// store's view, not just against itself.
+    #[tokio::test]
+    async fn get_limiter_bounds_peak_concurrent_gets_to_permit_count() {
+        use ravel_object_store::fault::{FaultPlan, FaultStore, GateHandle, Occurrence};
+
+        let memory = MemoryStore::new();
+        let records = vec![span_with_attrs_and_events(trace(1), span(1), 100, 200)];
+        let seg = write_object(&memory, 0, &records).await;
+        let fault = Arc::new(FaultStore::new(memory, FaultPlan::default()));
+        let gate: GateHandle =
+            fault.hold(ravel_object_store::fault::Op::Get, None, Occurrence::Always);
+        let backend: Arc<dyn ObjectStoreBackend> = fault;
+
+        let fetcher = SpanSegmentFetcher::new(backend).with_max_concurrent_gets(1);
+        let query = all_query();
+
+        let fetcher_a = fetcher.clone();
+        let seg_a = seg.clone();
+        let query_a = query;
+        let handle_a =
+            tokio::spawn(async move { fetcher_a.fetch(&seg_a, &query_a, None, None, &[]).await });
+        let fetcher_b = fetcher.clone();
+        let seg_b = seg.clone();
+        let query_b = query;
+        let handle_b =
+            tokio::spawn(async move { fetcher_b.fetch(&seg_b, &query_b, None, None, &[]).await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(1))
+            .await
+            .expect("one of the two fetches issues its GET within 30 s");
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert_eq!(
+            gate.held_count(),
+            1,
+            "one permit must cap in-flight GETs at exactly 1, not merely more than 0"
+        );
+
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(1))
+            .await
+            .expect("releasing the first permit lets the second GET proceed within 30 s");
+        assert_eq!(
+            gate.held_count(),
+            1,
+            "the second GET must be the only one held once the first releases"
+        );
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+
+        let a = tokio::time::timeout(std::time::Duration::from_secs(30), handle_a)
+            .await
+            .expect("fetch a completes within 30 s")
+            .expect("join fetch a")
+            .expect("fetch a")
+            .expect("fetch a found the segment relevant");
+        let b = tokio::time::timeout(std::time::Duration::from_secs(30), handle_b)
+            .await
+            .expect("fetch b completes within 30 s")
+            .expect("join fetch b")
+            .expect("fetch b")
+            .expect("fetch b found the segment relevant");
+        assert_eq!(a.records.len(), 1);
+        assert_eq!(b.records.len(), 1);
     }
 }

--- a/docs/adrs/0107-pruning-proportional-logs-fetch.md
+++ b/docs/adrs/0107-pruning-proportional-logs-fetch.md
@@ -306,6 +306,25 @@ Before this amendment nothing set it, so every logs scan ran at most 16
 GETs in flight regardless of the flag, and a 100M-row `count(*)` measured
 the same 160 s at `--fetch-concurrency` 16 and 32.
 
+## Amendment 2026-09-05 (ADR-1195): the RLOG permit pool is the shared GET limiter
+
+ADR-1195 replaces the per-fetcher semaphores with one
+`ravel_query::GetLimiter` shared by every fetcher a `QueryEngine` owns, sized
+by the new `--store-get-concurrency` knob (derived default
+`max(8, 2 x cores)`, the formula `--fetch-concurrency` used). This supersedes
+"sized independently for RLOG's call volume" in decision 1 and "separate from
+RSEG's" in the amendment above: RLOG's `BlockRangeFetcher` now draws from the
+same pool as RSEG and RSPAN, and `LogSegmentFetcher::with_max_concurrent_gets`
+is a convenience that builds a private limiter for callers outside an engine
+(the benches). The knob ADR-1195 left for this ADR to name is
+`--store-get-concurrency`.
+
+Two things this amendment does not change. The RLOG whole-object funnel
+(`fetch_accounted` and `whole_object_bytes`) still issues GETs without a
+permit; the ADR-1195 follow-up closes that. And sharing one limiter across
+`ravel-server`'s engines and standalone fetchers lands with the server half of
+ADR-1195; until then the pool is per engine.
+
 ## Amendment 2026-08-26 (issue #693 part 3): a footer carried from the plan phase establishes the etag pin on the first data GET
 
 Decision 1 establishes the mandatory etag pin on the suffix probe: the probe is

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -683,6 +683,43 @@ resolution limit), wall deadline (server maximum, default
 server maximum are clamped to it. Exceeding a budget returns a
 Prometheus-style error, never a partial silent result.
 
+### GET concurrency (ADR-1195)
+
+The "max concurrent GETs (8, ...)" figure above is the *process-wide*
+ceiling, not a per-selector or per-fetcher one. Every query-side fetcher
+(RSEG `SegmentFetcher`, RLOG `LogSegmentFetcher`/`BlockRangeFetcher`, RSPAN
+`SpanSegmentFetcher`) draws its GET permits from one shared
+`ravel_query::GetLimiter`, an `Arc`-based wrapper over a `tokio::Semaphore`.
+`QueryEngine::new` builds this limiter once and hands the same `Arc` to
+every fetcher it owns; `QueryEngine::with_get_limiter` replaces it on all of
+them at once, letting a process share one ceiling across several engines.
+Before ADR-1195, each fetcher held its own independent semaphore, so N
+fetchers each configured to "8 concurrent GETs" could together put 8N GETs
+in flight against the store; the shared limiter closes that multiplication.
+`SpanSegmentFetcher` previously had no GET bound at all -- constructing one
+directly now gives it a private limiter sized to the fetcher module's
+default concurrent-GET constant, its first-ever concurrency bound, unless
+`with_get_limiter` wires it to the shared one instead.
+
+`EngineConfig::fetch_concurrency` remains the legacy uniform knob: a bare
+`EngineConfig::default()` (or any config that leaves the three knobs below
+unset) behaves exactly as before ADR-1195, because splitting the knob
+changes which lever an operator turns, not what an untouched deployment
+does. Three `Option<usize>` overrides on `EngineConfig` take precedence
+over it when set, each resolved through a same-named accessor method:
+
+- `store_get_concurrency` / `store_get_concurrency()` -- the resolved
+  permit count for the one shared `GetLimiter` described above.
+- `sql_partition_count` / `sql_partition_count()` -- DataFusion
+  `target_partitions`; exposed here, wired into
+  `crates/ravel-sql/src/session.rs` by a follow-up task.
+- `promql_fetch_fanout` / `promql_fetch_fanout()` -- the `buffer_unordered`
+  fan-out width PromQL's per-selector fetch streams use.
+
+`EngineConfig::validate` rejects zero on `fetch_concurrency` and on each
+knob's resolved value (an explicit override of `0`, not just an unset one),
+naming the specific knob in the returned `EngineConfigError`.
+
 ### Segment admission (ADR-0073)
 
 `max_segments` no longer counts every segment in the resolved snapshot. A

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -727,6 +727,15 @@ over it when set, each resolved through a same-named accessor method:
 - `promql_fetch_fanout` / `promql_fetch_fanout()` -- the `buffer_unordered`
   fan-out width PromQL's per-selector fetch streams use.
 
+The permit bounds GETs in flight, not fetch tasks in flight. An RLOG
+block-range read builds its object assembler (charged to the assembly pool)
+before its first extent asks the limiter for a permit, so when
+`promql_fetch_fanout` or `sql_partition_count` exceeds `store_get_concurrency`,
+up to that many object-sized assemblies can wait behind the limiter at once.
+Peak assembly memory therefore follows the fan-out setting, and an operator
+who raises fan-out without raising GET concurrency trades store pressure for
+memory, not for nothing.
+
 `EngineConfig::validate` rejects zero on `fetch_concurrency` and on each
 knob's resolved value (an explicit override of `0`, not just an unset one),
 naming the specific knob in the returned `EngineConfigError`.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -685,17 +685,28 @@ Prometheus-style error, never a partial silent result.
 
 ### GET concurrency (ADR-1195)
 
-The "max concurrent GETs (8, ...)" figure above is the *process-wide*
-ceiling, not a per-selector or per-fetcher one. Every query-side fetcher
-(RSEG `SegmentFetcher`, RLOG `LogSegmentFetcher`/`BlockRangeFetcher`, RSPAN
-`SpanSegmentFetcher`) draws its GET permits from one shared
-`ravel_query::GetLimiter`, an `Arc`-based wrapper over a `tokio::Semaphore`.
-`QueryEngine::new` builds this limiter once and hands the same `Arc` to
-every fetcher it owns; `QueryEngine::with_get_limiter` replaces it on all of
-them at once, letting a process share one ceiling across several engines.
+The "max concurrent GETs (8, ...)" figure above is the ceiling for the
+fetchers one `QueryEngine` owns, not a per-selector one. Inside an engine the
+RSEG `SegmentFetcher`, the RLOG `BlockRangeFetcher` (the block-range protocol
+that `LogSegmentFetcher` delegates to) and the RSPAN `SpanSegmentFetcher`
+draw their GET permits from one shared `ravel_query::GetLimiter`, an
+`Arc`-based wrapper over a `tokio::Semaphore`. `QueryEngine::new` builds this
+limiter once and hands the same `Arc` to the fetchers it owns;
+`QueryEngine::with_get_limiter` replaces it on all of them at once, so a
+process can share one ceiling across several engines.
+
+Two gaps remain until the server half of ADR-1195 lands. The ceiling is per
+engine, not per process: `ravel-server` and `ravel-sql` still construct
+engines and standalone fetchers with their own limiters. And the RLOG
+whole-object funnel (`LogSegmentFetcher::fetch_accounted` and
+`whole_object_bytes`, taken by every object at or below the block-range
+threshold) issues its GETs without a permit, as it did before ADR-1195; only
+the block-range protocol is bounded today.
+
 Before ADR-1195, each fetcher held its own independent semaphore, so N
 fetchers each configured to "8 concurrent GETs" could together put 8N GETs
-in flight against the store; the shared limiter closes that multiplication.
+in flight against the store; the shared limiter closes that multiplication
+for the fetchers it reaches.
 `SpanSegmentFetcher` previously had no GET bound at all -- constructing one
 directly now gives it a private limiter sized to the fetcher module's
 default concurrent-GET constant, its first-ever concurrency bound, unless


### PR DESCRIPTION
ADR-1195, crate half. A `QueryEngine` now builds one `GetLimiter` and hands
the same `Arc` to the RSEG, RLOG block-range and RSPAN fetchers it owns, so
their GETs draw permits from one pool instead of N private semaphores that
multiplied the configured concurrency by the number of fetchers. RSEG
fetchers honour the configured value for the first time (they were pinned
at the compiled 16), and RSPAN fetchers get their first GET bound.

`EngineConfig` gains `store_get_concurrency`, `sql_partition_count` and
`promql_fetch_fanout` as optional overrides with same-named accessors that
fall back to `fetch_concurrency`, so no default moves and every existing
literal keeps compiling. `validate` rejects zero in each and names the knob.
`QueryEngine::with_get_limiter` lets a process share one limiter across
engines; the server half of ADR-1195 wires that and the three flags.

Two gaps are named in docs/query-engine.md rather than hidden: the RLOG
whole-object funnel still issues GETs without a permit, and the ceiling is
per engine until the server half lands. A dated ADR-0107 amendment records
that the RLOG permit pool is now the shared limiter sized by
`--store-get-concurrency`, as ADR-1195's consequences required before the
split landed.

Tests pin the bound as an exact peak of in-flight GETs observed through a
held `FaultStore` gate: 1 with a shared single-permit limiter, 2 with
private ones.

Refs: #1195
