### PR TITLE
fix(cache-warm): warm from each tenant's latest ingest hour, not now

### DIFF
--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -1911,7 +1911,8 @@ impl Catalog {
     /// those shards even under a small configured `shard_count`, and a
     /// shard-count decrease keeps a retiring generation's higher indices in
     /// scope for `DEFAULT_SCAN_SLACK_HOURS`. Shards are fanned out
-    /// concurrently, `MAX_CONCURRENT_REQUESTS` at a time.
+    /// concurrently, `CatalogConfig::resolve_get_concurrency` at a time, the
+    /// same bound every other listing fan-out in this file uses.
     ///
     /// This cannot use `list_delimited`: that call has no `start_after` and
     /// no pagination, so it cannot be floored without listing a shard's
@@ -1967,7 +1968,7 @@ impl Catalog {
                 .map(|shard| {
                     self.latest_ingest_hour_for_shard(tenant, signal, shard, max_hour, accounting)
                 })
-                .buffered(MAX_CONCURRENT_REQUESTS)
+                .buffered(self.config.resolve_get_concurrency)
                 .collect()
                 .await;
 

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -1861,6 +1861,235 @@ impl Catalog {
         }
     }
 
+    /// The newest-ingest-hour probe widths [`Catalog::latest_ingest_hour`]
+    /// tries per shard, newest-window-first, each one doubling the last
+    /// (issue #1233). The widest entry is [`LATEST_HOUR_MAX_LOOKBACK_HOURS`];
+    /// once it also misses, the tenant/signal is reported as having no
+    /// ingest within the lookback cap rather than paging through its entire
+    /// history.
+    const LATEST_HOUR_PROBE_WINDOWS_HOURS: [u32; 7] = [24, 48, 96, 192, 384, 768, 1536];
+
+    /// The widest window [`Catalog::latest_ingest_hour`] will probe: 64 days,
+    /// the last entry of `LATEST_HOUR_PROBE_WINDOWS_HOURS`. A tenant whose
+    /// latest ingest for a signal is older than this returns `Ok(None)`.
+    pub const LATEST_HOUR_MAX_LOOKBACK_HOURS: u32 = 24 * 64;
+
+    /// The newest ingest-hour bucket holding any commit-record-shaped part
+    /// (a raw commit record, a compaction record, a rewrite record, or a
+    /// tombstone -- any of the four [`BucketEntry`] shapes anchors the hour,
+    /// not only a raw ingest) for this tenant and signal, across every
+    /// shard, or `None` if it has none within
+    /// [`Catalog::LATEST_HOUR_MAX_LOOKBACK_HOURS`] (issue #1233: startup cache
+    /// warmup needs this to warm a tenant whose last ingest is older than its
+    /// lookback window, rather than always resolving `[now - lookback,
+    /// now]`). The returned `bool` is `true` when the winning hour's page(s)
+    /// carried at least one non-tombstone entry (a commit, compaction, or
+    /// rewrite record): a caller resolving the warm window around a
+    /// tombstone-only anchor hour should expect an empty snapshot, since
+    /// [`Catalog::process_bucket`] drops a bucket outright the moment it
+    /// observes a tombstone, and that emptiness is not evidence of a failed
+    /// fetch.
+    ///
+    /// Probes each shard with a bounded, floored `list_after` starting at
+    /// `now - w` for each width `w` in
+    /// [`Catalog::LATEST_HOUR_PROBE_WINDOWS_HOURS`], newest first, stopping at
+    /// the first width whose probe returns any object: a narrower width
+    /// already came back empty, so nothing in this shard falls between it and
+    /// the current floor, and the returned page(s) already carry the shard's
+    /// true maximum (commit keys sort chronologically by ingest hour, so the
+    /// last page of a hit drains to the newest key). This bounds the shard to
+    /// at most seven probes -- one for a tenant that ingested in the last
+    /// 24h -- each probe draining its pages under
+    /// [`CatalogConfig::max_catalog_list_requests`](crate::CatalogConfig::max_catalog_list_requests),
+    /// refusing with [`CatalogError::WindowTooWide`] rather than paging a
+    /// shard's dense window unboundedly; it never lists the tenant's full
+    /// history. The shard set scanned is
+    /// [`crate::provisioning::scan_shards_over_range`] over
+    /// `[now - LATEST_HOUR_MAX_LOOKBACK_HOURS, now]`, the same mandated
+    /// over-a-range derivation every other read path uses (ADR-0052 section
+    /// 4, ADR-1101 decision 2): a signal with fixed read shards is probed on
+    /// those shards even under a small configured `shard_count`, and a
+    /// shard-count decrease keeps a retiring generation's higher indices in
+    /// scope for `DEFAULT_SCAN_SLACK_HOURS`. Shards are fanned out
+    /// concurrently, `MAX_CONCURRENT_REQUESTS` at a time.
+    ///
+    /// This cannot use `list_delimited`: that call has no `start_after` and
+    /// no pagination, so it cannot be floored without listing a shard's
+    /// entire commit-record prefix on every call, which is the exact
+    /// unbounded cost this method exists to avoid. `list_after` is the
+    /// in-scope primitive that supports a floor, at the cost of counting
+    /// object keys rather than one common prefix per ingest hour; a sparse
+    /// shard still resolves in one page per probe.
+    ///
+    /// An hour text past `now_ns + clock_skew_allowance_ns` is ignored, the
+    /// same guard [`Catalog::window_hour_bounds`] applies to a listing
+    /// window's upper edge: a clock-skewed or corrupt future-dated bucket
+    /// must never masquerade as "most recent". Symmetrically, a part is only
+    /// treated as anchoring "now" when its event time is within
+    /// `max_ingest_lag_ns` of its ingest hour AND that ingest hour is not
+    /// itself ahead of the wall clock: a part filed into an hour within
+    /// `clock_skew_allowance_ns` of the future can still move the anchor
+    /// forward by up to an hour, but never past `max_hour_ns` above.
+    ///
+    /// Past the lookback cap this returns `Ok(None)` silently (a `debug!` at
+    /// most, carrying the cap): a tenant that simply does not use a signal is
+    /// not a warning-worthy event in a library that cannot know the caller's
+    /// intent. The caller (`services/ravel-server/src/cache_warm.rs`'s
+    /// `log_warm_result`) alone decides the log level a caller should see for
+    /// that outcome.
+    pub async fn latest_ingest_hour(
+        &self,
+        tenant: &TenantHash,
+        signal: Signal,
+        now_ns: i64,
+        accounting: &QueryAccounting,
+    ) -> Result<Option<(u32, bool)>, CatalogError> {
+        let max_hour_ns = now_ns.saturating_add(self.config.clock_skew_allowance_ns);
+        if max_hour_ns < 0 {
+            return Ok(None);
+        }
+        let max_hour = u32::try_from(max_hour_ns.div_euclid(NS_PER_HOUR)).unwrap_or(u32::MAX);
+        let earliest_hour = max_hour.saturating_sub(Self::LATEST_HOUR_MAX_LOOKBACK_HOURS);
+
+        let generations = self
+            .read_scan_generations(tenant, signal, accounting)
+            .await?;
+        let scan_shards = crate::provisioning::scan_shards_over_range(
+            signal,
+            &generations,
+            earliest_hour,
+            max_hour,
+            crate::provisioning::DEFAULT_SCAN_SLACK_HOURS,
+        );
+
+        let shard_results: Vec<Result<Option<(u32, bool)>, CatalogError>> =
+            stream::iter(0..scan_shards)
+                .map(|shard| {
+                    self.latest_ingest_hour_for_shard(tenant, signal, shard, max_hour, accounting)
+                })
+                .buffered(MAX_CONCURRENT_REQUESTS)
+                .collect()
+                .await;
+
+        let mut latest: Option<(u32, bool)> = None;
+        for shard_result in shard_results {
+            if let Some((hour, has_ingest_part)) = shard_result? {
+                latest = Some(match latest {
+                    None => (hour, has_ingest_part),
+                    Some((cur_hour, _)) if hour > cur_hour => (hour, has_ingest_part),
+                    Some((cur_hour, cur_ingest)) if hour == cur_hour => {
+                        (cur_hour, cur_ingest || has_ingest_part)
+                    }
+                    Some(existing) => existing,
+                });
+            }
+        }
+        if latest.is_none() {
+            tracing::debug!(
+                tenant_hash = %tenant.to_hex(),
+                signal = ?signal,
+                max_lookback_hours = Self::LATEST_HOUR_MAX_LOOKBACK_HOURS,
+                "latest_ingest_hour: no ingest found for tenant/signal within max lookback"
+            );
+        }
+        Ok(latest)
+    }
+
+    /// One shard's contribution to [`Catalog::latest_ingest_hour`]: see that
+    /// method's doc comment for the probe/bound rationale. The LIST budget
+    /// in `self.config.max_catalog_list_requests` is applied PER SHARD here,
+    /// counted across every probe of this one shard (a dense window can
+    /// otherwise force many pages within a single probe); unlike
+    /// [`Catalog::list_window_by_prefix`], whose counter spans the whole
+    /// scan, the bound a start-up pays for one tenant and signal is
+    /// therefore `shard_count` times that budget.
+    async fn latest_ingest_hour_for_shard(
+        &self,
+        tenant: &TenantHash,
+        signal: Signal,
+        shard: u32,
+        max_hour: u32,
+        accounting: &QueryAccounting,
+    ) -> Result<Option<(u32, bool)>, CatalogError> {
+        let tenant_prefix = format!("t/{}/", tenant.to_hex());
+        let prefix = keys::commit_shard_prefix(tenant, signal, shard)?;
+        let cap = self.config.max_catalog_list_requests;
+        let mut lists_issued: u64 = 0;
+        for width_hours in Self::LATEST_HOUR_PROBE_WINDOWS_HOURS {
+            let floor_hour = max_hour.saturating_sub(width_hours);
+            let start_after = keys::commit_shard_hour_prefix(tenant, signal, shard, floor_hour)?;
+            let mut latest: Option<(u32, bool)> = None;
+            let mut page_token = None;
+            'pages: loop {
+                // Refuse before issuing a page that would exceed the
+                // ceiling, so at most `cap` LISTs are ever issued for this
+                // shard across all its probes (the request bound).
+                if lists_issued >= cap {
+                    return Err(CatalogError::WindowTooWide {
+                        estimate: lists_issued.saturating_add(1),
+                        limit: cap,
+                    });
+                }
+                let page = {
+                    let _permit = self.request_semaphore.acquire().await.map_err(|_| {
+                        StoreError::Transient("catalog request semaphore closed".to_string())
+                    })?;
+                    let page = self
+                        .store
+                        .list_after(&prefix, Some(&start_after), page_token)
+                        .await;
+                    accounting.record_s3_request(AccountedOp::List);
+                    lists_issued += 1;
+                    page?
+                };
+                for meta in &page.objects {
+                    // ADR-0050 §2 isolation assertion, identical to
+                    // `list_shard_hours` and `list_window_by_prefix`: every
+                    // returned key is under this tenant's prefix or the scan
+                    // hard-fails.
+                    if !meta.key.starts_with(&tenant_prefix) {
+                        self.record_isolation_breach();
+                        return Err(CatalogError::FieldMismatch {
+                            key: prefix.clone(),
+                            field: "list_prefix",
+                            expected: tenant_prefix,
+                            actual: meta.key.clone(),
+                        });
+                    }
+                    let (hour, is_tombstone) = match keys::partition_bucket_entry(&meta.key)? {
+                        BucketEntry::CommitRecord(k) => (k.ingest_hour_bucket, false),
+                        BucketEntry::CompactionRecord(k) => (k.ingest_hour_bucket, false),
+                        BucketEntry::RewriteRecord(k) => (k.ingest_hour_bucket, false),
+                        BucketEntry::Tombstone(k) => (k.ingest_hour_bucket, true),
+                    };
+                    // Keys sort chronologically, so the first hour past
+                    // `max_hour` (clock skew, a corrupt key) ends this probe:
+                    // paging on would spend the budget on the future tail at
+                    // every probe width, the same stop `list_shard_hours` takes.
+                    if hour > max_hour {
+                        break 'pages;
+                    }
+                    latest = Some(match latest {
+                        None => (hour, !is_tombstone),
+                        Some((cur, _)) if hour > cur => (hour, !is_tombstone),
+                        Some((cur, cur_ingest)) if hour == cur => {
+                            (cur, cur_ingest || !is_tombstone)
+                        }
+                        Some(existing) => existing,
+                    });
+                }
+                match page.next {
+                    Some(next) => page_token = Some(next),
+                    None => break,
+                }
+            }
+            if latest.is_some() {
+                return Ok(latest);
+            }
+        }
+        Ok(None)
+    }
+
     /// The (start_hour, end_hour) ingest-hour bucket range the listing
     /// window covers, inclusive, or `None` if the window is empty. Applies
     /// to every shard alike; callers cross it with `0..shard_count`
@@ -3873,6 +4102,261 @@ mod tests {
         // shard: 1 bounded LIST for shard 0, plus 1 for the empty `del/`
         // prefix. Total 2, exactly one fewer than audit's 3.
         assert_eq!(accounting.snapshot().s3_requests(AccountedOp::List), 2);
+    }
+
+    /// #1233 finding 7: the newest hour must be found regardless of which
+    /// shard holds it, and the count pins the floor's use, not merely the
+    /// early return. `hour_old` sits 40h before `max_hour` -- past the first
+    /// (24h) probe width, inside the second (48h) one -- so shard 0 must
+    /// widen once (2 list calls: a floored 24h miss, then a floored 48h hit)
+    /// while shard 1's fresh part hits its first probe (1 list call), for 3
+    /// total. An implementation that dropped the `start_after` floor would
+    /// still return the correct max (shard 0's unfloored first probe would
+    /// list its object directly, without needing to widen), but at 2 total
+    /// list calls, not 3 -- this test's exact count of 3 fails the moment
+    /// the floor is removed, which the bare early-return check on the
+    /// returned hour alone could not catch.
+    #[tokio::test]
+    async fn latest_ingest_hour_finds_the_newest_hour_across_shards() {
+        let memory = MemoryStore::new();
+        let max_hour = 500_010u32;
+        let hour_old = max_hour - 40;
+        let now = i64::from(max_hour) * NS_PER_HOUR + 30 * 60_000_000_000;
+
+        publish_segment(&memory, 0, 1, hour_old, now, now - 1_000, now).await;
+        publish_segment(&memory, 1, 1, max_hour, now, now - 1_000, now).await;
+
+        let instrumented = Arc::new(InstrumentedStore::new(memory));
+        let catalog = Catalog::new(instrumented.clone(), config(2)).expect("catalog");
+        let accounting = QueryAccounting::new();
+
+        let latest = catalog
+            .latest_ingest_hour(&tenant(), Signal::Metrics, now, &accounting)
+            .await
+            .expect("latest_ingest_hour");
+        assert_eq!(latest, Some((max_hour, true)));
+
+        // Provisioning enforcement is off (the default `Catalog::new`), so
+        // the generation-history read costs nothing: 3 list calls, 0 gets.
+        assert_eq!(instrumented.metrics().snapshot().list.calls, 3);
+        assert_eq!(instrumented.metrics().snapshot().get.calls, 0);
+    }
+
+    /// #1233 finding 1: a tenant whose latest part is older than the first
+    /// probe width but inside the second must widen exactly once per shard,
+    /// costing 2 * shard_count listings, and still find the true max.
+    /// #1233 finding 5: also pins the new path's `AccountedOp::List`
+    /// bookkeeping -- one credit per page issued, exactly matching the
+    /// instrumented store's own list-call count.
+    #[tokio::test]
+    async fn latest_ingest_hour_widens_once_for_a_tenant_outside_the_first_probe() {
+        let memory = MemoryStore::new();
+        let max_hour = 500_010u32;
+        // 40h before max_hour: outside the 24h probe width, inside the 48h
+        // one, so the 24h probe must miss and the 48h probe must hit.
+        let hour = max_hour - 40;
+        let now = i64::from(max_hour) * NS_PER_HOUR + 30 * 60_000_000_000;
+
+        publish_segment(&memory, 0, 1, hour, now, now - 1_000, now).await;
+        publish_segment(&memory, 1, 1, hour, now, now - 1_000, now).await;
+
+        let instrumented = Arc::new(InstrumentedStore::new(memory));
+        let catalog = Catalog::new(instrumented.clone(), config(2)).expect("catalog");
+        let accounting = QueryAccounting::new();
+
+        let latest = catalog
+            .latest_ingest_hour(&tenant(), Signal::Metrics, now, &accounting)
+            .await
+            .expect("latest_ingest_hour");
+        assert_eq!(latest, Some((hour, true)));
+
+        // Each of the 2 shards misses its 24h probe and hits its 48h probe:
+        // 2 * shard_count listings, exactly.
+        assert_eq!(instrumented.metrics().snapshot().list.calls, 4);
+        assert_eq!(accounting.snapshot().s3_requests(AccountedOp::List), 4);
+    }
+
+    /// #1233 finding 1: a tenant with no commit-record parts at all still
+    /// costs exactly the full 7-probe sweep per shard before giving up --
+    /// there is no cheaper way to prove "nothing newer than the cap exists"
+    /// than exhausting every probe width.
+    #[tokio::test]
+    async fn latest_ingest_hour_is_none_for_a_tenant_with_no_parts() {
+        let memory = MemoryStore::new();
+        let instrumented = Arc::new(InstrumentedStore::new(memory));
+        let catalog = Catalog::new(instrumented.clone(), config(2)).expect("catalog");
+        let now = 500_000i64 * NS_PER_HOUR;
+        let accounting = QueryAccounting::new();
+
+        let latest = catalog
+            .latest_ingest_hour(&tenant(), Signal::Metrics, now, &accounting)
+            .await
+            .expect("latest_ingest_hour");
+        assert_eq!(latest, None);
+
+        // All 7 probe widths miss for each of the 2 shards: 7 * shard_count.
+        assert_eq!(instrumented.metrics().snapshot().list.calls, 14);
+    }
+
+    /// #1233 finding 1: a part older than the widest (1536h / 64 day) probe
+    /// is indistinguishable from "no parts" -- it must not be found, and the
+    /// cap must still cost exactly the full 7-probe sweep, not an early
+    /// give-up.
+    #[tokio::test]
+    async fn latest_ingest_hour_ignores_a_part_older_than_the_lookback_cap() {
+        let memory = MemoryStore::new();
+        let max_hour = 500_010u32;
+        // 1600h before max_hour: past the widest (1536h) probe width.
+        let hour = max_hour - 1600;
+        let now = i64::from(max_hour) * NS_PER_HOUR + 30 * 60_000_000_000;
+
+        publish_segment(&memory, 0, 1, hour, now, now - 1_000, now).await;
+
+        let instrumented = Arc::new(InstrumentedStore::new(memory));
+        let catalog = Catalog::new(instrumented.clone(), config(1)).expect("catalog");
+        let accounting = QueryAccounting::new();
+
+        let latest = catalog
+            .latest_ingest_hour(&tenant(), Signal::Metrics, now, &accounting)
+            .await
+            .expect("latest_ingest_hour");
+        assert_eq!(latest, None);
+        assert_eq!(instrumented.metrics().snapshot().list.calls, 7);
+    }
+
+    /// #1233 finding 1: pagination inside a hit window must not lose the
+    /// maximum. 5 hour buckets in one shard, all inside the 24h probe width,
+    /// with `with_page_size(2)` forcing 3 pages (2 + 2 + 1); the newest hour
+    /// is on the last page and must still win.
+    #[tokio::test]
+    async fn latest_ingest_hour_finds_the_max_across_pages_within_a_probe() {
+        let memory = MemoryStore::with_page_size(2);
+        let max_hour = 500_010u32;
+        let now = i64::from(max_hour) * NS_PER_HOUR + 30 * 60_000_000_000;
+        let hours = [
+            max_hour - 4,
+            max_hour - 3,
+            max_hour - 2,
+            max_hour - 1,
+            max_hour,
+        ];
+        for (seq, hour) in hours.iter().enumerate() {
+            publish_segment(&memory, 0, seq as u64, *hour, now, now - 1_000, now).await;
+        }
+
+        let instrumented = Arc::new(InstrumentedStore::new(memory));
+        let catalog = Catalog::new(instrumented.clone(), config(1)).expect("catalog");
+        let accounting = QueryAccounting::new();
+
+        let latest = catalog
+            .latest_ingest_hour(&tenant(), Signal::Metrics, now, &accounting)
+            .await
+            .expect("latest_ingest_hour");
+        assert_eq!(latest, Some((max_hour, true)));
+
+        // 5 objects at page_size 2: 3 pages, all on the first (24h) probe.
+        assert_eq!(instrumented.metrics().snapshot().list.calls, 3);
+    }
+
+    /// #1233 finding 1: a foreign-tenant key surfacing inside
+    /// `latest_ingest_hour`'s listing must hard-fail with the same typed
+    /// error and isolation-breach counter the sibling listing paths use
+    /// (`list_shard_hours`, `list_window_by_prefix`), not be silently
+    /// consumed as if it were this tenant's own key.
+    #[tokio::test]
+    async fn latest_ingest_hour_hard_fails_on_a_foreign_tenant_key() {
+        let memory = MemoryStore::new();
+        let max_hour = 500_010u32;
+        let now = i64::from(max_hour) * NS_PER_HOUR + 30 * 60_000_000_000;
+        publish_segment(&memory, 0, 1, max_hour, now, now - 1_000, now).await;
+
+        let target_prefix =
+            keys::commit_shard_prefix(&tenant(), Signal::Metrics, 0).expect("commit shard prefix");
+        let store = Arc::new(ForeignKeyInjectingStore {
+            inner: memory,
+            target_prefix,
+            foreign_key: format!("t/{}/m/c/s0000/h{max_hour:08}/foreign-key", "f".repeat(32)),
+        });
+        let catalog = Catalog::new(store, config(1)).expect("catalog");
+        let accounting = QueryAccounting::new();
+
+        assert_eq!(catalog.isolation_breaches(), 0);
+        let err = catalog
+            .latest_ingest_hour(&tenant(), Signal::Metrics, now, &accounting)
+            .await
+            .expect_err("foreign key must hard-fail");
+        match err {
+            CatalogError::FieldMismatch { field, .. } => assert_eq!(field, "list_prefix"),
+            other => panic!("expected a list_prefix FieldMismatch, got {other:?}"),
+        }
+        assert_eq!(catalog.isolation_breaches(), 1);
+    }
+
+    /// #1233 finding 4: a shard whose newest probe window holds more commit
+    /// records than the configured `max_catalog_list_requests` budget must
+    /// refuse with `WindowTooWide` rather than paging unboundedly. 3 commit
+    /// records at `with_page_size(1)` force 3 pages; a budget of 2 refuses
+    /// on the 3rd page, having already issued exactly 2 lists.
+    #[tokio::test]
+    async fn latest_ingest_hour_refuses_past_the_list_request_budget() {
+        let memory = MemoryStore::with_page_size(1);
+        let max_hour = 500_010u32;
+        let now = i64::from(max_hour) * NS_PER_HOUR + 30 * 60_000_000_000;
+        for (seq, hour) in [max_hour - 2, max_hour - 1, max_hour].iter().enumerate() {
+            publish_segment(&memory, 0, seq as u64, *hour, now, now - 1_000, now).await;
+        }
+
+        let instrumented = Arc::new(InstrumentedStore::new(memory));
+        let mut cfg = config(1);
+        cfg.max_catalog_list_requests = 2;
+        let catalog = Catalog::new(instrumented.clone(), cfg).expect("catalog");
+        let accounting = QueryAccounting::new();
+
+        let err = catalog
+            .latest_ingest_hour(&tenant(), Signal::Metrics, now, &accounting)
+            .await
+            .expect_err("budget of 2 must refuse the 3rd page");
+        match err {
+            CatalogError::WindowTooWide { estimate, limit } => {
+                assert_eq!(estimate, 3);
+                assert_eq!(limit, 2);
+            }
+            other => panic!("expected WindowTooWide, got {other:?}"),
+        }
+        assert_eq!(instrumented.metrics().snapshot().list.calls, 2);
+    }
+
+    /// #1233 finding 4: the mirror case, with the budget exactly sufficient
+    /// for the same 3-object scan -- must succeed, find the correct hour,
+    /// and issue exactly 4 list calls, not 3: `MemoryStore::list_after`
+    /// reports `next: Some` on any page that comes back completely full,
+    /// even when that page happened to hold the last object, so a 4th,
+    /// empty page is required before the per-shard loop's `match page.next
+    /// { ... None => break }` can conclude the listing is exhausted. A
+    /// budget of 3 refuses on the would-be 4th call (that is exactly
+    /// `latest_ingest_hour_refuses_past_the_list_request_budget`, one
+    /// object fewer into the same scan); 4 is the true boundary.
+    #[tokio::test]
+    async fn latest_ingest_hour_succeeds_at_the_list_request_budget_boundary() {
+        let memory = MemoryStore::with_page_size(1);
+        let max_hour = 500_010u32;
+        let now = i64::from(max_hour) * NS_PER_HOUR + 30 * 60_000_000_000;
+        for (seq, hour) in [max_hour - 2, max_hour - 1, max_hour].iter().enumerate() {
+            publish_segment(&memory, 0, seq as u64, *hour, now, now - 1_000, now).await;
+        }
+
+        let instrumented = Arc::new(InstrumentedStore::new(memory));
+        let mut cfg = config(1);
+        cfg.max_catalog_list_requests = 4;
+        let catalog = Catalog::new(instrumented.clone(), cfg).expect("catalog");
+        let accounting = QueryAccounting::new();
+
+        let latest = catalog
+            .latest_ingest_hour(&tenant(), Signal::Metrics, now, &accounting)
+            .await
+            .expect("budget of 4 must be exactly sufficient");
+        assert_eq!(latest, Some((max_hour, true)));
+        assert_eq!(instrumented.metrics().snapshot().list.calls, 4);
     }
 
     #[tokio::test]

--- a/docs/adrs/0046-read-cache-tier.md
+++ b/docs/adrs/0046-read-cache-tier.md
@@ -251,3 +251,58 @@ protected by that key.
 - Nothing durable moves. No format, key layout, commit protocol, or
   consistency property changes. A node with its cache directory deleted
   mid-flight answers every query correctly and more slowly.
+
+## Amendment (2026-09-05): startup warm-up measures "most recent" from each tenant's latest ingest hour, not wall-clock now
+
+The startup cache warm-up pass (`services/ravel-server/src/cache_warm.rs`)
+resolves each tenant's most recent parts to prime the RAM/disk tiers
+before `/readyz` latches. It originally resolved a fixed `[now - 24h,
+now]` window, so a tenant whose last ingest predated `now` by more than
+24h got zero parts warmed on restart (issue #1233: such a tenant's first
+real query after restart paid the full cold-fetch cost this ADR exists to
+avoid). The pass now calls `Catalog::latest_ingest_hour` first and anchors
+the warm window to that tenant's own latest ingest hour, so "most recent"
+means the tenant's own most recent data, never data recent only relative
+to wall-clock time.
+
+This anchors to the ingest-hour bucket a part was filed under, not to the
+part's own `max_event_ts_ns`. The new window is a superset of the old
+`[now - 24h, now]` window only when every part's `max_event_ts_ns` stays
+within `max_ingest_lag_ns` of its ingest-hour bucket's span, which is the
+assumption this warm-up serves, not a guarantee `latest_ingest_hour`
+enforces. A part filed further out of that bound can still miss the warm
+pass.
+
+`Catalog::latest_ingest_hour` itself discovers the latest hour with a
+bounded, floored listing that doubles its lookback window backwards from
+now (24h, 48h, ..., capped at 64 days across at most 7 probes per shard)
+instead of listing a shard's entire commit history, so a tenant with a
+long or gapless history no longer pages through it all before `/readyz`.
+An "ingest hour" here means any hour bucket holding a commit-record-shaped
+key of any kind -- a commit record, a compaction record, a rewrite record,
+or a tombstone -- not only a live commit record; the shard loop reports
+whichever of those it finds newest, and separately reports whether that
+newest hour actually holds a live (non-tombstone) part.
+
+A tenant whose last ingest predates the 64-day cap, or one that has never
+ingested this signal at all, both resolve to `Ok(None)`. Exhausting the
+probe sweep without finding anything is a normal, expected outcome for a
+signal a tenant simply does not use, so `Catalog` itself never logs above
+`debug!` for it; only `cache_warm`'s own `log_warm_result` decides between
+`info!` and its "parts exist but none warmed" `warn!`, and it does so
+using the found hour's live-part flag, not merely whether a hour was
+found -- a tenant whose only bucket in range is tombstone-only resolves
+`Ok(Some((hour, false)))` and is logged the same as "nothing to warm",
+never as the warn-level "has parts but none warmed" case. The flag is
+per hour, not per bucket: an hour holding both a live record and a
+tombstone reports `true` while the resolve drops the tombstoned bucket,
+so that warning can still fire for such an hour when the rest of the
+window warms nothing; it is a hint, not a fault signal.
+
+Residual clock-skew case: an event whose timestamp is up to
+`max_ingest_lag_ns` behind its ingest-hour bucket, where that ingest hour
+is itself not ahead of the wall clock, still resolves correctly -- the
+probe's `max_hour` is computed from `now_ns + clock_skew_allowance_ns`,
+not from the event timestamp, so a late-arriving event filed under an
+hour at or before wall-clock `now` is always within the first probe's
+upper bound.

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -146,6 +146,9 @@ When the cache is on, `ravel-server` warms it before it reports ready
 (`/readyz`). For each tenant storage holds data for, it reads a small,
 bounded number of that tenant's most recent metric and log segments, so the
 first real query after a restart is not the one paying full cold cost.
+"Most recent" is measured from each tenant's own latest ingest hour, not
+from wall-clock time: a tenant that has not ingested in the
+last day still gets its most recent parts warmed, not zero.
 
 Warmup is best-effort:
 
@@ -154,6 +157,58 @@ Warmup is best-effort:
   starts with a smaller warm set.
 - A failure warming one tenant or one segment is logged and skipped. It
   never fails startup.
+
+To tell a warmed restart from an unwarmed one, or to see what was warmed,
+read the `cache_warm` module's log lines rather than guessing from query
+latency. `cache_warm` alone decides the level of the per-(tenant, signal)
+line -- `Catalog::latest_ingest_hour` never logs above `debug!`, so a
+signal a tenant does not use never produces a `warn!` on its own.
+The line is an `info!` (or `warn!` if the tenant has a live part for that
+signal but none of them warmed -- a resolve or fetch failure ate the
+whole signal) and carries `tenant_hash`, `signal`, `parts_warmed`, and
+`latest_ingest_hour`, which takes one of three values:
+
+- an hour number: the tenant's own latest ingest hour was found -- the
+  newest hour bucket holding a commit-record-shaped key of any kind
+  (commit, compaction, rewrite, or tombstone), not only a live commit
+  record. `parts_warmed` counts what actually warmed from it, which is 0
+  when that hour's only key was a tombstone; that case still logs at
+  `info!`, since a tombstone-only hour has no live part to have failed to
+  warm. An hour that holds both a live record and a tombstone counts as
+  having a live part while the resolve drops the tombstoned bucket, so
+  when nothing else in the window warms the `warn!` can fire for it;
+  read that warning as a hint to look at the resolve, not as a fault.
+- `"none"`: `Catalog::latest_ingest_hour` returned `Ok(None)` -- the
+  tenant has no discoverable ingest for that signal, either because it
+  never ingested it or because its last ingest predates the discovery
+  lookback cap (see below). `parts_warmed` is always 0 for this value,
+  and the `cache_warm` pass logs it at `info!`, not `warn!`: no parts to
+  warm is a normal outcome, not a failure.
+- `"error"`: the `Catalog::latest_ingest_hour` listing itself failed
+  (an object store fault, or the per-shard LIST budget refused). This
+  value appears on a separate `warn!` event, `cache warmup:
+  latest_ingest_hour failed; skipping this tenant and signal`, which
+  carries `tenant_hash`, `signal`, `error` and `latest_ingest_hour` and
+  no `parts_warmed`; the pass emits no result line for that tenant and
+  signal, so a filter on `parts_warmed` alone will not show it. It is
+  distinct from the `"none"` case so a store fault is never mistaken for
+  a tenant that has no data.
+
+`Catalog::latest_ingest_hour` exhausting its lookback cap (64 days)
+without finding anything logs at `debug!`, not `warn!`: it cannot itself
+tell a tenant that never used a signal apart from one whose ingest is
+genuinely stuck past the cap -- both produce the identical `Ok(None)` --
+and neither case is a failure worth a warning on its own. Do not expect a
+`warn!` from this path on a normal warmup pass; the only `warn!` a
+tenant/signal combination can produce is the `"error"` case above or
+`cache_warm`'s own "has parts but none warmed" line.
+
+One final `info!` at the end of the pass
+carries the total `parts_warmed` across every tenant and signal and the
+pass's `elapsed_ms`. A restart whose log shows this final line warmed the cache; one that hit
+the time budget above never reaches it, and logs the `warn!` naming the
+deadline instead -- the per-(tenant, signal) lines up to that point are
+whatever the pass warmed before it ran out of time.
 
 ## Metrics
 

--- a/services/ravel-server/src/cache_warm.rs
+++ b/services/ravel-server/src/cache_warm.rs
@@ -2,6 +2,22 @@
 //! recent parts before `/readyz` latches, so the first real query after a
 //! restart is not the one that pays every cold-fetch cost.
 //!
+//! "Most recent" is measured from each tenant's own latest ingest hour
+//! ([`Catalog::latest_ingest_hour`]), not from wall-clock `now` (issue
+//! #1233, ADR-0046 amendment 2026-09-05): a tenant whose last ingest predates
+//! `now` by more than [`WARM_LOOKBACK_NS`] still gets its most recent parts
+//! warmed, not zero. This anchors the window to the ingest-hour bucket a
+//! part was filed under, not to the part's own `max_event_ts_ns`; the two
+//! stay close enough for this warm-up to find the part whenever the part's
+//! event time is within `max_ingest_lag_ns` of its ingest hour AND that
+//! ingest hour is not itself ahead of the wall clock -- a part filed into an
+//! hour within `clock_skew_allowance_ns` of the future can still move the
+//! anchor forward by up to an hour, which nothing guarantees for every part
+//! in general. "Ingest hour" here means any hour holding a commit-record-
+//! shaped key of any kind (a raw commit record, a compaction record, a
+//! rewrite record, or a tombstone): a tombstone-only or rewrite-only hour
+//! can anchor the window exactly as a fresh commit record would.
+//!
 //! Bounded on two axes. Per (tenant, signal), at most
 //! [`MAX_PARTS_PER_TENANT_PER_SIGNAL`] of the most recent parts are warmed:
 //! this pass exists to take the edge off a cold restart, not to size a
@@ -42,10 +58,17 @@ const MAX_PARTS_PER_TENANT_PER_SIGNAL: usize = 4;
 /// first several were slow.
 const WARM_DEADLINE: Duration = Duration::from_secs(10);
 
-/// How far back "most recent" looks when resolving parts to warm. Wide
-/// enough to find a recent part for a slow ingest cadence without resolving
-/// a tenant's entire history.
+/// How far back "most recent" looks when resolving parts to warm, measured
+/// from the tenant's own latest ingest hour rather than wall-clock `now`
+/// (issue #1233, ADR-0046 amendment 2026-09-05): a tenant whose last ingest
+/// is older than this window relative to `now` must still get its most
+/// recent parts warmed, not zero. Wide enough to find a recent part for a
+/// slow ingest cadence without resolving a tenant's entire history.
 const WARM_LOOKBACK_NS: i64 = 24 * 60 * 60 * 1_000_000_000;
+
+/// Nanoseconds per hour, for converting an ingest-hour bucket
+/// ([`Catalog::latest_ingest_hour`]) to the nanosecond range `resolve` takes.
+const NS_PER_HOUR: i64 = 60 * 60 * 1_000_000_000;
 
 /// Discovers every tenant storage holds data for and warms the read cache
 /// with each one's most recent metric and log parts. Returns nothing: this
@@ -85,17 +108,13 @@ async fn warm_cache_inner(
     now_ns: i64,
     get_limiter: Arc<ravel_query::GetLimiter>,
 ) {
+    let started = tokio::time::Instant::now();
     let tenants = match ravel_maintain::discover_tenants(store.as_ref()).await {
         Ok(tenants) => tenants,
         Err(err) => {
             tracing::warn!(error = %err, "cache warmup: tenant discovery failed; skipping warmup");
             return;
         }
-    };
-
-    let range = TimeRange {
-        start_ns: now_ns.saturating_sub(WARM_LOOKBACK_NS),
-        end_ns: now_ns,
     };
 
     // ADR-1195: shares the process-wide `GetLimiter` rather than a private
@@ -107,23 +126,90 @@ async fn warm_cache_inner(
         .with_cache(cache)
         .with_get_limiter(get_limiter);
 
+    let mut total_parts_warmed: usize = 0;
     for tenant in tenants {
-        warm_metrics(&catalog, &metrics_fetcher, tenant, range, now_ns).await;
-        warm_logs(&catalog, &logs_fetcher, tenant, range, now_ns).await;
+        total_parts_warmed += warm_metrics(&catalog, &metrics_fetcher, tenant, now_ns).await;
+        total_parts_warmed += warm_logs(&catalog, &logs_fetcher, tenant, now_ns).await;
     }
+
+    tracing::info!(
+        parts_warmed = total_parts_warmed,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "cache warmup: pass complete"
+    );
+}
+
+/// What [`most_recent_parts`] learned about a (tenant, signal)'s latest
+/// ingest, distinguishing "never ingested this signal" from "the listing
+/// that would tell us failed" (issue #1233 finding 2): the two used to share
+/// a single `None`/`Ok(None)`-shaped return, so a mid-listing store fault
+/// was silently reported to operators identically to a signal the tenant
+/// never uses. They now log differently and must stay distinguishable
+/// through every caller.
+enum LatestHour {
+    /// The tenant has no commit-record parts for this signal within
+    /// [`Catalog::LATEST_HOUR_MAX_LOOKBACK_HOURS`]
+    /// (`latest_ingest_hour` returned `Ok(None)`). A normal outcome: logs at
+    /// `info!`.
+    None,
+    /// `latest_ingest_hour` itself returned `Err`: a store fault mid-listing,
+    /// not evidence the tenant has no parts. Not a normal outcome: logged at
+    /// `warn!` where it is discovered, inside [`most_recent_parts`].
+    Error,
+    /// The newest ingest-hour bucket found for this signal, and whether that
+    /// hour's listing carried at least one non-tombstone entry
+    /// (`has_ingest_part`). When it did not -- the anchor hour is
+    /// tombstone-only -- the catalog drops that bucket outright, so an empty
+    /// resolve for the warm window is expected, not evidence of a fetch
+    /// failure; [`log_warm_result`] uses this to avoid logging that ordinary
+    /// case as a `warn!`.
+    Found { hour: u32, has_ingest_part: bool },
 }
 
 /// Most-recent-first parts for one (tenant, signal), bounded to
-/// [`MAX_PARTS_PER_TENANT_PER_SIGNAL`]. A resolve error warms nothing for
-/// this (tenant, signal) and is otherwise silent: the same no-op-on-failure
-/// rule as every other step of this pass.
+/// [`MAX_PARTS_PER_TENANT_PER_SIGNAL`], alongside what was learned about the
+/// tenant's latest ingest hour ([`LatestHour`]). A resolve error still
+/// reports [`LatestHour::Found`] alongside empty parts, so it can be told
+/// apart from "no parts for this signal at all" ([`LatestHour::None`]) or a
+/// `latest_ingest_hour` listing failure ([`LatestHour::Error`]). Every
+/// failure -- `latest_ingest_hour` erroring or resolve erroring -- warms
+/// nothing for this (tenant, signal); `latest_ingest_hour` erroring also
+/// warns immediately, here, since the caller only sees [`LatestHour::Error`]
+/// and must not log it again as a plain "nothing to warm".
 async fn most_recent_parts(
     catalog: &Catalog,
     tenant: TenantHash,
     signal: Signal,
-    range: TimeRange,
     now_ns: i64,
-) -> Vec<SegmentRef> {
+) -> (Vec<SegmentRef>, LatestHour) {
+    // A fresh, discarded accounting handle: this pass is a best-effort
+    // optimization outside the query-cost-accounting surface (ADR-0044), the
+    // same convention `warm_logs` already uses for its own fetch below.
+    let accounting = ravel_types::accounting::QueryAccounting::new();
+    let (latest_hour, has_ingest_part) = match catalog
+        .latest_ingest_hour(&tenant, signal, now_ns, &accounting)
+        .await
+    {
+        Ok(Some((hour, has_ingest_part))) => (hour, has_ingest_part),
+        Ok(None) => return (Vec::new(), LatestHour::None),
+        Err(err) => {
+            tracing::warn!(
+                tenant_hash = %tenant.to_hex(),
+                signal = ?signal,
+                error = %err,
+                latest_ingest_hour = "error",
+                "cache warmup: latest_ingest_hour failed; skipping this tenant and signal"
+            );
+            return (Vec::new(), LatestHour::Error);
+        }
+    };
+
+    let latest_hour_start_ns = i64::from(latest_hour) * NS_PER_HOUR;
+    let range = TimeRange {
+        start_ns: latest_hour_start_ns.saturating_sub(WARM_LOOKBACK_NS),
+        end_ns: latest_hour_start_ns.saturating_add(NS_PER_HOUR),
+    };
+
     let snapshot = match catalog.resolve(&tenant, signal, range, &[], now_ns).await {
         Ok(snapshot) => snapshot,
         Err(err) => {
@@ -133,46 +219,129 @@ async fn most_recent_parts(
                 error = %err,
                 "cache warmup: resolve failed; skipping this tenant and signal"
             );
-            return Vec::new();
+            return (
+                Vec::new(),
+                LatestHour::Found {
+                    hour: latest_hour,
+                    has_ingest_part,
+                },
+            );
         }
     };
     let mut segments = snapshot.segments;
     segments.sort_unstable_by_key(|s| std::cmp::Reverse(s.max_event_ts_ns));
     segments.truncate(MAX_PARTS_PER_TENANT_PER_SIGNAL);
-    segments
+    (
+        segments,
+        LatestHour::Found {
+            hour: latest_hour,
+            has_ingest_part,
+        },
+    )
+}
+
+/// One `info!` per (tenant, signal) after warming, or a `warn!` instead when
+/// the tenant is known to have an ingest part for this signal at its latest
+/// hour but none were warmed: that combination means a resolve or fetch
+/// failure ate the whole signal, not that there was nothing to warm. When
+/// the latest hour is anchored by a tombstone- or rewrite-only bucket with
+/// no ingest part of its own (`has_ingest_part = false`), an empty warm is
+/// the expected outcome (the catalog drops a tombstoned bucket outright),
+/// so this logs at `info!` instead of `warn!` for that case.
+fn log_warm_result(
+    tenant: TenantHash,
+    signal: Signal,
+    parts_warmed: usize,
+    latest_hour: Option<(u32, bool)>,
+) {
+    let latest_ingest_hour =
+        latest_hour.map_or_else(|| "none".to_string(), |(hour, _)| hour.to_string());
+    let has_ingest_part = latest_hour.is_some_and(|(_, has_ingest_part)| has_ingest_part);
+    if parts_warmed == 0 && has_ingest_part {
+        tracing::warn!(
+            tenant_hash = %tenant.to_hex(),
+            signal = ?signal,
+            parts_warmed,
+            latest_ingest_hour,
+            "cache warmup: tenant has parts for this signal but none were warmed"
+        );
+    } else {
+        tracing::info!(
+            tenant_hash = %tenant.to_hex(),
+            signal = ?signal,
+            parts_warmed,
+            latest_ingest_hour,
+            "cache warmup: warmed tenant signal"
+        );
+    }
 }
 
 async fn warm_metrics(
     catalog: &Catalog,
     fetcher: &SegmentFetcher,
     tenant: TenantHash,
-    range: TimeRange,
     now_ns: i64,
-) {
-    let parts = most_recent_parts(catalog, tenant, Signal::Metrics, range, now_ns).await;
+) -> usize {
+    let (parts, latest_hour) = most_recent_parts(catalog, tenant, Signal::Metrics, now_ns).await;
+    let (hour, has_ingest_part) = match latest_hour {
+        LatestHour::Error => return 0,
+        LatestHour::None => {
+            log_warm_result(tenant, Signal::Metrics, 0, None);
+            return 0;
+        }
+        LatestHour::Found {
+            hour,
+            has_ingest_part,
+        } => (hour, has_ingest_part),
+    };
+
+    let mut warmed = 0usize;
     for part in &parts {
-        if let Err(err) = fetcher.fetch_series(tenant, part, &[]).await {
-            tracing::debug!(
-                tenant_hash = %tenant.to_hex(),
-                key = %part.data_object_key,
-                error = %err,
-                "cache warmup: metric part fetch failed; skipping"
-            );
+        match fetcher.fetch_series(tenant, part, &[]).await {
+            Ok(_) => warmed += 1,
+            Err(err) => {
+                tracing::debug!(
+                    tenant_hash = %tenant.to_hex(),
+                    key = %part.data_object_key,
+                    error = %err,
+                    "cache warmup: metric part fetch failed; skipping"
+                );
+            }
         }
     }
+
+    log_warm_result(
+        tenant,
+        Signal::Metrics,
+        warmed,
+        Some((hour, has_ingest_part)),
+    );
+    warmed
 }
 
 async fn warm_logs(
     catalog: &Catalog,
     fetcher: &LogSegmentFetcher,
     tenant: TenantHash,
-    range: TimeRange,
     now_ns: i64,
-) {
-    let parts = most_recent_parts(catalog, tenant, Signal::Logs, range, now_ns).await;
+) -> usize {
+    let (parts, latest_hour) = most_recent_parts(catalog, tenant, Signal::Logs, now_ns).await;
+    let (hour, has_ingest_part) = match latest_hour {
+        LatestHour::Error => return 0,
+        LatestHour::None => {
+            log_warm_result(tenant, Signal::Logs, 0, None);
+            return 0;
+        }
+        LatestHour::Found {
+            hour,
+            has_ingest_part,
+        } => (hour, has_ingest_part),
+    };
+
+    let mut warmed = 0usize;
     for part in &parts {
         let query = LogQuery::new(part.min_event_ts_ns, part.max_event_ts_ns);
-        if let Err(err) = fetcher
+        match fetcher
             .fetch_accounted_with_tenant(
                 part,
                 tenant,
@@ -181,14 +350,20 @@ async fn warm_logs(
             )
             .await
         {
-            tracing::debug!(
-                tenant_hash = %tenant.to_hex(),
-                key = %part.data_object_key,
-                error = %err,
-                "cache warmup: log part fetch failed; skipping"
-            );
+            Ok(_) => warmed += 1,
+            Err(err) => {
+                tracing::debug!(
+                    tenant_hash = %tenant.to_hex(),
+                    key = %part.data_object_key,
+                    error = %err,
+                    "cache warmup: log part fetch failed; skipping"
+                );
+            }
         }
     }
+
+    log_warm_result(tenant, Signal::Logs, warmed, Some((hour, has_ingest_part)));
+    warmed
 }
 
 #[cfg(test)]
@@ -205,8 +380,8 @@ mod tests {
     use ravel_object_store::fault::{FaultKind, FaultPlan, FaultStore, Op, Rule, ScriptedFault};
     use ravel_object_store::memory::MemoryStore;
     use ravel_object_store::{
-        Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, PageToken,
-        PutOptions, PutOutcome, StoreError,
+        Capabilities, DelimitedList, GetOutcome, GetRange, InstrumentedStore, ListPage, ObjectMeta,
+        PageToken, PutOptions, PutOutcome, StoreError,
     };
     use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
     use ravel_types::{Label, LabelSet, Sample, SeriesId, TenantId};
@@ -226,7 +401,16 @@ mod tests {
         (ns / NS_PER_SEC) * NS_PER_SEC
     }
 
-    async fn publish_metric_segment(store: &MemoryStore, tenant_hash: TenantHash, now: i64) {
+    /// Publishes one metric segment with a single sample at `event_ts_ns`,
+    /// filed under that timestamp's own ingest-hour bucket. Each call uses a
+    /// fresh writer id, so publishing several segments for the same tenant
+    /// (e.g. one per hour, to test [`Catalog::latest_ingest_hour`] and the
+    /// warm window it drives) never collides.
+    async fn publish_metric_segment_at(
+        store: &MemoryStore,
+        tenant_hash: TenantHash,
+        event_ts_ns: i64,
+    ) {
         let label_set = LabelSet::new(vec![Label {
             name: "__name__".to_string(),
             value: "http_requests_total".to_string(),
@@ -237,7 +421,7 @@ mod tests {
                 .expect("series id"),
             labels: label_set,
             samples: vec![Sample {
-                ts_ns: now - NS_PER_MIN,
+                ts_ns: event_ts_ns,
                 value: 42.0,
             }],
         }];
@@ -276,8 +460,8 @@ mod tests {
             min_ingest_ts_ns: written.summary.min_event_ts_ns,
             max_ingest_ts_ns: written.summary.max_event_ts_ns,
             segment_format_version: 1,
-            created_unix_ns: now,
-            ingest_hour_bucket: u32::try_from(now / NS_PER_HOUR).expect("hour bucket"),
+            created_unix_ns: event_ts_ns,
+            ingest_hour_bucket: u32::try_from(event_ts_ns / NS_PER_HOUR).expect("hour bucket"),
         })
         .expect("valid commit record");
 
@@ -289,6 +473,113 @@ mod tests {
         publish::publish(store, &rec, &RetryPolicy::default())
             .await
             .expect("publish");
+    }
+
+    async fn publish_metric_segment(store: &MemoryStore, tenant_hash: TenantHash, now: i64) {
+        publish_metric_segment_at(store, tenant_hash, now - NS_PER_MIN).await;
+    }
+
+    /// Publishes one real RLOG object (a single log record) plus its commit
+    /// record, filed under `event_ts_ns`'s own ingest-hour bucket -- the same
+    /// shape `fold_on_demand.rs`'s `seed_log_commit` seeds, needed here
+    /// because `LogSegmentFetcher::fetch_accounted_with_tenant` decodes a
+    /// real RLOG footer: a metrics-shaped segment filed under `Signal::Logs`
+    /// (as `publish_metric_segment_at` builds) would fail to decode and
+    /// never count as warmed.
+    async fn publish_log_segment_at(
+        store: &MemoryStore,
+        tenant_hash: TenantHash,
+        event_ts_ns: i64,
+    ) {
+        use ravel_logseg::{
+            AttrValue, LogRecord, ObjectIdentity, RlogConfig, RlogWriter, stream_attrs_bytes,
+        };
+        use ravel_types::logstream::log_stream_id;
+
+        let shard = 0u32;
+        let writer_id = Uuid::new_v4();
+        let epoch = 1u64;
+        let seq = 1u64;
+
+        let resource_attrs = vec![(
+            "service.name".to_string(),
+            AttrValue::Str("checkout".to_string()),
+        )];
+        let stream_attrs = stream_attrs_bytes(&resource_attrs, "", "", &[]);
+        let stream_id = log_stream_id(&resource_attrs, "", "", &[]);
+
+        let identity = ObjectIdentity {
+            tenant_hash: tenant_hash.0,
+            shard,
+            writer_id: writer_id.into_bytes(),
+            writer_epoch: epoch,
+            writer_seq: seq,
+        };
+        let mut writer = RlogWriter::new(RlogConfig::default(), identity);
+        writer
+            .push(LogRecord {
+                stream_id,
+                stream_attrs,
+                ts_ns: event_ts_ns,
+                observed_ts_ns: event_ts_ns,
+                severity_num: 9,
+                severity_text: "INFO".to_string(),
+                body: "checkout completed".to_string(),
+                trace_id: None,
+                span_id: None,
+                flags: 0,
+                attrs: Vec::new(),
+            })
+            .expect("push log record");
+        let bytes = writer.finish().expect("finish RLOG object");
+
+        let content_hash = [0x5au8; 32];
+        let data_key = keys::data_key(
+            &tenant_hash,
+            Signal::Logs,
+            shard,
+            writer_id,
+            epoch,
+            seq,
+            &content_hash,
+        )
+        .expect("build data key");
+        store
+            .put(
+                &data_key,
+                Bytes::from(bytes),
+                PutOptions::create_if_absent(),
+            )
+            .await
+            .expect("put RLOG object");
+
+        let commit = record::build(NewCommitRecord {
+            tenant_hash,
+            signal: Signal::Logs,
+            shard,
+            writer_id,
+            writer_epoch: epoch,
+            writer_seq: seq,
+            object_size: 0,
+            content_hash,
+            sample_count: 1,
+            series_count: 1,
+            min_event_ts_ns: event_ts_ns,
+            max_event_ts_ns: event_ts_ns,
+            min_ingest_ts_ns: event_ts_ns,
+            max_ingest_ts_ns: event_ts_ns,
+            segment_format_version: u32::from(ravel_ingest::LOG_SEGMENT_FORMAT_VERSION),
+            created_unix_ns: event_ts_ns,
+            ingest_hour_bucket: u32::try_from(event_ts_ns / NS_PER_HOUR).expect("hour bucket"),
+        })
+        .expect("valid commit record");
+        publish::publish(store, &commit, &RetryPolicy::default())
+            .await
+            .expect("publish");
+    }
+
+    async fn publish_log_segment(store: &MemoryStore, tenant_hash: TenantHash, now: i64) {
+        publish_log_segment_at(store, tenant_hash, now - NS_PER_MIN).await;
     }
 
     struct FixedClock(i64);
@@ -339,6 +630,127 @@ mod tests {
         assert!(
             !cache.is_empty(),
             "warming a tenant with a real recent metric part must populate the cache"
+        );
+    }
+
+    /// Issue #1233: a tenant whose only parts are ~48h old must still get
+    /// its most recent parts warmed, not zero. First asserts the pre-fix
+    /// behavior directly -- old code resolved the fixed `[now -
+    /// WARM_LOOKBACK_NS, now]` window regardless of when the tenant last
+    /// ingested, and that window finds none of these parts -- then asserts
+    /// the fixed behavior: exactly `min(MAX_PARTS_PER_TENANT_PER_SIGNAL,
+    /// parts)` warmed, and that they are the newest by `max_event_ts_ns`.
+    #[tokio::test]
+    async fn old_ingest_tenant_still_gets_its_most_recent_parts_warmed() {
+        let memory = MemoryStore::new();
+        let tenant = TenantId::new("acme").hash();
+        let now = now_ns();
+        let latest_hour = now / NS_PER_HOUR - 48;
+
+        // Six parts at hours H-5..=H (H = latest_hour), one sample each, so
+        // each part's max_event_ts_ns falls in a distinct hour and sorts
+        // unambiguously.
+        for offset in 0..6i64 {
+            let hour = latest_hour - offset;
+            let event_ts_ns = hour * NS_PER_HOUR + NS_PER_MIN;
+            publish_metric_segment_at(&memory, tenant, event_ts_ns).await;
+        }
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(memory);
+        let catalog = catalog_for(store.clone());
+
+        let old_fixed_window = TimeRange {
+            start_ns: now - WARM_LOOKBACK_NS,
+            end_ns: now,
+        };
+        let old_window_snapshot = catalog
+            .resolve(&tenant, Signal::Metrics, old_fixed_window, &[], now)
+            .await
+            .expect("resolve");
+        assert_eq!(
+            old_window_snapshot.segments.len(),
+            0,
+            "pre-fix behavior: a fixed [now - lookback, now] window finds none of this tenant's \
+             48h-old parts -- this is the #1233 bug"
+        );
+
+        let cache = Arc::new(Cache::new(CacheLimits::new(
+            16 * 1024 * 1024,
+            1024,
+            1024 * 1024,
+        )));
+        let fetcher = SegmentFetcher::new(store.clone()).with_cache(ReadCache::Ram(cache));
+        let warmed = warm_metrics(&catalog, &fetcher, tenant, now).await;
+        assert_eq!(
+            warmed, 4,
+            "post-fix behavior: min(MAX_PARTS_PER_TENANT_PER_SIGNAL, parts) of a 48h-old \
+             tenant's parts must warm"
+        );
+
+        let (parts, found_hour) = most_recent_parts(&catalog, tenant, Signal::Metrics, now).await;
+        let found_hour = match found_hour {
+            LatestHour::Found {
+                hour,
+                has_ingest_part,
+            } => {
+                assert!(
+                    has_ingest_part,
+                    "every published part here is a real commit record, not a tombstone"
+                );
+                hour
+            }
+            _ => panic!("tenant has parts for this signal"),
+        };
+        let latest_hour = u32::try_from(latest_hour).expect("hour");
+        assert_eq!(
+            found_hour, latest_hour,
+            "latest ingest hour must be H, not now's hour"
+        );
+        let warmed_hours: std::collections::BTreeSet<u32> =
+            parts.iter().map(|part| part.ingest_hour_bucket).collect();
+        let expected_hours: std::collections::BTreeSet<u32> = [
+            latest_hour,
+            latest_hour - 1,
+            latest_hour - 2,
+            latest_hour - 3,
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            warmed_hours, expected_hours,
+            "the 4 warmed parts must be the 4 newest by max_event_ts_ns: hours H, H-1, H-2, H-3"
+        );
+    }
+
+    /// The change in #1233 widens the lookback side of the window without
+    /// narrowing it, so a tenant that ingested within the last day (where
+    /// old and new windows agree) must still warm exactly as many parts as
+    /// before. This is not an unconditional superset: it holds only because
+    /// a part's `max_event_ts_ns` stays within `max_ingest_lag_ns` of the
+    /// ingest-hour bucket it was filed under, which is the assumption this
+    /// warm-up serves, not a guarantee `latest_ingest_hour` enforces (see the
+    /// module doc comment and ADR-0046's amendment).
+    #[tokio::test]
+    async fn tenant_with_recent_ingest_warms_exactly_as_before() {
+        let memory = MemoryStore::new();
+        let tenant = TenantId::new("acme").hash();
+        let now = now_ns();
+        publish_metric_segment(&memory, tenant, now).await;
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(memory);
+        let catalog = catalog_for(store.clone());
+        let cache = Arc::new(Cache::new(CacheLimits::new(
+            16 * 1024 * 1024,
+            1024,
+            1024 * 1024,
+        )));
+        let fetcher = SegmentFetcher::new(store.clone()).with_cache(ReadCache::Ram(cache));
+
+        let warmed = warm_metrics(&catalog, &fetcher, tenant, now).await;
+        assert_eq!(
+            warmed, 1,
+            "a tenant ingesting within the last day must warm its one recent part, unchanged \
+             from before #1233"
         );
     }
 
@@ -403,6 +815,263 @@ mod tests {
         );
     }
 
+    /// Records every field of every WARN event as one combined string (`"
+    /// name=value"` per field), so a test can prove a specific warn! did or
+    /// did not fire and inspect its structured fields (e.g.
+    /// `latest_ingest_hour="error"`), not just its message text.
+    #[derive(Default, Clone)]
+    struct WarnEventCapture(Arc<parking_lot::Mutex<Vec<String>>>);
+
+    impl<S> tracing_subscriber::Layer<S> for WarnEventCapture
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if *event.metadata().level() != tracing::Level::WARN {
+                return;
+            }
+            #[derive(Default)]
+            struct Visitor(String);
+            impl tracing::field::Visit for Visitor {
+                fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                    use std::fmt::Write as _;
+                    let _ = write!(self.0, " {}={value:?}", field.name());
+                }
+
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    use std::fmt::Write as _;
+                    let _ = write!(self.0, " {}={value:?}", field.name());
+                }
+            }
+            let mut visitor = Visitor::default();
+            event.record(&mut visitor);
+            self.0.lock().push(visitor.0);
+        }
+    }
+
+    /// #1233: a signal the tenant has never ingested must short-circuit at
+    /// `latest_ingest_hour` (`Ok(None)`) with no `resolve` call after it, and
+    /// `cache_warm`'s own `log_warm_result` must log at `info!`, never its
+    /// "has parts but none warmed" `warn!` -- "nothing to warm" is a normal
+    /// outcome for this pass, not the "parts exist but none warmed" failure
+    /// case.
+    ///
+    /// `latest_ingest_hour` itself now costs exactly 7 bounded `list_after`
+    /// calls per shard (finding 1's doubling probe sweep, `catalog_for`'s
+    /// `shard_count` of 1) to conclude there is nothing within the lookback
+    /// cap, rather than the single unbounded `list_delimited` the old
+    /// implementation used -- so "no resolve call after it" is asserted as
+    /// an exact `list.calls` delta of 7, not 0: `list_after` and `list` share
+    /// the `list.calls` counter (`resolve`'s own listing would add to the
+    /// same counter, which is exactly why this test needs an exact number
+    /// rather than "some listing happened"). `catalog_for` builds with
+    /// provisioning enforcement on, so `latest_ingest_hour` also costs
+    /// exactly one `get.calls` for the generation-history read
+    /// (`read_scan_generations`, finding 2) -- asserted separately, since a
+    /// GET and a LIST are different counters and a miscount in either one
+    /// would otherwise hide behind the other.
+    ///
+    /// #1233 finding 3: exhausting the 7-probe sweep without finding
+    /// anything now logs at `debug!`, not `warn!` -- a signal the tenant has
+    /// simply never used is not a failure. This test therefore asserts ZERO
+    /// warn-level events overall, not merely the absence of one specific
+    /// message.
+    #[tokio::test]
+    async fn tenant_with_no_parts_for_a_signal_issues_no_resolve_and_no_warn() {
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        let memory = MemoryStore::new();
+        let tenant = TenantId::new("acme").hash();
+        let now = now_ns();
+        publish_metric_segment(&memory, tenant, now).await;
+
+        let instrumented = Arc::new(InstrumentedStore::new(memory));
+        let store: Arc<dyn ObjectStoreBackend> = instrumented.clone();
+        let catalog = catalog_for(store.clone());
+        let cache = Arc::new(Cache::new(CacheLimits::new(
+            16 * 1024 * 1024,
+            1024,
+            1024 * 1024,
+        )));
+        let fetcher = LogSegmentFetcher::new(store.clone()).with_cache(ReadCache::Ram(cache));
+
+        let captured: Arc<parking_lot::Mutex<Vec<String>>> = Arc::default();
+        let subscriber = tracing_subscriber::registry().with(WarnEventCapture(captured.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let before = instrumented.metrics().snapshot();
+        let warmed = warm_logs(&catalog, &fetcher, tenant, now).await;
+        let after = instrumented.metrics().snapshot();
+
+        assert_eq!(warmed, 0, "a tenant with no log parts must warm zero");
+        assert_eq!(
+            after.list.calls - before.list.calls,
+            7,
+            "latest_ingest_hour returning Ok(None) must cost exactly its 7-probe sweep (shard_count \
+             1) and short-circuit before any resolve-issued list() call -- a resolve call here \
+             would push this delta past 7"
+        );
+        assert_eq!(
+            after.get.calls - before.get.calls,
+            1,
+            "read_scan_generations (provisioning enforcement is on in catalog_for) costs exactly \
+             one GET per latest_ingest_hour call, accounted separately from the 7 list_after calls \
+             above (#1233 finding 2)"
+        );
+        assert!(
+            captured.lock().is_empty(),
+            "no parts for a signal is a normal outcome for cache_warm: exhausting the lookback \
+             sweep now logs at debug! (#1233 finding 3), so this pass must produce zero warn-level \
+             events, not merely avoid one specific message"
+        );
+    }
+
+    /// #1233 finding 2: a `latest_ingest_hour` listing fault for one tenant
+    /// must warm nothing for that tenant/signal, log a `warn!` naming the
+    /// failure with a distinct `latest_ingest_hour="error"` value (never the
+    /// `"none"` value `log_warm_result` uses for a signal the tenant simply
+    /// never ingested), and must not stop the other tenant from warming
+    /// normally.
+    #[tokio::test]
+    async fn a_listing_fault_for_one_tenant_does_not_stop_the_other() {
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        let memory = MemoryStore::new();
+        let tenant_a = TenantId::new("faulty").hash();
+        let tenant_b = TenantId::new("healthy").hash();
+        let now = now_ns();
+        publish_metric_segment(&memory, tenant_a, now).await;
+        publish_metric_segment(&memory, tenant_b, now).await;
+
+        // Scoped to tenant_a's own commit-record prefix: tenant_b's listing,
+        // and tenant discovery's bare "t/" listing, must be unaffected.
+        let fault_prefix = format!(
+            "t/{}/{}/c/",
+            tenant_a.to_hex(),
+            Signal::Metrics.key_prefix()
+        );
+        let plan = FaultPlan::empty().with_rule(
+            Rule::new(Op::List, ScriptedFault::Transient("boom".to_string()))
+                .with_key_contains(fault_prefix),
+        );
+        let fault_store = Arc::new(FaultStore::new(memory, plan));
+        let store: Arc<dyn ObjectStoreBackend> = fault_store.clone();
+        let catalog = catalog_for(store.clone());
+        let cache = Arc::new(Cache::new(CacheLimits::new(
+            16 * 1024 * 1024,
+            1024,
+            1024 * 1024,
+        )));
+        let fetcher = SegmentFetcher::new(store.clone()).with_cache(ReadCache::Ram(cache));
+
+        let captured: Arc<parking_lot::Mutex<Vec<String>>> = Arc::default();
+        let subscriber = tracing_subscriber::registry().with(WarnEventCapture(captured.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let warmed_a = warm_metrics(&catalog, &fetcher, tenant_a, now).await;
+        let warmed_b = warm_metrics(&catalog, &fetcher, tenant_b, now).await;
+
+        assert_eq!(
+            warmed_a, 0,
+            "the faulted tenant must warm zero, not partially"
+        );
+        assert_eq!(
+            warmed_b, 1,
+            "the healthy tenant's own recent part must still warm, unaffected by tenant_a's fault"
+        );
+        assert_eq!(
+            fault_store.fault_count(Op::List, FaultKind::Transient),
+            1,
+            "the fault must fire exactly once: latest_ingest_hour_for_shard returns on the first \
+             list_after error, so it never retries into a second probe width"
+        );
+        assert!(
+            captured
+                .lock()
+                .iter()
+                .any(|msg| msg.contains("latest_ingest_hour failed")
+                    && msg.contains("latest_ingest_hour=\"error\"")),
+            "the faulted tenant must log a warn! naming the listing failure with a distinct \
+             latest_ingest_hour=\"error\" value, not the \"none\" value a signal the tenant never \
+             ingested would use"
+        );
+    }
+
+    /// #1233 finding 6: a `latest_ingest_hour` listing fault scoped to one
+    /// tenant's METRICS commit prefix must leave that same tenant's LOGS
+    /// warming normally -- per-signal isolation within a single tenant, not
+    /// just the cross-tenant isolation `a_listing_fault_for_one_tenant_does_not_stop_the_other`
+    /// already pins.
+    #[tokio::test]
+    async fn a_listing_fault_for_one_signal_does_not_stop_the_other_signal() {
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        let memory = MemoryStore::new();
+        let tenant = TenantId::new("acme").hash();
+        let now = now_ns();
+        publish_metric_segment(&memory, tenant, now).await;
+        publish_log_segment(&memory, tenant, now).await;
+
+        // Scoped to this tenant's METRICS commit-record prefix only: the
+        // LOGS commit-record prefix, and tenant discovery's bare "t/"
+        // listing, must be unaffected.
+        let fault_prefix = format!("t/{}/{}/c/", tenant.to_hex(), Signal::Metrics.key_prefix());
+        let plan = FaultPlan::empty().with_rule(
+            Rule::new(Op::List, ScriptedFault::Transient("boom".to_string()))
+                .with_key_contains(fault_prefix),
+        );
+        let fault_store = Arc::new(FaultStore::new(memory, plan));
+        let store: Arc<dyn ObjectStoreBackend> = fault_store.clone();
+        let catalog = catalog_for(store.clone());
+        let cache = Arc::new(Cache::new(CacheLimits::new(
+            16 * 1024 * 1024,
+            1024,
+            1024 * 1024,
+        )));
+        let metrics_fetcher =
+            SegmentFetcher::new(store.clone()).with_cache(ReadCache::Ram(cache.clone()));
+        let logs_fetcher = LogSegmentFetcher::new(store.clone()).with_cache(ReadCache::Ram(cache));
+
+        let captured: Arc<parking_lot::Mutex<Vec<String>>> = Arc::default();
+        let subscriber = tracing_subscriber::registry().with(WarnEventCapture(captured.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let warmed_metrics = warm_metrics(&catalog, &metrics_fetcher, tenant, now).await;
+        let warmed_logs = warm_logs(&catalog, &logs_fetcher, tenant, now).await;
+
+        assert_eq!(
+            warmed_metrics, 0,
+            "the faulted signal must warm zero, not partially"
+        );
+        assert_eq!(
+            warmed_logs, 1,
+            "the tenant's own unfaulted LOGS signal must still warm its one recent part, \
+             unaffected by the METRICS-scoped fault"
+        );
+        assert_eq!(
+            fault_store.fault_count(Op::List, FaultKind::Transient),
+            1,
+            "the fault must fire exactly once: it is scoped to the METRICS commit prefix, so \
+             warm_logs's own listing (a disjoint LOGS commit prefix) never triggers it"
+        );
+        assert!(
+            captured
+                .lock()
+                .iter()
+                .any(|msg| msg.contains("latest_ingest_hour failed")
+                    && msg.contains("latest_ingest_hour=\"error\"")),
+            "the faulted signal must log a warn! naming the listing failure"
+        );
+    }
+
     /// A never-resolving store: `list_delimited` and `get` both return a
     /// future that never completes. `FaultStore`'s `Timeout` fault fails
     /// instantly and cannot simulate a genuinely slow backend, so this pass's
@@ -449,6 +1118,120 @@ mod tests {
         fn capabilities(&self) -> Capabilities {
             Capabilities::mandatory()
         }
+    }
+
+    /// Delegates every call to a real `MemoryStore` except `list_delimited`
+    /// on a commit-shard prefix (`.../c/.../`), which hangs forever. Tenant
+    /// discovery (`list_delimited("t/")`) succeeds normally, so the pass
+    /// reaches the new `latest_ingest_hour` listing step before hanging --
+    /// unlike [`HangingStore`], which hangs before discovery ever completes
+    /// and so cannot exercise this step's own deadline coverage.
+    ///
+    /// `list_after` hangs on the same prefix, mirroring `list_delimited`:
+    /// [`Catalog::latest_ingest_hour`] probes each shard with `list_after`,
+    /// not `list_delimited` (issue #1233 finding 1), so leaving `list_after`
+    /// on the passthrough default (which forwards to `list`, never hanging)
+    /// would make this double stop intercepting the very call this test
+    /// means to hang.
+    struct HangsOnCommitListing(MemoryStore);
+
+    #[async_trait]
+    impl ObjectStoreBackend for HangsOnCommitListing {
+        async fn put(
+            &self,
+            key: &str,
+            data: Bytes,
+            opts: PutOptions,
+        ) -> Result<PutOutcome, StoreError> {
+            self.0.put(key, data, opts).await
+        }
+
+        async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+            self.0.get(key, range).await
+        }
+
+        async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+            self.0.head(key).await
+        }
+
+        async fn list(
+            &self,
+            prefix: &str,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            self.0.list(prefix, page).await
+        }
+
+        async fn list_after(
+            &self,
+            prefix: &str,
+            start_after: Option<&str>,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            if prefix.contains("/c/") {
+                std::future::pending().await
+            } else {
+                self.0.list_after(prefix, start_after, page).await
+            }
+        }
+
+        async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+            if prefix.contains("/c/") {
+                std::future::pending().await
+            } else {
+                self.0.list_delimited(prefix).await
+            }
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), StoreError> {
+            self.0.delete(key).await
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            self.0.capabilities()
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn warm_pass_deadline_still_bounds_the_new_listing_step() {
+        let memory = MemoryStore::new();
+        let tenant = TenantId::new("acme").hash();
+        publish_metric_segment(&memory, tenant, now_ns()).await;
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(HangsOnCommitListing(memory));
+        let catalog = catalog_for(store.clone());
+        let cache = Arc::new(Cache::new(CacheLimits::new(
+            16 * 1024 * 1024,
+            1024,
+            1024 * 1024,
+        )));
+        let cache_for_assertion = cache.clone();
+
+        let warm = tokio::spawn(async move {
+            warm_cache(
+                store,
+                catalog,
+                ReadCache::Ram(cache),
+                &FixedClock(now_ns()),
+                Arc::new(ravel_query::GetLimiter::new(8).expect("nonzero permits")),
+            )
+            .await;
+        });
+
+        tokio::time::timeout(WARM_DEADLINE * 3, warm)
+            .await
+            .expect(
+                "warm_cache must return once its deadline elapses even when only the new \
+                 latest_ingest_hour listing hangs, with tenant discovery already having \
+                 succeeded",
+            )
+            .expect("warm_cache task must not panic");
+
+        assert!(
+            cache_for_assertion.is_empty(),
+            "the hung latest_ingest_hour call must warm strictly less than planned (zero, not \
+             the one available part), proving the deadline bounds this new listing step too"
+        );
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
The ADR-0046 startup warm-up computed its lookback window as the wall
clock minus 24 hours, so a tenant whose last ingest was older than a
day warmed nothing, and every cold statement afterwards paid the full
catalog resolve (about 1,916 GETs and 3.2 s on the ClickBench tenant,
against one GET and 0.2 s inside the window). The warm-up now keys the
window off each tenant's latest ingest hour: 24 hours back from that
hour's start, one hour past it, for each signal separately.

Catalog::latest_ingest_hour finds that hour with a bounded number of
floored listings, newest window first: the floors double backwards
from now (24 h, 48 h, 96 h, up to a 64-day cap), each probe lists from
its floor, the first probe that returns an hour prefix yields the
maximum over all its pages, and the shard set comes from the catalog's
mandated scan-set derivation over the probe window (so pinned shards
and a retiring generation are covered), listed concurrently under the
catalog's request bound. Every returned key is checked against the
tenant prefix under the ADR-0050 isolation rule, each page is credited
as a list request and counted against max_catalog_list_requests with
the same typed refusal the prefix path uses. A tenant that ingested
within the last day costs one probe per shard plus the generation
read; one outside the cap costs seven and warms nothing.

The caller picks the log level: a listing fault or a budget refusal
logs at warn with latest_ingest_hour="error", warms nothing for that
tenant and signal, and leaves the other tenants and the other signal
untouched; a tenant with no commit records inside the lookback logs
"none" at info; the "has parts but none warmed" warning fires only
when the anchor hour holds an ingest part, not a tombstone or rewrite
alone. The library itself never warns for a signal a tenant does not
use.

Tests pin the exact list and generation-read counts for a recent
tenant, a three-day-old tenant, a tenant past the cap, and a
paginating store that must still return the newest hour across pages;
a foreign key inside a listing hard-fails with the breach counter at
one; a page budget one short of the need refuses with the typed error
after the exact number of pages; key-scoped FaultStore tests show a
fault on one tenant leaving the other tenant warming and a fault on
one signal leaving the other signal warming, each fired exactly once;
and the no-parts test asserts zero warn events. The commit message and
the ADR-0046 amendment state the superset property as the assumption
it is: the new window covers the old one whenever a part's event time
stays within max_ingest_lag_ns of its ingest hour and the ingest hour
is not ahead of the wall clock.

Fixes: #1233
