### PR TITLE
docs(maintain): drop stale "nothing resolves audit" parenthetical

### DIFF
--- a/crates/ravel-maintain/src/query_audit.rs
+++ b/crates/ravel-maintain/src/query_audit.rs
@@ -31,10 +31,14 @@
 //! request is unbounded, permanent growth - collocating it with the
 //! legal-hold control plane would mean every future legal-hold refresh (a
 //! full shard listing) reads and discards an ever-growing pile of query
-//! records. A distinct shard costs nothing today (no `Signal::Audit`
-//! resolution exists yet for either shard - the generic `audit` SQL table,
-//! crates/ravel-sql/src/audit_schema.rs, is not yet registered in any
-//! session) and is unfixable later, once records are immutable and keyed.
+//! records. The split is invisible to readers: `Signal::Audit`'s
+//! `fixed_read_shards` is 2 (crates/ravel-types/src/lib.rs), so the
+//! `Catalog::resolve` behind an `audit` query floors its scan set at both
+//! shards, and the generic `audit` SQL table
+//! (crates/ravel-sql/src/audit_schema.rs) is registered in the session
+//! `crates/ravel-sql/src/session.rs` builds for that query. Which shard a
+//! record rides is a write-side layout choice no reader sees, and it is
+//! unfixable later, once records are immutable and keyed.
 //!
 //! Every record carries:
 //!


### PR DESCRIPTION
query_audit.rs justified the separate query-audit shard partly on the
grounds that a distinct shard "costs nothing today", because no
Signal::Audit resolution existed for either shard and the generic audit SQL
table was not registered in any session. Issue #128 made both claims false
and left ravel-maintain out of scope, so the doc kept asserting them.

The replacement states what is true now and why the split still costs
readers nothing: Signal::Audit's fixed_read_shards is 2, so the
Catalog::resolve behind an audit query floors its scan set at both shards,
and audit_schema.rs is registered in the session ravel-sql builds for that
query. Which shard a record rides is a write-side layout choice no reader
sees.

The real justification for the split is unchanged and kept: one query-audit
record per SQL request is unbounded permanent growth, so collocating it with
the legal-hold control plane would make every legal-hold refresh read and
discard an ever-growing pile.

Doc comment only; no code, signature or test behaviour changes.

Fixes: #1173
