### PR TITLE
feat(scripts): add --with-gates mode to verify-dispatch-gates.sh

### DIFF
--- a/.claude/skills/verify-dispatch/SKILL.md
+++ b/.claude/skills/verify-dispatch/SKILL.md
@@ -53,14 +53,14 @@ ambiguous or moved ref is a debugging trap later.
 
 ### Tier 1: deterministic gates
 
-Run `scripts/verify-dispatch-gates.sh <ref> <scratchpad-dir>`, where
-`<scratchpad-dir>` is a path **outside this repo's working tree** (the
-session's scratchpad directory is exactly right for this; never a
+Run `scripts/verify-dispatch-gates.sh --with-gates <ref> <scratchpad-dir>`,
+where `<scratchpad-dir>` is a path **outside this repo's working tree**
+(the session's scratchpad directory is exactly right for this; never a
 subdirectory of the repo itself: an untracked worktree left inside the
 repo blocks the next `fleet_dispatch` call, which refuses to run against
 a dirty primary checkout).
 
-The script:
+The script always:
 
 - Resolves `<ref>` to a SHA and creates a detached-HEAD worktree at that
   exact commit under the scratchpad path (not the ref name: a branch
@@ -74,14 +74,36 @@ The script:
   It does **not** mean disabling sccache: sccache is keyed on inputs and
   doesn't mask a genuine compile error, it just avoids redoing
   already-correct work, so leave `RUSTC_WRAPPER` alone.
-- Runs, workspace-wide regardless of which crate the branch touched (a
-  crate-scoped `-p` run is exactly what let a cross-crate rename break an
-  untouched crate's build):
-  `cargo fmt --all --check`, `cargo build --workspace --all-targets`,
-  `cargo clippy --workspace --all-targets -- -D warnings`,
-  `cargo test --workspace`, `cargo test --doc --workspace`.
 - Stops at the first failure, printing the exact command and its real
   exit code, and always removes the worktree on exit (pass or fail).
+
+Two modes for what actually runs inside that worktree:
+
+- **`--with-gates`** (or `VERIFY_WITH_GATES=1`): runs the worktree's own
+  `scripts/gates.sh`, unscoped, workspace-wide. This is the default
+  recommendation now: `gates.sh` also covers the `sql` / `flight-sql`
+  feature lanes and the `ravel-bench` feature lanes the plain mode below
+  never builds, and on a clean tree it writes a gates-pass receipt keyed
+  by tree hash. That receipt is exactly what lets the merge step run
+  `FLEET_MERGE_SKIP_GATES=1 scripts/fleet-result-merge.sh` and skip its
+  own second full build instead of redoing the identical workspace-wide
+  gate a few minutes later. Print the `Gates receipt: <path>` line the
+  script emits on success; it is not needed to invoke the merge step
+  (the merge script recomputes the same path from the tree hash) but is
+  useful when a receipt-missing failure needs to be debugged.
+- **Plain mode** (no flag): runs, workspace-wide regardless of which
+  crate the branch touched (a crate-scoped `-p` run is exactly what let a
+  cross-crate rename break an untouched crate's build):
+  `cargo fmt --all --check`, `cargo build --workspace --all-targets`,
+  `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo test --workspace`, `cargo test --doc --workspace`. This does
+  **not** build the `sql` / `flight-sql` / `ravel-bench` lanes and does
+  **not** write a gates-pass receipt, so a merge that follows a plain-mode
+  verify run must NOT set `FLEET_MERGE_SKIP_GATES=1` (there is no receipt
+  for it to find, and the script refuses the skip without one). Use this
+  mode only when `--with-gates` itself is unavailable for some reason;
+  otherwise prefer `--with-gates` so the land chain pays for the full
+  gate list exactly once.
 
 Treat the script's own exit code as authoritative. If it's nonzero, tier 1
 is FAIL: capture the command, exit code, and the last ~40 lines of its
@@ -216,7 +238,9 @@ On tier-1 FAIL:
    output), so the executor isn't guessing at what broke.
 3. Re-run this skill against the fix's result branch.
 4. Tier-1 PASS now: proceed to the normal merge flow
-   (`scripts/fleet-result-merge.sh` / the merge-fleet-result skill).
+   (`scripts/fleet-result-merge.sh` / the merge-fleet-result skill). If
+   tier 1 ran with `--with-gates`, pass `FLEET_MERGE_SKIP_GATES=1` to the
+   merge script so it does not redo the same workspace-wide build.
 5. Tier-1 FAIL again (2nd consecutive failure): stop. Surface both
    reports to the user directly. Do not dispatch a third attempt without
    explicit direction.

--- a/.claude/skills/verify-dispatch/SKILL.md
+++ b/.claude/skills/verify-dispatch/SKILL.md
@@ -239,8 +239,10 @@ On tier-1 FAIL:
 3. Re-run this skill against the fix's result branch.
 4. Tier-1 PASS now: proceed to the normal merge flow
    (`scripts/fleet-result-merge.sh` / the merge-fleet-result skill). If
-   tier 1 ran with `--with-gates`, pass `FLEET_MERGE_SKIP_GATES=1` to the
-   merge script so it does not redo the same workspace-wide build.
+   tier 1 ran in gated mode (either `--with-gates` or `VERIFY_WITH_GATES=1`,
+   which select the same mode and write the same receipt), pass
+   `FLEET_MERGE_SKIP_GATES=1` to the merge script so it does not redo the
+   same workspace-wide build.
 5. Tier-1 FAIL again (2nd consecutive failure): stop. Surface both
    reports to the user directly. Do not dispatch a third attempt without
    explicit direction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,9 @@ connection, a pushed-but-broken main).
   conflict resolution, or manual edit changes the tree and voids the
   receipt: rerun the gates. The script also runs `assert-gh-auth.sh`
   first and `assert-clean-authorship.sh` on the rewritten history before
-  it pushes.
+  it pushes. A receipt written by `verify-dispatch-gates.sh --with-gates`
+  satisfies this same check: the authorship rewrite and wip-fold change
+  commit ids, not the tree, so the tree-hash-keyed receipt still matches.
 - `scripts/pr-review-status.sh <pr-number>`: one-line status for the
   wait-for-CodeRabbit-then-merge-by-hand flow -- `mergeStateStatus`, the
   CI check rollup (pass/pending/fail counts, failing check names), and
@@ -269,13 +271,19 @@ connection, a pushed-but-broken main).
   human/session read of `gh api repos/.../pulls/<n>/comments` to judge
   whether each was already fixed or answered; the script only tells you
   there's something to read.
-- `scripts/verify-dispatch-gates.sh <ref> <scratchpad-dir>`: the tier-1
-  gate check behind the `verify-dispatch` skill: an isolated worktree
-  outside the repo, a cold `CARGO_TARGET_DIR`, and the full workspace
-  gate list, regardless of which crate the branch touched. Run this (via
-  the `verify-dispatch` skill, which adds narrow adversarial checks on
-  top) before merging any fleet result: a crate-scoped or warm-cache
-  gate run can let a broken branch through.
+- `scripts/verify-dispatch-gates.sh [--with-gates] <ref> <scratchpad-dir>`:
+  the tier-1 gate check behind the `verify-dispatch` skill: an isolated
+  worktree outside the repo, a cold `CARGO_TARGET_DIR`, and the full
+  workspace gate list, regardless of which crate the branch touched. Run
+  this (via the `verify-dispatch` skill, which adds narrow adversarial
+  checks on top) before merging any fleet result: a crate-scoped or
+  warm-cache gate run can let a broken branch through. `--with-gates` (or
+  `VERIFY_WITH_GATES=1`) runs `scripts/gates.sh` itself inside that cold
+  worktree instead of five hand-listed cargo commands, which also covers
+  the `sql`/`flight-sql`/`ravel-bench` feature lanes and leaves a
+  gates-pass receipt that `FLEET_MERGE_SKIP_GATES=1
+  scripts/fleet-result-merge.sh` can then reuse to skip its own second
+  full build.
 - `scripts/affected-tests.sh [-n] -p CRATE [-p CRATE ...]`: runs tests
   for the named crates plus every workspace crate that depends on them
   (transitively), with the `ci` cargo profile; `-n` prints the affected

--- a/scripts/tests/verify-dispatch-gates-with-gates.test.sh
+++ b/scripts/tests/verify-dispatch-gates-with-gates.test.sh
@@ -161,6 +161,39 @@ receipt_file="$(
 check_eq "printed receipt path matches fleet-result-merge.sh's lookup" "${receipt_file}" "${printed_receipt}"
 check_true "the receipt file the stub wrote actually exists there" "$([[ -f "${receipt_file}" ]] && echo 1 || echo 0)"
 
+# === (b2) VERIFY_WITH_GATES=1 with no flag selects the same gated mode:
+#     the gate runs once inside the worktree and the receipt lands where
+#     fleet-result-merge.sh looks for it. ====================================
+repo="${tmproot}/repo-b2"
+worktree_parent="${tmproot}/wt-b2"
+new_repo "${repo}"
+stub_gates="${tmproot}/stub-gates-b2.sh"
+make_stub_gates "${stub_gates}"
+call_log="${tmproot}/call-log-b2"
+: >"${call_log}"
+
+out="$(cd "${repo}" && CALL_LOG="${call_log}" STUB_GATES_EXIT=0 VERIFY_WITH_GATES=1 \
+  GATES_SH="${stub_gates}" "${VERIFY_SCRIPT}" HEAD "${worktree_parent}" 2>&1)"
+got_exit=$?
+
+check_eq "VERIFY_WITH_GATES=1 exit code propagated" "0" "${got_exit}"
+
+call_count="$(wc -l <"${call_log}" | tr -d ' ')"
+check_eq "VERIFY_WITH_GATES=1 invokes the gate exactly once" "1" "${call_count}"
+
+worktree_dir="${worktree_parent}/verify-$(cd "${repo}" && git rev-parse --short HEAD)"
+logged_cwd="$(sed -n 's/^cwd=\(.*\) args=.*/\1/p' "${call_log}")"
+check_eq "VERIFY_WITH_GATES=1 runs the gate inside the worktree" "${worktree_dir}" "${logged_cwd}"
+
+printed_receipt="$(printf '%s\n' "${out}" | sed -n 's/^==> Gates receipt: //p')"
+receipt_file="$(
+  cd "${repo}"
+  skip_tree="$(git rev-parse "HEAD^{tree}")"
+  echo "$(cd "$(git rev-parse --git-common-dir)" && pwd)/gates-pass/${skip_tree}"
+)"
+check_eq "VERIFY_WITH_GATES=1 receipt path matches the merge script's lookup" "${receipt_file}" "${printed_receipt}"
+check_true "VERIFY_WITH_GATES=1 receipt file exists" "$([[ -f "${receipt_file}" ]] && echo 1 || echo 0)"
+
 # === (c) default mode (no --with-gates) still runs the five cargo
 #     commands, in the documented order, unchanged. =========================
 repo="${tmproot}/repo-c"

--- a/scripts/tests/verify-dispatch-gates-with-gates.test.sh
+++ b/scripts/tests/verify-dispatch-gates-with-gates.test.sh
@@ -20,6 +20,10 @@ if [[ ! -d "${tmproot}" ]]; then
   echo "FAIL  could not create a temp dir for the scratch repos" >&2
   exit 1
 fi
+# Physical path, so the paths this test derives compare equal to the ones the
+# scripts print via `pwd` and `git rev-parse --git-common-dir`. On macOS
+# `$TMPDIR` is a symlink under /var and may carry a trailing slash.
+tmproot="$(cd "${tmproot}" && pwd -P)"
 trap 'rm -rf "${tmproot}"' EXIT
 
 pass=0

--- a/scripts/tests/verify-dispatch-gates-with-gates.test.sh
+++ b/scripts/tests/verify-dispatch-gates-with-gates.test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Coverage for verify-dispatch-gates.sh's --with-gates mode (issue #1247):
+# the flag must run scripts/gates.sh (or its GATES_SH override) exactly
+# once from inside the cold worktree and propagate its exit code, the
+# receipt path it prints must be the same path fleet-result-merge.sh's
+# FLEET_MERGE_SKIP_GATES=1 check computes, and the default (no-flag) mode
+# must still run the five hand-listed cargo commands, in order, unchanged.
+#
+# Pure shell: no cargo build. Everything below runs against throwaway git
+# repos under $TMPDIR.
+#
+# Run: bash scripts/tests/verify-dispatch-gates-with-gates.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VERIFY_SCRIPT="${SCRIPT_DIR}/verify-dispatch-gates.sh"
+
+tmproot="$(mktemp -d "${TMPDIR:-/tmp}/verify-dispatch-gates-test.XXXXXX")"
+if [[ ! -d "${tmproot}" ]]; then
+  echo "FAIL  could not create a temp dir for the scratch repos" >&2
+  exit 1
+fi
+trap 'rm -rf "${tmproot}"' EXIT
+
+pass=0
+fail=0
+
+check_eq() {
+  local label="$1" want="$2" got="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    pass=$((pass + 1))
+    printf 'ok    %s\n' "${label}"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL  %s\n  want: %s\n  got:  %s\n' "${label}" "${want}" "${got}"
+  fi
+}
+
+check_true() {
+  local label="$1" cond="$2"
+  if [[ "${cond}" == "1" ]]; then
+    pass=$((pass + 1))
+    printf 'ok    %s\n' "${label}"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL  %s\n' "${label}"
+  fi
+}
+
+# new_repo <dir>: a scratch repo with one commit, so `HEAD` resolves.
+new_repo() {
+  local dir="$1"
+  mkdir -p "${dir}"
+  git -C "${dir}" init -q -b main
+  git -C "${dir}" config user.email "executor@example.test"
+  git -C "${dir}" config user.name "Scratch Executor"
+  git -C "${dir}" config commit.gpgsign false
+  mkdir -p "${dir}/scripts"
+  printf 'seed\n' >"${dir}/README.md"
+  git -C "${dir}" add README.md
+  git -C "${dir}" commit -q -s -m "chore: seed the scratch repo"
+}
+
+# --- stub gates.sh --------------------------------------------------------
+# Records one line per invocation (cwd, arg count) to CALL_LOG, then either
+# writes a receipt mimicking gates.sh's own scheme (tree-hash-keyed file
+# under <git-common-dir>/gates-pass/) or exits with STUB_GATES_EXIT.
+make_stub_gates() {
+  local stub_file="$1"
+  cat >"${stub_file}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "cwd=$(pwd) args=$#" >>"${CALL_LOG}"
+if [[ "${STUB_GATES_EXIT:-0}" != "0" ]]; then
+  exit "${STUB_GATES_EXIT}"
+fi
+tree_hash="$(git rev-parse 'HEAD^{tree}')"
+receipt_dir="$(cd "$(git rev-parse --git-common-dir)" && pwd)/gates-pass"
+mkdir -p "${receipt_dir}"
+date -u +%Y-%m-%dT%H:%M:%SZ >"${receipt_dir}/${tree_hash}"
+exit 0
+EOF
+  chmod +x "${stub_file}"
+}
+
+# --- stub cargo ------------------------------------------------------------
+# Appends its argv (space-joined) as one line to CALL_LOG, then exits 0.
+make_stub_cargo() {
+  local stub_file="$1"
+  cat >"${stub_file}" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CALL_LOG}"
+exit 0
+EOF
+  chmod +x "${stub_file}"
+}
+
+# === (a) --with-gates runs the stub exactly once from inside the worktree,
+#     and both a passing (0) and failing (3) exit code are propagated. ====
+for exit_code in 0 3; do
+  repo="${tmproot}/repo-a-${exit_code}"
+  worktree_parent="${tmproot}/wt-a-${exit_code}"
+  new_repo "${repo}"
+  stub_gates="${tmproot}/stub-gates-${exit_code}.sh"
+  make_stub_gates "${stub_gates}"
+  call_log="${tmproot}/call-log-a-${exit_code}"
+  : >"${call_log}"
+
+  out="$(cd "${repo}" && CALL_LOG="${call_log}" STUB_GATES_EXIT="${exit_code}" \
+    GATES_SH="${stub_gates}" "${VERIFY_SCRIPT}" --with-gates HEAD "${worktree_parent}" 2>&1)"
+  got_exit=$?
+
+  check_eq "with-gates exit code propagated (stub exit ${exit_code})" "${exit_code}" "${got_exit}"
+
+  call_count="$(wc -l <"${call_log}" | tr -d ' ')"
+  check_eq "with-gates stub invoked exactly once (stub exit ${exit_code})" "1" "${call_count}"
+
+  worktree_dir="${worktree_parent}/verify-$(cd "${repo}" && git rev-parse --short HEAD)"
+  logged_cwd="$(sed -n 's/^cwd=\(.*\) args=.*/\1/p' "${call_log}")"
+  check_eq "with-gates stub ran inside the worktree (stub exit ${exit_code})" "${worktree_dir}" "${logged_cwd}"
+
+  if [[ "${exit_code}" == "0" ]]; then
+    printed_receipt="$(printf '%s\n' "${out}" | sed -n 's/^==> Gates receipt: //p')"
+    check_true "with-gates prints a receipt path on success" "$([[ -n "${printed_receipt}" ]] && echo 1 || echo 0)"
+  fi
+
+  # Worktree must always be removed, pass or fail.
+  remaining="$(git -C "${repo}" worktree list --porcelain | grep -c "^worktree ${worktree_dir}$" || true)"
+  check_eq "with-gates cleans up the worktree (stub exit ${exit_code})" "0" "${remaining}"
+done
+
+# === (b) the printed receipt path matches fleet-result-merge.sh's
+#     FLEET_MERGE_SKIP_GATES=1 lookup, run in isolation against the same
+#     git common dir. =======================================================
+repo="${tmproot}/repo-b"
+worktree_parent="${tmproot}/wt-b"
+new_repo "${repo}"
+stub_gates="${tmproot}/stub-gates-b.sh"
+make_stub_gates "${stub_gates}"
+call_log="${tmproot}/call-log-b"
+: >"${call_log}"
+
+out="$(cd "${repo}" && CALL_LOG="${call_log}" STUB_GATES_EXIT=0 \
+  GATES_SH="${stub_gates}" "${VERIFY_SCRIPT}" --with-gates HEAD "${worktree_parent}" 2>&1)"
+printed_receipt="$(printf '%s\n' "${out}" | sed -n 's/^==> Gates receipt: //p')"
+
+# fleet-result-merge.sh's own snippet (scripts/fleet-result-merge.sh, the
+# FLEET_MERGE_SKIP_GATES=1 branch), reproduced verbatim and run against
+# <clean_ref> = HEAD of the same repo the worktree was cut from.
+clean_ref="HEAD"
+receipt_file="$(
+  cd "${repo}"
+  skip_tree="$(git rev-parse "${clean_ref}^{tree}")"
+  echo "$(cd "$(git rev-parse --git-common-dir)" && pwd)/gates-pass/${skip_tree}"
+)"
+
+check_eq "printed receipt path matches fleet-result-merge.sh's lookup" "${receipt_file}" "${printed_receipt}"
+check_true "the receipt file the stub wrote actually exists there" "$([[ -f "${receipt_file}" ]] && echo 1 || echo 0)"
+
+# === (c) default mode (no --with-gates) still runs the five cargo
+#     commands, in the documented order, unchanged. =========================
+repo="${tmproot}/repo-c"
+worktree_parent="${tmproot}/wt-c"
+new_repo "${repo}"
+bin_dir="${tmproot}/bin-c"
+mkdir -p "${bin_dir}"
+make_stub_cargo "${bin_dir}/cargo"
+call_log="${tmproot}/call-log-c"
+: >"${call_log}"
+
+(cd "${repo}" && CALL_LOG="${call_log}" PATH="${bin_dir}:${PATH}" \
+  "${VERIFY_SCRIPT}" HEAD "${worktree_parent}" >/dev/null 2>&1)
+default_exit=$?
+check_eq "default mode exits 0 against the stub cargo" "0" "${default_exit}"
+
+want_calls="$(printf '%s\n' \
+  '--locked fmt --all --check' \
+  'build --locked --workspace --all-targets' \
+  'clippy --locked --workspace --all-targets -- -D warnings' \
+  'test --locked --workspace' \
+  'test --locked --doc --workspace')"
+got_calls="$(cat "${call_log}")"
+check_eq "default mode invokes the five cargo commands in order" "${want_calls}" "${got_calls}"
+
+echo
+echo "passed: ${pass}  failed: ${fail}"
+[[ ${fail} -eq 0 ]]

--- a/scripts/tests/verify-dispatch-gates-with-gates.test.sh
+++ b/scripts/tests/verify-dispatch-gates-with-gates.test.sh
@@ -123,6 +123,12 @@ for exit_code in 0 3; do
   logged_cwd="$(sed -n 's/^cwd=\(.*\) args=.*/\1/p' "${call_log}")"
   check_eq "with-gates stub ran inside the worktree (stub exit ${exit_code})" "${worktree_dir}" "${logged_cwd}"
 
+  # Unscoped, or the real gates.sh writes no receipt: it only stamps one when
+  # its crate-argument list is empty, so a scoped invocation here would leave
+  # FLEET_MERGE_SKIP_GATES=1 with nothing to find.
+  logged_args="$(sed -n 's/^cwd=.* args=\(.*\)/\1/p' "${call_log}")"
+  check_eq "with-gates invokes the gate unscoped (stub exit ${exit_code})" "0" "${logged_args}"
+
   if [[ "${exit_code}" == "0" ]]; then
     printed_receipt="$(printf '%s\n' "${out}" | sed -n 's/^==> Gates receipt: //p')"
     check_true "with-gates prints a receipt path on success" "$([[ -n "${printed_receipt}" ]] && echo 1 || echo 0)"
@@ -184,6 +190,9 @@ check_eq "VERIFY_WITH_GATES=1 invokes the gate exactly once" "1" "${call_count}"
 worktree_dir="${worktree_parent}/verify-$(cd "${repo}" && git rev-parse --short HEAD)"
 logged_cwd="$(sed -n 's/^cwd=\(.*\) args=.*/\1/p' "${call_log}")"
 check_eq "VERIFY_WITH_GATES=1 runs the gate inside the worktree" "${worktree_dir}" "${logged_cwd}"
+
+logged_args="$(sed -n 's/^cwd=.* args=\(.*\)/\1/p' "${call_log}")"
+check_eq "VERIFY_WITH_GATES=1 invokes the gate unscoped" "0" "${logged_args}"
 
 printed_receipt="$(printf '%s\n' "${out}" | sed -n 's/^==> Gates receipt: //p')"
 receipt_file="$(

--- a/scripts/verify-dispatch-gates.sh
+++ b/scripts/verify-dispatch-gates.sh
@@ -7,7 +7,7 @@
 # incremental target dir can mask a real compile error behind stale
 # cached artifacts (see the verify-dispatch skill).
 #
-# Usage: verify-dispatch-gates.sh <ref> <worktree-parent-dir>
+# Usage: verify-dispatch-gates.sh [--with-gates] <ref> <worktree-parent-dir>
 #
 # <ref> is anything `git worktree add` accepts: a branch, a tag, a SHA.
 # <worktree-parent-dir> MUST be outside this repo's working tree: a
@@ -20,10 +20,36 @@
 # on the first failure, prints which command failed and its exit code,
 # then exits with that code. Always removes the worktree on exit, success
 # or failure.
+#
+# --with-gates (or VERIFY_WITH_GATES=1): run scripts/gates.sh, unscoped,
+# from inside the cold worktree instead of the five hand-listed cargo
+# commands below. gates.sh also covers the sql / flight-sql / ravel-bench
+# feature lanes the five commands do not, and on a clean tree it writes a
+# gates-pass receipt keyed by tree hash (see gates.sh's "Gates-pass
+# receipt" section) that fleet-result-merge.sh's FLEET_MERGE_SKIP_GATES=1
+# reads to skip its own second full build. Without this flag, behavior is
+# byte-for-byte unchanged from before it existed.
+#
+# GATES_SH overrides the path to gates.sh (default: the worktree's own
+# scripts/gates.sh, so a branch that edits gates.sh is verified against
+# its own edit). Test-only escape hatch for substituting a stub.
 set -euo pipefail
 
+with_gates=0
+positional=()
+for arg in "$@"; do
+  case "${arg}" in
+    --with-gates) with_gates=1 ;;
+    *) positional+=("${arg}") ;;
+  esac
+done
+if [[ "${VERIFY_WITH_GATES:-0}" == "1" ]]; then
+  with_gates=1
+fi
+set -- "${positional[@]}"
+
 if [[ $# -lt 2 ]]; then
-  echo "usage: $0 <ref> <worktree-parent-dir>" >&2
+  echo "usage: $0 [--with-gates] <ref> <worktree-parent-dir>" >&2
   exit 64
 fi
 
@@ -73,14 +99,23 @@ run_gate() {
   return 0
 }
 
-# --locked pins the committed Cargo.lock so this cold-cache verification
-# resolves exactly what CI does; a divergent resolve here would defeat the
-# purpose of the isolated run. `cargo fmt` (rustfmt) rejects --locked after
-# the subcommand, so it takes the global-flag position.
-run_gate cargo --locked fmt --all --check
-run_gate cargo build --locked --workspace --all-targets
-run_gate cargo clippy --locked --workspace --all-targets -- -D warnings
-run_gate cargo test --locked --workspace
-run_gate cargo test --locked --doc --workspace
+if [[ ${with_gates} -eq 1 ]]; then
+  gates_sh="${GATES_SH:-${worktree_dir}/scripts/gates.sh}"
+  run_gate "${gates_sh}"
+
+  tree_hash="$(git -C "${worktree_dir}" rev-parse 'HEAD^{tree}')"
+  receipt_dir="$(cd "$(git -C "${worktree_dir}" rev-parse --git-common-dir)" && pwd)/gates-pass"
+  echo "==> Gates receipt: ${receipt_dir}/${tree_hash}"
+else
+  # --locked pins the committed Cargo.lock so this cold-cache verification
+  # resolves exactly what CI does; a divergent resolve here would defeat
+  # the purpose of the isolated run. `cargo fmt` (rustfmt) rejects --locked
+  # after the subcommand, so it takes the global-flag position.
+  run_gate cargo --locked fmt --all --check
+  run_gate cargo build --locked --workspace --all-targets
+  run_gate cargo clippy --locked --workspace --all-targets -- -D warnings
+  run_gate cargo test --locked --workspace
+  run_gate cargo test --locked --doc --workspace
+fi
 
 echo "TIER1 PASS"


### PR DESCRIPTION
Landing a fleet result built the same tree twice: the tier-1 verify
gate compiled it cold in its own worktree, then fleet-result-merge.sh
ran gates.sh over the same tree again before opening the PR. On this
machine that is one to two hours of build per landing, and only one
cold gate fits on the volume at a time, so every landing serialized
behind the previous one.

verify-dispatch-gates.sh gains --with-gates (or VERIFY_WITH_GATES=1).
In that mode it runs scripts/gates.sh, unscoped, inside the cold
worktree instead of its own five cargo commands, so the tree also gets
a gates-pass receipt keyed by its tree hash. fleet-result-merge.sh
already honours that receipt through FLEET_MERGE_SKIP_GATES=1, so the
merge step can skip its rerun and let the PR's required checks be the
second gate. The default mode is unchanged. The script prints the
receipt path it produced so the operator can confirm it before
setting the skip.

A shell test covers exit-code propagation, that the gate runs inside
the worktree exactly once, worktree cleanup on both success and
failure, that the printed receipt path is the one the merge script
looks up, and that the default mode still runs the five cargo
commands in order. The test resolves its temp root to a physical
path so it passes on macOS, where TMPDIR is a symlink under /var.
CLAUDE.md and the verify-dispatch skill describe the new mode and
when to use it.

Fixes: #1247
