### PR TITLE
chore(scripts): add fleet-watch-loop.sh so the relaunch is not hand-written

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,10 +146,12 @@ Waiting is event-driven, never babysat. The harness kills background
 processes after about 10 minutes; an unbounded watcher dies unnoticed and
 the fallback becomes no-op status polls that burn turns and tokens.
 
-- Arm `scripts/fleet-watch-managed.sh` under a Monitor until-loop: each
-  bounded run exits 75 when its budget elapses and the Monitor relaunches
-  it; exit 0 prints the terminal event. Never nohup a watcher and never
-  poll one with `ps`.
+- Arm `scripts/fleet-watch-loop.sh <watch-url>` under a Monitor, as the
+  whole command. It relaunches the bounded watcher across budget
+  rollovers and emits one line only when the watch is actually over.
+  Writing that loop by hand in the Monitor command is a step that has
+  been got wrong twice: a command that prints the 75 and exits ends the
+  watch silently. Never nohup a watcher and never poll one with `ps`.
 - Idle fallback wakeups: 15 minutes or longer. Embed the current ledger
   state in every wakeup prompt so a compaction between wakeups costs
   nothing.
@@ -209,7 +211,15 @@ connection, a pushed-but-broken main).
   same polling, in bounded runs sized to survive the harness's 10-minute
   background cap. Exit 0 = terminal event printed; exit 75 = budget
   elapsed, relaunch (arm it under a Monitor until-loop that relaunches
-  on 75).
+  on 75). Prefer `fleet-watch-loop.sh` below, which is that loop.
+- `scripts/fleet-watch-loop.sh <watch-url> [budget-s] [poll-s]`: the
+  relaunch loop around `fleet-watch-managed.sh`, so a Monitor command is
+  the script name and nothing else. Arm this rather than hand-writing the
+  loop: a command that reports the 75 instead of relaunching ends the
+  watch, and every later terminal event is lost with nothing to say the
+  watch died. One stdout line per event, each worth a notification:
+  `TERMINAL <data: line>`, `WATCH-ERROR code=N`, or `WATCH-GAVE-UP` once
+  `FLEET_WATCH_MAX_SECONDS` (default 18000) elapses.
 - `scripts/epic-status.sh <epic-issue> [--fresh]`: one-call "where are we
   at?": reads the epic ledger (cached 60 s) and reconciles every task id
   in it against `refs/heads/task/*` on origin and the task-branch PRs.

--- a/scripts/fleet-watch-loop.sh
+++ b/scripts/fleet-watch-loop.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Watch a fleet task to its terminal event, relaunching the bounded watcher.
+#
+# fleet-watch-managed.sh exits 75 when its budget elapses, expecting the
+# caller to relaunch it. Hand-writing that loop in each Monitor command is
+# where it goes wrong: a command that merely reports the 75 ends the watch,
+# and every later terminal event is lost with nothing to say the watch died.
+# Arm this instead, and the only notifications are the ones worth reading.
+#
+# One stdout line per event, so it suits a Monitor directly:
+#   TERMINAL <data: line>   the task reached a terminal state (exit 0)
+#   WATCH-ERROR code=N      the watcher failed; the watch is over, act on it
+#   WATCH-GAVE-UP after Ns  the wall-clock cap elapsed with no terminal event
+#
+# Usage: fleet-watch-loop.sh <watch-url> [budget-seconds=540] [poll-seconds=60]
+# Environment: FLEET_WATCH_MAX_SECONDS caps total wall clock (default 18000,
+# comfortably past the fleet's own ~4h runtime ceiling).
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <watch-url> [budget-seconds] [poll-seconds]" >&2
+  exit 64
+fi
+
+watch_url="$1"
+budget="${2:-540}"
+poll="${3:-60}"
+max_seconds="${FLEET_WATCH_MAX_SECONDS:-18000}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+managed="${here}/fleet-watch-managed.sh"
+
+if [[ ! -x "${managed}" ]]; then
+  echo "WATCH-ERROR code=64 (${managed} not executable)"
+  exit 64
+fi
+
+give_up_at=$(( $(date +%s) + max_seconds ))
+
+while (( $(date +%s) < give_up_at )); do
+  event="$("${managed}" "${watch_url}" "${budget}" "${poll}")" && code=0 || code=$?
+  if (( code == 0 )); then
+    echo "TERMINAL ${event}"
+    exit 0
+  fi
+  if (( code != 75 )); then
+    echo "WATCH-ERROR code=${code}"
+    exit "${code}"
+  fi
+done
+
+echo "WATCH-GAVE-UP after ${max_seconds}s with no terminal event"
+exit 75

--- a/scripts/fleet-watch-loop.sh
+++ b/scripts/fleet-watch-loop.sh
@@ -27,6 +27,26 @@ budget="${2:-540}"
 poll="${3:-60}"
 max_seconds="${FLEET_WATCH_MAX_SECONDS:-18000}"
 
+# Reject a bad duration before the loop rather than inside it. A budget of 0 or
+# a non-number makes the managed watcher exit 75 immediately, and this loop
+# treats 75 as "relaunch", so an unchecked value spins as fast as the shell can
+# fork until the wall-clock cap.
+require_positive_int() {
+  local name="$1" value="$2"
+  if [[ ! ${value} =~ ^[0-9]+$ ]] || (( value <= 0 )); then
+    echo "WATCH-ERROR code=64 (${name} must be a positive integer, got '${value}')"
+    exit 64
+  fi
+}
+
+if [[ -z ${watch_url} ]]; then
+  echo "WATCH-ERROR code=64 (watch-url is empty)"
+  exit 64
+fi
+require_positive_int budget-seconds "${budget}"
+require_positive_int poll-seconds "${poll}"
+require_positive_int FLEET_WATCH_MAX_SECONDS "${max_seconds}"
+
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 managed="${here}/fleet-watch-managed.sh"
 
@@ -38,7 +58,12 @@ fi
 give_up_at=$(( $(date +%s) + max_seconds ))
 
 while (( $(date +%s) < give_up_at )); do
-  event="$("${managed}" "${watch_url}" "${budget}" "${poll}")" && code=0 || code=$?
+  # Never let a run outlive the cap: the last one gets only the time that is
+  # actually left, so a terminal event arriving after the cap is reported as
+  # WATCH-GAVE-UP rather than as a TERMINAL the caller no longer expects.
+  remaining=$(( give_up_at - $(date +%s) ))
+  run_budget=$(( budget < remaining ? budget : remaining ))
+  event="$("${managed}" "${watch_url}" "${run_budget}" "${poll}")" && code=0 || code=$?
   if (( code == 0 )); then
     echo "TERMINAL ${event}"
     exit 0

--- a/scripts/fleet-watch-loop.sh
+++ b/scripts/fleet-watch-loop.sh
@@ -57,15 +57,53 @@ fi
 
 give_up_at=$(( $(date +%s) + max_seconds ))
 
+give_up() {
+  echo "WATCH-GAVE-UP after ${max_seconds}s with no terminal event"
+  exit 75
+}
+
+# Run the managed watcher and kill it if it is still going at `give_up_at`.
+#
+# Shrinking the budget argument is not enough on its own. The managed watcher
+# checks its own deadline between polls, so after that check it can still spend
+# a `curl --max-time 25` and then a full `sleep ${poll}`, overrunning by most of
+# a poll interval; with a 60 s poll that is a minute past a cap the caller set.
+# Worse, an event arriving in that overrun would be reported as TERMINAL after
+# the watch was supposed to be over.
+#
+# Killing the process group rather than the pid matters: the watcher's own time
+# is spent inside `curl` and `sleep` children, and signalling only the wrapper
+# leaves those running. `setsid` is not on macOS, so the child is put in its own
+# group with `set -m` and signalled by negated pgid.
+run_bounded() {
+  local budget_arg="$1" out_file="$2" child code=0
+  set -m
+  "${managed}" "${watch_url}" "${budget_arg}" "${poll}" > "${out_file}" &
+  child=$!
+  set +m
+  while kill -0 "${child}" 2>/dev/null; do
+    if (( $(date +%s) >= give_up_at )); then
+      kill -TERM -"${child}" 2>/dev/null || kill -TERM "${child}" 2>/dev/null || true
+      wait "${child}" 2>/dev/null || true
+      return 75
+    fi
+    sleep 1
+  done
+  wait "${child}" || code=$?
+  return "${code}"
+}
+
+out_file="$(mktemp -t fleet-watch-loop)"
+trap 'rm -f "${out_file}"' EXIT
+
 while (( $(date +%s) < give_up_at )); do
-  # Never let a run outlive the cap: the last one gets only the time that is
-  # actually left, so a terminal event arriving after the cap is reported as
-  # WATCH-GAVE-UP rather than as a TERMINAL the caller no longer expects.
   remaining=$(( give_up_at - $(date +%s) ))
   run_budget=$(( budget < remaining ? budget : remaining ))
-  event="$("${managed}" "${watch_url}" "${run_budget}" "${poll}")" && code=0 || code=$?
+  run_bounded "${run_budget}" "${out_file}" && code=0 || code=$?
   if (( code == 0 )); then
-    echo "TERMINAL ${event}"
+    # A terminal event, but only one that arrived inside the cap: run_bounded
+    # returns 75 rather than 0 when it had to kill the child.
+    echo "TERMINAL $(cat "${out_file}")"
     exit 0
   fi
   if (( code != 75 )); then
@@ -74,5 +112,4 @@ while (( $(date +%s) < give_up_at )); do
   fi
 done
 
-echo "WATCH-GAVE-UP after ${max_seconds}s with no terminal event"
-exit 75
+give_up

--- a/scripts/fleet-watch-loop.sh
+++ b/scripts/fleet-watch-loop.sh
@@ -93,7 +93,11 @@ run_bounded() {
   return "${code}"
 }
 
-out_file="$(mktemp -t fleet-watch-loop)"
+# An explicit XXXXXX template rather than `mktemp -t fleet-watch-loop`: BSD
+# mktemp treats the argument as a prefix, GNU mktemp requires the Xs and fails
+# with "too few X's in template", which under `set -e` exits before the loop
+# ever starts. The bug is invisible on macOS and fatal on a Linux runner.
+out_file="$(mktemp "${TMPDIR:-/tmp}/fleet-watch-loop.XXXXXX")"
 trap 'rm -f "${out_file}"' EXIT
 
 while (( $(date +%s) < give_up_at )); do


### PR DESCRIPTION
`scripts/fleet-watch-managed.sh` exits 75 when its polling budget elapses and expects the caller to relaunch it. CLAUDE.md said to arm it under a Monitor until-loop, but that loop was written by hand at each call site, and getting it wrong fails silently: a Monitor command that prints the 75 and exits ends the watch, so every later terminal event is lost with nothing to say the watch died. That happened twice in one session, on three armed watchers.

This adds the loop as a script, so a Monitor command is the script name and its URL and nothing else.

## What it does

One stdout line per event, each one worth a notification:

- `TERMINAL <data: line>` — the task reached a terminal state (exit 0)
- `WATCH-ERROR code=N` — the watcher failed; the watch is over, act on it
- `WATCH-GAVE-UP after Ns` — the wall-clock cap elapsed with no terminal event

An error is therefore distinguishable from a quiet task, rather than both looking like silence. `FLEET_WATCH_MAX_SECONDS` bounds the whole watch and defaults to 18000 s, comfortably past the fleet's own runtime ceiling.

## Verification

Every branch exercised against stubs: usage (64), a terminal event (0), a non-75 failure passed through unchanged (7), relaunch across three budget rollovers followed by a terminal event (0), and the give-up path (75). `shellcheck` clean; `python3 scripts/check_docs.py` clean.

No behaviour change to `fleet-watch-managed.sh` or `fleet-watch.sh`; peers arming those directly are unaffected.