### PR TITLE
fix(query): carry the plan phase's whole-object read into the scan

### DIFF
--- a/crates/ravel-bench/src/logs_scan_scaling.rs
+++ b/crates/ravel-bench/src/logs_scan_scaling.rs
@@ -615,7 +615,7 @@ async fn measure_planning_latency(
             .plan_segment(seg, tenant_hash, &query, &accounting)
             .await
             .expect("plan segment");
-        if let Some((survivors, _, _)) = planned {
+        if let Some((survivors, _, _, _)) = planned {
             total_blocks += survivors;
         }
     }
@@ -640,7 +640,7 @@ async fn measure_planning_latency(
     assert_eq!(
         planned
             .iter()
-            .filter_map(|p| p.as_ref().map(|(s, _, _)| *s))
+            .filter_map(|p| p.as_ref().map(|(s, _, _, _)| *s))
             .sum::<usize>(),
         total_blocks,
         "both planning passes must prune to the same surviving-block count"

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -2726,6 +2726,46 @@ mod tests {
         write_records_as_objects(store, tenant, shard, &build_records(objects.max(1), 0)).await
     }
 
+    /// The number of segments whose plan-phase whole-object read is carried
+    /// into the scan (issue #835). The carry budget is the SQL partition
+    /// count, which on this lane resolves from
+    /// [`ExecutorSettings::fetch_concurrency`]; the fixtures below pin that to
+    /// this value so one object more than the budget already owns a segment
+    /// the carry does not cover, and the scan phase is exercised on a fixture
+    /// small enough to state its byte split exactly.
+    const CARRY_BUDGET: usize = 1;
+
+    /// `objects` RLOG objects on `shard`, each holding the SAME single record,
+    /// whose body carries the word `timeout`.
+    ///
+    /// Two properties the multi-segment fixtures rely on and
+    /// [`write_shard_objects`] does not give: every object survives
+    /// [`PROBE_MISS_SQL`]'s predicate and so reaches the scan (`build_records`
+    /// only puts `timeout` in every third body, and a segment the predicate
+    /// prunes to zero survivors is never opened and never carries), and every
+    /// object has the same length, which is what lets a fixture with more
+    /// segments than [`CARRY_BUDGET`] still state its per-phase byte split as
+    /// exact literals over one section table.
+    async fn write_matching_objects(
+        store: &Arc<dyn ObjectStoreBackend>,
+        tenant: &TenantId,
+        shard: u32,
+        objects: usize,
+    ) -> Vec<Vec<u8>> {
+        let one = build_records(1, 0).into_iter().next().expect("one record");
+        assert!(
+            one.body.contains("timeout"),
+            "fixture: the repeated record's body must match the has_word predicate"
+        );
+        let records = vec![one; objects.max(1)];
+        let written = write_records_as_objects(store, tenant, shard, &records).await;
+        assert!(
+            written.iter().all(|o| o.len() == written[0].len()),
+            "fixture: every object must be the same length"
+        );
+        written
+    }
+
     /// One RLOG object per record in `records`, each with its own commit
     /// record, on `shard`. Returns the object bytes in write order, so a test
     /// that needs the object's own layout (section offsets, total size) reads it
@@ -2759,7 +2799,13 @@ mod tests {
                 writer_epoch: 1,
                 writer_seq,
                 object_size: bytes.len() as u64,
-                content_hash: [0u8; 32],
+                // The real BLAKE3 of the bytes, not a zero placeholder: ADR-0046's
+                // cache key is `(tenant, content_hash, offset, object_size)`, so
+                // objects sharing a zero hash collide with each other whenever
+                // their sizes also match, and a fixture with several equal-size
+                // objects would read one object's bytes for all of them and count
+                // the collisions as cache hits.
+                content_hash: *blake3::hash(&bytes).as_bytes(),
                 sample_count: 1,
                 series_count: 1,
                 min_event_ts_ns: rec.ts_ns,
@@ -3778,37 +3824,63 @@ mod tests {
     /// The `--cache-bytes` cache is not inert: attaching it to the log fetcher
     /// cuts object-store GETs and adds fetch-cache hits.
     ///
-    /// Reachability (issue #677): the bench's SQL scan reaches the cache through
-    /// `LogSegmentFetcher::tenant_bytes` (via `plan_segment` +
-    /// `scan_accounted_with_tenant_subset` in `ravel_sql::logs_scan`), NOT the
-    /// `fetch_accounted_with_tenant` funnel the flag's ADR names. That path reads
-    /// each segment more than once per query (once to plan the surviving blocks,
-    /// once to scan them), so with the fetcher cache attached the scan is served
-    /// from the plan's fill within a single run. The catalog's own byte cache is
-    /// on under `CatalogConfig::default()` in both arms, so an isolated,
-    /// attributable comparison holds the catalog state identical (two FRESH
-    /// executors, one cold run each) and reads off the delta the fetcher cache
-    /// alone makes: strictly fewer store GETs, strictly more cache hits. This is
-    /// why the literal "warm hits == cold misses" identity does not hold and is
-    /// not asserted -- the cold run already hits, and the catalog cache
-    /// contributes hits of its own. Building the cached arm without `with_cache`
-    /// collapses both deltas to zero, which is what flips the assertions red.
+    /// Reachability (issue #677, restated for issue #835): the bench's SQL scan
+    /// reaches the cache through `LogSegmentFetcher::tenant_bytes` (via
+    /// `plan_segment` + `scan_accounted_with_tenant_subset` in
+    /// `ravel_sql::logs_scan`), NOT the `fetch_accounted_with_tenant` funnel the
+    /// flag's ADR names. That path plans each segment and then scans it. Since
+    /// #835 the plan phase's whole-object bytes are CARRIED into the scan for
+    /// the first [`CARRY_BUDGET`] segments whose plan completes, so those
+    /// segments cross the wire once and leave the fetcher cache nothing to
+    /// absorb; the carry is charged to `bytes_reused`, not to a cache hit. The
+    /// cache's contribution is on the segments the budget does not cover: their
+    /// plan read fills the cache and their scan re-open is served from it
+    /// instead of paying a second wire GET. So the fixture writes
+    /// `CARRY_BUDGET + SURPLUS_SEGMENTS` objects against an executor whose
+    /// partition count (and therefore whose carry budget) is `CARRY_BUDGET`,
+    /// and the surplus is what the two arms differ by.
+    ///
+    /// The catalog's own byte cache is on under `CatalogConfig::default()` in
+    /// both arms, so an isolated, attributable comparison holds the catalog
+    /// state identical (two FRESH executors, one cold run each) and reads off
+    /// the delta the fetcher cache alone makes: exactly one store GET per
+    /// surplus segment, and strictly more cache hits. This is why the literal
+    /// "warm hits == cold misses" identity does not hold and is not asserted --
+    /// the cold run already hits, and the catalog cache contributes hits of its
+    /// own. Building the cached arm without `with_cache` collapses both deltas
+    /// to zero (`get_on=9 get_off=9`), which is what flips the assertions red.
+    /// Dropping the `carried_seen < budget` bound from `compute_plan_counts` in
+    /// `ravel_sql::logs_scan` flips them red from the other side: every segment
+    /// is then carried, no scan re-open is left for the cache to serve, and both
+    /// arms read `get_on=7 get_off=7`.
     ///
     /// The `has_word` predicate is what keeps the query on that plan-then-scan
     /// path (issue #739). A predicate-free full-window statement now takes
     /// `LogsScanExec`'s whole-segment fast path, which reads each segment exactly
-    /// once and so leaves the fetcher cache nothing to absorb within a run -- the
-    /// double read this test is about is precisely what that path eliminates. The
-    /// fixture's single record body is `request 0 timeout after 30s`, so the
-    /// predicate matches it and the returned rows are the same as without it.
+    /// once and so leaves the fetcher cache nothing to absorb within a run. Since
+    /// #835 that fast path has a sibling: a carried segment on the plan-then-scan
+    /// path is also read exactly once. Both are why the fixture needs surplus
+    /// segments rather than a predicate alone. Every object holds the same
+    /// `request 0 timeout after 30s` body, so the predicate matches all of them
+    /// and every segment reaches the scan.
     #[tokio::test]
     async fn cache_flag_cuts_store_gets_within_a_run() {
         use ravel_types::accounting::AccountedOp;
 
+        // Segments beyond the carry budget. Each one's scan re-opens its object:
+        // a real store GET with the cache off, a cache hit with it on. The margin
+        // the assertion below states is this number, not whatever the fixture
+        // happens to produce.
+        const SURPLUS_SEGMENTS: usize = 2;
+
         let store = empty_store();
         let tenant = TenantId::new("cache-tenant");
         let th = tenant.hash();
-        write_shard_objects(&store, &tenant, 0, 1).await;
+        write_matching_objects(&store, &tenant, 0, CARRY_BUDGET + SURPLUS_SEGMENTS).await;
+        let settings = ExecutorSettings {
+            fetch_concurrency: CARRY_BUDGET,
+            ..ExecutorSettings::default()
+        };
         let req = SqlRequest {
             sql: "SELECT body FROM logs WHERE has_word(body, 'timeout')".to_string(),
             window: TimeRange {
@@ -3823,7 +3895,7 @@ mod tests {
         // Fetcher cache ON: a fresh executor (cold catalog byte cache, cold
         // fetcher cache), one run.
         let cache = build_read_cache(64 << 20);
-        let cached = cold_executor(&store, &[], Some(cache), ExecutorSettings::default())
+        let cached = cold_executor(&store, &[], Some(cache), settings)
             .expect("build cached executor")
             .executor;
         let on = cached.execute(th, &req).await.expect("cached run");
@@ -3831,17 +3903,24 @@ mod tests {
         // Fetcher cache OFF: a fresh executor (identical cold catalog byte cache,
         // no fetcher cache), one run. The catalog contribution is the same in
         // both, so any delta is the fetcher cache alone.
-        let uncached = cold_executor(&store, &[], None, ExecutorSettings::default())
+        let uncached = cold_executor(&store, &[], None, settings)
             .expect("build uncached executor")
             .executor;
         let off = uncached.execute(th, &req).await.expect("uncached run");
 
         let get_on = on.accounting.s3_requests(AccountedOp::Get);
         let get_off = off.accounting.s3_requests(AccountedOp::Get);
+
         assert!(
             get_on < get_off,
             "the fetcher cache must cut store GETs within a run; got get_on={get_on} \
              get_off={get_off}"
+        );
+        assert_eq!(
+            get_off - get_on,
+            SURPLUS_SEGMENTS as u64,
+            "the cache absorbs exactly the segments the carry budget does not \
+             cover: one scan re-open each; got get_on={get_on} get_off={get_off}"
         );
         assert!(
             on.accounting.cache_hits > off.accounting.cache_hits,
@@ -3963,13 +4042,16 @@ mod tests {
     ///
     /// The exact figures the fixture produces (pinned below, never `> 0`): the
     /// single RLOG object plus the catalog resolve are 3 store GETs on the cold
-    /// run (`l/HEAD` pointer, the commit record, the data object; the
-    /// plan-then-scan second read of the data object is absorbed by the fetcher
-    /// cache, 2 hits). On the warm run the data object and most of the resolve
-    /// are cache-served, so store GETs fall to 1 and cache hits rise to 4, with
-    /// no store bytes transferred. The `has_word` predicate keeps the query on
-    /// the plan-then-scan path so the cache has a within-run second read to
-    /// absorb (see `cache_flag_cuts_store_gets_within_a_run`).
+    /// run (`l/HEAD` pointer, the commit record, the data object). This
+    /// fixture's one segment is inside the carry budget (issue #835), so the
+    /// plan phase's whole-object read is handed to the scan rather than
+    /// re-read, and the cache has no within-run second read of the data object
+    /// to absorb: the cold run's hit is the catalog's, not the scan's. On the
+    /// warm run the data object and most of the resolve are cache-served, so
+    /// store GETs fall to 1 and cache hits rise from 1 to 3, with no store
+    /// bytes transferred. What the cache does absorb within a run is a segment
+    /// the carry budget does not cover, which needs more segments than this
+    /// fixture has (see `cache_flag_cuts_store_gets_within_a_run`).
     ///
     /// Red against the `run == 0` guard: moving the `per_run_accounting.push`
     /// back under `if run == 0` leaves the array length 1 with the warm entry
@@ -4020,7 +4102,11 @@ mod tests {
             acc[0].object_store_get_requests, 3,
             "cold run's store GETs: l/HEAD + commit record + the data object"
         );
-        assert_eq!(acc[0].cache_hits, 2, "cold run's fetcher-cache hits");
+        assert_eq!(
+            acc[0].cache_hits, 1,
+            "cold run's fetcher-cache hits: the carried plan read leaves the \
+             scan nothing to look up"
+        );
         assert_eq!(acc[0].cache_misses, 3, "cold run's fetcher-cache misses");
         assert_eq!(acc[0].object_store_bytes, 836, "cold run's store bytes");
 
@@ -4030,8 +4116,8 @@ mod tests {
             "warm run's store GETs fall from 3 to 1 (the rest cache-served)"
         );
         assert_eq!(
-            acc[1].cache_hits, 4,
-            "warm run's cache hits rise from 2 to 4"
+            acc[1].cache_hits, 3,
+            "warm run's cache hits rise from 1 to 3"
         );
         assert_eq!(
             acc[1].object_store_bytes, 0,
@@ -4072,23 +4158,58 @@ mod tests {
 
     /// The `has_word` statement the probe-miss tests measure. It is deliberately
     /// not skip-decidable: `plan_segment` falls back to a whole-object plan read
-    /// and hands no footer forward, so the scan probes the object a second time
-    /// on its own. That is what makes both phases counted, which is the split
-    /// the two `probe_misses_*` fields exist to show.
+    /// and hands no footer forward, so a scan open that is not served by the
+    /// plan phase's carried whole object (issue #835) probes the object a second
+    /// time on its own. That is what makes both phases counted, which is the
+    /// split the two `probe_misses_*` fields exist to show.
     const PROBE_MISS_SQL: &str = "SELECT body FROM logs WHERE has_word(body, 'timeout')";
+
+    /// The segment count the probe-miss and phase-split fixtures write: one more
+    /// than the carry budget, so exactly one segment's scan open is served from
+    /// the plan phase's carried whole object and exactly one pays its own probe
+    /// and its own data read. A one-object fixture would have its only segment
+    /// carried and report a scan phase of all zeros.
+    const PROBE_MISS_OBJECTS: usize = CARRY_BUDGET + 1;
+
+    /// Every scan-side expectation in those fixtures is
+    /// `PROBE_MISS_OBJECTS - CARRY_BUDGET`, so a fixture shrunk to the budget
+    /// would expect zero, never reach the scan phase, and pass while measuring
+    /// nothing. Refused at compile time rather than at review time.
+    const _: () = assert!(PROBE_MISS_OBJECTS > CARRY_BUDGET);
+
+    /// The executor settings the probe-miss and phase-split fixtures measure
+    /// under. `logs_block_range_threshold: 0` disables the whole-object
+    /// crossover so the reads go through the ranged probe-then-fetch path, the
+    /// only path that probes at all; `fetch_concurrency` pins both the partition
+    /// count and the carry budget to [`CARRY_BUDGET`].
+    fn probe_miss_settings(suffix: u64) -> ExecutorSettings {
+        ExecutorSettings {
+            logs_block_range_threshold: 0,
+            logs_suffix_len: Some(suffix),
+            fetch_concurrency: CARRY_BUDGET,
+            ..ExecutorSettings::default()
+        }
+    }
 
     /// A trailer that EXCEEDS the probe is reported in the per-run accounting,
     /// per phase, on every run.
     ///
-    /// The fixture is one RLOG object read through the ranged path
-    /// (`logs_block_range_threshold: 0`, the whole-object crossover disabled --
-    /// at the default threshold this object is read whole in one GET and never
-    /// probes at all, so none of the miss-counting sites is reached and the test
-    /// would be vacuous). The probe is pinned to start at SKIP_IDX's end, so
-    /// each read that has to locate blocks through SKIP_IDX misses exactly one
-    /// tail section: one in the plan phase (`plan_segment`'s whole-object
-    /// fallback) and one in the scan phase (the data read, which re-probes
-    /// because the fallback carried no footer).
+    /// The fixture is [`PROBE_MISS_OBJECTS`] equal-size RLOG objects read
+    /// through the ranged path (`logs_block_range_threshold: 0`, the
+    /// whole-object crossover disabled -- at the default threshold these
+    /// objects are read whole in one GET each and never probe at all, so none
+    /// of the miss-counting sites is reached and the test would be vacuous).
+    /// The probe is pinned to start at SKIP_IDX's end, so each read that has to
+    /// locate blocks through SKIP_IDX misses exactly one tail section.
+    ///
+    /// The two phases are counted separately, and the counts differ, which is
+    /// the point of splitting them. Every segment pays a plan-phase read
+    /// (`plan_segment`'s whole-object fallback), so the plan phase misses once
+    /// per object. Only the segments the carry budget does not cover pay a
+    /// scan-phase read: since issue #835 the plan phase hands its bytes to the
+    /// scan for the first [`CARRY_BUDGET`] segments whose plan completes, and
+    /// that open short-circuits before any probe. So the scan phase misses once
+    /// for the one surplus segment, not once per object.
     ///
     /// Both runs report the same figures even though the warm run's store GETs
     /// fall: a miss is measured against the probe WINDOW, not against what the
@@ -4098,16 +4219,20 @@ mod tests {
     /// during development by deleting the
     /// `self.probe_misses.record(phase, stats.probe_misses)` line from
     /// `LogSegmentFetcher::record_probe_misses` in `ravel-query` (reads 0
-    /// against the expected 1), and by deleting `stats.probe_misses += 1` from
-    /// `fetch_object_v4`'s tail-section loop, the counting site this version-4
-    /// fixture actually reaches (same result, from the other end of the
-    /// plumbing). Deleting the version-3 site in `fetch_object_with_footer`
+    /// against the expected count), and by deleting `stats.probe_misses += 1`
+    /// from `fetch_object_v4`'s tail-section loop, the counting site this
+    /// version-4 fixture actually reaches (same result, from the other end of
+    /// the plumbing). Deleting the version-3 site in `fetch_object_with_footer`
     /// instead leaves it green, which is what says the fixture is version 4.
+    /// Dropping the `carried_seen < budget` bound from `compute_plan_counts` in
+    /// `ravel_sql::logs_scan` carries every segment, so the scan-phase count
+    /// reads 0 against the expected 1: that is what says the surplus segment,
+    /// not the fixture's size alone, is what reaches the scan-phase site.
     #[tokio::test]
     async fn probe_misses_reach_per_run_accounting_when_the_trailer_exceeds_the_probe() {
         let store = empty_store();
         let tenant = TenantId::new("probe-miss-tenant");
-        let objects = write_shard_objects(&store, &tenant, 0, 1).await;
+        let objects = write_matching_objects(&store, &tenant, 0, PROBE_MISS_OBJECTS).await;
         let suffix = suffix_just_past_skip_idx(&objects[0]);
         let window = TimeRange {
             start_ns: 0,
@@ -4125,11 +4250,7 @@ mod tests {
             Duration::from_secs(30),
             false,
             None,
-            ExecutorSettings {
-                logs_block_range_threshold: 0,
-                logs_suffix_len: Some(suffix),
-                ..ExecutorSettings::default()
-            },
+            probe_miss_settings(suffix),
             false,
             None,
         )
@@ -4142,21 +4263,31 @@ mod tests {
             .expect("an in-process lane records per-run accounting");
         assert_eq!(acc.len(), 2, "one accounting entry per run");
 
+        // One plan-phase read per object; one scan-phase read for the segment
+        // the carry budget does not cover.
+        let plan_misses = PROBE_MISS_OBJECTS as u64;
+        let scan_misses = (PROBE_MISS_OBJECTS - CARRY_BUDGET) as u64;
         assert_eq!(
-            acc[0].probe_misses_plan, 1,
-            "cold run: the plan-phase read missed SKIP_IDX exactly once"
+            acc[0].probe_misses_plan, plan_misses,
+            "cold run: every object's plan-phase read missed SKIP_IDX exactly once"
         );
         assert_eq!(
-            acc[0].probe_misses_scan, 1,
-            "cold run: the scan-phase read missed SKIP_IDX exactly once"
+            acc[0].probe_misses_scan, scan_misses,
+            "cold run: only the uncarried segment took a scan-phase read, and it \
+             missed SKIP_IDX exactly once"
         );
         assert_eq!(
-            acc[1].probe_misses_plan, 1,
+            acc[1].probe_misses_plan, plan_misses,
             "warm run: the same window misses the same section"
         );
         assert_eq!(
-            acc[1].probe_misses_scan, 1,
+            acc[1].probe_misses_scan, scan_misses,
             "warm run: a miss is a property of the probe window, not of the cache"
+        );
+        assert_ne!(
+            plan_misses, scan_misses,
+            "the fixture must separate the phases: equal counts would pass a \
+             plumbing that reported one figure under both names"
         );
 
         // What a measurement pass actually reads: the figure has to be in the
@@ -4165,31 +4296,40 @@ mod tests {
         let per_run = v["per_run_accounting"]
             .as_array()
             .expect("per_run_accounting is a JSON array");
-        assert_eq!(per_run[0]["probe_misses_plan"], 1);
-        assert_eq!(per_run[0]["probe_misses_scan"], 1);
-        assert_eq!(per_run[1]["probe_misses_plan"], 1);
-        assert_eq!(per_run[1]["probe_misses_scan"], 1);
+        assert_eq!(per_run[0]["probe_misses_plan"], plan_misses);
+        assert_eq!(per_run[0]["probe_misses_scan"], scan_misses);
+        assert_eq!(per_run[1]["probe_misses_plan"], plan_misses);
+        assert_eq!(per_run[1]["probe_misses_scan"], scan_misses);
     }
 
     /// A trailer that FITS inside the derived probe reports exactly zero, on
     /// both phases and both runs.
     ///
-    /// Same fixture and same ranged path as the exceeding case, with the probe
-    /// left at the per-object derivation: this object is far below
-    /// `LOG_SUFFIX_FLOOR_BYTES`, so the derived window is the whole object and
-    /// covers every tail section. Paired with the exceeding case so a plumbing
-    /// change that reported a constant zero could not pass both.
+    /// Same fixture and same ranged path as the exceeding case,
+    /// [`PROBE_MISS_OBJECTS`] equal-size objects at a carry budget of
+    /// [`CARRY_BUDGET`], with the probe left at the per-object derivation:
+    /// these objects are far below `LOG_SUFFIX_FLOOR_BYTES`, so the derived
+    /// window is the whole object and covers every tail section. Paired with
+    /// the exceeding case so a plumbing change that reported a constant zero
+    /// could not pass both.
     ///
-    /// Prove-the-test: pinned to 0, never `>= 0`. Demonstrated failing during
-    /// development by making `probe_window_covers` in `ravel-query` return
-    /// `false` unconditionally: every counting read then reports its tail
-    /// sections as missed and the first assertion reads 2 (SKIP_IDX and
-    /// PAGE_DIR) against the expected 0.
+    /// The fixture has to exceed the carry budget for the SCAN half of this
+    /// test to mean anything. With one object the plan's bytes are carried
+    /// into the scan, the scan opens nothing, and `probe_misses_scan` is zero
+    /// for want of a read rather than because the probe covered the trailer:
+    /// no production change could falsify it. The surplus segment restores a
+    /// real scan-phase read.
+    ///
+    /// Prove-the-test: pinned to 0, never `>= 0`. Making `probe_window_covers`
+    /// in `ravel-query` return `false` unconditionally fails the plan
+    /// assertion at 2 (SKIP_IDX and PAGE_DIR) against the expected 0; suppress
+    /// that assertion and the scan assertion fails the same way, which is what
+    /// the one-object fixture could not do.
     #[tokio::test]
     async fn probe_misses_are_zero_when_the_derived_probe_covers_the_trailer() {
         let store = empty_store();
         let tenant = TenantId::new("probe-fit-tenant");
-        let objects = write_shard_objects(&store, &tenant, 0, 1).await;
+        let objects = write_matching_objects(&store, &tenant, 0, PROBE_MISS_OBJECTS).await;
         let total = objects[0].len() as u64;
         assert!(
             ravel_query::derive_suffix_len(total) >= total,
@@ -4216,6 +4356,7 @@ mod tests {
             ExecutorSettings {
                 logs_block_range_threshold: 0,
                 logs_suffix_len: None,
+                fetch_concurrency: CARRY_BUDGET,
                 ..ExecutorSettings::default()
             },
             false,
@@ -4248,13 +4389,19 @@ mod tests {
     /// on every run.
     ///
     /// Same fixture and same ranged path as the probe-miss tests above (at the
-    /// default threshold this object is read whole in one GET, which is a real
+    /// default threshold each object is read whole in one GET, which is a real
     /// but uninteresting amplification shape and would exercise none of the
     /// per-phase split), and with the read cache OFF. With a cache, this
     /// statement's plan-phase whole-object fallback admits `(0, object_size)`
     /// and the scan that follows is served entirely from it, so the scan phase
     /// correctly reports zero wire bytes and the numerator this test is about
     /// is never exercised.
+    ///
+    /// The fixture needs [`PROBE_MISS_OBJECTS`] objects against a carry budget
+    /// of [`CARRY_BUDGET`] for the same reason (issue #835): the carried
+    /// segments' scan opens are served from the plan phase's bytes and are
+    /// charged to `bytes_reused`, so a fixture with no surplus segment reports
+    /// a zero scan phase and a zero numerator, cache or no cache.
     ///
     /// What is pinned exactly:
     ///
@@ -4283,7 +4430,7 @@ mod tests {
     async fn wire_bytes_and_amplification_reach_per_run_accounting() {
         let store = empty_store();
         let tenant = TenantId::new("amplification-tenant");
-        let objects = write_shard_objects(&store, &tenant, 0, 1).await;
+        let objects = write_matching_objects(&store, &tenant, 0, PROBE_MISS_OBJECTS).await;
         let suffix = suffix_just_past_skip_idx(&objects[0]);
         let window = TimeRange {
             start_ns: 0,
@@ -4301,11 +4448,7 @@ mod tests {
             Duration::from_secs(30),
             false,
             None,
-            ExecutorSettings {
-                logs_block_range_threshold: 0,
-                logs_suffix_len: Some(suffix),
-                ..ExecutorSettings::default()
-            },
+            probe_miss_settings(suffix),
             false,
             None,
         )
@@ -4433,25 +4576,46 @@ mod tests {
     /// path; `logs_suffix_len: Some(suffix)` pins the probe window to start
     /// exactly at SKIP_IDX's end, so every probe misses SKIP_IDX and chases it;
     /// and `PROBE_MISS_SQL` is not skip-decidable, so `plan_segment` gives up
-    /// and reads the whole object, handing no footer forward, which is why the
-    /// data read that follows probes the object again on its own account.
+    /// and reads the whole object, handing no footer forward, which is why a
+    /// data read that is not served by the plan phase's carried bytes probes
+    /// the object again on its own account.
     ///
-    /// That makes each phase a named list of GETs whose lengths the section
+    /// The fixture is [`PROBE_MISS_OBJECTS`] equal-size objects against a carry
+    /// budget of [`CARRY_BUDGET`] (issue #835), so the counts per phase differ:
+    /// every segment pays a plan read, and the one surplus segment pays the
+    /// scan-side probe and data read that the carried segments do not. That is
+    /// what makes each phase a named list of GETs whose lengths the section
     /// table gives:
     ///
     /// - `resolve`: nothing. The RLOG read path issues no resolve request at
     ///   all; the catalog's commit-record GETs are the unattributed residual.
-    /// - `plan`: the pinned suffix probe, the SKIP_IDX chase it forces, and the
-    ///   whole-object fallback. `suffix + skip_idx_len + object_len`.
-    /// - `probe`: the data read's own suffix probe, its SKIP_IDX chase, and
-    ///   FIELD_DIR. `suffix + skip_idx_len + field_dir_len`.
-    /// - `scan`: one whole-object GET for the block data. `object_len`.
+    /// - `plan`: per object, the pinned suffix probe, the SKIP_IDX chase it
+    ///   forces, and the whole-object fallback.
+    ///   `PROBE_MISS_OBJECTS * (suffix + skip_idx_len + object_len)`.
+    /// - `probe`: the uncarried segment's data read pays its own suffix probe,
+    ///   its SKIP_IDX chase, and FIELD_DIR.
+    ///   `surplus * (suffix + skip_idx_len + field_dir_len)`.
+    /// - `scan`: one whole-object GET for that segment's block data.
+    ///   `surplus * object_len`.
+    ///
+    /// The carried segments contribute nothing to `probe` or `scan`: their
+    /// subset open short-circuits on the carried bytes and is charged to
+    /// `bytes_reused`, never to a phase's wire bytes.
     ///
     /// Prove-the-test: the four `reconcile_rejects_*` tests below perturb one
     /// field of this same measured run and show the reconciler failing on each.
+    /// For the carry-dependent half of the split, dropping the
+    /// `carried_seen < budget` bound from `compute_plan_counts` in
+    /// `ravel_sql::logs_scan` carries every segment: the probe literal then
+    /// reads 0 against the expected 438 and the scan literal 0 against the
+    /// expected object length.
     #[tokio::test]
     async fn reconcile_accepts_a_measured_run_with_an_exact_phase_split() {
         let (measured, object_len, suffix, object) = probe_miss_fixture_run().await;
+        // Segments whose scan open the carry does not cover: they, and only
+        // they, pay the scan-side probe and data read.
+        let surplus = (PROBE_MISS_OBJECTS - CARRY_BUDGET) as u64;
+        let planned = PROBE_MISS_OBJECTS as u64;
         let footer = ravel_logseg::footer::open(&object).expect("footer");
         let section = |kind: u32| {
             footer
@@ -4480,26 +4644,30 @@ mod tests {
         );
         assert_eq!(
             phase(QueryPhase::Plan),
-            suffix + skip_idx_len + object_len,
-            "plan: the {suffix}-byte suffix probe, the {skip_idx_len}-byte \
-             SKIP_IDX chase, and the {object_len}-byte whole-object fallback"
+            planned * (suffix + skip_idx_len + object_len),
+            "plan: per object, the {suffix}-byte suffix probe, the \
+             {skip_idx_len}-byte SKIP_IDX chase, and the {object_len}-byte \
+             whole-object fallback, over {planned} objects"
         );
         assert_eq!(
             phase(QueryPhase::Probe),
-            suffix + skip_idx_len + field_dir_len,
-            "probe: the data read's own {suffix}-byte suffix probe, its \
-             {skip_idx_len}-byte SKIP_IDX chase, and {field_dir_len} bytes of FIELD_DIR"
+            surplus * (suffix + skip_idx_len + field_dir_len),
+            "probe: the {surplus} uncarried segment's data read pays its own \
+             {suffix}-byte suffix probe, its {skip_idx_len}-byte SKIP_IDX \
+             chase, and {field_dir_len} bytes of FIELD_DIR"
         );
         assert_eq!(
             phase(QueryPhase::Scan),
-            object_len,
-            "scan: one whole-object GET for the block data"
+            surplus * object_len,
+            "scan: one whole-object GET for the {surplus} uncarried segment's \
+             block data"
         );
 
         // The residual is the catalog's, and it is the whole of the difference:
         // nothing else in this statement's read path goes unattributed.
-        let attributed =
-            suffix + skip_idx_len + object_len + suffix + skip_idx_len + field_dir_len + object_len;
+        let attributed = planned * (suffix + skip_idx_len + object_len)
+            + surplus * (suffix + skip_idx_len + field_dir_len)
+            + surplus * object_len;
         assert_eq!(
             attributed + cold.wire_bytes_unattributed,
             cold.object_store_bytes,
@@ -4557,10 +4725,20 @@ mod tests {
         );
     }
 
-    /// The same flip in the other direction: keep all four phases but charge
-    /// one GET's bytes to two of them, which is what a call site that recorded
-    /// into the wrong handle alongside the right one would produce. The pooled
-    /// GET total does not move, so the attributed sum rises above it.
+    /// The same flip in the other direction: keep all four phases but charge a
+    /// phase's GET bytes to a second phase as well, which is what a call site
+    /// that recorded into the wrong handle alongside the right one would
+    /// produce. The pooled GET total does not move, so the attributed sum rises
+    /// above it.
+    ///
+    /// The bytes double-charged are the PLAN phase's, not the scan's, and the
+    /// choice is the point rather than a detail: the detector this test is
+    /// about fires on `attributed > pooled`, so a double-charge smaller than
+    /// the unattributed residual stays inside the pooled total and is caught by
+    /// the residual rule instead, under a different message. The plan phase
+    /// reads every object whole and the residual is only the catalog's
+    /// commit-record GETs, so the plan phase is larger by construction; the
+    /// assertion below states that as a precondition rather than trusting it.
     #[tokio::test]
     async fn reconcile_rejects_a_get_charged_to_two_phases() {
         let (measured, _, _, _) = probe_miss_fixture_run().await;
@@ -4569,12 +4747,15 @@ mod tests {
             .as_ref()
             .expect("per-run accounting")[0]
             .clone();
-        let scan = cold.wire_bytes_by_phase[QueryPhase::Scan.index()].wire_bytes;
+        let plan = cold.wire_bytes_by_phase[QueryPhase::Plan.index()].wire_bytes;
         assert!(
-            scan > 0,
-            "the fixture must have scan bytes to double-charge"
+            plan > cold.wire_bytes_unattributed,
+            "the double-charged bytes must exceed the unattributed residual, or \
+             the attributed sum stays inside the pooled total and the residual \
+             rule fires instead; plan={plan} residual={}",
+            cold.wire_bytes_unattributed
         );
-        cold.wire_bytes_by_phase[QueryPhase::Probe.index()].wire_bytes += scan;
+        cold.wire_bytes_by_phase[QueryPhase::Probe.index()].wire_bytes += plan;
 
         let err = reconcile_run_accounting("q", 0, &cold)
             .expect_err("a doubly-charged GET must not reconcile");
@@ -4719,10 +4900,16 @@ mod tests {
 
     /// One cold-plus-warm measurement over the #913 probe-miss fixture, with the
     /// object length and pinned suffix the exact per-phase literals derive from.
+    ///
+    /// [`PROBE_MISS_OBJECTS`] equal-size objects, not one: with a single
+    /// segment the carry (issue #835) serves the whole scan and the probe and
+    /// scan phases both report zero, which would make the exact-split test
+    /// state nothing about them and leave the double-charge flip with no bytes
+    /// to double-charge.
     async fn probe_miss_fixture_run() -> (EntryReport, u64, u64, Vec<u8>) {
         let store = empty_store();
         let tenant = TenantId::new("reconcile-tenant");
-        let objects = write_shard_objects(&store, &tenant, 0, 1).await;
+        let objects = write_matching_objects(&store, &tenant, 0, PROBE_MISS_OBJECTS).await;
         let object_len = objects[0].len() as u64;
         let suffix = suffix_just_past_skip_idx(&objects[0]);
         let window = TimeRange {
@@ -4741,11 +4928,7 @@ mod tests {
             Duration::from_secs(30),
             false,
             None,
-            ExecutorSettings {
-                logs_block_range_threshold: 0,
-                logs_suffix_len: Some(suffix),
-                ..ExecutorSettings::default()
-            },
+            probe_miss_settings(suffix),
             false,
             None,
         )
@@ -5017,31 +5200,36 @@ mod tests {
     /// Asserted at the point of reliance, not the parse site: the exact pinned
     /// window flows through the config-to-settings seam
     /// ([`tenant_executor_settings`]) and, at the fetcher, misses exactly the
-    /// SKIP_IDX section it cannot cover -- once in the plan phase and once in the
-    /// scan phase, the same fixture and reasoning as
+    /// SKIP_IDX section it cannot cover -- once per plan-phase read and once for
+    /// the one segment the carry budget does not cover in the scan phase, the
+    /// same fixture and reasoning as
     /// [`probe_misses_reach_per_run_accounting_when_the_trailer_exceeds_the_probe`].
     ///
     /// The whole-object crossover is dropped for this tiny fixture
     /// (`logs_block_range_threshold: 0`) only so the ranged probe path runs at
-    /// all; the value under test is `logs_suffix_len`, which the settings step
-    /// carries verbatim (first assertion) and the fetcher then applies (the
-    /// probe-miss assertions).
+    /// all, and the config's `fetch_concurrency` is pinned to [`CARRY_BUDGET`]
+    /// only so a scan-phase read exists to probe at all (issue #835); the value
+    /// under test is `logs_suffix_len`, which the settings step carries verbatim
+    /// (first assertion) and the fetcher then applies (the probe-miss
+    /// assertions).
     ///
     /// Prove-the-test: pinned exact values, never `> 0`. Demonstrated failing
     /// against the pre-change code by removing `logs_suffix_len: cfg.logs_suffix_len`
     /// from [`tenant_executor_settings`] (the field then falls back to
     /// `ExecutorSettings::default()`'s `None`): the settings assertion reads
     /// `None` against `Some(suffix)`, and the derived probe covers the whole
-    /// tiny object so both probe-miss assertions read 0 against the expected 1.
+    /// tiny object so both probe-miss assertions read 0 against the expected
+    /// counts.
     #[tokio::test]
     async fn tenant_config_logs_suffix_len_reaches_the_fetcher() {
         let store = empty_store();
         let tenant = TenantId::new("suffix-flag-tenant");
-        let objects = write_shard_objects(&store, &tenant, 0, 1).await;
+        let objects = write_matching_objects(&store, &tenant, 0, PROBE_MISS_OBJECTS).await;
         let suffix = suffix_just_past_skip_idx(&objects[0]);
 
         let mut cfg = tenant_cfg(&store, "suffix-flag-tenant", None, 0);
         cfg.logs_suffix_len = Some(suffix);
+        cfg.fetch_concurrency = CARRY_BUDGET;
         // The seam the loaded-tenant lane builds carries the pinned window
         // verbatim; run_tenant feeds this same value to measure_corpus.
         let settings = tenant_settings_for(&cfg, 1);
@@ -5082,12 +5270,14 @@ mod tests {
             .as_ref()
             .expect("an in-process lane records per-run accounting");
         assert_eq!(
-            acc[0].probe_misses_plan, 1,
-            "the pinned window misses SKIP_IDX in the plan phase exactly once"
+            acc[0].probe_misses_plan, PROBE_MISS_OBJECTS as u64,
+            "the pinned window misses SKIP_IDX once per plan-phase read"
         );
         assert_eq!(
-            acc[0].probe_misses_scan, 1,
-            "the pinned window misses SKIP_IDX in the scan phase exactly once"
+            acc[0].probe_misses_scan,
+            (PROBE_MISS_OBJECTS - CARRY_BUDGET) as u64,
+            "the pinned window misses SKIP_IDX once in the scan phase, for the \
+             one segment the carry budget does not cover"
         );
     }
 

--- a/crates/ravel-query/src/distrib/service.rs
+++ b/crates/ravel-query/src/distrib/service.rs
@@ -1032,7 +1032,9 @@ fn map_fetch_error(err: FetchError) -> (pb::status::Code, String) {
 /// Maps an RLOG fetch-path error to the worker's typed status, mirroring
 /// [`map_fetch_error`]: a vanished object is a snapshot invalidation
 /// (retryable), a transient store error is unavailable, and a corrupt object is
-/// terminal.
+/// terminal. A carried whole object paired with the wrong segment is terminal
+/// too, like [`map_span_fetch_error`]'s tenant mismatch: the pairing is fixed
+/// by the caller, so retrying or re-dispatching it elsewhere reproduces it.
 fn map_log_fetch_error(err: LogFetchError) -> (pb::status::Code, String) {
     match err {
         LogFetchError::Store {
@@ -1042,6 +1044,7 @@ fn map_log_fetch_error(err: LogFetchError) -> (pb::status::Code, String) {
         LogFetchError::Store { .. } => (pb::status::Code::Unavailable, err.to_string()),
         LogFetchError::Corrupt { .. } => (pb::status::Code::Corrupt, err.to_string()),
         LogFetchError::EtagChanged { .. } => (pb::status::Code::Corrupt, err.to_string()),
+        LogFetchError::CarryMismatch { .. } => (pb::status::Code::Corrupt, err.to_string()),
     }
 }
 

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -1955,6 +1955,19 @@ impl QueryEngine {
                     source: StoreError::Corrupted(source.to_string()),
                 })
             }
+            // A carry paired with the wrong segment breaks the caller's
+            // contract rather than the object: it surfaces as hard corruption
+            // like `Corrupt`, never as a retryable store fault.
+            log_series::LogSeriesError::Fetch(carry @ LogFetchError::CarryMismatch { .. }) => {
+                let key = match &carry {
+                    LogFetchError::CarryMismatch { key, .. } => key.clone(),
+                    _ => String::new(),
+                };
+                QueryError::Fetch(FetchError::Store {
+                    key,
+                    source: StoreError::Corrupted(carry.to_string()),
+                })
+            }
             log_series::LogSeriesError::Decode(source) => QueryError::Fetch(FetchError::Store {
                 key: String::new(),
                 source: StoreError::Corrupted(source.to_string()),

--- a/crates/ravel-query/src/http/error.rs
+++ b/crates/ravel-query/src/http/error.rs
@@ -14,6 +14,7 @@ use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use ravel_catalog::CatalogError;
+use ravel_object_store::StoreError;
 
 use crate::QueryError;
 use crate::fetcher::FetchError;
@@ -162,6 +163,17 @@ fn redacted_storage_message(err: &QueryError) -> Option<&'static str> {
     match err {
         QueryError::Fetch(fetch) => Some(match fetch {
             FetchError::Corrupt { .. } => MSG_CORRUPT,
+            // An RLOG fault reaches this enum as `Store` carrying a
+            // `Corrupted` source, because `FetchError::Corrupt` can only hold
+            // an RSEG `SegmentError`: `engine`'s log-series mapper folds
+            // `LogFetchError::Corrupt` and `CarryMismatch` in that way. Both
+            // are permanent data faults, so they take the corruption class
+            // here rather than the retryable one, which a client would retry
+            // forever against data that cannot change.
+            FetchError::Store {
+                source: StoreError::Corrupted(_),
+                ..
+            } => MSG_CORRUPT,
             FetchError::Store { .. } | FetchError::EtagChanged { .. } => MSG_UNAVAILABLE,
         }),
         // An over-wide-window refusal carries only counts and is
@@ -529,6 +541,47 @@ mod tests {
             actual: TENANT_HASH.to_string(),
         });
         assert_eq!(status_code(catalog_mismatch), 500);
+    }
+
+    #[test]
+    fn log_path_corruption_is_500_not_503() {
+        // The local (non-distributed) PromQL log path folds every RLOG fault
+        // through `FetchError::Store`, since `FetchError::Corrupt` can only
+        // carry an RSEG error. Without matching on the `Corrupted` source
+        // these land in the retryable class, so a corrupt object and a carry
+        // paired with the wrong segment would both answer 503 and a client
+        // would retry forever against data that cannot change.
+        let corrupt_rlog = QueryError::Fetch(FetchError::Store {
+            key: LEAKY_KEY.to_string(),
+            source: StoreError::Corrupted("corrupt log segment: bad footer".to_string()),
+        });
+        assert_eq!(status_code(corrupt_rlog), 500);
+
+        let carry_mismatch = QueryError::Fetch(FetchError::Store {
+            key: LEAKY_KEY.to_string(),
+            source: StoreError::Corrupted(
+                crate::log_fetcher::LogFetchError::CarryMismatch {
+                    key: LEAKY_KEY.to_string(),
+                    carried_key: format!("{LEAKY_KEY}.other"),
+                    tenant: ravel_types::TenantHash([1u8; 16]),
+                    carried_tenant: ravel_types::TenantHash([2u8; 16]),
+                }
+                .to_string(),
+            ),
+        });
+        assert_eq!(status_code(carry_mismatch), 500);
+
+        // Still redacted: neither key nor tenant reaches the body.
+        match ApiError::from(QueryError::Fetch(FetchError::Store {
+            key: LEAKY_KEY.to_string(),
+            source: StoreError::Corrupted(LEAKY_KEY.to_string()),
+        })) {
+            ApiError::Corrupt(msg) => {
+                assert_eq!(msg, MSG_CORRUPT);
+                assert!(!msg.contains(LEAKY_KEY), "leaked key: {msg}");
+            }
+            other => panic!("expected Corrupt, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -36,12 +36,12 @@ pub use fetcher::{
 pub use limiter::{GetLimiter, GetLimiterClosed};
 pub use log_fetcher::{
     AssemblyBufferStats, BlockRangeFetcher, BlockRangeStats, BlockStatsReport, CarriedFooter,
-    ColumnarBlockOutcome, DEFAULT_LOG_COALESCE_GAP, DEFAULT_LOG_COVERAGE_THRESHOLD,
-    DEFAULT_LOG_MAX_CONCURRENT_GETS, DEFAULT_LOG_REQUEST_COST_BYTES, DEFAULT_LOG_SUFFIX_LEN,
-    DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LOG_SUFFIX_FLOOR_BYTES, LOG_SUFFIX_SIZE_DIVISOR,
-    LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher, LogSegmentScan, ProbeMissCounter,
-    ProbeMissCounts, ProbePhase, ReadPhases, StreamAttrEquals, WHOLE_OBJECT_REQUEST_MULTIPLE,
-    derive_suffix_len,
+    CarriedWholeObject, ColumnarBlockOutcome, DEFAULT_LOG_COALESCE_GAP,
+    DEFAULT_LOG_COVERAGE_THRESHOLD, DEFAULT_LOG_MAX_CONCURRENT_GETS,
+    DEFAULT_LOG_REQUEST_COST_BYTES, DEFAULT_LOG_SUFFIX_LEN, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+    LOG_SUFFIX_FLOOR_BYTES, LOG_SUFFIX_SIZE_DIVISOR, LogFetchError, LogFetchOutput, LogQuery,
+    LogSegmentFetcher, LogSegmentScan, ProbeMissCounter, ProbeMissCounts, ProbePhase, ReadPhases,
+    StreamAttrEquals, WHOLE_OBJECT_REQUEST_MULTIPLE, derive_suffix_len,
 };
 pub use phase_accounting::{
     PhaseAccounting, PhaseAccountingSnapshot, PhaseWireByteCounter, PhaseWireByteCounts, QueryPhase,

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -1300,7 +1300,15 @@ impl LogSegmentFetcher {
         tenant_hash: TenantHash,
         query: &LogQuery,
         caller_accounting: &QueryAccounting,
-    ) -> Result<Option<(usize, ScanStats, Option<footer::LogFooter>)>, LogFetchError> {
+    ) -> Result<
+        Option<(
+            usize,
+            ScanStats,
+            Option<footer::LogFooter>,
+            Option<CarriedWholeObject>,
+        )>,
+        LogFetchError,
+    > {
         let phase = PhaseAccounting::new();
         let accounting = phase.plan();
         let result = async {
@@ -1336,7 +1344,9 @@ impl LogSegmentFetcher {
                     .await?;
                 // Footer-carrying branch: no block byte is read here, so the
                 // touch is the scan that follows a nonzero survivor count.
-                return Ok(Some((n, stats, Some(footer), n > 0)));
+                // No whole-object bytes to carry either: this branch reads
+                // only the footer, never a block.
+                return Ok(Some((n, stats, Some(footer), n > 0, None)));
             }
 
             // Skip-index-only survivor count (#761): when every block-level predicate
@@ -1406,8 +1416,15 @@ impl LogSegmentFetcher {
                 };
                 // Footer-carrying branch: only the probe, SKIP_IDX and FIELD_DIR
                 // were read, no block byte, so the touch is the scan a nonzero
-                // survivor count will drive.
-                return Ok(Some((survivors, plan_stats, Some(footer), survivors > 0)));
+                // survivor count will drive. No whole-object bytes either, for
+                // the same reason as the fast path above.
+                return Ok(Some((
+                    survivors,
+                    plan_stats,
+                    Some(footer),
+                    survivors > 0,
+                    None,
+                )));
             }
 
             // Fallback: a predicate the skip index cannot decide (a `has_word`/text
@@ -1417,7 +1434,11 @@ impl LogSegmentFetcher {
             // buffer -- and hand no footer forward. This whole-object plan read is the
             // amplification #761 could not remove for these shapes; the caller counts
             // it (a `None` footer on a relevant segment) as a `plan_full_reads` so a
-            // report can see which queries still pay it.
+            // report can see which queries still pay it. Issue #835: when it resolved
+            // the WHOLE object (`blocks_read` is `None`), these bytes are carried
+            // forward as a [`CarriedWholeObject`] so the scan that follows does not
+            // pay a second wire GET for them -- the amplification #761 could not
+            // remove from this plan read no longer forces a second one at scan time.
             let all = ColumnSelection::all();
             let Some((bytes, blocks_read)) = self
                 .tenant_bytes(
@@ -1445,7 +1466,26 @@ impl LogSegmentFetcher {
                 None => true,
                 Some(n) => n > 0,
             };
-            Ok(Some((scan.remaining_blocks(), scan.stats(), None, touched)))
+            // `blocks_read` is `None` exactly when the whole object is present in
+            // `bytes` (the below-threshold path, or an above-threshold read that
+            // crossed over to a whole-object GET): safe to carry forward whatever
+            // the scan's own column selection turns out to be. `Some(_)` is a
+            // ranged read fetched under `ColumnSelection::all`, which is not
+            // necessarily what the scan will select on a version-4 object (ADR-0699
+            // decision 5), so it is not carried.
+            let carried = match blocks_read {
+                None => Some(CarriedWholeObject {
+                    bytes: bytes.clone(),
+                }),
+                Some(_) => None,
+            };
+            Ok(Some((
+                scan.remaining_blocks(),
+                scan.stats(),
+                None,
+                touched,
+                carried,
+            )))
         }
         .await;
         caller_accounting.merge_snapshot(&phase.snapshot().pooled());
@@ -1488,12 +1528,14 @@ impl LogSegmentFetcher {
         // fallback from whether `tenant_bytes` read any block (contract:
         // `ravel_types::accounting`, blocks read are cache-inclusive, so the
         // signal is resolved blocks, never wire bytes).
-        if let Ok(Some((_, _, _, touched))) = &result
+        if let Ok(Some((_, _, _, touched, _))) = &result
             && *touched
         {
             caller_accounting.add_data_objects_touched(1);
         }
-        result.map(|opt| opt.map(|(survivors, stats, footer, _)| (survivors, stats, footer)))
+        result.map(|opt| {
+            opt.map(|(survivors, stats, footer, _, carried)| (survivors, stats, footer, carried))
+        })
     }
 
     /// Whether [`plan_segment`](Self::plan_segment)'s survivor count can be read
@@ -1744,6 +1786,14 @@ impl LogSegmentFetcher {
     /// [`fetch_object_with_footer`](Self::fetch_object_with_footer)); `None`
     /// probes as before. It changes only the read shape, never the bytes decoded.
     ///
+    /// `carried_whole`, when `Some`, is the whole-object [`Bytes`] a prior
+    /// [`plan_segment`](Self::plan_segment) fallback already fetched for this
+    /// exact (immutable) object (issue #835). Supplying it skips this call's own
+    /// wire GET entirely -- no cache lookup, no store round trip -- and charges
+    /// the reused bytes to `accounting.add_bytes_reused` instead of a cache hit
+    /// or miss. `None` fetches as before (cache-aware whole-object or ranged
+    /// read, per [`tenant_bytes_with_footer`](Self::tenant_bytes_with_footer)).
+    ///
     /// [`scan_accounted_with_tenant`]: Self::scan_accounted_with_tenant
     ///
     /// Issue #796: `scan` phase, same reasoning and the same not-buffered
@@ -1759,6 +1809,7 @@ impl LogSegmentFetcher {
         columns: &ColumnSelection,
         indices: &[usize],
         footer: Option<&footer::LogFooter>,
+        carried_whole: Option<CarriedWholeObject>,
         accounting: &QueryAccounting,
     ) -> Result<Option<LogSegmentScan>, LogFetchError> {
         let Some((bytes, _blocks_read)) = self
@@ -1768,6 +1819,7 @@ impl LogSegmentFetcher {
                 query,
                 columns,
                 footer,
+                carried_whole,
                 ProbePhase::Scan,
                 accounting,
             )
@@ -1824,6 +1876,7 @@ impl LogSegmentFetcher {
             query,
             columns,
             None,
+            None,
             phase,
             accounting,
         )
@@ -1855,6 +1908,15 @@ impl LogSegmentFetcher {
     /// a caller decide "were this object's blocks read" from the blocks actually
     /// resolved, not from wire bytes, which a fully-pruned ranged read moves none
     /// of even though the read happened.
+    ///
+    /// `carried_whole`, when `Some`, is a [`CarriedWholeObject`] a prior
+    /// `plan_segment` fallback fetched for this exact object (issue #835): its
+    /// bytes are the whole object, valid for any `columns` selection, so this
+    /// short-circuits both the below- and above-threshold branches below,
+    /// issuing no store GET and no cache lookup at all. The reused bytes are
+    /// charged to `accounting.add_bytes_reused`, not to a cache hit -- the
+    /// object was never asked of the cache on this call. Safe with no etag
+    /// re-check: see [`CarriedWholeObject`]'s doc.
     #[allow(clippy::too_many_arguments)]
     async fn tenant_bytes_with_footer(
         &self,
@@ -1863,11 +1925,17 @@ impl LogSegmentFetcher {
         query: &LogQuery,
         columns: &ColumnSelection,
         footer: Option<&footer::LogFooter>,
+        carried_whole: Option<CarriedWholeObject>,
         phase: ProbePhase,
         accounting: &QueryAccounting,
     ) -> Result<Option<(Bytes, Option<u64>)>, LogFetchError> {
         if !Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns) {
             return Ok(None);
+        }
+
+        if let Some(carried) = carried_whole {
+            accounting.add_bytes_reused(carried.bytes.len() as u64);
+            return Ok(Some((carried.bytes, None)));
         }
 
         // #913: which phase this read's metadata GETs and its BLOCKS-section
@@ -2807,6 +2875,41 @@ pub struct CarriedFooter<'a> {
     /// this object's tail-section probe misses
     /// ([`BlockRangeStats::probe_misses`]).
     pub tail_misses_counted: bool,
+}
+
+/// The whole-object bytes [`LogSegmentFetcher::plan_segment`]'s whole-object
+/// fallback already fetched for this exact (immutable) `SegmentRef`, carried
+/// into the scan so it does not issue a second wire GET for the same object
+/// (issue #835).
+///
+/// Reuse needs no etag re-check, unlike [`CarriedFooter`]'s scan read: the
+/// plan and the scan of one statement share the very same `SegmentRef` out of
+/// one resolved snapshot, and `LogSegmentFetcher`'s whole-object cache key is
+/// keyed on `seg_ref.content_hash` (see [`EtagPin`]'s doc: "a cache key
+/// carries the object's `content_hash`, so an entry is by construction bytes
+/// of this exact content rather than of whatever the store holds now"). No
+/// live GET spans the gap between the plan read and the scan read for this
+/// carry to defend against -- there is no second live GET at all -- so the
+/// same reasoning that exempts a cache hit from the pin applies here.
+///
+/// Always the ENTIRE object: the plan fallback only carries these bytes
+/// forward when its own read resolved every block (the below-threshold
+/// whole-object path, or an above-threshold read that crossed over to a
+/// whole-object GET), never a column-selection-scoped ranged read. So the
+/// bytes are valid for the scan's column selection whatever it is, even
+/// though the plan fetched with [`ColumnSelection::all`].
+#[derive(Clone)]
+pub struct CarriedWholeObject {
+    bytes: Bytes,
+}
+
+impl CarriedWholeObject {
+    /// The carried object's byte length, for a caller that needs to account
+    /// for held-but-not-yet-consumed carry bytes (issue #835's memory bound)
+    /// without decoding or copying them.
+    pub fn byte_len(&self) -> u64 {
+        self.bytes.len() as u64
+    }
 }
 
 /// One candidate block's absolute byte extent in the object and its stored crc,
@@ -5994,7 +6097,7 @@ mod plan_fast_path_tests {
 
         // Predicate-free, ts window strictly contains [min, max].
         let query = LogQuery::new(i64::MIN, i64::MAX);
-        let (count, stats, _footer) = f
+        let (count, stats, _footer, _carried) = f
             .plan_segment(&seg, TENANT, &query, &acc)
             .await
             .expect("plan_segment")
@@ -6032,7 +6135,7 @@ mod plan_fast_path_tests {
 
         // Exact span bounds: ts_min == min_event_ts_ns, ts_max == max_event_ts_ns.
         let query = LogQuery::new(seg.min_event_ts_ns, seg.max_event_ts_ns);
-        let (count, _stats, _footer) = f
+        let (count, _stats, _footer, _carried) = f
             .plan_segment(&seg, TENANT, &query, &acc)
             .await
             .expect("plan_segment")
@@ -6064,7 +6167,7 @@ mod plan_fast_path_tests {
             word: "hello".into(),
         });
         let acc = QueryAccounting::new();
-        let (count, _, _) = f
+        let (count, _, _, _) = f
             .plan_segment(&seg, TENANT, &q, &acc)
             .await
             .expect("plan")
@@ -6082,7 +6185,7 @@ mod plan_fast_path_tests {
             AttrValue::Str("svc".into()),
         ));
         let acc = QueryAccounting::new();
-        let (count, _, _) = f
+        let (count, _, _, _) = f
             .plan_segment(&seg, TENANT, &q, &acc)
             .await
             .expect("plan")
@@ -6099,7 +6202,7 @@ mod plan_fast_path_tests {
             vec![("request.id".into(), "r0".into())],
         )]);
         let acc = QueryAccounting::new();
-        let (count, _, _) = f
+        let (count, _, _, _) = f
             .plan_segment(&seg, TENANT, &q, &acc)
             .await
             .expect("plan")
@@ -6115,7 +6218,7 @@ mod plan_fast_path_tests {
         // run and the survivor count is N-2, not N.
         let q = LogQuery::new(2, i64::MAX);
         let acc = QueryAccounting::new();
-        let (count, _, _) = f
+        let (count, _, _, _) = f
             .plan_segment(&seg, TENANT, &q, &acc)
             .await
             .expect("plan")
@@ -6137,7 +6240,7 @@ mod plan_fast_path_tests {
             word: "hello".into(),
         });
         let acc = QueryAccounting::new();
-        let (count, _, _) = f
+        let (count, _, _, _) = f
             .plan_segment(&seg, TENANT, &q, &acc)
             .await
             .expect("plan")
@@ -6175,7 +6278,7 @@ mod plan_fast_path_tests {
             );
         let query = LogQuery::new(i64::MIN, i64::MAX);
         let acc = QueryAccounting::new();
-        let (count, _, _) = f
+        let (count, _, _, _) = f
             .plan_segment(&seg, TENANT, &query, &acc)
             .await
             .expect("plan")
@@ -7274,7 +7377,7 @@ mod plan_skip_decidable_span_tests {
             min: Some(0i64 as u64),
             max: Some(1_000i64 as u64),
         });
-        let (count, _stats, footer) = f
+        let (count, _stats, footer, carried) = f
             .plan_segment(&seg, TENANT, &query, &acc)
             .await
             .expect("plan_segment")
@@ -7283,6 +7386,10 @@ mod plan_skip_decidable_span_tests {
         assert!(
             footer.is_some(),
             "skip-decidable branch forwards the parsed footer like the fast path does"
+        );
+        assert!(
+            carried.is_none(),
+            "skip-decidable branch reads no block byte, so it carries no whole-object bytes"
         );
 
         let closed = collector.closed.lock().expect("lock");
@@ -7403,7 +7510,7 @@ mod plan_skip_decidable_span_tests {
             let f = fetcher_with_suffix(store, suffix);
             let acc = QueryAccounting::new();
 
-            let (count, _stats, footer) = f
+            let (count, _stats, footer, _carried) = f
                 .plan_segment(&seg, TENANT, &query, &acc)
                 .await
                 .expect("plan_segment")
@@ -7419,6 +7526,7 @@ mod plan_skip_decidable_span_tests {
                     &ColumnSelection::all(),
                     &indices,
                     footer.as_ref(),
+                    None,
                     &acc,
                 )
                 .await

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -510,6 +510,23 @@ pub enum LogFetchError {
     /// (ADR-0107 decision 1).
     #[error("etag changed between reads of log segment {key}: store returned inconsistent data")]
     EtagChanged { key: String },
+    /// A [`CarriedWholeObject`] produced by one `plan_segment` read was supplied
+    /// to a read of a different object, or of the same object under a different
+    /// tenant. The carry short-circuits the fetch, so decoding it would answer
+    /// from the wrong object's bytes whenever both are decodable, rather than
+    /// fail; the mismatch is rejected before any decode. Terminal like
+    /// `SpanFetchError::TenantMismatch`, never a retry: the pairing is fixed by
+    /// the caller, so the same request retried anywhere reproduces it.
+    #[error(
+        "carried whole object from {carried_key} (tenant {carried_tenant:?}) was supplied to a \
+         read of log segment {key} (tenant {tenant:?})"
+    )]
+    CarryMismatch {
+        key: String,
+        carried_key: String,
+        tenant: TenantHash,
+        carried_tenant: TenantHash,
+    },
 }
 
 /// Fetches and scans one RLOG log segment at a time. Constructed with the same
@@ -1476,6 +1493,8 @@ impl LogSegmentFetcher {
             let carried = match blocks_read {
                 None => Some(CarriedWholeObject {
                     bytes: bytes.clone(),
+                    source_key: seg_ref.data_object_key.clone(),
+                    source_tenant: tenant_hash,
                 }),
                 Some(_) => None,
             };
@@ -1916,7 +1935,9 @@ impl LogSegmentFetcher {
     /// issuing no store GET and no cache lookup at all. The reused bytes are
     /// charged to `accounting.add_bytes_reused`, not to a cache hit -- the
     /// object was never asked of the cache on this call. Safe with no etag
-    /// re-check: see [`CarriedWholeObject`]'s doc.
+    /// re-check: see [`CarriedWholeObject`]'s doc. A carry whose own
+    /// `(key, tenant)` is not this call's is rejected as
+    /// [`LogFetchError::CarryMismatch`] before any decode.
     #[allow(clippy::too_many_arguments)]
     async fn tenant_bytes_with_footer(
         &self,
@@ -1934,6 +1955,18 @@ impl LogSegmentFetcher {
         }
 
         if let Some(carried) = carried_whole {
+            // The carry answers without consulting `seg_ref`, so a carry paired
+            // with another segment would decode that segment's rows out of these
+            // bytes wherever both objects are decodable. Prove the pairing first.
+            if carried.source_key != seg_ref.data_object_key || carried.source_tenant != tenant_hash
+            {
+                return Err(LogFetchError::CarryMismatch {
+                    key: seg_ref.data_object_key.clone(),
+                    carried_key: carried.source_key,
+                    tenant: tenant_hash,
+                    carried_tenant: carried.source_tenant,
+                });
+            }
             accounting.add_bytes_reused(carried.bytes.len() as u64);
             return Ok(Some((carried.bytes, None)));
         }
@@ -2898,9 +2931,22 @@ pub struct CarriedFooter<'a> {
 /// whole-object GET), never a column-selection-scoped ranged read. So the
 /// bytes are valid for the scan's column selection whatever it is, even
 /// though the plan fetched with [`ColumnSelection::all`].
+///
+/// The bytes travel with the identity of the read that produced them, and a
+/// consumer proves the pairing before decoding. Nothing in the type system
+/// stops a caller from handing this carry to a read of a different segment:
+/// the carry branch answers from these bytes without consulting the supplied
+/// `SegmentRef` at all, so a mismatched pairing would return the wrong
+/// object's rows wherever both objects decode. The key alone would settle it
+/// in practice (a data-object key embeds the tenant hex), but the tenant is
+/// stored and checked too rather than inferred from that.
 #[derive(Clone)]
 pub struct CarriedWholeObject {
     bytes: Bytes,
+    /// `data_object_key` of the segment the plan read fetched these bytes for.
+    source_key: String,
+    /// Tenant the plan read fetched them under.
+    source_tenant: TenantHash,
 }
 
 impl CarriedWholeObject {
@@ -5732,6 +5778,19 @@ fn to_cache_error(err: LogFetchError) -> crate::fetcher::CacheFetchError {
             key,
             message: source.to_string(),
         },
+        // A carry mismatch is refused before any fetch, so it never reaches a
+        // single-flight waiter today. Preserved as hard corruption rather than
+        // flattened, so it stays in its class if a carry ever fronts the cache.
+        carry @ LogFetchError::CarryMismatch { .. } => {
+            let key = match &carry {
+                LogFetchError::CarryMismatch { key, .. } => key.clone(),
+                _ => String::new(),
+            };
+            crate::fetcher::CacheFetchError::Corrupt {
+                key,
+                message: carry.to_string(),
+            }
+        }
     }
 }
 

--- a/crates/ravel-query/tests/log_fetch_bound.rs
+++ b/crates/ravel-query/tests/log_fetch_bound.rs
@@ -708,6 +708,7 @@ async fn striped_subset_scans_do_not_double_count_a_touch() {
                 &columns,
                 &indices,
                 None,
+                None,
                 &accounting,
             )
             .await
@@ -757,7 +758,7 @@ async fn a_zero_survivor_skip_decidable_plan_records_no_touch() {
 
     // `code` is 500 on every record, so this arm is disjoint from every block's
     // numeric stat and prunes them all.
-    let (survivors, _stats, footer) = fetcher
+    let (survivors, _stats, footer, _whole_object) = fetcher
         .plan_segment(&seg, TENANT, &coded_query(9_000, 10_000), &accounting)
         .await
         .expect("plan")
@@ -792,7 +793,7 @@ async fn a_surviving_skip_decidable_plan_records_exactly_one_touch() {
     let fetcher = LogSegmentFetcher::new(store);
     let accounting = QueryAccounting::new();
 
-    let (survivors, _stats, footer) = fetcher
+    let (survivors, _stats, footer, _whole_object) = fetcher
         .plan_segment(&seg, TENANT, &coded_query(0, 1_000), &accounting)
         .await
         .expect("plan")
@@ -867,7 +868,7 @@ async fn a_zero_candidate_fallback_plan_records_no_touch() {
 
     // `code` is 500 on every record, so this arm is disjoint from every block's
     // numeric stat and prunes them all; the content arm forces the fallback.
-    let (survivors, _stats, footer) = fetcher
+    let (survivors, _stats, footer, _whole_object) = fetcher
         .plan_segment(
             &seg,
             TENANT,
@@ -915,7 +916,7 @@ async fn a_block_decoding_fallback_plan_records_exactly_one_touch() {
 
     // `code = 500` on every record falls inside this arm, so every block is a
     // candidate and the ranged fetch resolves and decodes blocks.
-    let (_survivors, _stats, footer) = fetcher
+    let (_survivors, _stats, footer, _whole_object) = fetcher
         .plan_segment(
             &seg,
             TENANT,

--- a/crates/ravel-query/tests/log_footer_carry.rs
+++ b/crates/ravel-query/tests/log_footer_carry.rs
@@ -89,6 +89,33 @@ fn one_record_cfg() -> RlogConfig {
     }
 }
 
+/// A second key in the same tenant, for the carry-pairing test below.
+const OTHER_KEY: &str = "logs/other.rlog";
+
+/// The same `N` records as [`build_object`], written as ONE block instead of
+/// `N`. Same tenant and same schema, so its bytes and [`build_object`]'s decode
+/// under each other's `SegmentRef`; the block shape is what tells the two apart,
+/// so reading the wrong one shows up as a row count rather than an error.
+fn build_other_object() -> Vec<u8> {
+    let cfg = RlogConfig {
+        block_target_records: N,
+        ..RlogConfig::default()
+    };
+    let mut w = RlogWriter::new(cfg, identity());
+    for ts in 0..N as i64 {
+        w.push(record(ts)).expect("push");
+    }
+    w.finish().expect("finish")
+}
+
+/// [`seg_ref`] for [`build_other_object`]: same tenant and window, different key.
+fn other_seg_ref(size: u64) -> SegmentRef {
+    SegmentRef {
+        data_object_key: OTHER_KEY.to_string(),
+        ..seg_ref(size)
+    }
+}
+
 fn seg_ref(size: u64) -> SegmentRef {
     SegmentRef {
         data_object_key: KEY.to_string(),
@@ -400,5 +427,167 @@ async fn footer_carried_open_still_catches_an_etag_change() {
     assert!(
         matches!(&err, Some(m) if m.contains("etag changed")),
         "a footer-carried open must catch a mid-sequence etag change, got {err:?}"
+    );
+}
+
+/// A [`CarriedWholeObject`] is bound to the object and tenant its plan read
+/// fetched, and a read that supplies it for anything else is refused before the
+/// bytes are decoded (issue #835 review).
+///
+/// The carry branch answers from the carried bytes without consulting the
+/// supplied `SegmentRef` at all, so without the guard this is not an error at
+/// all: both fixtures are valid RLOG objects in one tenant, so the wrong bytes
+/// decode happily and the scan returns the wrong object's rows. That is what
+/// the row-count assertion pins. The two objects hold the same `N` records in
+/// different block shapes -- `N` blocks of one row against one block of `N` --
+/// so selecting block 0 of the intended object yields `N` rows and block 0 of
+/// the carried one yields exactly 1.
+#[tokio::test]
+async fn a_carried_whole_object_is_refused_for_another_segment_or_tenant() {
+    let carried_bytes = build_object();
+    let target_bytes = build_other_object();
+    let carried_seg = seg_ref(carried_bytes.len() as u64);
+    let target_seg = other_seg_ref(target_bytes.len() as u64);
+    let query = LogQuery::new(i64::MIN, i64::MAX);
+
+    let store = Arc::new(MemoryStore::new());
+    for (key, bytes) in [
+        (KEY, carried_bytes.clone()),
+        (OTHER_KEY, target_bytes.clone()),
+    ] {
+        store
+            .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put");
+    }
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&store) as Arc<dyn ObjectStoreBackend>);
+    let acc = QueryAccounting::new();
+
+    // The carry under test, produced by a real plan read of `carried_seg`.
+    let (_survivors, _stats, _footer, carry) = fetcher
+        .plan_segment(&carried_seg, TENANT, &query, &acc)
+        .await
+        .expect("plan")
+        .expect("relevant");
+    let carry = carry.expect(
+        "a below-threshold plan read carries its whole object; without one this test is vacuous",
+    );
+
+    // Wrong segment, right tenant. Both objects decode, so the guard is the only
+    // thing standing between this call and the wrong object's rows.
+    let refused = fetcher
+        .scan_accounted_with_tenant_subset(
+            &target_seg,
+            TENANT,
+            &query,
+            &ColumnSelection::all(),
+            &[0],
+            None,
+            Some(carry.clone()),
+            &acc,
+        )
+        .await;
+    let err = match refused {
+        Err(e) => e,
+        Ok(ok) => {
+            let mut leaked = 0usize;
+            let mut s = ok.expect("relevant");
+            while let Some(b) = s.next_block().expect("decode") {
+                leaked += b.len();
+            }
+            panic!(
+                "a carry from {KEY} was decoded for a read of {OTHER_KEY} and returned \
+                 {leaked} row(s) of the wrong object instead of being refused"
+            );
+        }
+    };
+    assert!(
+        matches!(
+            &err,
+            ravel_query::LogFetchError::CarryMismatch { key, carried_key, .. }
+                if key == OTHER_KEY && carried_key == KEY
+        ),
+        "expected CarryMismatch naming both objects, got {err:?}"
+    );
+
+    // Right segment, wrong tenant. The key matches, so only the tenant check
+    // can refuse this one.
+    let other_tenant = TenantHash([8u8; 16]);
+    let refused = fetcher
+        .scan_accounted_with_tenant_subset(
+            &carried_seg,
+            other_tenant,
+            &query,
+            &ColumnSelection::all(),
+            &[0],
+            None,
+            Some(carry.clone()),
+            &acc,
+        )
+        .await;
+    let Err(err) = refused else {
+        panic!("a carry fetched for another tenant must be refused, not decoded");
+    };
+    assert!(
+        matches!(
+            &err,
+            ravel_query::LogFetchError::CarryMismatch { tenant, carried_tenant, .. }
+                if *tenant == other_tenant && *carried_tenant == TENANT
+        ),
+        "expected CarryMismatch naming both tenants, got {err:?}"
+    );
+
+    // The matching pairing still works, and the guard costs it nothing.
+    let mut scan = fetcher
+        .scan_accounted_with_tenant_subset(
+            &carried_seg,
+            TENANT,
+            &query,
+            &ColumnSelection::all(),
+            &[0],
+            None,
+            Some(carry),
+            &acc,
+        )
+        .await
+        .expect("the carry's own segment and tenant are accepted")
+        .expect("relevant");
+    let mut carried_rows = 0usize;
+    while let Some(block) = scan.next_block().expect("decode") {
+        carried_rows += block.len();
+    }
+    assert_eq!(
+        carried_rows, 1,
+        "block 0 of the carried object holds exactly one row"
+    );
+
+    // The row count the refused call would have returned had it decoded the
+    // carried bytes, against what its own object actually holds. They differ,
+    // so a dropped guard returns wrong rows rather than an error.
+    let mut target_scan = fetcher
+        .scan_accounted_with_tenant_subset(
+            &target_seg,
+            TENANT,
+            &query,
+            &ColumnSelection::all(),
+            &[0],
+            None,
+            None,
+            &acc,
+        )
+        .await
+        .expect("target scan")
+        .expect("relevant");
+    let mut target_rows = 0usize;
+    while let Some(block) = target_scan.next_block().expect("decode") {
+        target_rows += block.len();
+    }
+    assert_eq!(
+        target_rows, N,
+        "block 0 of the intended object holds all N rows"
+    );
+    assert_ne!(
+        carried_rows, target_rows,
+        "the fixtures must disagree on row count, or the guard's absence would be invisible"
     );
 }

--- a/crates/ravel-query/tests/log_footer_carry.rs
+++ b/crates/ravel-query/tests/log_footer_carry.rs
@@ -274,7 +274,7 @@ async fn footer_carried_subset_open_skips_the_probe() {
     let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
     let fetcher = ranged_fetcher(store, tail);
     let acc = QueryAccounting::new();
-    let (survivors, _stats, footer) = fetcher
+    let (survivors, _stats, footer, _whole_object) = fetcher
         .plan_segment(&seg, TENANT, &query, &acc)
         .await
         .expect("plan")
@@ -294,6 +294,7 @@ async fn footer_carried_subset_open_skips_the_probe() {
             &ColumnSelection::all(),
             &indices,
             Some(&footer),
+            None,
             &acc,
         )
         .await
@@ -326,6 +327,7 @@ async fn footer_carried_subset_open_skips_the_probe() {
             &query,
             &ColumnSelection::all(),
             &indices,
+            None,
             None,
             &acc2,
         )
@@ -366,7 +368,7 @@ async fn footer_carried_open_still_catches_an_etag_change() {
     let base = store_with_object(bytes).await;
     let plan_fetcher = ranged_fetcher(Arc::clone(&base) as Arc<dyn ObjectStoreBackend>, tail);
     let acc = QueryAccounting::new();
-    let (_survivors, _stats, footer) = plan_fetcher
+    let (_survivors, _stats, footer, _whole_object) = plan_fetcher
         .plan_segment(&seg, TENANT, &query, &acc)
         .await
         .expect("plan")
@@ -390,6 +392,7 @@ async fn footer_carried_open_still_catches_an_etag_change() {
             &ColumnSelection::all(),
             &indices,
             Some(&footer),
+            None,
             &QueryAccounting::new(),
         )
         .await;

--- a/crates/ravel-query/tests/log_page_dir_fetch.rs
+++ b/crates/ravel-query/tests/log_page_dir_fetch.rs
@@ -804,7 +804,7 @@ async fn plan_segment_on_a_version_4_object_fetches_no_page_bytes() {
     let query = LogQuery::new(i64::MIN, i64::MAX).with_prune(code_between(0, 0));
     let acc = QueryAccounting::new();
 
-    let (survivors, stats, footer) = fetcher
+    let (survivors, stats, footer, _whole_object) = fetcher
         .plan_segment(&seg, TENANT, &query, &acc)
         .await
         .expect("plan_segment")

--- a/crates/ravel-sql/src/error.rs
+++ b/crates/ravel-sql/src/error.rs
@@ -433,7 +433,13 @@ impl SqlError {
                 }
             },
             SqlError::LogFetch(fetch) => match fetch {
-                LogFetchError::Corrupt { .. } => MSG_CORRUPT.to_string(),
+                // A carry paired with the wrong segment is an integrity
+                // violation of the read relative to the request, redacted like
+                // corruption: its `Display` names both object keys and both
+                // tenant hashes, none of which reaches the client.
+                LogFetchError::Corrupt { .. } | LogFetchError::CarryMismatch { .. } => {
+                    MSG_CORRUPT.to_string()
+                }
                 LogFetchError::Store { .. } | LogFetchError::EtagChanged { .. } => {
                     MSG_UNAVAILABLE.to_string()
                 }
@@ -636,6 +642,25 @@ mod tests {
         // The detail string stays available server-side and leaks nothing.
         assert!(reverify.to_string().contains("stream_attrs truncated"));
         assert_redacted(&reverify.client_message());
+    }
+
+    #[test]
+    fn a_carry_mismatch_is_redacted_like_corruption() {
+        // `CarryMismatch`'s Display names BOTH object keys and BOTH tenant
+        // hashes, so an un-redacted arm would leak two keys at once rather
+        // than one. It shares the corruption class: the read's integrity
+        // relative to the request is broken, and no retry can fix it.
+        let err = SqlError::LogFetch(LogFetchError::CarryMismatch {
+            key: LEAKY_KEY.to_string(),
+            carried_key: format!("{LEAKY_KEY}.other"),
+            tenant: ravel_types::TenantHash([1u8; 16]),
+            carried_tenant: ravel_types::TenantHash([2u8; 16]),
+        });
+        assert_eq!(err.client_message(), MSG_CORRUPT);
+        assert_eq!(err.class(), ErrorClass::Unavailable);
+        // The detail survives server-side, where it is the whole point.
+        assert!(err.to_string().contains(LEAKY_KEY));
+        assert_redacted(&err.client_message());
     }
 
     #[test]

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -133,8 +133,9 @@
 //! place. Since #835, [`LogSegmentFetcher::plan_segment`]'s fallback branch carries its fetched
 //! bytes forward as a [`ravel_query::CarriedWholeObject`] (`SegPlan::whole_object`,
 //! threaded through [`OwnedSeg::whole_object`] to the subset open), so the
-//! object crosses the wire once for the first `plan_concurrency` segments
-//! whose plan completes. Every other relevant segment is re-fetched by the
+//! object is read once for the statement, rather than twice, for the first
+//! `plan_concurrency` segments whose plan completes: their subset open issues
+//! neither a store GET nor a cache lookup. Every other relevant segment is re-fetched by the
 //! scan exactly as it was before #835; the peak bytes this carry retains is
 //! bounded by the plan fan-out (`plan_concurrency` objects) times object
 //! size, not by corpus size. Removing the remaining duplicate reads needs
@@ -152,7 +153,8 @@
 //! segment order, so which segments those are is scheduling-dependent -- keep
 //! their [`SegPlan::whole_object`]; every later arrival has its
 //! `whole_object` forced to `None` before it is stored, so that segment's
-//! subset open pays a real wire GET during the scan, exactly as it would have
+//! subset open pays a second read during the scan, a wire GET whenever the
+//! cache does not still hold the object, exactly as it would have
 //! before #835. `compute_plan_counts` sums only the bytes actually retained
 //! and records that figure via
 //! [`ravel_types::accounting::QueryAccounting::observe_intermediate_bytes`]; a

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -117,6 +117,60 @@
 //! not a general result about striping. Cache size, eviction, object size, and
 //! store latency all move it.
 //!
+//! # Whole-object fallback carry, and its memory bound (issue #835)
+//!
+//! `plan_segment`'s whole-object fallback (an undecidable block predicate, e.g.
+//! a text `has_word` arm the skip index cannot resolve) already reads the
+//! entire object to count survivors. Before #835 that read was thrown away:
+//! the scan phase re-opened the same object and, unless a read cache happened
+//! to be wired AND large enough to still hold every relevant object's bytes by
+//! the time the scan reached it, paid a second real wire GET for content the
+//! plan phase had just fetched. This is a different failure from issue #691's
+//! "an evicted plan entry is simply re-fetched by the scan" a few paragraphs
+//! up: #691 is about a cache-keyed footer/probe/section entry on the ABOVE-
+//! threshold ranged path, which by design may be re-fetched on a miss; #835 is
+//! about the whole object itself never being cache-size-dependent in the first
+//! place. Since #835, [`LogSegmentFetcher::plan_segment`]'s fallback branch carries its fetched
+//! bytes forward as a [`ravel_query::CarriedWholeObject`] (`SegPlan::whole_object`,
+//! threaded through [`OwnedSeg::whole_object`] to the subset open), so the
+//! object crosses the wire once for the first `plan_concurrency` segments
+//! whose plan completes. Every other relevant segment is re-fetched by the
+//! scan exactly as it was before #835; the peak bytes this carry retains is
+//! bounded by the plan fan-out (`plan_concurrency` objects) times object
+//! size, not by corpus size. Removing the remaining duplicate reads needs
+//! the carry to stream per partition instead of being held at the plan
+//! barrier, tracked separately as issue #1272. A reused read is charged to
+//! [`ravel_types::accounting::QueryAccounting::add_bytes_reused`], not folded
+//! into the GET-bytes figure the issuing (plan) phase already recorded.
+//!
+//! This carry's memory cost is bounded by `plan_concurrency`, not by corpus
+//! size: [`compute_plan_counts`] consumes the segment-plan stream as each
+//! `plan_segment` call completes (`buffer_unordered(plan_concurrency)`), not
+//! after the whole pass finishes, so it never retains more carried whole
+//! objects than are actually in flight at once. The first `plan_concurrency`
+//! segments to COMPLETE with a carried whole object -- arrival order, not
+//! segment order, so which segments those are is scheduling-dependent -- keep
+//! their [`SegPlan::whole_object`]; every later arrival has its
+//! `whole_object` forced to `None` before it is stored, so that segment's
+//! subset open pays a real wire GET during the scan, exactly as it would have
+//! before #835. `compute_plan_counts` sums only the bytes actually retained
+//! and records that figure via
+//! [`ravel_types::accounting::QueryAccounting::observe_intermediate_bytes`]; a
+//! dropped whole object is never charged to
+//! [`ravel_types::accounting::QueryAccounting::add_bytes_reused`], since the
+//! scan performs a real GET for it and that GET's own accounting covers it.
+//!
+//! The barrier itself is unchanged by this bound: no partition drains a block
+//! until every segment's survivor count is known, because the flattened
+//! block-striping assignment (ADR-0102) needs every segment's count to
+//! compute unit `i`'s owning partition, not just the segments before it in
+//! isolation. Only the CARRIED-BYTES retention is now concurrency-bounded;
+//! survivor counts, stats, and footers for every relevant segment are still
+//! held until the pass completes, because `owned_work` indexes all of them by
+//! segment position regardless. Letting a partition start draining before the
+//! whole pass completes would need ADR-0102's partitioning protocol itself to
+//! change, and is not made here.
+//!
 //! # Streaming, and why no ordering is declared (ADR-0087)
 //!
 //! This stage declares **no** output ordering. It used to declare `ts`
@@ -250,7 +304,7 @@ use datafusion::physical_plan::{
     SendableRecordBatchStream, Statistics,
 };
 use datafusion::scalar::ScalarValue;
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::{Stream, StreamExt};
 use ravel_catalog::{
     DeclaredColumnStats, LoadedColumnStats, SegmentRef, unique_column_stat,
     validate_min_max_presence,
@@ -265,7 +319,8 @@ use ravel_proto::catalog::v1::column_value::Kind as ColumnValueKind;
 use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue};
 use ravel_query::erasure::ErasurePredicate;
 use ravel_query::{
-    ColumnarBlockOutcome, LogFetchError, LogQuery, LogSegmentFetcher, LogSegmentScan,
+    CarriedWholeObject, ColumnarBlockOutcome, LogFetchError, LogQuery, LogSegmentFetcher,
+    LogSegmentScan,
 };
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
@@ -2073,6 +2128,7 @@ impl RowFetchSource {
                 &self.columns,
                 &[block],
                 None,
+                None,
                 &self.accounting,
             )
             .await
@@ -2380,6 +2436,7 @@ impl ExecutionPlan for LogsScanExec {
             pending_range: None,
             current_indices: Vec::new(),
             current_footer: None,
+            current_whole_object: None,
             seg_columnar_blocks: 0,
             state,
         }))
@@ -2417,6 +2474,16 @@ struct SegPlan {
     /// instead. Carried to each per-partition subset open through [`OwnedSeg`] so
     /// the open reuses it and skips its own suffix probe.
     footer: Option<LogFooter>,
+    /// The whole-object bytes the plan fallback branch already fetched for
+    /// this segment (issue #835), when that branch resolved the entire
+    /// object. Carried to the subset open through [`OwnedSeg`] so it does not
+    /// pay a second wire GET for bytes the plan phase already holds. `None`
+    /// on the fast/skip-decidable footer branches (no block read), on the
+    /// fallback's ranged crossover (not the whole object), and when
+    /// [`compute_plan_counts`]'s concurrency bound dropped an already-fetched
+    /// whole object because `plan_concurrency` other segments' bytes were
+    /// retained first -- that segment's subset open re-fetches instead.
+    whole_object: Option<CarriedWholeObject>,
 }
 
 type CountsFuture = Pin<Box<dyn Future<Output = DFResult<Arc<PlanCounts>>> + Send>>;
@@ -2439,19 +2506,51 @@ fn plan_counts_future(
     })
 }
 
+/// One segment's [`LogSegmentFetcher::plan_segment`] result: survivor count,
+/// stats, a carried footer (skip-decidable branches), and a carried
+/// whole-object body (the fallback branch, issue #835). `None` when the
+/// segment was pruned by ts bounds alone and never reached the fetcher.
+type PlanSegmentResult = Option<(
+    usize,
+    ScanStats,
+    Option<LogFooter>,
+    Option<CarriedWholeObject>,
+)>;
+
 /// Prune every segment once (no block decode) to build the shared block plan.
 ///
-/// The prunes run `plan_concurrency` at a time (`buffered`, so `segs` keeps
-/// snapshot order and [`owned_work`] can index it by segment position). Every
-/// partition awaits this whole pass before it drains anything, so the plan
-/// phase sits alone on the query's critical path: run serially it costs one
-/// object-store round trip per segment in sequence (issue #691 measured about
-/// 20 minutes per statement on 8424 objects, one GET in flight for the whole
-/// time). Concurrency here changes only how many of those reads are in flight,
-/// never their count (still one plan read sequence per segment) or their
-/// semantics (the first error aborts the plan, and `get_or_try_init` does not
-/// cache it); the fetcher's own in-flight GET semaphore remains the global
-/// bound, so an oversized `plan_concurrency` is safe.
+/// The prunes run `plan_concurrency` at a time (`buffer_unordered`, consumed
+/// as each completes rather than after the whole pass), and results are
+/// written into a position-indexed `Vec` so `segs` keeps snapshot order and
+/// [`owned_work`] can still index it by segment position even though
+/// completion order does not match it. Every partition awaits this whole pass
+/// before it drains anything, so the plan phase sits alone on the query's
+/// critical path: run serially it costs one object-store round trip per
+/// segment in sequence (issue #691 measured about 20 minutes per statement on
+/// 8424 objects, one GET in flight for the whole time). Concurrency here
+/// changes only how many of those reads are in flight, never their count
+/// (still one plan read sequence per segment) or their semantics (the first
+/// error aborts the plan, and `get_or_try_init` does not cache it). Which
+/// error that is became scheduling-dependent when the pass moved to
+/// completion order: a query whose segments fail differently can surface
+/// either one. The
+/// fetcher's own in-flight GET semaphore remains the global bound, so an
+/// oversized `plan_concurrency` is safe.
+///
+/// `plan_concurrency` here is `self.target_partitions`, the query's SQL
+/// partition count -- not `--store-get-concurrency`'s object-store GET
+/// limiter (ADR-1195), which bounds in-flight wire requests process-wide
+/// and, since ADR-1195 T2, is a separate knob from this one.
+///
+/// `plan_concurrency` also bounds how many carried whole objects (issue #835)
+/// this pass retains at once (issue #835 follow-up): the first
+/// `plan_concurrency` segments to COMPLETE with a carried whole object (not
+/// the first `plan_concurrency` by segment position -- completion order under
+/// `buffer_unordered` is scheduling-dependent) keep their bytes; every later
+/// one has its `whole_object` forced to `None` before it is stored, so its
+/// subset open pays a real re-fetch in the scan phase instead of holding
+/// bytes the rest of the pass has not yet caught up to consuming. See this
+/// module's doc, "Whole-object fallback carry, and its memory bound".
 // Issue #693 part 3: the predicate-free full-window fast path in `execute`
 // skips this whole pass; see `owned_work` and `plan_segment_fast`.
 async fn compute_plan_counts(
@@ -2459,49 +2558,83 @@ async fn compute_plan_counts(
     segments: &[SegmentRef],
     plan_concurrency: usize,
 ) -> DFResult<Arc<PlanCounts>> {
-    // Not-yet-polled futures, one per segment, so `buffered` decides how many
-    // run at once. Built with a loop rather than a `map` closure: a closure
-    // returning a future that borrows its argument cannot satisfy the
-    // higher-ranked bound this `Send` boxed future needs.
+    // Not-yet-polled futures, one per segment tagged with its snapshot
+    // position, so `buffer_unordered` decides how many run at once and the
+    // consumer loop below can still store each result at its original index.
+    // Built with a loop rather than a `map` closure: a closure returning a
+    // future that borrows its argument cannot satisfy the higher-ranked bound
+    // this `Send` boxed future needs.
     let mut prunes = Vec::with_capacity(segments.len());
-    for seg in segments {
+    for (idx, seg) in segments.iter().enumerate() {
         // Refuse an unreadable version BEFORE the plan probe, not after. This
         // is a second entry point into the fetch layer alongside the three
         // route choices below, and `plan_segment` issues its footer probe
         // before the open phase can reject the version -- so without this the
         // ordering guarantee holds on the scan path and quietly fails here.
         refuse_unreadable_version(seg)?;
-        prunes.push(
-            ctx.fetcher
-                .plan_segment(seg, ctx.tenant_hash, &ctx.query, &ctx.accounting),
-        );
+        let prune = ctx
+            .fetcher
+            .plan_segment(seg, ctx.tenant_hash, &ctx.query, &ctx.accounting);
+        prunes.push(async move { (idx, prune.await) });
     }
-    let planned: Vec<Option<(usize, ScanStats, Option<LogFooter>)>> = futures::stream::iter(prunes)
-        .buffered(plan_concurrency.max(1))
-        .map_err(SqlError::from)
-        .try_collect()
-        .await?;
-    let mut segs = Vec::with_capacity(segments.len());
+    let budget = plan_concurrency.max(1);
+    let mut stream = futures::stream::iter(prunes).buffer_unordered(budget);
+    let mut segs: Vec<Option<SegPlan>> = std::iter::repeat_with(|| None)
+        .take(segments.len())
+        .collect();
     let mut total_blocks = 0usize;
     let mut full_reads = 0usize;
-    for entry in planned {
-        match entry {
-            Some((survivors, stats, footer)) => {
-                total_blocks += survivors;
-                // A relevant segment planned from the skip index carries its
-                // footer forward; the whole-object fallback (#761) carries none.
-                if footer.is_none() {
-                    full_reads += 1;
-                }
-                segs.push(Some(SegPlan {
-                    survivors,
-                    stats,
-                    footer,
-                }));
+    // Only the RETAINED carried bytes -- the first `budget` segments to
+    // complete with a whole object -- are summed here, so this is the true
+    // peak `compute_plan_counts` holds at once, not the whole corpus. A
+    // dropped whole object never reaches this sum: its `whole_object` is
+    // `None` before `SegPlan` is built below.
+    let mut carried_bytes = 0u64;
+    let mut carried_seen = 0usize;
+    while let Some((idx, entry)) = stream.next().await {
+        let entry: PlanSegmentResult = entry.map_err(SqlError::from)?;
+        if let Some((survivors, stats, footer, whole_object)) = entry {
+            total_blocks += survivors;
+            // A relevant segment planned from the skip index carries its
+            // footer forward; the whole-object fallback (#761) carries none.
+            if footer.is_none() {
+                full_reads += 1;
             }
-            None => segs.push(None),
+            let whole_object = match whole_object {
+                // `survivors > 0` mirrors the condition `owned_work` uses to
+                // decide whether any partition ever opens this segment: a
+                // zero-survivor segment is dropped there regardless, so
+                // spending the budget on its carry here would retain bytes
+                // no partition ever reuses and starve a segment that would
+                // have.
+                Some(w) if survivors > 0 && carried_seen < budget => {
+                    carried_seen += 1;
+                    carried_bytes += w.byte_len();
+                    Some(w)
+                }
+                // Either no whole object to begin with, no surviving block to
+                // spend it on, or one arrived after the budget was already
+                // spent by earlier completions: drop it before it is ever
+                // stored, so it is never retained and never charged as
+                // reused.
+                _ => None,
+            };
+            segs[idx] = Some(SegPlan {
+                survivors,
+                stats,
+                footer,
+                whole_object,
+            });
         }
     }
+    // A single call with the final sum is only correct because `carried_bytes`
+    // is monotonically non-decreasing across this loop: nothing here ever
+    // releases a retained buffer mid-pass, so the last value is also the
+    // peak. If a future change lets retention shrink before this function
+    // returns (an eviction, an early release), this call must move inside
+    // the loop so `observe_intermediate_bytes` sees every local maximum, not
+    // just the end state.
+    ctx.accounting.observe_intermediate_bytes(carried_bytes);
     Ok(Arc::new(PlanCounts {
         segs,
         total_blocks,
@@ -2521,6 +2654,11 @@ struct OwnedSeg {
     /// carried to the subset open so it skips its own suffix probe. `None` on the
     /// whole-segment fast path (no plan phase) and when the plan slow branch ran.
     footer: Option<LogFooter>,
+    /// The plan fallback's whole-object bytes for this segment (issue #835),
+    /// carried to the subset open so it does not pay a second wire GET.
+    /// `None` whenever [`SegPlan::whole_object`] was `None`, and always
+    /// `None` on the whole-segment fast path (no plan phase).
+    whole_object: Option<CarriedWholeObject>,
 }
 
 /// This partition's share of the block assignment, in one of two modes
@@ -2565,6 +2703,7 @@ fn owned_work(
                     ordinal: seg_idx,
                     indices,
                     footer: plan.footer.clone(),
+                    whole_object: plan.whole_object.clone(),
                 });
             }
         }
@@ -2581,6 +2720,7 @@ fn owned_work(
                     ordinal: seg_idx,
                     indices: (0..plan.survivors).collect(),
                     footer: plan.footer.clone(),
+                    whole_object: plan.whole_object.clone(),
                 });
             }
             seg_ordinal += 1;
@@ -2619,6 +2759,7 @@ fn owned_whole_segments(
                 ordinal: seg_idx,
                 indices: Vec::new(),
                 footer: None,
+                whole_object: None,
             });
         }
         ordinal += 1;
@@ -2777,6 +2918,7 @@ fn open_segment_subset(
     seg: SegmentRef,
     indices: Vec<usize>,
     footer: Option<LogFooter>,
+    whole_object: Option<CarriedWholeObject>,
 ) -> OpenFuture {
     Box::pin(async move {
         refuse_unreadable_version(&seg)?;
@@ -2789,6 +2931,7 @@ fn open_segment_subset(
                 &ctx.columns,
                 &indices,
                 footer.as_ref(),
+                whole_object,
                 &ctx.accounting,
             )
             .await
@@ -3059,6 +3202,24 @@ struct LogScanStream {
     /// 2), kept so the `attrs_raw` fallback re-opens the subset with the same
     /// footer it first used. `None` on the whole-segment fast path.
     current_footer: Option<LogFooter>,
+    /// The plan fallback's whole-object bytes for [`Self::current_seg`]
+    /// (issue #835), consumed exactly once per stream by the FIRST open of
+    /// this segment (`Option::take` at the `NextSegment` state, before
+    /// `open_segment_subset`). `None` whenever the plan phase did not carry
+    /// whole-object bytes forward for this segment, always `None` on the
+    /// whole-segment fast path, and `None` here after that first take even
+    /// though the carry existed -- a later `ReopenRows`/`attrs_raw`-overflow
+    /// reopen of the SAME segment therefore takes the normal fetch/cache path
+    /// rather than reusing these bytes a second time.
+    ///
+    /// Once per stream, not once per buffer: under block striping a segment's
+    /// survivors can be owned by several partitions, each of which clones the
+    /// carry and charges the object's length to
+    /// `QueryAccounting::add_bytes_reused`. That matches what the figure
+    /// counts, one avoided store call per open, and is the same convention
+    /// those opens were charged under as cache hits before this carry existed.
+    /// The memory bound is unaffected: `Bytes` clones share one allocation.
+    current_whole_object: Option<CarriedWholeObject>,
     /// How many of this partition's blocks in the current segment the columnar
     /// fast path has already emitted. The `attrs_raw` fallback re-opens the
     /// segment over `current_indices` and skips this many positions so none is
@@ -3284,11 +3445,20 @@ impl Stream for LogScanStream {
                         ordinal,
                         indices,
                         footer,
+                        whole_object,
                     }) => {
                         this.current_seg = Some(seg.clone());
                         this.current_seg_ordinal = ordinal;
                         this.current_indices = indices.clone();
                         this.current_footer = footer.clone();
+                        // Moved, not cloned: this stream consumes the carried
+                        // whole object exactly once, by whichever open below
+                        // `take()`s it first. A later `ReopenRows` reopen
+                        // must see `None` and pay for its own fetch (real GET
+                        // or read-cache hit), or `tenant_bytes_with_footer`
+                        // charges `add_bytes_reused` twice for one buffer
+                        // (issue #835 follow-up).
+                        this.current_whole_object = whole_object;
                         this.seg_columnar_blocks = 0;
                         this.block_cursor = 0;
                         // Whole-segment fast path reads the object in one GET
@@ -3312,11 +3482,18 @@ impl Stream for LogScanStream {
                                 by_chunk,
                             ))
                         } else {
+                            // `take()`, not the moved-in value directly: this
+                            // IS the one consumption of the carried whole
+                            // object (see the comment above where it moved
+                            // into `current_whole_object`). Taking it here
+                            // leaves `None` behind for any later reopen.
+                            let whole_object = this.current_whole_object.take();
                             LogScanState::Opening(open_segment_subset(
                                 Arc::clone(&this.ctx),
                                 seg,
                                 indices,
                                 footer,
+                                whole_object,
                             ))
                         };
                     }
@@ -3480,11 +3657,19 @@ impl Stream for LogScanStream {
                                 let by_chunk = this.ctx.open_by_column_chunk(&seg);
                                 open_segment_fast(Arc::clone(&this.ctx), seg, by_chunk)
                             } else {
+                                // `take()`, not `clone()`: the first open
+                                // already took the carried whole object (if
+                                // any), so this is always `None` here. `take`
+                                // rather than reading the field directly keeps
+                                // that single-consumption invariant true by
+                                // construction instead of by this call site
+                                // happening to run after the first one.
                                 open_segment_subset(
                                     Arc::clone(&this.ctx),
                                     seg,
                                     this.current_indices.clone(),
                                     this.current_footer.clone(),
+                                    this.current_whole_object.take(),
                                 )
                             };
                             this.state = LogScanState::ReopenRows {

--- a/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
+++ b/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
@@ -67,9 +67,11 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_trait::async_trait;
+use datafusion::catalog::TableProvider;
 use datafusion::execution::TaskContext;
 use datafusion::logical_expr::{Expr, col, lit};
 use datafusion::physical_plan::{ExecutionPlan, collect};
+use datafusion::prelude::{SessionConfig, SessionContext};
 use ravel_cache::{Cache, CacheLimits};
 use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
 use ravel_logseg::writer::ObjectIdentity;
@@ -79,8 +81,10 @@ use ravel_object_store::{
     Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
     PageToken, PutOptions, PutOutcome, StoreError,
 };
-use ravel_query::{BlockRangeFetcher, CacheFetchError, LogSegmentFetcher};
-use ravel_sql::{DeclaredColumn, DeclaredType, LogsTableProvider, has_word_udf};
+use ravel_query::{BlockRangeFetcher, CacheFetchError, LogSegmentFetcher, QueryPhase};
+use ravel_sql::{
+    DeclaredColumn, DeclaredType, FIRST_DECLARED_COL, LOG_COL_TS, LogsTableProvider, has_word_udf,
+};
 use ravel_types::TenantHash;
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
 use uuid::Uuid;
@@ -119,6 +123,14 @@ const SUFFIX_LEN: u64 = 8192;
 /// shape exercises the plan-phase whole-object fallback (`plan_full_reads`) that
 /// #761 could not remove.
 const MARKER_FEW: &str = "MARKERFEW";
+
+/// A marker word present in exactly the first block of exactly the first
+/// segment (nowhere else). A `has_word` query for it is, like `MARKER_FEW`,
+/// undecidable at the skip index, so every segment's plan phase still reads
+/// the whole object to count survivors (issue #835 fixture below) -- but only
+/// one segment actually survives, so the scan opens exactly one object and the
+/// other `SEGMENTS - 1` are never opened at all.
+const MARKER_RARE: &str = "MARKERRARE";
 
 /// The declared numeric column every record carries: `code = <block index>`
 /// (0..BLOCKS_PER_SEG). A `NumRange` prune arm on it (ClickBench q20/q37 shape)
@@ -169,6 +181,10 @@ fn body(seg: usize, blk: usize) -> String {
     let mut head = String::new();
     if blk == 0 {
         head.push_str(MARKER_FEW);
+        head.push(' ');
+    }
+    if seg == 0 && blk == 0 {
+        head.push_str(MARKER_RARE);
         head.push(' ');
     }
     let seed = (seg as u64) << 32 | blk as u64;
@@ -241,6 +257,267 @@ async fn build_snapshot(store: &dyn ObjectStoreBackend) -> Snapshot {
     }
     Snapshot {
         segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    }
+}
+
+/// Body for block `blk`, byte-identical across every segment: only
+/// `MARKER_FEW` at block 0, no segment-conditional `MARKER_RARE` (unlike
+/// [`body`], whose segment-0 addition of `MARKER_RARE` makes that segment's
+/// object a few bytes larger than the rest). Issue #835's budgeted-carry test
+/// needs every relevant segment's whole-object read to be the exact same
+/// size, so its `bytesReused` figure is an exact `2 * S`, not an
+/// approximation.
+fn body_uniform(blk: usize) -> String {
+    let mut head = String::new();
+    if blk == 0 {
+        head.push_str(MARKER_FEW);
+        head.push(' ');
+    }
+    format!("{head}{}", filler(blk as u64, BODY_BYTES))
+}
+
+fn record_uniform(blk: usize) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("svc".to_string()),
+    )];
+    // Same `ts_ns` in every segment (not `seg`-offset like [`record`]):
+    // varint-style encoding of the timestamp would otherwise make segments
+    // with a larger `seg` component a different byte length, defeating the
+    // uniform-size fixture this exists for. Segment identity comes from the
+    // object key, not from a distinct ts range.
+    let ts = blk as i64;
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body_uniform(blk),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![(CODE_COL.to_string(), AttrValue::I64(blk as i64))],
+    }
+}
+
+async fn write_segment_uniform(store: &dyn ObjectStoreBackend, seg: usize) -> SegmentRef {
+    let recs: Vec<LogRecord> = (0..BLOCKS_PER_SEG).map(record_uniform).collect();
+    let mut w = RlogWriter::new(one_record_blocks(), identity((seg + 1) as u64));
+    for r in &recs {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    let key = format!("logs/uniform_seg{seg}.rlog");
+    let content_hash = *blake3::hash(&bytes).as_bytes();
+    store
+        .put(&key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    let min = recs.iter().map(|r| r.ts_ns).min().unwrap();
+    let max = recs.iter().map(|r| r.ts_ns).max().unwrap();
+    SegmentRef {
+        data_object_key: key,
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: recs.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: (seg + 1) as u64,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
+    }
+}
+
+async fn build_snapshot_uniform(store: &dyn ObjectStoreBackend) -> Snapshot {
+    let mut segments = Vec::with_capacity(SEGMENTS);
+    for s in 0..SEGMENTS {
+        segments.push(write_segment_uniform(store, s).await);
+    }
+    Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    }
+}
+
+/// [`body_uniform`]'s block 0, minus the marker: the same `MARKER_FEW.len() +
+/// 1` bytes replaced by filler instead of the word, so a segment built from
+/// this has no block anywhere that a `has_word(MARKER_FEW)` predicate
+/// survives, while its block 0 body is still byte-for-byte the same length
+/// as a marker-carrying segment's -- the object comes out the same stored
+/// size either way, only the content differs (issue #835 follow-up, finding
+/// 3b's zero-survivor fixture needs this to keep its byte arithmetic exact).
+fn body_uniform_no_marker(blk: usize) -> String {
+    if blk == 0 {
+        let prefix_len = MARKER_FEW.len() + 1;
+        format!(
+            "{}{}",
+            filler(u64::MAX ^ blk as u64, prefix_len),
+            filler(blk as u64, BODY_BYTES)
+        )
+    } else {
+        body_uniform(blk)
+    }
+}
+
+/// [`write_segment_uniform`], but with `has_marker: false` swapping every
+/// record's body for [`body_uniform_no_marker`], so the segment's plan-phase
+/// whole-object read finds zero surviving blocks for `has_word(MARKER_FEW)`.
+async fn write_segment_uniform_variant(
+    store: &dyn ObjectStoreBackend,
+    seg: usize,
+    has_marker: bool,
+) -> SegmentRef {
+    let recs: Vec<LogRecord> = (0..BLOCKS_PER_SEG)
+        .map(|blk| {
+            let mut r = record_uniform(blk);
+            if !has_marker {
+                r.body = body_uniform_no_marker(blk);
+            }
+            r
+        })
+        .collect();
+    let mut w = RlogWriter::new(one_record_blocks(), identity((seg + 1) as u64));
+    for r in &recs {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    let key = format!("logs/uniform_variant_seg{seg}.rlog");
+    let content_hash = *blake3::hash(&bytes).as_bytes();
+    store
+        .put(&key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    let min = recs.iter().map(|r| r.ts_ns).min().unwrap();
+    let max = recs.iter().map(|r| r.ts_ns).max().unwrap();
+    SegmentRef {
+        data_object_key: key,
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: recs.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: (seg + 1) as u64,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
+    }
+}
+
+/// Same corpus as [`build_snapshot_uniform`] except segment 0 carries no
+/// `MARKER_FEW` anywhere (issue #835 follow-up, finding 3b): a `has_word`
+/// query against it still forces a plan-phase whole-object read (the skip
+/// index cannot decide the predicate without reading), but finds zero
+/// surviving blocks, so `owned_work` never lets any partition open it.
+async fn build_snapshot_uniform_first_zero_survivor(store: &dyn ObjectStoreBackend) -> Snapshot {
+    let mut segments = Vec::with_capacity(SEGMENTS);
+    for s in 0..SEGMENTS {
+        segments.push(write_segment_uniform_variant(store, s, s != 0).await);
+    }
+    Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    }
+}
+
+/// Record for the issue #835 follow-up (Finding 2) reopen-path fixture: block
+/// `blk`'s one record always carries the `filler` attribute; block 1 also
+/// adds `tags`, which overflows [`one_record_blocks_overflow`]'s
+/// `max_dynamic_columns = 1` budget (`filler` sorts first) into an
+/// `attrs_raw` page for that block only. Every block's body carries
+/// `MARKER_FEW` so a `has_word` predicate matches both rows.
+fn record_reopen(blk: usize) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("svc".to_string()),
+    )];
+    let ts = blk as i64;
+    let mut attrs = vec![("filler".to_string(), AttrValue::Str("f".to_string()))];
+    if blk == 1 {
+        attrs.push(("tags".to_string(), AttrValue::Str(format!("spilled-{blk}"))));
+    }
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: format!("{MARKER_FEW} {}", filler(blk as u64, BODY_BYTES)),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs,
+    }
+}
+
+fn one_record_blocks_overflow() -> RlogConfig {
+    RlogConfig {
+        block_target_records: 1,
+        max_dynamic_columns: 1,
+        ..RlogConfig::default()
+    }
+}
+
+async fn write_segment_reopen(store: &dyn ObjectStoreBackend) -> SegmentRef {
+    let recs: Vec<LogRecord> = (0..2).map(record_reopen).collect();
+    let mut w = RlogWriter::new(one_record_blocks_overflow(), identity(1));
+    for r in &recs {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    let key = "logs/reopen_seg.rlog".to_string();
+    let content_hash = *blake3::hash(&bytes).as_bytes();
+    store
+        .put(&key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    let min = recs.iter().map(|r| r.ts_ns).min().unwrap();
+    let max = recs.iter().map(|r| r.ts_ns).max().unwrap();
+    SegmentRef {
+        data_object_key: key,
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: recs.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
+    }
+}
+
+async fn build_snapshot_reopen(store: &dyn ObjectStoreBackend) -> Snapshot {
+    Snapshot {
+        segments: vec![write_segment_reopen(store).await],
         segments_pruned: 0,
         pending_erasure: Vec::new(),
     }
@@ -350,6 +627,19 @@ fn fetcher(store: Arc<dyn ObjectStoreBackend>, cache_bytes: u64) -> LogSegmentFe
         .with_block_range_threshold(0)
 }
 
+/// Same fetcher settings as [`fetcher`], with no read cache wired at all --
+/// the configuration issue #835 concerns, where a second wire GET for the
+/// same object cannot hide behind a cache hit of any size.
+fn fetcher_uncached(store: Arc<dyn ObjectStoreBackend>) -> LogSegmentFetcher {
+    let block_range = BlockRangeFetcher::new(Arc::clone(&store))
+        .with_suffix_len(SUFFIX_LEN)
+        .with_coalesce_gap(0)
+        .with_whole_object_threshold(0);
+    LogSegmentFetcher::new(store)
+        .with_block_range(block_range)
+        .with_block_range_threshold(0)
+}
+
 fn provider(
     snapshot: Snapshot,
     fetcher: LogSegmentFetcher,
@@ -411,22 +701,93 @@ struct Shape {
     plan_full_reads: usize,
     acc_gets: u64,
     acc_bytes: u64,
+    acc_bytes_reused: u64,
+    acc_peak_intermediate_bytes: u64,
+    /// Store GET requests the fetcher's [`PhaseWireByteCounter`] attributed to
+    /// [`QueryPhase::Plan`] (issue #835 attribution): the footer/suffix probe
+    /// plus, for an undecidable predicate, the whole-object fallback read --
+    /// both issued by `plan_segment`, never by the scan.
+    plan_phase_gets: u64,
+    /// Store GET requests attributed to [`QueryPhase::Scan`]: the BLOCKS-
+    /// section data range (or a whole-object GET) a data read issues to
+    /// obtain block data. Zero on the fully-carried path; nonzero once a
+    /// segment's carry is dropped and its data read has to fetch block
+    /// bytes it can no longer take from the carry (issue #835 follow-up).
+    scan_phase_gets: u64,
+    /// Store GET requests attributed to [`QueryPhase::Probe`]: a data read's
+    /// OWN metadata GETs (suffix probe, footer chase, directories) -- issued
+    /// again whenever a segment's carry was dropped and its normal open has
+    /// to re-derive that metadata from the wire, since the carry no longer
+    /// covers it either.
+    probe_phase_gets: u64,
+    /// Blocks emitted by the fast columnar path vs. by a row-path reopen
+    /// (`LogScanState::ReopenRows`, triggered by a block's `attrs_raw`
+    /// overflow page). Both nonzero proves a segment took the columnar path
+    /// for part of its blocks and fell back to the row path partway through.
+    columnar_batches: usize,
+    rowpath_batches: usize,
 }
 
 async fn measure(label: &'static str, filters: &[Expr], cache_bytes: u64) -> Shape {
+    measure_opt(label, filters, Some(cache_bytes), PARTS).await
+}
+
+/// `cache_bytes: None` wires no read cache at all (see [`fetcher_uncached`]).
+/// `plan_concurrency` is the provider's `target_partitions`, which this
+/// codebase also uses as the plan phase's fetch fan-out (`LogsScanExec`
+/// threads one value into both roles); most callers pass [`PARTS`] to keep
+/// the two concerns decoupled from a test's assertions, but the issue #835
+/// budget test drives it down deliberately.
+async fn measure_opt(
+    label: &'static str,
+    filters: &[Expr],
+    cache_bytes: Option<u64>,
+    plan_concurrency: usize,
+) -> Shape {
     let base = Arc::new(MemoryStore::new());
     let snapshot = build_snapshot(base.as_ref()).await;
+    measure_with_snapshot(
+        label,
+        filters,
+        cache_bytes,
+        plan_concurrency,
+        base,
+        snapshot,
+    )
+    .await
+}
+
+/// Same measurement as [`measure_opt`], against a caller-supplied snapshot
+/// instead of always building the standard (segment-0-carries-an-extra-marker)
+/// corpus -- the issue #835 budget test needs every segment's object the exact
+/// same size, which [`build_snapshot`]'s `MARKER_RARE`-on-segment-0 asymmetry
+/// does not give it.
+async fn measure_with_snapshot(
+    label: &'static str,
+    filters: &[Expr],
+    cache_bytes: Option<u64>,
+    plan_concurrency: usize,
+    base: Arc<MemoryStore>,
+    snapshot: Snapshot,
+) -> Shape {
     let counting = CountingStore::new(base);
     let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
     let acc = QueryAccounting::new();
-    let prov = provider(snapshot, fetcher(store, cache_bytes), acc.clone());
+    let fetch = match cache_bytes {
+        Some(bytes) => fetcher(store, bytes),
+        None => fetcher_uncached(store),
+    };
+    let wire_bytes = fetch.phase_wire_byte_counter();
+    let prov = provider(snapshot, fetch, acc.clone());
     let plan = if filters.is_empty() {
-        prov.plan(PARTS).expect("plan")
+        prov.plan(plan_concurrency).expect("plan")
     } else {
-        prov.plan_filters(PARTS, filters).expect("plan_filters")
+        prov.plan_filters(plan_concurrency, filters)
+            .expect("plan_filters")
     };
     let rows = drain(Arc::clone(&plan)).await;
     let snap = acc.snapshot();
+    let phases = wire_bytes.snapshot();
     Shape {
         label,
         gets: counting.gets(),
@@ -439,13 +800,22 @@ async fn measure(label: &'static str, filters: &[Expr], cache_bytes: u64) -> Sha
         plan_full_reads: sum_metric(&plan, "plan_full_reads"),
         acc_gets: snap.s3_requests(AccountedOp::Get),
         acc_bytes: snap.total_s3_bytes(),
+        acc_bytes_reused: snap.bytes_reused,
+        acc_peak_intermediate_bytes: snap.peak_intermediate_bytes,
+        plan_phase_gets: phases.phase_requests(QueryPhase::Plan),
+        scan_phase_gets: phases.phase_requests(QueryPhase::Scan),
+        probe_phase_gets: phases.phase_requests(QueryPhase::Probe),
+        columnar_batches: sum_metric(&plan, "columnar_batches"),
+        rowpath_batches: sum_metric(&plan, "rowpath_batches"),
     }
 }
 
 fn report(s: &Shape) {
     eprintln!(
         "[{}] gets={} (full={} suffix={}) bytes={} blocks_scanned={}/{} rows={} \
-         plan_full_reads={} | accounting: gets={} bytes={}",
+         plan_full_reads={} | accounting: gets={} bytes={} bytes_reused={} \
+         peak_intermediate_bytes={} | phases: plan_gets={} probe_gets={} scan_gets={} \
+         | path: columnar_batches={} rowpath_batches={}",
         s.label,
         s.gets,
         s.full_gets,
@@ -457,6 +827,13 @@ fn report(s: &Shape) {
         s.plan_full_reads,
         s.acc_gets,
         s.acc_bytes,
+        s.acc_bytes_reused,
+        s.acc_peak_intermediate_bytes,
+        s.plan_phase_gets,
+        s.probe_phase_gets,
+        s.scan_phase_gets,
+        s.columnar_batches,
+        s.rowpath_batches,
     );
 }
 
@@ -522,11 +899,13 @@ async fn selective_numeric_reads_only_surviving_blocks() {
         "full scan decodes every block"
     );
     assert_eq!(full.rows, TOTAL_BLOCKS, "full scan returns every record");
-    // 649,900 = the eight version-4 objects' bytes exactly (81,144 B each plus
-    // rounding across the writer's per-object framing). One whole-object GET per
-    // segment and nothing else, so this is the object bytes and not a byte more.
+    // 649,903 = the eight version-4 objects' bytes exactly (segment 0 carries
+    // `MARKER_RARE` in addition to `MARKER_FEW`, so its object is a few bytes
+    // larger than the other seven after compression). One whole-object GET
+    // per segment and nothing else, so this is the object bytes and not a
+    // byte more.
     assert_eq!(
-        full.bytes, 649_900,
+        full.bytes, 649_903,
         "full scan reads exactly the object bytes"
     );
     assert_eq!(full.plan_full_reads, 0, "full scan skips the plan phase");
@@ -576,15 +955,16 @@ async fn selective_numeric_reads_only_surviving_blocks() {
         q37.bytes,
         q37_block_bytes
     );
-    // 165,355 = 99,147 page bytes (the 8 surviving blocks' pages across their
-    // eight column chunks; blocks differ slightly in encoded size, so the term
-    // is the measured sum, not blocks x a constant) + 65,536 probe bytes
-    // (8 x 8 KiB) + 672 front-section bytes (8 x (STREAM_DIR 62 + FIELD_DIR
-    // 22)). The page term is 15% of the full scan; the probe term is the fixed
-    // per-object directory cost, which on this deliberately tiny fixture is
-    // 40% of the total and on a production 1.3 MB object is a rounding error.
+    // 165,365 = 99,157 page bytes (the 8 surviving blocks' pages across their
+    // eight column chunks; blocks differ slightly in encoded size -- segment
+    // 0's surviving block also carries `MARKER_RARE` -- so the term is the
+    // measured sum, not blocks x a constant) + 65,536 probe bytes (8 x 8 KiB)
+    // + 672 front-section bytes (8 x (STREAM_DIR 62 + FIELD_DIR 22)). The page
+    // term is 15% of the full scan; the probe term is the fixed per-object
+    // directory cost, which on this deliberately tiny fixture is 40% of the
+    // total and on a production 1.3 MB object is a rounding error.
     assert_eq!(
-        q37.bytes, 165_355,
+        q37.bytes, 165_365,
         "q37 moves the surviving blocks' page bytes plus the probe and the two \
          front sections, not the object"
     );
@@ -625,11 +1005,11 @@ async fn selective_numeric_reads_only_surviving_blocks() {
         q20.bytes,
         q20_block_bytes
     );
-    // 264,405 = 198,197 page bytes (16 surviving blocks) + the same 65,536 probe
+    // 264,415 = 198,207 page bytes (16 surviving blocks) + the same 65,536 probe
     // and 672 front-section bytes q37 pays: twice q37's page term, identical
     // fixed term.
     assert_eq!(
-        q20.bytes, 264_405,
+        q20.bytes, 264_415,
         "q20 moves twice q37's page bytes and the same fixed directory bytes"
     );
     assert!(
@@ -668,10 +1048,15 @@ async fn selective_numeric_reads_only_surviving_blocks() {
 
 /// A text predicate (`has_word`) is bloom-pruned only at DECODE: the skip index
 /// cannot decide it, so #761's fetch-side pruning does not apply. The plan phase
-/// falls back to a whole-object read per segment (`plan_full_reads`), the scan
-/// still reads the whole object, and only the byte-decode is reduced (bloom
-/// leaves one block per segment). This pins the fallback the fix deliberately
-/// keeps for shapes the skip index cannot prune.
+/// falls back to a whole-object read per segment (`plan_full_reads`), and since
+/// #835 the scan reuses that plan-carried whole object rather than reading it
+/// again, so only the byte-decode is reduced (bloom leaves one block per
+/// segment). This pins the fallback the fix deliberately keeps for shapes the
+/// skip index cannot prune. The 64 MiB cache here is far larger than this
+/// fixture's ~650 KB corpus, which is exactly the configuration that used to
+/// mask issue #835's double wire GET as a cache hit -- see
+/// `text_predicate_no_second_wire_read_regardless_of_cache` below for the
+/// cache-size-independent assertion this test cannot make on its own.
 #[tokio::test]
 async fn text_predicate_falls_back_to_full_object_read() {
     let cache = 64 << 20;
@@ -693,13 +1078,16 @@ async fn text_predicate_falls_back_to_full_object_read() {
     );
     assert_eq!(text.rows, SEGMENTS, "one matching record per segment");
     // The whole objects are read: bytes ~ a full scan plus the probes, the
-    // amplification #761 cannot remove for a text predicate. 715,612 = 649,900
-    // object bytes + 65,536 probe bytes (8 x 8 KiB) + 176 FIELD_DIR bytes
-    // (8 x 22, read to resolve the arms before the fallback decides), the plan
-    // phase's cost on top of the whole-object read its fallback then issues.
+    // amplification #761 cannot remove for a text predicate. 715,439 = 649,903
+    // object bytes + 65,536 probe bytes (8 x 8 KiB). The 176 FIELD_DIR bytes
+    // (8 x 22) this figure carried before #835 were the scan open's, not the
+    // plan's: the plan fallback selects every column, while the scan's
+    // selection is built from fixed-only builders and so is not `is_all()`,
+    // which is what makes `place_and_decode_field_dir` fire. The carry
+    // short-circuits that open, so the read goes with it.
     let full = measure("full_scan", &[], cache).await;
     assert_eq!(
-        text.bytes, 715_612,
+        text.bytes, 715_439,
         "text fallback: the whole objects plus one plan probe each"
     );
     assert!(
@@ -765,13 +1153,544 @@ async fn selective_third_no_partition_multiplication_under_cache_pressure() {
         small.bytes,
         full.bytes
     );
-    // 264,405 with no eviction (16 surviving blocks' page bytes plus the fixed
-    // probe and front-section bytes) against 479,147 under pressure: the
+    // 264,415 with no eviction (16 surviving blocks' page bytes plus the fixed
+    // probe and front-section bytes) against 479,157 under pressure: the
     // difference is re-fetched probe and directory extents, never a re-read
-    // page. Both stay under the 649,900 a single full pass moves.
-    assert_eq!(big.bytes, 264_405, "q20 with no eviction");
+    // page. Both stay under the 649,903 a single full pass moves.
+    assert_eq!(big.bytes, 264_415, "q20 with no eviction");
     assert_eq!(
-        small.bytes, 479_147,
+        small.bytes, 479_157,
         "q20 under eviction: more directory re-reads, still under one full pass"
+    );
+}
+
+/// Issue #835's attribution fixture, the "prunes nothing" shape: `MARKER_FEW`
+/// matches one block in EVERY segment, so nothing is pruned at the segment
+/// level and every relevant segment's plan phase falls back to a whole-object
+/// read (same predicate as `text_predicate_falls_back_to_full_object_read`
+/// above, deliberately, so the two tests are directly comparable).
+///
+/// Before issue #835's fix, the scan phase re-opened every one of those
+/// objects from scratch: `PLAN` issued `SEGMENTS` (8) whole-object GETs,
+/// `SCAN` issued `SEGMENTS` (8) more for the identical bytes, `2 * SEGMENTS`
+/// (16) total and twice the corpus bytes on the wire -- masked to 8 and one
+/// corpus's worth of bytes only when a read cache happened to be wired AND
+/// sized larger than the whole corpus (`text_predicate_falls_back_to_full_object_read`'s
+/// 64 MiB cache is exactly that masking case; this fixture's corpus is only
+/// ~650 KB, so a real deployment's cache is not reliably bigger).
+///
+/// Since the fix, the plan's fetched bytes are carried forward
+/// (`ravel_query::CarriedWholeObject`) into the scan, so the wire cost is
+/// `SEGMENTS` (8) GETs and exactly the corpus bytes moved once, identical to
+/// the big-cache figures and now true under a cache too small to hold the
+/// corpus and with no cache at all. That equality is a property of this
+/// fixture, not of the carry: the plan fan-out here covers every segment, so
+/// every carry survives. A snapshot with more segments than partitions pays a
+/// second read for the surplus, which
+/// [`plan_carry_peak_bytes_bounded_by_plan_concurrency`] pins.
+#[tokio::test]
+async fn text_predicate_no_second_wire_read_regardless_of_cache() {
+    // Below the ~650 KB corpus: without the carry, at least some plan-phase
+    // entries would not survive to be reused by the scan.
+    let small = measure_opt(
+        "text_fallback (small cache)",
+        &[has_word(MARKER_FEW)],
+        Some(128 << 10),
+        PARTS,
+    )
+    .await;
+    let uncached = measure_opt(
+        "text_fallback (no cache)",
+        &[has_word(MARKER_FEW)],
+        None,
+        PARTS,
+    )
+    .await;
+    report(&small);
+    report(&uncached);
+
+    for s in [&small, &uncached] {
+        assert_eq!(
+            s.plan_full_reads, SEGMENTS,
+            "{}: every relevant segment's plan phase reads the whole object",
+            s.label
+        );
+        // The exact-count claim this fixture exists to pin: full_gets is
+        // SEGMENTS, NOT 2 * SEGMENTS -- the scan issues no whole-object GET of
+        // its own, regardless of cache size. (Total `gets` below is
+        // 2 * SEGMENTS because the plan phase's suffix probe, not the scan,
+        // adds the other half.)
+        assert_eq!(
+            s.full_gets, SEGMENTS as u64,
+            "{}: exactly one whole-object wire GET per segment total -- the \
+             plan's carried bytes cover the scan, never a second GET, \
+             regardless of cache size",
+            s.label
+        );
+        assert_eq!(
+            s.gets,
+            2 * SEGMENTS as u64,
+            "{}: one suffix probe plus one whole-object GET per segment, and \
+             nothing beyond that -- the scan adds no GET of any shape",
+            s.label
+        );
+        // 715,439: identical to the big-cache figure
+        // (`text_predicate_falls_back_to_full_object_read`), proving the byte
+        // cost no longer depends on cache size.
+        assert_eq!(
+            s.bytes, 715_439,
+            "{}: exactly the corpus bytes plus the fixed per-segment plan \
+             overhead, moved once, never twice",
+            s.label
+        );
+        assert_eq!(
+            s.acc_bytes, s.bytes,
+            "{}: accounting wire-bytes agrees with the raw store bytes",
+            s.label
+        );
+        assert_eq!(
+            s.acc_gets, s.gets,
+            "{}: accounting GET count agrees with the raw store GETs -- the \
+             reused read is not double-counted as a second GET",
+            s.label
+        );
+        assert_eq!(
+            s.blocks_scanned, SEGMENTS,
+            "{}: bloom still prunes to one block per segment at decode",
+            s.label
+        );
+        assert_eq!(
+            s.rows, SEGMENTS,
+            "{}: one matching record per segment",
+            s.label
+        );
+        // 649,903: the whole corpus (see `full.bytes` in the sibling test),
+        // charged as reused rather than folded into the GET-bytes figure the
+        // plan phase already recorded -- the truthful-accounting deliverable.
+        assert_eq!(
+            s.acc_bytes_reused, 649_903,
+            "{}: the scan's reuse of every carried whole object is charged via \
+             bytes_reused, not silently absorbed into acc_bytes",
+            s.label
+        );
+        // Per-phase attribution (issue #835 follow-up, finding 3a): this test
+        // drives `plan_concurrency == PARTS == SEGMENTS`, so the carry budget
+        // never drops a single segment -- every whole-object read the plan
+        // phase issues survives to be reused, and the scan phase issues no
+        // store GET of any shape. `plan_phase_gets` equals `s.gets` in full:
+        // both the suffix probe AND the undecidable predicate's whole-object
+        // fallback are plan-phase GETs (`ravel_query::QueryPhase::Plan`),
+        // never the scan's.
+        assert_eq!(
+            s.plan_phase_gets, s.gets,
+            "{}: with an unbudgeted carry, every store GET (suffix probe and \
+             whole-object fallback alike) is attributed to the plan phase",
+            s.label
+        );
+        assert_eq!(
+            s.scan_phase_gets, 0,
+            "{}: the scan phase reuses every carried whole object and issues \
+             zero store GETs of its own",
+            s.label
+        );
+    }
+}
+
+/// Issue #835, the q37-style "prunes most" shape: `MARKER_RARE` is confined to
+/// one block of one segment out of `SEGMENTS`. The skip index still cannot
+/// decide a text predicate whether or not it ultimately matches, so EVERY
+/// relevant segment's plan phase reads the whole object to find out
+/// (`plan_full_reads == SEGMENTS`) -- but only the one segment containing the
+/// marker has a surviving block, so `owned_work` assigns no partition any
+/// work in the other `SEGMENTS - 1` segments and the scan phase never opens
+/// them. The one surviving segment's scan reuses its plan-carried bytes (no
+/// second GET), so the total wire GET count is exactly `SEGMENTS`: the plan
+/// pass moves every object once, and the scan adds nothing.
+#[tokio::test]
+async fn text_predicate_prunes_most_scan_adds_no_gets() {
+    let cache = 128 << 10; // below the ~650 KB corpus
+    let s = measure(
+        "text_fallback (prunes most)",
+        &[has_word(MARKER_RARE)],
+        cache,
+    )
+    .await;
+    report(&s);
+
+    assert_eq!(
+        s.plan_full_reads, SEGMENTS,
+        "every relevant segment's plan phase reads the whole object -- the \
+         skip index cannot decide a text predicate whether or not it matches"
+    );
+    assert_eq!(
+        s.full_gets, SEGMENTS as u64,
+        "exactly one whole-object GET per segment (the plan pass); the scan \
+         adds zero GETs for the surviving segment and none of the other \
+         SEGMENTS - 1 segments are ever opened"
+    );
+    assert_eq!(
+        s.gets,
+        2 * SEGMENTS as u64,
+        "one suffix probe plus one whole-object GET per segment (the plan \
+         pass over every segment); no GET of any shape beyond that"
+    );
+    assert_eq!(
+        s.blocks_scanned, 1,
+        "only the one segment carrying the marker survives"
+    );
+    assert_eq!(s.rows, 1, "exactly one matching record, from segment 0");
+    // 81,147: segment 0's whole-object size, a few bytes larger than the
+    // other seven (its block 0 carries `MARKER_RARE` in addition to
+    // `MARKER_FEW`) -- the only segment whose carry the scan ever reuses.
+    assert_eq!(
+        s.acc_bytes_reused, 81_147,
+        "the one surviving segment's scan reuses its plan-carried bytes \
+         rather than issuing a second GET"
+    );
+}
+
+/// Issue #835's memory-bound requirement, honestly measured: peak carried-
+/// whole-object bytes retained at the plan barrier is bounded by
+/// `plan_concurrency` (in OBJECT COUNT), not by corpus size. As each
+/// `plan_segment` future completes (`buffer_unordered(plan_concurrency)`,
+/// completion order, not segment order), the first `plan_concurrency`
+/// arrivals to produce a carried whole object keep it; every later arrival
+/// has its `whole_object` forced to `None` before it is stored, so that
+/// segment's scan pays a real wire GET, exactly as it did before #835.
+///
+/// This fixture uses [`build_snapshot_uniform`] rather than the standard
+/// [`build_snapshot`]: every one of its `SEGMENTS` (8) objects is the exact
+/// same stored size `S` (no segment-conditional `MARKER_RARE`), so the
+/// dropped/retained split can be pinned as an exact byte sum (`2 * S`)
+/// instead of an inequality. `MARKER_FEW` is present in every segment's block
+/// 0, so (like the "prunes nothing" fixture above) nothing is pruned at the
+/// segment level and every segment's plan phase falls back to a whole-object
+/// read -- all 8 are candidates for the carry, only `plan_concurrency` (2) of
+/// them survive it.
+///
+/// The barrier itself is unchanged: no partition drains any block until
+/// every segment's survivor count is known (ADR-0102's flattened
+/// block-striping assignment needs all of them at once), so this test does
+/// not claim the barrier waits any less long -- only that what it retains
+/// meanwhile no longer scales with corpus size.
+#[tokio::test]
+async fn plan_carry_peak_bytes_bounded_by_plan_concurrency() {
+    const BUDGET: usize = 2;
+
+    let base = Arc::new(MemoryStore::new());
+    let snapshot = build_snapshot_uniform(base.as_ref()).await;
+    let object_size = snapshot.segments[0].object_size;
+    assert!(
+        snapshot
+            .segments
+            .iter()
+            .all(|seg| seg.object_size == object_size),
+        "fixture precondition: every uniform-fixture segment is the exact \
+         same stored size"
+    );
+
+    let s = measure_with_snapshot(
+        "text_fallback (budgeted carry)",
+        &[has_word(MARKER_FEW)],
+        None,
+        BUDGET,
+        base,
+        snapshot,
+    )
+    .await;
+    report(&s);
+
+    assert_eq!(
+        s.plan_full_reads, SEGMENTS,
+        "every relevant segment's plan phase reads the whole object, \
+         regardless of whether the budget later lets it keep those bytes"
+    );
+    assert_eq!(
+        s.blocks_scanned, SEGMENTS,
+        "MARKER_FEW survives one block in every segment, so the scan opens \
+         all SEGMENTS segments"
+    );
+    assert_eq!(s.rows, SEGMENTS, "one matching record per segment");
+
+    // Exactly `BUDGET` (2) carried whole objects reused by the scan, never
+    // more: `2 * S`, not an approximation and not the corpus.
+    assert_eq!(
+        s.acc_bytes_reused,
+        BUDGET as u64 * object_size,
+        "exactly BUDGET carried whole objects are reused by the scan -- the \
+         other SEGMENTS - BUDGET segments pay a real wire re-fetch instead"
+    );
+    // The deliverable this test exists to pin: peak intermediate bytes is
+    // `BUDGET * S`, never the corpus (`SEGMENTS * S`).
+    assert_eq!(
+        s.acc_peak_intermediate_bytes,
+        BUDGET as u64 * object_size,
+        "peak carried-whole-object bytes at the plan barrier is bounded by \
+         plan_concurrency (in object count), not by corpus size"
+    );
+
+    // Wire-GET accounting: the plan phase issues one suffix probe and one
+    // whole-object read per segment regardless of the carry budget (the read
+    // already happened before the budget decides whether to keep it), so
+    // `plan_phase_gets` is `2 * SEGMENTS` unconditionally. The scan phase
+    // then re-fetches the `SEGMENTS - BUDGET` segments the budget dropped,
+    // each with its own whole-object GET, and reuses the other `BUDGET`
+    // segments' carried bytes for free.
+    assert_eq!(
+        s.plan_phase_gets,
+        2 * SEGMENTS as u64,
+        "plan phase: one suffix probe plus one whole-object read per \
+         segment, unaffected by the carry budget"
+    );
+    // Each of the SEGMENTS - BUDGET (6) dropped segments falls back to a
+    // normal (uncarried) segment open: one data read whose own metadata GETs
+    // (suffix probe + front directories, `QueryPhase::Probe`) precede its
+    // block-data range read (`QueryPhase::Scan`). Empirically 2 probe GETs
+    // and 1 scan GET per dropped segment (measured directly, not derived --
+    // the exact shape of a data read's own metadata fetch is this fetcher
+    // configuration's business, not this test's).
+    assert_eq!(
+        s.probe_phase_gets,
+        2 * (SEGMENTS - BUDGET) as u64,
+        "probe phase: each of the SEGMENTS - BUDGET segments the carry \
+         budget dropped re-derives its own open metadata from the wire"
+    );
+    assert_eq!(
+        s.scan_phase_gets,
+        (SEGMENTS - BUDGET) as u64,
+        "scan phase: exactly one block-data wire GET per segment the \
+         budget dropped, zero for the BUDGET segments whose carry survived"
+    );
+    assert_eq!(
+        s.gets,
+        s.plan_phase_gets + s.probe_phase_gets + s.scan_phase_gets,
+        "the counting store's raw total agrees with the per-phase split \
+         (no bytes land in QueryPhase::Resolve on this read path)"
+    );
+    assert_eq!(
+        s.acc_gets, s.gets,
+        "accounting GET count agrees with the raw store GETs"
+    );
+}
+
+/// Issue #835 follow-up (finding 3): the carry budget must not be spent on a
+/// segment `owned_work` was always going to drop for having zero surviving
+/// blocks -- that would retain bytes no partition ever reuses while starving
+/// a segment that would have used the slot.
+///
+/// [`build_snapshot_uniform_first_zero_survivor`] gives segment 0 no
+/// `MARKER_FEW` anywhere, so its plan phase still pays the whole-object
+/// fallback read (the skip index cannot decide the predicate without
+/// reading) but finds zero survivors; segments 1..`SEGMENTS` are otherwise
+/// identical to [`build_snapshot_uniform`] and each keep one surviving
+/// block. `plan_concurrency` (`BUDGET`, 2) is small enough, and completion
+/// order in this single-threaded fixture matches segment order closely
+/// enough, that segment 0 is always the first `plan_segment` future to
+/// complete: before this fix, its budget slot would be wasted and only
+/// `BUDGET - 1` real segments would be carried; after it, segment 0 is
+/// skipped for having no survivors and the full `BUDGET` real segments (1
+/// and 2) are carried.
+#[tokio::test]
+async fn plan_carry_skips_zero_survivor_segment_budget() {
+    const BUDGET: usize = 2;
+
+    let base = Arc::new(MemoryStore::new());
+    let snapshot = build_snapshot_uniform_first_zero_survivor(base.as_ref()).await;
+    let object_size = snapshot.segments[1].object_size;
+    assert!(
+        snapshot.segments[1..]
+            .iter()
+            .all(|seg| seg.object_size == object_size),
+        "fixture precondition: every marker-carrying segment (1..SEGMENTS) is \
+         the exact same stored size"
+    );
+
+    let s = measure_with_snapshot(
+        "text_fallback (zero-survivor budget skip)",
+        &[has_word(MARKER_FEW)],
+        None,
+        BUDGET,
+        base,
+        snapshot,
+    )
+    .await;
+    report(&s);
+
+    assert_eq!(
+        s.plan_full_reads, SEGMENTS,
+        "every segment's plan phase reads the whole object, including \
+         segment 0, which the skip index cannot rule out without reading"
+    );
+    assert_eq!(
+        s.blocks_scanned,
+        SEGMENTS - 1,
+        "segment 0 has no surviving block and is never opened by any \
+         partition; segments 1..SEGMENTS each keep one"
+    );
+    assert_eq!(
+        s.rows,
+        SEGMENTS - 1,
+        "one matching record per segment, excluding segment 0"
+    );
+
+    // Exactly BUDGET (2) carried whole objects, both real (segments 1 and
+    // 2): segment 0's whole-object read is never even offered to the budget,
+    // so it cannot consume a slot a real segment would otherwise get.
+    assert_eq!(
+        s.acc_bytes_reused,
+        BUDGET as u64 * object_size,
+        "the carry budget is spent entirely on segments with a surviving \
+         block -- segment 0's zero-survivor read never competes for a slot"
+    );
+    assert_eq!(
+        s.acc_peak_intermediate_bytes,
+        BUDGET as u64 * object_size,
+        "peak carried bytes is exactly BUDGET real objects, not BUDGET \
+         objects including a wasted zero-survivor one"
+    );
+
+    // Plan phase: one suffix probe plus one whole-object read per segment,
+    // unconditionally, including segment 0 (its read still happens, only its
+    // result is never retained past this loop iteration).
+    assert_eq!(
+        s.plan_phase_gets,
+        2 * SEGMENTS as u64,
+        "plan phase pays for every segment's whole-object read regardless of \
+         survivor count or carry budget"
+    );
+    // Segment 0 is skipped by owned_work outright (zero survivors) and is
+    // never opened by anything past the plan phase, so it contributes zero
+    // probe/scan GETs whether or not its carry was retained. Segments 1 and 2
+    // are carried and reused for free. The remaining SEGMENTS - 1 - BUDGET
+    // (5) segments (3..SEGMENTS) have a surviving block but no carry left,
+    // so each pays a real re-fetch: 2 probe GETs (suffix + front directories)
+    // and 1 scan GET (block data), the same per-dropped-segment shape
+    // `plan_carry_peak_bytes_bounded_by_plan_concurrency` measures.
+    assert_eq!(
+        s.probe_phase_gets,
+        2 * (SEGMENTS - 1 - BUDGET) as u64,
+        "each of the SEGMENTS - 1 - BUDGET real segments the carry budget \
+         dropped re-derives its own open metadata from the wire"
+    );
+    assert_eq!(
+        s.scan_phase_gets,
+        (SEGMENTS - 1 - BUDGET) as u64,
+        "one block-data wire GET per real segment the budget dropped, zero \
+         for segment 0 (never opened) and zero for segments 1-2 (carried)"
+    );
+    assert_eq!(
+        s.gets,
+        s.plan_phase_gets + s.probe_phase_gets + s.scan_phase_gets,
+        "the counting store's raw total agrees with the per-phase split"
+    );
+    assert_eq!(
+        s.acc_gets, s.gets,
+        "accounting GET count agrees with the raw store GETs"
+    );
+}
+
+/// Issue #835 follow-up (Finding 2): a segment's carried whole-object read is
+/// reused once, by the fast columnar open of its first (clean) block, then
+/// abandoned mid-segment when the second block's `attrs_raw` overflow page
+/// falls the scan back to [`LogScanState::ReopenRows`]. The reopen must not
+/// charge [`QueryAccounting::add_bytes_reused`] for the same buffer a second
+/// time -- fixed by `Option::take()`ing the carry at the first open (see
+/// `logs_scan.rs`'s `current_whole_object` field), so the reopen always sees
+/// `None` and pays for a real re-fetch instead.
+///
+/// `plan_concurrency = 1` keeps this fixture's one segment inside the
+/// Finding 1 carry budget, so the buffer really is carried into the scan;
+/// the regression this test guards is specific to the reused-then-abandoned
+/// buffer, not to the budget dropping it before it ever gets here.
+///
+/// `measure_with_snapshot` (used by every other test in this file) always
+/// projects every column, including the merged `attrs` map -- which makes
+/// [`columnar_static_eligible`] false and routes straight to the row path,
+/// never touching the fast columnar path or `ReopenRows` at all. Reaching
+/// the reopen needs a projection of only `ts` and the declared `code`
+/// column, so this test drives `TableProvider::scan` directly instead
+/// (same pattern `logs_fast_path_projection_routing.rs` uses).
+#[tokio::test]
+async fn carried_object_reopen_does_not_double_charge_reused_bytes() {
+    let base = Arc::new(MemoryStore::new());
+    let snapshot = build_snapshot_reopen(base.as_ref()).await;
+    let object_size = snapshot.segments[0].object_size;
+
+    let counting = CountingStore::new(base);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
+    let acc = QueryAccounting::new();
+    let fetch = fetcher_uncached(store);
+    let prov = Arc::new(provider(snapshot, fetch, acc.clone()));
+
+    let ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+    let projection = vec![LOG_COL_TS, FIRST_DECLARED_COL];
+    let filters = vec![has_word(MARKER_FEW)];
+    let plan = TableProvider::scan(
+        prov.as_ref(),
+        &ctx.state(),
+        Some(&projection),
+        &filters,
+        None,
+    )
+    .await
+    .expect("scan");
+    let rows = drain(Arc::clone(&plan)).await;
+    let snap = acc.snapshot();
+
+    eprintln!(
+        "[attrs_raw reopen] gets={} bytes={} rows={} plan_full_reads={} \
+         bytes_reused={} peak_intermediate_bytes={} columnar_batches={} \
+         rowpath_batches={}",
+        counting.gets(),
+        counting.bytes(),
+        rows,
+        sum_metric(&plan, "plan_full_reads"),
+        snap.bytes_reused,
+        snap.peak_intermediate_bytes,
+        sum_metric(&plan, "columnar_batches"),
+        sum_metric(&plan, "rowpath_batches"),
+    );
+
+    // 5: the plan phase's one whole-object GET for the segment, plus the
+    // attrs_raw reopen's own suffix probe and BLOCKS-range GETs for block 1 --
+    // block 0's fast columnar open pays none of these, since it opens from
+    // the carry. If the reopen ever started drawing from the carried buffer
+    // instead of paying for its own re-fetch, this count would drop and
+    // `bytes_reused` above would grow past `object_size`.
+    assert_eq!(
+        counting.gets(),
+        5,
+        "the attrs_raw reopen re-fetches its own metadata and block data \
+         rather than drawing a second time on the carried buffer"
+    );
+    assert_eq!(
+        sum_metric(&plan, "plan_full_reads"),
+        1,
+        "one segment, its has_word predicate forces exactly one plan-phase \
+         whole-object read"
+    );
+    assert_eq!(
+        sum_metric(&plan, "columnar_batches"),
+        1,
+        "block 0 has no attrs_raw overflow page and is emitted by the fast \
+         columnar path"
+    );
+    assert_eq!(
+        sum_metric(&plan, "rowpath_batches"),
+        1,
+        "block 1's attrs_raw overflow page falls this segment back to the \
+         re-opened row path"
+    );
+    assert_eq!(
+        rows, 2,
+        "both blocks' one record each survive the has_word predicate -- the \
+         mid-segment attrs_raw reopen must lose or repeat none of them"
+    );
+    assert_eq!(
+        snap.bytes_reused, object_size,
+        "the carried whole object is reused exactly once, by the fast \
+         columnar open of block 0 -- the attrs_raw reopen of block 1 must \
+         pay for its own re-fetch instead of double-charging the same \
+         buffer as reused a second time"
     );
 }

--- a/crates/ravel-sql/tests/logs_uncached_assignment.rs
+++ b/crates/ravel-sql/tests/logs_uncached_assignment.rs
@@ -9,9 +9,13 @@
 //! Without a cache nothing coalesces them, so the scan pays one whole-object GET
 //! per partition per segment. The fix (deliverable of #693) makes the un-cached
 //! path segment-granular: relevant segment `j` (snapshot order) goes to
-//! partition `j % n` and drains all of that segment's surviving blocks, so the
-//! scan issues exactly one plan read plus one scan read per segment. The cached
-//! path keeps the intra-segment block striping unchanged.
+//! partition `j % n` and drains all of that segment's surviving blocks. That
+//! #693 fix left one read per phase per segment (a plan read plus a separate
+//! scan read); #835 removes the second read only for the segments whose plan
+//! completes inside the carry budget, which is the SQL partition count,
+//! `PARTS` here. The other `SEGMENTS - PARTS` segments still pay both reads,
+//! so the un-cached cost is `SEGMENTS + (SEGMENTS - PARTS)`, not `SEGMENTS`.
+//! The cached path keeps the intra-segment block striping unchanged.
 //!
 //! Every fixture here carries a pending erasure predicate that matches nothing
 //! ([`non_matching_erasure`]), which changes no row and prunes no block but does
@@ -300,15 +304,26 @@ fn build_read_cache(cache_bytes: u64) -> Arc<Cache<CacheFetchError>> {
     )))
 }
 
-/// The pinned request-count property (#693, #680). Without a read cache the scan
-/// must open each of the six segments exactly once: one plan read per segment
-/// plus one scan read per segment, `2 * 6 = 12` whole-object GETs total.
+/// The pinned request-count property (#693, #680, amended by #835). The name
+/// is #693's property: no segment is opened by more than one partition in the
+/// scan phase. It is not a claim that a segment's object crosses the wire only
+/// once per statement, and the assertion below says so.
 ///
-/// Against the pre-fix ADR-0102 code this fails: block striping puts every
-/// segment's four blocks into all four partitions, each partition opens the
-/// segment itself, and nothing coalesces the re-opens, so the scan costs
-/// `6 + 6 * 4 = 30` GETs (one plan read per segment plus one scan read per
-/// partition per segment).
+/// Without a read cache the plan phase reads all `SEGMENTS = 6` objects whole.
+/// Before #835 those bytes were discarded once the predicate was decided, so
+/// the scan (uncached, nothing to coalesce a re-open onto) issued its own
+/// second GET per segment: `2 * 6 = 12`. Since #835 the plan's fetch is
+/// carried forward (`CarriedWholeObject`) for as many segments as the carry
+/// budget holds, which is the SQL partition count `PARTS = 4`; the other
+/// `SEGMENTS - PARTS = 2` are re-fetched by the scan exactly as before. The
+/// un-cached cost is therefore `SEGMENTS + (SEGMENTS - PARTS) = 8`, between
+/// the old 12 and the 6 a corpus-sized cache reaches.
+///
+/// Against the pre-#693 ADR-0102 code this fails much worse: block striping
+/// puts every segment's four blocks into all four partitions, each partition
+/// opens the segment itself, and nothing coalesces the re-opens, so the scan
+/// costs `6 + 6 * 4 = 30` GETs (one plan read per segment plus one scan read
+/// per partition per segment).
 #[tokio::test]
 async fn uncached_scan_opens_each_segment_once() {
     let counting = CountingStore::new(Arc::new(MemoryStore::new()));
@@ -327,12 +342,24 @@ async fn uncached_scan_opens_each_segment_once() {
     let _ = collect_plan(Arc::clone(&plan)).await;
     assert_declined_fast_path(&plan);
 
+    // SEGMENTS (6) exceeds PARTS (4), and this fixture's plan_concurrency is
+    // PARTS, so the issue #835 follow-up carry budget lets only PARTS of the
+    // SEGMENTS whole-object reads survive to the scan; the other
+    // SEGMENTS - PARTS (2) pay one real re-fetch GET each. Which segments
+    // those are is scheduling-dependent (`buffer_unordered`), but the count
+    // is not: SEGMENTS plan-phase reads plus SEGMENTS - PARTS scan-phase
+    // re-fetches, never SEGMENTS alone and never 2 * SEGMENTS.
     assert_eq!(
         counting.gets(),
-        (2 * SEGMENTS) as u64,
-        "un-cached scan must open each segment once: {SEGMENTS} plan reads + \
-         {SEGMENTS} scan reads. The pre-fix striped path issues \
-         {} (= {SEGMENTS} + {SEGMENTS} * {PARTS}).",
+        (SEGMENTS + (SEGMENTS - PARTS)) as u64,
+        "un-cached scan opens each segment once in the plan phase \
+         ({SEGMENTS} GETs), and re-fetches the SEGMENTS - PARTS segments \
+         whose carry the plan_concurrency budget dropped ({} GETs) -- \
+         since #835 this is far below the pre-#835 {} (= 2 * {SEGMENTS}), \
+         and the pre-#693 striped path cost {} (= {SEGMENTS} + \
+         {SEGMENTS} * {PARTS}).",
+        SEGMENTS - PARTS,
+        2 * SEGMENTS,
         SEGMENTS + SEGMENTS * PARTS,
     );
 }

--- a/docs/adrs/0107-pruning-proportional-logs-fetch.md
+++ b/docs/adrs/0107-pruning-proportional-logs-fetch.md
@@ -364,20 +364,23 @@ fast path so the scan skips its own probe. It does not cover the fallback
 this ADR's "Requests per object" section already describes: a predicate the
 skip index cannot decide (`has_word`/text, an `attrs` POSTINGS equality, a
 stream filter) makes `plan_segment` read the WHOLE object to count survivors,
-counted in `plan_full_reads`, and forwards no footer. Before #835 those bytes
-were then discarded: the scan that followed reopened the same object from
-scratch, so the object crossed the wire twice per statement -- masked to once
-only when a read cache happened to be wired and still large enough to hold
-every relevant object by the time the scan reached it. A tenant whose corpus
-exceeds the cache, or a query run with no cache at all, paid the second GET
-in full.
+counted in `plan_full_reads`, and forwards no footer. `plan_full_reads` counts
+those fallback reads, not wire GETs: the read goes through ADR-0046's read
+cache, so a counted read can be served from cache and issue no store GET at
+all. Before #835 those bytes were then discarded: the scan that followed
+reopened the same object from scratch, so the object was read twice per
+statement, and the second read crossed the wire whenever a read cache was not
+wired, or was too small to still hold the object by the time the scan reached
+it. A tenant whose corpus exceeds the cache, or a query run with no cache at
+all, paid the second GET in full.
 
 Since #835, `plan_segment`'s fallback branch carries its fetched buffer
 forward as a `ravel_query::CarriedWholeObject` (threaded through
 `SegPlan::whole_object` in `ravel_sql::logs_scan`), and the scan's subset open
-consumes it instead of issuing its own GET when supplied, for the first
-`plan_concurrency` segments whose plan completes: those objects cross the
-wire once. Every other relevant segment is re-fetched by the scan exactly as
+consumes it instead of issuing its own read when supplied, for the first
+`plan_concurrency` segments whose plan completes: those objects are read once
+for the statement rather than twice, so the scan issues neither a store GET
+nor a cache lookup for them. Every other relevant segment is re-read by the scan exactly as
 it was before #835, and the peak bytes this carry retains is bounded by the
 plan fan-out (`plan_concurrency` objects) times object size, not by corpus
 size. Removing the remaining duplicate reads needs the carry to stream per
@@ -390,7 +393,7 @@ one resolved snapshot, and the whole-object cache key is already keyed on
 carried read and its reuse for a replaced object to slip through. The reused
 bytes are charged to `QueryAccounting::add_bytes_reused`, kept distinct from
 the GET-bytes figure the issuing plan phase already recorded, so a report
-can still tell a genuine wire GET from a carried reuse.
+can still tell a fresh read from a carried reuse.
 
 This carry's memory cost is bounded by `plan_concurrency`, not by corpus
 size. `plan_concurrency` here is `LogsScanExec::target_partitions`, the SQL
@@ -406,7 +409,8 @@ segments to COMPLETE with a carried whole object -- arrival order, not
 segment order, so which segments those are is scheduling-dependent -- keep
 their `SegPlan::whole_object`; every later arrival has its `whole_object`
 forced to `None` before it is stored, so that segment's subset open pays a
-real wire GET during the scan, exactly as it would have before #835. Survivor
+second read during the scan, a wire GET whenever the cache does not still
+hold the object, exactly as it would have before #835. Survivor
 counts, stats, and footers for every relevant segment are still held until
 the shared pass returns, because ADR-0102's flattened block-striping
 assignment needs every segment's survivor count before any partition can

--- a/docs/adrs/0107-pruning-proportional-logs-fetch.md
+++ b/docs/adrs/0107-pruning-proportional-logs-fetch.md
@@ -356,3 +356,67 @@ bytes `RlogReader` re-parses to open the assembled buffer. The block-range
 (non-coverage) branch, reachable only when a caller forces the ranged path,
 places that tail region explicitly so a footer-carried open never assembles a
 buffer with a zeroed trailer.
+
+## Amendment 2026-09-05 (issue #835): the plan phase's whole-object fallback carries its bytes into the scan
+
+The amendment above carries a *footer* from the plan phase's predicate-free
+fast path so the scan skips its own probe. It does not cover the fallback
+this ADR's "Requests per object" section already describes: a predicate the
+skip index cannot decide (`has_word`/text, an `attrs` POSTINGS equality, a
+stream filter) makes `plan_segment` read the WHOLE object to count survivors,
+counted in `plan_full_reads`, and forwards no footer. Before #835 those bytes
+were then discarded: the scan that followed reopened the same object from
+scratch, so the object crossed the wire twice per statement -- masked to once
+only when a read cache happened to be wired and still large enough to hold
+every relevant object by the time the scan reached it. A tenant whose corpus
+exceeds the cache, or a query run with no cache at all, paid the second GET
+in full.
+
+Since #835, `plan_segment`'s fallback branch carries its fetched buffer
+forward as a `ravel_query::CarriedWholeObject` (threaded through
+`SegPlan::whole_object` in `ravel_sql::logs_scan`), and the scan's subset open
+consumes it instead of issuing its own GET when supplied, for the first
+`plan_concurrency` segments whose plan completes: those objects cross the
+wire once. Every other relevant segment is re-fetched by the scan exactly as
+it was before #835, and the peak bytes this carry retains is bounded by the
+plan fan-out (`plan_concurrency` objects) times object size, not by corpus
+size. Removing the remaining duplicate reads needs the carry to stream per
+partition instead of being held at the plan barrier; that redesign is
+tracked separately as issue #1272. As
+with the footer carry, this needs no etag re-check of its own: the plan and
+scan of one statement resolve against the same immutable `SegmentRef` out of
+one resolved snapshot, and the whole-object cache key is already keyed on
+`seg_ref.content_hash`, so there is no live GET spanning the gap between the
+carried read and its reuse for a replaced object to slip through. The reused
+bytes are charged to `QueryAccounting::add_bytes_reused`, kept distinct from
+the GET-bytes figure the issuing plan phase already recorded, so a report
+can still tell a genuine wire GET from a carried reuse.
+
+This carry's memory cost is bounded by `plan_concurrency`, not by corpus
+size. `plan_concurrency` here is `LogsScanExec::target_partitions`, the SQL
+partition count DataFusion assigned this scan; since ADR-1195 T2 it is a
+separate knob from `--store-get-concurrency`'s object-store GET limiter,
+which bounds in-flight wire requests process-wide rather than how many
+segments' plan results this pass retains. `compute_plan_counts` consumes the
+segment-plan stream as each
+`plan_segment` call completes (`buffer_unordered(plan_concurrency)`), not
+after the whole pass finishes, so it never retains more carried whole
+objects than are actually in flight at once: the first `plan_concurrency`
+segments to COMPLETE with a carried whole object -- arrival order, not
+segment order, so which segments those are is scheduling-dependent -- keep
+their `SegPlan::whole_object`; every later arrival has its `whole_object`
+forced to `None` before it is stored, so that segment's subset open pays a
+real wire GET during the scan, exactly as it would have before #835. Survivor
+counts, stats, and footers for every relevant segment are still held until
+the shared pass returns, because ADR-0102's flattened block-striping
+assignment needs every segment's survivor count before any partition can
+drain a block, not just the segments ahead of it in isolation; only the
+CARRIED-BYTES retention is concurrency-bounded, not the rest of the plan
+result. `compute_plan_counts` sums only the bytes actually retained and
+reports that figure via `QueryAccounting::observe_intermediate_bytes`, so a
+dropped whole object is never double-counted: the scan's own real GET for it
+carries its own accounting. `crates/ravel-sql/src/logs_scan.rs`'s module doc
+("Whole-object fallback carry, and its memory bound (issue #835)") describes
+the same bound, and
+`crates/ravel-sql/tests/logs_selective_scan_amplification.rs`'s
+`plan_carry_peak_bytes_bounded_by_plan_concurrency` pins it.

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -1006,6 +1006,15 @@ memory is unknown; an explicit flag bounds both at that one value) and
 `--gc-max-query-duration` (11 minutes). Memory is read from `/proc/meminfo`'s
 `MemTotal` on Linux and is "unknown" everywhere else; cores come from the
 process's available parallelism, floored at 1. Percentages truncate.
+`--cache-max-bytes` changes less than it used to about how many times a logs
+statement moves a given object's bytes: a query's plan-phase whole-object
+read (the `has_word`/text and other skip-index-undecidable fallback) is now
+carried into the scan for a bounded number of segments regardless of cache
+size, so those objects cross the wire once. The bound is the SQL partition
+count times object size, not the corpus, so undersizing this flag can
+still turn the remaining segments' one wire GET into two; removing that
+residual duplication needs the carry to stream per partition instead of
+being held at the plan barrier, which is a separate, not-yet-shipped change.
 
 Every resolved value is logged once at startup with the source it came from
 (`derived`, `flag`, or `fallback`), so `journalctl -u ravel-server | grep

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -476,6 +476,26 @@ segment at or below the block-range threshold counts there too: the fetch reads
 such an object whole in one GET regardless, so planning it from the skip index
 would cost a second read rather than save one.
 
+That plan-phase whole-object read is now carried forward into
+the scan (`ravel_query::CarriedWholeObject`) instead of being thrown away,
+for the first `plan_concurrency` segments whose plan completes: those
+objects cross the wire once. Every other relevant segment is re-fetched by
+the scan exactly as before, and the peak retained bytes are bounded by the
+plan fan-out times object size, not by corpus size. Removing the remaining
+duplicate reads needs the plan carry to stream per partition instead of
+being held at the plan barrier; that redesign is tracked separately. Before
+the fix, only a cache large enough to still hold the object by the time the
+scan reached it turned the second read into a hit instead of a real GET, so
+a corpus larger than the cache paid the full double read on every such
+statement. Reuse needs no etag re-check: the plan and scan of one statement
+share the same immutable `SegmentRef` out of one resolved snapshot, and the
+whole-object cache key is already keyed on `seg_ref.content_hash`, so there
+is no live GET spanning the gap between the two reads for a changed object
+to be missed by. The one `plan_full_reads` GET remains the true cost; the
+reused bytes are charged to `QueryAccounting::add_bytes_reused`, not folded
+into the GET-bytes figure the plan phase already recorded, so a report
+distinguishes a genuine wire GET from a carried reuse.
+
 ### Requests per object on a version-4 object
 
 A version-4 RLOG object (ADR-0699) stores each row group's pages column-major


### PR DESCRIPTION
On the RLOG scan's whole-object fallback, plan_segment fetched each
object to plan it and the scan fetched the same object again. On
ClickBench q20 that was 6,785 GETs and 21.1 GB where a corpus-sized
cache gives 4,533 GETs and 11.24 GB.

The plan phase now hands its bytes to the scan as a carried whole
object, and the scan short-circuits on it before any GET, charging the
bytes to a new bytesReused figure instead of a cache hit. Retention is
bounded: the first segments to complete their plan keep their buffer up
to the plan fan-out in objects, and every later one, and every segment
whose plan leaves no survivors, drops it so the scan re-fetches exactly
as before. Peak retained bytes are therefore the fan-out times the
object size, never the corpus.

What that does not do is remove every duplicate read. The plan barrier
holds each result until the whole pass finishes, so a bounded carry and
a complete saving are mutually exclusive in this shape: the carry
removes about one duplicate per unit of plan fan-out and the rest are
re-fetched. The documents say so rather than claiming the object
crosses the wire once per statement, and the design that would remove
the remainder, streaming the carry per partition with no barrier, is
tracked separately.

The carried buffer is taken at its first use in a stream, so the attrs
overflow reopen path carries nothing and pays its own fetch. Under
block striping a segment's survivors can be owned by several
partitions; each of those opens is charged to bytesReused, which is the
convention the same opens were charged under as cache hits before the
carry existed. Bytes clones share one allocation, so the memory bound
is unaffected.

Tests pin the attribution per phase, the memory bound on eight
equal-size objects, the reopen path's exact GET count, and the
zero-survivor case that would otherwise spend a budget slot on a
segment no partition opens. The zero-survivor guard was shown failing
by a deliberate flip. ADR-0107 gains an amendment stating the bound.

The plan result grew a fourth element, so the planning-latency bench
harness destructures four. It drops the carried object, which is what a
plan-phase latency measurement wants: it makes no reuse claim and the
scan half of the bench does not run.

Seven sql-latency tests measured the second read this change removes, so
their fixtures are restated rather than their assertions relaxed. Each
now writes more segments than the carry budget, which restores the
scan-phase work they were written to observe, and the cache test gains an
exact assertion that the saving equals the surplus, on top of the strict
inequality it already had. The fixtures also stopped sharing one
placeholder content hash, which had them colliding on the read cache key
and measuring the collision rather than the cache. The paired
probe-fits case is restated the same way: at one object its scan half
read zero for want of a read rather than because the probe covered the
trailer, and no production change could falsify it.

Refs: #835
