### PR TITLE
ci: pin supply-chain references and add a nightly deny clock

### DIFF
--- a/.github/workflows/bench-s3.yml
+++ b/.github/workflows/bench-s3.yml
@@ -23,6 +23,9 @@ on:
     # week is enough to keep the numbers current without a per-PR cost.
     - cron: "17 4 * * 1"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -34,7 +37,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       # Credential guard: the org-level secret is mapped into an env var and
       # checked for non-emptiness. On a fork or an unconfigured org the secret
       # is empty, `have_creds` is false, and every real step below is skipped,
@@ -66,7 +69,7 @@ jobs:
       - name: Disable sccache if its install flaked
         if: steps.creds.outputs.have_creds == 'true' && steps.sccache.outcome == 'failure'
         run: echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         if: steps.creds.outputs.have_creds == 'true'
       - name: Build the bench_report bin
         if: steps.creds.outputs.have_creds == 'true'
@@ -92,7 +95,7 @@ jobs:
             --out bench/reports/report-s3.json
       - name: Upload the JSON report
         if: steps.creds.outputs.have_creds == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bench-s3-report
           path: bench/reports/report-s3.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Supply-chain pin check (issue #1310)
+        run: deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh
       - name: Check derived-doc drift (docs/query-engine.md)
         run: scripts/check-doc-drift.sh
       # Documentation gate (ADR-1040 D3). Run UNPIPED: a pipeline's exit code is

--- a/.github/workflows/quickstart-published.yml
+++ b/.github/workflows/quickstart-published.yml
@@ -107,7 +107,7 @@ jobs:
           - name: pinned-default
             image: ""
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # Bring up the SAME compose stack the reader runs (ADR-0081 decisions 1-3),
       # modelled on the per-PR quickstart job. `--pull always` forces the freshest

--- a/.github/workflows/supply-chain-nightly.yml
+++ b/.github/workflows/supply-chain-nightly.yml
@@ -1,0 +1,103 @@
+name: supply-chain-nightly
+
+# Nightly `cargo deny check` (issue #1310). The per-PR `supply-chain` job in
+# ci.yml (needs: changes, if: docs_only != 'true') skips on a documentation-only
+# change, so a new advisory, license violation, or banned dependency that lands
+# only via a docs-only PR (or via a dependency bump with no other code change,
+# on a day nobody happens to touch Cargo.lock in a non-docs PR) is never
+# rechecked until the next code change touches it. ci.yml itself has no
+# `schedule:` trigger at all, so nothing gives that drift a clock. This lane is
+# that clock: it runs unconditionally, every night, with no docs-only skip.
+#
+# Deliberately its own workflow file rather than a `schedule:` trigger added to
+# ci.yml: ci.yml's single `on:` block is shared by all fourteen of its jobs, so
+# a schedule added there would fire every one of them nightly (including the
+# k8s and coverage lanes) just to get one `cargo deny` run on a clock.
+#
+# Failure routing (ADR-0081 decision 8 pattern, copied from
+# quickstart-published.yml): a red run files a labelled tracking issue linking
+# the run, or comments on the existing open one, so a recurring advisory does
+# not open a fresh issue every night.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly, 05:43 UTC. Off-peak and off the :00/:30 marks, and distinct from
+    # every other scheduled lane in this repo (sim-nightly 03:17, k8s-nightly
+    # 03:00, tla-nightly 04:37, bench-s3 weekly 04:17, quickstart-published
+    # weekly 06:29) so none of the scheduled runs contend.
+    - cron: "43 5 * * *"
+
+# Minimum permissions for the deliverable's failure routing: `issues: write`
+# lets a red run file or comment on a tracking issue; `contents: read` is what
+# actions/checkout needs. Nothing else is granted.
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # Label carried by every tracking issue this lane files, and the key it
+  # dedups on.
+  ISSUE_LABEL: supply-chain-nightly
+
+jobs:
+  supply-chain-nightly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-deny
+      - name: cargo deny check
+        run: cargo deny check
+
+      # Failure routing (ADR-0081 decision 8): a red run files a labelled
+      # tracking issue linking this run, or comments on the existing open one
+      # for this lane so an ongoing breakage does not open a fresh issue every
+      # night. Deterministic marker (no run id) in both the issue title and the
+      # dedup key, so a recurring failure maps to one open issue.
+      - name: File or update the tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MARKER: "Nightly supply-chain cargo deny check is red"
+        run: |
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          # Best-effort: ensure the label exists so `gh issue create --label`
+          # cannot fail on a missing label. Ignores "already exists".
+          gh label create "$ISSUE_LABEL" \
+            --color BFD4F2 \
+            --description "Nightly cargo-deny supply-chain check failures (issue #1310)" \
+            2>/dev/null || true
+          # Find an existing open issue by matching the deterministic marker in
+          # the title (env.MARKER inside the jq filter, literal substring via
+          # contains -- no regex escaping). Empty when none exists.
+          existing=$(gh issue list --state open --label "$ISSUE_LABEL" \
+            --json number,title \
+            --jq 'map(select(.title | contains(env.MARKER))) | .[0].number // empty') || existing=""
+          body=$(cat <<EOF
+          The nightly \`supply-chain-nightly\` lane failed running \`cargo deny check\`.
+
+          - Run: $run_url
+          - Config: \`deny.toml\`
+
+          This lane runs unconditionally every night (no documentation-only
+          skip), closing the gap left by the per-PR \`supply-chain\` job in
+          ci.yml, which skips when a change is docs-only. A failure here means
+          an advisory, license, or ban was newly triggered (a fresh RUSTSEC
+          entry, a dependency version bump, or a new transitive dependency)
+          since the last green run, not necessarily anything in the commit
+          that happened to be at HEAD when the clock ticked.
+
+          See the run's \`cargo deny check\` step output for which check
+          (advisories/bans/licenses/sources) and which crate triggered it.
+          EOF
+          )
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+            echo "commented on existing issue #$existing"
+          else
+            gh issue create --title "$MARKER" --label "$ISSUE_LABEL" --body "$body"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # ---- Builder ----------------------------------------------------------------
 # Pinned to the workspace toolchain (rust-toolchain.toml channel = 1.97.1) so
 # the image build uses the same compiler CI and local development pin to.
-FROM rust:1.97.1-bookworm AS builder
+FROM rust:1.97.1-bookworm@sha256:0e2bcaef56d041a486784e54104a81aebe0da44bd03019bd70bc0401e42e4a97 AS builder
 
 WORKDIR /app
 
@@ -78,7 +78,7 @@ RUN set -eux; \
 # distroless/cc: glibc (no untested musl), ships ca-certificates for
 # object_store's TLS path against real AWS S3, and carries no shell or package
 # manager. The :nonroot tag runs as an unprivileged user by default.
-FROM gcr.io/distroless/cc-debian12:nonroot AS server
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:9dac0a79194e45a7da0158a9c6da57b217585af0786db3845d1f0ec1a0dd182f AS server
 
 COPY --from=builder /app/target/release/ravel-server /usr/local/bin/ravel-server
 COPY --from=builder /app/target/release/ravel-cli /usr/local/bin/ravel-cli
@@ -101,7 +101,7 @@ ENTRYPOINT ["/usr/local/bin/ravel-server"]
 # base and the same CARGO_BUILD_JOBS=2 builder stage as the server image, so it
 # inherits the OOM fix without a second build configuration.
 # `--target operator` builds only this image.
-FROM gcr.io/distroless/cc-debian12:nonroot AS operator
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:9dac0a79194e45a7da0158a9c6da57b217585af0786db3845d1f0ec1a0dd182f AS operator
 
 COPY --from=builder /app/target/release/ravel-operator /usr/local/bin/ravel-operator
 
@@ -119,7 +119,7 @@ ENTRYPOINT ["/usr/local/bin/ravel-operator"]
 # same CARGO_BUILD_JOBS=2 builder stage as the server and operator images, so it
 # inherits the OOM fix without a second build configuration.
 # `--target ingest-router` builds only this image.
-FROM gcr.io/distroless/cc-debian12:nonroot AS ingest-router
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:9dac0a79194e45a7da0158a9c6da57b217585af0786db3845d1f0ec1a0dd182f AS ingest-router
 
 COPY --from=builder /app/target/release/ravel-ingest-router /usr/local/bin/ravel-ingest-router
 

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -40,7 +40,7 @@
 # bookworm container in CI (which throws away the warm cache this split
 # exists to use). Override RUNTIME_BASE to build against the shipping base
 # when the build host's glibc is old enough:
-#   docker build --build-arg RUNTIME_BASE=gcr.io/distroless/cc-debian12:nonroot ...
+#   docker build --build-arg RUNTIME_BASE=gcr.io/distroless/cc-debian12:nonroot@sha256:9dac0a79194e45a7da0158a9c6da57b217585af0786db3845d1f0ec1a0dd182f ...
 #
 # Usage (see the `k8s-integration` job for the real invocation):
 #
@@ -57,7 +57,7 @@
 # the dynamic linker's own message rather than as a pod CrashLoopBackOff minutes
 # later. That check is what turned the glibc problem above from a k8s-lane
 # mystery into a one-line error.
-ARG RUNTIME_BASE=gcr.io/distroless/cc-debian13:nonroot
+ARG RUNTIME_BASE=gcr.io/distroless/cc-debian13:nonroot@sha256:c31ff9abcb1910f3ab25c7957bdaf0bfe12a01eb546e8df2282f1c8f682b606c
 
 # ---- Runtime: server image --------------------------------------------------
 FROM ${RUNTIME_BASE} AS server

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,5 @@
 [graph]
-all-features = false
+all-features = true
 
 [advisories]
 version = 2
@@ -18,17 +18,35 @@ ignore = [
   # acceptable to ignore. No fixed bincode 1.x exists; revisit when
   # promql-parser drops the lrpar bincode dependency.
   "RUSTSEC-2025-0141",
-  # RUSTSEC-2024-0436: paste 1.0.15 is unmaintained (repo archived). It
-  # enters only through parquet (services/ravel-cli's bulk-import loader,
-  # ADR-0089), which uses it purely as a proc-macro for compile-time
-  # identifier concatenation. paste has no runtime API surface at all: it
-  # expands entirely during macro invocation and contributes nothing to
-  # the compiled binary or its runtime behavior, so "unmaintained" has no
+  # RUSTSEC-2024-0436: paste 1.0.15 is unmaintained (repo archived).
+  # `cargo tree -i paste --depth 1 --all-features` shows three entry
+  # points: arrow-flight, parquet (services/ravel-cli's bulk-import
+  # loader, ADR-0089), and tikv-jemalloc-ctl (dev-dependency only). All
+  # three use it purely as a proc-macro for compile-time identifier
+  # concatenation. paste has no runtime API surface at all: it expands
+  # entirely during macro invocation and contributes nothing to the
+  # compiled binary or its runtime behavior, so "unmaintained" has no
   # runtime security implication here, unlike a crate that ships code
   # that executes. No safe upgrade exists (the advisory's own suggested
-  # forks, pastey and with_builtin_macros, are not drop-in and parquet
-  # does not depend on either); revisit if parquet drops paste upstream.
+  # forks, pastey and with_builtin_macros, are not drop-in and none of
+  # the three depends on either); revisit if they drop paste upstream.
   "RUSTSEC-2024-0436",
+  # RUSTSEC-2026-0194 and RUSTSEC-2026-0195: quick-xml 0.26.0 and 0.39.4
+  # (two versions, both affected) enter only through inferno's SVG
+  # rendering (inferno <- pprof, `flamegraph` feature), which both
+  # ravel-bench and services/ravel-cli pull behind their own
+  # off-by-default `profiling` feature (see the matching `inferno`
+  # CDDL-1.0 license exception below). Both advisories describe CPU/memory
+  # exhaustion from parsing attacker-controlled, untrusted XML with many
+  # attributes or namespace declarations on a single start tag. inferno's
+  # quick-xml usage here only parses and writes flamegraph SVG built from
+  # locally generated pprof sample data (symbol names and stack frames
+  # from the same process), never externally supplied or untrusted XML,
+  # so the reachable input is not attacker-controlled even when the
+  # feature is enabled. No fixed inferno release pins quick-xml
+  # >=0.41.0 yet; revisit when it does.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
 ]
 
 [licenses]
@@ -49,11 +67,14 @@ allow = [
 # Scoped so the global allow list above stays tight.
 #
 # inferno 0.11.x is CDDL-1.0. It enters only through pprof's `flamegraph`
-# feature (inferno <- pprof), which ravel-bench pulls behind its
-# off-by-default `profiling` feature. ravel-bench is `publish = false` and
-# is a benchmark harness with no production caller, so inferno never reaches
-# a shipped binary. Scoped to the crate name so the global allow list stays
-# tight and CDDL-1.0 is not permitted for any other dependency.
+# feature (inferno <- pprof), which both ravel-bench and services/ravel-cli
+# pull behind their own off-by-default `profiling` feature. ravel-bench is
+# `publish = false` with no production caller; ravel-cli is a shipped
+# binary, but its default build (the root Dockerfile's `cargo build
+# --release --locked -p ravel-cli`, no --features) never turns `profiling`
+# on, so inferno never reaches the shipped image either. Scoped to the
+# crate name so the global allow list stays tight and CDDL-1.0 is not
+# permitted for any other dependency.
 exceptions = [
   { name = "tiny-keccak", allow = ["CC0-1.0"] },
   { name = "inferno", allow = ["CDDL-1.0"] },

--- a/deploy/metricsbench/README.md
+++ b/deploy/metricsbench/README.md
@@ -73,16 +73,31 @@ docker compose -f deploy/metricsbench/docker-compose.yml down -v
 deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh
 ```
 
-Exit 0 means every image reference in the deployment carries an `@sha256:`
-digest, every ADR-0927-required comparator is present, and the number of image
-references equals the expected count. Any unpinned reference, any missing
-required comparator, or a reference count that drifts from the expected number
-fails the check with a non-zero exit. The script prints what it checked and how
-many references it found.
+Originally scoped to this directory's compose file alone (issue #934), the
+script now also checks the two repo-wide supply-chain pins issue #1310 added:
+every `FROM`/`ARG` base image in the root `Dockerfile` and `Dockerfile.prebuilt`,
+and every `uses:` action reference under `.github/workflows/` and
+`.github/actions/`. All three categories run in one invocation and each is
+checked against its own expected count:
 
-This check is **not yet run by CI**. Wiring it into `scripts/gates.sh` or a CI
-workflow is a deliberate follow-up: those are shared files outside issue #934's
-scope.
+- **Compose images** (this directory): every image reference carries an
+  `@sha256:` digest, every ADR-0927-required comparator is present, and the
+  number of image references equals the expected count.
+- **Dockerfile base images**: every `FROM`/`ARG` base image reference in the
+  root `Dockerfile` and `Dockerfile.prebuilt` carries an `@sha256:` digest
+  (`FROM scratch` is exempt: no registry manifest exists for it), and the
+  number of references equals the expected count.
+- **Workflow actions**: every `uses:` reference in every workflow and
+  composite action carries a 40-hex commit SHA pin, and the number of
+  references equals the expected count.
+
+Exit 0 means all three categories passed. Any unpinned reference, any missing
+required comparator, or a reference count that drifts from any category's
+expected number fails the check with a non-zero exit. The script prints what
+it checked and how many references it found in each category.
+
+This check runs in CI, wired into the `doc-scripts` job in
+`.github/workflows/ci.yml`.
 
 ## Pinned image digests
 

--- a/deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh
+++ b/deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh
@@ -1,30 +1,45 @@
 #!/bin/sh
-# every_comparator_pins_an_image_digest.sh (issue #934, ADR-0927).
+# every_comparator_pins_an_image_digest.sh (issue #934, ADR-0927; generalised
+# for issue #1310).
 #
-# Acceptance check for the MetricsBench comparator deployment. Issue #934 names
-# this check `metricsbench::deploy::tests::every_comparator_pins_an_image_digest`,
-# a Rust test path, but its own scope line says the task touches no crate, and
-# the crate that path would live in (crates/ravel-bench) is edited by the
-# parallel M1 task. This is that check implemented instead as a dependency-free
-# script under deploy/metricsbench/, preserving the name exactly. The deviation
-# is recorded in the task report and in README.md.
+# Started as the MetricsBench comparator deployment's acceptance check. Issue
+# #934 names this check
+# `metricsbench::deploy::tests::every_comparator_pins_an_image_digest`, a Rust
+# test path, but its own scope line says the task touches no crate, and the
+# crate that path would live in (crates/ravel-bench) was edited by a parallel
+# task. This is that check implemented instead as a dependency-free script
+# under deploy/metricsbench/, preserving the name exactly. The deviation is
+# recorded in README.md.
 #
-# It enforces, over the deployment files:
-#   1. every image reference is pinned by an `@sha256:` digest (a tag alone, or a
-#      tag with no digest, fails: a moving tag makes a run unreproducible);
-#   2. every comparator ADR-0927 requires is present (deleting a system cannot
-#      make the check pass);
-#   3. the number of image references equals the exact expected count (a check
-#      that scanned zero files and exited zero is the failure this guards
-#      against).
-# Exit 0 only when all three hold.
+# Issue #1310 generalised it into a repo-wide pin check, on the same rationale:
+# a moving tag or a mutable action ref is unreproducible and unauditable
+# wherever it appears, not just in this one compose file. It now scans three
+# categories, each with its own exact-count assertion so a scan that finds
+# nothing in a category fails rather than passing silently:
+#
+#   1. every `image:` reference in deploy/metricsbench/docker-compose.yml
+#      (the original check, unchanged in behaviour);
+#   2. every base image in Dockerfile and Dockerfile.prebuilt (`FROM ...` and
+#      the `ARG RUNTIME_BASE=...` default) -- excluding `scratch` (a
+#      zero-content pseudo-image with no registry manifest to pin) and a bare
+#      `${VAR}` FROM (Dockerfile.prebuilt's runtime stages source the build
+#      arg, whose own default is what carries the pin, checked separately);
+#   3. every `uses:` action reference in .github/workflows/*.yml and
+#      .github/actions/*/*.yml -- excluding a local action (`uses: ./...`),
+#      which is repo-tracked code, not a fetched external action.
+#
+# Every category requires an `@sha256:<64 hex>` digest (categories 1 and 2) or
+# a full 40-character commit SHA (category 3): a tag alone, a branch, or a
+# short SHA is a moving or ambiguous reference and fails the same as a bare
+# tag. Exit 0 only when every category is fully pinned and every category's
+# reference count equals its expected total.
 #
 # POSIX sh, no external dependencies beyond grep/sed. Fails closed.
 
 set -u
 
-# Resolve the deployment directory from this script's own location so the check
-# runs correctly from any working directory.
+# Resolve directories from this script's own location so the check runs
+# correctly from any working directory.
 # `CDPATH= cd` clears CDPATH for that one command, so a user's CDPATH cannot
 # make `cd` resolve somewhere else and print the directory it chose. The empty
 # assignment is the point, not a typo; SC1007 cannot tell the two apart.
@@ -32,6 +47,8 @@ set -u
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 # shellcheck disable=SC1007
 DEPLOY_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+# shellcheck disable=SC1007
+REPO_ROOT=$(CDPATH= cd -- "$DEPLOY_DIR/../.." && pwd)
 COMPOSE_FILE="$DEPLOY_DIR/docker-compose.yml"
 
 # The comparators ADR-0927 requires in the portable cross-engine lane. Each must
@@ -43,16 +60,49 @@ REQUIRED_COMPARATORS="prometheus victoriametrics mimir"
 # Exact number of `image:` references the committed deployment must contain:
 # prometheus, victoriametrics, minio, createbuckets, mimir. If a service is added
 # or removed, update this number deliberately in the same change.
-EXPECTED_IMAGE_COUNT=5
+COMPOSE_EXPECTED_IMAGE_COUNT=5
+
+# Exact number of base-image references across both Dockerfiles that must
+# carry a digest: Dockerfile's four `FROM` stages that pull a real image
+# (builder, server, operator, ingest-router -- `debug-symbols`'s `FROM scratch`
+# is excluded, see above) plus Dockerfile.prebuilt's one `ARG RUNTIME_BASE=`
+# default. Update deliberately if a stage is added, removed, or repointed at a
+# build-arg.
+DOCKERFILE_EXPECTED_IMAGE_COUNT=5
+
+# Exact number of external `uses:` action references across every workflow and
+# composite action file. Update deliberately whenever a workflow gains,
+# loses, or repoints a `uses:` step.
+WORKFLOW_EXPECTED_ACTION_COUNT=89
+
+# A pinned image reference ends in `@sha256:` followed by exactly 64 hex
+# digits. Matching the bare substring `@sha256:` is not enough: `repo:tag@sha256:`
+# with an empty or truncated digest would satisfy it while pinning nothing,
+# which is the failure this check exists to catch.
+IMAGE_DIGEST_RE='@sha256:[0-9a-f]\{64\}$'
+
+# A pinned action reference ends in `@` followed by exactly 40 hex digits (a
+# full git commit SHA). A tag (`@v4`), a branch, or an abbreviated SHA all fail
+# this, which is the point: only a full commit SHA is an immutable pin.
+ACTION_SHA_RE='@[0-9a-f]\{40\}$'
 
 fail=0
+
+DOCKERFILE_REFS_FILE=$(mktemp)
+WORKFLOW_REFS_FILE=$(mktemp)
+trap 'rm -f "$DOCKERFILE_REFS_FILE" "$WORKFLOW_REFS_FILE"' EXIT
+
+echo "Repo-wide pin check (issue #1310)"
+
+# --- 1. MetricsBench compose file -------------------------------------------
 
 if [ ! -f "$COMPOSE_FILE" ]; then
   echo "FAIL: compose file not found at $COMPOSE_FILE"
   exit 1
 fi
 
-echo "MetricsBench image-pin check"
+echo
+echo "== docker-compose image pins =="
 echo "  deployment file: $COMPOSE_FILE"
 
 # Collect image references. Match indented `image:` keys only, strip the key and
@@ -62,40 +112,29 @@ IMAGE_REFS=$(grep -E '^[[:space:]]*image:[[:space:]]*' "$COMPOSE_FILE" \
 
 if [ -z "$IMAGE_REFS" ]; then
   echo "FAIL: no image references found; the check must never scan zero images"
-  exit 1
-fi
+  fail=1
+else
+  image_count=$(printf '%s\n' "$IMAGE_REFS" | grep -c .)
+  echo "  image references found: $image_count (expected $COMPOSE_EXPECTED_IMAGE_COUNT)"
+  echo "  references:"
+  printf '%s\n' "$IMAGE_REFS" | while IFS= read -r ref; do
+    if printf '%s\n' "$ref" | grep -q "$IMAGE_DIGEST_RE"; then
+      echo "    [pinned]   $ref"
+    else
+      echo "    [UNPINNED] $ref"
+    fi
+  done
 
-# Count references. `grep -c` counts matching lines, which is one per image key.
-image_count=$(printf '%s\n' "$IMAGE_REFS" | grep -c .)
-
-echo "  image references found: $image_count (expected $EXPECTED_IMAGE_COUNT)"
-echo "  references:"
-# A pinned reference ends in `@sha256:` followed by exactly 64 hex digits.
-# Matching the bare substring `@sha256:` is not enough: `repo:tag@sha256:` with
-# an empty or truncated digest would satisfy it while pinning nothing, which is
-# the failure this check exists to catch.
-DIGEST_RE='@sha256:[0-9a-f]\{64\}$'
-
-# Check every reference carries a complete digest.
-printf '%s\n' "$IMAGE_REFS" | while IFS= read -r ref; do
-  if printf '%s\n' "$ref" | grep -q "$DIGEST_RE"; then
-    echo "    [pinned]   $ref"
-  else
-    echo "    [UNPINNED] $ref"
+  unpinned=$(printf '%s\n' "$IMAGE_REFS" | grep -vc "$IMAGE_DIGEST_RE")
+  if [ "$unpinned" -ne 0 ]; then
+    echo "FAIL: $unpinned compose image reference(s) lack an @sha256: digest"
+    fail=1
   fi
-done
 
-# The digest check drives the exit code from the parent shell (the while loop
-# above runs in a subshell and cannot set `fail`). Recount unpinned refs here.
-unpinned=$(printf '%s\n' "$IMAGE_REFS" | grep -vc "$DIGEST_RE")
-if [ "$unpinned" -ne 0 ]; then
-  echo "FAIL: $unpinned image reference(s) lack an @sha256: digest"
-  fail=1
-fi
-
-if [ "$image_count" -ne "$EXPECTED_IMAGE_COUNT" ]; then
-  echo "FAIL: found $image_count image references, expected exactly $EXPECTED_IMAGE_COUNT"
-  fail=1
+  if [ "$image_count" -ne "$COMPOSE_EXPECTED_IMAGE_COUNT" ]; then
+    echo "FAIL: found $image_count compose image references, expected exactly $COMPOSE_EXPECTED_IMAGE_COUNT"
+    fail=1
+  fi
 fi
 
 # Every ADR-0927-required comparator must be present as a service. A service key
@@ -110,10 +149,143 @@ for svc in $REQUIRED_COMPARATORS; do
   fi
 done
 
+# --- 2. Dockerfile base images -----------------------------------------------
+
+echo
+echo "== Dockerfile base-image pins =="
+
+for df in "$REPO_ROOT/Dockerfile" "$REPO_ROOT/Dockerfile.prebuilt"; do
+  if [ ! -f "$df" ]; then
+    echo "FAIL: Dockerfile not found at $df"
+    fail=1
+    continue
+  fi
+  echo "  scanning: $df"
+
+  # `FROM <image> [AS <stage>]`. Field 2 is the image token. Skip `scratch`
+  # (no registry manifest exists to pin) and a bare `${VAR}` reference (its
+  # value's own default, not the FROM line, is what carries the pin -- see the
+  # ARG scan below).
+  grep -n '^FROM[[:space:]]' "$df" | while IFS= read -r line; do
+    lineno=$(printf '%s\n' "$line" | cut -d: -f1)
+    content=$(printf '%s\n' "$line" | cut -d: -f2-)
+    image=$(printf '%s\n' "$content" | awk '{print $2}')
+    case "$image" in
+      scratch) continue ;;
+      '$'*) continue ;;
+    esac
+    echo "$df:$lineno:$image" >>"$DOCKERFILE_REFS_FILE"
+  done
+
+  # `ARG NAME=<value>` whose value looks like an image reference (contains a
+  # `/`, e.g. a registry/repo path). Dockerfile.prebuilt's `ARG RUNTIME_BASE=`
+  # default is the only line in either file this currently matches.
+  grep -n '^ARG[[:space:]]\+[A-Za-z_][A-Za-z0-9_]*=' "$df" | while IFS= read -r line; do
+    lineno=$(printf '%s\n' "$line" | cut -d: -f1)
+    content=$(printf '%s\n' "$line" | cut -d: -f2-)
+    value=$(printf '%s\n' "$content" | sed -E 's/^ARG[[:space:]]+[A-Za-z_][A-Za-z0-9_]*=//')
+    case "$value" in
+      */*) echo "$df:$lineno:$value" >>"$DOCKERFILE_REFS_FILE" ;;
+    esac
+  done
+done
+
+dockerfile_count=$(wc -l <"$DOCKERFILE_REFS_FILE" | tr -d '[:space:]')
+echo "  base-image references found: $dockerfile_count (expected $DOCKERFILE_EXPECTED_IMAGE_COUNT)"
+
+if [ "$dockerfile_count" -eq 0 ]; then
+  echo "FAIL: no Dockerfile base-image references found; the check must never scan zero images"
+  fail=1
+else
+  while IFS=: read -r file lineno image; do
+    if printf '%s\n' "$image" | grep -q "$IMAGE_DIGEST_RE"; then
+      echo "    [pinned]   $file:$lineno: $image"
+    else
+      echo "    [UNPINNED] $file:$lineno: $image"
+    fi
+  done <"$DOCKERFILE_REFS_FILE"
+
+  unpinned=$(grep -vc "$IMAGE_DIGEST_RE" "$DOCKERFILE_REFS_FILE")
+  if [ "$unpinned" -ne 0 ]; then
+    echo "FAIL: $unpinned Dockerfile base-image reference(s) lack an @sha256: digest"
+    fail=1
+  fi
+
+  if [ "$dockerfile_count" -ne "$DOCKERFILE_EXPECTED_IMAGE_COUNT" ]; then
+    echo "FAIL: found $dockerfile_count Dockerfile base-image references, expected exactly $DOCKERFILE_EXPECTED_IMAGE_COUNT"
+    fail=1
+  fi
+fi
+
+# --- 3. Workflow and composite-action `uses:` pins ---------------------------
+
+echo
+echo "== GitHub Actions 'uses:' pins =="
+
+# shellcheck disable=SC2044
+for wf in $(find "$REPO_ROOT/.github/workflows" -maxdepth 1 -name '*.yml' -type f | sort) \
+          $(find "$REPO_ROOT/.github/actions" -mindepth 2 -maxdepth 2 -name '*.yml' -type f 2>/dev/null | sort); do
+  # A step's `uses:` key appears either on its own line (following a separate
+  # `- name:` line) or inline after the list-item dash (`- uses: ...`, for a
+  # step with no `name:`). Both forms must match, or every no-name step (most
+  # of the `- uses: ./.github/actions/...` and bare `- uses: actions/...`
+  # steps in this repo) is silently skipped.
+  grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*' "$wf" | while IFS= read -r line; do
+    lineno=$(printf '%s\n' "$line" | cut -d: -f1)
+    ref=$(printf '%s\n' "$line" | sed -E 's/^[0-9]+:[[:space:]]*-?[[:space:]]*uses:[[:space:]]*//; s/[[:space:]]*$//')
+    case "$ref" in
+      ./*) continue ;; # local action: repo-tracked code, not a fetched external action
+    esac
+    echo "$wf:$lineno:$ref" >>"$WORKFLOW_REFS_FILE"
+  done
+done
+
+workflow_count=$(wc -l <"$WORKFLOW_REFS_FILE" | tr -d '[:space:]')
+echo "  external action references found: $workflow_count (expected $WORKFLOW_EXPECTED_ACTION_COUNT)"
+
+if [ "$workflow_count" -eq 0 ]; then
+  echo "FAIL: no workflow action references found; the check must never scan zero actions"
+  fail=1
+else
+  # `read <file` (not a pipe) keeps this loop in the current shell, so
+  # `unpinned` accumulates correctly -- unlike the compose section's loop
+  # above, which pipes into `while` and therefore runs in a subshell.
+  #
+  # The stored ref is the whole trailing content of the `uses:` line,
+  # including a `# vX.Y.Z` comment where one is present (kept for display,
+  # matching how this pin reads elsewhere in the repo). The pin itself is
+  # only the first whitespace-delimited token, so the comment must be
+  # stripped before the anchored SHA regex is applied, or every commented
+  # reference would spuriously fail the `$`-anchored check.
+  unpinned=0
+  while IFS=: read -r file lineno ref; do
+    pin=$(printf '%s\n' "$ref" | awk '{print $1}')
+    if printf '%s\n' "$pin" | grep -q "$ACTION_SHA_RE"; then
+      echo "    [pinned]   $file:$lineno: $ref"
+    else
+      echo "    [UNPINNED] $file:$lineno: $ref"
+      unpinned=$((unpinned + 1))
+    fi
+  done <"$WORKFLOW_REFS_FILE"
+
+  if [ "$unpinned" -ne 0 ]; then
+    echo "FAIL: $unpinned workflow action reference(s) lack a full 40-character commit SHA"
+    fail=1
+  fi
+
+  if [ "$workflow_count" -ne "$WORKFLOW_EXPECTED_ACTION_COUNT" ]; then
+    echo "FAIL: found $workflow_count workflow action references, expected exactly $WORKFLOW_EXPECTED_ACTION_COUNT"
+    fail=1
+  fi
+fi
+
+# --- Result -------------------------------------------------------------
+
+echo
 if [ "$fail" -ne 0 ]; then
   echo "RESULT: FAIL"
   exit 1
 fi
 
-echo "RESULT: PASS ($image_count image references, all pinned; comparators: $REQUIRED_COMPARATORS)"
+echo "RESULT: PASS ($image_count compose images, $dockerfile_count Dockerfile base images, $workflow_count workflow actions, all pinned; comparators: $REQUIRED_COMPARATORS)"
 exit 0


### PR DESCRIPTION
Three gaps in the supply chain, all found by the due-diligence review.

The benchmark workflow used tag-pinned third-party actions while exporting
bucket credentials, with no permissions block, on a weekly schedule. A retagged
upstream action would have run with those credentials unreviewed. Its actions are
now pinned by commit SHA, as every other workflow here already does, and the
workflow declares read-only contents.

The container base images used mutable tags, so the digest push, the SBOM, the
provenance attestation and the signature all described bytes nobody reviewed and
none of them would have differed if the base changed underneath. They are pinned
by digest now.

Advisory scanning had no clock. The supply-chain job is a required check but it
is skipped for documentation-only changes and the workflow has no schedule, so a
new advisory against a crate in the lockfile surfaced only when someone happened
to open a code pull request. A nightly workflow now runs the check
unconditionally and routes failures to a tracking issue.

The digest-pin script that enforces this convention for the benchmark comparators
was itself invoked by nothing, so extending it would have enforced nothing. It
now covers both Dockerfiles and the workflow action references, and it runs in
the documentation-scripts job.

One correction to the issue: it states that the supply-chain job is not in the
required check set. It is. The gap was the missing schedule and the
documentation-only skip, not the required set, so the required set is unchanged.

Refs: #1310
Refs: #1313
