### PR TITLE
perf(maintain): release RSEG compaction part bytes at PUT

### DIFF
--- a/crates/ravel-maintain/src/build.rs
+++ b/crates/ravel-maintain/src/build.rs
@@ -25,8 +25,12 @@
 //! id-ranges are disjoint, since series are emitted in ascending id order and a
 //! part is a contiguous id range. Each finished part is a whole object written
 //! with a single `CreateIfAbsent` PUT (no multipart), and its encoded bytes are
-//! retained in the returned `Vec` until publish so the convergence-repair path
-//! can re-PUT a part a racing winner is missing.
+//! released the moment that PUT succeeds (ADR-0979 decision 3), so the returned
+//! `Vec` carries part metadata only and the retained-parts memory term does not
+//! grow with the bucket's output. A part whose PUT answered `AlreadyExists` is
+//! HEAD-verified after the record PUT
+//! ([`crate::publish::verify_already_existed_parts`]) instead of being repaired
+//! from a retained copy.
 //!
 //! Format-migration note (ADR-0066 decision 5): an input recorded *below* the
 //! current output version (its commit record's `segment_format_version` is older
@@ -51,12 +55,12 @@
 //! re-encoded) in ascending id order and the window's fetched buffers are then
 //! dropped, so peak fetch buffering is one window's worth. A part accumulates
 //! re-encoded series across windows until its estimated STORED bytes reach
-//! `max_l1_part_bytes`, checked between series; the encoded parts held until
-//! publish, plus one series' decoded samples at a time, dominate peak memory.
-//! Neither of those two terms is sized by a config knob: the retained parts grow
-//! with the bucket's output, and one series' decoded samples grow with that
-//! series. `l1_part_memory_target_bytes` governs the RLOG and RSPAN merges and
-//! is not read on this path.
+//! `max_l1_part_bytes`, checked between series; the pending output part plus one
+//! series' decoded samples at a time dominate peak memory. Neither term is sized
+//! by a config knob: one series' decoded samples grow with that series, and the
+//! pending part runs one whole series past `max_l1_part_bytes`.
+//! `l1_part_memory_target_bytes` governs the RLOG and RSPAN merges and is not
+//! read on this path.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::future::Future;
@@ -110,10 +114,10 @@ pub const OUTPUT_FORMAT_VERSION: u32 = ravel_segment::SUPPORTED_VERSIONS.newest(
 ///
 /// `bytes` is `Option<Bytes>` (ADR-0979 decision 3): a caller that retains the
 /// encoded bytes for its own publish path (the erasure rewrite, and for now the
-/// RSEG/RSPAN codecs) carries `Some`; the bounded RLOG compaction path releases
-/// them the moment the part's PUT succeeds and carries `None`, so the
-/// retained-parts memory term goes to zero instead of scaling with the bucket's
-/// whole L1 output. A `None`-bytes part cannot be re-PUT by the convergence
+/// RSPAN codec) carries `Some`; the RLOG and RSEG compaction paths release them
+/// the moment the part's PUT succeeds and carry `None`, so the retained-parts
+/// memory term goes to zero instead of scaling with the bucket's whole L1
+/// output. A `None`-bytes part cannot be re-PUT by the convergence
 /// repair path, which is sound on the compaction path because every part is PUT
 /// (content-addressed) before the record is; see
 /// [`crate::publish::resolve_already_exists`].
@@ -127,8 +131,8 @@ pub const OUTPUT_FORMAT_VERSION: u32 = ravel_segment::SUPPORTED_VERSIONS.newest(
 /// `AlreadyExists` part would recreate the whole-output term D3 exists to kill,
 /// in exactly the abandoned-run-retry case) and instead HEAD-verifies these
 /// parts after the record PUT succeeds
-/// ([`crate::publish::verify_already_existed_parts`]). The flag is only set on
-/// the bounded RLOG compaction path; every other constructor leaves it `false`.
+/// ([`crate::publish::verify_already_existed_parts`]). The flag is set on the
+/// RLOG and RSEG compaction paths; every other constructor leaves it `false`.
 #[derive(Debug, Clone)]
 pub struct BuiltPart {
     pub key: String,
@@ -287,13 +291,14 @@ pub async fn build_parts(
     //
     // `l1_part_memory_target_bytes` is not read here at all, so no configured
     // number sizes this builder's heap. What it holds at once is one fetch
-    // window's raw pages (the stored-size target applied to INPUT page bytes),
-    // one series' decoded samples while `materialize_series` decodes, merges,
-    // and re-encodes its runs (bounded by that series' own size and by nothing
-    // configurable), and every finished part's encoded bytes, which are retained
-    // until publish so convergence repair can re-PUT one. The pending output
-    // part is the only term `max_l1_part_bytes` sizes, and it is checked between
-    // series, so that term runs one whole series past the target.
+    // window's raw pages (the stored-size target applied to INPUT page bytes)
+    // and one series' decoded samples while `materialize_series` decodes,
+    // merges, and re-encodes its runs (bounded by that series' own size and by
+    // nothing configurable). A finished part's encoded bytes are released at its
+    // PUT (ADR-0979 decision 3), so no term here grows with the bucket's whole
+    // output. The pending output part is the only term `max_l1_part_bytes`
+    // sizes, and it is checked between series, so that term runs one whole
+    // series past the target.
     let mut pending: Vec<SeriesInputV7> = Vec::new();
     let mut pending_exemplars: Vec<ExemplarInput> = Vec::new();
     let mut pending_estimate = PartSizeEstimate::new();
@@ -327,7 +332,7 @@ pub async fn build_parts(
                 pending_exemplars.append(&mut records);
             }
             if pending_estimate.bytes() >= config.max_l1_part_bytes {
-                let part = flush_part(
+                let mut part = flush_part(
                     bucket,
                     config,
                     &ingest_bounds,
@@ -337,9 +342,7 @@ pub async fn build_parts(
                     std::mem::take(&mut pending),
                     std::mem::take(&mut pending_exemplars),
                 )?;
-                if !config.dry_run {
-                    put_part_with_ledger(store, &part, ledger).await?;
-                }
+                put_and_release_part(store, &mut part, config.dry_run, ledger).await?;
                 parts.push(part);
                 part_index += 1;
                 pending_estimate.reset();
@@ -351,7 +354,7 @@ pub async fn build_parts(
 
     // The tail part: whatever series remain below the stored-size target.
     if !pending.is_empty() {
-        let part = flush_part(
+        let mut part = flush_part(
             bucket,
             config,
             &ingest_bounds,
@@ -361,9 +364,7 @@ pub async fn build_parts(
             pending,
             pending_exemplars,
         )?;
-        if !config.dry_run {
-            put_part_with_ledger(store, &part, ledger).await?;
-        }
+        put_and_release_part(store, &mut part, config.dry_run, ledger).await?;
         parts.push(part);
     }
 
@@ -1129,6 +1130,38 @@ fn flush_part(
         part,
         put_already_existed: false,
     })
+}
+
+/// PUT one finished part and release its encoded bytes (ADR-0979 decision 3),
+/// the same shape `rlog.rs`'s `finalize_part` applies on the bounded RLOG
+/// compaction path.
+///
+/// Compaction never retains: a fresh PUT's part is age-zero and so unreachable
+/// by the unreferenced-part sweep for the run's whole duration, which made its
+/// in-RAM copy belt-and-braces rather than a correctness dependency. A part
+/// whose PUT answered `AlreadyExists` carries an abandoned run's
+/// `last_modified` and CAN be swept mid-run, so it is flagged here and
+/// HEAD-verified after the record PUT
+/// ([`crate::publish::verify_already_existed_parts`]); its bytes are dropped
+/// too, because a retry after an abandoned run that uploaded every part answers
+/// `AlreadyExists` for all of them and retaining those would recreate the
+/// whole-output memory term this decision removes, in exactly the recovery
+/// case. Under `dry_run` nothing is ever PUT, so the bytes are released
+/// immediately.
+async fn put_and_release_part(
+    store: &dyn ObjectStoreBackend,
+    part: &mut BuiltPart,
+    dry_run: bool,
+    ledger: Option<&RequestLedger>,
+) -> Result<()> {
+    if !dry_run {
+        match put_part_with_ledger(store, part, ledger).await? {
+            PartPut::Created => {}
+            PartPut::AlreadyExisted => part.put_already_existed = true,
+        }
+    }
+    part.bytes = None;
+    Ok(())
 }
 
 /// PUT one part `CreateIfAbsent`; `AlreadyExists` is idempotent success (the

--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -94,7 +94,7 @@ use crate::request_ledger::RequestLedger;
 ///   accumulated records, decoded heap.
 /// - retained closed parts ([`Self::add_retained_part_bytes`]): the encoded
 ///   bytes of every closed part still held resident until publish. Since
-///   ADR-0979 decision 3 the bounded RLOG compaction path releases each part's
+///   ADR-0979 decision 3 the RLOG and RSEG compaction paths release each part's
 ///   bytes at PUT, so this term is ZERO there; it is nonzero only for a path
 ///   that defers its PUTs and keeps the bytes (the erasure rewrite).
 /// - finish and publish ([`Self::set_publish_record_bytes`]): the encoded
@@ -853,8 +853,9 @@ pub struct CompactorConfig {
     ///   on [`Self::max_l1_part_bytes`] (the estimated stored object), and that path's
     ///   peak is one fetch window's raw pages, plus one series' decoded samples
     ///   (a multi-run series is decoded and merged whole, so it is bounded by
-    ///   that series' size and by nothing configurable), plus every finished
-    ///   part's encoded bytes, which are retained until publish.
+    ///   that series' size and by nothing configurable). A finished part's
+    ///   encoded bytes are released at its PUT (ADR-0979 decision 3), so they
+    ///   are not a term of that peak.
     ///
     /// Named for what it measures and what it does: a split target in decoded
     /// heap. It was `max_l1_part_memory_bytes`, which reads as a resident-bytes

--- a/crates/ravel-maintain/src/read.rs
+++ b/crates/ravel-maintain/src/read.rs
@@ -11,7 +11,8 @@
 //! metadata bound. The verbatim TS/VAL/HIST page bytes are
 //! fetched lazily during the merge ([`crate::build`]) with ranged GETs, so
 //! peak memory is catalog metadata plus one fetch window, plus the series being
-//! materialized, plus the parts held until publish -- not the whole bucket's
+//! materialized -- a finished part releases its encoded bytes at its PUT
+//! (ADR-0979 decision 3), so the parts are not a term -- not the whole bucket's
 //! page data ([`crate::build`]'s header comment splits those terms and says
 //! which of them a config knob sizes).
 

--- a/crates/ravel-maintain/tests/crash_matrix.rs
+++ b/crates/ravel-maintain/tests/crash_matrix.rs
@@ -167,11 +167,21 @@ async fn row4_partial_part_upload() {
 }
 
 /// Row 10: two compactors race on the same inputs. One wins the record's
-/// CreateIfAbsent; the loser HEAD-and-repairs the winner's parts and reports
-/// convergence. Here the winner runs first, one of its parts is dropped, then
-/// the loser's publish converges and repairs the missing part.
+/// CreateIfAbsent; the loser HEADs the winner's parts on the converging path.
+/// Here the winner runs first, one of its parts is dropped, then the loser
+/// publishes.
+///
+/// Since ADR-0979 decision 3 (issue #981 for the metrics path) the loser
+/// released its own parts' bytes at PUT, so it holds nothing to repair the
+/// dropped part from: the converging publish fails closed with
+/// [`ravel_maintain::MaintainError::ConvergedWinnerPartMissing`] rather than
+/// reporting `Converged` over a record that references an absent object. The
+/// hole is healed by re-running the build, whose PUT of the now-absent key is a
+/// FRESH put that restores the byte-identical part before the record resolves;
+/// the publish then converges by presence, repairing nothing. This is the same
+/// convergence-by-presence shape `tombstone_race.rs` pins for RLOG.
 #[tokio::test]
-async fn row10_racing_compactors_loser_converges_and_repairs() {
+async fn row10_racing_compactors_loser_converges_by_presence_after_rerun() {
     let store = MemoryStore::new();
     let specs = seed(&store).await;
     let clock = FixedClock::new(sealed_now_ns());
@@ -207,15 +217,22 @@ async fn row10_racing_compactors_loser_converges_and_repairs() {
     .await
     .unwrap();
 
+    // ... releasing each part's bytes at its PUT, so no in-RAM repair copy
+    // exists (ADR-0979 decision 3).
+    assert!(
+        parts.iter().all(|p| p.bytes.is_none()),
+        "the loser's build released every part's bytes at PUT"
+    );
+
     // ... then a winner part goes missing (e.g. a stray delete), so the
-    // loser's converging publish must HEAD-and-repair it.
+    // loser's converging publish HEADs an absent key it cannot re-PUT.
     let victim = ravel_commit::keys::reconstruct_l1_part_key(&winner, &winner.parts[0]).unwrap();
     store.delete(&victim).await.unwrap();
     assert!(store.get(&victim, GetRange::Full).await.is_err());
 
     // The loser's record PUT hits AlreadyExists with the same input_set_hash,
-    // so it converges and repairs the dropped part.
-    let outcome = publish::publish_record(
+    // so it converges -- and fails closed on the hole it cannot fill.
+    let err = publish::publish_record(
         &store,
         &cfg(),
         &clock,
@@ -226,12 +243,48 @@ async fn row10_racing_compactors_loser_converges_and_repairs() {
         clock.now_ns(),
     )
     .await
-    .expect("loser publish");
-    assert_eq!(outcome, PublishOutcome::Converged { parts_repaired: 1 });
+    .expect_err("an unrepairable missing winner part must fail typed");
+    match err {
+        ravel_maintain::MaintainError::ConvergedWinnerPartMissing { part_key } => {
+            assert_eq!(part_key, victim, "the error names the absent winner part");
+        }
+        other => panic!("expected ConvergedWinnerPartMissing, got {other:?}"),
+    }
+
+    // The re-run heals it: the deleted key is absent, so rebuilding PUTs it
+    // fresh, and the converging publish then finds every winner part present.
+    let mut rerun_catalogs = Vec::new();
+    for i in &inputs {
+        rerun_catalogs.push(read::load_input_catalog(&store, &cfg(), i).await.unwrap());
+    }
+    let rerun_parts = build::build_parts(
+        &store,
+        &cfg(),
+        &bucket,
+        &inputs,
+        rerun_catalogs,
+        &HashSet::new(),
+        &hash,
+    )
+    .await
+    .unwrap();
     assert!(
         store.get(&victim, GetRange::Full).await.is_ok(),
-        "part repaired"
+        "the rerun's fresh PUT restored the part before record resolution"
     );
+    let outcome = publish::publish_record(
+        &store,
+        &cfg(),
+        &clock,
+        &bucket,
+        &inputs,
+        &hash,
+        &rerun_parts,
+        clock.now_ns(),
+    )
+    .await
+    .expect("rerun publish");
+    assert_eq!(outcome, PublishOutcome::Converged { parts_repaired: 0 });
 
     let record = fetch_compaction_record(&store, &bucket).await;
     assert_eq!(

--- a/crates/ravel-maintain/tests/tombstone_race.rs
+++ b/crates/ravel-maintain/tests/tombstone_race.rs
@@ -1,9 +1,11 @@
-//! ADR-0979 decision 3: the bounded RLOG compaction path releases each part's
-//! bytes at PUT and closes the tombstone race by post-publish HEAD verification
-//! rather than by retaining bytes.
+//! ADR-0979 decision 3: the RLOG and RSEG compaction paths release each part's
+//! bytes at PUT and close the tombstone race by post-publish HEAD verification
+//! rather than by retaining bytes. The RLOG tests come first, then the RSEG
+//! (metrics) ones (issue #981), which assert the same two properties on
+//! [`RsegCodec::build_parts`].
 //!
 //! These tests drive the compaction pipeline at its two seams --
-//! [`RlogCodec::build_parts`] (which PUTs the content-addressed parts) and
+//! `build_parts` (which PUTs the content-addressed parts) and
 //! [`publish_record`] (which PUTs the record, then verifies) -- in sequence,
 //! exactly as `rewrite_and_publish` calls them. Splitting the two lets a test
 //! delete an already-PUT part in the window between the part PUTs and the
@@ -27,7 +29,7 @@ use ravel_maintain::error::MaintainError;
 use ravel_maintain::publish::{PublishOutcome, publish_record};
 use ravel_maintain::read::{input_set_hash, list_bucket, load_inputs};
 use ravel_maintain::rlog::RlogCodec;
-use ravel_maintain::{Bucket, CompactorConfig, FixedClock};
+use ravel_maintain::{Bucket, CompactorConfig, FixedClock, RsegCodec};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
 use uuid::Uuid;
@@ -496,4 +498,206 @@ async fn rerun_with_revanished_part_fails_typed_not_converged() {
     // referencing a key this deterministic, content-addressed build did not
     // produce would require a corrupted record. The arm stays as
     // defense-in-depth against exactly that corruption.
+}
+
+/// Seed a small metrics bucket whose whole output fits one L1 part, so a test
+/// reasons about exactly one content-addressed part key.
+async fn seed_one_part_metrics_bucket(store: &MemoryStore) -> Bucket {
+    // Two small inputs over two shared series, well under the default
+    // stored-size target, so the rewrite closes a single part.
+    seed_input(
+        store,
+        &InputSpec::new(
+            Uuid::from_u128(11),
+            5,
+            1,
+            vec![
+                raw_series("m", &[("k", "a")], &[(1_000, 1.0), (5_000, 2.0)]),
+                raw_series("m", &[("k", "b")], &[(2_000, 3.0)]),
+            ],
+        ),
+    )
+    .await;
+    seed_input(
+        store,
+        &InputSpec::new(
+            Uuid::from_u128(12),
+            5,
+            2,
+            vec![
+                raw_series("m", &[("k", "a")], &[(3_000, 4.0)]),
+                raw_series("m", &[("k", "b")], &[(4_000, 5.0)]),
+            ],
+        ),
+    )
+    .await;
+    bucket()
+}
+
+/// Load every input's RSEG catalog in canonical input order, aligned with
+/// `inputs`, exactly as `rewrite_and_publish` does before `build_parts`.
+async fn load_rseg_catalogs(
+    store: &dyn ObjectStoreBackend,
+    config: &CompactorConfig,
+    inputs: &[ravel_maintain::read::InputRecord],
+) -> Vec<<RsegCodec as SegmentCodec>::Catalog> {
+    let mut catalogs = Vec::with_capacity(inputs.len());
+    for input in inputs {
+        catalogs.push(
+            RsegCodec::load_input_catalog(store, config, input)
+                .await
+                .expect("load catalog"),
+        );
+    }
+    catalogs
+}
+
+/// Build and PUT one run's metrics parts, the seam `rewrite_and_publish` calls
+/// before `publish_record`.
+async fn rseg_build(
+    store: &dyn ObjectStoreBackend,
+    config: &CompactorConfig,
+    bucket: &Bucket,
+    inputs: &[ravel_maintain::read::InputRecord],
+    hash: &[u8; 32],
+) -> Vec<ravel_maintain::build::BuiltPart> {
+    let catalogs = load_rseg_catalogs(store, config, inputs).await;
+    RsegCodec::build_parts(store, config, bucket, inputs, catalogs, hash)
+        .await
+        .expect("rseg build_parts")
+}
+
+/// Issue #981: the RSEG (metrics) compaction path releases each finished part's
+/// encoded bytes as soon as its `CreateIfAbsent` PUT succeeds, instead of
+/// holding the bucket's whole output until publish. The parts are provably in
+/// the store, so `bytes == None` is a release after a real PUT rather than a
+/// PUT that never ran, and the run still publishes.
+///
+/// Flip proof (non-vacuous): drop the `part.bytes = None;` line in
+/// `build.rs::put_and_release_part` (the pre-fix behaviour, where
+/// `flush_part`'s `bytes: Some(written.bytes)` survived to publish) and the
+/// `bytes.is_none()` assertion fails on every part. The assertion is on the
+/// released state directly, not on a byte total.
+#[tokio::test]
+async fn rseg_flush_part_drops_bytes_after_put() {
+    let store = MemoryStore::new();
+    let bucket = seed_one_part_metrics_bucket(&store).await;
+    let config = CompactorConfig::default();
+    let commit_keys = list_bucket(&store, &bucket)
+        .await
+        .expect("list")
+        .commit_keys;
+    let inputs = load_inputs(&store, &bucket, &commit_keys, config.input_read_concurrency)
+        .await
+        .expect("inputs");
+    let hash = input_set_hash(&inputs);
+
+    let parts = rseg_build(&store, &config, &bucket, &inputs, &hash).await;
+    assert_eq!(parts.len(), 1, "the fixture builds exactly one part");
+    for p in &parts {
+        assert!(
+            p.bytes.is_none(),
+            "RSEG compaction releases a part's bytes at PUT (ADR-0979 D3)"
+        );
+        assert!(
+            !p.put_already_existed,
+            "a first build PUTs every part fresh"
+        );
+        assert!(
+            store.head(&p.key).await.is_ok(),
+            "the released part must be present in the store"
+        );
+    }
+
+    // The run still publishes with no part bytes retained anywhere.
+    let clock = FixedClock::new(sealed_now_ns());
+    let outcome = publish_record(
+        &store,
+        &config,
+        &clock,
+        &bucket,
+        &inputs,
+        &hash,
+        &parts,
+        sealed_now_ns(),
+    )
+    .await
+    .expect("publish must complete without retained part bytes");
+    assert_eq!(outcome, PublishOutcome::Published);
+    let record = fetch_compaction_record(&store, &bucket).await;
+    assert_eq!(record.level, 1);
+}
+
+/// Issue #981, the `AlreadyExists` half: a metrics part whose PUT answered
+/// `AlreadyExists` retains no bytes either (retaining them on an abandoned-run
+/// retry would rebuild the whole-output term D3 removes), and is covered
+/// instead by `publish.rs`'s existing `verify_already_existed_parts` HEAD
+/// check. Deleting that part in the window between the part PUTs and the record
+/// PUT -- the tombstone race -- makes the run fail loud with
+/// [`MaintainError::AlreadyExistsPartVanished`], which only that verification
+/// produces, so this pins the routing as well as the flag.
+///
+/// Flip proof (non-vacuous): drop the `PartPut::AlreadyExisted =>
+/// part.put_already_existed = true` arm in `build.rs::put_and_release_part` (the
+/// pre-fix behaviour: RSEG discarded the `PartPut` outcome) and the run reports
+/// `Published` over a record referencing the deleted part, failing both the
+/// `put_already_existed` assertion and the `expect_err`.
+#[tokio::test]
+async fn rseg_already_exists_part_retains_no_bytes_and_is_head_verified() {
+    let store = MemoryStore::new();
+    let bucket = seed_one_part_metrics_bucket(&store).await;
+    let config = CompactorConfig::default();
+    let commit_keys = list_bucket(&store, &bucket)
+        .await
+        .expect("list")
+        .commit_keys;
+    let inputs = load_inputs(&store, &bucket, &commit_keys, config.input_read_concurrency)
+        .await
+        .expect("inputs");
+    let hash = input_set_hash(&inputs);
+
+    // An abandoned run that died between its part PUTs and its record PUT: the
+    // content-addressed parts are in the store, no record is.
+    let abandoned = rseg_build(&store, &config, &bucket, &inputs, &hash).await;
+    let vanished = abandoned[0].key.clone();
+
+    // Our run rebuilds the byte-identical part; its PUT answers AlreadyExists.
+    let parts = rseg_build(&store, &config, &bucket, &inputs, &hash).await;
+    assert!(
+        parts.iter().all(|p| p.put_already_existed),
+        "every rebuilt part's PUT must answer AlreadyExists"
+    );
+    assert!(
+        parts.iter().all(|p| p.bytes.is_none()),
+        "no AlreadyExists part retains bytes (D3 kills the whole-output term)"
+    );
+
+    // The unreferenced-part sweep deletes the abandoned part between our part
+    // PUTs and our record PUT. Prove the deletion took effect, so the failure
+    // below is a real vanished part rather than a vacuous check.
+    store.delete(&vanished).await.expect("delete part");
+    assert!(
+        matches!(store.head(&vanished).await, Err(StoreError::NotFound)),
+        "the raced deletion must actually remove the part"
+    );
+
+    let clock = FixedClock::new(sealed_now_ns());
+    let err = publish_record(
+        &store,
+        &config,
+        &clock,
+        &bucket,
+        &inputs,
+        &hash,
+        &parts,
+        sealed_now_ns(),
+    )
+    .await
+    .expect_err("a vanished AlreadyExists part must fail the run loud");
+    match err {
+        MaintainError::AlreadyExistsPartVanished { part_key } => {
+            assert_eq!(part_key, vanished, "the error names the vanished part");
+        }
+        other => panic!("expected AlreadyExistsPartVanished, got {other:?}"),
+    }
 }


### PR DESCRIPTION
The metrics compaction path held every finished part's encoded bytes until
publish, the same unbounded-with-bucket-output term ADR-0979 decision 3
removed for RLOG. On a large metrics bucket that term alone can exceed the
box at publish time.

build.rs now releases a part's bytes as soon as its PUT succeeds, in both
arms. Retaining them for the AlreadyExists case would recreate the whole
term in exactly the recovery scenario the decision exists to protect, which
is what ADR-0979 says and what the shipped RLOG path already does.

The one path that consumed those bytes was convergence repair in publish.rs,
which could rebuild a raced-away winner part from RAM within a single run.
It now fails closed with a typed ConvergedWinnerPartMissing and converges by
presence on a rerun, the narrowing ADR-0979 analyses. Crash-matrix row 10
records that change of outcome rather than working around it.

The erasure rewrite is untouched: it defers its PUTs and legitimately keeps
its bytes, and it builds through a different path.

Tests cover the release, the AlreadyExists routing through the existing
verify_already_existed_parts, and the rerun convergence. Each was checked to
have a production line whose flip makes it fail.

Two follow-ups, filed rather than folded in. build.rs never charges
MergeMemoryTracker, so the retained-part counter reads zero on this path
whether or not the fix is present, which also bounds how strongly these
tests can assert; and the RSEG fixtures are single-part where the RLOG side
has a multi-part one. Both are #1326.

Refs: #981
