### PR TITLE
fix(iam): scope KMS grant to tenant keys and case-fold the guard

### DIFF
--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -421,7 +421,10 @@ fn no_kms_statement_grants_every_key_in_the_region() {
                     .collect(),
                 _ => continue,
             };
-            if !actions.iter().any(|a| a.starts_with("kms:")) {
+            if !actions
+                .iter()
+                .any(|a| a.to_ascii_lowercase().starts_with("kms:"))
+            {
                 continue;
             }
             let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
@@ -465,7 +468,10 @@ fn every_kms_statement_names_a_key_id() {
                     .collect(),
                 _ => continue,
             };
-            if !actions.iter().any(|a| a.starts_with("kms:")) {
+            if !actions
+                .iter()
+                .any(|a| a.to_ascii_lowercase().starts_with("kms:"))
+            {
                 continue;
             }
             let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
@@ -488,6 +494,73 @@ fn every_kms_statement_names_a_key_id() {
             }
         }
     }
+}
+
+/// Regression fixture for the case-sensitivity fix above: `KMS:Decrypt` (or any
+/// other capitalization) on `"Resource": "*"` is exactly as fully-permissive as
+/// `kms:Decrypt`, and the case-sensitive `starts_with("kms:")` selection both
+/// guards above used to run would silently skip it -- reporting the templates
+/// safe while a fully-permissive statement sat unexamined. This is not a real
+/// shipped template; it is a synthetic statement built to prove the matcher
+/// itself, independent of what `deploy/iam/*.json` currently contains.
+#[test]
+fn mixed_case_kms_action_is_not_a_bypass() {
+    let stmt = serde_json::json!({
+        "Sid": "MixedCaseFullyPermissive",
+        "Effect": "Allow",
+        "Action": "KMS:Decrypt",
+        "Resource": "*"
+    });
+    let actions: Vec<String> = match &stmt["Action"] {
+        serde_json::Value::String(s) => vec![s.clone()],
+        serde_json::Value::Array(a) => a
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
+        _ => vec![],
+    };
+
+    // Observation 1: the pre-fix selection (case-sensitive) misses the
+    // mixed-case action entirely, exactly the hole this test guards against.
+    let selected_before_fix = actions.iter().any(|a| a.starts_with("kms:"));
+    assert!(
+        !selected_before_fix,
+        "fixture invalid: the pre-fix case-sensitive matcher was expected to \
+         miss \"KMS:Decrypt\" -- if it didn't, this fixture no longer proves \
+         the hole existed"
+    );
+
+    // Observation 2: the post-fix selection (lowercased) catches it.
+    let selected_after_fix = actions
+        .iter()
+        .any(|a| a.to_ascii_lowercase().starts_with("kms:"));
+    assert!(
+        selected_after_fix,
+        "fixture invalid: the post-fix matcher should select \"KMS:Decrypt\""
+    );
+
+    // With the statement selected, the real guard's own assertion (resource
+    // != "*" && !resource.ends_with(":key/*")) must now fire on this
+    // fixture's "Resource": "*". Run it through catch_unwind so this test
+    // reports the panic as an assertion result instead of aborting the binary.
+    let resource = stmt["Resource"]
+        .as_str()
+        .expect("Resource is a string")
+        .to_string();
+    let sid = stmt["Sid"].clone();
+    let guard_result = std::panic::catch_unwind(|| {
+        assert!(
+            resource != "*" && !resource.ends_with(":key/*"),
+            "statement {sid:?} grants a kms: action on {resource:?}, which \
+             covers every key in the account/region"
+        );
+    });
+    assert!(
+        guard_result.is_err(),
+        "the guard must reject \"KMS:Decrypt\" on Resource \"*\" once the \
+         statement is selected -- a mixed-case action must not bypass the \
+         no-account-wide-key assertion"
+    );
 }
 
 #[test]

--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -401,6 +401,95 @@ fn every_role_has_kms_decrypt() {
     }
 }
 
+/// Every statement whose `Action` grants any `kms:` action must not name a
+/// `Resource` that covers every key in the account/region: neither the bare
+/// wildcard `"*"` nor any ARN ending `:key/*`. Pinned as a negation (not an
+/// exact tenant-key ARN) so it survives an operator's post-substitution
+/// value. Widen any of the four templates' KMS `Resource` back to
+/// `arn:aws:kms:us-east-1:111122223333:key/*` and this test fails, naming
+/// the role and the statement `Sid`.
+#[test]
+fn no_kms_statement_grants_every_key_in_the_region() {
+    for role in ALL_ROLES {
+        let policy = load_policy(role);
+        for stmt in policy.statements.as_array().unwrap() {
+            let actions: Vec<String> = match &stmt["Action"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect(),
+                _ => continue,
+            };
+            if !actions.iter().any(|a| a.starts_with("kms:")) {
+                continue;
+            }
+            let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
+            let resources: Vec<String> = match &stmt["Resource"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .map(|v| v.as_str().expect("Resource entry is a string").to_string())
+                    .collect(),
+                other => {
+                    panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
+                }
+            };
+            for resource in &resources {
+                assert!(
+                    resource != "*" && !resource.ends_with(":key/*"),
+                    "{role}: statement {sid:?} grants a kms: action on {resource:?}, \
+                     which covers every key in the account/region"
+                );
+            }
+        }
+    }
+}
+
+/// Every statement whose `Action` grants any `kms:` action must name a
+/// `Resource` that pins a specific key id, so an operator cannot re-widen
+/// the grant to every key by substituting `arn:aws:kms:<region>:<account>:key/*`
+/// (or any other bare-wildcard variant) in place of the placeholder.
+#[test]
+fn every_kms_statement_names_a_key_id() {
+    let key_arn_pattern =
+        regex::Regex::new(r"^arn:aws:kms:[^:]+:[^:]+:key/[^*]+$").expect("valid regex");
+    for role in ALL_ROLES {
+        let policy = load_policy(role);
+        for stmt in policy.statements.as_array().unwrap() {
+            let actions: Vec<String> = match &stmt["Action"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect(),
+                _ => continue,
+            };
+            if !actions.iter().any(|a| a.starts_with("kms:")) {
+                continue;
+            }
+            let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
+            let resources: Vec<String> = match &stmt["Resource"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .map(|v| v.as_str().expect("Resource entry is a string").to_string())
+                    .collect(),
+                other => {
+                    panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
+                }
+            };
+            for resource in &resources {
+                assert!(
+                    key_arn_pattern.is_match(resource),
+                    "{role}: statement {sid:?} resource {resource:?} does not name a \
+                     specific key id (expected arn:aws:kms:<region>:<account>:key/<id>)"
+                );
+            }
+        }
+    }
+}
+
 #[test]
 fn discovery_prefix_admitted_for_every_discovering_role() {
     for role in ROLES_WITH_DISCOVERY {

--- a/deploy/iam/admin.json
+++ b/deploy/iam/admin.json
@@ -39,7 +39,7 @@
       "Sid": "AdminTenantKms",
       "Effect": "Allow",
       "Action": "kms:Decrypt",
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/deploy/iam/gateway.json
+++ b/deploy/iam/gateway.json
@@ -48,7 +48,7 @@
       "Sid": "GatewayTenantKms",
       "Effect": "Allow",
       "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/deploy/iam/maintain.json
+++ b/deploy/iam/maintain.json
@@ -58,7 +58,7 @@
       "Sid": "MaintainTenantKms",
       "Effect": "Allow",
       "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/deploy/iam/query.json
+++ b/deploy/iam/query.json
@@ -47,7 +47,7 @@
       "Sid": "QueryTenantKms",
       "Effect": "Allow",
       "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -169,11 +169,21 @@ shipped topology does.
 One policy document per role lives in [`deploy/iam/`](../../../deploy/iam/)
 rather than being transcribed here, so a policy edit is a diff that a test
 checks against the real object-key layout in CI. Replace `my-ravel-bucket` with
-your bucket, and `arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID`
-with your tenant key ARN(s), in each file, then attach each document to the
-principal whose access key that role's deployment uses. An operator who
-attaches a template without substituting the KMS ARN gets `AccessDenied` on
-the first KMS-routed PUT: the placeholder names no real key.
+your bucket in each file, then attach each document to the principal whose
+access key that role's deployment uses.
+
+The KMS statement's `Resource` value is a JSON array, shipped with exactly one
+entry: the placeholder `arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID`.
+That single-entry array is correct as shipped only for a deployment with one
+KMS key. `--tenant-kms-config` routes different tenants to different keys (see
+[Encrypting objects with SSE-KMS](#encrypting-objects-with-sse-kms)), and each
+role's policy must authorize every key its own writes and reads can reach:
+for each key you configure in the tenant-KMS file, add its exact ARN as its own
+entry in that array, rather than replacing the single placeholder with your
+one key and calling it done. A configured tenant key missing from the array
+does not fail at startup: the process starts normally, and the gap surfaces
+only when a request first routes to that key, as `AccessDenied` on that KMS
+call, at runtime rather than at deploy time.
 
 Three facts about those documents are worth knowing before you edit them.
 

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -169,8 +169,11 @@ shipped topology does.
 One policy document per role lives in [`deploy/iam/`](../../../deploy/iam/)
 rather than being transcribed here, so a policy edit is a diff that a test
 checks against the real object-key layout in CI. Replace `my-ravel-bucket` with
-your bucket in each file, then attach each document to the principal whose
-access key that role's deployment uses.
+your bucket, and `arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID`
+with your tenant key ARN(s), in each file, then attach each document to the
+principal whose access key that role's deployment uses. An operator who
+attaches a template without substituting the KMS ARN gets `AccessDenied` on
+the first KMS-routed PUT: the placeholder names no real key.
 
 Three facts about those documents are worth knowing before you edit them.
 
@@ -356,8 +359,10 @@ to narrow.
 }
 ```
 
-The matching role-side statement in each `deploy/iam/*.json` template is scoped
-to the tenant key ARNs rather than to every key:
+The matching role-side statement in each `deploy/iam/*.json` template holds a
+placeholder tenant key ARN that you must replace with your own (see
+[the shipped policy documents](#the-shipped-policy-documents)); scoped to a
+real tenant key rather than to every key:
 
 - Gateway and Maintain write tenant data through the routing store and read some
   of what they write, so they hold encrypt, generate-data-key and decrypt.


### PR DESCRIPTION
All four shipped IAM templates granted their KMS actions on every key in the
account and region, while the configuration guide told the operator those
statements were scoped to the tenant key ARNs. The templates are files the guide
says to attach as-is, so the guide was wrong about what it ships.

That grant is what ADR-0072 relies on for containment: a leaked single-role
credential is supposed to yield ciphertext for other tenants' data. A role that
can decrypt every key removes it.

Each template now names a placeholder tenant key ARN in array form, and the guide
explains that the array takes one entry per configured tenant key rather than one
substitution. It also says what happens when a configured key is missing from the
list, because that failure is invisible at deploy time: the process starts
normally and the gap surfaces as AccessDenied on the first request that routes to
that key.

Two rounds of guard work, because the first was not sound.

The template test could not catch the original defect at all: it validated the KMS
action lists and never read the Resource field, and its two existing helpers strip
an S3 bucket prefix and silently drop every non-S3 ARN, so an assertion built on
either would have passed against the unfixed templates. The new tests read
Resource inline and pin the negation rather than an exact ARN, so they survive an
operator's substitution.

The first version of those tests then had a hole of its own. They selected
statements with a case-sensitive prefix match, but IAM action prefixes are
case-insensitive, so a policy naming KMS:Decrypt on a wildcard resource passed
both guards untouched. That is worse than having no assertion, because the guard
reports that it checked. Both selections are now case-folded.

The regression fixture for that encodes both halves as assertions rather than
claiming them: it asserts the pre-fix case-sensitive matcher misses KMS:Decrypt,
and that the case-folded matcher selects it, so the proof cannot decay into a
sentence in a commit message. A synthetic statement, deliberately not one of the
shipped templates, so it tests the matcher rather than the current contents of
deploy/iam.

The two existing tests asserting that admin has no kms:GenerateDataKey and that
every role has kms:Decrypt still pass unmodified. They are the positive controls
showing the narrowing did not delete the grants.

Refs: #1303
Refs: #1313
