### PR TITLE
fix(ravel-query): permit every RLOG GET and harden the limiter tests

### DIFF
--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -7553,6 +7553,14 @@ mod get_limiter_tests {
     /// owns, and record the new `Arc` as the engine's own, so a later
     /// `with_get_limiter` call (or another engine sharing this one) still sees
     /// the current limiter rather than the one `new` built privately.
+    ///
+    /// Three fetchers reach here, not two: RSEG's `fetcher`, RLOG's OWN
+    /// whole-object limiter, and RLOG's block-range limiter. Before the
+    /// ADR-1195 gap this closes, `log_fetcher`'s own whole-object GETs (the
+    /// funnel every RLOG object at or below `block_range_threshold` routes
+    /// through, which is the stock `cost-based`-policy ClickBench path) had no
+    /// limiter of their own to replace, so a test asserting only the
+    /// block-range side could not see that gap.
     #[test]
     fn with_get_limiter_replaces_every_owned_fetcher() {
         let engine = engine(Arc::new(MemoryStore::new()));
@@ -7567,6 +7575,10 @@ mod get_limiter_tests {
         ));
         assert!(Arc::ptr_eq(
             engine.log_fetcher.get_limiter_for_test(),
+            &replacement
+        ));
+        assert!(Arc::ptr_eq(
+            engine.log_fetcher.block_range_get_limiter_for_test(),
             &replacement
         ));
         assert!(!Arc::ptr_eq(

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -746,7 +746,9 @@ impl SegmentFetcher {
         range: GetRange,
         accounting: &QueryAccounting,
     ) -> Result<GetOutcome, StoreError> {
-        let _permit = self.get_limiter.acquire().await;
+        let _permit = self.get_limiter.acquire().await.map_err(|_| {
+            StoreError::Transient("GetLimiter semaphore closed unexpectedly".into())
+        })?;
         accounting.record_s3_request(AccountedOp::Get);
         let got = self.store.get(key, range).await?;
         accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
@@ -3447,16 +3449,24 @@ mod tests {
             .await
             .expect("one of the two fetches issues its GET within 30 s");
 
-        // Give the other fetch's task every chance to also reach the store: if
-        // the shared limiter did not actually bound concurrency, its GET would
-        // land here too and `held_count` would climb to 2 well within this
-        // window.
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        // The other fetch's GET must never become in-flight while the shared
+        // permit is held: if the shared limiter did not actually bound
+        // concurrency, `wait_until_held(2)` would resolve well within this
+        // window instead of timing out.
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                gate.wait_until_held(2)
+            )
+            .await
+            .is_err(),
+            "one shared permit must cap in-flight GETs at exactly 1, \
+             not merely at more than 0"
+        );
         assert_eq!(
             gate.held_count(),
             1,
-            "one shared permit must cap in-flight GETs at exactly 1, \
-             not merely at more than 0"
+            "one shared permit must cap in-flight GETs at exactly 1"
         );
 
         for id in gate.held() {

--- a/crates/ravel-query/src/limiter.rs
+++ b/crates/ravel-query/src/limiter.rs
@@ -16,6 +16,14 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::config::EngineConfigError;
 
+/// [`GetLimiter::acquire`]'s semaphore closed before granting a permit. The
+/// semaphore is private to `GetLimiter`, which exposes no `close`, so no
+/// caller can ever trigger this; it exists so `acquire` fails typed instead
+/// of panicking if that invariant is ever violated.
+#[derive(Debug, thiserror::Error)]
+#[error("GetLimiter semaphore closed unexpectedly")]
+pub struct GetLimiterClosed;
+
 /// A bound on concurrent object-store GETs, shareable across fetchers and
 /// engines by cloning the `Arc` it is always held behind.
 pub struct GetLimiter {
@@ -52,19 +60,17 @@ impl GetLimiter {
 
     /// Acquires one owned permit. Owned rather than borrowed so a fetcher can
     /// hold it across an `.await` on the store GET itself without borrowing
-    /// this limiter; drop the permit to release it back to the pool.
-    pub fn acquire(&self) -> impl Future<Output = OwnedSemaphorePermit> {
+    /// this limiter; drop the permit to release it back to the pool. Errors
+    /// with [`GetLimiterClosed`] if the semaphore is ever closed, which no
+    /// current caller can trigger (see that type's doc), so a caller maps it
+    /// into its own error type rather than treating it as reachable today.
+    pub fn acquire(&self) -> impl Future<Output = Result<OwnedSemaphorePermit, GetLimiterClosed>> {
         let semaphore = Arc::clone(&self.semaphore);
         async move {
-            match semaphore.acquire_owned().await {
-                Ok(permit) => permit,
-                // A `Semaphore` only closes when `close()` is called on it,
-                // and no fetcher or engine ever reaches this `Arc` to do
-                // so: it is private to `GetLimiter`, which exposes no
-                // `close`. This arm is therefore unreachable, not merely
-                // rare.
-                Err(_) => unreachable!("GetLimiter's semaphore is never closed"),
-            }
+            semaphore
+                .acquire_owned()
+                .await
+                .map_err(|_| GetLimiterClosed)
         }
     }
 }
@@ -104,7 +110,7 @@ mod tests {
     #[tokio::test]
     async fn acquire_yields_an_owned_permit_and_releases_on_drop() {
         let limiter = GetLimiter::new(1).expect("1 permit is valid");
-        let permit = limiter.acquire().await;
+        let permit = limiter.acquire().await.expect("semaphore is never closed");
         assert_eq!(limiter.semaphore.available_permits(), 0);
         drop(permit);
         assert_eq!(limiter.semaphore.available_permits(), 1);

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -538,6 +538,16 @@ pub struct LogSegmentFetcher {
     /// The block-range fetcher used for objects above `block_range_threshold`.
     /// Kept in sync with `store`/`cfg`/`cache` by the builders.
     block_range: BlockRangeFetcher,
+    /// Bounds this fetcher's OWN whole-object GETs (`fetch_accounted` and
+    /// `whole_object_bytes`'s two sites), the funnel every object at or below
+    /// `block_range_threshold` routes through. Distinct from
+    /// `block_range`'s limiter, which bounds only the above-threshold
+    /// ranged path; [`Self::with_get_limiter`] sets both to the same `Arc` so
+    /// a caller shares one pool across both funnels, and
+    /// [`Self::with_block_range`] re-applies this field's current limiter to
+    /// the replacement `BlockRangeFetcher` so builder order cannot silently
+    /// drop it (ADR-1195).
+    get_limiter: Arc<crate::GetLimiter>,
     /// Per-phase tail-section probe misses across every read this fetcher has
     /// served (#883). Shared by every clone, like `block_range`'s GET semaphore,
     /// and read through [`probe_miss_counter`](Self::probe_miss_counter).
@@ -559,6 +569,9 @@ impl LogSegmentFetcher {
             cache: None,
             block_range_threshold: DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             block_range: BlockRangeFetcher::new(store).with_wire_byte_counter(wire_bytes.clone()),
+            get_limiter: Arc::new(crate::GetLimiter::new_unchecked(
+                DEFAULT_LOG_MAX_CONCURRENT_GETS,
+            )),
             probe_misses: ProbeMissCounter::new(),
             wire_bytes,
         }
@@ -658,22 +671,37 @@ impl LogSegmentFetcher {
         self
     }
 
-    /// Wires the block-range path to a caller-owned [`crate::GetLimiter`]
-    /// (ADR-1195), so it draws GET permits from the same pool as every other
-    /// fetcher (and, via [`crate::QueryEngine::with_get_limiter`], every
-    /// other engine) holding the same `Arc`.
+    /// Wires this fetcher's OWN whole-object GETs and the block-range path to
+    /// the same caller-owned [`crate::GetLimiter`] (ADR-1195), so both funnels
+    /// draw permits from the same pool as every other fetcher (and, via
+    /// [`crate::QueryEngine::with_get_limiter`], every other engine) holding
+    /// the same `Arc`.
     #[must_use]
     pub fn with_get_limiter(mut self, limiter: std::sync::Arc<crate::GetLimiter>) -> Self {
+        self.get_limiter = Arc::clone(&limiter);
         self.block_range = self.block_range.with_get_limiter(limiter);
         self
     }
 
-    /// The block-range path's current limiter, for a test to `Arc::ptr_eq`
-    /// against another fetcher's or an engine's, proving two fetchers
-    /// actually share one `GetLimiter` rather than each holding an
-    /// equal-but-distinct one.
+    /// This fetcher's own limiter (bounds `fetch_accounted` and
+    /// `whole_object_bytes`), for a test to `Arc::ptr_eq` against another
+    /// fetcher's or an engine's, proving two fetchers actually share one
+    /// `GetLimiter` rather than each holding an equal-but-distinct one. See
+    /// [`Self::block_range_get_limiter_for_test`] for the block-range path's
+    /// limiter.
     #[cfg(test)]
     pub(crate) fn get_limiter_for_test(&self) -> &std::sync::Arc<crate::GetLimiter> {
+        &self.get_limiter
+    }
+
+    /// The block-range path's current limiter, for the same `Arc::ptr_eq`
+    /// purpose as [`Self::get_limiter_for_test`]. Kept separate because
+    /// `with_block_range` can, in principle, be handed a `BlockRangeFetcher`
+    /// wired to a different limiter than this instance's own before this
+    /// builder re-applies the shared one; a test asserting both proves that
+    /// re-apply actually happened.
+    #[cfg(test)]
+    pub(crate) fn block_range_get_limiter_for_test(&self) -> &std::sync::Arc<crate::GetLimiter> {
         self.block_range.get_limiter_for_test()
     }
 
@@ -722,9 +750,18 @@ impl LogSegmentFetcher {
     /// counter (#913), so a caller that took the handle from
     /// [`phase_wire_byte_counter`](Self::phase_wire_byte_counter) before or
     /// after this call reads the same totals either way.
+    ///
+    /// It is also re-wired to this instance's current `get_limiter` (ADR-1195),
+    /// overriding whatever limiter `block_range` was built with. This makes
+    /// builder order irrelevant: `with_get_limiter().with_block_range(...)`
+    /// and `with_block_range(...).with_get_limiter(...)` both end with the
+    /// block-range path sharing this fetcher's limiter, rather than the first
+    /// order silently dropping it in favor of the replacement's own.
     #[must_use]
     pub fn with_block_range(mut self, block_range: BlockRangeFetcher) -> Self {
-        self.block_range = block_range.with_wire_byte_counter(self.wire_bytes.clone());
+        self.block_range = block_range
+            .with_wire_byte_counter(self.wire_bytes.clone())
+            .with_get_limiter(Arc::clone(&self.get_limiter));
         self
     }
 
@@ -973,6 +1010,18 @@ impl LogSegmentFetcher {
                 s3_bytes = tracing::field::Empty,
             );
             let got = async {
+                // Held across the GET only: dropped when this inner block
+                // returns, before `decode_spanned` below (ADR-1195).
+                let _permit =
+                    self.get_limiter
+                        .acquire()
+                        .await
+                        .map_err(|_| LogFetchError::Store {
+                            key: key.to_string(),
+                            source: StoreError::Transient(
+                                "GetLimiter semaphore closed unexpectedly".to_string(),
+                            ),
+                        })?;
                 self.store
                     .get(key, GetRange::Full)
                     .await
@@ -1975,6 +2024,19 @@ impl LogSegmentFetcher {
 
         let Some(cache) = &self.cache else {
             let got = async {
+                // Held across the GET only: dropped when this inner block
+                // returns, before this function hands the bytes to its
+                // caller's decode (ADR-1195).
+                let _permit =
+                    self.get_limiter
+                        .acquire()
+                        .await
+                        .map_err(|_| LogFetchError::Store {
+                            key: key.to_string(),
+                            source: StoreError::Transient(
+                                "GetLimiter semaphore closed unexpectedly".to_string(),
+                            ),
+                        })?;
                 self.store
                     .get(key, GetRange::Full)
                     .await
@@ -2000,6 +2062,13 @@ impl LogSegmentFetcher {
         let (bytes, source) = async {
             cache
                 .get_or_fetch(cache_key, || async move {
+                    // Held across the GET only: dropped before this closure
+                    // returns the bytes to its caller's decode (ADR-1195).
+                    let _permit = self.get_limiter.acquire().await.map_err(|_| {
+                        StoreError::Transient(
+                            "GetLimiter semaphore closed unexpectedly".to_string(),
+                        )
+                    })?;
                     let got = self.store.get(key, GetRange::Full).await?;
                     accounting.record_s3_request(AccountedOp::Get);
                     accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
@@ -3506,7 +3575,16 @@ impl BlockRangeFetcher {
         phase: QueryPhase,
         accounting: &QueryAccounting,
     ) -> Result<GetOutcome, LogFetchError> {
-        let _permit = self.get_limiter.acquire().await;
+        let _permit = self
+            .get_limiter
+            .acquire()
+            .await
+            .map_err(|_| LogFetchError::Store {
+                key: key.to_string(),
+                source: StoreError::Transient(
+                    "GetLimiter semaphore closed unexpectedly".to_string(),
+                ),
+            })?;
         let got = self
             .store
             .get(key, range)
@@ -6101,6 +6179,244 @@ mod plan_fast_path_tests {
             acc.snapshot().total_s3_bytes() > tail,
             "at-threshold: block-range fetch ran, not the footer-only probe"
         );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod whole_object_get_limiter_tests {
+    //! Pins the ADR-1195 gap the adversarial review of #1195 found: the RLOG
+    //! whole-object funnel (`fetch_accounted`, the path every object at or
+    //! below `block_range_threshold` takes) issued its GET with no permit at
+    //! all, so it could never be bounded no matter how the caller configured
+    //! `get_limiter`. `fetch_accounted` is used here rather than the
+    //! tenant-aware `fetch_accounted_with_tenant` because it takes the
+    //! whole-object path unconditionally (no threshold branch to thread a
+    //! tenant hash and cache through); the default `block_range_threshold`
+    //! (`DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`, far larger than this test's
+    //! object) confirms the same funnel is what production's cost-based
+    //! default policy reaches for small objects.
+
+    use super::*;
+    use ravel_catalog::SegmentLevel;
+    use ravel_logseg::writer::ObjectIdentity;
+    use ravel_logseg::{RlogWriter, stream_attrs_bytes};
+    use ravel_object_store::ObjectStoreBackend;
+    use ravel_object_store::PutOptions;
+    use ravel_object_store::fault::{FaultPlan, FaultStore, GateHandle, Occurrence, Op};
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_types::logstream::log_stream_id;
+    use uuid::Uuid;
+
+    const CONTENT_HASH: [u8; 32] = [9u8; 32];
+    const KEY: &str = "t/whole.rlog";
+
+    fn identity() -> ObjectIdentity {
+        ObjectIdentity {
+            tenant_hash: [7u8; 16],
+            shard: 0,
+            writer_id: [2u8; 16],
+            writer_epoch: 1,
+            writer_seq: 1,
+        }
+    }
+
+    fn record(ts: i64) -> LogRecord {
+        let resource = vec![("service.name".to_string(), AttrValue::Str("svc".into()))];
+        LogRecord {
+            stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+            stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+            ts_ns: ts,
+            observed_ts_ns: ts,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: "hello world".into(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: vec![("request.id".to_string(), AttrValue::Str(format!("r{ts}")))],
+        }
+    }
+
+    fn build_object() -> Vec<u8> {
+        let mut w = RlogWriter::new(RlogConfig::default(), identity());
+        w.push(record(0)).expect("push");
+        w.finish().expect("finish")
+    }
+
+    fn seg_ref(size: u64) -> SegmentRef {
+        SegmentRef {
+            data_object_key: KEY.to_string(),
+            object_size: size,
+            min_event_ts_ns: 0,
+            max_event_ts_ns: 0,
+            ingest_hour_bucket: 0,
+            sample_count: 1,
+            series_count: 0,
+            shard: 0,
+            content_hash: CONTENT_HASH,
+            writer_id: Uuid::from_u128(1),
+            writer_epoch: 1,
+            writer_seq: 1,
+            created_unix_ns: 0,
+            level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+            declared_column_stats: Default::default(),
+        }
+    }
+
+    async fn store_with_object(bytes: Vec<u8>) -> MemoryStore {
+        let store = MemoryStore::new();
+        store
+            .put(KEY, Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put");
+        store
+    }
+
+    /// Object well under `DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`, so every
+    /// fetcher below takes the unconditional whole-object GET in
+    /// `fetch_accounted`, never `block_range`.
+    async fn small_object_backend() -> (Arc<FaultStore<MemoryStore>>, SegmentRef) {
+        let bytes = build_object();
+        let size = bytes.len() as u64;
+        assert!(
+            size < DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            "fixture object must stay below the whole-object threshold"
+        );
+        let store = store_with_object(bytes).await;
+        let fault = Arc::new(FaultStore::new(store, FaultPlan::default()));
+        (fault, seg_ref(size))
+    }
+
+    /// Two `LogSegmentFetcher`s sharing one `GetLimiter::new(1)` must never
+    /// let both whole-object GETs be in flight at once.
+    ///
+    /// Non-vacuity: before Deliverable 1 wired a private `get_limiter` field
+    /// onto `LogSegmentFetcher` and threaded it through `fetch_accounted`'s
+    /// GET (the `let _permit = self.get_limiter.acquire()...` block added
+    /// ahead of `self.store.get(key, GetRange::Full)` there), that GET took
+    /// no permit at all, so `gate.wait_until_held(2)` below would resolve
+    /// immediately instead of timing out and this test would fail at the
+    /// `is_err()` assertion.
+    #[tokio::test]
+    async fn shared_get_limiter_bounds_whole_object_gets_to_one() {
+        let (fault, seg) = small_object_backend().await;
+        let gate: GateHandle = fault.hold(Op::Get, None, Occurrence::Always);
+        let backend: Arc<dyn ObjectStoreBackend> = fault;
+
+        let shared = Arc::new(crate::GetLimiter::new(1).expect("1 permit is valid"));
+        let fetcher_a = LogSegmentFetcher::new(backend.clone()).with_get_limiter(shared.clone());
+        let fetcher_b = LogSegmentFetcher::new(backend).with_get_limiter(shared);
+        let query = LogQuery::new(i64::MIN, i64::MAX);
+
+        let seg_a = seg.clone();
+        let query_a = query.clone();
+        let handle_a = tokio::spawn(async move { fetcher_a.fetch(&seg_a, &query_a).await });
+        let seg_b = seg.clone();
+        let query_b = query.clone();
+        let handle_b = tokio::spawn(async move { fetcher_b.fetch(&seg_b, &query_b).await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(1))
+            .await
+            .expect("one of the two fetches issues its GET within 30 s");
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                gate.wait_until_held(2)
+            )
+            .await
+            .is_err(),
+            "one shared permit must cap in-flight whole-object GETs at exactly 1"
+        );
+        assert_eq!(
+            gate.held_count(),
+            1,
+            "peak in-flight whole-object GETs must be exactly 1"
+        );
+
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(1))
+            .await
+            .expect("releasing the first permit lets the second GET proceed within 30 s");
+        assert_eq!(
+            gate.held_count(),
+            1,
+            "the second GET must now be the only one held"
+        );
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+
+        let a = tokio::time::timeout(std::time::Duration::from_secs(30), handle_a)
+            .await
+            .expect("fetch a completes within 30 s")
+            .expect("join fetch a")
+            .expect("fetch a")
+            .expect("fetch a found the segment relevant");
+        let b = tokio::time::timeout(std::time::Duration::from_secs(30), handle_b)
+            .await
+            .expect("fetch b completes within 30 s")
+            .expect("join fetch b")
+            .expect("fetch b")
+            .expect("fetch b found the segment relevant");
+        assert_eq!(a.records.len(), 1);
+        assert_eq!(b.records.len(), 1);
+    }
+
+    /// Control for the test above: two `LogSegmentFetcher`s with PRIVATE
+    /// `GetLimiter::new(1)` instances (not shared) must reach 2 in-flight
+    /// whole-object GETs, proving the shared case above bounds because the
+    /// limiter is shared, not because the store or fixture serializes them.
+    #[tokio::test]
+    async fn private_get_limiters_do_not_share_a_bound() {
+        let (fault, seg) = small_object_backend().await;
+        let gate: GateHandle = fault.hold(Op::Get, None, Occurrence::Always);
+        let backend: Arc<dyn ObjectStoreBackend> = fault;
+
+        let fetcher_a = LogSegmentFetcher::new(backend.clone()).with_get_limiter(Arc::new(
+            crate::GetLimiter::new(1).expect("1 permit is valid"),
+        ));
+        let fetcher_b = LogSegmentFetcher::new(backend).with_get_limiter(Arc::new(
+            crate::GetLimiter::new(1).expect("1 permit is valid"),
+        ));
+        let query = LogQuery::new(i64::MIN, i64::MAX);
+
+        let seg_a = seg.clone();
+        let query_a = query.clone();
+        let handle_a = tokio::spawn(async move { fetcher_a.fetch(&seg_a, &query_a).await });
+        let seg_b = seg.clone();
+        let query_b = query.clone();
+        let handle_b = tokio::spawn(async move { fetcher_b.fetch(&seg_b, &query_b).await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(2))
+            .await
+            .expect("both fetches issue their GET within 30 s: private limiters do not share");
+        assert_eq!(
+            gate.held_count(),
+            2,
+            "private limiters must let both whole-object GETs be in flight at once"
+        );
+
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+        let a = tokio::time::timeout(std::time::Duration::from_secs(30), handle_a)
+            .await
+            .expect("fetch a completes within 30 s")
+            .expect("join fetch a")
+            .expect("fetch a")
+            .expect("fetch a found the segment relevant");
+        let b = tokio::time::timeout(std::time::Duration::from_secs(30), handle_b)
+            .await
+            .expect("fetch b completes within 30 s")
+            .expect("join fetch b")
+            .expect("fetch b")
+            .expect("fetch b found the segment relevant");
+        assert_eq!(a.records.len(), 1);
+        assert_eq!(b.records.len(), 1);
     }
 }
 

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -660,15 +660,19 @@ impl LogSegmentFetcher {
         self
     }
 
-    /// Bounds the in-flight object-store GETs of the block-range path (ADR-0107
-    /// decision 1's permit pool, [`DEFAULT_LOG_MAX_CONCURRENT_GETS`] by
-    /// default). This is the seam `--fetch-concurrency` (ADR-0088) reaches the
-    /// logs signal through; a scan planned at more partitions than this pool
-    /// has permits queues on it (issue #700).
+    /// Bounds the in-flight object-store GETs of BOTH RLOG paths with one
+    /// private [`crate::GetLimiter`] of `n` permits (0 is clamped to 1): the
+    /// fetcher's own whole-object funnel and the block-range path share it, so
+    /// a standalone fetcher built this way is governed by `n` on either path
+    /// and not by [`DEFAULT_LOG_MAX_CONCURRENT_GETS`]. This is the seam
+    /// `--fetch-concurrency` (ADR-0088) reaches the logs signal through; a scan
+    /// planned at more partitions than this pool has permits queues on it
+    /// (issue #700). A fetcher a `QueryEngine` owns is wired with
+    /// [`Self::with_get_limiter`] to the engine's shared limiter instead.
     #[must_use]
-    pub fn with_max_concurrent_gets(mut self, n: usize) -> Self {
-        self.block_range = self.block_range.with_max_concurrent_gets(n);
-        self
+    pub fn with_max_concurrent_gets(self, n: usize) -> Self {
+        let limiter = Arc::new(crate::GetLimiter::new_unchecked(n.max(1)));
+        self.with_get_limiter(limiter)
     }
 
     /// Wires this fetcher's OWN whole-object GETs and the block-range path to

--- a/crates/ravel-query/src/span_fetcher.rs
+++ b/crates/ravel-query/src/span_fetcher.rs
@@ -312,24 +312,28 @@ impl SpanSegmentFetcher {
         }
 
         let key = &seg_ref.data_object_key;
-        let _permit = self
-            .get_limiter
-            .acquire()
-            .await
-            .map_err(|_| SpanFetchError::Store {
-                key: key.to_string(),
-                source: StoreError::Transient(
-                    "GetLimiter semaphore closed unexpectedly".to_string(),
-                ),
-            })?;
-        let got = self
-            .store
-            .get(key, GetRange::Full)
-            .await
-            .map_err(|source| SpanFetchError::Store {
-                key: key.to_string(),
-                source,
-            })?;
+        // The permit covers the GET only; decode below runs without it, as on
+        // every other funnel.
+        let got = async {
+            let _permit = self
+                .get_limiter
+                .acquire()
+                .await
+                .map_err(|_| SpanFetchError::Store {
+                    key: key.to_string(),
+                    source: StoreError::Transient(
+                        "GetLimiter semaphore closed unexpectedly".to_string(),
+                    ),
+                })?;
+            self.store
+                .get(key, GetRange::Full)
+                .await
+                .map_err(|source| SpanFetchError::Store {
+                    key: key.to_string(),
+                    source,
+                })
+        }
+        .await?;
 
         // Unaccounted entry point: the page-byte fold lands in a throwaway
         // handle, exactly as the logs side routes `fetch` through

--- a/crates/ravel-query/src/span_fetcher.rs
+++ b/crates/ravel-query/src/span_fetcher.rs
@@ -312,7 +312,16 @@ impl SpanSegmentFetcher {
         }
 
         let key = &seg_ref.data_object_key;
-        let _permit = self.get_limiter.acquire().await;
+        let _permit = self
+            .get_limiter
+            .acquire()
+            .await
+            .map_err(|_| SpanFetchError::Store {
+                key: key.to_string(),
+                source: StoreError::Transient(
+                    "GetLimiter semaphore closed unexpectedly".to_string(),
+                ),
+            })?;
         let got = self
             .store
             .get(key, GetRange::Full)
@@ -541,7 +550,16 @@ impl SpanSegmentFetcher {
         let key = &seg_ref.data_object_key;
 
         let Some(cache) = &self.cache else {
-            let _permit = self.get_limiter.acquire().await;
+            let _permit = self
+                .get_limiter
+                .acquire()
+                .await
+                .map_err(|_| SpanFetchError::Store {
+                    key: key.to_string(),
+                    source: StoreError::Transient(
+                        "GetLimiter semaphore closed unexpectedly".to_string(),
+                    ),
+                })?;
             let got = self
                 .store
                 .get(key, GetRange::Full)
@@ -561,7 +579,9 @@ impl SpanSegmentFetcher {
         // tiered tier (see `ReadCache::get_or_fetch`).
         let (bytes, source) = cache
             .get_or_fetch(cache_key, || async move {
-                let _permit = self.get_limiter.acquire().await;
+                let _permit = self.get_limiter.acquire().await.map_err(|_| {
+                    StoreError::Transient("GetLimiter semaphore closed unexpectedly".to_string())
+                })?;
                 let got = self.store.get(key, GetRange::Full).await?;
                 accounting.record_s3_request(AccountedOp::Get);
                 accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
@@ -1657,11 +1677,19 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(1))
             .await
             .expect("one of the two fetches issues its GET within 30 s");
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                gate.wait_until_held(2)
+            )
+            .await
+            .is_err(),
+            "the second GET must never become in-flight while the one permit is held"
+        );
         assert_eq!(
             gate.held_count(),
             1,
-            "one permit must cap in-flight GETs at exactly 1, not merely more than 0"
+            "one permit must cap in-flight GETs at exactly 1"
         );
 
         for id in gate.held() {
@@ -1692,6 +1720,99 @@ mod tests {
             .expect("fetch b")
             .expect("fetch b found the segment relevant");
         assert_eq!(a.records.len(), 1);
+        assert_eq!(b.records.len(), 1);
+    }
+
+    /// The permits=1 test above cannot distinguish "at most 1", "exactly 1",
+    /// and "exactly the permit count": all three coincide at 1. This pins the
+    /// count itself: three concurrent fetches from two INDEPENDENTLY
+    /// constructed `SpanSegmentFetcher`s sharing one `GetLimiter::new(2)`
+    /// (ADR-1195) must peak at EXACTLY 2 in-flight GETs, never all 3.
+    #[tokio::test]
+    async fn shared_get_limiter_bounds_three_fetches_to_permit_count_two() {
+        use ravel_object_store::fault::{FaultPlan, FaultStore, GateHandle, Occurrence};
+
+        let memory = MemoryStore::new();
+        let records = vec![span_with_attrs_and_events(trace(1), span(1), 100, 200)];
+        let seg = write_object(&memory, 0, &records).await;
+        let fault = Arc::new(FaultStore::new(memory, FaultPlan::default()));
+        let gate: GateHandle =
+            fault.hold(ravel_object_store::fault::Op::Get, None, Occurrence::Always);
+        let backend: Arc<dyn ObjectStoreBackend> = fault;
+
+        let shared = Arc::new(crate::GetLimiter::new(2).expect("2 permits is valid"));
+        let fetcher_a = SpanSegmentFetcher::new(backend.clone()).with_get_limiter(shared.clone());
+        let fetcher_b = SpanSegmentFetcher::new(backend).with_get_limiter(shared);
+        let query = all_query();
+
+        let seg_a = seg.clone();
+        let query_a = query;
+        let fa1 = fetcher_a.clone();
+        let handle_a1 =
+            tokio::spawn(async move { fa1.fetch(&seg_a, &query_a, None, None, &[]).await });
+        let seg_a2 = seg.clone();
+        let query_a2 = query;
+        let fa2 = fetcher_a.clone();
+        let handle_a2 =
+            tokio::spawn(async move { fa2.fetch(&seg_a2, &query_a2, None, None, &[]).await });
+        let seg_b = seg.clone();
+        let query_b = query;
+        let handle_b =
+            tokio::spawn(async move { fetcher_b.fetch(&seg_b, &query_b, None, None, &[]).await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(2))
+            .await
+            .expect("two of the three fetches issue their GET within 30 s");
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                gate.wait_until_held(3)
+            )
+            .await
+            .is_err(),
+            "two permits must cap in-flight GETs at exactly 2, never all 3"
+        );
+        assert_eq!(
+            gate.held_count(),
+            2,
+            "peak in-flight GETs must be exactly 2, not 1 and not 3"
+        );
+
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(30), gate.wait_until_held(1))
+            .await
+            .expect("releasing two permits lets the third GET proceed within 30 s");
+        assert_eq!(
+            gate.held_count(),
+            1,
+            "the third GET must be the only one held once the first two release"
+        );
+        for id in gate.held() {
+            assert!(gate.release(id), "held id must release");
+        }
+
+        let a1 = tokio::time::timeout(std::time::Duration::from_secs(30), handle_a1)
+            .await
+            .expect("fetch a1 completes within 30 s")
+            .expect("join fetch a1")
+            .expect("fetch a1")
+            .expect("fetch a1 found the segment relevant");
+        let a2 = tokio::time::timeout(std::time::Duration::from_secs(30), handle_a2)
+            .await
+            .expect("fetch a2 completes within 30 s")
+            .expect("join fetch a2")
+            .expect("fetch a2")
+            .expect("fetch a2 found the segment relevant");
+        let b = tokio::time::timeout(std::time::Duration::from_secs(30), handle_b)
+            .await
+            .expect("fetch b completes within 30 s")
+            .expect("join fetch b")
+            .expect("fetch b")
+            .expect("fetch b found the segment relevant");
+        assert_eq!(a1.records.len(), 1);
+        assert_eq!(a2.records.len(), 1);
         assert_eq!(b.records.len(), 1);
     }
 }

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -700,17 +700,22 @@ One gap remains until the server half of ADR-1195 lands: the ceiling is per
 engine, not per process. `ravel-server` and `ravel-sql` still construct
 engines and standalone fetchers with their own limiters.
 
-Every RLOG GET is now permitted, both paths. `LogSegmentFetcher` holds its
-own `GetLimiter` for its whole-object funnel (`fetch_accounted` and
-`whole_object_bytes`, taken by every object at or below the block-range
-threshold) in addition to the one it hands to its internal
-`BlockRangeFetcher`; `with_get_limiter` sets both to the same `Arc`, and
-`with_block_range` re-applies the fetcher's current limiter to a replacement
-`BlockRangeFetcher` so builder order cannot drop it. `QueryEngine::new`
-builds the RLOG fetcher used by every server query path, so the whole-object
-RLOG reads that the `cost-based` default policy issues -- the stock
-ClickBench path -- are bounded by `store_get_concurrency()` for the first
-time.
+Every RLOG GET a `LogSegmentFetcher` issues now takes a permit, on both
+paths. The fetcher holds its own `GetLimiter` for its whole-object funnel
+(`fetch_accounted` and `whole_object_bytes`, taken by every object at or
+below the block-range threshold) in addition to the one it hands to its
+internal `BlockRangeFetcher`; `with_get_limiter` sets both to the same
+`Arc`, and `with_block_range` re-applies the fetcher's current limiter to a
+replacement `BlockRangeFetcher` so builder order cannot drop it. Which
+limiter that is depends on who built the fetcher: the RLOG fetcher a
+`QueryEngine` owns draws from the engine's shared limiter, sized by
+`store_get_concurrency()`. The standalone RLOG fetcher that `ravel-server`'s
+SQL path builds (`build_sql_state`) still uses `with_max_concurrent_gets`,
+which reaches only the block-range protocol, so its whole-object funnel is
+bounded by the fetcher's private default until the server half wires it to
+the process limiter with `with_get_limiter`. The stock ClickBench path runs
+through that SQL fetcher, so it is not yet governed by
+`store_get_concurrency()`.
 
 Before ADR-1195, each fetcher held its own independent semaphore, so N
 fetchers each configured to "8 concurrent GETs" could together put 8N GETs

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -687,21 +687,30 @@ Prometheus-style error, never a partial silent result.
 
 The "max concurrent GETs (8, ...)" figure above is the ceiling for the
 fetchers one `QueryEngine` owns, not a per-selector one. Inside an engine the
-RSEG `SegmentFetcher`, the RLOG `BlockRangeFetcher` (the block-range protocol
-that `LogSegmentFetcher` delegates to) and the RSPAN `SpanSegmentFetcher`
-draw their GET permits from one shared `ravel_query::GetLimiter`, an
-`Arc`-based wrapper over a `tokio::Semaphore`. `QueryEngine::new` builds this
-limiter once and hands the same `Arc` to the fetchers it owns;
-`QueryEngine::with_get_limiter` replaces it on all of them at once, so a
-process can share one ceiling across several engines.
+RSEG `SegmentFetcher`, RLOG's `LogSegmentFetcher` (both its own whole-object
+funnel and the `BlockRangeFetcher` it delegates to above the block-range
+threshold), and the RSPAN `SpanSegmentFetcher` draw their GET permits from
+one shared `ravel_query::GetLimiter`, an `Arc`-based wrapper over a
+`tokio::Semaphore`. `QueryEngine::new` builds this limiter once and hands
+the same `Arc` to the fetchers it owns; `QueryEngine::with_get_limiter`
+replaces it on all of them at once, so a process can share one ceiling
+across several engines.
 
-Two gaps remain until the server half of ADR-1195 lands. The ceiling is per
-engine, not per process: `ravel-server` and `ravel-sql` still construct
-engines and standalone fetchers with their own limiters. And the RLOG
-whole-object funnel (`LogSegmentFetcher::fetch_accounted` and
+One gap remains until the server half of ADR-1195 lands: the ceiling is per
+engine, not per process. `ravel-server` and `ravel-sql` still construct
+engines and standalone fetchers with their own limiters.
+
+Every RLOG GET is now permitted, both paths. `LogSegmentFetcher` holds its
+own `GetLimiter` for its whole-object funnel (`fetch_accounted` and
 `whole_object_bytes`, taken by every object at or below the block-range
-threshold) issues its GETs without a permit, as it did before ADR-1195; only
-the block-range protocol is bounded today.
+threshold) in addition to the one it hands to its internal
+`BlockRangeFetcher`; `with_get_limiter` sets both to the same `Arc`, and
+`with_block_range` re-applies the fetcher's current limiter to a replacement
+`BlockRangeFetcher` so builder order cannot drop it. `QueryEngine::new`
+builds the RLOG fetcher used by every server query path, so the whole-object
+RLOG reads that the `cost-based` default policy issues -- the stock
+ClickBench path -- are bounded by `store_get_concurrency()` for the first
+time.
 
 Before ADR-1195, each fetcher held its own independent semaphore, so N
 fetchers each configured to "8 concurrent GETs" could together put 8N GETs

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -710,11 +710,12 @@ replacement `BlockRangeFetcher` so builder order cannot drop it. Which
 limiter that is depends on who built the fetcher: the RLOG fetcher a
 `QueryEngine` owns draws from the engine's shared limiter, sized by
 `store_get_concurrency()`. The standalone RLOG fetcher that `ravel-server`'s
-SQL path builds (`build_sql_state`) still uses `with_max_concurrent_gets`,
-which reaches only the block-range protocol, so its whole-object funnel is
-bounded by the fetcher's private default until the server half wires it to
-the process limiter with `with_get_limiter`. The stock ClickBench path runs
-through that SQL fetcher, so it is not yet governed by
+SQL path builds (`build_sql_state`) uses `with_max_concurrent_gets`, which
+gives it a private limiter of `fetch_concurrency` permits shared by its
+whole-object and block-range paths; that limiter is separate from the
+process-wide one until the server half wires the fetcher to it with
+`with_get_limiter`. The stock ClickBench path runs through that SQL fetcher,
+so it is bounded by `fetch_concurrency` and not yet by
 `store_get_concurrency()`.
 
 Before ADR-1195, each fetcher held its own independent semaphore, so N


### PR DESCRIPTION
The ADR-1195 crate half left the RLOG whole-object funnel outside the
shared GET limiter: `fetch_accounted` and both `whole_object_bytes` paths
issued their GET without a permit, so every object at or below the
block-range threshold escaped the ceiling, and `with_block_range` dropped a
limiter set earlier in the builder chain. `LogSegmentFetcher` now holds the
limiter itself, every GET it issues takes a permit for the duration of the
GET only, `with_block_range` re-applies the current limiter, and the engine
test asserts the shared limiter reaches RSEG, RLOG and RLOG's block-range
fetcher.

`GetLimiter::acquire` returns a typed `GetLimiterClosed` instead of an
`unreachable!`, and each call site maps it into its own error.

Tests pin exact magnitudes without wall-clock windows: a shared single
permit holds the second GET out (`wait_until_held(2)` under a timeout
returns `Err`, then release and completion), private limiters admit two,
and the span fetcher at two permits with three concurrent fetches peaks at
exactly two. The whole-object test uses objects below the block-range
threshold so the funnel under test is the one taken. docs/query-engine.md
no longer names the whole-object funnel as unbounded.

Refs: #1195
