### PR TITLE
docs(ingest): document flush cadence and fix knob overclaims

### DIFF
--- a/crates/ravel-ingest/src/config.rs
+++ b/crates/ravel-ingest/src/config.rs
@@ -141,17 +141,25 @@ pub struct IngestConfig {
     /// "Flush cadence on the acknowledged path"). It only sets a
     /// buffered-mode tenant's cadence, and only once that tenant's arrival
     /// rate is high enough to reach it before `max_flush_delay_idle` does.
+    /// The size trigger is not gated on the strict path, so a strict tenant
+    /// sustaining that rate does flush on size; the measurements show only
+    /// that it did not win in either measured run.
     pub target_bytes: usize,
     /// Flush a tenant's buffer once its oldest point is at least this old.
     /// This is the trigger that actually sets commit-record cadence on the
     /// acknowledged (strict) path: a strict write leaves the buffer's
     /// waiters non-empty for its whole flush window, so the age-trigger
-    /// selector always returns this value there rather than
-    /// `max_flush_delay_idle`, and `target_bytes` rarely wins the race
-    /// against it. Raising it lowers acknowledged-path record cadence, but
-    /// a strict acknowledgement waits for its own flush to land, so every
-    /// millisecond added here is added to acknowledged write latency, one
-    /// for one. Not a knob to retune without owning that latency trade.
+    /// selector returns this value there rather than `max_flush_delay_idle`,
+    /// and `target_bytes` rarely wins the race against it. With
+    /// `adaptive_flush_delay` on, this is the FLOOR of a per-tenant corridor
+    /// rather than the threshold itself; the description above holds for the
+    /// default, which is off. Raising it lowers acknowledged-path record
+    /// cadence at the cost of acknowledged write latency, since a strict
+    /// acknowledgement waits for its own flush to land. The added latency is
+    /// bounded by the increase rather than equal to it: ages are checked on
+    /// the `flush_tick` interval, and a buffer that reaches `target_bytes`
+    /// first flushes without waiting for the age trigger at all. Not a knob
+    /// to retune without owning that latency trade.
     pub max_flush_delay: Duration,
     /// Interval on which each shard actor checks buffered ages against
     /// `max_flush_delay`.

--- a/crates/ravel-ingest/src/config.rs
+++ b/crates/ravel-ingest/src/config.rs
@@ -130,16 +130,37 @@ pub struct IngestConfig {
     pub shard_count: u32,
     /// Bounded mpsc channel depth per shard.
     pub channel_depth: usize,
-    /// Flush a tenant's buffer once its estimated size reaches this many bytes.
+    /// Flush a tenant's buffer once its estimated size reaches this many
+    /// bytes, checked on every message received regardless of whether the
+    /// buffer has a strict-mode waiter. On the acknowledged (strict) path
+    /// this rarely wins the race against `max_flush_delay`: doing so needs
+    /// a sustained arrival rate above roughly `target_bytes /
+    /// max_flush_delay`, well over normal per-shard write rates, so at
+    /// realistic strict traffic `max_flush_delay` decides every flush and
+    /// this knob does not move commit-record cadence there (docs/ingest.md,
+    /// "Flush cadence on the acknowledged path"). It only sets a
+    /// buffered-mode tenant's cadence, and only once that tenant's arrival
+    /// rate is high enough to reach it before `max_flush_delay_idle` does.
     pub target_bytes: usize,
     /// Flush a tenant's buffer once its oldest point is at least this old.
+    /// This is the trigger that actually sets commit-record cadence on the
+    /// acknowledged (strict) path: a strict write leaves the buffer's
+    /// waiters non-empty for its whole flush window, so the age-trigger
+    /// selector always returns this value there rather than
+    /// `max_flush_delay_idle`, and `target_bytes` rarely wins the race
+    /// against it. Raising it lowers acknowledged-path record cadence, but
+    /// a strict acknowledgement waits for its own flush to land, so every
+    /// millisecond added here is added to acknowledged write latency, one
+    /// for one. Not a knob to retune without owning that latency trade.
     pub max_flush_delay: Duration,
     /// Interval on which each shard actor checks buffered ages against
     /// `max_flush_delay`.
     pub flush_tick: Duration,
     /// Age threshold applied instead of `max_flush_delay` when a buffer has
     /// no strict-mode waiter and holds fewer than `min_flush_bytes`
-    /// (ADR-0051 section 7). Keeps the fast age trigger for
+    /// (ADR-0051 section 7). Unreachable whenever a strict-mode waiter is
+    /// present, so this never applies on the acknowledged path: it sets a
+    /// buffered-mode tenant's cadence only, keeping the fast age trigger for
     /// buffers a caller is blocked on or that are already worth a PUT, while
     /// an idle, low-volume buffered-mode tenant waits this long instead of
     /// paying a PUT every `max_flush_delay` regardless of how little data it
@@ -147,7 +168,9 @@ pub struct IngestConfig {
     pub max_flush_delay_idle: Duration,
     /// A buffer at or above this many estimated bytes is never treated as
     /// idle for the age trigger, even with no strict-mode waiter: it is
-    /// already worth the PUT cost `max_flush_delay` pays for.
+    /// already worth the PUT cost `max_flush_delay` pays for. Irrelevant
+    /// whenever a strict-mode waiter is present: that buffer is never idle
+    /// regardless of size, so this has no effect on the acknowledged path.
     pub min_flush_bytes: usize,
     /// Retries after the first attempt for the data-object PUT (total
     /// attempts = this + 1). Also bounds retries of the commit-record PUT.
@@ -158,7 +181,17 @@ pub struct IngestConfig {
     pub put_retry_base_delay: Duration,
     pub put_retry_max_delay: Duration,
     /// A flush that cannot complete within this long after it opened is
-    /// abandoned: never published, waiters errored (ADR-0010 §1/§11).
+    /// abandoned: never published, waiters errored (ADR-0010 §1/§11). Not a
+    /// flush trigger: never consulted before a flush opens, only after, to
+    /// bound how long an already-open one may run. It is also the largest
+    /// single term in how long a published record sits in the catalog's
+    /// unfolded listing path before a fold can seal it away
+    /// (docs/guides/operations/maintenance.md, "the seal margin"). Lowering
+    /// it shortens that window but tightens the deadline every in-flight
+    /// flush must complete inside, including the largest, slowest-to-encode
+    /// buffers; too tight for a tenant's typical flush duration turns
+    /// legitimate flushes into abandoned ones instead of shortening
+    /// anything.
     pub max_flush_lifetime: Duration,
     /// Window width of the flush-scoped exemplar admission cap (ADR-0047
     /// decision 2): at most one exemplar per series per window reaches the

--- a/crates/ravel-ingest/src/config.rs
+++ b/crates/ravel-ingest/src/config.rs
@@ -153,7 +153,8 @@ pub struct IngestConfig {
     /// and `target_bytes` rarely wins the race against it. With
     /// `adaptive_flush_delay` on, this is the FLOOR of a per-tenant corridor
     /// rather than the threshold itself; the description above holds for the
-    /// default, which is off. Raising it lowers acknowledged-path record
+    /// default, which is off, and for the log and span shard actors in every
+    /// configuration, since only the metrics actor consults that knob. Raising it lowers acknowledged-path record
     /// cadence at the cost of acknowledged write latency, since a strict
     /// acknowledgement waits for its own flush to land. The added latency is
     /// bounded by the increase rather than equal to it: ages are checked on

--- a/docs/guides/operations/maintenance.md
+++ b/docs/guides/operations/maintenance.md
@@ -114,6 +114,49 @@ incremental fold, which re-lists only hours after the watermark. The repair is
 the HEAD-deletion rebuild in
 [troubleshooting](troubleshooting.md#queries-are-missing-recently-written-data).
 
+### Ingest flush cadence: byte-driven vs timer-driven, and what tightening `max_flush_lifetime` costs
+
+Two different things move independently here: how often a shard flushes
+(the write side's record cadence) and how long a published record sits in
+the unfolded listing path before the fold above can seal its hour away
+(the seal margin just described).
+
+On an acknowledged (strict) write, cadence is set by `--max-flush-delay`
+(2s default), not by `target_bytes`: a strict write keeps a waiter on its
+buffer for the whole flush window, so the size trigger almost never wins
+the race against the age clock at realistic write rates. Turning
+`target_bytes` down does not reduce an acknowledged tenant's commit-record
+rate. Raising `--max-flush-delay` is the knob that does, and it does so by
+directly raising acknowledged write latency: a strict acknowledgement
+waits for its own flush to land, so every added millisecond of
+`max_flush_delay` is a millisecond added to every strict write for that
+tenant.
+
+A buffered write (no waiter) is different, and this is where the
+byte-driven/timer-driven split applies: a buffered-mode tenant is
+byte-driven when its arrival rate reaches `target_bytes` before
+`max_flush_delay_idle` (40s default) elapses, and timer-driven otherwise.
+Only a byte-driven buffered tenant ever exercises the size trigger; a
+timer-driven one always flushes on `max_flush_delay_idle`, however little
+data it holds.
+
+`max_flush_lifetime` is neither of those triggers: it is never consulted
+before a flush opens, only after, to bound how long an already-open flush
+may run before it is abandoned (waiters errored, nothing published). It is
+also, per the seal-margin arithmetic above, the largest single term in how
+long a published record sits in the unfolded tail. Lowering it shortens
+that tail, but the same tighter deadline now bounds every in-flight flush,
+including a byte-driven tenant's largest buffers, which take longer to
+encode and PUT than a timer-driven tenant's small ones. Cut it too close
+for that tenant's typical flush duration and legitimate flushes start
+hitting the deadline instead of completing, which is a write-availability
+cost, not just a slower one. Reviewing `fold_safety_margin` alongside a
+`max_flush_lifetime` change, as above, protects the seal-timing invariant;
+it does nothing for in-flight flush completion. A tenant that stays
+timer-driven, with small buffers that always PUT well inside the deadline,
+tolerates a much tighter `max_flush_lifetime` than a byte-driven one with
+large buffers near `target_bytes`.
+
 ### Routine verification
 
 ```sh

--- a/docs/guides/operations/maintenance.md
+++ b/docs/guides/operations/maintenance.md
@@ -124,13 +124,22 @@ the unfolded listing path before the fold above can seal its hour away
 On an acknowledged (strict) write, cadence is set by `--max-flush-delay`
 (2s default), not by `target_bytes`: a strict write keeps a waiter on its
 buffer for the whole flush window, so the size trigger almost never wins
-the race against the age clock at realistic write rates. Turning
-`target_bytes` down does not reduce an acknowledged tenant's commit-record
-rate. Raising `--max-flush-delay` is the knob that does, and it does so by
-directly raising acknowledged write latency: a strict acknowledgement
-waits for its own flush to land, so every added millisecond of
-`max_flush_delay` is a millisecond added to every strict write for that
-tenant.
+the race against the age clock at realistic write rates. It is not disabled
+there, though, so a tenant sustaining more than roughly `target_bytes /
+max_flush_delay` per shard (about 4 MiB/s at the defaults) does flush on
+size; below that, turning `target_bytes` down does not reduce an
+acknowledged tenant's commit-record rate. Raising `--max-flush-delay` is the
+knob that does, at the cost of acknowledged write latency, since a strict
+acknowledgement waits for its own flush to land. Budget that cost as bounded
+by the increase rather than equal to it: ages are checked on the
+`flush_tick` interval rather than continuously.
+
+Two configurations change this picture. With `--adaptive-flush-delay` on
+(off by default), `--max-flush-delay` becomes the floor of a per-tenant
+corridor rather than the threshold itself, so raising the floor moves only
+the bottom of a range the shard picks from. And a tenant fast enough to hit
+the size trigger is byte-driven even on the strict path, which puts it in
+the regime described next rather than this one.
 
 A buffered write (no waiter) is different, and this is where the
 byte-driven/timer-driven split applies: a buffered-mode tenant is

--- a/docs/guides/operations/maintenance.md
+++ b/docs/guides/operations/maintenance.md
@@ -144,12 +144,21 @@ trigger is byte-driven even on the strict path, which puts it in the regime
 described next rather than this one.
 
 A buffered write (no waiter) is different, and this is where the
-byte-driven/timer-driven split applies: a buffered-mode tenant is
-byte-driven when its arrival rate reaches `target_bytes` before
-`max_flush_delay_idle` (40s default) elapses, and timer-driven otherwise.
-Only a byte-driven buffered tenant ever exercises the size trigger; a
-timer-driven one always flushes on `max_flush_delay_idle`, however little
-data it holds.
+byte-driven/timer-driven split applies. It has three regimes, not two,
+because `min_flush_bytes` selects which age clock a buffered tenant gets:
+
+- reaches `target_bytes` before any age trigger fires: byte-driven, and the
+  only regime that exercises the size trigger at all;
+- below `target_bytes` but holding at least `min_flush_bytes`: flushes on
+  `max_flush_delay` (2s default), the same fast clock a strict write gets,
+  so its PUT cadence is nothing like idle;
+- below `min_flush_bytes`: flushes on `max_flush_delay_idle` (40s default),
+  however little it holds.
+
+Only the third is genuinely timer-driven in the slow sense. A tenant that
+merely fails to reach `target_bytes` is not automatically in it, which
+matters when sizing `max_flush_lifetime` below: a middle-regime tenant
+flushes twenty times more often than the idle figure suggests.
 
 `max_flush_lifetime` is neither of those triggers: it is never consulted
 before a flush opens, only after, to bound how long an already-open flush

--- a/docs/guides/operations/maintenance.md
+++ b/docs/guides/operations/maintenance.md
@@ -135,11 +135,13 @@ by the increase rather than equal to it: ages are checked on the
 `flush_tick` interval rather than continuously.
 
 Two configurations change this picture. With `--adaptive-flush-delay` on
-(off by default), `--max-flush-delay` becomes the floor of a per-tenant
-corridor rather than the threshold itself, so raising the floor moves only
-the bottom of a range the shard picks from. And a tenant fast enough to hit
-the size trigger is byte-driven even on the strict path, which puts it in
-the regime described next rather than this one.
+(off by default, and metrics only: the log and span shard actors do not
+consult it, so for those signals `--max-flush-delay` is always the
+threshold), `--max-flush-delay` becomes the floor of a per-tenant corridor
+rather than the threshold itself, so raising the floor moves only the bottom
+of a range the shard picks from. And a tenant fast enough to hit the size
+trigger is byte-driven even on the strict path, which puts it in the regime
+described next rather than this one.
 
 A buffered write (no waiter) is different, and this is where the
 byte-driven/timer-driven split applies: a buffered-mode tenant is

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -236,9 +236,14 @@ selector, mirrored across the metrics, log and span shard actors) picks a
 threshold of `max_flush_delay_idle` only when a buffer has no strict-mode
 waiter and holds fewer than `min_flush_bytes`. A strict write keeps a
 `oneshot::Sender` in `waiters` for its whole flush window, so that
-condition never holds on the acknowledged path: `age_threshold_ns` always
-returns `max_flush_delay` there, regardless of how many bytes are
-buffered.
+condition never holds on the acknowledged path: `age_threshold_ns` returns
+`max_flush_delay` there, regardless of how many bytes are buffered.
+
+That last step assumes `adaptive_flush_delay` is off, which is the default.
+With it on, the selector returns a per-tenant threshold in
+`[max_flush_delay, ceiling]` derived from the tenant's arrival rate and the
+shard's observed PUT round trip, so `max_flush_delay` becomes the floor of a
+corridor rather than the value. Everything below describes the default.
 
 `target_bytes` is checked separately, on the message-received branch, and
 is not gated on `waiters`: a buffer that crosses `target_bytes` before the
@@ -251,8 +256,10 @@ above normal per-shard write rates. Measured across two loads spanning a
 produced close to the same commit-record rate per shard per hour, 1,413.6
 and 1,435.7 respectively, a 1.6% difference against the 47x difference in
 input rate, and the `target_bytes` size trigger fired zero times in either
-run. Commit-record count on the acknowledged path is set by the flush
-clock, not by ingest volume.
+run. So the flush clock, not ingest volume, set the commit-record count in
+both measured runs. That is a statement about the rates measured, not a
+property of the strict path: the size trigger is live there, and a tenant
+sustaining more than roughly 4 MiB/s per shard would reach it.
 
 What each knob actually moves there:
 
@@ -265,11 +272,13 @@ What each knob actually moves there:
   acknowledged path. They set a buffered-mode tenant's PUT cadence when its
   arrival rate is too low to reach `target_bytes`.
 - `max_flush_delay`: the knob that sets acknowledged-path flush cadence.
-  Raising it produces fewer, larger commit records per hour, but a strict
-  acknowledgement waits for its own flush to land, so every millisecond
-  added to `max_flush_delay` is added to acknowledged write latency,
-  one for one. It is not a free tuning knob; see the operations guide for
-  the seal-delay trade-off this interacts with through
+  Raising it produces fewer, larger commit records per hour at the cost of
+  acknowledged write latency, since a strict acknowledgement waits for its
+  own flush to land. The cost is bounded by the increase rather than equal
+  to it: ages are checked on the `flush_tick` interval rather than
+  continuously, and a buffer reaching `target_bytes` flushes without waiting
+  for the age trigger at all. It is not a free tuning knob; see the
+  operations guide for the seal-delay trade-off this interacts with through
   `max_flush_lifetime`.
 
 ### Pipelined flushes (ADR-0067)

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -229,6 +229,49 @@ object written) rather than defaulting to bucket 0 (ADR-0051 section 7):
 a fallback bucket would make the data undiscoverable by hour
 with no trace of the failure.
 
+### Flush cadence on the acknowledged path
+
+On `mode=strict`, `age_threshold_ns` (the shard actor's age-trigger
+selector, mirrored across the metrics, log and span shard actors) picks a
+threshold of `max_flush_delay_idle` only when a buffer has no strict-mode
+waiter and holds fewer than `min_flush_bytes`. A strict write keeps a
+`oneshot::Sender` in `waiters` for its whole flush window, so that
+condition never holds on the acknowledged path: `age_threshold_ns` always
+returns `max_flush_delay` there, regardless of how many bytes are
+buffered.
+
+`target_bytes` is checked separately, on the message-received branch, and
+is not gated on `waiters`: a buffer that crosses `target_bytes` before the
+next age check flushes on size, strict or buffered. In practice this
+almost never happens on the acknowledged path, because winning that race
+needs a sustained arrival rate above roughly `target_bytes /
+max_flush_delay` (about 4 MiB/s at the defaults, 8 MiB over 2 s), well
+above normal per-shard write rates. Measured across two loads spanning a
+47x range in ingest rate (8,474 points/second and 178 points/second), both
+produced close to the same commit-record rate per shard per hour, 1,413.6
+and 1,435.7 respectively, a 1.6% difference against the 47x difference in
+input rate, and the `target_bytes` size trigger fired zero times in either
+run. Commit-record count on the acknowledged path is set by the flush
+clock, not by ingest volume.
+
+What each knob actually moves there:
+
+- `target_bytes`: does not set acknowledged-path cadence at realistic
+  write rates. It matters only for a buffered-mode tenant (see [Modes]
+  below) whose arrival rate is high enough to reach it before an age
+  trigger does.
+- `min_flush_bytes` and `max_flush_delay_idle`: unreachable whenever a
+  strict-mode waiter is present, so they have no effect on the
+  acknowledged path. They set a buffered-mode tenant's PUT cadence when its
+  arrival rate is too low to reach `target_bytes`.
+- `max_flush_delay`: the knob that sets acknowledged-path flush cadence.
+  Raising it produces fewer, larger commit records per hour, but a strict
+  acknowledgement waits for its own flush to land, so every millisecond
+  added to `max_flush_delay` is added to acknowledged write latency,
+  one for one. It is not a free tuning knob; see the operations guide for
+  the seal-delay trade-off this interacts with through
+  `max_flush_lifetime`.
+
 ### Pipelined flushes (ADR-0067)
 
 The PUTs no longer run inline in the actor. At flush-open the actor pins

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -273,8 +273,10 @@ What each knob actually moves there:
   trigger does.
 - `min_flush_bytes` and `max_flush_delay_idle`: unreachable whenever a
   strict-mode waiter is present, so they have no effect on the
-  acknowledged path. They set a buffered-mode tenant's PUT cadence when its
-  arrival rate is too low to reach `target_bytes`.
+  acknowledged path. On the buffered path `min_flush_bytes` is the
+  threshold that selects between the two age clocks: a buffer holding at
+  least that much takes `max_flush_delay`, and only one holding less waits
+  `max_flush_delay_idle`.
 - `max_flush_delay`: the knob that sets acknowledged-path flush cadence.
   Raising it produces fewer, larger commit records per hour at the cost of
   acknowledged write latency, since a strict acknowledgement waits for its

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -239,11 +239,15 @@ waiter and holds fewer than `min_flush_bytes`. A strict write keeps a
 condition never holds on the acknowledged path: `age_threshold_ns` returns
 `max_flush_delay` there, regardless of how many bytes are buffered.
 
-That last step assumes `adaptive_flush_delay` is off, which is the default.
-With it on, the selector returns a per-tenant threshold in
-`[max_flush_delay, ceiling]` derived from the tenant's arrival rate and the
-shard's observed PUT round trip, so `max_flush_delay` becomes the floor of a
-corridor rather than the value. Everything below describes the default.
+That last step assumes `adaptive_flush_delay` is off, which is the default,
+and it is a metrics-pipeline knob: only the metrics shard actor consults it.
+The log and span shard actors return `max_flush_delay` or
+`max_flush_delay_idle` flatly, so for those two signals the description above
+is the whole story in every configuration. On the metrics path with the knob
+on, the selector returns a per-tenant threshold in `[max_flush_delay,
+ceiling]` derived from the tenant's arrival rate and the shard's observed PUT
+round trip, so `max_flush_delay` becomes the floor of a corridor rather than
+the value. Everything below describes the default.
 
 `target_bytes` is checked separately, on the message-received branch, and
 is not gated on `waiters`: a buffer that crosses `target_bytes` before the


### PR DESCRIPTION
The ingest knob documentation supported a wrong belief: that turning
`target_bytes` down reduces commit records per hour on the acknowledged
path. It does not, and the catalog listing cost it appears to control is
not reachable that way.

Measurement across two loads spanning a 47x range in ingest rate (8,474
and 178 points per second) produced 1,413.6 and 1,435.7 commit records per
hour per shard, a 1.6% difference, with the `target_bytes` size trigger
firing zero times in either run. The mechanism is in the shard actor: a
strict write keeps a waiter on its buffer for the whole flush window, so
the age-trigger selector always returns `max_flush_delay` rather than
`max_flush_delay_idle`, and the size trigger only wins the race at a
sustained arrival rate above roughly `target_bytes / max_flush_delay`,
about 4 MiB/s at the defaults. `max_flush_delay` is the knob that sets
acknowledged-path cadence, and it costs write latency one millisecond for
one, because a strict acknowledgement waits for its own flush.

docs/ingest.md gains the mechanism and a per-knob statement of what each
one does and does not move. The operations guide gains the byte-driven
versus timer-driven distinction and the `max_flush_lifetime` trade-off:
that knob is never consulted before a flush opens, only afterwards to
bound how long an open flush may run, so lowering it to shorten the
unfolded tail also tightens the deadline on every in-flight flush, and a
byte-driven tenant with large buffers tolerates far less tightening than a
timer-driven one. Knob doc comments in the ingest config are corrected to
name the path each one governs.

No default value changes.

Fixes: #1217
Refs: #1199
