### PR TITLE
docs(adrs): name the current RLOG stamping symbols in ADR-0049 and ADR-0095

### DIFF
--- a/docs/adrs/0049-rlog-postings.md
+++ b/docs/adrs/0049-rlog-postings.md
@@ -380,3 +380,37 @@ declines a `Str`-literal prune arm on a name that also has a non-`Str` column
 (widen-only, ADR-0013). This is a different mechanism than the duplicate fold
 order -- the term written is right, the column probed is wrong -- and is fixed
 here because it sits in the same prune path.
+
+## Amendment 2026-09-06: the write-side function names in this ADR (#1135)
+
+The 2026-08-20 amendment named `writer.rs::indexed_term_columns` as the
+write side's cross-type winner computation, with `stat_winner_columns` as
+the sibling that computed the NumStat projection. Neither function exists
+any more. Issue #1135 replaced the name-keyed, per-record path both used
+with a slot-keyed one-pass stamp, so this amendment names the current
+implementation shape rather than editing the original text above.
+
+The write side's prediction of what `rebuild_record` plus `merged_attrs`
+report for an indexed key is now computed in `StampScratch::finish`
+(`crates/ravel-logseg/src/writer.rs`) and projected onto POSTINGS terms by
+`emit_merged`. `intern_tracked_names` interns the tracked names into
+ascending slots once per object; `StampIndex` resolves each `(slot, type
+byte)` pair to a dynamic column id, also once per object, replacing the old
+per-record two-level hash probe over owned `String` keys; `StreamSeed`
+decodes one stream's tracked resource and scope attributes once per stream,
+keyed by slot, seeding the value a record-level occurrence may override.
+`resolve_row` pushes a record's tracked occurrences into a `StampScratch`
+and calls `finish` once, which computes the record-level two-tier winner
+(columnar occurrences ascending by type byte, then overflow occurrences
+ascending by `canonical_value_bytes`, last wins) and overlays it on the
+stream seed. `emit_merged` then projects that one merged view onto POSTINGS:
+every indexed entry becomes a term.
+
+The two-tier winner order and the emitted terms are unchanged. This
+amendment renames nothing in the decision above and changes no on-disk
+format: the `POSTINGS_VERSION` byte stays exactly as the 2026-08-20
+amendment left it. The old names survive only as a frozen pre-#1135
+reference, verbatim, inside `writer.rs`'s `stamp_differential` test module
+and in `benches/common/stamp_shape.rs`; that frozen copy is the differential
+reference the #1135 regression test compares the new stamp against and is
+not code to maintain.

--- a/docs/adrs/0049-rlog-postings.md
+++ b/docs/adrs/0049-rlog-postings.md
@@ -404,7 +404,9 @@ and calls `finish` once, which computes the record-level two-tier winner
 (columnar occurrences ascending by type byte, then overflow occurrences
 ascending by `canonical_value_bytes`, last wins) and overlays it on the
 stream seed. `emit_merged` then projects that one merged view onto POSTINGS:
-every indexed entry becomes a term.
+an indexed entry becomes a term when the slot is indexed and the object
+carries a dynamic column for that slot's type byte. An indexed slot whose
+type byte resolves to no column emits nothing.
 
 The two-tier winner order and the emitted terms are unchanged. This
 amendment renames nothing in the decision above and changes no on-disk

--- a/docs/adrs/0095-numstat-crosstype-declared-column-agreement.md
+++ b/docs/adrs/0095-numstat-crosstype-declared-column-agreement.md
@@ -298,3 +298,35 @@ flowchart TD
     SKIP -->|range cannot overlap min/max| PRUNE["block skipped"]
     SKIP -->|range may overlap| LOAD["block loaded, declared_column_array resolves via same winner rule"]
 ```
+
+## Amendment 2026-09-06: the write-side function names in this ADR (#1135)
+
+This ADR names `record_level_winners` (Context, Decision 1, Consequences,
+and the diagram above) and cites `writer.rs:753-791`; it also names
+`merged_indexed_terms` (Context). Issue #1135 replaced the name-keyed,
+per-record path all three described with a slot-keyed one-pass stamp, so
+this amendment names the current implementation shape rather than editing
+the original text above. The winner rule and the stamped output are
+unchanged; this decision stands exactly as written.
+
+Old name, or cite | Current implementation
+--- | ---
+`record_level_winners` / `record_level_winners_slot` | `StampScratch::finish` (`crates/ravel-logseg/src/writer.rs`) computes the same two-tier winner order (columnar occurrences ascending by type byte, then overflow occurrences ascending by `canonical_value_bytes`, last wins), fed by `StampScratch::push_columnar` / `push_overflow`.
+`resolved_tracked_values` | the stream-seed overlay inside `StampScratch::finish`, seeded once per stream by `StreamSeed`.
+`stat_winner_columns` and `indexed_term_columns` | `emit_merged`, which projects the one merged view onto both consumers: every indexed entry becomes a POSTINGS term, and the first entry per name becomes the SKIP_IDX NumStat winner.
+`merged_indexed_terms` | `resolve_row` plus `StampScratch::finish`.
+`writer.rs:753-791` | stale. That range today spans the BLOOM/POSTINGS `push_section` calls (through roughly line 770) and the `LogFooter` construction that follows; no part of it computes a winner. The winner now lives in `StampScratch::finish` (`writer.rs:2049`).
+
+`intern_tracked_names` interns the tracked name set (`indexed_names` union
+`numstat_names`, decision 1 above) into ascending slots once per object, and
+`StampIndex` resolves each `(slot, type byte)` pair to a dynamic column id,
+also once per object. Both are new plumbing `resolve_row` and
+`StampScratch::finish` use to reach the same winner this ADR already
+decided on, not a change to the winner rule itself.
+
+Decision 1's requirement -- one shared resolution for POSTINGS and NumStat,
+not two implementations -- is what the single `StampScratch::finish` plus
+`emit_merged` pair now enforces structurally: both consumers read the one
+merged view `emit_merged` projects, so a second divergent implementation is
+no longer even reachable as a separate code path. The RLOG v3 trailer
+decision (decision 4) is untouched by any of this.

--- a/docs/adrs/0095-numstat-crosstype-declared-column-agreement.md
+++ b/docs/adrs/0095-numstat-crosstype-declared-column-agreement.md
@@ -313,7 +313,7 @@ Old name, or cite | Current implementation
 --- | ---
 `record_level_winners` / `record_level_winners_slot` | `StampScratch::finish` (`crates/ravel-logseg/src/writer.rs`) computes the same two-tier winner order (columnar occurrences ascending by type byte, then overflow occurrences ascending by `canonical_value_bytes`, last wins), fed by `StampScratch::push_columnar` / `push_overflow`.
 `resolved_tracked_values` | the stream-seed overlay inside `StampScratch::finish`, seeded once per stream by `StreamSeed`.
-`stat_winner_columns` and `indexed_term_columns` | `emit_merged`, which projects the one merged view onto both consumers: every indexed entry becomes a POSTINGS term, and the first entry per name becomes the SKIP_IDX NumStat winner.
+`stat_winner_columns` and `indexed_term_columns` | `emit_merged`, which projects the one merged view onto both consumers under each one's own eligibility. An entry becomes a POSTINGS term when its slot is indexed and a dynamic column exists for that slot's type byte. It becomes the SKIP_IDX NumStat winner when its slot is a NumStat slot, no entry for that slot has been taken yet, the type is `I64`, `F64` or `Bool`, and a dynamic column exists for that pair; a first entry of any other type consumes the slot's one chance and emits nothing.
 `merged_indexed_terms` | `resolve_row` plus `StampScratch::finish`.
 `writer.rs:753-791` | stale. That range today spans the BLOOM/POSTINGS `push_section` calls (through roughly line 770) and the `LogFooter` construction that follows; no part of it computes a winner. The winner now lives in `StampScratch::finish` (`writer.rs:2049`).
 


### PR DESCRIPTION
The one-pass declared-stat stamping in the RLOG writer replaced
record_level_winners, record_level_winners_slot, resolved_tracked_values,
stat_winner_columns and indexed_term_columns with intern_tracked_names,
StampIndex, StreamSeed and StampScratch::finish, and the writer.rs line
range ADR-0095 cites now spans the BLOOM and POSTINGS section pushes and
the footer construction. The winner rule and the stamped output did not
change, so both decisions stand as written.

Each ADR gains a dated amendment section that names the current shape
and maps every old symbol to its replacement; the original decision text
stays byte for byte, so the six pre-existing citations of the old names
remain in place inside the accepted text and the amendments retire them.
The old names survive on purpose as the frozen pre-change reference in
the writer's differential test module and in the stamp-shape bench
fixture, and the amendments say so. docs/log-segment-format.md carries
no stale stamp name and is untouched.

Refs: #1154
