### PR TITLE
chore(release): prepare 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.14.0]
+
 ### Added
 
 - **A `latency-first` logs fetch policy** (ADR-0996 amendment, superseded by
@@ -43,8 +45,55 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   provisioning history and the signal's fixed shard count. An `audit` query on
   a `--shards 1` deployment reads the query-audit shard instead of silently
   omitting it, and a wider deployment scans exactly as before.
+- **`ravel-memory`, one process-wide memory budget** (ADR-1170). The server
+  derived four memory ceilings from the host and enforced each in a component
+  that knew nothing of the others, so N tenants could each reserve half the
+  box. `ravel-memory` is a leaf crate holding one counter every ledger draws
+  from: a compare-and-swap reserve for the SQL adapter and an RAII reservation
+  for the fetch layer.
+- **Bloom pruning for PromQL `__body__` matchers** (ADR-1103 follow-up). A
+  `__body__` equality, or an anchored regex with a token-bounded mandatory
+  literal run, now pushes that literal onto the scan as a `has_word`
+  predicate, so the RLOG block bloom skips blocks before decode. The
+  per-record check still runs on every decoded record: the pushed word only
+  prunes, it never decides. Negated matchers, unsupported metacharacters and
+  `+`-quantified patterns are rejected by the extractor rather than pushed,
+  because token matching is not a superset of substring matching.
+- **A gate against wall-clock waits in injected-clock tests.**
+  `scripts/check-injected-clock-helpers.sh`, run by `gates.sh` and CI, fails on
+  `thread::sleep`, `tokio::time::sleep`, `tokio::time::timeout`, `Instant::`,
+  `SystemTime`, a bare `sleep(...)` or `.elapsed()` inside a helper that takes
+  a `TestClock` or `FixedClock`, unless the line carries
+  `// allow-wall-clock: <reason>`. Its default scope is the loader's test
+  module in `ravel-cli`; the one wait it found there was made clock-driven
+  rather than exempted.
+- **`scripts/verify-dispatch-gates.sh --with-gates`** runs `gates.sh` itself
+  inside the cold worktree instead of a hand-listed command set, so a
+  dispatched branch is checked against the same feature lanes CI runs and the
+  run leaves a gate receipt the merge script can reuse.
 
 ### Changed
+
+- **Cache warm-up keys off each tenant's latest ingest hour, not the current
+  hour.** On a tenant whose data is older than the warm-up window the previous
+  pass issued about 1,900 small object reads from the first query's own path
+  before warming nothing; those reads are gone, and the first query on a cold
+  process is about 3 s faster on the reference corpus. The replacement probe
+  costs about 1 s at startup, so end to end a cold start is about 2.5 s
+  faster, not 3. The probe fans out on the configured resolve concurrency,
+  asserts tenant isolation on every listed key, and is bounded per shard.
+- **Catalog resolve GET concurrency is configurable, default 128.** Every
+  record GET in `Catalog::resolve_impl` passed through a fixed bound of 16.
+  Measured against S3 on a 10,000-record unsealed tail, one cold resolve each:
+  23.2 s at 16, 4.4 s at 64, 2.3 s at 128, with the same 10,001 GETs at every
+  level. Cold resolve is concurrency-bound; this was the lever.
+- **SQL reservations are charged to the process budget** (ADR-1170). Every SQL
+  reservation now flows query, then tenant, then process on the way up, with a
+  process refusal rolling the tenant and query charges back before surfacing
+  as `ResourcesExhausted` naming the process figures. The infallible grow path
+  trips a ceiling breach when the process limit is exceeded, so a DataFusion
+  overshoot still ends in a typed error on the stream's next poll rather than
+  an unaccounted allocation.
 
 - **`--fetch-concurrency` unbundled into three flags** (ADR-1195): the SQL
   scan partition count, the PromQL/analytics per-query fetch fan-out, and the
@@ -70,6 +119,26 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   no GET limit at all, so a span-heavy deployment can see lower read
   concurrency and should size `--store-get-concurrency` for it. No fetcher in
   the server process owns a private limiter anymore.
+
+### Fixed
+
+- **The RLOG plan phase's whole-object read is carried into the scan.** On the
+  whole-object fallback, `plan_segment` fetched each object to plan it and the
+  scan fetched the same object again. The plan phase now hands its bytes to
+  the scan, which short-circuits on them before any GET and charges them to a
+  `bytesReused` figure rather than a cache hit. Retention is bounded: the
+  first segments to complete their plan keep their buffer, up to the SQL
+  partition count, and every later segment is re-fetched exactly as before, so
+  peak retained bytes are the partition count times the object size, never
+  the corpus. The saving is therefore about one duplicate read per unit of
+  plan fan-out; removing the rest needs the carry to stream per partition
+  instead of being held at the plan barrier, tracked separately.
+- **The RLOG raw prefetch is gated on the cursor budget before `try_join!`**
+  (ADR-0979 decision 4). The merge cursor's refill fetched the next two
+  row-group blocks before the budget had been checked, so up to twice the
+  group size was allocated and only accounted for on the following iteration.
+  The pending fetch window is now priced from resident metadata and reserved
+  before the fetch is issued.
 
 ## [0.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   pass issued about 1,900 small object reads from the first query's own path
   before warming nothing; those reads are gone, and the first query on a cold
   process is about 3 s faster on the reference corpus. The replacement probe
-  costs about 1 s at startup, so end to end a cold start is about 2.5 s
-  faster, not 3. The probe fans out on the configured resolve concurrency,
+  costs about 1 s at startup, so the end-to-end saving on a cold start is
+  about 2.5 s, not 3. The probe fans out on the configured resolve concurrency,
   asserts tenant isolation on every listed key, and is bounded per shard.
 - **Catalog resolve GET concurrency is configurable, default 128.** Every
   record GET in `Catalog::resolve_impl` passed through a fixed bound of 16.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4468,14 +4468,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-affinity"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
 ]
 
 [[package]]
 name = "ravel-alerting"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "hex",
@@ -4487,14 +4487,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-analytics"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ravel-bench"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arrow 59.1.0",
  "arrow-flight",
@@ -4547,7 +4547,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cache"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bytes",
  "crc32c",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-catalog"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-codec"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-commit"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-failure-tests"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bytes",
  "futures",
@@ -4685,7 +4685,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-fleet"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "futures",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4736,7 +4736,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest-router"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-logseg"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-maintain"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4808,11 +4808,11 @@ dependencies = [
 
 [[package]]
 name = "ravel-memory"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "ravel-object-store"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-operator"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "clap",
  "futures",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otap"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ipc 59.1.0",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otlp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -4903,7 +4903,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "promql-parser",
@@ -4916,7 +4916,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql-difftest"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4944,7 +4944,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-proto"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4953,7 +4953,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-query"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-remote-write"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bytes",
  "hex",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-rspan"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "crc32c",
  "proptest",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-segment"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -5047,7 +5047,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-server"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sim"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sql"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tenant-resolve"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "axum",
  "base64 0.23.0",
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tracing-export"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "services/*"]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.97"
@@ -26,30 +26,30 @@ expect_used = "warn"
 # Version fields pin each path dependency so cargo-deny does not count them as
 # wildcards. allow-wildcard-paths is not usable here because these
 # crates are not marked publish = false, so it does not exempt them.
-ravel-types = { path = "crates/ravel-types", version = "0.13.0" }
-ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.13.0" }
-ravel-proto = { path = "crates/ravel-proto", version = "0.13.0" }
-ravel-codec = { path = "crates/ravel-codec", version = "0.13.0" }
-ravel-object-store = { path = "crates/ravel-object-store", version = "0.13.0" }
-ravel-segment = { path = "crates/ravel-segment", version = "0.13.0" }
-ravel-logseg = { path = "crates/ravel-logseg", version = "0.13.0" }
-ravel-rspan = { path = "crates/ravel-rspan", version = "0.13.0" }
-ravel-commit = { path = "crates/ravel-commit", version = "0.13.0" }
-ravel-catalog = { path = "crates/ravel-catalog", version = "0.13.0" }
-ravel-cache = { path = "crates/ravel-cache", version = "0.13.0" }
-ravel-maintain = { path = "crates/ravel-maintain", version = "0.13.0" }
-ravel-fleet = { path = "crates/ravel-fleet", version = "0.13.0" }
-ravel-otlp = { path = "crates/ravel-otlp", version = "0.13.0" }
-ravel-otap = { path = "crates/ravel-otap", version = "0.13.0" }
-ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.13.0" }
-ravel-alerting = { path = "crates/ravel-alerting", version = "0.13.0" }
-ravel-ingest = { path = "crates/ravel-ingest", version = "0.13.0" }
-ravel-promql = { path = "crates/ravel-promql", version = "0.13.0" }
-ravel-query = { path = "crates/ravel-query", version = "0.13.0" }
-ravel-analytics = { path = "crates/ravel-analytics", version = "0.13.0" }
-ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.13.0" }
-ravel-affinity = { path = "crates/ravel-affinity", version = "0.13.0" }
-ravel-memory = { path = "crates/ravel-memory", version = "0.13.0" }
+ravel-types = { path = "crates/ravel-types", version = "0.14.0" }
+ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.14.0" }
+ravel-proto = { path = "crates/ravel-proto", version = "0.14.0" }
+ravel-codec = { path = "crates/ravel-codec", version = "0.14.0" }
+ravel-object-store = { path = "crates/ravel-object-store", version = "0.14.0" }
+ravel-segment = { path = "crates/ravel-segment", version = "0.14.0" }
+ravel-logseg = { path = "crates/ravel-logseg", version = "0.14.0" }
+ravel-rspan = { path = "crates/ravel-rspan", version = "0.14.0" }
+ravel-commit = { path = "crates/ravel-commit", version = "0.14.0" }
+ravel-catalog = { path = "crates/ravel-catalog", version = "0.14.0" }
+ravel-cache = { path = "crates/ravel-cache", version = "0.14.0" }
+ravel-maintain = { path = "crates/ravel-maintain", version = "0.14.0" }
+ravel-fleet = { path = "crates/ravel-fleet", version = "0.14.0" }
+ravel-otlp = { path = "crates/ravel-otlp", version = "0.14.0" }
+ravel-otap = { path = "crates/ravel-otap", version = "0.14.0" }
+ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.14.0" }
+ravel-alerting = { path = "crates/ravel-alerting", version = "0.14.0" }
+ravel-ingest = { path = "crates/ravel-ingest", version = "0.14.0" }
+ravel-promql = { path = "crates/ravel-promql", version = "0.14.0" }
+ravel-query = { path = "crates/ravel-query", version = "0.14.0" }
+ravel-analytics = { path = "crates/ravel-analytics", version = "0.14.0" }
+ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.14.0" }
+ravel-affinity = { path = "crates/ravel-affinity", version = "0.14.0" }
+ravel-memory = { path = "crates/ravel-memory", version = "0.14.0" }
 
 # async runtime / rpc / http
 tokio = { version = "1.53", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ See the [Kubernetes guide](docs/guides/kubernetes.md).
 GitHub Container Registry on every `vX.Y.Z` release tag, built from the root
 `Dockerfile`. Both `linux/amd64` and `linux/arm64` are published. Each published
 object is an OCI image index that carries an SBOM and full build provenance. The
-quickstart pins `ghcr.io/nofireai/ravel-server:0.13.0`. Override it with
+quickstart pins `ghcr.io/nofireai/ravel-server:0.14.0`. Override it with
 `RAVEL_IMAGE`.
 
 ```sh
@@ -327,12 +327,12 @@ so that is the identity in the certificate:
 
 ```sh
 cosign verify \
-  --certificate-identity 'https://github.com/NOFireAI/ravel/.github/workflows/publish-images.yml@refs/tags/v0.13.0' \
+  --certificate-identity 'https://github.com/NOFireAI/ravel/.github/workflows/publish-images.yml@refs/tags/v0.14.0' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-  ghcr.io/nofireai/ravel-server:0.13.0
+  ghcr.io/nofireai/ravel-server:0.14.0
 ```
 
-Replace `v0.13.0` and `0.13.0` with the release you are verifying. The tag ref in
+Replace `v0.14.0` and `0.14.0` with the release you are verifying. The tag ref in
 `--certificate-identity` must be the exact tag that produced the image.
 
 ## How Ravel is verified

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -29,7 +29,7 @@ ravel-promql = { workspace = true }
 # (`metricsbench_gen`) runs the gate, which a dev-dependency would be invisible
 # to. It is already a workspace member, so a `--workspace` build compiled it
 # before this edge existed too.
-ravel-promql-difftest = { path = "../ravel-promql-difftest", version = "0.13.0" }
+ravel-promql-difftest = { path = "../ravel-promql-difftest", version = "0.14.0" }
 prost = { workspace = true }
 # MetricsBench Remote Write 1.0 ingest lane (ADR-0927, issue #937, task M5).
 # `ravel-remote-write` supplies the `prometheus.WriteRequest`/`TimeSeries`/
@@ -99,7 +99,7 @@ futures = { workspace = true, optional = true }
 # ravel-sql is an internal path crate not yet listed in the workspace
 # `[workspace.dependencies]`, so it is named by path here; every other dep
 # below reuses a workspace pin.
-ravel-sql = { path = "../ravel-sql", version = "0.13.0", optional = true, features = ["flight-sql"] }
+ravel-sql = { path = "../ravel-sql", version = "0.14.0", optional = true, features = ["flight-sql"] }
 # Gated behind `sql-latency`. The spans-scan bench lane (`src/spans_scan.rs`)
 # writes its RSPAN corpus with the real span writer and drives `SpansScanExec`
 # directly, so it needs the writer/record types (`RspanWriter`, `SpanRecord`,

--- a/crates/ravel-ingest/Cargo.toml
+++ b/crates/ravel-ingest/Cargo.toml
@@ -30,7 +30,7 @@ ravel-catalog = { workspace = true }
 # [workspace.dependencies]; the root Cargo.toml is out of this task's scope, so
 # this is a version-pinned path dependency (the pin keeps cargo-deny from
 # counting it as a wildcard, matching the workspace's path-dep convention).
-ravel-rspan = { path = "../ravel-rspan", version = "0.13.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.14.0" }
 # The router live switch (ADR-0052) decodes the provisioning record read for a
 # generation refresh; prost's Message trait provides `decode`.
 prost = { workspace = true }
@@ -54,7 +54,7 @@ ravel-promql = { workspace = true }
 # zero data GETs. ravel-sql depends on ravel-catalog/ravel-query/ravel-commit/
 # ravel-logseg, none of which depend on ravel-ingest, so this dev-only edge adds
 # no cycle. No feature flag: ravel-sql's SQL surface is unconditional.
-ravel-sql = { path = "../ravel-sql", version = "0.13.0" }
+ravel-sql = { path = "../ravel-sql", version = "0.14.0" }
 # Match ravel-sql's datafusion pin exactly (same arrow 58 line) so the test's
 # SessionContext/collect interop with ravel-sql's plan types.
 datafusion = { version = "54", default-features = false, features = ["sql"] }

--- a/crates/ravel-otlp/Cargo.toml
+++ b/crates/ravel-otlp/Cargo.toml
@@ -16,7 +16,7 @@ ravel-logseg = { workspace = true }
 # Used for the span record's StatusCode and the frozen resource+scope+span
 # attribute merge rule, so trace normalization and the RSPAN writer cannot
 # drift apart on either.
-ravel-rspan = { path = "../ravel-rspan", version = "0.13.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.14.0" }
 opentelemetry-proto = { workspace = true }
 # Span events and links are stored as an opaque serialized blob in RSPAN v1
 # (ADR-0041 decision 4), which needs prost's own length-delimited encoding.

--- a/crates/ravel-query/Cargo.toml
+++ b/crates/ravel-query/Cargo.toml
@@ -95,7 +95,7 @@ ravel-cache = { workspace = true }
 # proof (tests/differential_compaction.rs) drives P4's real compactor to
 # produce write_v4 L1 parts. ravel-maintain does not depend on ravel-query,
 # so this is acyclic.
-ravel-maintain = { path = "../ravel-maintain", version = "0.13.0" }
+ravel-maintain = { path = "../ravel-maintain", version = "0.14.0" }
 proptest = { workspace = true }
 # The ADR-0046 disk cache tier (crates/ravel-query/src/cache_correctness.rs)
 # needs a real on-disk directory to construct a `ravel_cache::DiskCache`; the

--- a/deploy/docker-compose/ravel.yml
+++ b/deploy/docker-compose/ravel.yml
@@ -50,7 +50,7 @@ services:
   # already-qualified bucket it reports the existing record and exits 0, so this
   # tolerates a populated `minio-data/` across runs.
   qualify:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.13.0}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.14.0}
     depends_on:
       createbucket:
         condition: service_completed_successfully
@@ -72,7 +72,7 @@ services:
   # container boundary forbids, so the demo authenticates with a real bearer
   # token against a real tenant map, exactly as a deployment does.
   ravel-server:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.13.0}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.14.0}
     depends_on:
       qualify:
         condition: service_completed_successfully

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -32,7 +32,7 @@ That brings up five things, all from published images:
   bootstrap-and-continue path for it, so a freshly created bucket has to be
   qualified before the server starts. The step is idempotent: on an
   already-qualified bucket it reports the existing record and exits 0.
-- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.13.0` (override the pin
+- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.14.0` (override the pin
   with the `RAVEL_IMAGE` environment variable), listening on `127.0.0.1:4318`
   (HTTP) and `127.0.0.1:4317` (gRPC), with the tenant token `demo-token` mapped
   to tenant `demo-tenant`.

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -133,7 +133,7 @@ Two routes Grafana's built-in Prometheus datasource probes on every datasource
 save. They take no parameters.
 
 ```json
-{"status": "success", "data": {"version": "0.13.0", "revision": "", "branch": "", "buildUser": "", "buildDate": "", "goVersion": ""}}
+{"status": "success", "data": {"version": "0.14.0", "revision": "", "branch": "", "buildUser": "", "buildDate": "", "goVersion": ""}}
 ```
 
 `version` is Ravel's own version, not a Prometheus one. `revision` is the

--- a/services/ravel-cli/Cargo.toml
+++ b/services/ravel-cli/Cargo.toml
@@ -109,7 +109,7 @@ tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
 # `LogsTableProvider` logs path is in ravel-sql's default build (the
 # `flight-sql` feature only gates the Flight transport), so no feature is
 # needed here.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.13.0" }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.14.0" }
 # The reachability test builds a SqlExecutor's segment fetchers from ravel-query
 # (SegmentFetcher/LogSegmentFetcher/SpanSegmentFetcher); ravel-catalog is
 # already a normal dependency. Workspace pin, test construction only.
@@ -126,7 +126,7 @@ async-trait = { workspace = true }
 # ravel-server is a workspace path crate not listed in
 # `[workspace.dependencies]`, so it is named by path with a pinned version here,
 # exactly as ravel-sql above is; no new external crate enters Cargo.lock.
-ravel-server = { path = "../ravel-server", version = "0.13.0", features = ["sql"] }
+ravel-server = { path = "../ravel-server", version = "0.14.0", features = ["sql"] }
 # The reachability test's axum request/response plumbing (the same shape
 # ravel-server's own endpoint tests use). Already resolved in this workspace's
 # dependency graph; test-only.

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -154,14 +154,14 @@ reqwest = { version = "0.13", features = ["json"] }
 # ravel-rspan below are: the workspace root Cargo.toml is outside this task's
 # scope. The pin keeps cargo-deny from counting it as a wildcard path
 # dependency.
-ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.13.0" }
+ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.14.0" }
 
 # ravel-sql is declared here as a path dependency rather than through
 # `[workspace.dependencies]` because the workspace root Cargo.toml is outside
 # this task's scope. The version is pinned so cargo-deny does not count it as
 # a wildcard path dependency, matching how every other
 # internal crate is pinned.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.13.0", optional = true }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.14.0", optional = true }
 
 # Flight service codegen for the `flight-sql` feature. This is arrow 58's
 # arrow-flight, a different arrow major than the `arrow` dev-dependency below;
@@ -222,7 +222,7 @@ tokio = { workspace = true, features = ["test-util"] }
 # listed in the workspace [workspace.dependencies]; the root Cargo.toml is out
 # of this task's scope, so this is a version-pinned path dependency (the pin
 # keeps cargo-deny from counting it as a wildcard).
-ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.13.0" }
+ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.14.0" }
 uuid = { workspace = true }
 # Real-authn end-to-end test (tests/real_authn_e2e.rs): mint a JWT and build a
 # local oct (HMAC) JWKS so the OIDC resolver runs through a real HTTP request


### PR DESCRIPTION
Bump the workspace and every path dependency to 0.14.0, regenerate the
lockfile, and move the changelog's unreleased section under a 0.14.0
heading. The quickstart pin, the cosign identity in the README, the
compose image tags and the two guide references move with it, as the
0.13.0 bump did.

The changelog section gains the entries that landed since 0.13.0 without
one: the process-wide memory budget crate and the SQL adapter charging
into it, the configurable catalog resolve concurrency, the cache warm-up
keyed off the latest ingest hour, bloom pruning for PromQL body matchers,
the plan-carry fix for the RLOG whole-object read, the prefetch budget
gate, and the two gate scripts. Each is written from its commit or pull
request rather than from memory, and the warm-up entry states the
end-to-end saving of about 2.5 s rather than the 3 s of query time it
removes, since about 1 s of that moved to a startup probe.

The tag is cut only after this and the plan-carry fix are both on main,
so the release carries the change the benchmark work exists to measure.

Refs: #1185
Signed-off-by: Panagiotis Moustafellos <pmoust@nofire.ai>
