### PR TITLE
feat(scripts): refuse a merge whose base is behind main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,13 @@ jobs:
         run: bash scripts/tests/check-injected-clock-helpers.test.sh
       - name: Injected-clock helper guard (issue #1260)
         run: bash scripts/check-injected-clock-helpers.sh
+      # The merge-readiness script's own cases: its jq filters, its verdict
+      # order, and the end-to-end runs that drive the real script against
+      # fixtures with stand-in gh and git. Bash and jq only, no toolchain. It
+      # ran in no job until now, which is how it went stale and non-hermetic
+      # without anything noticing.
+      - name: pr-review-status.sh cases
+        run: bash scripts/pr-review-status.test.sh
       - name: Python script unit tests
         run: make test-python
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,6 +373,21 @@ there before changing a rule.
   SHA read earlier in the session goes stale the moment another PR merges,
   and dispatching it silently rebuilds on a superseded tree.
   `ALLOW_STALE_REF=1` to dispatch an intentionally older ref.
+- `scripts/guards/assert-fresh-merge-base.sh <pr-number>`: exits non-zero
+  when a PR's merge base is behind `origin/main`, printing how far and what
+  it has not seen. `pr-review-status.sh` runs it, so a stale PR never gets
+  the merge command printed; run it directly for any merge that bypasses
+  that script. Green CI on a stale base is not evidence about the merge:
+  `main` runs no CI of its own, so a PR green against an older base can
+  still break it (8a534f43 left main uncompilable exactly this way, a
+  five-argument call site landing minutes before another PR made the
+  function take six, both PRs green), and a gate added to `main` after a PR
+  went green has never run against that PR at all. Four PRs were CI-green
+  and behind simultaneously on 2026-09-06. `ALLOW_STALE_MERGE_BASE=1` to
+  proceed anyway. Note it fetches with an explicit destination refspec: a
+  hand-rolled version using `git fetch origin main <other-ref>` and then
+  `rev-parse FETCH_HEAD` reads back MAIN, so it compares main with itself
+  and reports every branch fresh.
 - `scripts/guards/assert-gh-auth.sh [hostname]`: exits non-zero when gh
   cannot complete an authenticated API call. Run it before any landing
   sequence: tokens die mid-session, and a failure found at push time

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,7 +384,10 @@ there before changing a rule.
   function take six, both PRs green), and a gate added to `main` after a PR
   went green has never run against that PR at all. Four PRs were CI-green
   and behind simultaneously on 2026-09-06. `ALLOW_STALE_MERGE_BASE=1` to
-  proceed anyway. Note it fetches with an explicit destination refspec: a
+  proceed anyway. It exits 1 for a base that is behind and 2 when it could
+  not tell (bad argument, no such pull request, git failed), so a caller
+  reporting to a human can say which it got; a caller that only needs "may
+  I merge" treats any non-zero as no. Note it fetches with an explicit destination refspec: a
   hand-rolled version using `git fetch origin main <other-ref>` and then
   `rev-parse FETCH_HEAD` reads back MAIN, so it compares main with itself
   and reports every branch fresh.

--- a/scripts/guards/assert-fresh-merge-base.sh
+++ b/scripts/guards/assert-fresh-merge-base.sh
@@ -51,7 +51,10 @@ git fetch "$remote" "+${branch}:${tip_ref}" >/dev/null 2>&1 || {
 # branch and cannot be aimed at the wrong ref by a stale local copy. The
 # destination carries the pid and is deleted on exit: a name per PR would leave
 # one ref behind for every PR ever checked, and a single fixed name would race
-# two concurrent runs against each other.
+# two concurrent runs against each other. The leading `+` is load-bearing rather
+# than habit: SIGKILL cannot run the trap, so a ref can survive, and forcing the
+# update means a later run that draws the same pid overwrites the orphan instead
+# of failing on it.
 local_ref="refs/remotes/${remote}/freshness-check-$$"
 trap 'git update-ref -d "$local_ref" 2>/dev/null || true' EXIT HUP INT TERM
 git fetch "$remote" "+refs/pull/${pr}/head:${local_ref}" >/dev/null 2>&1 || {

--- a/scripts/guards/assert-fresh-merge-base.sh
+++ b/scripts/guards/assert-fresh-merge-base.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# assert-fresh-merge-base.sh <pr-number> [remote] [branch]
+# Verify a pull request's merge base IS the current tip of origin/main, fetched
+# in THIS invocation. Exit 0 when the branch already contains that tip; exit 1
+# when main has moved ahead of it, printing how far behind and what landed.
+#
+# Green CI on a stale base is not evidence about the merge. `main` runs no CI of
+# its own here, so a PR that passed against an older base can still break `main`
+# the moment it lands: that is how commit 8a534f43 left main uncompilable, when a
+# five-argument call site landed minutes before another PR made the same function
+# take six. Both PRs were green. Neither had seen the other.
+#
+# It also silently skips gates. A gate added to `main` after a PR went green has
+# never run against that PR, so the branch merges without the check its author
+# added precisely to catch it.
+#
+# ALLOW_STALE_MERGE_BASE=1 to proceed anyway (a docs-only branch whose CI you
+# have reason to trust across the gap).
+#
+# Fetches with an explicit destination refspec rather than reading FETCH_HEAD.
+# `git fetch origin main <other-ref>` leaves FETCH_HEAD naming main, so a check
+# written that way compares main with itself and reports success for any branch.
+set -u
+
+pr=${1:-}
+remote=${2:-origin}
+branch=${3:-main}
+
+if [ -z "$pr" ]; then
+  echo "guard: usage: assert-fresh-merge-base.sh <pr-number> [remote] [branch]" >&2
+  exit 1
+fi
+
+case "$pr" in
+  *[!0-9]* | '')
+    echo "guard: pr-number must be numeric, got '$pr'" >&2
+    exit 1
+    ;;
+esac
+
+git fetch "$remote" "$branch" >/dev/null 2>&1 || {
+  echo "guard: git fetch $remote $branch failed" >&2
+  exit 1
+}
+
+# refs/pull/<n>/head needs no branch name, so this works for a PR from any
+# branch and cannot be aimed at the wrong ref by a stale local copy.
+local_ref="refs/remotes/${remote}/pr-${pr}-freshness-check"
+git fetch "$remote" "refs/pull/${pr}/head:${local_ref}" -f >/dev/null 2>&1 || {
+  echo "guard: git fetch $remote refs/pull/${pr}/head failed (is $pr a pull request on $remote?)" >&2
+  exit 1
+}
+
+tip=$(git rev-parse "${remote}/${branch}") || exit 1
+head=$(git rev-parse "$local_ref") || exit 1
+base=$(git merge-base "$tip" "$head") || exit 1
+
+if [ "$tip" = "$base" ]; then
+  echo "guard: PR #$pr merge base is the current $remote/$branch ($(git rev-parse --short "$tip"))"
+  exit 0
+fi
+
+behind=$(git rev-list --count "$base".."$tip")
+echo "guard: PR #$pr is $behind commit(s) behind $remote/$branch." >&2
+echo "guard: its CI ran against $(git rev-parse --short "$base"), not $(git rev-parse --short "$tip")." >&2
+echo "guard: most recent unseen commits:" >&2
+git log --oneline --max-count=10 "$base".."$tip" 2>/dev/null | sed 's/^/guard:   /' >&2
+if [ "$behind" -gt 10 ]; then
+  echo "guard:   ... and $((behind - 10)) more" >&2
+fi
+
+if [ "${ALLOW_STALE_MERGE_BASE:-0}" = "1" ]; then
+  echo "guard: ALLOW_STALE_MERGE_BASE=1, proceeding on a stale base" >&2
+  exit 0
+fi
+
+echo "guard: rebase onto $remote/$branch and let CI re-run before merging." >&2
+exit 1

--- a/scripts/guards/assert-fresh-merge-base.sh
+++ b/scripts/guards/assert-fresh-merge-base.sh
@@ -56,7 +56,18 @@ git fetch "$remote" "+${branch}:${tip_ref}" >/dev/null 2>&1 || {
 # update means a later run that draws the same pid overwrites the orphan instead
 # of failing on it.
 local_ref="refs/remotes/${remote}/freshness-check-$$"
-trap 'git update-ref -d "$local_ref" 2>/dev/null || true' EXIT HUP INT TERM
+# shellcheck disable=SC2329  # invoked via the exit trap below
+cleanup() {
+  git update-ref -d "$local_ref" 2>/dev/null || true
+}
+# Cleanup on exit, and make each signal actually exit. A handler bound directly
+# to HUP/INT/TERM only runs and RETURNS in POSIX sh, so the script would carry
+# on past the interruption having already deleted the ref it is about to read.
+# Exiting from the handler runs the exit trap, so cleanup still happens once.
+trap cleanup 0
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 git fetch "$remote" "+refs/pull/${pr}/head:${local_ref}" >/dev/null 2>&1 || {
   echo "guard: git fetch $remote refs/pull/${pr}/head failed (is $pr a pull request on $remote?)" >&2
   exit 1

--- a/scripts/guards/assert-fresh-merge-base.sh
+++ b/scripts/guards/assert-fresh-merge-base.sh
@@ -38,20 +38,28 @@ case "$pr" in
     ;;
 esac
 
-git fetch "$remote" "$branch" >/dev/null 2>&1 || {
+# Both fetches name their destination, per the note above: relying on the
+# opportunistic remote-tracking update would make this depend on the clone's
+# `remote.<name>.fetch` refspec being the standard one.
+tip_ref="refs/remotes/${remote}/${branch}"
+git fetch "$remote" "+${branch}:${tip_ref}" >/dev/null 2>&1 || {
   echo "guard: git fetch $remote $branch failed" >&2
   exit 1
 }
 
 # refs/pull/<n>/head needs no branch name, so this works for a PR from any
-# branch and cannot be aimed at the wrong ref by a stale local copy.
-local_ref="refs/remotes/${remote}/pr-${pr}-freshness-check"
-git fetch "$remote" "refs/pull/${pr}/head:${local_ref}" -f >/dev/null 2>&1 || {
+# branch and cannot be aimed at the wrong ref by a stale local copy. The
+# destination carries the pid and is deleted on exit: a name per PR would leave
+# one ref behind for every PR ever checked, and a single fixed name would race
+# two concurrent runs against each other.
+local_ref="refs/remotes/${remote}/freshness-check-$$"
+trap 'git update-ref -d "$local_ref" 2>/dev/null || true' EXIT HUP INT TERM
+git fetch "$remote" "+refs/pull/${pr}/head:${local_ref}" >/dev/null 2>&1 || {
   echo "guard: git fetch $remote refs/pull/${pr}/head failed (is $pr a pull request on $remote?)" >&2
   exit 1
 }
 
-tip=$(git rev-parse "${remote}/${branch}") || exit 1
+tip=$(git rev-parse "$tip_ref") || exit 1
 head=$(git rev-parse "$local_ref") || exit 1
 base=$(git merge-base "$tip" "$head") || exit 1
 
@@ -60,7 +68,10 @@ if [ "$tip" = "$base" ]; then
   exit 0
 fi
 
-behind=$(git rev-list --count "$base".."$tip")
+behind=$(git rev-list --count "$base".."$tip") || {
+  echo "guard: git rev-list --count $base..$tip failed" >&2
+  exit 1
+}
 echo "guard: PR #$pr is $behind commit(s) behind $remote/$branch." >&2
 echo "guard: its CI ran against $(git rev-parse --short "$base"), not $(git rev-parse --short "$tip")." >&2
 echo "guard: most recent unseen commits:" >&2

--- a/scripts/guards/assert-fresh-merge-base.sh
+++ b/scripts/guards/assert-fresh-merge-base.sh
@@ -38,14 +38,10 @@ case "$pr" in
     ;;
 esac
 
-# Both fetches name their destination, per the note above: relying on the
+# Both refspecs name their destination, per the note above: relying on the
 # opportunistic remote-tracking update would make this depend on the clone's
 # `remote.<name>.fetch` refspec being the standard one.
 tip_ref="refs/remotes/${remote}/${branch}"
-git fetch "$remote" "+${branch}:${tip_ref}" >/dev/null 2>&1 || {
-  echo "guard: git fetch $remote $branch failed" >&2
-  exit 1
-}
 
 # refs/pull/<n>/head needs no branch name, so this works for a PR from any
 # branch and cannot be aimed at the wrong ref by a stale local copy. The
@@ -68,8 +64,15 @@ trap cleanup 0
 trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
-git fetch "$remote" "+refs/pull/${pr}/head:${local_ref}" >/dev/null 2>&1 || {
-  echo "guard: git fetch $remote refs/pull/${pr}/head failed (is $pr a pull request on $remote?)" >&2
+# One fetch for both refs: two round trips to the same remote buy nothing, and
+# callers document this guard as costing one.
+git fetch "$remote" "+${branch}:${tip_ref}" "+refs/pull/${pr}/head:${local_ref}" \
+  >/dev/null 2>&1 || {
+  if ! git ls-remote --exit-code "$remote" "refs/pull/${pr}/head" >/dev/null 2>&1; then
+    echo "guard: $remote has no refs/pull/${pr}/head (is $pr a pull request on $remote?)" >&2
+  else
+    echo "guard: git fetch $remote ($branch, refs/pull/${pr}/head) failed" >&2
+  fi
   exit 1
 }
 
@@ -89,7 +92,12 @@ behind=$(git rev-list --count "$base".."$tip") || {
 echo "guard: PR #$pr is $behind commit(s) behind $remote/$branch." >&2
 echo "guard: its CI ran against $(git rev-parse --short "$base"), not $(git rev-parse --short "$tip")." >&2
 echo "guard: most recent unseen commits:" >&2
-git log --oneline --max-count=10 "$base".."$tip" 2>/dev/null | sed 's/^/guard:   /' >&2
+# A commit subject is attacker-controlled text and reaches a terminal or a CI
+# log from here, so strip the control bytes that could rewrite what the reader
+# sees. Tab and newline stay.
+git log --oneline --max-count=10 "$base".."$tip" 2>/dev/null |
+  LC_ALL=C tr -d '\001-\010\013\014\016-\037\177' |
+  sed 's/^/guard:   /' >&2
 if [ "$behind" -gt 10 ]; then
   echo "guard:   ... and $((behind - 10)) more" >&2
 fi

--- a/scripts/guards/assert-fresh-merge-base.sh
+++ b/scripts/guards/assert-fresh-merge-base.sh
@@ -17,6 +17,12 @@
 # ALLOW_STALE_MERGE_BASE=1 to proceed anyway (a docs-only branch whose CI you
 # have reason to trust across the gap).
 #
+# Exit codes: 0 the base is current (or the override is set), 1 the base is
+# behind, 2 the question could not be answered (bad argument, no such pull
+# request, git failed). A caller that only needs "may I merge" can treat any
+# non-zero as no; one that reports to a human should say which of the two it
+# got, since "behind" and "could not tell" have different fixes.
+#
 # Fetches with an explicit destination refspec rather than reading FETCH_HEAD.
 # `git fetch origin main <other-ref>` leaves FETCH_HEAD naming main, so a check
 # written that way compares main with itself and reports success for any branch.
@@ -28,13 +34,13 @@ branch=${3:-main}
 
 if [ -z "$pr" ]; then
   echo "guard: usage: assert-fresh-merge-base.sh <pr-number> [remote] [branch]" >&2
-  exit 1
+  exit 2
 fi
 
 case "$pr" in
   *[!0-9]* | '')
     echo "guard: pr-number must be numeric, got '$pr'" >&2
-    exit 1
+    exit 2
     ;;
 esac
 
@@ -66,19 +72,19 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 # One fetch for both refs: two round trips to the same remote buy nothing, and
 # callers document this guard as costing one.
-git fetch "$remote" "+${branch}:${tip_ref}" "+refs/pull/${pr}/head:${local_ref}" \
+git fetch -- "$remote" "+${branch}:${tip_ref}" "+refs/pull/${pr}/head:${local_ref}" \
   >/dev/null 2>&1 || {
-  if ! git ls-remote --exit-code "$remote" "refs/pull/${pr}/head" >/dev/null 2>&1; then
+  if ! git ls-remote --exit-code -- "$remote" "refs/pull/${pr}/head" >/dev/null 2>&1; then
     echo "guard: $remote has no refs/pull/${pr}/head (is $pr a pull request on $remote?)" >&2
   else
     echo "guard: git fetch $remote ($branch, refs/pull/${pr}/head) failed" >&2
   fi
-  exit 1
+  exit 2
 }
 
-tip=$(git rev-parse "$tip_ref") || exit 1
-head=$(git rev-parse "$local_ref") || exit 1
-base=$(git merge-base "$tip" "$head") || exit 1
+tip=$(git rev-parse "$tip_ref") || exit 2
+head=$(git rev-parse "$local_ref") || exit 2
+base=$(git merge-base "$tip" "$head") || exit 2
 
 if [ "$tip" = "$base" ]; then
   echo "guard: PR #$pr merge base is the current $remote/$branch ($(git rev-parse --short "$tip"))"
@@ -87,7 +93,7 @@ fi
 
 behind=$(git rev-list --count "$base".."$tip") || {
   echo "guard: git rev-list --count $base..$tip failed" >&2
-  exit 1
+  exit 2
 }
 echo "guard: PR #$pr is $behind commit(s) behind $remote/$branch." >&2
 echo "guard: its CI ran against $(git rev-parse --short "$base"), not $(git rev-parse --short "$tip")." >&2
@@ -96,7 +102,7 @@ echo "guard: most recent unseen commits:" >&2
 # log from here, so strip the control bytes that could rewrite what the reader
 # sees. Tab and newline stay.
 git log --oneline --max-count=10 "$base".."$tip" 2>/dev/null |
-  LC_ALL=C tr -d '\001-\010\013\014\016-\037\177' |
+  LC_ALL=C tr -d '\000-\010\013-\037\177' |
   sed 's/^/guard:   /' >&2
 if [ "$behind" -gt 10 ]; then
   echo "guard:   ... and $((behind - 10)) more" >&2

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -22,6 +22,8 @@
 # gate exactly as without it.
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 pr="${1:?usage: pr-review-status.sh <pr-number> [--confirm-addressed]}"
 repo="NOFireAI/ravel"
 confirm_addressed=0
@@ -214,6 +216,15 @@ elif [[ "${cr_comments}" != "0" && "${confirm_addressed}" != "1" ]]; then
   echo "  -> ${cr_comments} CodeRabbit inline comment(s); read them, then re-run with --confirm-addressed once each is fixed or answered (the API cannot tell; see the header comment)"
 elif [[ "${cr_outside_diff}" != "0" && "${confirm_addressed}" != "1" ]]; then
   echo "  -> ${cr_outside_diff} CodeRabbit outside-diff finding(s) in the review BODY at head, not inline; read the body with \`gh api repos/${repo}/pulls/${pr}/reviews --jq '.[] | select(.commit_id==\"${head_sha}\") | .body'\`, then re-run with --confirm-addressed once each is fixed or answered"
+# Ahead of the mergeState check on purpose. A stale base is always actionable
+# and the fix is always the same; mergeState UNKNOWN is often just GitHub still
+# computing. Green CI on a stale base says nothing about the merge: `main` runs
+# no CI of its own, so a PR that passed against an older base can still break
+# it, and a gate added to `main` after the PR went green has never run against
+# the PR at all. Costs one fetch.
+elif ! stale_base="$("${script_dir}/guards/assert-fresh-merge-base.sh" "${pr}" 2>&1)"; then
+  echo "  -> merge base is behind origin/main; rebase and let CI re-run before merging"
+  echo "${stale_base//guard: /     }"
 elif [[ "${merge_state}" != "CLEAN" && "${merge_state}" != "UNSTABLE" ]]; then
   echo "  -> every check and review looks clean, but mergeState is ${merge_state} (not CLEAN/UNSTABLE); verify by hand before merging"
 else

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -237,5 +237,9 @@ else
   else
     echo "  -> clean: CI green, CodeRabbit's risk line names the current head with zero inline comments"
   fi
-  echo "  -> gh pr merge ${pr} --rebase --delete-branch --match-head-commit ${head_sha}"
+  # The freshness check above proved the base current at the moment it ran, not
+  # for however long the operator takes to run this line; `--match-head-commit`
+  # pins the PR head, not `main`. So the printed command re-runs the guard and
+  # merges only if it still passes.
+  echo "  -> scripts/guards/assert-fresh-merge-base.sh ${pr} && gh pr merge ${pr} --rebase --delete-branch --match-head-commit ${head_sha}"
 fi

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -30,12 +30,16 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # belongs to while every other check here is pinned to ${repo} by `gh --repo`,
 # so it runs with the cwd pinned to this script's own checkout; otherwise the
 # two halves of the verdict can be about different repositories.
+#
+# The `cd` failing is its own outcome, not a stale base: left bare in the `&&`
+# it would exit 1, which is the code reserved for "behind", and the operator
+# would be told to rebase over a guard that never ran.
 guard_rc=0
 guard_out=""
 merge_base_guard() {
   guard_rc=0
-  guard_out="$(cd "${script_dir}/.." && \
-    "${script_dir}/guards/assert-fresh-merge-base.sh" "${pr}" 2>&1)" || guard_rc=$?
+  guard_out="$( { { cd "${script_dir}/.." || exit 2; } && \
+    "${script_dir}/guards/assert-fresh-merge-base.sh" "${pr}"; } 2>&1)" || guard_rc=$?
   return "${guard_rc}"
 }
 

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -24,6 +24,21 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Runs the merge-base guard and keeps both halves of its answer. It is a
+# function so the exit code survives: `$?` read after an `if`/`elif` reports the
+# test, not the command. The guard asks git about whatever repository the cwd
+# belongs to while every other check here is pinned to ${repo} by `gh --repo`,
+# so it runs with the cwd pinned to this script's own checkout; otherwise the
+# two halves of the verdict can be about different repositories.
+guard_rc=0
+guard_out=""
+merge_base_guard() {
+  guard_rc=0
+  guard_out="$(cd "${script_dir}/.." && \
+    "${script_dir}/guards/assert-fresh-merge-base.sh" "${pr}" 2>&1)" || guard_rc=$?
+  return "${guard_rc}"
+}
+
 pr="${1:?usage: pr-review-status.sh <pr-number> [--confirm-addressed]}"
 repo="NOFireAI/ravel"
 confirm_addressed=0
@@ -222,9 +237,13 @@ elif [[ "${cr_outside_diff}" != "0" && "${confirm_addressed}" != "1" ]]; then
 # no CI of its own, so a PR that passed against an older base can still break
 # it, and a gate added to `main` after the PR went green has never run against
 # the PR at all. Costs one fetch.
-elif ! stale_base="$("${script_dir}/guards/assert-fresh-merge-base.sh" "${pr}" 2>&1)"; then
-  echo "  -> merge base is behind origin/main; rebase and let CI re-run before merging"
-  echo "${stale_base//guard: /     }"
+elif ! merge_base_guard; then
+  if [[ "${guard_rc}" == "1" ]]; then
+    echo "  -> merge base is behind origin/main; rebase and let CI re-run before merging"
+  else
+    echo "  -> could not check merge-base freshness (guard exit ${guard_rc}); check by hand before merging"
+  fi
+  echo "${guard_out//guard: /     }"
 elif [[ "${merge_state}" != "CLEAN" && "${merge_state}" != "UNSTABLE" ]]; then
   echo "  -> every check and review looks clean, but mergeState is ${merge_state} (not CLEAN/UNSTABLE); verify by hand before merging"
 else

--- a/scripts/pr-review-status.test.sh
+++ b/scripts/pr-review-status.test.sh
@@ -330,6 +330,20 @@ resolve() {
     *) printf '%s' "${tip}" ;;
   esac
 }
+# E2E_GIT_FAIL_AT names one call the guard makes and fails exactly that one, so
+# each of the guard's internal failure paths can be reached on its own. The two
+# rev-parse calls are distinguished by which ref they resolve, since reverting
+# only the second one's exit code is otherwise invisible.
+fail_at="${E2E_GIT_FAIL_AT:-}"
+case "$1:${2:-}" in
+  "rev-parse:refs/remotes/origin/main")
+    [[ "${fail_at}" == "rev-parse-tip" ]] && exit 1 ;;
+  "rev-parse:refs/remotes/origin/freshness-check-"*)
+    [[ "${fail_at}" == "rev-parse-local" ]] && exit 1 ;;
+esac
+case "$1" in
+  merge-base|rev-list) [[ "${fail_at}" == "$1" ]] && exit 1 ;;
+esac
 case "$1" in
   fetch)
     # E2E_GIT_FETCH_FAIL=1 makes the fetch fail while the remote still has the
@@ -630,6 +644,72 @@ unset E2E_GIT_FETCH_FAIL
 check_eq "a fetch that fails is reported as could-not-check, not as behind" \
   "  -> could not check merge-base freshness (guard exit 2); check by hand before merging" \
   "$(printf '%s\n' "${fetchfail_out}" | sed -n 2p)"
+# And which diagnostic it chose: the guard asks the remote whether the pull
+# request ref exists at all, and reporting "no such pull request" for a fetch
+# that merely failed sends the operator somewhere else entirely.
+check_eq "a fetch that fails says so, rather than blaming the pull request" \
+  "     git fetch origin (main, refs/pull/908/head) failed" \
+  "$(printf '%s\n' "${fetchfail_out}" | sed -n 3p)"
+
+# The guard's remaining internal failure paths, one at a time, so that a revert
+# of any single `exit 2` in it shows up as a verdict of "behind" here. Without
+# these only two of its seven such sites are pinned.
+for failing_call in rev-parse-tip rev-parse-local merge-base; do
+  export E2E_GIT_FAIL_AT="${failing_call}"
+  failed_call_out="$(e2e "${CLEAN_BODY_JSON}")"
+  unset E2E_GIT_FAIL_AT
+  check_eq "a failing ${failing_call} is reported as could-not-check" \
+    "  -> could not check merge-base freshness (guard exit 2); check by hand before merging" \
+    "$(printf '%s\n' "${failed_call_out}" | sed -n 2p)"
+done
+
+# rev-list runs only after the base is known to be behind, so this one needs
+# the stale mode too.
+export E2E_GIT_STALE=1 E2E_GIT_FAIL_AT=rev-list
+revlist_out="$(e2e "${CLEAN_BODY_JSON}")"
+unset E2E_GIT_STALE E2E_GIT_FAIL_AT
+check_eq "a failing rev-list is reported as could-not-check" \
+  "  -> could not check merge-base freshness (guard exit 2); check by hand before merging" \
+  "$(printf '%s\n' "${revlist_out}" | sed -n 2p)"
+
+# The caller pins the guard to its own checkout with a `cd`, and that `cd`
+# failing is its own outcome rather than a stale base: left bare in the `&&` it
+# exits 1, the code reserved for "behind", and the operator is told to rebase
+# over a guard that never ran. Reaching it needs the script's directory to
+# disappear after the last thing the script reads from there, which is the
+# outside-diff jq filter, so this jq passes every call through to the real one
+# and removes the tree once that filter has been served.
+VANISH_DIR="${E2E_DIR}/vanish"
+mkdir -p "${VANISH_DIR}/scripts" "${VANISH_DIR}/bin"
+ln -s "$(cd "$(dirname "$0")" && pwd)/lib" "${VANISH_DIR}/scripts/lib"
+ln -s "$(cd "$(dirname "$0")" && pwd)/guards" "${VANISH_DIR}/scripts/guards"
+cp "$(dirname "$0")/pr-review-status.sh" "${VANISH_DIR}/scripts/pr-review-status.sh"
+REAL_JQ="$(command -v jq)"
+cat >"${VANISH_DIR}/bin/jq" <<SHIM
+#!/usr/bin/env bash
+"${REAL_JQ}" "\$@"
+rc=\$?
+case "\$*" in
+  *coderabbit-outside-diff.jq*) rm -rf "${VANISH_DIR}/scripts" ;;
+esac
+exit \$rc
+SHIM
+chmod +x "${VANISH_DIR}/bin/jq"
+
+vanished_out="$(E2E_SCRIPT="${VANISH_DIR}/scripts/pr-review-status.sh" \
+  PATH="${VANISH_DIR}/bin:${PATH}" e2e "${CLEAN_BODY_JSON}")"
+
+check_eq "a cd that fails is reported as could-not-check, not as behind" \
+  "  -> could not check merge-base freshness (guard exit 2); check by hand before merging" \
+  "$(printf '%s\n' "${vanished_out}" | sed -n 2p)"
+
+# The usage path, which no e2e case can reach because the caller always passes
+# the pull request number it was given.
+guard_noarg_rc=0
+"$(dirname "$0")/guards/assert-fresh-merge-base.sh" >/dev/null 2>&1 || guard_noarg_rc=$?
+check_eq "the guard exits 2 when given no argument at all" \
+  "2" \
+  "${guard_noarg_rc}"
 
 printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
 [[ "${fails}" -eq 0 ]]

--- a/scripts/pr-review-status.test.sh
+++ b/scripts/pr-review-status.test.sh
@@ -292,7 +292,10 @@ check_risk "null body is tolerated" "|active" \
 # --- end-to-end verdict, pr-review-status.sh ------------------------------
 #
 # The count above only matters if it flips the verdict. These run the real
-# script against fixtures with a stand-in `gh` on PATH: no network, no token.
+# script against fixtures with stand-in `gh` and `git` on PATH: no network, no
+# token. The `git` stand-in exists because the script now calls the merge-base
+# guard, which fetches; without it these cases would reach the network and
+# their verdict would depend on the state of whatever repository they ran in.
 
 E2E_DIR="$(mktemp -d)"
 trap 'rm -rf "${E2E_DIR}"' EXIT
@@ -310,6 +313,43 @@ case "$*" in
 esac
 SHIM
 chmod +x "${E2E_DIR}/bin/gh"
+
+# Stand-in for git, so the merge-base guard the script calls runs offline and
+# deterministically. Fresh by default; E2E_GIT_STALE=1 puts the pull request's
+# base three commits behind main. The unseen-commit subjects carry an escape
+# sequence and a carriage return on purpose: the guard is supposed to strip
+# both before the text reaches a terminal, and a test below checks that it did.
+cat >"${E2E_DIR}/bin/git" <<'SHIM'
+#!/usr/bin/env bash
+tip=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+old=cccccccccccccccccccccccccccccccccccccccc
+resolve() {
+  case "$1" in
+    *freshness-check*) printf '%s' "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;
+    [0-9a-f][0-9a-f]*) printf '%s' "$1" ;;
+    *) printf '%s' "${tip}" ;;
+  esac
+}
+case "$1" in
+  fetch|update-ref|ls-remote) exit 0 ;;
+  rev-parse)
+    if [[ "$2" == "--short" ]]; then
+      resolve "$3" | cut -c1-8
+    else
+      resolve "$2"
+      printf '\n'
+    fi
+    ;;
+  merge-base)
+    if [[ "${E2E_GIT_STALE:-0}" == "1" ]]; then printf '%s\n' "${old}"
+    else printf '%s\n' "${tip}"; fi
+    ;;
+  rev-list) printf '3\n' ;;
+  log) printf 'ccccccc1 innocent\033[31mSPOOFED\033[0m\rsubject\ncccccc2 second\ncccccc3 third\n' ;;
+  *) echo "unexpected git call: $*" >&2; exit 91 ;;
+esac
+SHIM
+chmod +x "${E2E_DIR}/bin/git"
 
 # Everything except the review body is held constant and clean: CI green,
 # mergeState CLEAN, one COMMENTED review at head, zero inline comments, and a
@@ -372,7 +412,7 @@ check_eq "walkthrough-only body: verdict is unchanged clean" \
   "  -> clean: CI green, CodeRabbit's risk line names the current head with zero inline comments" \
   "$(printf '%s\n' "${clean_out}" | sed -n 2p)"
 check_eq "walkthrough-only body: merge command still printed" \
-  "  -> gh pr merge 908 --rebase --delete-branch --match-head-commit ${SHA}" \
+  "  -> scripts/guards/assert-fresh-merge-base.sh 908 && gh pr merge 908 --rebase --delete-branch --match-head-commit ${SHA}" \
   "$(printf '%s\n' "${clean_out}" | sed -n 3p)"
 
 # The #908 regression: same PR, same green CI, same zero inline comments, one
@@ -392,7 +432,7 @@ check_eq "outside-diff body finding: --confirm-addressed clears it" \
   "  -> clean (operator confirmed all 1 outside-diff body finding(s) addressed): CI green, CodeRabbit's risk line names the current head" \
   "$(printf '%s\n' "${confirmed_out}" | sed -n 2p)"
 check_eq "outside-diff body finding: --confirm-addressed prints the merge command" \
-  "  -> gh pr merge 908 --rebase --delete-branch --match-head-commit ${SHA}" \
+  "  -> scripts/guards/assert-fresh-merge-base.sh 908 && gh pr merge 908 --rebase --delete-branch --match-head-commit ${SHA}" \
   "$(printf '%s\n' "${confirmed_out}" | sed -n 3p)"
 
 # --- risk-line freshness end-to-end (issue #950) --------------------------
@@ -428,6 +468,10 @@ check_eq "stale risk line: no merge command offered" \
 FLIP_DIR="${E2E_DIR}/flip"
 mkdir -p "${FLIP_DIR}"
 ln -s "$(cd "$(dirname "$0")" && pwd)/lib" "${FLIP_DIR}/lib"
+# The copy resolves its own script_dir, so the guard has to be reachable from
+# there too; without this the flipped script cannot run the guard, reads that
+# as a refusal, and the case proves nothing.
+ln -s "$(cd "$(dirname "$0")" && pwd)/guards" "${FLIP_DIR}/guards"
 sed 's/^elif .*# PROVE-FLIP$/elif false; then/' \
   "$(dirname "$0")/pr-review-status.sh" >"${FLIP_DIR}/pr-review-status.sh"
 if grep -q '^elif false; then$' "${FLIP_DIR}/pr-review-status.sh"; then
@@ -446,7 +490,7 @@ check_eq "prove: the pre-#950 rule calls the stale fixture clean" \
   "  -> clean: CI green, CodeRabbit's risk line names the current head with zero inline comments" \
   "$(printf '%s\n' "${flipped_out}" | sed -n 2p)"
 check_eq "prove: the pre-#950 rule even offers the merge command" \
-  "  -> gh pr merge 908 --rebase --delete-branch --match-head-commit ${SHA}" \
+  "  -> scripts/guards/assert-fresh-merge-base.sh 908 && gh pr merge 908 --rebase --delete-branch --match-head-commit ${SHA}" \
   "$(printf '%s\n' "${flipped_out}" | sed -n 3p)"
 
 # Degraded mode 1: no CodeRabbit comment at all. Nothing to parse, and the
@@ -508,6 +552,48 @@ unset E2E_ISSUE_COMMENTS
 check_eq "multiple walkthroughs: the newest one decides, fresh clears" \
   "  -> clean: CI green, CodeRabbit's risk line names the current head with zero inline comments" \
   "$(printf '%s\n' "${multi_fresh_out}" | sed -n 2p)"
+
+# --- merge-base freshness end-to-end --------------------------------------
+#
+# Same clean fixture throughout; the only thing that moves is what git says
+# about the base. The fresh direction is already covered by the very first e2e
+# case, which comes back clean with a merge command, so these two cover the
+# ways the check can refuse, and the third covers not being able to check.
+
+# Exported, not just assigned: unlike E2E_ISSUE_COMMENTS, which e2e() reads
+# itself, this one is read by the stand-in git two processes down.
+export E2E_GIT_STALE=1
+stale_base_out="$(e2e "${CLEAN_BODY_JSON}")"
+unset E2E_GIT_STALE
+
+check_eq "stale merge base: blocks a verdict that is otherwise clean" \
+  "  -> merge base is behind origin/main; rebase and let CI re-run before merging" \
+  "$(printf '%s\n' "${stale_base_out}" | sed -n 2p)"
+check_eq "stale merge base: no merge command offered" \
+  "0" \
+  "$(printf '%s\n' "${stale_base_out}" | grep -c 'gh pr merge')"
+# The stand-in git puts an escape sequence and a carriage return in the first
+# unseen subject. Both must be gone by the time the text is printed: a subject
+# is attacker-controlled and this output is what the operator reads before
+# deciding to merge.
+check_eq "stale merge base: printed commit subjects carry no control bytes" \
+  "0" \
+  "$(printf '%s' "${stale_base_out}" | LC_ALL=C tr -cd '\000-\010\013-\037\177' | wc -c | tr -d ' ')"
+
+# A guard that cannot run at all must not be reported as a stale base: one is
+# fixed by rebasing and the other by fixing the checkout, and the headline is
+# the line the operator acts on.
+NOGUARD_DIR="${E2E_DIR}/noguard"
+mkdir -p "${NOGUARD_DIR}"
+ln -s "$(cd "$(dirname "$0")" && pwd)/lib" "${NOGUARD_DIR}/lib"
+cp "$(dirname "$0")/pr-review-status.sh" "${NOGUARD_DIR}/pr-review-status.sh"
+E2E_SCRIPT="${NOGUARD_DIR}/pr-review-status.sh"
+noguard_out="$(e2e "${CLEAN_BODY_JSON}")"
+unset E2E_SCRIPT
+
+check_eq "a guard that cannot run is not reported as a stale base" \
+  "  -> could not check merge-base freshness (guard exit 127); check by hand before merging" \
+  "$(printf '%s\n' "${noguard_out}" | sed -n 2p)"
 
 printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
 [[ "${fails}" -eq 0 ]]

--- a/scripts/pr-review-status.test.sh
+++ b/scripts/pr-review-status.test.sh
@@ -331,7 +331,13 @@ resolve() {
   esac
 }
 case "$1" in
-  fetch|update-ref|ls-remote) exit 0 ;;
+  fetch)
+    # E2E_GIT_FETCH_FAIL=1 makes the fetch fail while the remote still has the
+    # pull request ref, which is the guard's "could not answer" path.
+    if [[ "${E2E_GIT_FETCH_FAIL:-0}" == "1" ]]; then exit 1; fi
+    exit 0
+    ;;
+  update-ref|ls-remote) exit 0 ;;
   rev-parse)
     if [[ "$2" == "--short" ]]; then
       resolve "$3" | cut -c1-8
@@ -345,7 +351,7 @@ case "$1" in
     else printf '%s\n' "${tip}"; fi
     ;;
   rev-list) printf '3\n' ;;
-  log) printf 'ccccccc1 innocent\033[31mSPOOFED\033[0m\rsubject\ncccccc2 second\ncccccc3 third\n' ;;
+  log) printf 'ccccccc1 innocent\033[31mSPOOFED\033[0m\rsubject\ncccccc2 tab:\there\ncccccc3 third\n' ;;
   *) echo "unexpected git call: $*" >&2; exit 91 ;;
 esac
 SHIM
@@ -579,6 +585,17 @@ check_eq "stale merge base: no merge command offered" \
 check_eq "stale merge base: printed commit subjects carry no control bytes" \
   "0" \
   "$(printf '%s' "${stale_base_out}" | LC_ALL=C tr -cd '\000-\010\013-\037\177' | wc -c | tr -d ' ')"
+# The other half of the filter's claim. Counting bytes in the complement of the
+# code's own delete set cannot see a set that is too WIDE, and a set eating tab
+# and newline would flatten this listing into one line while still passing the
+# count above. So: the tab in the second stub subject survives, and the three
+# subjects are still three prefixed lines.
+check_eq "stale merge base: the filter keeps tab" \
+  "1" \
+  "$(printf '%s' "${stale_base_out}" | LC_ALL=C grep -cF "$(printf 'tab:\there')")"
+check_eq "stale merge base: one prefixed line per unseen commit" \
+  "3" \
+  "$(printf '%s\n' "${stale_base_out}" | grep -c '^ \{1,\}c\{1,\}[123] ')"
 
 # A guard that cannot run at all must not be reported as a stale base: one is
 # fixed by rebasing and the other by fixing the checkout, and the headline is
@@ -594,6 +611,25 @@ unset E2E_SCRIPT
 check_eq "a guard that cannot run is not reported as a stale base" \
   "  -> could not check merge-base freshness (guard exit 127); check by hand before merging" \
   "$(printf '%s\n' "${noguard_out}" | sed -n 2p)"
+
+# The guard's own half of that contract: 2 for a question it cannot answer, and
+# 1 kept for the stale verdict. The case above only exercises bash's 127 for a
+# missing file, which the guard never reaches, so without these two the guard
+# could go back to exiting 1 on every internal failure unnoticed.
+guard_direct_rc=0
+"$(dirname "$0")/guards/assert-fresh-merge-base.sh" not-a-number >/dev/null 2>&1 \
+  || guard_direct_rc=$?
+check_eq "the guard exits 2 on an argument it cannot use" \
+  "2" \
+  "${guard_direct_rc}"
+
+export E2E_GIT_FETCH_FAIL=1
+fetchfail_out="$(e2e "${CLEAN_BODY_JSON}")"
+unset E2E_GIT_FETCH_FAIL
+
+check_eq "a fetch that fails is reported as could-not-check, not as behind" \
+  "  -> could not check merge-base freshness (guard exit 2); check by hand before merging" \
+  "$(printf '%s\n' "${fetchfail_out}" | sed -n 2p)"
 
 printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
 [[ "${fails}" -eq 0 ]]


### PR DESCRIPTION
A pull request's green CI says nothing about the merge once `main` has moved underneath it. `main` runs no CI of its own here, so a PR that passed against an older base can still break it — `8a534f43` left main uncompilable exactly that way, a five-argument call site landing minutes before another PR made the same function take six, both PRs green and neither having seen the other. The quieter case is a gate landing on `main` after a PR went green: the PR then merges without ever running the check its author added to catch it.

The rule was already written down, in CLAUDE.md and in a session memory, and it still did not hold. Four PRs (#1281–#1284) were CI-green and behind simultaneously today, one seventeen commits back and about to merge past the wall-clock-wait gate that had landed since. A rule that depends on being remembered at merge time is not a rule.

## What it does

`scripts/guards/assert-fresh-merge-base.sh <pr-number>` exits non-zero when a PR's merge base is behind `origin/main`, printing how far behind and the commits it has not seen (capped at ten). `pr-review-status.sh` now runs it and withholds the merge command from a stale PR, so the flow that already gates on CodeRabbit gates on this too.

It sits ahead of the `mergeState` check deliberately: staleness is always actionable and the fix is always the same, whereas `mergeState UNKNOWN` is usually GitHub still computing. It costs one fetch.

`ALLOW_STALE_MERGE_BASE=1` proceeds anyway, for a case where the gap is genuinely irrelevant.

## The trap it avoids

The guard fetches through an explicit destination refspec rather than reading `FETCH_HEAD`. That is not incidental: the hand-rolled check that produced this commit's own near miss did `git fetch origin main <other-ref>` and then `git rev-parse FETCH_HEAD`, which returns **main**, so it compared main with itself and printed `BASE CURRENT: safe to merge` for a branch two commits stale. A freshness check that cannot fail loudly reports success.

## Verification

Both paths exercised against real PRs rather than reasoned about: a freshly rebased PR passes, a genuinely stale one (324 commits behind) fails with its listing capped, non-numeric and missing arguments exit 1, `ALLOW_STALE_MERGE_BASE=1` proceeds, and a current-base PR still reaches its normal verdict through `pr-review-status.sh`. `shellcheck` clean on both scripts; docs gate clean.