### PR TITLE
feat(query): report commit records served from the resolve cache

### DIFF
--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -1563,7 +1563,12 @@ impl QueryEngine {
         //   data-independent pair of chains does not satisfy.
         // `unfolded_segments_resolved` IS additive (an exact total count
         // across both lanes' resolves, with no ambiguity about how the two
-        // lanes' costs compose).
+        // lanes' costs compose), and `unfolded_records_served_from_cache`
+        // follows the same rule for the same reason: it is an exact count of
+        // commit records served from cache during each lane's own resolve,
+        // and the two lanes' resolves are distinct resolves against
+        // (possibly) distinct commit records, so the query's total is the
+        // sum, not a max.
         //
         // The log lane's `whole_object_threshold` is not reachable from
         // here (`BlockRangeFetcher::effective_whole_object_threshold` is
@@ -1597,10 +1602,8 @@ impl QueryEngine {
             .io_shape
             .service_batches
             .saturating_add(log_counts.service_batches);
-        let log_list_requests = log_accounting
-            .resolve()
-            .snapshot()
-            .s3_requests(AccountedOp::List);
+        let log_resolve_snapshot = log_accounting.resolve().snapshot();
+        let log_list_requests = log_resolve_snapshot.s3_requests(AccountedOp::List);
         log_counts.record_list_pages(log_list_requests.min(u64::from(u32::MAX)) as u32);
         log_counts.list_page_depth = stats
             .io_shape
@@ -1623,6 +1626,8 @@ impl QueryEngine {
         let log_plan_class = PlanClass::Unclassified;
         stats.io_shape = log_counts.into_shape(
             stats.io_shape.unfolded_segments_resolved + log_unfolded,
+            stats.io_shape.unfolded_records_served_from_cache
+                + log_resolve_snapshot.commit_record_cache_hits,
             crate::io_shape::merge_plan_class(stats.io_shape.plan_class, log_plan_class),
         );
 
@@ -2861,10 +2866,8 @@ fn io_shape_for_resolve(
         concurrency,
         shared_get_permits,
     ));
-    let resolve_list_requests = accounting
-        .resolve()
-        .snapshot()
-        .s3_requests(AccountedOp::List);
+    let resolve_snapshot = accounting.resolve().snapshot();
+    let resolve_list_requests = resolve_snapshot.s3_requests(AccountedOp::List);
     counts.record_list_pages(resolve_list_requests.min(u64::from(u32::MAX)) as u32);
     let plan_class = if metadata_only {
         PlanClass::MetadataOnly
@@ -2873,7 +2876,11 @@ fn io_shape_for_resolve(
     } else {
         PlanClass::ExhaustiveScan
     };
-    counts.into_shape(unfolded_segments_resolved, plan_class)
+    counts.into_shape(
+        unfolded_segments_resolved,
+        resolve_snapshot.commit_record_cache_hits,
+        plan_class,
+    )
 }
 
 /// A locally-scoped series identity for a log-derived series returned from
@@ -8139,6 +8146,181 @@ mod prefetch_tests {
              1 batch, summing to 2 -- not the 1 a single peak-capacity \
              division (ceil(3 / min(4, 1000)) == ceil(3 / 4) == 1) would \
              report"
+        );
+    }
+
+    /// Issue #1219: `QueryIoShape::unfolded_records_served_from_cache` must be
+    /// the EXACT count of commit records a resolve served from the catalog's
+    /// local decoded-record cache, read straight from accounting -- never a
+    /// `> 0` check, which the deleted `(cache_hits - (cache_misses - 1)) / 2`
+    /// pooled-counter inference also passed while reading one too high
+    /// whenever a snapshot HEAD exists. Same `QueryEngine` (so the same
+    /// `Catalog` and its decoded-record cache persist across both calls),
+    /// same window, `record_count` commit records both times: the first
+    /// resolve is cold, so its own delta is 0; the second serves every one of
+    /// the `record_count` commit records from cache, so its delta is exactly
+    /// `record_count`.
+    ///
+    /// FLIP: change `record_count` from 3 to 4 (one more `publish_metric`
+    /// call) to watch the second assertion read 4, not 3 -- the figure
+    /// tracks the exact number of commit records the window holds, not a
+    /// fixed constant.
+    #[tokio::test]
+    async fn unfolded_records_served_from_cache_reports_exact_commit_record_serves() {
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        let record_count = 3u64;
+        for seq in 1..=record_count {
+            let ts = BASE_NS - (record_count as i64 + 1 - seq as i64) * NS_PER_MIN;
+            publish_metric(
+                &store,
+                tenant_hash,
+                seq,
+                "cache_serve_metric",
+                ts,
+                seq as f64,
+            )
+            .await;
+        }
+
+        let eng = engine(store);
+        let plans = vec![window_plan("cache_serve_metric")];
+        let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
+
+        let (_source, cold_stats) = eng
+            .prefetch(tenant_hash, &plans, &eval_window, &[], BASE_NS)
+            .await
+            .expect("cold prefetch");
+        assert_eq!(
+            cold_stats.io_shape.unfolded_records_served_from_cache, 0,
+            "a cold resolve fetches every commit record it touches, so none is \
+             served from cache"
+        );
+
+        let (_source, warm_stats) = eng
+            .prefetch(tenant_hash, &plans, &eval_window, &[], BASE_NS)
+            .await
+            .expect("warm prefetch");
+        assert_eq!(
+            warm_stats.io_shape.unfolded_records_served_from_cache, record_count,
+            "the second resolve over the same window serves every commit \
+             record the first one warmed"
+        );
+    }
+
+    /// Issue #1219, the case the deleted pooled-counter inference got wrong
+    /// by one: a tenant WITH a folded snapshot HEAD must not have its decoded
+    /// snapshot-HEAD probe inflate `unfolded_records_served_from_cache`. One
+    /// sealed hour folds into a snapshot; `record_count` commit records are
+    /// published above the watermark in later hours, the only commit records
+    /// a resolve of this window ever lists. A first resolve (cold) warms them
+    /// and admits the HEAD to the head cache, its own delta 0; a second
+    /// resolve at the same `now_ns` (so the HEAD probe is itself a cache hit)
+    /// serves all `record_count` recent records from the decoded-record
+    /// cache. The figure must read exactly `record_count`, not
+    /// `record_count + 1` with the HEAD probe folded in.
+    ///
+    /// FLIP: add a `record_commit_record_cache_hit()` call to the head-cache
+    /// hit branch of `ravel-catalog`'s `read_head` (`snapshot_resolve.rs`,
+    /// mirroring the same regression the sibling `ravel-catalog` test
+    /// `commit_record_cache_serves_are_counted_exactly_with_a_folded_snapshot_head`
+    /// pins directly) to watch the assertion below fail: it would then read
+    /// `record_count + 1`.
+    #[tokio::test]
+    async fn unfolded_records_served_from_cache_excludes_the_folded_head_probe() {
+        const NS_PER_HOUR: i64 = 3_600 * NS_PER_SEC;
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        let fold_margin = ravel_catalog::DEFAULT_MAX_FLUSH_LIFETIME_NS
+            + ravel_catalog::DEFAULT_CLOCK_SKEW_ALLOWANCE_NS
+            + ravel_catalog::DEFAULT_FOLD_SAFETY_MARGIN_NS;
+
+        // One sealed hour, folded into a snapshot (HEAD + one part).
+        let sealed_hour = 500_000u32;
+        let sealed_created = (i64::from(sealed_hour) + 1) * NS_PER_HOUR - 1_000;
+        publish_metric_segment(
+            &store,
+            tenant_hash,
+            1,
+            "folded_cache_metric",
+            vec![Sample {
+                ts_ns: sealed_created - 1_000,
+                value: 1.0,
+            }],
+            sealed_hour,
+            sealed_created,
+        )
+        .await;
+        let fold_now = (i64::from(sealed_hour) + 1) * NS_PER_HOUR + fold_margin;
+        let fold_backend: Arc<dyn ObjectStoreBackend> = Arc::clone(&store) as Arc<_>;
+        let fold_catalog =
+            Catalog::new(Arc::clone(&fold_backend), CatalogConfig::default()).expect("catalog");
+        fold_catalog
+            .fold(
+                &tenant_hash,
+                Signal::Metrics,
+                Uuid::new_v4(),
+                fold_now,
+                &[],
+                None,
+            )
+            .await
+            .expect("fold produces a snapshot HEAD");
+
+        // `record_count` commit records above the watermark, published in
+        // later hours: the only listed commit records a resolve of this
+        // window ever touches.
+        let record_count = 2u32;
+        for i in 0..record_count {
+            let hour = sealed_hour + 10 + i;
+            let created = i64::from(hour) * NS_PER_HOUR + 60 * NS_PER_SEC;
+            publish_metric_segment(
+                &store,
+                tenant_hash,
+                2 + u64::from(i),
+                "folded_cache_metric",
+                vec![Sample {
+                    ts_ns: created - 1_000,
+                    value: 1.0,
+                }],
+                hour,
+                created,
+            )
+            .await;
+        }
+        let now_ns = i64::from(sealed_hour + 10 + record_count) * NS_PER_HOUR + fold_margin;
+
+        // A fresh engine/catalog so both the head cache and the record cache
+        // start empty; the same instance across both prefetches so they
+        // persist.
+        let backend: Arc<dyn ObjectStoreBackend> = Arc::clone(&store) as Arc<_>;
+        let catalog =
+            Catalog::new(Arc::clone(&backend), CatalogConfig::default()).expect("catalog");
+        let eng = QueryEngine::new(Arc::new(catalog), backend, EngineConfig::default());
+        let plans = vec![SelectorPlan {
+            range_ns: NS_PER_HOUR * i64::from(record_count + 11),
+            ..window_plan("folded_cache_metric")
+        }];
+        let eval_window = EvalWindow::Instant { t_ns: now_ns };
+
+        let (_source, cold_stats) = eng
+            .prefetch(tenant_hash, &plans, &eval_window, &[], now_ns)
+            .await
+            .expect("cold prefetch over folded tenant");
+        assert_eq!(
+            cold_stats.io_shape.unfolded_records_served_from_cache, 0,
+            "a cold resolve serves no commit record from cache"
+        );
+
+        let (_source, warm_stats) = eng
+            .prefetch(tenant_hash, &plans, &eval_window, &[], now_ns)
+            .await
+            .expect("warm prefetch over folded tenant");
+        assert_eq!(
+            warm_stats.io_shape.unfolded_records_served_from_cache,
+            u64::from(record_count),
+            "the two recent commit records are counted; the folded HEAD cache \
+             hit must not inflate the figure"
         );
     }
 

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -390,6 +390,20 @@ pub struct IoShapeJson {
     /// underlying records (`crate::io_shape` module docs).
     #[serde(rename = "unfoldedSegmentsResolved")]
     pub unfolded_segments_resolved: u64,
+    /// EXACT count of COMMIT RECORDS this query's resolve served from the
+    /// catalog's local decoded commit-record cache
+    /// (`QueryAccountingSnapshot::commit_record_cache_hits`), read straight
+    /// from accounting. A RECORD count, not a segment count: the listing
+    /// window is padded by `max_ingest_lag_ns` and runs to the current hour
+    /// regardless of the query's end, so a resolve prewarms buckets its
+    /// range never touches and `include_l0_if_overlaps` drops those records
+    /// afterwards -- on a live tenant a narrow range counts records from
+    /// hours that contribute no segment at all, so this figure reads above
+    /// any segment-based cache count. Meant as the numerator of a
+    /// cold-resolve fraction (records served from cache over records the
+    /// resolve touched), not a segment total.
+    #[serde(rename = "unfoldedRecordsServedFromCache")]
+    pub unfolded_records_served_from_cache: u64,
     /// Pre-execution access-pattern classification: `metadata_only`,
     /// `selective_indexed`, `exhaustive_scan`, or `unclassified` (a lane,
     /// such as the log lane, whose own resolve carries no signal this crate
@@ -406,6 +420,7 @@ impl From<crate::io_shape::QueryIoShape> for IoShapeJson {
             list_page_depth: shape.list_page_depth,
             service_batches: shape.service_batches,
             unfolded_segments_resolved: shape.unfolded_segments_resolved,
+            unfolded_records_served_from_cache: shape.unfolded_records_served_from_cache,
             plan_class: shape.plan_class.name(),
         }
     }
@@ -1391,6 +1406,7 @@ mod tests {
             list_page_depth: 13,
             service_batches: 4,
             unfolded_segments_resolved: 2_500,
+            unfolded_records_served_from_cache: 1_800,
             plan_class: crate::io_shape::PlanClass::SelectiveIndexed,
         };
         let stats = crate::QueryStats {
@@ -1405,16 +1421,20 @@ mod tests {
         assert_eq!(io["listPageDepth"], serde_json::json!(13));
         assert_eq!(io["serviceBatches"], serde_json::json!(4));
         assert_eq!(io["unfoldedSegmentsResolved"], serde_json::json!(2_500));
+        assert_eq!(
+            io["unfoldedRecordsServedFromCache"],
+            serde_json::json!(1_800)
+        );
         assert_eq!(io["planClass"], serde_json::json!("selective_indexed"));
 
         // Every figure exactly once: no duplicate key, and no field beyond
-        // the five `QueryIoShape` carries (an object key, field value,
+        // the six `QueryIoShape` carries (an object key, field value,
         // predicate, or index term would show up here as an extra field).
         let obj = io.as_object().expect("io is a JSON object");
         assert_eq!(
             obj.len(),
-            5,
-            "io carries exactly the five QueryIoShape figures, no more"
+            6,
+            "io carries exactly the six QueryIoShape figures, no more"
         );
 
         assert!(
@@ -1446,6 +1466,7 @@ mod tests {
             list_page_depth: 13,
             service_batches: 4,
             unfolded_segments_resolved: 2_500,
+            unfolded_records_served_from_cache: 1_800,
             plan_class: crate::io_shape::PlanClass::SelectiveIndexed,
         };
         let stats = crate::QueryStats {
@@ -1473,6 +1494,7 @@ mod tests {
             "\"listPageDepth\"",
             "\"serviceBatches\"",
             "\"unfoldedSegmentsResolved\"",
+            "\"unfoldedRecordsServedFromCache\"",
             "\"planClass\"",
         ] {
             let occurrences = io_text.matches(key).count();

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -390,18 +390,20 @@ pub struct IoShapeJson {
     /// underlying records (`crate::io_shape` module docs).
     #[serde(rename = "unfoldedSegmentsResolved")]
     pub unfolded_segments_resolved: u64,
-    /// EXACT count of COMMIT RECORDS this query's resolve served from the
-    /// catalog's local decoded commit-record cache
+    /// EXACT count of COMMIT RECORDS this query's resolve found already
+    /// resident during its listing prewarm pass
     /// (`QueryAccountingSnapshot::commit_record_cache_hits`), read straight
-    /// from accounting. A RECORD count, not a segment count: the listing
-    /// window is padded by `max_ingest_lag_ns` and runs to the current hour
-    /// regardless of the query's end, so a resolve prewarms buckets its
-    /// range never touches and `include_l0_if_overlaps` drops those records
-    /// afterwards -- on a live tenant a narrow range counts records from
-    /// hours that contribute no segment at all, so this figure reads above
-    /// any segment-based cache count. Meant as the numerator of a
-    /// cold-resolve fraction (records served from cache over records the
-    /// resolve touched), not a segment total.
+    /// from accounting; a record served afterwards through
+    /// `resolve_min_token` is outside it, as are the records an attempt
+    /// abandoned to `SnapshotInvalidated` had warmed. A RECORD count, not a
+    /// segment count: the listing window is padded by `max_ingest_lag_ns`
+    /// and runs to the current hour regardless of the query's end, so a
+    /// resolve prewarms buckets its range never touches and
+    /// `include_l0_if_overlaps` drops those records afterwards -- on a live
+    /// tenant a narrow range counts records from hours that contribute no
+    /// segment at all. Meant as the numerator of a cold-resolve fraction
+    /// (records served from cache over records the resolve touched), not a
+    /// segment total.
     #[serde(rename = "unfoldedRecordsServedFromCache")]
     pub unfolded_records_served_from_cache: u64,
     /// Pre-execution access-pattern classification: `metadata_only`,

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -152,6 +152,20 @@
 //!   documented, for the quantity it actually counts.
 //! - [`plan_class`](QueryIoShape::plan_class): decided before any segment is
 //!   opened, from the query's shape and the resolve's own pruning outcome.
+//! - [`unfolded_records_served_from_cache`](QueryIoShape::unfolded_records_served_from_cache):
+//!   the EXACT count of COMMIT RECORDS this query's resolve served from the
+//!   catalog's local decoded commit-record cache
+//!   (`QueryAccountingSnapshot::commit_record_cache_hits`), read straight
+//!   from accounting, never inferred from the pooled cache counters. A
+//!   RECORD count, not a segment count, and the two differ for the same
+//!   reason `unfolded_segments_resolved` above is a segment count: the
+//!   listing window is padded by `max_ingest_lag_ns` and runs to the current
+//!   hour regardless of the query's end, so a resolve prewarms buckets its
+//!   range never touches and `include_l0_if_overlaps` drops those records
+//!   afterwards -- on a live tenant a narrow range counts records from hours
+//!   that contribute no segment at all. The figure exists to be the
+//!   numerator of a cold-resolve fraction (records served from cache over
+//!   records the resolve touched), not a segment total.
 //!
 //! # Tests
 //!
@@ -212,6 +226,15 @@ pub struct QueryIoShape {
     pub list_page_depth: u32,
     pub service_batches: u32,
     pub unfolded_segments_resolved: u64,
+    /// EXACT count of commit records this query's resolve served from the
+    /// catalog's local decoded commit-record cache
+    /// (`QueryAccountingSnapshot::commit_record_cache_hits`), read straight
+    /// from accounting for the resolve(s) this query ran. A RECORD count,
+    /// not a segment count -- see the module docs' entry of the same name
+    /// for why a padded listing window makes the two diverge on a live
+    /// tenant. Meant as the numerator of a cold-resolve fraction, not a
+    /// segment total.
+    pub unfolded_records_served_from_cache: u64,
     pub plan_class: PlanClass,
 }
 
@@ -229,6 +252,7 @@ impl Default for QueryIoShape {
             list_page_depth: 0,
             service_batches: 0,
             unfolded_segments_resolved: 0,
+            unfolded_records_served_from_cache: 0,
             plan_class: PlanClass::MetadataOnly,
         }
     }
@@ -422,6 +446,7 @@ impl IoShapeCounts {
     pub fn into_shape(
         self,
         unfolded_segments_resolved: u64,
+        unfolded_records_served_from_cache: u64,
         plan_class: PlanClass,
     ) -> QueryIoShape {
         QueryIoShape {
@@ -429,6 +454,7 @@ impl IoShapeCounts {
             list_page_depth: self.list_page_depth,
             service_batches: self.service_batches,
             unfolded_segments_resolved,
+            unfolded_records_served_from_cache,
             plan_class,
         }
     }

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -153,12 +153,18 @@
 //! - [`plan_class`](QueryIoShape::plan_class): decided before any segment is
 //!   opened, from the query's shape and the resolve's own pruning outcome.
 //! - [`unfolded_records_served_from_cache`](QueryIoShape::unfolded_records_served_from_cache):
-//!   the EXACT count of COMMIT RECORDS this query's resolve served from the
-//!   catalog's local decoded commit-record cache
+//!   the EXACT count of COMMIT RECORDS this query's resolve found already
+//!   resident during its listing prewarm pass
 //!   (`QueryAccountingSnapshot::commit_record_cache_hits`), read straight
-//!   from accounting, never inferred from the pooled cache counters. A
-//!   RECORD count, not a segment count, and the two differ for the same
-//!   reason `unfolded_segments_resolved` above is a segment count: the
+//!   from accounting, never inferred from the pooled cache counters. That
+//!   prewarm pass is the whole of it: a record served afterwards through
+//!   `resolve_min_token`'s own cache lookup is not counted, nor are the
+//!   records an attempt abandoned to `SnapshotInvalidated` had warmed. The
+//!   counter's contract in `ravel-types` states both exclusions and is the
+//!   normative description.
+//!   A RECORD count, not a segment count, diverging from
+//!   `unfolded_segments_resolved` by its own mechanism rather than by the L1
+//!   part expansion described above, and in the opposite direction: the
 //!   listing window is padded by `max_ingest_lag_ns` and runs to the current
 //!   hour regardless of the query's end, so a resolve prewarms buckets its
 //!   range never touches and `include_l0_if_overlaps` drops those records
@@ -226,14 +232,15 @@ pub struct QueryIoShape {
     pub list_page_depth: u32,
     pub service_batches: u32,
     pub unfolded_segments_resolved: u64,
-    /// EXACT count of commit records this query's resolve served from the
-    /// catalog's local decoded commit-record cache
+    /// EXACT count of commit records this query's resolve found already
+    /// resident during its listing prewarm pass
     /// (`QueryAccountingSnapshot::commit_record_cache_hits`), read straight
     /// from accounting for the resolve(s) this query ran. A RECORD count,
     /// not a segment count -- see the module docs' entry of the same name
     /// for why a padded listing window makes the two diverge on a live
-    /// tenant. Meant as the numerator of a cold-resolve fraction, not a
-    /// segment total.
+    /// tenant, and the counter's own contract in `ravel-types` for the two
+    /// serves it leaves out. Meant as the numerator of a cold-resolve
+    /// fraction, not a segment total.
     pub unfolded_records_served_from_cache: u64,
     pub plan_class: PlanClass,
 }

--- a/crates/ravel-query/tests/log_series_engine.rs
+++ b/crates/ravel-query/tests/log_series_engine.rs
@@ -649,6 +649,79 @@ async fn log_lane_never_escalates_a_selectively_indexed_metrics_lane_to_exhausti
     );
 }
 
+/// `unfolded_records_served_from_cache` is a SUM over the two lanes, and the
+/// log lane's term is the one no other test pins: the metrics-lane tests
+/// exercise the other `into_shape` call site only.
+///
+/// The fixture makes the two adjacent `u64` arguments of that call differ on
+/// purpose. Three log commit records sit in the resolve's padded listing
+/// window and are prewarmed; only two of them name a segment this query's
+/// range overlaps, so `include_l0_if_overlaps` drops the third and it never
+/// becomes a resolved segment. The metrics lane contributes to neither count,
+/// its records having been folded into a snapshot part.
+///
+/// FLIP: in `engine.rs`'s log-lane `into_shape` call, replacing
+/// `log_resolve_snapshot.commit_record_cache_hits` with `0` makes the warm
+/// figure 0, and transposing that argument with the segment one makes it 2.
+/// Both fail the warm assertions below.
+#[tokio::test]
+async fn mixed_lane_records_served_from_cache_sums_the_log_lane_term() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    // A third log commit record in the same ingest hour, so the resolve's
+    // listing pass prewarms it, carrying a record after this query's range end
+    // so nothing of it is resolved as a segment.
+    let s1 = [("service.name", AttrValue::Str("api".to_string()))];
+    let late = vec![record(&s1, BASE + 30 * NS, "ERROR", "z", &[])];
+    publish_log_segment(&store, th, 2, &late).await;
+    publish_metric(&store, &tid, th, BASE + 2 * NS, 3.0).await;
+
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let catalog = Catalog::new(backend.clone(), CatalogConfig::default()).expect("catalog");
+
+    let hour = u32::try_from(BASE / NS_PER_HOUR).expect("hour fits u32");
+    let fold_now_ns = (i64::from(hour) + 1) * NS_PER_HOUR
+        + DEFAULT_MAX_FLUSH_LIFETIME_NS
+        + DEFAULT_CLOCK_SKEW_ALLOWANCE_NS
+        + DEFAULT_FOLD_SAFETY_MARGIN_NS;
+    catalog
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), fold_now_ns, &[], None)
+        .await
+        .expect("fold");
+
+    let engine = QueryEngine::new(Arc::new(catalog), backend, EngineConfig::default());
+    let query =
+        r#"sum by (job) (count_over_time(ravel_log_lines{job="api"}[1h])) - target_rps{job="api"}"#;
+
+    let (_value, cold) = engine
+        .instant_with_stats(th, query, ms(BASE + 20 * NS), &[], fold_now_ns, DEADLINE)
+        .await
+        .expect("cold query succeeds");
+    assert_eq!(
+        cold.io_shape.unfolded_records_served_from_cache, 0,
+        "nothing is resident before the first query, so every commit record this resolve \
+         prewarms is a miss"
+    );
+
+    let (_value, warm) = engine
+        .instant_with_stats(th, query, ms(BASE + 20 * NS), &[], fold_now_ns, DEADLINE)
+        .await
+        .expect("warm query succeeds");
+    assert_eq!(
+        warm.io_shape.unfolded_records_served_from_cache, 3,
+        "the log lane's resolve prewarms all three log commit records in the padded listing \
+         window and finds every one resident; the metrics lane adds none, its records being \
+         folded into a snapshot part"
+    );
+    assert_eq!(
+        warm.io_shape.unfolded_segments_resolved, 2,
+        "only two of those three records name a segment overlapping the query's range, so the \
+         record count and the segment count differ and a transposed argument cannot pass"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Nameless selectors and ordinary metric queries never touch Signal::Logs.
 // ---------------------------------------------------------------------------

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -2064,12 +2064,16 @@ leftover request, so the model is one round too many. The same sliding
   whether or not a fold has run, so folding can never remove that cost and
   counting it here would overstate the fold benefit.
 - `unfoldedRecordsServedFromCache`: the EXACT count of COMMIT RECORDS this
-  query's resolve served from the catalog's local decoded commit-record
-  cache, read straight from accounting
+  query's resolve found already resident during its listing prewarm pass,
+  read straight from accounting
   (`QueryAccountingSnapshot::commit_record_cache_hits`) rather than inferred
-  from any pooled cache counter. A RECORD count, not a segment count, and the
-  two differ for the same reason `unfoldedSegmentsResolved` above is a
-  segment count: the listing window is padded by `max_ingest_lag_ns` and
+  from any pooled cache counter. The prewarm pass is the whole of it: a
+  record served afterwards through a read-your-write token lookup is not
+  counted, and neither are the records an attempt abandoned to a snapshot
+  invalidation had warmed. A RECORD count, not a segment count, diverging
+  from `unfoldedSegmentsResolved` by its own mechanism and in the opposite
+  direction to the compaction-part expansion described above: the listing
+  window is padded by `max_ingest_lag_ns` and
   runs to the current hour regardless of the query's end, so a resolve
   prewarms commit-record buckets its range never touches and
   `include_l0_if_overlaps` drops those records afterwards -- on a live

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -2063,6 +2063,20 @@ leftover request, so the model is one round too many. The same sliding
   read-your-write token match always costs its own GET by explicit key,
   whether or not a fold has run, so folding can never remove that cost and
   counting it here would overstate the fold benefit.
+- `unfoldedRecordsServedFromCache`: the EXACT count of COMMIT RECORDS this
+  query's resolve served from the catalog's local decoded commit-record
+  cache, read straight from accounting
+  (`QueryAccountingSnapshot::commit_record_cache_hits`) rather than inferred
+  from any pooled cache counter. A RECORD count, not a segment count, and the
+  two differ for the same reason `unfoldedSegmentsResolved` above is a
+  segment count: the listing window is padded by `max_ingest_lag_ns` and
+  runs to the current hour regardless of the query's end, so a resolve
+  prewarms commit-record buckets its range never touches and
+  `include_l0_if_overlaps` drops those records afterwards -- on a live
+  tenant a narrow range counts records from hours that contribute no segment
+  at all. The figure exists to be the numerator of a cold-resolve fraction
+  (records served from cache over records the resolve touched), not a
+  segment total.
 - `planClass`: `metadata_only` (a labels/label-values/series discovery query
   that never reaches a page fetch), `selective_indexed` (the resolve's
   postings-based pruning excluded at least one snapshot-sourced segment),
@@ -2112,7 +2126,12 @@ fetch chain has no DATA dependency on the metrics lane's bytes, so the two
 chains are independent chains that happen to run one after the other, and
 the reported figure is the longest independent chain, not their sum.
 `unfoldedSegmentsResolved` sums across lanes (an exact total count, with no
-ambiguity about how the two lanes' costs compose), and `planClass` takes
+ambiguity about how the two lanes' costs compose).
+`unfoldedRecordsServedFromCache` follows the same rule for the same reason:
+it is an exact count of commit records served from cache during each lane's
+own resolve, and the two lanes' resolves are distinct resolves against
+(possibly) distinct commit records, so the query's total is the sum, not a
+max. `planClass` takes
 the more severe of the two (`exhaustive_scan` outranks `selective_indexed`
 outranks `unclassified` outranks `metadata_only`), so a lane that never ran
 cannot understate a lane that did, and the log lane's `unclassified` result


### PR DESCRIPTION
Add `unfolded_records_served_from_cache` to `QueryIoShape`, read straight from `QueryAccountingSnapshot::commit_record_cache_hits` at the resolve site instead of inferred from any pooled cache counter. Rendered as `unfoldedRecordsServedFromCache` in the HTTP JSON stats, additive beside the existing io_shape figures. Multi-lane composition sums the field across the metrics and log lanes for the same reason `unfolded_segments_resolved` does: the two lanes run distinct resolves serially, so the query's total is the sum of both, not the max.

This is a record count, not a segment count: the resolve's listing window is padded by `max_ingest_lag_ns` and runs to the current hour regardless of the query's end, so a resolve prewarms commit-record buckets its range never touches. The figure is meant as the numerator of a cold-resolve fraction.

A prior attempt derived this figure as an inference over pooled cache hit/miss counters, `(cache_hits - (cache_misses - 1)) / 2`, which read one too high whenever a snapshot HEAD existed. That derivation and its helper are gone; the exact per-resolve counter added earlier this cycle made the inference unnecessary.

## Landing note

The dispatched task's final result push failed (executor unreachable), but its intermediate checkpoint push to `refs/heads/task/910e6fa2-2b84-4025-9423-af2b05ae3b35/checkpoint` succeeded and carries the complete, signed-off commit. Verified independently rather than trusted: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `python3 scripts/check_docs.py`, and `scripts/affected-tests.sh -p ravel-query` (3273 tests, 0 failed) all pass clean against this exact commit on top of current main.

Fixes: #1219
Refs: #1199