### PR TITLE
fix(iam): scope KMS grant in shipped templates to tenant keys

### DIFF
--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -401,6 +401,95 @@ fn every_role_has_kms_decrypt() {
     }
 }
 
+/// Every statement whose `Action` grants any `kms:` action must not name a
+/// `Resource` that covers every key in the account/region: neither the bare
+/// wildcard `"*"` nor any ARN ending `:key/*`. Pinned as a negation (not an
+/// exact tenant-key ARN) so it survives an operator's post-substitution
+/// value. Widen any of the four templates' KMS `Resource` back to
+/// `arn:aws:kms:us-east-1:111122223333:key/*` and this test fails, naming
+/// the role and the statement `Sid`.
+#[test]
+fn no_kms_statement_grants_every_key_in_the_region() {
+    for role in ALL_ROLES {
+        let policy = load_policy(role);
+        for stmt in policy.statements.as_array().unwrap() {
+            let actions: Vec<String> = match &stmt["Action"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect(),
+                _ => continue,
+            };
+            if !actions.iter().any(|a| a.starts_with("kms:")) {
+                continue;
+            }
+            let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
+            let resources: Vec<String> = match &stmt["Resource"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .map(|v| v.as_str().expect("Resource entry is a string").to_string())
+                    .collect(),
+                other => {
+                    panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
+                }
+            };
+            for resource in &resources {
+                assert!(
+                    resource != "*" && !resource.ends_with(":key/*"),
+                    "{role}: statement {sid:?} grants a kms: action on {resource:?}, \
+                     which covers every key in the account/region"
+                );
+            }
+        }
+    }
+}
+
+/// Every statement whose `Action` grants any `kms:` action must name a
+/// `Resource` that pins a specific key id, so an operator cannot re-widen
+/// the grant to every key by substituting `arn:aws:kms:<region>:<account>:key/*`
+/// (or any other bare-wildcard variant) in place of the placeholder.
+#[test]
+fn every_kms_statement_names_a_key_id() {
+    let key_arn_pattern =
+        regex::Regex::new(r"^arn:aws:kms:[^:]+:[^:]+:key/[^*]+$").expect("valid regex");
+    for role in ALL_ROLES {
+        let policy = load_policy(role);
+        for stmt in policy.statements.as_array().unwrap() {
+            let actions: Vec<String> = match &stmt["Action"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect(),
+                _ => continue,
+            };
+            if !actions.iter().any(|a| a.starts_with("kms:")) {
+                continue;
+            }
+            let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
+            let resources: Vec<String> = match &stmt["Resource"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .map(|v| v.as_str().expect("Resource entry is a string").to_string())
+                    .collect(),
+                other => {
+                    panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
+                }
+            };
+            for resource in &resources {
+                assert!(
+                    key_arn_pattern.is_match(resource),
+                    "{role}: statement {sid:?} resource {resource:?} does not name a \
+                     specific key id (expected arn:aws:kms:<region>:<account>:key/<id>)"
+                );
+            }
+        }
+    }
+}
+
 #[test]
 fn discovery_prefix_admitted_for_every_discovering_role() {
     for role in ROLES_WITH_DISCOVERY {

--- a/deploy/iam/admin.json
+++ b/deploy/iam/admin.json
@@ -39,7 +39,7 @@
       "Sid": "AdminTenantKms",
       "Effect": "Allow",
       "Action": "kms:Decrypt",
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/deploy/iam/gateway.json
+++ b/deploy/iam/gateway.json
@@ -48,7 +48,7 @@
       "Sid": "GatewayTenantKms",
       "Effect": "Allow",
       "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/deploy/iam/maintain.json
+++ b/deploy/iam/maintain.json
@@ -58,7 +58,7 @@
       "Sid": "MaintainTenantKms",
       "Effect": "Allow",
       "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/deploy/iam/query.json
+++ b/deploy/iam/query.json
@@ -47,7 +47,7 @@
       "Sid": "QueryTenantKms",
       "Effect": "Allow",
       "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -169,8 +169,11 @@ shipped topology does.
 One policy document per role lives in [`deploy/iam/`](../../../deploy/iam/)
 rather than being transcribed here, so a policy edit is a diff that a test
 checks against the real object-key layout in CI. Replace `my-ravel-bucket` with
-your bucket in each file, then attach each document to the principal whose
-access key that role's deployment uses.
+your bucket, and `arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID`
+with your tenant key ARN(s), in each file, then attach each document to the
+principal whose access key that role's deployment uses. An operator who
+attaches a template without substituting the KMS ARN gets `AccessDenied` on
+the first KMS-routed PUT: the placeholder names no real key.
 
 Three facts about those documents are worth knowing before you edit them.
 
@@ -356,8 +359,10 @@ to narrow.
 }
 ```
 
-The matching role-side statement in each `deploy/iam/*.json` template is scoped
-to the tenant key ARNs rather than to every key:
+The matching role-side statement in each `deploy/iam/*.json` template holds a
+placeholder tenant key ARN that you must replace with your own (see
+[the shipped policy documents](#the-shipped-policy-documents)); scoped to a
+real tenant key rather than to every key:
 
 - Gateway and Maintain write tenant data through the routing store and read some
   of what they write, so they hold encrypt, generate-data-key and decrypt.


### PR DESCRIPTION
All four shipped IAM templates granted their KMS actions on every key in the
account and region, while the configuration guide told the operator those
statements were scoped to the tenant key ARNs. The templates are files the guide
says to attach as-is, so the guide was wrong about what it ships.

That grant is what ADR-0072 relies on for containment: a leaked single-role
credential is supposed to yield ciphertext for other tenants' data. A role that
can decrypt every key removes it. A correctly written key policy would block the
grant on AWS, but the key policy is prose while the template is a checked-in
file, and it does nothing on MinIO, which the same guide documents as an attach
path.

Each template now names a placeholder tenant key ARN, the substitution
instruction covers that ARN alongside the bucket name, and the guide sentence
describes what the files actually do.

The template test could not have caught this. It validated the KMS action lists
and never read the Resource field, and its two existing helpers strip an S3
bucket prefix and silently drop every non-S3 ARN, so an assertion built on either
would have passed against the unfixed templates. The two new tests read Resource
inline instead, and pin the negation rather than an exact ARN so they survive an
operator's substitution: no statement granting a kms: action may name "*" or an
ARN ending in :key/*, and every such Resource must name a specific key id.

The two existing tests asserting that admin has no kms:GenerateDataKey and that
every role has kms:Decrypt still pass unmodified. They are the positive controls
showing the narrowing did not delete the grants.

Refs: #1303
Refs: #1313
