### PR TITLE
docs(scripts): state that the intent script writes comments, not the body

### DIFF
--- a/scripts/epic-status.sh
+++ b/scripts/epic-status.sh
@@ -6,6 +6,14 @@
 # task-branch PRs. This is the pre-dispatch ledger reconciliation from
 # CLAUDE.md as one command.
 #
+# The body is the ONLY source. Comments are not read, and
+# fleet-dispatch-intent.sh records into comments, so a dispatch wrapped in
+# that script is not reconciled here until its task id also appears in the
+# body. The failure is silent in the direction that matters: a task missing
+# from the body cannot be reported as dead, because it is not reported at
+# all. A row count lower than the number of dispatches you remember making
+# is the symptom.
+#
 # Usage: epic-status.sh <epic-issue-number> [--fresh]
 #   --fresh bypasses the cache.
 set -euo pipefail

--- a/scripts/fleet-dispatch-intent.sh
+++ b/scripts/fleet-dispatch-intent.sh
@@ -15,12 +15,24 @@
 #   fleet-dispatch-intent.sh record <epic-issue> <nonce> <task-id>
 #   fleet-dispatch-intent.sh failed <epic-issue> <nonce> [reason...]
 #
+# This script writes COMMENTS. epic-status.sh reads the issue BODY and
+# nothing else, so a task recorded only here is invisible to the
+# reconciliation that exists to catch a silently dead task: it reports
+# nothing wrong because it never saw the task at all. Step 5 below is what
+# closes that, and it is not optional if you rely on epic-status.sh.
+#
 # Flow in the orchestrator turn:
 #   1. sha=$(git fetch origin main -q && git rev-parse origin/main)
 #   2. nonce=$(scripts/fleet-dispatch-intent.sh intent <epic> <ticket> "$sha")
 #   3. call fleet_dispatch with ref=$sha
 #   4a. scripts/fleet-dispatch-intent.sh record <epic> "$nonce" <task-id>
 #   4b. on error: scripts/fleet-dispatch-intent.sh failed <epic> "$nonce" <why>
+#   5. append the task id to the epic BODY's ledger, in the form
+#      `- #<ticket> task=<uuid> <status>`, then re-run
+#      `scripts/epic-status.sh <epic> --fresh` and confirm the id appears
+#      (an in-flight task reads `start=yes result=no`). Any body line
+#      containing the UUID works; epic-status.sh scans the whole body, so a
+#      dedicated section is a convenience, not a requirement.
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Two script headers now state a contract that neither did, and that cost a real reconciliation gap tonight.

`scripts/fleet-dispatch-intent.sh` records into issue **comments**. `scripts/epic-status.sh` reads the issue **body** and nothing else. So a dispatch wrapped correctly in the intent script is invisible to the script whose entire purpose is catching a task that died silently.

The failure is silent in the direction that matters. A task missing from the body is not reported as dead. It is not reported at all, so the reconciliation returns clean and says nothing is wrong.

Found by running `epic-status.sh 1257` with five dispatches outstanding. It listed nine task ids, all written into the body by hand at planning time, and none of the five that had gone through the intent script. Appending them took it from nine rows to fourteen and surfaced the in-flight one as `start=yes result=no`.

Two other sessions running epics on this repo checked their own ledgers after this surfaced; neither was exposed, both because they write task ids straight into the body prose rather than relying on `record`. That is the workaround this change documents, not a reason the gap is theoretical: the next epic that uses `record` as its ledger source hits it.

Changes are comment-only:

- the intent script's flow gains a step 5, appending the task id to the body and verifying with `epic-status.sh --fresh` that it appears, plus a note that any body line containing the UUID works since the scan is whole-body
- `epic-status.sh`'s header says the body is its only source, that the intent script writes comments, and what the symptom looks like: a row count lower than the number of dispatches you remember making

No behaviour change. Verified both scripts still parse (`bash -n`), still exit 64 on their usage paths, and that `epic-status.sh 1257 --fresh` still reconciles, returning fourteen rows against fourteen unique UUIDs in the body.

Refs: #1257
