### PR TITLE
feat(scripts): gate wall-clock waits in injected-clock test helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,10 @@ jobs:
         run: bash scripts/guards/check-test-hygiene.test.sh
       - name: Test-hygiene guard (issue #778)
         run: scripts/guards/check-test-hygiene.sh
+      - name: Injected-clock helper guard cases (issue #1260)
+        run: bash scripts/tests/check-injected-clock-helpers.test.sh
+      - name: Injected-clock helper guard (issue #1260)
+        run: bash scripts/check-injected-clock-helpers.sh
       - name: Python script unit tests
         run: make test-python
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,6 +374,39 @@ there before changing a rule.
   merge script runs it after its rewrite; run it yourself after any
   manual amend or script-bypassing merge. A wrong identity on protected
   `main` cannot be fixed later.
+- `scripts/check-injected-clock-helpers.sh [file]`: exits non-zero when an
+  injected-clock test helper contains `thread::sleep`, `tokio::time::sleep`,
+  a bare or aliased `sleep()` call, `tokio::time::timeout`, `Instant::`,
+  `.elapsed()`, or `SystemTime`. A helper is any function in the
+  `#[cfg(test)]` module whose signature or body mentions an injected-clock
+  type (`TestClock` or `FixedClock`), plus the two helpers issue #1260 names
+  by name so a rename of a clock type cannot silently empty the scan. It is
+  bypassable per line with a trailing `// allow-wall-clock: <reason>`
+  comment; the reason is required (an empty reason does not suppress), and
+  the marker is matched on the string-stripped line so a string literal
+  containing the marker text cannot suppress a real finding. Wired into
+  `gates.sh` and into `.github/workflows/ci.yml` (its own cases run first,
+  so a suite broken into always-passing fails CI rather than going quiet).
+  Run it after touching that helper region: a wall-clock wait smuggled back
+  into a clock-driven test reads as a real defect on a loaded machine, then
+  as flakiness on a quiet one, and both readings cost a full gate rerun
+  before anyone thinks to look at the test's own timing model. An injected
+  clock's own `sleep`/`elapsed` is exempt (a receiver chain naming a clock
+  type, or an identifier containing "clock"); any other receiver still
+  reports. A scan that finds zero helpers is itself a failure, and so is a
+  scan of the default target that finds fewer than 20 (a clock-type rename
+  would otherwise empty the scan silently, and dropping one clock type from
+  the predicate would silently narrow it from 26 helpers to 5).
+  Scope: the default target is the single file
+  `services/ravel-cli/src/load.rs`; the rule is NOT yet enforced
+  workspace-wide. Pointing it at every other `.rs` that mentions an
+  injected-clock type surfaces 9 findings across 5 files (in ravel-cache,
+  ravel-maintain, and ravel-server; a mix of idle-eviction sleeps that poll
+  a clock-controlled state and `tokio::time::timeout` deadlock guards that
+  would each need a real allow-wall-clock reason), and it finds no helper at
+  all in 78 more clock-mentioning files, 70 of them integration tests: 60
+  under `crates/*/tests/` and 10 under `services/*/tests/`. Issue #1278 is
+  the follow-up that widens the scan and resolves those.
 
 ### Writing gate and poll shell
 

--- a/scripts/check-injected-clock-helpers.sh
+++ b/scripts/check-injected-clock-helpers.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# Injected-clock test-helper guard (issue #1260, follow-up from #1235).
+#
+# "No wall-clock wait in an injected-clock test helper" cost two gate reruns
+# (the flaky pair test, then its rewrite under #1235). That rule is now a
+# check, not a paragraph: this scans every injected-clock test helper in
+# services/ravel-cli/src/load.rs for thread::sleep, tokio::time::sleep,
+# a bare/aliased sleep() call, tokio::time::timeout, Instant::, .elapsed()
+# and SystemTime, and fails on a hit.
+#
+# Scan span and predicate. The whole `#[cfg(test)]` module (from the first
+# `#[cfg(test)]` line to end of file) is the scan region, not a hand-picked
+# set of helper spans. Inside it, a function item is scanned when its
+# signature or body mentions one of the injected-clock types named once in
+# CLOCK_TYPES below (TestClock, FixedClock), plus the two helpers issue #1260
+# names by name (load_two_writes_across_one_clock_advance,
+# load_with_released_tail) so a rename of a clock type cannot silently empty
+# the scan. A scan that finds zero helpers is itself a failure -- see below.
+#
+# Not covered, on purpose: a helper that delegates its wait to another
+# function which never names a clock type. The scan keys on the clock type
+# appearing in the function that also holds the wall-clock construct; a wait
+# hidden one call deep in a clock-free helper is out of scope. Widening to it
+# would need a call graph, which this source-only scan does not build.
+#
+# Injected-clock receivers are not wall-clock waits. `clock.sleep(..).await`
+# and `clock.elapsed()` are the idiom this guard exists to encourage, so a
+# `.sleep(` / `.elapsed(` call is masked when its receiver chain names an
+# injected clock. The test is name-based, since a source-only scan has no
+# types: the chain has to mention one of CLOCK_TYPES or an identifier
+# containing "clock" in either case. Any other receiver (`start.elapsed()`,
+# `timer.sleep(..)`) still reports.
+#
+# Allowlist: a single trailing comment marker on the offending line,
+# `// allow-wall-clock: <reason>`, with a non-empty reason and nothing else
+# (no env var, no exempt file). The marker is matched on the string-stripped
+# line, so a string literal that merely contains the marker text cannot
+# suppress a real finding.
+#
+# Helper-count floor on the default target. The zero-helpers guard below
+# catches a predicate that finds nothing at all, but not one that narrows: as
+# shipped the real file scans 26 helpers, and dropping FixedClock from
+# CLOCK_TYPES takes that to 5 (dropping both clock types, to 2) while still
+# exiting 0. So a scan of the default target that finds fewer than
+# DEFAULT_TARGET_MIN_HELPERS helpers fails. It is a floor rather than an exact
+# count on purpose: a new injected-clock helper in load.rs must never fail the
+# gate, only a predicate that stops seeing the ones already there.
+#
+# Scope note. This guard scans one file, services/ravel-cli/src/load.rs. It is
+# not yet enforced workspace-wide: other crates hold injected-clock tests it
+# does not read (see CLAUDE.md for the measured out-of-scope counts).
+#
+# Usage:
+#   scripts/check-injected-clock-helpers.sh [file]
+#     file defaults to services/ravel-cli/src/load.rs (relative to the repo
+#     root). Tests pass a throwaway fixture path here instead.
+#
+# Exit 0 clean, 1 on a wall-clock hit, on a zero-helpers scan, or on a
+# default-target scan under the helper-count floor, 64 on bad usage, 70 if the
+# scan itself could not run (unreadable file).
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+case "${1:-}" in
+  -h | --help)
+    sed -n '2,60p' "$0"
+    exit 0
+    ;;
+esac
+
+if [[ $# -gt 1 ]]; then
+  echo "check-injected-clock-helpers.sh: unexpected extra argument: $2" >&2
+  exit 64
+fi
+
+default_target="${repo_root}/services/ravel-cli/src/load.rs"
+target="${1:-${default_target}}"
+
+if [[ ! -f "${target}" ]]; then
+  echo "check-injected-clock-helpers.sh: no such file: ${target}" >&2
+  exit 64
+fi
+
+# The helper-count floor applies to the default target only (see the header):
+# a fixture legitimately holds a handful of helpers. `-ef` compares the files
+# themselves, so a relative path or a symlink to load.rs is still the default
+# target.
+is_default=0
+if [[ "${target}" -ef "${default_target}" ]]; then
+  is_default=1
+fi
+DEFAULT_TARGET_MIN_HELPERS=20
+
+# --- the scan ---------------------------------------------------------------
+#
+# Single-file scan, so no per-file state reset is needed (unlike
+# check-test-hygiene.sh, which processes many files through one awk pass).
+#
+# strip_both computes two views of each line in one walk that carries string
+# and block-comment state across lines:
+#   clean[] -- comment AND string/char-literal content removed. Used for the
+#     `fn` keyword, the clock-type mention, and the wall-clock symbols, so
+#     none of them ever match inside a comment or a string.
+#   nostr[] -- string/char-literal content removed but comments KEPT. Used
+#     only for the allow-wall-clock marker, which is itself a trailing
+#     comment: clean[] would erase it, and the raw line would let a string
+#     literal containing the marker text suppress a real finding.
+#
+# A function's body span is found by paren/brace counting on the clean text,
+# starting from column 1 of its `fn` line: any parens in a `pub(crate)`
+# prefix close before `fn` is reached, so paren depth is already back at 0 by
+# the time the real argument list opens, and the first top-level `{` after
+# that is unambiguously the body open. This needs no argument-list special
+# case and no generic-bracket tracking, because Rust never leaves a `(` open
+# across the function signature into the body.
+awk_prog='
+function charlit_len(s, i,   c2, c, j) {
+  c2 = substr(s, i + 1, 1)
+  if (c2 == "\\") {
+    j = i + 2
+    c = substr(s, j, 1)
+    if (c == "x") j = j + 3
+    else if (c == "u") {
+      j = j + 1
+      while (j <= length(s) && substr(s, j, 1) != "}") j++
+      j++
+    } else j = j + 1
+    if (substr(s, j, 1) == SQ) return j - i + 1
+    return 0
+  }
+  if (substr(s, i + 2, 1) == SQ) return 3
+  return 0
+}
+# Walk s once, setting globals CLEAN (code only) and NOSTR (code + comments,
+# strings blanked). String/block-comment state (bdepth, sstate, sesc,
+# shashes) is global on purpose so a multi-line string or block comment is
+# tracked across successive calls.
+function strip_both(s,   i, n, c, j, k, hashes, hs, cl) {
+  CLEAN = ""; NOSTR = ""; n = length(s); i = 1
+  while (i <= n) {
+    c = substr(s, i, 1)
+    if (bdepth > 0) {
+      if (c == "/" && substr(s, i + 1, 1) == "*") { bdepth++; NOSTR = NOSTR "/*"; i += 2; continue }
+      if (c == "*" && substr(s, i + 1, 1) == "/") { bdepth--; NOSTR = NOSTR "*/"; i += 2; continue }
+      NOSTR = NOSTR c; i++; continue
+    }
+    if (sstate == 1) {
+      if (sesc) { sesc = 0; i++; continue }
+      if (c == "\\") { sesc = 1; i++; continue }
+      if (c == "\"") sstate = 0
+      i++; continue
+    }
+    if (sstate == 2) {
+      if (c == "\"") {
+        hs = ""
+        for (j = 0; j < shashes; j++) hs = hs "#"
+        if (shashes == 0 || substr(s, i + 1, shashes) == hs) {
+          sstate = 0; i += 1 + shashes; continue
+        }
+      }
+      i++; continue
+    }
+    if (c == "/" && substr(s, i + 1, 1) == "*") { bdepth = 1; NOSTR = NOSTR "/*"; i += 2; continue }
+    if (c == "/" && substr(s, i + 1, 1) == "/") { NOSTR = NOSTR substr(s, i); break }
+    if (c == SQ) {
+      cl = charlit_len(s, i)
+      if (cl > 0) { i += cl; continue }
+      CLEAN = CLEAN c; NOSTR = NOSTR c; i++; continue
+    }
+    if (c == "r" || (c == "b" && substr(s, i + 1, 1) == "r")) {
+      j = i
+      if (c == "b") j++
+      k = j + 1
+      hashes = 0
+      while (substr(s, k, 1) == "#") { hashes++; k++ }
+      if (substr(s, k, 1) == "\"") {
+        sstate = 2; shashes = hashes; i = k + 1; continue
+      }
+    }
+    if (c == "\"") { sstate = 1; i++; continue }
+    CLEAN = CLEAN c; NOSTR = NOSTR c; i++
+  }
+}
+# Returns the function name if `line` (already comment/string-stripped) is
+# the start of a `fn` item -- optionally preceded by pub()/async/unsafe/
+# const/extern modifiers -- or "" otherwise.
+function fn_candidate(line,   t, i, n, c) {
+  t = line
+  sub(/^[ \t]+/, "", t)
+  while (1) {
+    if (t ~ /^pub\(crate\)[ \t]+/)  { sub(/^pub\(crate\)[ \t]+/, "", t); continue }
+    if (t ~ /^pub\(super\)[ \t]+/)  { sub(/^pub\(super\)[ \t]+/, "", t); continue }
+    if (t ~ /^pub\(self\)[ \t]+/)   { sub(/^pub\(self\)[ \t]+/, "", t); continue }
+    if (t ~ /^pub[ \t]+/)           { sub(/^pub[ \t]+/, "", t); continue }
+    if (t ~ /^async[ \t]+/)         { sub(/^async[ \t]+/, "", t); continue }
+    if (t ~ /^unsafe[ \t]+/)        { sub(/^unsafe[ \t]+/, "", t); continue }
+    if (t ~ /^const[ \t]+/)         { sub(/^const[ \t]+/, "", t); continue }
+    if (t ~ /^extern[ \t]+"[A-Za-z]+"[ \t]+/) {
+      sub(/^extern[ \t]+"[A-Za-z]+"[ \t]+/, "", t); continue
+    }
+    break
+  }
+  if (t !~ /^fn[ \t]+[A-Za-z_][A-Za-z0-9_]*/) return ""
+  sub(/^fn[ \t]+/, "", t)
+  n = length(t); i = 1
+  while (i <= n) {
+    c = substr(t, i, 1)
+    if (c !~ /[A-Za-z0-9_]/) break
+    i++
+  }
+  return substr(t, 1, i - 1)
+}
+# True when a receiver chain names an injected clock: it mentions one of
+# CLOCK_TYPES, or an identifier containing "clock" in either case. Name-based
+# because this scan has no types; see the header.
+function is_clock_receiver(chain,   ci) {
+  if (tolower(chain) ~ /clock/) return 1
+  for (ci = 1; ci <= nct; ci++) {
+    if (index(chain, clock_types[ci]) > 0) return 1
+  }
+  return 0
+}
+# Rewrite `<recv>.sleep(` / `<recv>.elapsed(` to an inert method name when
+# <recv> is an injected clock, so awaiting the clock this guard exists to
+# encourage is not itself reported as a wall-clock wait. Only the two
+# receiver-form patterns can be masked: `thread::sleep`, `tokio::time::sleep`,
+# `tokio::time::timeout`, `Instant::` and `SystemTime` carry no leading dot,
+# and masking is per call, so a real finding elsewhere on the line still
+# reports.
+function mask_clock_calls(s,   out, rest, pos, len, base, chain) {
+  out = ""
+  rest = s
+  while (1) {
+    pos = match(rest, /\.(sleep|elapsed)[ \t]*\(/)
+    if (pos == 0) return out rest
+    len = RLENGTH
+    base = substr(rest, 1, pos - 1)
+    chain = base
+    sub(/^.*[^A-Za-z0-9_:.()&*]/, "", chain)
+    if (is_clock_receiver(chain)) out = out base ".injected_clock_call("
+    else out = out base substr(rest, pos, len)
+    rest = substr(rest, pos + len)
+  }
+}
+BEGIN { SQ = sprintf("%c", 39) }
+{
+  nlines++
+  strip_both($0)
+  raw[nlines] = $0
+  clean[nlines] = CLEAN
+  nostr[nlines] = NOSTR
+  if (cfg_test_line == 0 && $0 ~ /#\[cfg\(test\)\]/) cfg_test_line = nlines
+}
+END {
+  if (nlines == 0) {
+    print "check-injected-clock-helpers.sh: " FILENAME " is empty" > "/dev/stderr"
+    exit 70
+  }
+  scan_start = (cfg_test_line > 0) ? cfg_test_line : nlines + 1
+
+  NAMED_1 = "load_two_writes_across_one_clock_advance"
+  NAMED_2 = "load_with_released_tail"
+
+  # The injected-clock types, named once. A function that mentions any of
+  # these (or is one of the two named helpers) is scanned.
+  nct = 0
+  clock_types[++nct] = "TestClock"
+  clock_types[++nct] = "FixedClock"
+
+  # Wall-clock constructs, matched as regexes on the clean line. First match
+  # per line wins, so the qualified sleep names report before the bare
+  # sleep() pattern (which exists to catch an aliased `use ...::sleep`).
+  np = 0
+  pname[++np] = "thread::sleep";        pre[np] = "thread::sleep"
+  pname[++np] = "tokio::time::sleep";   pre[np] = "tokio::time::sleep"
+  pname[++np] = "tokio::time::timeout"; pre[np] = "tokio::time::timeout"
+  pname[++np] = "Instant::";            pre[np] = "Instant::"
+  pname[++np] = "SystemTime";           pre[np] = "SystemTime"
+  pname[++np] = ".elapsed()";           pre[np] = "\\.elapsed\\(\\)"
+  pname[++np] = "sleep()";              pre[np] = "(^|[^A-Za-z0-9_:])sleep[ \t]*\\("
+
+  helper_count = 0
+  finding_count = 0
+
+  i = scan_start
+  while (i <= nlines) {
+    name = fn_candidate(clean[i])
+    if (name == "") { i++; continue }
+
+    # Find the body-opening brace: scan from column 1 of the fn line,
+    # tracking paren depth, for the first "{" at depth 0. A ";" at depth 0
+    # first means a body-less signature (a trait method) -- skip it.
+    pd = 0; l = i; c = 1
+    found_open = 0; no_body = 0
+    body_line = 0; body_col = 0
+    while (l <= nlines && !found_open && !no_body) {
+      s = clean[l]; n = length(s)
+      while (c <= n) {
+        ch = substr(s, c, 1)
+        if (ch == "(") pd++
+        else if (ch == ")") pd--
+        else if (ch == "{" && pd == 0) { body_line = l; body_col = c; found_open = 1; break }
+        else if (ch == ";" && pd == 0) { no_body = 1; break }
+        c++
+      }
+      if (!found_open && !no_body) { l++; c = 1 }
+    }
+    if (no_body || !found_open) { i++; continue }
+
+    bd = 1; l2 = body_line; c2 = body_col + 1; end_line = 0
+    while (l2 <= nlines && bd > 0) {
+      s = clean[l2]; n = length(s)
+      while (c2 <= n) {
+        ch = substr(s, c2, 1)
+        if (ch == "{") bd++
+        else if (ch == "}") { bd--; if (bd == 0) break }
+        c2++
+      }
+      if (bd == 0) { end_line = l2; break }
+      l2++; c2 = 1
+    }
+    if (end_line == 0) { i++; continue }
+
+    mentions = 0
+    for (k = i; k <= end_line && !mentions; k++) {
+      for (ci = 1; ci <= nct; ci++) {
+        if (index(clean[k], clock_types[ci]) > 0) { mentions = 1; break }
+      }
+    }
+    is_named = (name == NAMED_1 || name == NAMED_2)
+
+    if (mentions || is_named) {
+      helper_count++
+      for (k = i; k <= end_line; k++) {
+        masked = mask_clock_calls(clean[k])
+        sym = ""
+        for (pi = 1; pi <= np; pi++) {
+          if (masked ~ pre[pi]) { sym = pname[pi]; break }
+        }
+        if (sym == "") continue
+        # allow-wall-clock marker, matched on the string-stripped line and
+        # requiring a non-empty reason.
+        if (nostr[k] ~ /\/\/ allow-wall-clock:[ \t]*[^ \t]/) continue
+        finding_count++
+        printf "%s:%d: %s in %s\n", FILENAME, k, sym, name
+      }
+    }
+
+    i = end_line + 1
+  }
+
+  if (finding_count > 0) {
+    printf "check-injected-clock-helpers.sh: %d finding(s) across %d scanned helper(s)\n", \
+      finding_count, helper_count > "/dev/stderr"
+    exit 1
+  }
+  if (helper_count == 0) {
+    printf "check-injected-clock-helpers.sh: 0 injected-clock helpers scanned in %s -- " \
+      "a clock type renamed, or the named helpers (%s / %s) removed?\n", \
+      FILENAME, NAMED_1, NAMED_2 > "/dev/stderr"
+    exit 1
+  }
+  if (is_default && helper_count < min_helpers) {
+    printf "check-injected-clock-helpers.sh: only %d injected-clock helper(s) scanned in %s, " \
+      "under the floor of %d -- did the helper predicate narrow (a clock type dropped from " \
+      "CLOCK_TYPES)?\n", helper_count, FILENAME, min_helpers > "/dev/stderr"
+    exit 1
+  }
+  printf "check-injected-clock-helpers.sh: clean (%d helper(s) scanned)\n", helper_count
+  exit 0
+}
+'
+
+scan_status=0
+awk -v is_default="${is_default}" -v min_helpers="${DEFAULT_TARGET_MIN_HELPERS}" \
+  "${awk_prog}" "${target}" || scan_status=$?
+if [[ ${scan_status} -gt 1 ]]; then
+  echo "check-injected-clock-helpers.sh: the scan failed (awk exit ${scan_status})" >&2
+  exit 70
+fi
+exit "${scan_status}"

--- a/scripts/check-injected-clock-helpers.sh
+++ b/scripts/check-injected-clock-helpers.sh
@@ -250,7 +250,10 @@ BEGIN { SQ = sprintf("%c", 39) }
   raw[nlines] = $0
   clean[nlines] = CLEAN
   nostr[nlines] = NOSTR
-  if (cfg_test_line == 0 && $0 ~ /#\[cfg\(test\)\]/) cfg_test_line = nlines
+  # Anchored on the stripped line like every other predicate here: a doc
+  # comment or string literal mentioning the attribute would otherwise start
+  # the scan above the real test module and pull production functions in.
+  if (cfg_test_line == 0 && CLEAN ~ /#\[cfg\(test\)\]/) cfg_test_line = nlines
 }
 END {
   if (nlines == 0) {

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -62,6 +62,13 @@ cargo --locked fmt --all --check
 echo "==> scripts/guards/check-test-hygiene.sh"
 "$(dirname "$0")/guards/check-test-hygiene.sh"
 
+# "No wall-clock wait in an injected-clock test helper" cost two gate reruns
+# (issue #1260: the flaky pair test, then its rewrite under #1235). Another
+# check rather than another paragraph, same reasoning as the hygiene guard
+# above: a source scan, no build, ahead of the expensive lanes.
+echo "==> scripts/check-injected-clock-helpers.sh"
+"$(dirname "$0")/check-injected-clock-helpers.sh"
+
 # Match CI's `check` job: it runs `cargo nextest run --workspace
 # --cargo-profile ci`. Use nextest when it is installed so a local run
 # warms the same `ci`-profile artifacts CI reuses; fall back to `cargo

--- a/scripts/tests/check-injected-clock-helpers.test.sh
+++ b/scripts/tests/check-injected-clock-helpers.test.sh
@@ -1,0 +1,514 @@
+#!/usr/bin/env bash
+# Coverage for check-injected-clock-helpers.sh (issue #1260): the scan must
+# find the injected-clock test helpers by structure (any fn item in the
+# #[cfg(test)] module whose body or signature mentions an injected-clock type
+# -- TestClock or FixedClock -- plus the two named helpers) rather than by a
+# hand-maintained line list, flag the wall-clock constructs only inside that
+# scanned region, honor the single-line allow-wall-clock marker only when it
+# carries a non-empty reason and is not merely inside a string literal, and
+# fail outright -- not pass silently -- when the scan finds no helpers at all
+# or fewer of them than the real default target holds.
+#
+# Every one of the gate's seven wall-clock patterns has at least one case
+# here, so deleting any single pattern line from the gate fails this suite:
+# thread::sleep, tokio::time::sleep, tokio::time::timeout, Instant::,
+# SystemTime, .elapsed() and a bare/aliased sleep() call. The two
+# receiver-form patterns also have to exempt an injected clock's own
+# sleep/elapsed while still flagging any other receiver.
+#
+# Portability: fixtures are written whole with heredocs, never mutated with
+# `sed -i` (whose backup-extension argument differs between GNU and BSD sed),
+# so this suite runs unchanged on Linux and macOS.
+#
+# Stub-resistance: every case asserts the gate's exact exit code AND either
+# the exact finding text (file:line: symbol in helper, with the line derived
+# from the fixture so a wrong line fails) or the exact clean-line helper
+# count. A gate that only echoes a clean line and exits 0 fails nearly every
+# case. Prove it: `CHECK_OVERRIDE=/path/to/stub bash <this-file>`.
+#
+# Run: bash scripts/tests/check-injected-clock-helpers.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CHECK="${CHECK_OVERRIDE:-${SCRIPT_DIR}/check-injected-clock-helpers.sh}"
+
+tmproot="$(mktemp -d "${TMPDIR:-/tmp}/check-injected-clock-helpers-test.XXXXXX")"
+if [[ ! -d "${tmproot}" ]]; then
+  echo "FAIL  could not create a temp dir for the fixtures" >&2
+  exit 1
+fi
+# Physical path, so the paths this test compares against equal the ones the
+# script's own printf %s reports (a symlinked $TMPDIR would otherwise mismatch).
+tmproot="$(cd "${tmproot}" && pwd -P)"
+trap 'rm -rf "${tmproot}"' EXIT
+
+pass=0
+fail=0
+
+check_eq() {
+  local label="$1" want="$2" got="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    pass=$((pass + 1))
+    printf 'ok    %s\n' "${label}"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL  %s\n  want: %s\n  got:  %s\n' "${label}" "${want}" "${got}"
+  fi
+}
+
+# Assert that ${haystack} contains the exact fixed line ${needle}.
+check_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if printf '%s\n' "${haystack}" | grep -qF -- "${needle}"; then
+    pass=$((pass + 1))
+    printf 'ok    %s\n' "${label}"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL  %s\n  expected to contain: %s\n  in:                  %s\n' \
+      "${label}" "${needle}" "${haystack}"
+  fi
+}
+
+# Assert that ${haystack} does NOT contain the fixed substring ${needle}.
+check_absent() {
+  local label="$1" haystack="$2" needle="$3"
+  if printf '%s\n' "${haystack}" | grep -qF -- "${needle}"; then
+    fail=$((fail + 1))
+    printf 'FAIL  %s\n  did not expect: %s\n  in:             %s\n' \
+      "${label}" "${needle}" "${haystack}"
+  else
+    pass=$((pass + 1))
+    printf 'ok    %s\n' "${label}"
+  fi
+}
+
+# Assert that ${got} is an integer at or above ${floor}.
+check_ge() {
+  local label="$1" floor="$2" got="$3"
+  if [[ "${got}" =~ ^[0-9]+$ ]] && ((got >= floor)); then
+    pass=$((pass + 1))
+    printf 'ok    %s (%s >= %s)\n' "${label}" "${got}" "${floor}"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL  %s\n  want: an integer >= %s\n  got:  %s\n' "${label}" "${floor}" "${got}"
+  fi
+}
+
+# The 1-indexed line number of the first line matching a fixed pattern.
+line_of() {
+  grep -nF -- "$2" "$1" | head -1 | cut -d: -f1
+}
+
+# The scanned-helper count out of a clean run's report line, or "" if the run
+# did not print one. Parsed from an already-captured string, so no pipeline
+# ever masks the gate's own exit code.
+helper_count_of() {
+  printf '%s\n' "$1" | sed -n 's/^.*clean (\([0-9]\{1,\}\) helper(s) scanned)$/\1/p'
+}
+
+# === (a) a clean fixture passes with the exact helper count ================
+# Three scanned helpers: one keyed on TestClock, one on FixedClock, one via
+# the named-helper fallback with no clock mention. `some_other_test` mentions
+# no clock and is not named, so it is not scanned.
+clean="${tmproot}/clean.rs"
+cat >"${clean}" <<'RS'
+pub struct Thing;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestClock {
+        now_ns: i64,
+    }
+    struct FixedClock(i64);
+
+    async fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+        tokio::task::yield_now().await;
+    }
+
+    async fn helper_on_fixedclock() {
+        let _c = FixedClock(0);
+    }
+
+    async fn load_with_released_tail() -> usize {
+        0
+    }
+
+    #[test]
+    fn some_other_test() {
+        assert_eq!(1 + 1, 2);
+    }
+}
+RS
+
+out="$(bash "${CHECK}" "${clean}" 2>&1)"
+rc=$?
+check_eq "clean fixture exits 0" "0" "${rc}"
+check_eq "clean fixture reports the exact scanned-helper count" \
+  "check-injected-clock-helpers.sh: clean (3 helper(s) scanned)" "${out}"
+
+# === (b) a tokio::time::sleep inside a TestClock helper fails, naming the
+#     file, line and symbol ==================================================
+sleeping="${tmproot}/sleeping.rs"
+cat >"${sleeping}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    async fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+}
+RS
+ln="$(line_of "${sleeping}" 'tokio::time::sleep(std::time::Duration')"
+out="$(bash "${CHECK}" "${sleeping}" 2>&1)"
+rc=$?
+check_eq "a sleep in a TestClock helper exits 1" "1" "${rc}"
+check_contains "the finding names file:line: symbol in helper" "${out}" \
+  "${sleeping}:${ln}: tokio::time::sleep in helper_on_testclock"
+
+# === (c) a FixedClock helper's sleep is flagged too (proves the predicate
+#     covers FixedClock, not just TestClock) =================================
+fixedsleep="${tmproot}/fixedsleep.rs"
+cat >"${fixedsleep}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct FixedClock(i64);
+
+    async fn waits_under_a_fixed_clock() {
+        let _c = FixedClock(0);
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    }
+}
+RS
+ln="$(line_of "${fixedsleep}" 'tokio::time::sleep(std::time::Duration')"
+out="$(bash "${CHECK}" "${fixedsleep}" 2>&1)"
+rc=$?
+check_eq "a sleep in a FixedClock helper exits 1" "1" "${rc}"
+check_contains "the FixedClock finding names file:line: symbol in helper" "${out}" \
+  "${fixedsleep}:${ln}: tokio::time::sleep in waits_under_a_fixed_clock"
+
+# === (d) the same line with a trailing allow-wall-clock marker and a reason
+#     passes =================================================================
+allowed="${tmproot}/allowed.rs"
+cat >"${allowed}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    async fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await; // allow-wall-clock: fixture reason
+    }
+}
+RS
+out="$(bash "${CHECK}" "${allowed}" 2>&1)"
+rc=$?
+check_eq "an allow-wall-clock marker with a reason suppresses the finding" "0" "${rc}"
+check_eq "the allowlisted fixture still reports 1 scanned helper" \
+  "check-injected-clock-helpers.sh: clean (1 helper(s) scanned)" "${out}"
+
+# === (e) an allow-wall-clock marker with an EMPTY reason does NOT suppress ==
+emptyreason="${tmproot}/emptyreason.rs"
+cat >"${emptyreason}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    async fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await; // allow-wall-clock:
+    }
+}
+RS
+ln="$(line_of "${emptyreason}" 'tokio::time::sleep(std::time::Duration')"
+out="$(bash "${CHECK}" "${emptyreason}" 2>&1)"
+rc=$?
+check_eq "an empty-reason marker still exits 1" "1" "${rc}"
+check_contains "the empty-reason finding is still reported" "${out}" \
+  "${emptyreason}:${ln}: tokio::time::sleep in helper_on_testclock"
+
+# === (f) a string literal that merely contains the marker text does NOT
+#     suppress a real finding on the same line ===============================
+stringmarker="${tmproot}/stringmarker.rs"
+cat >"${stringmarker}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    async fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+        let _n = "// allow-wall-clock: not a real marker"; tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+}
+RS
+ln="$(line_of "${stringmarker}" 'not a real marker')"
+out="$(bash "${CHECK}" "${stringmarker}" 2>&1)"
+rc=$?
+check_eq "a marker inside a string literal does not suppress" "1" "${rc}"
+check_contains "the string-literal case still reports the finding" "${out}" \
+  "${stringmarker}:${ln}: tokio::time::sleep in helper_on_testclock"
+
+# === (g) an aliased `use ...::sleep;` followed by a bare sleep() call is
+#     caught as sleep() =======================================================
+aliased="${tmproot}/aliased.rs"
+cat >"${aliased}" <<'RS'
+#[cfg(test)]
+mod tests {
+    use std::thread::sleep;
+    struct TestClock;
+
+    fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+        sleep(std::time::Duration::from_millis(1));
+    }
+}
+RS
+ln="$(line_of "${aliased}" 'sleep(std::time::Duration::from_millis(1));')"
+out="$(bash "${CHECK}" "${aliased}" 2>&1)"
+rc=$?
+check_eq "an aliased bare sleep() call exits 1" "1" "${rc}"
+check_contains "the aliased call is reported as sleep()" "${out}" \
+  "${aliased}:${ln}: sleep() in helper_on_testclock"
+
+# === (h) a `.elapsed()` with no Instant:: on the line is caught ============
+elapsed="${tmproot}/elapsed.rs"
+cat >"${elapsed}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    fn helper_on_testclock(clock: &TestClock, start: std::time::Instant) {
+        let _ = clock;
+        let _d = start.elapsed();
+    }
+}
+RS
+ln="$(line_of "${elapsed}" 'let _d = start.elapsed();')"
+out="$(bash "${CHECK}" "${elapsed}" 2>&1)"
+rc=$?
+check_eq "a bare .elapsed() exits 1" "1" "${rc}"
+check_contains "the .elapsed() call is reported" "${out}" \
+  "${elapsed}:${ln}: .elapsed() in helper_on_testclock"
+
+# === (i) a wall-clock call OUTSIDE any injected-clock helper passes: the
+#     check is scoped to clock helpers, not a file-wide grep =================
+outside="${tmproot}/outside.rs"
+cat >"${outside}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    async fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+    }
+
+    #[test]
+    fn some_other_test() {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        assert_eq!(1 + 1, 2);
+    }
+}
+RS
+out="$(bash "${CHECK}" "${outside}" 2>&1)"
+rc=$?
+check_eq "a wall-clock call outside any clock helper exits 0" "0" "${rc}"
+check_eq "the out-of-scope fixture reports only the 1 clock helper" \
+  "check-injected-clock-helpers.sh: clean (1 helper(s) scanned)" "${out}"
+check_absent "no finding is emitted for the out-of-scope sleep" "${out}" \
+  "some_other_test"
+
+# === (j) a fixture whose helpers no longer mention any clock type fails with
+#     the zero-helpers error, not a silent pass ==============================
+renamed="${tmproot}/renamed.rs"
+cat >"${renamed}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct WallClock;
+
+    fn totally_renamed_helper(clock: &WallClock) {
+        let _ = clock;
+    }
+}
+RS
+out="$(bash "${CHECK}" "${renamed}" 2>&1)"
+rc=$?
+check_eq "a fixture with no clock mention and no named helper exits 1" "1" "${rc}"
+check_contains "the zero-helpers error names the file" "${out}" \
+  "0 injected-clock helpers scanned in ${renamed}"
+
+# === (k) self-check: a fixture with a known helper set reports the exact
+#     count and names, so a gate that silently scans nothing (or a stub with
+#     a hardcoded count) fails ===============================================
+knownset="${tmproot}/knownset.rs"
+cat >"${knownset}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+    struct FixedClock(i64);
+
+    fn a_testclock_helper(c: &TestClock) { let _ = c; }
+    fn a_fixedclock_helper() { let _c = FixedClock(0); }
+    fn load_two_writes_across_one_clock_advance() {}
+    fn load_with_released_tail() {}
+    fn a_plain_test() { assert!(true); }
+}
+RS
+out="$(bash "${CHECK}" "${knownset}" 2>&1)"
+rc=$?
+# Four scanned: two clock-keyed, two named-fallback. a_plain_test is neither.
+check_eq "the known-set fixture exits 0" "0" "${rc}"
+check_eq "the known-set fixture reports exactly 4 scanned helpers" \
+  "check-injected-clock-helpers.sh: clean (4 helper(s) scanned)" "${out}"
+
+# === (l) thread::sleep is flagged =========================================
+# One case per remaining wall-clock pattern, so deleting any single pattern
+# line from the gate fails at least one case here. Before these, only
+# tokio::time::sleep and the two receiver-form patterns were covered, and four
+# of the five symbols issue #1260 names by name could be deleted outright with
+# the suite still green.
+threadsleep="${tmproot}/threadsleep.rs"
+cat >"${threadsleep}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+}
+RS
+ln="$(line_of "${threadsleep}" 'std::thread::sleep(std::time::Duration')"
+out="$(bash "${CHECK}" "${threadsleep}" 2>&1)"
+rc=$?
+check_eq "a thread::sleep in a clock helper exits 1" "1" "${rc}"
+check_contains "the thread::sleep finding names file:line: symbol in helper" "${out}" \
+  "${threadsleep}:${ln}: thread::sleep in helper_on_testclock"
+
+# === (m) tokio::time::timeout is flagged ==================================
+timeout_fx="${tmproot}/timeout.rs"
+cat >"${timeout_fx}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    async fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), work()).await;
+    }
+}
+RS
+ln="$(line_of "${timeout_fx}" 'tokio::time::timeout(std::time::Duration')"
+out="$(bash "${CHECK}" "${timeout_fx}" 2>&1)"
+rc=$?
+check_eq "a tokio::time::timeout in a clock helper exits 1" "1" "${rc}"
+check_contains "the timeout finding names file:line: symbol in helper" "${out}" \
+  "${timeout_fx}:${ln}: tokio::time::timeout in helper_on_testclock"
+
+# === (n) Instant:: is flagged =============================================
+instant="${tmproot}/instant.rs"
+cat >"${instant}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct FixedClock(i64);
+
+    fn helper_on_fixedclock() {
+        let _c = FixedClock(0);
+        let _started = std::time::Instant::now();
+    }
+}
+RS
+ln="$(line_of "${instant}" 'std::time::Instant::now();')"
+out="$(bash "${CHECK}" "${instant}" 2>&1)"
+rc=$?
+check_eq "an Instant:: in a clock helper exits 1" "1" "${rc}"
+check_contains "the Instant:: finding names file:line: symbol in helper" "${out}" \
+  "${instant}:${ln}: Instant:: in helper_on_fixedclock"
+
+# === (o) SystemTime is flagged ============================================
+systemtime="${tmproot}/systemtime.rs"
+cat >"${systemtime}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+        let _wall = std::time::SystemTime::now();
+    }
+}
+RS
+ln="$(line_of "${systemtime}" 'std::time::SystemTime::now();')"
+out="$(bash "${CHECK}" "${systemtime}" 2>&1)"
+rc=$?
+check_eq "a SystemTime in a clock helper exits 1" "1" "${rc}"
+check_contains "the SystemTime finding names file:line: symbol in helper" "${out}" \
+  "${systemtime}:${ln}: SystemTime in helper_on_testclock"
+
+# === (p) an injected clock's OWN sleep/elapsed is not a wall-clock wait ====
+# The idiom the guard exists to encourage: a helper that awaits the injected
+# clock, in three receiver shapes. Reporting these would leave writing an
+# allow-wall-clock reason for code that is not a wall-clock wait as the only
+# escape.
+clockrecv="${tmproot}/clockrecv.rs"
+cat >"${clockrecv}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    async fn helper_awaiting_the_injected_clock(clock: &TestClock, holder: &Holder) {
+        clock.sleep(std::time::Duration::from_millis(1)).await;
+        let _d = clock.elapsed();
+        holder.test_clock.as_ref().sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+RS
+out="$(bash "${CHECK}" "${clockrecv}" 2>&1)"
+rc=$?
+check_eq "awaiting the injected clock's own sleep/elapsed exits 0" "0" "${rc}"
+check_eq "the clock-receiver fixture still reports 1 scanned helper" \
+  "check-injected-clock-helpers.sh: clean (1 helper(s) scanned)" "${out}"
+
+# === (q) the receiver exemption is scoped to clocks, not blanket ===========
+otherrecv="${tmproot}/otherrecv.rs"
+cat >"${otherrecv}" <<'RS'
+#[cfg(test)]
+mod tests {
+    struct TestClock;
+
+    fn helper_on_testclock(clock: &TestClock, timer: &Timer) {
+        let _ = clock;
+        timer.sleep(std::time::Duration::from_millis(1));
+    }
+}
+RS
+ln="$(line_of "${otherrecv}" 'timer.sleep(std::time::Duration')"
+out="$(bash "${CHECK}" "${otherrecv}" 2>&1)"
+rc=$?
+check_eq "a non-clock receiver's sleep is still flagged" "1" "${rc}"
+check_contains "the non-clock receiver finding is reported as sleep()" "${out}" \
+  "${otherrecv}:${ln}: sleep() in helper_on_testclock"
+
+# === (r) the real default target stays above the helper-count floor ========
+# The zero-helpers guard only catches a predicate that finds NOTHING. This
+# catches one that narrows: dropping FixedClock from the gate's CLOCK_TYPES
+# takes the real file from 26 scanned helpers to 5, and dropping both clock
+# types to 2, each of which passed every other case in this suite. A floor,
+# not an exact count, so a new helper in load.rs never fails the gate.
+REAL_TARGET_HELPER_FLOOR=20
+check_eq "the gate declares the expected default-target helper floor" \
+  "DEFAULT_TARGET_MIN_HELPERS=${REAL_TARGET_HELPER_FLOOR}" \
+  "$(grep -m1 '^DEFAULT_TARGET_MIN_HELPERS=' "${CHECK}")"
+out="$(bash "${CHECK}" 2>&1)"
+rc=$?
+check_eq "the real default target scans clean" "0" "${rc}"
+check_ge "the real default target's scanned-helper count clears the floor" \
+  "${REAL_TARGET_HELPER_FLOOR}" "$(helper_count_of "${out}")"
+
+echo
+echo "passed: ${pass}  failed: ${fail}"
+[[ ${fail} -eq 0 ]]

--- a/scripts/tests/check-injected-clock-helpers.test.sh
+++ b/scripts/tests/check-injected-clock-helpers.test.sh
@@ -509,6 +509,41 @@ check_eq "the real default target scans clean" "0" "${rc}"
 check_ge "the real default target's scanned-helper count clears the floor" \
   "${REAL_TARGET_HELPER_FLOOR}" "$(helper_count_of "${out}")"
 
+# === (s) the scan start is anchored on the stripped line ===================
+# `scan_start` is found by matching the cfg(test) attribute. Matched on the RAW
+# line, a doc comment or string literal naming that attribute starts the scan
+# above the real test module, and production functions that mention a clock
+# type then enter the scan. The wall-clock call below sits in production code
+# and must NOT be reported.
+anchor="${tmproot}/anchor.rs"
+cat >"${anchor}" <<'RS'
+//! Module docs that mention #[cfg(test)] in prose.
+
+pub struct TestClock;
+
+/// Production helper. Not a test, not scanned.
+pub fn prod_helper_on_testclock(_c: &TestClock) {
+    std::thread::sleep(std::time::Duration::from_millis(1));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn helper_on_testclock(clock: &TestClock) {
+        let _ = clock;
+        tokio::task::yield_now().await;
+    }
+
+    #[test]
+    fn t() {}
+}
+RS
+out="$(bash "${CHECK}" "${anchor}" 2>&1)"
+rc=$?
+check_eq "a cfg(test) mention in a doc comment does not move the scan start" "0" "${rc}"
+check_eq "only the real test module's helper is scanned past a doc-comment mention"   "1" "$(helper_count_of "${out}")"
+
 echo
 echo "passed: ${pass}  failed: ${fail}"
 [[ ${fail} -eq 0 ]]

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -6053,25 +6053,55 @@ type = "i64"
     /// triggered by a LATER batch (or by the age trigger), not by the write
     /// itself, so the ack now waits for one.
     ///
-    /// Pinned without a timing band: under a `FixedClock` the age trigger can
-    /// never fire, and at an 8 MiB target no write in this 16-row fixture can
-    /// reach the size trigger either. With no trigger reachable, the load
-    /// cannot finish and -- the part that would be false under the old
-    /// semantics -- the store holds zero data objects while it is suspended.
-    /// The store is read with the load future still alive and pinned, so no
-    /// shutdown flush from dropping the router can race the observation.
+    /// Pinned without a timing band: under a [`TestClock`] this test never
+    /// advances, the age trigger can never fire (the shard actor's flush tick
+    /// waits on that clock's own `sleep`, which only returns on an advance),
+    /// and at an 8 MiB target no write in this 16-row fixture can reach the
+    /// size trigger either. With no trigger reachable, the load cannot finish
+    /// and -- the part that would be false under the old semantics -- the
+    /// store holds zero data objects while it is suspended. The store is read
+    /// with the load future still alive and pinned, so no shutdown flush from
+    /// dropping the router can race the observation.
     ///
-    /// Prove-the-test: hardcode `target_bytes: 1` back into the `IngestConfig`
-    /// in `load_instrumented` and the load completes inside the window, hitting
+    /// The suspension is observed off the pipeline's own progress, not off a
+    /// wall-clock window and not off a yield count: the decoder's
+    /// `on_batch_queued` hook gates on every batch having been queued (that
+    /// hook runs on the `spawn_blocking` decode thread, so no filesystem read
+    /// of the fixture can still be outstanding), and
+    /// [`yield_until_router_is_quiet`] then waits for `clock.reads()` to
+    /// settle (so no routed write can still be moving toward its shard
+    /// buffer). A yield count would bound neither, since yields on this task
+    /// do not wait on the blocking decode thread.
+    ///
+    /// Prove-the-test: pass `1` as `target_bytes` to the
+    /// `build_ingest_config` call in `load_instrumented` (that function has
+    /// other callers, so change the call, not the function) and every write
+    /// triggers its own flush, so the
+    /// acks are answered, the load runs to completion while the driver is
+    /// still waiting for the router to go quiet, and the `biased` select hits
     /// the `panic!` arm ("the load must not complete...").
     #[tokio::test]
     async fn a_strict_ack_above_target_one_waits_for_a_later_batchs_flush() {
         use ravel_object_store::memory::MemoryStore;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
         let shards = 4u32;
         let rows_per_group = 4usize;
+        // The fixture holds one row group of `rows_per_group` rows per shard and
+        // `--batch-rows` is `rows_per_group`, so the decoder queues exactly
+        // `shards` batches of `rows_per_group` rows each.
+        let batches = shards as usize;
         let (_dir, pq, m) = sorted_by_shard_fixture(shards, rows_per_group);
         let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let clock = TestClock::new(NOW_NS);
+
+        let queued = Arc::new(AtomicUsize::new(0));
+        let (gate_tx, mut gate_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        let on_batch_queued: BuildStartHook = Arc::new(move || {
+            if queued.fetch_add(1, Ordering::SeqCst) + 1 == batches {
+                let _ = gate_tx.send(());
+            }
+        });
 
         let load_fut = load_instrumented(
             Arc::clone(&store),
@@ -6087,20 +6117,28 @@ type = "i64"
             8 * 1024 * 1024,
             None,
             NOW_NS,
-            Arc::new(FixedClock(NOW_NS)),
+            Arc::clone(&clock) as Arc<dyn Clock>,
             LoadPath::Columnar,
             None,
-            None,
+            Some(on_batch_queued),
         );
         tokio::pin!(load_fut);
 
+        // Wait for the pipeline to run out of work, then confirm the load is
+        // still parked and nothing was made durable. `biased` polls the load
+        // first on every round, so a load that does complete trips the panic
+        // rather than losing the race to the driver.
         let stored = tokio::select! {
+            biased;
             _ = &mut load_fut => panic!(
                 "the load must not complete: at an 8 MiB target no write reaches the size \
-                 trigger, and a FixedClock never fires the age trigger, so no ack can be \
-                 answered"
+                 trigger, and a TestClock this test never advances cannot fire the age \
+                 trigger, so no ack can be answered"
             ),
-            () = tokio::time::sleep(Duration::from_millis(300)) => {
+            () = async {
+                let () = gate_rx.recv().await.expect("every batch is queued");
+                yield_until_router_is_quiet(&clock).await;
+            } => {
                 list_data_objects(store.as_ref()).await
             }
         };
@@ -8158,7 +8196,7 @@ type = "i64"
                 watch_completed: Arc::new(AtomicUsize::new(0)),
             });
 
-            let started = Instant::now();
+            let started = Instant::now(); // allow-wall-clock: measures real wall for the diagnostic printed below, never asserted on; the test's claim is the exact peak-concurrency count, not any elapsed time
             let report = load_instrumented(
                 store as Arc<dyn ObjectStoreBackend>,
                 &pq,
@@ -8180,7 +8218,7 @@ type = "i64"
             )
             .await
             .expect("the load succeeds");
-            let wall = started.elapsed();
+            let wall = started.elapsed(); // allow-wall-clock: real elapsed for the printed diagnostic only; the peak-concurrency assertions below carry the whole claim
             assert_eq!(
                 report.rows_processed, BATCHES as u64,
                 "every row is written at depth {depth} / flushes {flushes}"


### PR DESCRIPTION
A test that takes an injected clock and then waits on the wall clock is a
flake with a schedule. The rule was written down twice and broken twice, so
it becomes a check: `scripts/check-injected-clock-helpers.sh` scans the test
module of `services/ravel-cli/src/load.rs`, finds the helpers that take a
`TestClock` or a `FixedClock`, and fails on `thread::sleep`,
`tokio::time::sleep`, `tokio::time::timeout`, `Instant::`, `SystemTime`, a
bare aliased `sleep(...)`, or `.elapsed()` inside one. A wait that is
genuinely necessary carries `// allow-wall-clock: <reason>`, and the reason is
required. Symbols and the marker are both matched on the comment- and
string-stripped line, so a marker inside a string literal suppresses nothing.
A receiver that is itself an injected clock is exempt, so `clock.sleep(...)`
and `clock.elapsed()` read as what they are.

The gate runs from `gates.sh` and from CI's `doc-scripts` job, its own suite
first so a suite broken into always-passing fails there rather than going
quiet.

The suite is the part worth reviewing. Each of the seven patterns has a case
that dies when that pattern is deleted, between two and eight of them, and a
stub gate that only echoes the clean line and exits 0 fails 30 of the 38
cases. A helper-count floor on the default target catches the other direction:
the zero-helpers guard sees a predicate that matches nothing, but not one that
narrows, and dropping a clock type from the list quietly took the real file
from 26 helpers to 5 while still exiting 0. The floor fails that and does not
fire when load.rs grows a new helper.

The one wall-clock wait the gate found in its own target is fixed rather than
exempted. `a_strict_ack_above_target_one_waits_for_a_later_batchs_flush` slept
300 ms to observe a load that must not finish; it now waits on the decode
pipeline's own progress, through a batch-queued hook that runs on the blocking
decode thread and a clock-read counter that cannot settle while a routed write
is still in flight. Its prove-the-test was re-run against the new wait rather
than inherited: passing 1 as `target_bytes` makes the load complete and hits
the named `panic!` arm, 30 times out of 30.

The rule is not enforced workspace-wide yet, and CLAUDE.md says so with the
numbers: 9 findings across 5 files in ravel-cache, ravel-maintain and
ravel-server, and 78 more clock-mentioning files where the scan finds no
helper at all, 60 of them under `crates/*/tests/` and 10 under
`services/*/tests/`. Issue #1278 carries that widening.

Fixes: #1260
