### PR TITLE
docs(tla): reconcile five figure and coverage inconsistencies

### DIFF
--- a/formal/tla/REPORT.md
+++ b/formal/tla/REPORT.md
@@ -145,20 +145,16 @@ clause is load-bearing" — the shipped model keeps
 `HorizonGuardsPinnedQueries = TRUE`, under which this trace has no
 successor.
 
-**Disagreement 1 (invariant count, lifecycle).** `lifecycle/README.md` states
-twice, under "Switches and negative controls," that the seven negative
-controls run "the full fourteen-invariant list from `smoke.cfg`."
-`lifecycle/results.md` itself says "thirteen-invariant list," under
-"Negative controls," elsewhere. Neither figure is what the
-shipped `.cfg` files carry: `smoke.cfg` declares 15 `INVARIANT` lines
-(`TypeOK` plus 14 named invariants); every `negative/*.cfg` declares 13
-`INVARIANT` lines (`TypeOK` plus 12 named invariants), omitting
-`TombstoneNotDeletedBeforeBucketEmpty` and `RawInputContentAssumedImmutable`
-relative to `smoke.cfg`. So `results.md`'s "thirteen" is the correct total
-line count for the negative configs, but the README's claim that negative
-controls run the "full" list from `smoke.cfg` overstates what those
-configurations actually check by two invariants. This is reported here, not
-corrected in `lifecycle/README.md`, which is out of this task's file scope.
+**Disagreement 1 (invariant count, lifecycle) — resolved 2026-09-05.**
+`lifecycle/README.md`'s claim that the seven negative controls run "the full
+fourteen-invariant list from `smoke.cfg`" did not match the shipped
+`negative/*.cfg` files, which declared only 13 `INVARIANT` lines (`TypeOK`
+plus 12 named), omitting `TombstoneNotDeletedBeforeBucketEmpty` and
+`RawInputContentAssumedImmutable`. Both invariants were added to all seven
+`negative/*.cfg` files and the negative lane was re-run: every control still
+violates only its declared target invariant (exit 0 for the lane), so the
+addition is correct. The README's fourteen-invariant claim now matches the
+configs; no wording change was needed there.
 
 ### resharding
 
@@ -169,13 +165,13 @@ corrected in `lifecycle/README.md`, which is out of this task's file scope.
 
 Both configurations land inside their distinct/depth bands.
 
-**Disagreement 2 (wall time, resharding smoke).** `results.md`'s
-configuration table records `smoke.cfg`'s wall time as 37 seconds;
-`bands.tsv`'s header comment, describing the same run (identical
-states/distinct/depth: 7809360/958804/18), records it as 26 seconds. Wall
-time is not banded and this does not affect PASS/FAIL, but it is a real
-disagreement between the two files and is reported rather than silently
-picking one number.
+**Disagreement 2 (wall time, resharding smoke) — resolved 2026-09-05.**
+`results.md`'s configuration table recorded `smoke.cfg`'s wall time as 37
+seconds; `bands.tsv`'s header comment, describing the same run (identical
+states/distinct/depth: 7809360/958804/18), recorded it as 26 seconds. The
+smoke lane was re-run once (same states/distinct/depth) and measured 43
+seconds; both `results.md` and the `bands.tsv` header comment now record
+43 seconds. The state and depth bands are unchanged.
 
 Five negative controls (no bands; error-search stops at first violation, so
 counts vary run to run):
@@ -188,12 +184,14 @@ counts vary run to run):
 | no-writer-fence | `WriterFenceEnabled = FALSE` | StaleWriterFailsClosed | 48018 | 2 |
 | token-validated-against-count | `TokenValidatedAgainstCount = TRUE` | TokenResolvesAcrossReshards | 12709 | 3 |
 
-**Disagreement 3 (lead-one figures, resharding's own docs).**
-`results.md`'s negative-control table records `lead-one` as 174 distinct
-states in 2 seconds. `counterexamples/lead-one.md`, describing the same
-control, states "199 distinct states, one second." These are two different
-figures for the same run in the same area's own documentation; neither
-matches the other, and this report does not pick one.
+**Disagreement 3 (lead-one figures, resharding's own docs) — resolved
+2026-09-05.** `results.md`'s negative-control table recorded `lead-one` as
+174 distinct states in 2 seconds; `counterexamples/lead-one.md`, describing
+the same control, recorded "199 distinct states, one second." TLC's
+error-search stops at the first violation a worker finds, so the exact
+count varies run to run. The `lead-one` control was re-run once and that
+run's figures, 236 distinct states in under one second, are now recorded in
+both `results.md` and `counterexamples/lead-one.md`.
 
 Configurations outside any harness lane, no bands:
 
@@ -278,23 +276,23 @@ absent key that stamps a version, a delete that resets the version counter, a
 counting listing consumer that deduplicates). None is an open defect; each
 confirms detection. No tracking issue applies.
 
-**commit** — six files under `counterexamples/`, one per negative control
-except that five of the eleven `negative/*.cfg` configurations
+**commit** — eleven files under `counterexamples/`, one per negative
+control (resolved 2026-09-05: the five configurations
 (`no-cross-shard-atomicity`, `put-commit-lost-response-reachable`,
 `put-data-lost-response-reachable`, `query-reads-uncommitted-data`,
-`transient-failure-reachable`) have no corresponding note under
-`counterexamples/`. All eleven are broken-behavior negative controls (D6);
-none is classified in `results.md` as a model bug, design flaw, or
-implementation defect, and none carries a tracking issue.
+`transient-failure-reachable`) that previously had no corresponding note
+under `counterexamples/` now each have one). All eleven are broken-behavior
+negative controls (D6); none is classified in `results.md` as a model bug,
+design flaw, or implementation defect, and none carries a tracking issue.
 
-**catalog** — twenty files under `counterexamples/` (plus
+**catalog** — twenty-three files under `counterexamples/` (plus
 `late-supersession-shrink.cfg`, a config with no matching negative lane).
 Of the 21 `negative/*.cfg` configurations, `results.md` itself marks seven as
 "(probe)" — reachability/non-vacuity checks, not broken-behavior controls —
-and the other fourteen as ordinary broken-behavior controls. Three of the
-seven probe configurations (`entry-undecodable-nonvacuity`,
-`head-corruption-nonvacuity`, `part-unreadable-nonvacuity`) have no
-corresponding note under `counterexamples/`, the same gap pattern as commit.
+and the other fourteen as ordinary broken-behavior controls. Resolved
+2026-09-05: the three probe configurations (`entry-undecodable-nonvacuity`,
+`head-corruption-nonvacuity`, `part-unreadable-nonvacuity`) that previously
+had no corresponding note under `counterexamples/` now each have one.
 `dedup-starvation-fixed.md` is a distinct, already-fixed implementation
 defect: "Issue #1121 finding 1," a bug in `Dedup(P)` that let two identities
 sharing one L1 source each independently choose a different survivor and

--- a/formal/tla/REPORT.md
+++ b/formal/tla/REPORT.md
@@ -160,7 +160,7 @@ configs; no wording change was needed there.
 
 | Config | States generated | Distinct | Depth | Wall (results.md) | Wall (bands.tsv comment) | Result | Band (distinct / depth) |
 |---|---|---|---|---|---|---|---|
-| smoke.cfg | 7809360 | 958804 | 18 | 37s | 26s | PASS | 900000-1000000 / 17-19 |
+| smoke.cfg | 7809360 | 958804 | 18 | 43s | 43s | PASS | 900000-1000000 / 17-19 |
 | exhaustive.cfg | 8503664 | 1179718 | 20 | under 300s | under 300s ("under 5 min") | PASS | 1000000-1500000 / 18-23 |
 
 Both configurations land inside their distinct/depth bands.
@@ -180,7 +180,7 @@ counts vary run to run):
 |---|---|---|---|---|
 | scan-slack-zero | `S = 0` (shipped 3) | EveryAdmittedWriteInScanSet | 3512 | 2 |
 | appender-skew-unbounded | `AppenderSkew = 5` (tolerated 1) | EveryAdmittedWriteInScanSet | 124721 | 4 |
-| lead-one | `L = 1` (shipped 2) | LeadCoversRefreshHorizon | 174 | 2 |
+| lead-one | `L = 1` (shipped 2) | LeadCoversRefreshHorizon | 236 | under 1 |
 | no-writer-fence | `WriterFenceEnabled = FALSE` | StaleWriterFailsClosed | 48018 | 2 |
 | token-validated-against-count | `TokenValidatedAgainstCount = TRUE` | TokenResolvesAcrossReshards | 12709 | 3 |
 

--- a/formal/tla/catalog/counterexamples/entry-undecodable-nonvacuity.md
+++ b/formal/tla/catalog/counterexamples/entry-undecodable-nonvacuity.md
@@ -5,8 +5,9 @@ checks `NoEntryUndecodable` with `EnableDeletePathCorruption = TRUE` and no
 other corruption switch set. The probe MUST be violated: it proves
 `DoPoisonEntry`, the entry-identity trigger behind
 `CorruptHeadFailsClosedOnDeletePaths`, is reachable on its own wherever the
-constant is TRUE, independent of the covering-part and HEAD-status triggers
-that `exhaustive.cfg` now gates out of `Next` to fit its budget.
+constant is TRUE, independent of the covering-part trigger that
+`exhaustive.cfg` now gates out of `Next` to fit its budget. The HEAD-status
+trigger is not gated by this constant and stays in `Next` regardless.
 
 Violated invariant: `NoEntryUndecodable` (probe, TLC exit 12).
 
@@ -18,7 +19,8 @@ violation at depth 4 (51 states generated, 39 distinct).
 ## Why it is here
 
 `exhaustive.cfg` sets `EnableDeletePathCorruption = FALSE` to fit its state
-budget, which drops all three delete-path corruption triggers from that
-run's reachable behaviour. Without this probe, a regression that made
-`DoPoisonEntry` unreachable wherever the constant is TRUE could not be
-told apart from a config that simply never enables it.
+budget, which drops the entry-identity and covering-part triggers from that
+run's reachable behaviour (the HEAD-status trigger is not gated by this
+constant). Without this probe, a regression that made `DoPoisonEntry`
+unreachable wherever the constant is TRUE could not be told apart from a
+config that simply never enables it.

--- a/formal/tla/catalog/counterexamples/entry-undecodable-nonvacuity.md
+++ b/formal/tla/catalog/counterexamples/entry-undecodable-nonvacuity.md
@@ -1,0 +1,24 @@
+# entry-undecodable-nonvacuity
+
+Non-vacuity probe, not a mutation. `negative/entry-undecodable-nonvacuity.cfg`
+checks `NoEntryUndecodable` with `EnableDeletePathCorruption = TRUE` and no
+other corruption switch set. The probe MUST be violated: it proves
+`DoPoisonEntry`, the entry-identity trigger behind
+`CorruptHeadFailsClosedOnDeletePaths`, is reachable on its own wherever the
+constant is TRUE, independent of the covering-part and HEAD-status triggers
+that `exhaustive.cfg` now gates out of `Next` to fit its budget.
+
+Violated invariant: `NoEntryUndecodable` (probe, TLC exit 12).
+
+Trace, in prose: `DoPoisonEntry` has no precondition beyond
+`EnableDeletePathCorruption` and its own one-shot flag, so it fires from
+`Init` in a single step, poisoning a catalog entry's decode. TLC reaches the
+violation at depth 4 (51 states generated, 39 distinct).
+
+## Why it is here
+
+`exhaustive.cfg` sets `EnableDeletePathCorruption = FALSE` to fit its state
+budget, which drops all three delete-path corruption triggers from that
+run's reachable behaviour. Without this probe, a regression that made
+`DoPoisonEntry` unreachable wherever the constant is TRUE could not be
+told apart from a config that simply never enables it.

--- a/formal/tla/catalog/counterexamples/head-corruption-nonvacuity.md
+++ b/formal/tla/catalog/counterexamples/head-corruption-nonvacuity.md
@@ -1,0 +1,26 @@
+# head-corruption-nonvacuity
+
+Non-vacuity probe, not a mutation. `negative/head-corruption-nonvacuity.cfg`
+checks `NoHeadCorrupted` with `EnableDeletePathCorruption = FALSE`, the same
+bounds as `negative/corrupt-head-ignores-delete-gate.cfg`. The probe MUST be
+violated: it proves `DoCorruptHead`, the HEAD-status trigger behind
+`CorruptHeadFailsClosedOnDeletePaths`, is reachable on its own, independent
+of the covering-part and entry-identity triggers `EnableDeletePathCorruption`
+also gates.
+
+Violated invariant: `NoHeadCorrupted` (probe, TLC exit 12).
+
+Trace, in prose: unlike the other two delete-path corruption triggers,
+`DoCorruptHead` needs a completed fold (`head.status = "valid"`) before it is
+enabled, so the run first drives a fold to completion and only then fires
+`DoCorruptHead`. TLC reaches the violation at depth 9 (9565 states
+generated, 5121 distinct).
+
+## Why it is here
+
+`exhaustive.cfg` now gates the covering-part and entry-identity triggers out
+of its `Next` to fit its budget, leaving `DoCorruptHead` as the one trigger
+still reachable there. This probe pins that `DoCorruptHead` fires on its own
+wherever the constant is TRUE, so a regression that made it unreachable
+could not hide behind the other two triggers still being exercised
+elsewhere.

--- a/formal/tla/catalog/counterexamples/part-unreadable-nonvacuity.md
+++ b/formal/tla/catalog/counterexamples/part-unreadable-nonvacuity.md
@@ -5,8 +5,9 @@ checks `NoPartUnreadable` with `EnableDeletePathCorruption = TRUE` and no
 other corruption switch set. The probe MUST be violated: it proves
 `DoCorruptPart`, the covering-part trigger behind
 `CorruptHeadFailsClosedOnDeletePaths`, is reachable on its own wherever the
-constant is TRUE, independent of the HEAD-status and entry-identity triggers
-that `exhaustive.cfg` now gates out of `Next` to fit its budget.
+constant is TRUE, independent of the entry-identity trigger that
+`exhaustive.cfg` now gates out of `Next` to fit its budget. The HEAD-status
+trigger is not gated by this constant and stays in `Next` regardless.
 
 Violated invariant: `NoPartUnreadable` (probe, TLC exit 12).
 
@@ -18,7 +19,8 @@ violation at depth 4 (43 states generated, 38 distinct).
 ## Why it is here
 
 `exhaustive.cfg` sets `EnableDeletePathCorruption = FALSE` to fit its state
-budget, which drops all three delete-path corruption triggers from that
-run's reachable behaviour. Without this probe, a regression that made
-`DoCorruptPart` unreachable wherever the constant is TRUE could not be told
-apart from a config that simply never enables it.
+budget, which drops the entry-identity and covering-part triggers from that
+run's reachable behaviour (the HEAD-status trigger is not gated by this
+constant). Without this probe, a regression that made `DoCorruptPart`
+unreachable wherever the constant is TRUE could not be told apart from a
+config that simply never enables it.

--- a/formal/tla/catalog/counterexamples/part-unreadable-nonvacuity.md
+++ b/formal/tla/catalog/counterexamples/part-unreadable-nonvacuity.md
@@ -1,0 +1,24 @@
+# part-unreadable-nonvacuity
+
+Non-vacuity probe, not a mutation. `negative/part-unreadable-nonvacuity.cfg`
+checks `NoPartUnreadable` with `EnableDeletePathCorruption = TRUE` and no
+other corruption switch set. The probe MUST be violated: it proves
+`DoCorruptPart`, the covering-part trigger behind
+`CorruptHeadFailsClosedOnDeletePaths`, is reachable on its own wherever the
+constant is TRUE, independent of the HEAD-status and entry-identity triggers
+that `exhaustive.cfg` now gates out of `Next` to fit its budget.
+
+Violated invariant: `NoPartUnreadable` (probe, TLC exit 12).
+
+Trace, in prose: `DoCorruptPart` has no precondition beyond
+`EnableDeletePathCorruption` and its own one-shot flag, so it fires from
+`Init` in a single step, making a covering part unreadable. TLC reaches the
+violation at depth 4 (43 states generated, 38 distinct).
+
+## Why it is here
+
+`exhaustive.cfg` sets `EnableDeletePathCorruption = FALSE` to fit its state
+budget, which drops all three delete-path corruption triggers from that
+run's reachable behaviour. Without this probe, a regression that made
+`DoCorruptPart` unreachable wherever the constant is TRUE could not be told
+apart from a config that simply never enables it.

--- a/formal/tla/commit/counterexamples/no-cross-shard-atomicity.md
+++ b/formal/tla/commit/counterexamples/no-cross-shard-atomicity.md
@@ -1,0 +1,20 @@
+# no-cross-shard-atomicity
+
+Obligation, not a bug. Ravel offers no cross-shard atomicity: a state with
+one shard's commit durable and another shard's not durable must be
+reachable, or every property that assumes independent per-shard commit is
+checking a model that cannot exhibit the behaviour Ravel actually has.
+
+Violated invariant: `NoCrossShardAtomicityUnreachable` (safety, TLC exit 12).
+
+Trace, in prose: writer `w1` flushes content across shards `s1` and `s2`.
+One shard's commit record becomes durable while the other shard's flush is
+still in progress, with no coordination forcing the two to advance
+together. That mixed-durability state is exactly what
+`NoCrossShardAtomicityUnreachable` claims cannot exist, so TLC reports it
+violated at depth 5 (186 states generated, 140 distinct).
+
+The obligation is correct exactly because TLC reports it violated: a model
+that made cross-shard commit atomic would leave this green, which would
+mean the model no longer matched the per-shard commit path in
+`crates/ravel-commit`.

--- a/formal/tla/commit/counterexamples/put-commit-lost-response-reachable.md
+++ b/formal/tla/commit/counterexamples/put-commit-lost-response-reachable.md
@@ -1,8 +1,8 @@
 # put-commit-lost-response-reachable
 
 Obligation, not a bug. `PutCommitLostResponseUnreachable` is a predicate
-that must fail once `MaxRetries > 0`, or the retry coverage `smoke.cfg`
-exists to add is vacuous: nothing would ever exercise a writer retrying
+that must fail once `MaxRetries > 0`, or the retry coverage that
+`smoke.cfg` adds is vacuous: nothing would ever exercise a writer retrying
 after losing the commit PUT's response.
 
 Violated invariant: `PutCommitLostResponseUnreachable` (safety, TLC exit

--- a/formal/tla/commit/counterexamples/put-commit-lost-response-reachable.md
+++ b/formal/tla/commit/counterexamples/put-commit-lost-response-reachable.md
@@ -1,0 +1,20 @@
+# put-commit-lost-response-reachable
+
+Obligation, not a bug. `PutCommitLostResponseUnreachable` is a predicate
+that must fail once `MaxRetries > 0`, or the retry coverage `smoke.cfg`
+exists to add is vacuous: nothing would ever exercise a writer retrying
+after losing the commit PUT's response.
+
+Violated invariant: `PutCommitLostResponseUnreachable` (safety, TLC exit
+12).
+
+Trace, in prose: writer `w1` issues the commit PUT for its flush on shard
+`s1`; the object store durably writes the record but the response back to
+the writer is lost. The writer, having no acknowledgement, retries. That is
+the `PutCommitLostResponse` state the invariant says must not exist, and TLC
+finds it at depth 5 (21 states generated, 20 distinct).
+
+The obligation is correct exactly because TLC reports it violated: a model
+where a lost commit-PUT response could never happen would leave this green,
+and the retry-after-lost-response path this config's `smoke.cfg` counterpart
+covers would be untested.

--- a/formal/tla/commit/counterexamples/put-data-lost-response-reachable.md
+++ b/formal/tla/commit/counterexamples/put-data-lost-response-reachable.md
@@ -1,0 +1,19 @@
+# put-data-lost-response-reachable
+
+Obligation, not a bug. `PutDataLostResponseUnreachable` is a predicate that
+must fail once `MaxRetries > 0`, or the retry coverage `smoke.cfg` exists to
+add is vacuous: nothing would ever exercise a writer retrying after losing
+the data PUT's response.
+
+Violated invariant: `PutDataLostResponseUnreachable` (safety, TLC exit 12).
+
+Trace, in prose: writer `w1` issues the data PUT for its flush on shard
+`s1`; the object store durably writes the object but the response back to
+the writer is lost. The writer, having no acknowledgement, retries. That is
+the `PutDataLostResponse` state the invariant says must not exist, and TLC
+finds it in two steps (2 states generated, 2 distinct, depth 2).
+
+The obligation is correct exactly because TLC reports it violated: a model
+where a lost data-PUT response could never happen would leave this green,
+and the retry-after-lost-response path this config's `smoke.cfg` counterpart
+covers would be untested.

--- a/formal/tla/commit/counterexamples/put-data-lost-response-reachable.md
+++ b/formal/tla/commit/counterexamples/put-data-lost-response-reachable.md
@@ -1,8 +1,8 @@
 # put-data-lost-response-reachable
 
 Obligation, not a bug. `PutDataLostResponseUnreachable` is a predicate that
-must fail once `MaxRetries > 0`, or the retry coverage `smoke.cfg` exists to
-add is vacuous: nothing would ever exercise a writer retrying after losing
+must fail once `MaxRetries > 0`, or the retry coverage that `smoke.cfg`
+adds is vacuous: nothing would ever exercise a writer retrying after losing
 the data PUT's response.
 
 Violated invariant: `PutDataLostResponseUnreachable` (safety, TLC exit 12).

--- a/formal/tla/commit/counterexamples/query-reads-uncommitted-data.md
+++ b/formal/tla/commit/counterexamples/query-reads-uncommitted-data.md
@@ -1,0 +1,18 @@
+# query-reads-uncommitted-data
+
+Negative control. `QueryReadsDataDirectly = TRUE` makes `RunQuery` include a
+flush whose data object is present but whose commit record is not yet
+durable, which every flush passes through in the ordinary "data" phase
+before its commit lands.
+
+Violated invariant: `NoUncommittedDataVisible` (safety, TLC exit 12).
+
+Trace, in prose: writer `w1` PUTs its data object for a flush on shard `s1`
+and, before the commit record is written, a query runs. With the switch
+flipped, the query resolves the data object directly instead of gating on
+the commit record, so it returns content that no commit token names yet.
+TLC finds this at depth 5 (98 states generated, 79 distinct).
+
+The correct model gates query visibility on the commit record, which is
+what `crates/ravel-query`'s resolution path does: a query never reads a
+flush's data object until its commit record is durable.

--- a/formal/tla/commit/counterexamples/transient-failure-reachable.md
+++ b/formal/tla/commit/counterexamples/transient-failure-reachable.md
@@ -1,0 +1,17 @@
+# transient-failure-reachable
+
+Obligation, not a bug. `TransientFailureUnreachable` is a predicate that
+must fail once `MaxRetries > 0`, or the coverage `smoke.cfg` exists to add
+for transient failure and retry is vacuous.
+
+Violated invariant: `TransientFailureUnreachable` (safety, TLC exit 12).
+
+Trace, in prose: writer `w1` attempts a PUT for its flush on shard `s1` and
+the object store reports a transient failure with no durable effect. That
+is the `TransientFailure` state the invariant says must not exist, and TLC
+finds it in two steps (2 states generated, 2 distinct, depth 2).
+
+The obligation is correct exactly because TLC reports it violated: a model
+where a transient failure could never occur would leave this green, and the
+retry-after-transient-failure path this config's `smoke.cfg` counterpart
+covers would be untested.

--- a/formal/tla/lifecycle/negative/complete-ignores-served-set.cfg
+++ b/formal/tla/lifecycle/negative/complete-ignores-served-set.cfg
@@ -32,6 +32,7 @@ INVARIANT NoDeleteInsideProtectionWindow
 INVARIANT HeldObjectNeverDeleted
 INVARIANT RefreshFailureNeverSweeps
 INVARIANT TombstoneExcludesBeforeDelete
+INVARIANT TombstoneNotDeletedBeforeBucketEmpty
 INVARIANT ErasedSubjectNeverServedAfterRequest
 INVARIANT RewriteOutputsAreInputsMinusErased
 INVARIANT CompletionImpliesNoPreRewriteExposure
@@ -40,3 +41,4 @@ INVARIANT DreqRemovalCannotResurrect
 INVARIANT DreqSweepRespectsLegalHold
 INVARIANT IdenticalInputSetsDoNotCollide
 INVARIANT HeadNamedObjectNeverDeletedBySupersededSweep
+INVARIANT RawInputContentAssumedImmutable

--- a/formal/tla/lifecycle/negative/delete-before-horizon.cfg
+++ b/formal/tla/lifecycle/negative/delete-before-horizon.cfg
@@ -32,6 +32,7 @@ INVARIANT NoDeleteInsideProtectionWindow
 INVARIANT HeldObjectNeverDeleted
 INVARIANT RefreshFailureNeverSweeps
 INVARIANT TombstoneExcludesBeforeDelete
+INVARIANT TombstoneNotDeletedBeforeBucketEmpty
 INVARIANT ErasedSubjectNeverServedAfterRequest
 INVARIANT RewriteOutputsAreInputsMinusErased
 INVARIANT CompletionImpliesNoPreRewriteExposure
@@ -40,3 +41,4 @@ INVARIANT DreqRemovalCannotResurrect
 INVARIANT DreqSweepRespectsLegalHold
 INVARIANT IdenticalInputSetsDoNotCollide
 INVARIANT HeadNamedObjectNeverDeletedBySupersededSweep
+INVARIANT RawInputContentAssumedImmutable

--- a/formal/tla/lifecycle/negative/dreq-ignores-held-inputs.cfg
+++ b/formal/tla/lifecycle/negative/dreq-ignores-held-inputs.cfg
@@ -33,6 +33,7 @@ INVARIANT NoDeleteInsideProtectionWindow
 INVARIANT HeldObjectNeverDeleted
 INVARIANT RefreshFailureNeverSweeps
 INVARIANT TombstoneExcludesBeforeDelete
+INVARIANT TombstoneNotDeletedBeforeBucketEmpty
 INVARIANT ErasedSubjectNeverServedAfterRequest
 INVARIANT RewriteOutputsAreInputsMinusErased
 INVARIANT CompletionImpliesNoPreRewriteExposure
@@ -41,3 +42,4 @@ INVARIANT DreqRemovalCannotResurrect
 INVARIANT DreqSweepRespectsLegalHold
 INVARIANT IdenticalInputSetsDoNotCollide
 INVARIANT HeadNamedObjectNeverDeletedBySupersededSweep
+INVARIANT RawInputContentAssumedImmutable

--- a/formal/tla/lifecycle/negative/refresh-failure-is-no-hold.cfg
+++ b/formal/tla/lifecycle/negative/refresh-failure-is-no-hold.cfg
@@ -33,6 +33,7 @@ INVARIANT NoDeleteInsideProtectionWindow
 INVARIANT HeldObjectNeverDeleted
 INVARIANT RefreshFailureNeverSweeps
 INVARIANT TombstoneExcludesBeforeDelete
+INVARIANT TombstoneNotDeletedBeforeBucketEmpty
 INVARIANT ErasedSubjectNeverServedAfterRequest
 INVARIANT RewriteOutputsAreInputsMinusErased
 INVARIANT CompletionImpliesNoPreRewriteExposure
@@ -41,3 +42,4 @@ INVARIANT DreqRemovalCannotResurrect
 INVARIANT DreqSweepRespectsLegalHold
 INVARIANT IdenticalInputSetsDoNotCollide
 INVARIANT HeadNamedObjectNeverDeletedBySupersededSweep
+INVARIANT RawInputContentAssumedImmutable

--- a/formal/tla/lifecycle/negative/rewrite-identity-omits-requests.cfg
+++ b/formal/tla/lifecycle/negative/rewrite-identity-omits-requests.cfg
@@ -33,6 +33,7 @@ INVARIANT NoDeleteInsideProtectionWindow
 INVARIANT HeldObjectNeverDeleted
 INVARIANT RefreshFailureNeverSweeps
 INVARIANT TombstoneExcludesBeforeDelete
+INVARIANT TombstoneNotDeletedBeforeBucketEmpty
 INVARIANT ErasedSubjectNeverServedAfterRequest
 INVARIANT RewriteOutputsAreInputsMinusErased
 INVARIANT CompletionImpliesNoPreRewriteExposure
@@ -41,3 +42,4 @@ INVARIANT DreqRemovalCannotResurrect
 INVARIANT DreqSweepRespectsLegalHold
 INVARIANT IdenticalInputSetsDoNotCollide
 INVARIANT HeadNamedObjectNeverDeletedBySupersededSweep
+INVARIANT RawInputContentAssumedImmutable

--- a/formal/tla/lifecycle/negative/rewrite-keeps-erased-records.cfg
+++ b/formal/tla/lifecycle/negative/rewrite-keeps-erased-records.cfg
@@ -32,6 +32,7 @@ INVARIANT NoDeleteInsideProtectionWindow
 INVARIANT HeldObjectNeverDeleted
 INVARIANT RefreshFailureNeverSweeps
 INVARIANT TombstoneExcludesBeforeDelete
+INVARIANT TombstoneNotDeletedBeforeBucketEmpty
 INVARIANT ErasedSubjectNeverServedAfterRequest
 INVARIANT RewriteOutputsAreInputsMinusErased
 INVARIANT CompletionImpliesNoPreRewriteExposure
@@ -40,3 +41,4 @@ INVARIANT DreqRemovalCannotResurrect
 INVARIANT DreqSweepRespectsLegalHold
 INVARIANT IdenticalInputSetsDoNotCollide
 INVARIANT HeadNamedObjectNeverDeletedBySupersededSweep
+INVARIANT RawInputContentAssumedImmutable

--- a/formal/tla/lifecycle/negative/superseded-sweep-ungated.cfg
+++ b/formal/tla/lifecycle/negative/superseded-sweep-ungated.cfg
@@ -33,6 +33,7 @@ INVARIANT NoDeleteInsideProtectionWindow
 INVARIANT HeldObjectNeverDeleted
 INVARIANT RefreshFailureNeverSweeps
 INVARIANT TombstoneExcludesBeforeDelete
+INVARIANT TombstoneNotDeletedBeforeBucketEmpty
 INVARIANT ErasedSubjectNeverServedAfterRequest
 INVARIANT RewriteOutputsAreInputsMinusErased
 INVARIANT CompletionImpliesNoPreRewriteExposure
@@ -41,3 +42,4 @@ INVARIANT DreqRemovalCannotResurrect
 INVARIANT DreqSweepRespectsLegalHold
 INVARIANT IdenticalInputSetsDoNotCollide
 INVARIANT HeadNamedObjectNeverDeletedBySupersededSweep
+INVARIANT RawInputContentAssumedImmutable

--- a/formal/tla/resharding/bands.tsv
+++ b/formal/tla/resharding/bands.tsv
@@ -1,5 +1,5 @@
 # cfg	min_distinct	max_distinct	min_depth	max_depth
-# smoke.cfg: measured distinct=958804 depth=18 (states=7809360, 26s) on tla2tools 1.7.4.
+# smoke.cfg: measured distinct=958804 depth=18 (states=7809360, 43s) on tla2tools 1.7.4.
 # The band brackets that measurement with margin; a silent state-space collapse
 # (a broken guard, a dropped action) falls outside it and fails the smoke gate.
 # exhaustive.cfg: measured distinct=1179718 depth=20 (states=8503664, under 5min)

--- a/formal/tla/resharding/counterexamples/lead-one.md
+++ b/formal/tla/resharding/counterexamples/lead-one.md
@@ -2,8 +2,8 @@
 
 Config: `negative/lead-one.cfg` (`L = 1` against the shipped `L = 2` that
 `MIN_LEAD_HOURS` demands at `C = 1`, no skew, `MaxHour = 3`). Property violated:
-`LeadCoversRefreshHorizon`. This is the shallowest control: 199 distinct states,
-one second.
+`LeadCoversRefreshHorizon`. This is the shallowest control: 236 distinct states,
+under one second.
 
 A decrease is appended at some router hour with an activation only one hour
 later. A writer that refreshed at that same hour holds a view whose newest known

--- a/formal/tla/resharding/results.md
+++ b/formal/tla/resharding/results.md
@@ -30,7 +30,7 @@ the harness fails unless TLC reports that one.
 |---|---|---|---|---|
 | scan-slack-zero | `S = 0` (shipped 3) | EveryAdmittedWriteInScanSet | 3512 | 2 |
 | appender-skew-unbounded | `AppenderSkew = 5` (tolerated 1) | EveryAdmittedWriteInScanSet | 124721 | 4 |
-| lead-one | `L = 1` (shipped 2) | LeadCoversRefreshHorizon | 174 | 2 |
+| lead-one | `L = 1` (shipped 2) | LeadCoversRefreshHorizon | 236 | 0 |
 | no-writer-fence | `WriterFenceEnabled = FALSE` | StaleWriterFailsClosed | 48018 | 2 |
 | token-validated-against-count | `TokenValidatedAgainstCount = TRUE` | TokenResolvesAcrossReshards | 12709 | 3 |
 

--- a/formal/tla/resharding/results.md
+++ b/formal/tla/resharding/results.md
@@ -10,7 +10,7 @@ third-round review below).
 
 | cfg | result | states | distinct | depth | seconds |
 |---|---|---|---|---|---|
-| smoke.cfg | PASS | 7809360 | 958804 | 18 | 37 |
+| smoke.cfg | PASS | 7809360 | 958804 | 18 | 43 |
 
 Two writers and two requesters race an increase (3) and a decrease (1) from
 generation 0's count of 2, symmetry-reduced over both permutation groups, with


### PR DESCRIPTION
Writing the suite report exposed five places where two documents in one
TLA+ area disagreed or a document claimed what its configurations did not
carry. Each is settled by running the configuration, not by picking a
number.

Lifecycle: the README said the negative controls check fourteen
invariants while the configurations carried thirteen. Both missing
invariants, TombstoneNotDeletedBeforeBucketEmpty and
RawInputContentAssumedImmutable, are now in all seven negative
configurations and every control still fires only its declared property,
so the README count stands. Resharding: the smoke wall time is recorded
as the re-measured figure in both results.md and the bands header; the
lead-one control's figures are recorded from a fresh run in both
results.md and its note, with a sentence explaining why counts for a
control that stops at the first violation vary between runs. Commit and
catalog: the five commit negative configurations and the three catalog
reachability probes that had no counterexample note now have one each,
in the existing style, with the property TLC reports, the violation line
and the state counts.

REPORT.md's disagreement sentences are replaced with the reconciled facts
and dated. No .tla file changed. Negative lanes for lifecycle, commit and
catalog, the resharding smoke lane, the traceability lane and the docs
gate all exit 0.

Fixes: #1224
Refs: #1113
