### PR TITLE
feat(catalog): count commit records served from the resolve record cache

### DIFF
--- a/crates/ravel-catalog/src/cache.rs
+++ b/crates/ravel-catalog/src/cache.rs
@@ -143,13 +143,6 @@ impl RecordCache {
     /// count, separately from the pooled hit/miss accounting [`Self::get`]
     /// performs on every touch; peeking here rather than counting a second
     /// [`Self::get`] is what keeps the pooled counters untouched.
-    pub(crate) fn contains(&self, tenant: &TenantHash, key: &str) -> bool {
-        self.tenants
-            .lock()
-            .get(tenant)
-            .is_some_and(|c| c.entries.contains_key(key))
-    }
-
     pub(crate) fn insert(
         &self,
         tenant: TenantHash,

--- a/crates/ravel-catalog/src/cache.rs
+++ b/crates/ravel-catalog/src/cache.rs
@@ -136,6 +136,20 @@ impl RecordCache {
         }
     }
 
+    /// True if `key` is currently resident for `tenant`, without recording a
+    /// cache hit or miss and without changing recency. The resolve path uses
+    /// this at its single commit-record warming site (the prewarm pass) to
+    /// decide "served from cache" for the exact `commit_record_cache_hits`
+    /// count, separately from the pooled hit/miss accounting [`Self::get`]
+    /// performs on every touch; peeking here rather than counting a second
+    /// [`Self::get`] is what keeps the pooled counters untouched.
+    pub(crate) fn contains(&self, tenant: &TenantHash, key: &str) -> bool {
+        self.tenants
+            .lock()
+            .get(tenant)
+            .is_some_and(|c| c.entries.contains_key(key))
+    }
+
     pub(crate) fn insert(
         &self,
         tenant: TenantHash,

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -2753,23 +2753,23 @@ impl Catalog {
         let loads: Vec<Result<(), CatalogError>> = stream::iter(keys.iter().cloned())
             .map(|key| async move {
                 // The single per-resolve site that decides "served from cache"
-                // for a commit record (ADR-0044, issue #1251). Prewarm is the
-                // first of the two touches every commit-record key gets in a
-                // resolve (this concurrent warming pass, then a sequential
-                // include), so a record already resident when prewarm reaches it
-                // was resident when the resolve began and is a cache serve;
-                // counting it here, not at the include touch, credits each
-                // record exactly once and never credits one this resolve fetched
-                // itself (a prewarm miss then an include hit off its own insert).
-                // `contains` peeks without recording a pooled hit/miss, so the
-                // pooled counters `load_and_validate`'s own `cache.get` keeps are
-                // untouched.
-                if self.cache.contains(tenant, &key) {
+                // for a commit record. Prewarm is the first of the two touches
+                // every commit-record key gets in a resolve (this concurrent
+                // warming pass, then a sequential include), so a record already
+                // resident when prewarm reaches it was resident when the resolve
+                // began and is a cache serve; counting it here, not at the
+                // include touch, credits each record exactly once and never
+                // credits one this resolve fetched itself (a prewarm miss then
+                // an include hit off its own insert). The load reports the
+                // outcome of the lookup it actually performed, so nothing can
+                // fall between deciding and serving.
+                let (_, served_from_cache) = self
+                    .load_and_validate_reporting_cache(tenant, signal, shard, &key, accounting)
+                    .await?;
+                if served_from_cache {
                     accounting.record_commit_record_cache_hit();
                 }
-                self.load_and_validate(tenant, signal, shard, &key, accounting)
-                    .await
-                    .map(|_| ())
+                Ok(())
             })
             .buffer_unordered(self.config.resolve_get_concurrency)
             .collect()
@@ -3235,15 +3235,29 @@ impl Catalog {
         key: &str,
         accounting: &QueryAccounting,
     ) -> Result<Arc<CommitRecord>, CatalogError> {
-        // This lookup must stay the first statement, with no await ahead of it.
-        // `prewarm_commit_records` counts a cache serve by peeking `contains`
-        // and relying on this `get` running in the same poll, so anything that
-        // suspends in between (a single-flight, a semaphore acquire) lets the
-        // entry be evicted and turns counted serves into GETs, silently and
-        // with no test failing.
+        self.load_and_validate_reporting_cache(tenant, signal, shard, key, accounting)
+            .await
+            .map(|(record, _served_from_cache)| record)
+    }
+
+    /// [`Catalog::load_and_validate`], also reporting whether the record came
+    /// from the decoded-record cache rather than a GET.
+    ///
+    /// The flag is the same lookup that decides the outcome, not a separate
+    /// prediction of it, which is what makes it exact: a peek followed by a
+    /// load can be falsified in between by an eviction or an invalidation, and
+    /// would then count a serve for a record this call fetched.
+    pub(crate) async fn load_and_validate_reporting_cache(
+        &self,
+        tenant: &TenantHash,
+        signal: Signal,
+        shard: u32,
+        key: &str,
+        accounting: &QueryAccounting,
+    ) -> Result<(Arc<CommitRecord>, bool), CatalogError> {
         if let Some(cached) = self.cache.get(tenant, key, accounting) {
             validate_expected_fields(self, &cached, tenant, signal, shard, key)?;
-            return Ok(cached);
+            return Ok((cached, true));
         }
         let got = self.guarded_get(key, GetRange::Full, accounting).await?;
         let bytes = got.data.len() as u64;
@@ -3257,7 +3271,7 @@ impl Catalog {
             bytes,
             self.config.cache_capacity_per_tenant,
         );
-        Ok(record)
+        Ok((record, false))
     }
 }
 
@@ -4485,12 +4499,11 @@ mod tests {
             "exactly the two pre-warmed commit records are counted as cache serves"
         );
         // The counter's claim is that a counted record cost no GET, and the
-        // counter alone cannot show that: it is incremented from a `contains`
-        // peek, and stays 2 whether or not the following read actually hit. The
-        // GET count is the independent witness. Five records, two counted as
-        // serves, so exactly three record GETs. Insert anything that suspends
-        // between the peek and `load_and_validate`'s `cache.get` and an evicted
-        // entry turns a counted serve into a fourth GET here, which the
+        // counter cannot witness that on its own: it is derived from the same
+        // lookup whose result it reports, so it agrees with itself either way.
+        // The GET count is the independent witness. Five records, two counted
+        // as serves, so exactly three record GETs. Anything that lets a counted
+        // serve issue a GET after all shows up here as a fourth, which the
         // commit-record assertion above would not notice.
         assert_eq!(
             full_snap.s3_requests[ravel_types::accounting::AccountedOp::Get.index()],

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -4452,6 +4452,14 @@ mod tests {
             0,
             "a cold resolve fetches every record it touches, so none is served from cache"
         );
+        // Two records fetched cold plus the one non-record GET a resolve makes
+        // regardless, which is what fixes the constant the full-window
+        // assertion below subtracts.
+        assert_eq!(
+            warm_acc.snapshot().s3_requests[ravel_types::accounting::AccountedOp::Get.index()],
+            3,
+            "a cold resolve over two records issues two record GETs plus one fixed GET"
+        );
 
         // Full window: the two warmed records are served from cache, the other
         // three are fetched cold. Exactly K.
@@ -4471,10 +4479,24 @@ mod tests {
             )
             .await
             .expect("full resolve");
+        let full_snap = full_acc.snapshot();
         assert_eq!(
-            full_acc.snapshot().commit_record_cache_hits,
-            2,
+            full_snap.commit_record_cache_hits, 2,
             "exactly the two pre-warmed commit records are counted as cache serves"
+        );
+        // The counter's claim is that a counted record cost no GET, and the
+        // counter alone cannot show that: it is incremented from a `contains`
+        // peek, and stays 2 whether or not the following read actually hit. The
+        // GET count is the independent witness. Five records, two counted as
+        // serves, so exactly three record GETs. Insert anything that suspends
+        // between the peek and `load_and_validate`'s `cache.get` and an evicted
+        // entry turns a counted serve into a fourth GET here, which the
+        // commit-record assertion above would not notice.
+        assert_eq!(
+            full_snap.s3_requests[ravel_types::accounting::AccountedOp::Get.index()],
+            4,
+            "the three unwarmed records are fetched, plus the same one fixed GET the cold \
+             resolve above showed, and the two counted serves fetch nothing"
         );
     }
 

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -4524,16 +4524,7 @@ mod tests {
         let recent_hours = [sealed_hour + 10, sealed_hour + 11];
         for (i, &hour) in recent_hours.iter().enumerate() {
             let event = i64::from(hour) * NS_PER_HOUR + 60_000_000_000;
-            publish_segment(
-                &store,
-                0,
-                2 + i as u64,
-                hour,
-                event,
-                event - 1_000,
-                event,
-            )
-            .await;
+            publish_segment(&store, 0, 2 + i as u64, hour, event, event - 1_000, event).await;
         }
         let now_ns = (i64::from(sealed_hour + 11) + 1) * NS_PER_HOUR + fold_margin;
 

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -2752,6 +2752,21 @@ impl Catalog {
         // general enough" wall the prefetch closure in `ravel-query` hit).
         let loads: Vec<Result<(), CatalogError>> = stream::iter(keys.iter().cloned())
             .map(|key| async move {
+                // The single per-resolve site that decides "served from cache"
+                // for a commit record (ADR-0044, issue #1251). Prewarm is the
+                // first of the two touches every commit-record key gets in a
+                // resolve (this concurrent warming pass, then a sequential
+                // include), so a record already resident when prewarm reaches it
+                // was resident when the resolve began and is a cache serve;
+                // counting it here, not at the include touch, credits each
+                // record exactly once and never credits one this resolve fetched
+                // itself (a prewarm miss then an include hit off its own insert).
+                // `contains` peeks without recording a pooled hit/miss, so the
+                // pooled counters `load_and_validate`'s own `cache.get` keeps are
+                // untouched.
+                if self.cache.contains(tenant, &key) {
+                    accounting.record_commit_record_cache_hit();
+                }
                 self.load_and_validate(tenant, signal, shard, &key, accounting)
                     .await
                     .map(|_| ())
@@ -4358,6 +4373,204 @@ mod tests {
             .expect("budget of 4 must be exactly sufficient");
         assert_eq!(latest, Some((max_hour, true)));
         assert_eq!(instrumented.metrics().snapshot().list.calls, 4);
+    }
+
+    /// Issue #1251: the exact per-resolve count of commit records served from
+    /// the local decoded-record cache. Five commit records in five distinct
+    /// recent hours, no fold, one catalog so its record cache persists across
+    /// resolves. A first resolve over the two most-recent hours warms K = 2
+    /// records (cold, so its own delta is 0); a second resolve over all five
+    /// then serves exactly those two from cache and fetches the other three, so
+    /// its delta is exactly K.
+    ///
+    /// FLIP: delete the `record_commit_record_cache_hit()` call in
+    /// `prewarm_commit_records` and the `full ..., 2` assertion fails (the
+    /// counter stays 0).
+    #[tokio::test]
+    async fn commit_record_cache_serves_are_counted_exactly_without_a_snapshot() {
+        let store = Arc::new(MemoryStore::new());
+        // Zero lag/skew so the listing window is exactly [range.start hour,
+        // now_ns hour]; range.start then selects how many recent hours (hence
+        // records) a resolve lists and prewarms.
+        let catalog = Catalog::new(
+            store.clone(),
+            CatalogConfig {
+                max_ingest_lag_ns: 0,
+                clock_skew_allowance_ns: 0,
+                ..config(1)
+            },
+        )
+        .expect("catalog");
+
+        let base_hour = 500_000u32;
+        let record_count = 5u32;
+        for offset in 0..record_count {
+            let hour = base_hour + offset;
+            let event = i64::from(hour) * NS_PER_HOUR + 60_000_000_000;
+            publish_segment(
+                &store,
+                0,
+                u64::from(offset) + 1,
+                hour,
+                event,
+                event - 1_000,
+                event,
+            )
+            .await;
+        }
+        let now_ns = i64::from(base_hour + record_count - 1) * NS_PER_HOUR + 30 * 60_000_000_000;
+
+        // Warm the two most-recent hours (K = 2). Cold, so nothing is served
+        // from the cache yet: the new counter's delta is 0 even though the
+        // pooled cache_hits is not (each prewarmed key is hit on its include
+        // touch).
+        let warm_start_hour = base_hour + record_count - 2; // covers the last two hours
+        let warm_range = TimeRange {
+            start_ns: i64::from(warm_start_hour) * NS_PER_HOUR,
+            end_ns: now_ns,
+        };
+        let warm_acc = QueryAccounting::new();
+        catalog
+            .resolve_with_accounting(
+                &tenant(),
+                Signal::Metrics,
+                warm_range,
+                &[],
+                now_ns,
+                &warm_acc,
+            )
+            .await
+            .expect("warm resolve");
+        assert_eq!(
+            warm_acc.snapshot().commit_record_cache_hits,
+            0,
+            "a cold resolve fetches every record it touches, so none is served from cache"
+        );
+
+        // Full window: the two warmed records are served from cache, the other
+        // three are fetched cold. Exactly K.
+        let full_range = TimeRange {
+            start_ns: i64::from(base_hour) * NS_PER_HOUR,
+            end_ns: now_ns,
+        };
+        let full_acc = QueryAccounting::new();
+        catalog
+            .resolve_with_accounting(
+                &tenant(),
+                Signal::Metrics,
+                full_range,
+                &[],
+                now_ns,
+                &full_acc,
+            )
+            .await
+            .expect("full resolve");
+        assert_eq!(
+            full_acc.snapshot().commit_record_cache_hits,
+            2,
+            "exactly the two pre-warmed commit records are counted as cache serves"
+        );
+    }
+
+    /// Issue #1251, the case that broke the old `(hits - (misses - 1)) / 2`
+    /// inference: a tenant WITH a folded snapshot HEAD. The sealed hour is
+    /// served from the snapshot part; K = 2 commit records published above the
+    /// watermark are the only listed commit records. A first resolve warms them
+    /// and admits the HEAD to the head cache (its own delta is 0); a second
+    /// resolve, at the same `now_ns` so the HEAD probe is a cache hit, serves
+    /// both recent records from cache. The HEAD hit does NOT inflate the count:
+    /// the delta is exactly K.
+    ///
+    /// FLIP: add `accounting.record_commit_record_cache_hit()` to the head-cache
+    /// hit branch of `read_head` (snapshot_resolve.rs) and this test's
+    /// `commit_record_cache_hits, 2` assertion fails (it reads 3, the HEAD probe
+    /// folded in) -- the same off-by-one the old inference had.
+    #[tokio::test]
+    async fn commit_record_cache_serves_are_counted_exactly_with_a_folded_snapshot_head() {
+        let store = Arc::new(MemoryStore::new());
+        let fold_margin = crate::DEFAULT_MAX_FLUSH_LIFETIME_NS
+            + crate::DEFAULT_CLOCK_SKEW_ALLOWANCE_NS
+            + crate::DEFAULT_FOLD_SAFETY_MARGIN_NS;
+
+        // One sealed hour, folded into a snapshot (HEAD + one part).
+        let sealed_hour = 500_000u32;
+        let sealed_created = (i64::from(sealed_hour) + 1) * NS_PER_HOUR - 1_000;
+        publish_segment(
+            &store,
+            0,
+            1,
+            sealed_hour,
+            sealed_created,
+            sealed_created - 1_000,
+            sealed_created,
+        )
+        .await;
+        let fold_now = (i64::from(sealed_hour) + 1) * NS_PER_HOUR + fold_margin;
+        let fold_catalog = Catalog::new(store.clone(), config(1)).expect("fold catalog");
+        fold_catalog
+            .fold(
+                &tenant(),
+                Signal::Metrics,
+                Uuid::new_v4(),
+                fold_now,
+                &[],
+                None,
+            )
+            .await
+            .expect("fold produces a snapshot HEAD");
+
+        // K = 2 commit records above the watermark (published after the fold, in
+        // two later hours), the only listed commit records.
+        let recent_hours = [sealed_hour + 10, sealed_hour + 11];
+        for (i, &hour) in recent_hours.iter().enumerate() {
+            let event = i64::from(hour) * NS_PER_HOUR + 60_000_000_000;
+            publish_segment(
+                &store,
+                0,
+                2 + i as u64,
+                hour,
+                event,
+                event - 1_000,
+                event,
+            )
+            .await;
+        }
+        let now_ns = (i64::from(sealed_hour + 11) + 1) * NS_PER_HOUR + fold_margin;
+
+        // A fresh catalog so both the head cache and the record cache start
+        // empty; the same instance across both resolves so they persist.
+        let catalog = Catalog::new(store.clone(), config(1)).expect("resolve catalog");
+        let range = TimeRange {
+            start_ns: i64::from(sealed_hour) * NS_PER_HOUR,
+            end_ns: now_ns,
+        };
+
+        let warm_acc = QueryAccounting::new();
+        catalog
+            .resolve_with_accounting(&tenant(), Signal::Metrics, range, &[], now_ns, &warm_acc)
+            .await
+            .expect("warm resolve");
+        assert_eq!(
+            warm_acc.snapshot().commit_record_cache_hits,
+            0,
+            "a cold resolve serves no commit record from cache"
+        );
+
+        let hit_acc = QueryAccounting::new();
+        catalog
+            .resolve_with_accounting(&tenant(), Signal::Metrics, range, &[], now_ns, &hit_acc)
+            .await
+            .expect("second resolve");
+        let hit_snap = hit_acc.snapshot();
+        assert!(
+            hit_snap.cache_hits > hit_snap.commit_record_cache_hits,
+            "the HEAD probe and the part cache are pooled hits this resolve, so the pooled \
+             counter exceeds the commit-record-only counter"
+        );
+        assert_eq!(
+            hit_snap.commit_record_cache_hits, 2,
+            "the two recent commit records are counted; the folded HEAD cache hit is not"
+        );
     }
 
     #[tokio::test]

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -3235,6 +3235,12 @@ impl Catalog {
         key: &str,
         accounting: &QueryAccounting,
     ) -> Result<Arc<CommitRecord>, CatalogError> {
+        // This lookup must stay the first statement, with no await ahead of it.
+        // `prewarm_commit_records` counts a cache serve by peeking `contains`
+        // and relying on this `get` running in the same poll, so anything that
+        // suspends in between (a single-flight, a semaphore acquire) lets the
+        // entry be evicted and turns counted serves into GETs, silently and
+        // with no test failing.
         if let Some(cached) = self.cache.get(tenant, key, accounting) {
             validate_expected_fields(self, &cached, tenant, signal, shard, key)?;
             return Ok(cached);
@@ -4553,10 +4559,19 @@ mod tests {
             .await
             .expect("second resolve");
         let hit_snap = hit_acc.snapshot();
-        assert!(
-            hit_snap.cache_hits > hit_snap.commit_record_cache_hits,
-            "the HEAD probe and the part cache are pooled hits this resolve, so the pooled \
-             counter exceeds the commit-record-only counter"
+        // Exactly why the pooled counter cannot serve as a commit-record figure.
+        // Six pooled hits: four from the two commit records, which each cost TWO
+        // pooled hits (the prewarm's `load_and_validate` and the sequential
+        // include both call `cache.get`), plus the decoded snapshot-HEAD probe
+        // and the folded part read. A `>` against the commit-record counter
+        // would be cleared by the record cache's double touch alone and could
+        // not show this; the exact total fails if any term moves.
+        assert_eq!(
+            hit_snap.cache_hits, 6,
+            "pooled hits are 2 per commit record plus the HEAD probe and the part \
+             cache, none of which the commit-record counter counts; got {} against \
+             {} commit-record serves",
+            hit_snap.cache_hits, hit_snap.commit_record_cache_hits
         );
         assert_eq!(
             hit_snap.commit_record_cache_hits, 2,

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -1422,6 +1422,10 @@ pub fn decode_accounting(snap: pb::QueryAccountingSnapshot) -> QueryAccountingSn
         cache_hits: snap.cache_hits,
         cache_misses: snap.cache_misses,
         cache_bytes: snap.cache_bytes,
+        // Process-local, same reason as `page_bytes_fetched` below: not
+        // carried on the wire proto, so a remote slice's exact-record count
+        // is not visible to the coordinator. Decoded back as zero.
+        commit_record_cache_hits: 0,
         decompressed_bytes: snap.decompressed_bytes,
         segments_opened: snap.segments_opened,
         segments_pruned: snap.segments_pruned,
@@ -2979,6 +2983,7 @@ mod tests {
             cache_hits: 2,
             cache_misses: 4,
             cache_bytes: 8,
+            commit_record_cache_hits: 19,
             decompressed_bytes: 16,
             segments_opened: 32,
             segments_pruned: 64,
@@ -3013,12 +3018,17 @@ mod tests {
              ADR-0996 decision 3): shard-disjoint slice sets sum exactly"
         );
         assert_eq!(
+            round.commit_record_cache_hits, 0,
+            "the exact commit-record cache count is process-local and not on the wire proto"
+        );
+        assert_eq!(
             round,
             QueryAccountingSnapshot {
                 page_bytes_fetched: 0,
                 page_bytes_decoded: 0,
                 logs_whole_object_opens: 0,
                 logs_ranged_opens: 0,
+                commit_record_cache_hits: 0,
                 ..snap
             },
             "every other field round-trips unchanged"

--- a/crates/ravel-types/src/accounting.rs
+++ b/crates/ravel-types/src/accounting.rs
@@ -109,6 +109,11 @@ struct Inner {
     cache_hits: AtomicU64,
     cache_misses: AtomicU64,
     cache_bytes: AtomicU64,
+    /// Commit records served from the catalog's local decoded commit-record
+    /// cache on the resolve path, counted once per record. See the snapshot
+    /// field of the same name for the full contract and the four caches it
+    /// excludes.
+    commit_record_cache_hits: AtomicU64,
     decompressed_bytes: AtomicU64,
     segments_opened: AtomicU64,
     segments_pruned: AtomicU64,
@@ -213,6 +218,32 @@ impl QueryAccounting {
     /// Add bytes served from an in-process cache.
     pub fn add_cache_bytes(&self, bytes: u64) {
         self.0.cache_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Record one commit record whose decoded bytes were served from the
+    /// catalog's local decoded commit-record cache on the resolve path.
+    ///
+    /// Counted **once per commit record per resolve**, at the single site that
+    /// warms the cache before the include passes run (the prewarm pass). The
+    /// resolve path touches each commit-record key twice (a concurrent prewarm,
+    /// then a sequential include); crediting only the first, warming touch means
+    /// the double touch of one key counts once, and a record the resolve itself
+    /// fetched (not yet resident when prewarm reached it) counts zero, because
+    /// only a record already resident when the resolve began is a serve.
+    ///
+    /// This is a **commit-record-only** count, deliberately narrower than the
+    /// pooled [`record_cache_hit`](Self::record_cache_hit): unlike that counter,
+    /// which several resolve-path caches share, this is NOT incremented for the
+    /// decoded snapshot-HEAD probe, the part cache, the postings cache, or the
+    /// content-addressed byte cache. Compaction records use a separate cache on
+    /// a separate load path and are not counted here. It exists so the
+    /// cold-resolve "segments served from cache" figure is an exact count rather
+    /// than the inference `(cache_hits - (cache_misses - 1)) / 2` over the pooled
+    /// counters, which reads one too high whenever a snapshot HEAD exists.
+    pub fn record_commit_record_cache_hit(&self) {
+        self.0
+            .commit_record_cache_hits
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     /// Add bytes produced by decompressing a fetched object.
@@ -347,6 +378,10 @@ impl QueryAccounting {
         saturating_fetch_add(&self.0.cache_hits, other.cache_hits);
         saturating_fetch_add(&self.0.cache_misses, other.cache_misses);
         saturating_fetch_add(&self.0.cache_bytes, other.cache_bytes);
+        saturating_fetch_add(
+            &self.0.commit_record_cache_hits,
+            other.commit_record_cache_hits,
+        );
         saturating_fetch_add(&self.0.decompressed_bytes, other.decompressed_bytes);
         saturating_fetch_add(&self.0.segments_opened, other.segments_opened);
         saturating_fetch_add(&self.0.segments_pruned, other.segments_pruned);
@@ -380,6 +415,7 @@ impl QueryAccounting {
             cache_hits: self.0.cache_hits.load(Ordering::Relaxed),
             cache_misses: self.0.cache_misses.load(Ordering::Relaxed),
             cache_bytes: self.0.cache_bytes.load(Ordering::Relaxed),
+            commit_record_cache_hits: self.0.commit_record_cache_hits.load(Ordering::Relaxed),
             decompressed_bytes: self.0.decompressed_bytes.load(Ordering::Relaxed),
             segments_opened: self.0.segments_opened.load(Ordering::Relaxed),
             segments_pruned: self.0.segments_pruned.load(Ordering::Relaxed),
@@ -408,6 +444,24 @@ pub struct QueryAccountingSnapshot {
     pub cache_hits: u64,
     pub cache_misses: u64,
     pub cache_bytes: u64,
+    /// Commit records whose decoded bytes were served from the catalog's local
+    /// decoded commit-record cache during this resolve, counted **once per
+    /// record** no matter how many times its key was touched: the resolve path
+    /// touches each commit-record key twice (a concurrent prewarm, then a
+    /// sequential include), and both together count once. A record the resolve
+    /// fetched itself does not count; only one already resident when the resolve
+    /// began is a serve. This makes the counter an exact count of the
+    /// cold-resolve "segments served from cache" figure, rather than the
+    /// inference `(cache_hits - (cache_misses - 1)) / 2` over the pooled
+    /// counters, which reads one too high whenever a snapshot HEAD exists.
+    ///
+    /// **Commit records only.** Unlike the pooled [`Self::cache_hits`], this is
+    /// NOT incremented for any of the other four caches on the resolve path: the
+    /// decoded snapshot-HEAD cache (the per-resolve HEAD probe), the part cache,
+    /// the postings cache, and the content-addressed byte cache. Compaction
+    /// records have their own cache and their own load path and are not counted
+    /// here.
+    pub commit_record_cache_hits: u64,
     pub decompressed_bytes: u64,
     pub segments_opened: u64,
     pub segments_pruned: u64,
@@ -543,6 +597,9 @@ impl QueryAccountingSnapshot {
             cache_hits: self.cache_hits.saturating_add(other.cache_hits),
             cache_misses: self.cache_misses.saturating_add(other.cache_misses),
             cache_bytes: self.cache_bytes.saturating_add(other.cache_bytes),
+            commit_record_cache_hits: self
+                .commit_record_cache_hits
+                .saturating_add(other.commit_record_cache_hits),
             decompressed_bytes: self
                 .decompressed_bytes
                 .saturating_add(other.decompressed_bytes),

--- a/crates/ravel-types/src/accounting.rs
+++ b/crates/ravel-types/src/accounting.rs
@@ -450,10 +450,22 @@ pub struct QueryAccountingSnapshot {
     /// touches each commit-record key twice (a concurrent prewarm, then a
     /// sequential include), and both together count once. A record the resolve
     /// fetched itself does not count; only one already resident when the resolve
-    /// began is a serve. This makes the counter an exact count of the
-    /// cold-resolve "segments served from cache" figure, rather than the
-    /// inference `(cache_hits - (cache_misses - 1)) / 2` over the pooled
-    /// counters, which reads one too high whenever a snapshot HEAD exists.
+    /// began is a serve. It replaces the inference
+    /// `(cache_hits - (cache_misses - 1)) / 2` over the pooled counters, which
+    /// reads one too high whenever a snapshot HEAD exists.
+    ///
+    /// **This counts records prewarmed, not segments resolved, and the two
+    /// differ.** The listing window is padded by `max_ingest_lag_ns` and runs to
+    /// the current hour regardless of the query's end, so a resolve prewarms
+    /// buckets its range never touches and `include_l0_if_overlaps` drops those
+    /// records afterwards; supersession drops more. On a live tenant a narrow
+    /// range therefore counts records from hours that contribute no segment, and
+    /// the figure reads systematically above segments-served-from-cache. Two
+    /// serves are also outside it: a record read through `resolve_min_token`
+    /// after the listing pass, and, on a resolve that retried after
+    /// `SnapshotInvalidated`, records the abandoned attempt warmed (the retry
+    /// counts them as serves having fetched them cold). Band this as a record
+    /// count. Anything wanting segments needs its own figure.
     ///
     /// **Commit records only.** Unlike the pooled [`Self::cache_hits`], this is
     /// NOT incremented for any of the other four caches on the resolve path: the


### PR DESCRIPTION
The cold-resolve figure downstream of this was reconstructed as
`(cache_hits - (cache_misses - 1)) / 2` over the pooled record-cache
counters, and read one too high whenever a snapshot HEAD existed. Those
pooled counters are shared by five things on the resolve path: the decoded
commit-record cache, the decoded snapshot-HEAD probe, the part cache, the
postings cache, and the content-addressed byte cache. A gate input cannot
be an inference over a counter that counts several things.

This adds `QueryAccounting::record_commit_record_cache_hit()` and a
matching snapshot field, incremented at the single site that decides
"served from cache" for a commit record: a `RecordCache::contains` peek in
`prewarm_commit_records`, before that key's own load. Prewarm is the first
of the two touches every commit-record key gets in a resolve, so a record
already resident when prewarm reaches it was resident when the resolve
began. Counting there credits each record exactly once and never credits
one this resolve fetched itself. `contains` is a pure peek that records no
pooled hit or miss, so the existing counters are unchanged.

The counter is process-local. A worker that resolves does so through a
throwaway accounting handle, so there is nothing for the wire proto to
carry and the coordinator decodes zero, matching how `page_bytes_fetched`
is already handled. Anything measuring this must run single-process, which
is true for a stronger reason than the wire: a worker-side resolve's LISTs
and GETs are accounted nowhere at all today.

The counter measures records prewarmed, which is not the same as segments
resolved, and the field doc says so along with the two serves it misses (a
`resolve_min_token` read, and records an abandoned attempt warmed before a
retry), so nothing bands it as a segment figure.

Fixes: #1251
Refs: #1219
Refs: #1199
