### PR TITLE
docs: scope the serviceBatches lower-bound claim to a single wave

### DIFF
--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -365,8 +365,14 @@ pub struct IoShapeJson {
     /// object-store mechanisms with different causes.
     #[serde(rename = "listPageDepth")]
     pub list_page_depth: u32,
-    /// Batches this query's per-segment fan-out was forced into by its
-    /// concurrency permit: `ceil(segment_count / fetch_concurrency)`.
+    /// A deterministic model figure for the serial service rounds this
+    /// query's metrics fan-out needs: the sum over outer plan waves of
+    /// `ceil(segments * active_plans / min(fanout * active_plans,
+    /// shared_permits))`, with plans counted as distinct matcher sets. Exact
+    /// for identical work and comparable across queries; a lower bound only
+    /// within a single wave, not across the sum. See
+    /// [`crate::io_shape::service_batches_over_plan_waves`] for the model and
+    /// its counterexample.
     #[serde(rename = "serviceBatches")]
     pub service_batches: u32,
     /// EXACT count of SEGMENTS (`SegmentOrigin::Recent` entries, one per

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -367,10 +367,14 @@ pub struct IoShapeJson {
     pub list_page_depth: u32,
     /// A deterministic model figure for the serial service rounds this
     /// query's metrics fan-out needs: the sum over outer plan waves of
-    /// `ceil(segments * active_plans / min(fanout * active_plans,
-    /// shared_permits))`, with plans counted as distinct matcher sets. Exact
-    /// for identical work and comparable across queries; a lower bound only
-    /// within a single wave, not across the sum. See
+    /// `ceil(segments * active_plans / max(1, min(fanout * active_plans,
+    /// shared_permits)))`, with plans counted as distinct matcher sets (the
+    /// `max(1, ..)` is the helper's own clamp, so a zero permit count divides
+    /// by one, not zero). Identical for identical work and comparable across
+    /// queries; a lower bound within a single wave only. The cross-wave sum
+    /// is neither a lower nor an upper bound on the real sliding-window
+    /// scheduler, which can take fewer rounds (a child admitted into a
+    /// parent wave's leftover capacity) or more (a partial outer window). See
     /// [`crate::io_shape::service_batches_over_plan_waves`] for the model and
     /// its counterexample.
     #[serde(rename = "serviceBatches")]

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -366,7 +366,10 @@ pub struct IoShapeJson {
     #[serde(rename = "listPageDepth")]
     pub list_page_depth: u32,
     /// A deterministic model figure for the serial service rounds this
-    /// query's metrics fan-out needs: the sum over outer plan waves of
+    /// QUERY needs, metrics lane plus log lane: the two lanes never overlap
+    /// (the log resolve is awaited only after the metrics lane completes), so
+    /// their figures ADD, and this field is the sum. Each lane's own figure
+    /// is the sum over its outer plan waves of
     /// `ceil(segments * active_plans / max(1, min(fanout * active_plans,
     /// shared_permits)))`, with plans counted as distinct matcher sets (the
     /// `max(1, ..)` is the helper's own clamp, so a zero permit count divides

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -55,9 +55,9 @@
 //!   recorded separately from `dependency_depth` because pagination
 //!   (`Catalog::list_shard_hours`) and the GET dependency chain are different
 //!   object-store mechanisms with different causes.
-//! - [`service_batches`](QueryIoShape::service_batches): a LOWER bound on
-//!   the serial service rounds this query's per-segment fan-out needed,
-//!   under a wave-synchronous model of the nested fan-out
+//! - [`service_batches`](QueryIoShape::service_batches): a deterministic
+//!   model figure for the serial service rounds this query's per-segment
+//!   fan-out needs, under a wave-synchronous model of the nested fan-out
 //!   (`crates/ravel-query/src/engine.rs`) with three levels of admission,
 //!   all of which bound the round count:
 //!   1. the OUTER `buffer_unordered(promql_fetch_fanout)` over distinct
@@ -73,23 +73,38 @@
 //!      docs/query-engine.md), which every GET from every plan passes
 //!      through regardless of which plan or segment issued it.
 //!
-//!   It is a lower bound, never an upper bound or an exact count, because
-//!   the OUTER `buffer_unordered` is a SLIDING window, not a wave-synchronous
-//!   one: as soon as one admitted plan finishes, the next plan is admitted
-//!   immediately, without waiting for its siblings. A model that assumed the
-//!   whole outer window empties and refills together (`ceil(segment_count *
-//!   service_fetch_multiplier / min(promql_fetch_fanout *
-//!   min(service_fetch_multiplier, promql_fetch_fanout),
-//!   shared_get_permits))`, dividing TOTAL work by PEAK capacity) undercounts
-//!   whenever the outer window is not full for the query's entire duration:
-//!   3 distinct plans, 1 segment each, `promql_fetch_fanout` 2, and a
-//!   1000-permit limiter gives peak capacity `min(2 * 2, 1000) = 4`, so that
-//!   model reports `ceil(3 / 4) = 1` round -- but plans 1 and 2 admit
-//!   together in the first round, and plan 3 is only admitted after one of
-//!   them finishes, in a second round: the real scheduler takes at least 2
-//!   rounds, never fewer than the wave-synchronous model computes, because a
-//!   sliding window can only pack work as tightly as a synchronized one, not
-//!   more loosely.
+//!   Within a single wave, `batches_w` (defined below) is a lower bound on
+//!   that wave's own serial rounds: the OUTER `buffer_unordered`'s binding
+//!   capacity for that wave is `capacity_w`, and a wave cannot service more
+//!   than `capacity_w` requests per round, so it cannot finish in fewer than
+//!   `batches_w` rounds. But `service_batches` sums `batches_w` across
+//!   waves, and that sum is a model figure, not a bound in either direction,
+//!   because the OUTER `buffer_unordered` is a SLIDING window, not a
+//!   wave-synchronous one: as soon as one admitted plan finishes, the next
+//!   plan is admitted immediately, without waiting for its siblings, so a
+//!   later wave's work can start -- and finish -- before an earlier wave's
+//!   is done. Concretely: 16 shared permits, 17 distinct matcher plans
+//!   admitted through an outer fan-out width of 16 (one segment each), plus
+//!   one further plan whose single segment fetch only becomes eligible
+//!   after the first of the 17 resolves. The real scheduler finishes all of
+//!   it in two rounds, because that further fetch is admitted into the same
+//!   round that drains the 17th plan's leftover request, while the summed
+//!   per-wave model reports `ceil(17 / 16) + ceil(1 / 16) = 3`, one round
+//!   too many. The same sliding window can also undercount: a model that
+//!   assumed the whole outer window empties and refills together
+//!   (`ceil(segment_count * service_fetch_multiplier /
+//!   min(promql_fetch_fanout * min(service_fetch_multiplier,
+//!   promql_fetch_fanout), shared_get_permits))`, dividing TOTAL work by
+//!   PEAK capacity) reports `ceil(3 / 4) = 1` round for 3 distinct plans, 1
+//!   segment each, `promql_fetch_fanout` 2, and a 1000-permit limiter
+//!   (peak capacity `min(2 * 2, 1000) = 4`), but plans 1 and 2 admit
+//!   together in the first round and plan 3 only after one of them
+//!   finishes, in a second round -- the real scheduler needs at least 2.
+//!   `service_batches` is therefore a deterministic model figure: identical
+//!   work always produces the same number, which makes it comparable across
+//!   queries and useful for spotting a regression in fan-out width or
+//!   permit sizing, but the cross-wave sum is neither an upper nor a lower
+//!   bound on the rounds the real scheduler takes.
 //!
 //!   So this figure is computed per WAVE of the outer fan-out instead of
 //!   once over the total: `waves = ceil(service_fetch_multiplier /
@@ -99,12 +114,13 @@
 //!   wave, `capacity_w = min(promql_fetch_fanout * active_w,
 //!   shared_get_permits)` is that wave's binding concurrency, and `batches_w
 //!   = ceil(segment_count * active_w / capacity_w)` is the serial rounds
-//!   that wave alone needs. `service_batches` sums `batches_w` over every
-//!   wave: because the outer stream never admits a plan from wave `w + 1`
-//!   until wave `w`'s plans have all been admitted (though not necessarily
-//!   finished -- see the sliding-window caveat above, which is exactly why
-//!   this sum is a lower rather than an exact bound), the waves are at least
-//!   this serial, and their round counts add.
+//!   that wave alone needs (a true lower bound on that wave in isolation).
+//!   `service_batches` sums `batches_w` over every wave: the outer stream
+//!   never admits a plan from wave `w + 1` until wave `w`'s plans have all
+//!   been admitted (though not necessarily finished -- see the
+//!   counterexample above), so the sum is a deterministic model of the
+//!   nested fan-out, not a bound on the true round count in either
+//!   direction once more than one wave is involved.
 //!
 //!   Reviewer's case above: 2 waves. Wave 0: `active_0 = min(2, 3) = 2`,
 //!   `capacity_0 = min(2 * 2, 1000) = 4`, `batches_0 = ceil(1 * 2 / 4) = 1`.

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -83,14 +83,14 @@
 //!   wave-synchronous one: as soon as one admitted plan finishes, the next
 //!   plan is admitted immediately, without waiting for its siblings, so a
 //!   later wave's work can start -- and finish -- before an earlier wave's
-//!   is done. Concretely: 16 shared permits, 17 distinct matcher plans
-//!   admitted through an outer fan-out width of 16 (one segment each), plus
-//!   one further plan whose single segment fetch only becomes eligible
-//!   after the first of the 17 resolves. The real scheduler finishes all of
-//!   it in two rounds, because that further fetch is admitted into the same
-//!   round that drains the 17th plan's leftover request, while the summed
-//!   per-wave model reports `ceil(17 / 16) + ceil(1 / 16) = 3`, one round
-//!   too many. The same sliding window can also undercount: a model that
+//!   is done. Concretely, in this function's own inputs: 18 distinct matcher
+//!   plans of one segment each, an outer fan-out width of 17, and 16 shared
+//!   permits. Wave 0 admits 17 plans, 17 requests against a capacity of
+//!   `min(17 * 17, 16) = 16`, so `ceil(17 / 16) = 2` batches; wave 1 admits
+//!   the last plan, 1 request, 1 batch; the summed model reports 3. The real
+//!   scheduler drains all 18 requests through the 16 permits in two rounds,
+//!   because the last plan's request is admitted into the round that clears
+//!   wave 0's one leftover request, so the model is one round too many. The same sliding window can also undercount: a model that
 //!   assumed the whole outer window empties and refills together
 //!   (`ceil(segment_count * service_fetch_multiplier /
 //!   min(promql_fetch_fanout * min(service_fetch_multiplier,

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1832,8 +1832,7 @@ leftover request, so the model is one round too many. The same sliding
   capacity_w)` is its own serial round count, a true lower bound on that
   wave in isolation; `serviceBatches` sums `batches_w` over every wave
   (distinct matcher sets, not the raw plan count `stats.estimate` scales
-  by -- a query naming two `SelectorPlan`s that share one matcher set, `up
-  + up offset 5m`, is fetched in one pass, so its `serviceBatches` does not
+  by -- a query naming two `SelectorPlan`s that share one matcher set, `up + up offset 5m`, is fetched in one pass, so its `serviceBatches` does not
   double). This sum is a deterministic model, not a bound: identical work
   always produces the same number, which makes it comparable across
   queries and useful for spotting a fan-out or permit-sizing regression,

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1899,15 +1899,19 @@ lane's resolve is only reached after the metrics lane has already been
 awaited to completion, never alongside it -- and each field's combining
 rule follows from one criterion, not from the same criterion applied
 loosely three times:
-`listPageDepth` and `serviceBatches` are both SERIALIZATION-ROUND counts
-(the number of sequential rounds a lane's own fan-out actually waited
-through), and ADD across lanes for that reason: because the lanes never
-overlap, the rounds a query waits through end-to-end are one lane's rounds
-followed by the other's. A query whose metrics lane paginated 4 LIST pages
-and whose log lane paginated 2 more waited through 6 serial pages, not 4,
-and a query whose metrics fetch was forced into 3 concurrency-permit
-batches and whose log fetch needed 2 more waited through 5 serial batches,
-not `max(3, 2)`.
+`listPageDepth` and `serviceBatches` are both SERIALIZATION-ROUND figures,
+and ADD across lanes for that reason: because the lanes never overlap, a
+query's end-to-end figure is one lane's followed by the other's. They differ
+in what the per-lane figure is. `listPageDepth` counts pages the lane really
+paginated through, so a query whose metrics lane paginated 4 LIST pages and
+whose log lane paginated 2 more paginated 6 serial pages, not 4.
+`serviceBatches` is a deterministic MODEL of a lane's rounds, not a count of
+rounds it waited through (see the field's own description above: within one
+wave it is a lower bound, and the cross-wave sum can overcount or undercount
+the real sliding-window scheduler). Adding the lanes therefore adds two model
+figures: a query whose metrics lane models 3 batches and whose log lane
+models 2 reports 5, not `max(3, 2)`, and that 5 carries the same
+model-versus-scheduler caveat each lane's figure does.
 `dependencyDepth` uses a DIFFERENT criterion -- DATA independence, not
 serialization order -- and stays max-based across lanes: the log lane's
 fetch chain has no DATA dependency on the metrics lane's bytes, so the two

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1805,14 +1805,14 @@ and rendered as `stats.io`, additive beside `stats.phases`:
   `buffer_unordered` is a SLIDING window, not a wave-synchronous one: as
   soon as one admitted plan finishes, the next plan is admitted
   immediately, without waiting for its siblings, so a later wave's work
-  can start -- and finish -- before an earlier wave's is done. Concretely:
-  16 shared permits, 17 distinct matcher plans admitted through an outer
-  fan-out width of 16 (one segment each), plus one further plan whose
-  single segment fetch only becomes eligible after the first of the 17
-  resolves. The real scheduler finishes all of it in two rounds, because
-  that further fetch is admitted into the same round that drains the 17th
-  plan's leftover request, while the summed per-wave model reports
-  `ceil(17 / 16) + ceil(1 / 16) = 3`, one round too many. The same sliding
+  can start -- and finish -- before an earlier wave's is done. Concretely, in the formula's own
+inputs: 18 distinct matcher plans of one segment each, an outer fan-out width
+of 17, and 16 shared permits. Wave 0 admits 17 plans, 17 requests against a
+capacity of `min(17 * 17, 16) = 16`, so `ceil(17 / 16) = 2` batches; wave 1
+admits the last plan, 1 request, 1 batch; the summed model reports 3. The real
+scheduler drains all 18 requests through the 16 permits in two rounds, because
+the last plan's request is admitted into the round that clears wave 0's one
+leftover request, so the model is one round too many. The same sliding
   window can also undercount: modeling the whole query as wave-synchronous
   in one shot -- one binding concurrency (`min(promql_fetch_fanout *
   min(distinctMatcherSets, promql_fetch_fanout), sharedGetPermits)`)

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1778,9 +1778,9 @@ and rendered as `stats.io`, additive beside `stats.phases`:
   shards' LIST pages ran concurrently with each other or one after another,
   only that they happened (`ravel-catalog` owns that fan-out; out of this
   task's scope to change).
-- `serviceBatches`: a LOWER bound on the serial service rounds this query's
-  per-segment fan-out needed, under a wave-synchronous model of the nested
-  fan-out. The metrics fetch is a NESTED fan-out with three levels of
+- `serviceBatches`: a deterministic model figure for the serial service
+  rounds this query's per-segment fan-out needs, under a wave-synchronous
+  model of the nested fan-out. The metrics fetch is a NESTED fan-out with three levels of
   admission, all of which bound the round count: an OUTER
   `buffer_unordered(promql_fetch_fanout)` over distinct matcher plans
   (`distinct_plans_by_matcher` in `crates/ravel-query/src/engine.rs`), which
@@ -1796,35 +1796,50 @@ and rendered as `stats.io`, additive beside `stats.phases`:
   query: GETs that other queries, the SQL path, or the RLOG whole-object
   funnel (which takes a permit too since ADR-1195) issue at the same time
   compete for the same permits and are not counted here.
-  It is a lower bound, never an upper bound or an exact count, because the
-  OUTER `buffer_unordered` is a SLIDING window, not a wave-synchronous one:
-  as soon as one admitted plan finishes, the next plan is admitted
-  immediately, without waiting for its siblings. Modeling it as
-  wave-synchronous anyway -- one binding concurrency
-  (`min(promql_fetch_fanout * min(distinctMatcherSets,
-  promql_fetch_fanout), sharedGetPermits)`) dividing the total work
-  (`segment_count * distinctMatcherSets` GETs) in a single division --
-  undercounts whenever the outer window is not full for the query's whole
-  duration: 3 distinct matcher sets, 1 segment each, `promql_fetch_fanout`
-  2, and 1000 shared permits gives peak capacity `min(2 * 2, 1000) = 4`, so
-  that single division reports `ceil(3 / 4) = 1` round, but plans 1 and 2
-  admit together in the first round and plan 3 only after one of them
-  finishes, in a second round -- the real schedule needs at least 2 rounds,
-  not 1.
+  Within a single wave, that wave's own `batches_w` (defined below) is a
+  true lower bound: the OUTER `buffer_unordered`'s binding capacity for
+  that wave cannot service more than `capacity_w` requests per round, so
+  the wave cannot finish in fewer than `batches_w` rounds. But
+  `serviceBatches` sums `batches_w` across waves, and that sum is a model
+  figure, not a bound in either direction, because the OUTER
+  `buffer_unordered` is a SLIDING window, not a wave-synchronous one: as
+  soon as one admitted plan finishes, the next plan is admitted
+  immediately, without waiting for its siblings, so a later wave's work
+  can start -- and finish -- before an earlier wave's is done. Concretely:
+  16 shared permits, 17 distinct matcher plans admitted through an outer
+  fan-out width of 16 (one segment each), plus one further plan whose
+  single segment fetch only becomes eligible after the first of the 17
+  resolves. The real scheduler finishes all of it in two rounds, because
+  that further fetch is admitted into the same round that drains the 17th
+  plan's leftover request, while the summed per-wave model reports
+  `ceil(17 / 16) + ceil(1 / 16) = 3`, one round too many. The same sliding
+  window can also undercount: modeling the whole query as wave-synchronous
+  in one shot -- one binding concurrency (`min(promql_fetch_fanout *
+  min(distinctMatcherSets, promql_fetch_fanout), sharedGetPermits)`)
+  dividing the total work (`segment_count * distinctMatcherSets` GETs) in a
+  single division -- undercounts whenever the outer window is not full for
+  the query's whole duration: 3 distinct matcher sets, 1 segment each,
+  `promql_fetch_fanout` 2, and 1000 shared permits gives peak capacity
+  `min(2 * 2, 1000) = 4`, so that single division reports `ceil(3 / 4) = 1`
+  round, but plans 1 and 2 admit together in the first round and plan 3
+  only after one of them finishes, in a second round -- the real schedule
   So this figure is computed per WAVE of the outer fan-out instead: `waves
   = ceil(distinctMatcherSets / promql_fetch_fanout)`; for 0-based wave `w`,
   `active_w = min(promql_fetch_fanout, distinctMatcherSets - w *
   promql_fetch_fanout)` plans are admitted, `capacity_w =
   min(promql_fetch_fanout * active_w, sharedGetPermits)` is that wave's
   binding concurrency, and `batches_w = ceil(segment_count * active_w /
-  capacity_w)` is its own serial round count; `serviceBatches` sums
-  `batches_w` over every wave (distinct matcher sets, not the raw plan
-  count `stats.estimate` scales by -- a query naming two `SelectorPlan`s
-  that share one matcher set, `up + up offset 5m`, is fetched in one pass,
-  so its `serviceBatches` does not double). This sum is still a lower
-  bound, never exact: the sliding window can only pack work at least as
-  tightly as the wave-synchronous model assumes, never more loosely, so the
-  real scheduler takes at least this many rounds. 64 segments,
+  capacity_w)` is its own serial round count, a true lower bound on that
+  wave in isolation; `serviceBatches` sums `batches_w` over every wave
+  (distinct matcher sets, not the raw plan count `stats.estimate` scales
+  by -- a query naming two `SelectorPlan`s that share one matcher set, `up
+  + up offset 5m`, is fetched in one pass, so its `serviceBatches` does not
+  double). This sum is a deterministic model, not a bound: identical work
+  always produces the same number, which makes it comparable across
+  queries and useful for spotting a fan-out or permit-sizing regression,
+  but once more than one wave is involved the sum is neither an upper nor
+  a lower bound on the real scheduler's round count (see the 17-plus-1
+  counterexample above). 64 segments,
   `promql_fetch_fanout` 8, two distinct matcher sets, and 16 shared permits:
   one wave, `active_0 = 2`, `capacity_0 = min(16, 16) = 16`, `batches_0 =
   ceil(128 / 16) = 8`. `promql_fetch_fanout` 1 with three distinct matcher


### PR DESCRIPTION
The io_shape module doc and the serviceBatches paragraph in
docs/query-engine.md said the figure is a lower bound on serial service
rounds that the real scheduler can only exceed. That holds within one wave
of the nested fan-out, where a sliding-window scheduler cannot beat peak
capacity. It does not hold across waves: the per-wave figures are summed as
if each stage were a full barrier, and buffer_unordered is a sliding window,
so a child request can start before its parent stage's last wave completes.
With 16 permits, 17 parent requests and one child released by the first
parent finish in two rounds where the sum says three.

Both places now describe the figure as a deterministic model figure,
identical for identical work and comparable across queries, with the
lower-bound property scoped to a single wave and the cross-wave sum named as
a model rather than a bound in either direction. The worked examples stay
and the counterexample sits beside them so the old claim is not restored.
The dependency_depth field's own upper-bound wording is a different claim
and is untouched.

Fixes: #1258
Refs: #1199
