### PR TITLE
fix(ravel-server): pass the resolve concurrency in the limiter test

### DIFF
--- a/services/ravel-server/tests/get_limiter_process_wide_sharing.rs
+++ b/services/ravel-server/tests/get_limiter_process_wide_sharing.rs
@@ -390,6 +390,7 @@ async fn build_gated_app(get_limiter: Arc<GetLimiter>) -> (Router, GateHandle) {
         cli.disable_cache,
         ravel_server::config::DEFAULT_CACHE_MAX_BYTES,
         cli.cache_dir.clone(),
+        None,
     )
     .expect("catalog");
 


### PR DESCRIPTION
Main does not compile the sql-feature tests: `get_limiter_process_wide_sharing.rs` (from #1261) calls `build_catalog` with five arguments, and #1263 made it six. Each PR was green on its own base; the merge order broke the combination, and main runs no ci workflow of its own, so it surfaced as a failed lint on the next PR.

This passes `None` for the resolve concurrency, the default every other test caller uses. No behaviour change.
