### PR TITLE
fix(sql,ingest,maintain): resolve duplicate attribute keys last-wins

### DIFF
--- a/crates/ravel-ingest/src/log_declared_stats.rs
+++ b/crates/ravel-ingest/src/log_declared_stats.rs
@@ -19,8 +19,9 @@
 //! row reads NULL for a declared column when the attribute is absent **or its
 //! stored value is not of the declared type**. So the count is kept per
 //! `(name, value kind)`: a declared I64 column's non-null rows are exactly the
-//! rows carrying an I64 value under that name, and a row carrying the same name
-//! as a BOOL (or the row not carrying it at all) is a NULL for the I64 column.
+//! rows whose RESOLVED value under that name is an I64, and a row that resolves
+//! the same name to a BOOL (or does not resolve it at all) is a NULL for the
+//! I64 column.
 //! `null_count = sample_count - non_null` is derived at stamp time, so the
 //! stamp is always internally consistent with the record's own row count and
 //! its own reader never drops it (decision 3, "a flush must never emit a stamp
@@ -37,9 +38,16 @@
 //! from (issue #1057). So each stream's attributes are decoded once, per
 //! stream, and a row that does not set a declared key contributes its stream's
 //! value instead of a NULL.
+//!
+//! Within the record layer, a record that carries one name more than once
+//! resolves it to a single value, and which occurrence wins is fixed by
+//! docs/log-segment-format.md ("Within the record layer"), NOT by the order the
+//! record was written in. [`record_winner`] is this module's implementation of
+//! that rule; the OTLP normalizer does not deduplicate attribute keys, so the
+//! shape is reachable from malformed input (issue #1182).
 
-use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 
 use ravel_catalog::DeclaredColumnType;
 use ravel_logseg::{ColumnarLogBatch, stream_attr_pairs};
@@ -115,20 +123,13 @@ impl<T: Ord + Copy> Running<T> {
 /// count of a declared column of one type is not inflated by same-named values
 /// of the other type (which read NULL for that declaration).
 ///
-/// The two epochs implement first-occurrence-wins within one record: a record
-/// is folded under a fresh epoch, and a kind that has already taken its value
-/// from that record carries the record's epoch. This replaces a per-record
-/// `seen` list scanned once per attribute, so a wide record costs one hash
-/// lookup per attribute rather than a scan over its own attributes.
+/// A record contributes at most one value to at most one of the two, because
+/// its record layer resolves the name to a single winning occurrence
+/// ([`record_winner`]) before anything is folded.
 #[derive(Default, Clone, Copy, Debug)]
 struct ColumnAccum {
     i64: Option<Running<i64>>,
     boolean: Option<Running<bool>>,
-    /// Epoch of the record this column's I64 running value last took a value
-    /// from, or 0 before any (epochs start at 1).
-    i64_epoch: u64,
-    /// The same for the BOOL running value.
-    bool_epoch: u64,
 }
 
 /// A stream-level attribute value of a stamp-eligible kind, as the fallback a
@@ -148,9 +149,6 @@ struct StreamAttrState {
     /// value kind. Those rows read the record's value (or NULL, if its kind
     /// does not match the declaration), never this fallback.
     overrides: u64,
-    /// Epoch of the record this override count last counted, so a record
-    /// repeating the key counts once.
-    epoch: u64,
 }
 
 /// One stream's contribution to the merged view: how many of the buffer's rows
@@ -198,7 +196,6 @@ fn stream_state(blob: &[u8]) -> Option<StreamState> {
                     StreamAttrState {
                         value,
                         overrides: 0,
-                        epoch: 0,
                     },
                 )
             })
@@ -223,10 +220,6 @@ pub(crate) struct DeclaredStatAccum {
     /// eligible stream attribute the buffer's streams carry; on the common
     /// shape (resource attributes are service identity strings) it holds none.
     streams: HashMap<LogStreamId, StreamState>,
-    /// Monotonic per-record counter driving the first-occurrence-wins epochs.
-    /// Starts at 0 and is incremented before each record is folded, so a live
-    /// epoch is never 0.
-    epoch: u64,
     /// Set when a stream's attribute blob did not decode, which leaves the
     /// merged view unknown for that stream's rows. The buffer then stamps
     /// nothing: an affirmative statement over a view this fold could not
@@ -234,58 +227,119 @@ pub(crate) struct DeclaredStatAccum {
     stream_attrs_undecodable: bool,
 }
 
-/// Fold one I64 attribute value of the record being folded under `epoch`.
-fn observe_i64(cols: &mut HashMap<String, ColumnAccum>, epoch: u64, name: &str, v: i64) {
+/// Fold one record's winning I64 value for `name`.
+fn observe_i64(cols: &mut HashMap<String, ColumnAccum>, name: &str, v: i64) {
     match cols.get_mut(name) {
-        Some(col) => {
-            if col.i64_epoch == epoch {
-                return;
-            }
-            col.i64_epoch = epoch;
-            match &mut col.i64 {
-                Some(run) => run.observe(v),
-                slot @ None => *slot = Some(Running::start(v)),
-            }
-        }
+        Some(col) => match &mut col.i64 {
+            Some(run) => run.observe(v),
+            slot @ None => *slot = Some(Running::start(v)),
+        },
         None => {
             cols.insert(
                 name.to_string(),
                 ColumnAccum {
                     i64: Some(Running::start(v)),
                     boolean: None,
-                    i64_epoch: epoch,
-                    bool_epoch: 0,
                 },
             );
         }
     }
 }
 
-/// Fold one BOOL attribute value of the record being folded under `epoch`.
-fn observe_bool(cols: &mut HashMap<String, ColumnAccum>, epoch: u64, name: &str, b: bool) {
+/// Fold one record's winning BOOL value for `name`.
+fn observe_bool(cols: &mut HashMap<String, ColumnAccum>, name: &str, b: bool) {
     match cols.get_mut(name) {
-        Some(col) => {
-            if col.bool_epoch == epoch {
-                return;
-            }
-            col.bool_epoch = epoch;
-            match &mut col.boolean {
-                Some(run) => run.observe(b),
-                slot @ None => *slot = Some(Running::start(b)),
-            }
-        }
+        Some(col) => match &mut col.boolean {
+            Some(run) => run.observe(b),
+            slot @ None => *slot = Some(Running::start(b)),
+        },
         None => {
             cols.insert(
                 name.to_string(),
                 ColumnAccum {
                     i64: None,
                     boolean: Some(Running::start(b)),
-                    i64_epoch: 0,
-                    bool_epoch: epoch,
                 },
             );
         }
     }
+}
+
+/// The batch's attribute names whose per-row winner is not simply "the column's
+/// cell": a name split across two typed dynamic columns, or one some row
+/// repeated so its later occurrences went to `residual_attrs` (which the writer
+/// folds into `attrs_raw`). Every other name has exactly one occurrence per
+/// record and folds column-at-a-time.
+fn contested_names(batch: &ColumnarLogBatch) -> HashSet<&str> {
+    let mut seen: HashSet<&str> = HashSet::with_capacity(batch.dyn_columns.len());
+    let mut contested: HashSet<&str> = HashSet::new();
+    for col in &batch.dyn_columns {
+        if !seen.insert(col.name.as_str()) {
+            contested.insert(col.name.as_str());
+        }
+    }
+    // Empty for almost every row, so this is a walk over `num_rows` with no
+    // inner work on the shape a well-formed producer emits.
+    for extra in &batch.residual_attrs {
+        for (name, _) in extra {
+            contested.insert(name.as_str());
+        }
+    }
+    contested
+}
+
+/// The record layer's winning occurrence of `name` among a record's own
+/// attributes, or `None` when the record does not carry the name.
+///
+/// docs/log-segment-format.md ("Within the record layer") fixes which
+/// occurrence a reader resolves when a record carries one name more than once,
+/// and it is NOT the order the record was written in: the on-disk format does
+/// not preserve that order. It is the order `rebuild_record` reconstructs, which
+/// restricted to one name is the record's columnar occurrences ascending by
+/// FIELD_DIR type byte, then its `attrs_raw` overflow occurrences ascending by
+/// canonical encoded value bytes, last entry wins. So the overflow tier beats
+/// every columnar occurrence, and within a tier the last occurrence of the
+/// maximum key wins. This is the same reduction `RlogWriter`'s `StampScratch`
+/// performs for POSTINGS and the SKIP_IDX numeric stats.
+///
+/// The tier split is the writer's: the first occurrence of each distinct
+/// `(name, type)` takes the dynamic column slot and every later one folds into
+/// `attrs_raw`. The one thing this fold cannot know is the writer's
+/// dynamic-column budget, which the flush resolves later: a name that overflows
+/// the 1000-column cap has ALL its occurrences in `attrs_raw`, and this reads
+/// its first occurrence per type as columnar. That case needs a thousand
+/// distinct dynamic columns in one flush AND a repeated key on the overflowing
+/// name; every in-budget object, which is every object in practice, resolves
+/// exactly as the reader does.
+fn record_winner<'a>(attrs: &'a [(String, AttrValue)], name: &str) -> Option<&'a AttrValue> {
+    // Type bytes that have already taken a columnar slot on this record.
+    let mut columnar_types: u32 = 0;
+    let mut columnar: Option<(u8, &'a AttrValue)> = None;
+    let mut overflow: Option<(Vec<u8>, &'a AttrValue)> = None;
+    for (k, value) in attrs {
+        if k != name {
+            continue;
+        }
+        let ty = ravel_logseg::record::resolve_value(value).0.to_u8();
+        let bit = 1u32 << ty;
+        if columnar_types & bit == 0 {
+            columnar_types |= bit;
+            if columnar.is_none_or(|(incumbent, _)| ty >= incumbent) {
+                columnar = Some((ty, value));
+            }
+        } else {
+            let encoded = ravel_logseg::record::canonical_value_bytes(value);
+            if overflow
+                .as_ref()
+                .is_none_or(|(incumbent, _)| encoded >= *incumbent)
+            {
+                overflow = Some((encoded, value));
+            }
+        }
+    }
+    overflow
+        .map(|(_, value)| value)
+        .or(columnar.map(|(_, value)| value))
 }
 
 impl DeclaredStatAccum {
@@ -311,8 +365,6 @@ impl DeclaredStatAccum {
                             non_null: count,
                         }),
                         boolean: None,
-                        i64_epoch: 0,
-                        bool_epoch: 0,
                     },
                 );
             }
@@ -341,8 +393,6 @@ impl DeclaredStatAccum {
                             max,
                             non_null: count,
                         }),
-                        i64_epoch: 0,
-                        bool_epoch: 0,
                     },
                 );
             }
@@ -350,11 +400,11 @@ impl DeclaredStatAccum {
     }
 
     /// Fold a row-major write's records into the accumulator. Each record
-    /// contributes at most one non-null row per `(name, kind)`: a record that
-    /// repeats an attribute key with the same value kind counts once (the first
-    /// occurrence, matching the writer's first-occurrence-wins column slot), so
-    /// no column's non-null count can exceed the buffer's row count and the
-    /// derived `null_count` can never go negative.
+    /// contributes at most one non-null row per name: its record layer resolves
+    /// the name to ONE winning occurrence ([`record_winner`]), and that winner
+    /// is non-null for a declaration only when its kind matches. So no column's
+    /// non-null count can exceed the buffer's row count and the derived
+    /// `null_count` can never go negative.
     ///
     /// The record's own attributes are folded here; the stream-level half of
     /// the merged view is folded in [`Self::build_stamps`], from the per-stream
@@ -362,15 +412,25 @@ impl DeclaredStatAccum {
     /// what this records in [`StreamAttrState::overrides`]. Deferring it is
     /// what lets the fold stay O(1) per attribute without knowing the declared
     /// set, which the flush only resolves from the tenant config later.
+    ///
+    /// Cost is one hash entry per record attribute plus one pass over the
+    /// record's distinct names. A record carrying a name twice pays one extra
+    /// scan of its own attribute list per repeated name, which is the shape the
+    /// OTLP normalizer only produces from malformed input.
     pub(crate) fn observe_records(&mut self, records: &[NormalizedLogRecord]) {
         let Self {
             cols,
             streams,
-            epoch,
             stream_attrs_undecodable,
         } = self;
+        // The record being folded, reduced to one entry per distinct name.
+        // Declared outside the loop so a buffered write pays one allocation
+        // rather than one per record; `repeated` names the entries whose value
+        // here is provisional because the record carries the name more than
+        // once.
+        let mut distinct: HashMap<&str, &AttrValue> = HashMap::new();
+        let mut repeated: Vec<&str> = Vec::new();
         for rec in records {
-            *epoch += 1;
             let stream = match streams.entry(rec.stream_id) {
                 Entry::Occupied(slot) => slot.into_mut(),
                 Entry::Vacant(slot) => match stream_state(&rec.stream_attrs) {
@@ -382,33 +442,65 @@ impl DeclaredStatAccum {
                 },
             };
             stream.rows += 1;
+            distinct.clear();
+            repeated.clear();
             for (name, value) in &rec.attrs {
+                match distinct.entry(name.as_str()) {
+                    Entry::Vacant(slot) => {
+                        slot.insert(value);
+                    }
+                    Entry::Occupied(_) => {
+                        if !repeated.contains(&name.as_str()) {
+                            repeated.push(name.as_str());
+                        }
+                    }
+                }
+            }
+            for (name, value) in distinct.iter() {
                 // A record that sets the key at ANY value kind overrides its
-                // stream's attribute of the same name, the reader's
-                // `record_sets_key` rule: a wrong-typed record value reads NULL
-                // for the declaration rather than falling back.
-                if let Some(attr) = stream.attrs.get_mut(name.as_str())
-                    && attr.epoch != *epoch
-                {
-                    attr.epoch = *epoch;
+                // stream's attribute of the same name: a record value whose kind
+                // does not match the declaration reads NULL for it rather than
+                // falling back.
+                if let Some(attr) = stream.attrs.get_mut(*name) {
                     attr.overrides += 1;
                 }
-                match value {
-                    AttrValue::I64(v) => observe_i64(cols, *epoch, name, *v),
-                    AttrValue::Bool(b) => observe_bool(cols, *epoch, name, *b),
+                let winner = if repeated.contains(name) {
+                    match record_winner(&rec.attrs, name) {
+                        Some(winner) => winner,
+                        None => continue,
+                    }
+                } else {
+                    *value
+                };
+                match winner {
+                    AttrValue::I64(v) => observe_i64(cols, name, *v),
+                    AttrValue::Bool(b) => observe_bool(cols, name, *b),
                     _ => {}
                 }
             }
         }
     }
 
-    /// Fold one columnar batch into the accumulator. A dynamic column holds one
-    /// dense value per present row (the batch already applied the row path's
-    /// first-occurrence-wins rule, so its `cells.len()` is the column's non-null
-    /// row count), which lets each column be folded in a single pass.
+    /// Fold one columnar batch into the accumulator.
+    ///
+    /// An UNCONTESTED name -- one the batch carries in exactly one dynamic
+    /// column and in no row's `residual_attrs` -- has one occurrence per record
+    /// by construction, so that column's cells are already its records' winning
+    /// values and the whole column folds in a single pass.
+    ///
+    /// A CONTESTED name (a name split across two typed columns, or repeated
+    /// within a record so its later occurrences landed in `residual_attrs`,
+    /// which the writer folds into `attrs_raw`) has to be resolved per row under
+    /// the record layer's last-occurrence-wins order, exactly as
+    /// [`record_winner`] does for the row-major path. That is
+    /// [`Self::observe_batch_contested`].
     pub(crate) fn observe_batch(&mut self, batch: &ColumnarLogBatch) {
         self.observe_batch_streams(batch);
+        let contested = contested_names(batch);
         for col in &batch.dyn_columns {
+            if contested.contains(col.name.as_str()) {
+                continue;
+            }
             match col.cells.first() {
                 Some(AttrValue::I64(_)) => {
                     let mut min = i64::MAX;
@@ -451,7 +543,84 @@ impl DeclaredStatAccum {
                 _ => {}
             }
         }
+        self.observe_batch_contested(batch, &contested);
         self.observe_batch_overrides(batch);
+    }
+
+    /// Fold the batch's contested names (see [`Self::observe_batch`]) row by
+    /// row, each row contributing only its record layer's winning occurrence.
+    ///
+    /// The order is the one docs/log-segment-format.md pins: a row's
+    /// `residual_attrs` entries are the occurrences the writer folds into
+    /// `attrs_raw`, so they beat every column of the same name, and the greatest
+    /// canonical encoding wins among them; otherwise the present column with the
+    /// highest [`FieldType`] byte wins.
+    fn observe_batch_contested(&mut self, batch: &ColumnarLogBatch, contested: &HashSet<&str>) {
+        for name in contested {
+            let cols: Vec<&ravel_logseg::DynColumn> = batch
+                .dyn_columns
+                .iter()
+                .filter(|c| c.name == *name)
+                .collect();
+            // How many present cells of each column have been passed, so row
+            // `row`'s cell is `cells[ranks[i]]` when the column is present there.
+            let mut ranks = vec![0usize; cols.len()];
+            let mut i64_run: Option<Running<i64>> = None;
+            let mut bool_run: Option<Running<bool>> = None;
+            for row in 0..batch.num_rows {
+                let mut best: Option<(u8, &AttrValue)> = None;
+                for (i, col) in cols.iter().enumerate() {
+                    if !col.validity.get(row) {
+                        continue;
+                    }
+                    let cell = col.cells.get(ranks[i]);
+                    ranks[i] += 1;
+                    let Some(cell) = cell else {
+                        continue;
+                    };
+                    let ty = col.field_type.to_u8();
+                    if best.is_none_or(|(incumbent, _)| ty >= incumbent) {
+                        best = Some((ty, cell));
+                    }
+                }
+                let mut overflow: Option<(Vec<u8>, &AttrValue)> = None;
+                if let Some(extra) = batch.residual_attrs.get(row) {
+                    for (k, value) in extra {
+                        if k != name {
+                            continue;
+                        }
+                        let encoded = ravel_logseg::record::canonical_value_bytes(value);
+                        if overflow
+                            .as_ref()
+                            .is_none_or(|(incumbent, _)| encoded >= *incumbent)
+                        {
+                            overflow = Some((encoded, value));
+                        }
+                    }
+                }
+                let winner = match overflow.as_ref().map(|(_, value)| *value) {
+                    Some(value) => Some(value),
+                    None => best.map(|(_, value)| value),
+                };
+                match winner {
+                    Some(AttrValue::I64(v)) => match &mut i64_run {
+                        Some(run) => run.observe(*v),
+                        slot @ None => *slot = Some(Running::start(*v)),
+                    },
+                    Some(AttrValue::Bool(b)) => match &mut bool_run {
+                        Some(run) => run.observe(*b),
+                        slot @ None => *slot = Some(Running::start(*b)),
+                    },
+                    _ => {}
+                }
+            }
+            if let Some(run) = i64_run {
+                self.merge_i64(name, run.min, run.max, run.non_null);
+            }
+            if let Some(run) = bool_run {
+                self.merge_bool(name, run.min, run.max, run.non_null);
+            }
+        }
     }
 
     /// The stream-level half of a columnar batch: each distinct stream's blob
@@ -863,7 +1032,13 @@ mod tests {
     fn repeated_attribute_in_one_record_counts_once() {
         // A record repeating the same I64 attribute must not push non_null past
         // the row count (which would make null_count go negative and the stamp
-        // self-drop). First occurrence wins the value.
+        // self-drop).
+        //
+        // Which of the two the row counts is the reader's answer, not the
+        // record's write order: the first `(EventDate, i64)` occurrence takes
+        // the dynamic column slot and the second folds into `attrs_raw`, and the
+        // `attrs_raw` tier beats every columnar occurrence, so `rebuild_record`
+        // plus `merged_attrs` resolve 99 (issue #1182).
         let mut acc = DeclaredStatAccum::default();
         acc.observe_records(&[rec(vec![
             ("EventDate", AttrValue::I64(7)),
@@ -871,8 +1046,8 @@ mod tests {
         ])]);
         let stamps = acc.build_stamps(&[i64_col("EventDate")], 1);
         let s = stat(&stamps, "EventDate").expect("stamped");
-        assert_eq!(s.min(), Some(DeclaredStatValue::I64(7)));
-        assert_eq!(s.max(), Some(DeclaredStatValue::I64(7)));
+        assert_eq!(s.min(), Some(DeclaredStatValue::I64(99)));
+        assert_eq!(s.max(), Some(DeclaredStatValue::I64(99)));
         assert_eq!(s.null_count(), 0);
     }
 
@@ -1046,6 +1221,166 @@ mod tests {
         assert_eq!(row[0].min(), s.min());
         assert_eq!(row[0].max(), s.max());
         assert_eq!(row[0].null_count(), s.null_count());
+    }
+
+    /// Issue #1182, consumer 3: this fold must resolve a record that carries one
+    /// attribute name more than once to the SAME value the readers do.
+    ///
+    /// The record table and the resolved values are the ones
+    /// `ravel_sql::logs_scan::columnar_lookup_tests::a_duplicate_key_resolves_last_occurrence_wins_on_both_reader_paths`
+    /// pins for the two reader paths, and
+    /// `ravel_maintain::rlog::tests::duplicate_key_stamp_follows_the_readers_rule`
+    /// pins for the compaction recompute:
+    ///
+    /// | record's own attributes             | resolved `k`  |
+    /// |-------------------------------------|---------------|
+    /// | `I64(5)` then `Str("x")`            | `I64(5)`      |
+    /// | `Str("x")` then `I64(5)`            | `I64(5)`      |
+    /// | `Bool(true)` then `I64(9)`          | `Bool(true)`  |
+    /// | `I64(1)` then `Bytes([0xab])`       | `Bytes(..)`   |
+    /// | `Str("y")`                          | `Str("y")`    |
+    ///
+    /// So a declared I64 `k` is non-null on exactly the first two rows and a
+    /// declared BOOL `k` on exactly the third, whatever order each record wrote
+    /// its occurrences in. Both fold entry points are driven, because a batch
+    /// ingested column-major must not stamp a different statement than the same
+    /// records ingested row-major.
+    ///
+    /// Prove-the-test, both halves separately. Folding every occurrence's own
+    /// value in `observe_records` (the base's first-occurrence-per-(name, kind)
+    /// rule: iterate `rec.attrs` instead of the distinct names and drop the
+    /// `record_winner` lookup) makes the row-major I64 stamp read min 1, max 9,
+    /// null_count 1 -- rows 3 and 4 claim the 9 and the 1 that the Bool and the
+    /// Bytes occurrence shadow -- and the first assertion fails with
+    /// `left: Some(I64(1))`. Dropping the `contested_names` skip and the
+    /// `observe_batch_contested` call from `observe_batch` fails the columnar
+    /// half the same way.
+    #[test]
+    fn duplicate_key_stamp_follows_the_readers_rule() {
+        use ravel_logseg::LogRecord;
+
+        let stream = blob(&[], &[]);
+        let records = vec![
+            rec_in(
+                1,
+                &stream,
+                vec![
+                    ("k", AttrValue::I64(5)),
+                    ("k", AttrValue::Str("x".to_string())),
+                ],
+            ),
+            rec_in(
+                1,
+                &stream,
+                vec![
+                    ("k", AttrValue::Str("x".to_string())),
+                    ("k", AttrValue::I64(5)),
+                ],
+            ),
+            rec_in(
+                1,
+                &stream,
+                vec![("k", AttrValue::Bool(true)), ("k", AttrValue::I64(9))],
+            ),
+            rec_in(
+                1,
+                &stream,
+                vec![
+                    ("k", AttrValue::I64(1)),
+                    ("k", AttrValue::Bytes(vec![0xab])),
+                ],
+            ),
+            rec_in(1, &stream, vec![("k", AttrValue::Str("y".to_string()))]),
+        ];
+        let declared = vec![i64_col("k"), bool_col("k")];
+
+        let check = |stamps: &[DeclaredColumnStat], what: &str| {
+            // `build_stamps` emits one stat per declared entry, so the two
+            // declarations of `k` are told apart by their stat type.
+            let i64_stat = stamps
+                .iter()
+                .find(|s| s.declared_type() == DeclaredStatType::I64)
+                .unwrap_or_else(|| panic!("{what}: I64 stamp"));
+            assert_eq!(
+                i64_stat.min(),
+                Some(DeclaredStatValue::I64(5)),
+                "{what}: I64 min is the two rows resolving to 5, not the shadowed 1"
+            );
+            assert_eq!(
+                i64_stat.max(),
+                Some(DeclaredStatValue::I64(5)),
+                "{what}: I64 max is the two rows resolving to 5, not the shadowed 9"
+            );
+            assert_eq!(
+                i64_stat.null_count(),
+                3,
+                "{what}: the Bool, Bytes and Str winners are NULL for a declared I64"
+            );
+            let bool_stat = stamps
+                .iter()
+                .find(|s| s.declared_type() == DeclaredStatType::Bool)
+                .unwrap_or_else(|| panic!("{what}: BOOL stamp"));
+            assert_eq!(bool_stat.min(), Some(DeclaredStatValue::Bool(true)));
+            assert_eq!(bool_stat.max(), Some(DeclaredStatValue::Bool(true)));
+            assert_eq!(
+                bool_stat.null_count(),
+                4,
+                "{what}: only the record whose winner is a Bool is non-null"
+            );
+        };
+
+        let mut row = DeclaredStatAccum::default();
+        row.observe_records(&records);
+        check(&row.build_stamps(&declared, 5), "row-major fold");
+
+        let to_logrecord = |r: &NormalizedLogRecord| LogRecord {
+            stream_id: r.stream_id,
+            stream_attrs: r.stream_attrs.clone(),
+            ts_ns: r.ts_ns,
+            observed_ts_ns: r.observed_ts_ns,
+            severity_num: r.severity_num,
+            severity_text: r.severity_text.clone(),
+            body: r.body.clone(),
+            trace_id: None,
+            span_id: None,
+            flags: r.flags,
+            attrs: r.attrs.clone(),
+        };
+        let batch =
+            ColumnarLogBatch::from_records(&records.iter().map(to_logrecord).collect::<Vec<_>>());
+        let mut columnar = DeclaredStatAccum::default();
+        columnar.observe_batch(&batch);
+        check(&columnar.build_stamps(&declared, 5), "columnar fold");
+    }
+
+    /// The `attrs_raw` tier of the same rule: a record repeating one name at ONE
+    /// type puts every occurrence past the first into `attrs_raw`, and that tier
+    /// beats the columnar occurrence outright, with the greatest canonical
+    /// encoding winning inside it. So the value the row resolves is neither the
+    /// first occurrence nor the largest.
+    ///
+    /// Prove-the-test: return `columnar` before consulting `overflow` in
+    /// `record_winner` and the stamp reads 7 (the first occurrence, the base's
+    /// answer) instead of 2.
+    #[test]
+    fn an_overflowing_duplicate_beats_the_columnar_occurrence() {
+        // `I64(7)` takes the `(k, i64)` column and `I64(-1)`, `I64(2)` fold into
+        // `attrs_raw`. The frozen canonical encoding of an i64 is the tag byte 2
+        // followed by the LEB128 zigzag, so `I64(-1)` encodes as `.. 02 01` and
+        // `I64(2)` as `.. 02 04`: 2 is the greater canonical key of the two
+        // overflow occurrences and wins the row. Neither the first occurrence
+        // nor the largest integer.
+        let mut acc = DeclaredStatAccum::default();
+        acc.observe_records(&[rec(vec![
+            ("k", AttrValue::I64(7)),
+            ("k", AttrValue::I64(-1)),
+            ("k", AttrValue::I64(2)),
+        ])]);
+        let stamps = acc.build_stamps(&[i64_col("k")], 1);
+        let s = stat(&stamps, "k").expect("stamped");
+        assert_eq!(s.min(), Some(DeclaredStatValue::I64(2)));
+        assert_eq!(s.max(), Some(DeclaredStatValue::I64(2)));
+        assert_eq!(s.null_count(), 0, "one record, one non-null row");
     }
 
     /// Issue #1057 finding 1: a stream whose RESOURCE attributes carry the

--- a/crates/ravel-ingest/src/log_declared_stats.rs
+++ b/crates/ravel-ingest/src/log_declared_stats.rs
@@ -1383,6 +1383,60 @@ mod tests {
         assert_eq!(s.null_count(), 0, "one record, one non-null row");
     }
 
+    /// The same `attrs_raw` tier through the COLUMNAR fold rather than the
+    /// row-major one. Both paths must resolve the row identically, and the
+    /// columnar path reaches the overflow tier through different code.
+    ///
+    /// Repeating one name at ONE type is what makes this reach it: a single
+    /// `(k, i64)` column slot exists, so the column scan alone never sees a
+    /// repeat and the name is marked contested only by the `residual_attrs`
+    /// walk. The sibling test above repeats `k` at two DISTINCT types, which
+    /// the multi-column rule catches on its own, so it does not exercise
+    /// either overflow block.
+    ///
+    /// Prove-the-test, both blocks this covers and nothing else does:
+    /// delete the `residual_attrs` loop in `contested_names` and `k` is never
+    /// contested, so the fold takes the first occurrence and stamps 7; or
+    /// delete the `overflow` scan in `observe_batch_contested` and the
+    /// columnar occurrence wins, also stamping 7. Either way this reads 7
+    /// where the reader resolves 2.
+    #[test]
+    fn the_columnar_fold_also_lets_an_overflowing_duplicate_win() {
+        use ravel_logseg::LogRecord;
+        let records = [rec(vec![
+            ("k", AttrValue::I64(7)),
+            ("k", AttrValue::I64(-1)),
+            ("k", AttrValue::I64(2)),
+        ])];
+        let to_logrecord = |r: &NormalizedLogRecord| LogRecord {
+            stream_id: r.stream_id,
+            stream_attrs: r.stream_attrs.clone(),
+            ts_ns: r.ts_ns,
+            observed_ts_ns: r.observed_ts_ns,
+            severity_num: r.severity_num,
+            severity_text: r.severity_text.clone(),
+            body: r.body.clone(),
+            trace_id: None,
+            span_id: None,
+            flags: r.flags,
+            attrs: r.attrs.clone(),
+        };
+        let batch =
+            ColumnarLogBatch::from_records(&records.iter().map(to_logrecord).collect::<Vec<_>>());
+        let mut columnar = DeclaredStatAccum::default();
+        columnar.observe_batch(&batch);
+        let stamps = columnar.build_stamps(&[i64_col("k")], 1);
+        let s = stat(&stamps, "k").expect("stamped");
+        assert_eq!(
+            s.min(),
+            Some(DeclaredStatValue::I64(2)),
+            "greatest canonical encoding wins, not the first occurrence (7) \
+             and not the largest integer (7)"
+        );
+        assert_eq!(s.max(), Some(DeclaredStatValue::I64(2)));
+        assert_eq!(s.null_count(), 0, "one record, one non-null row");
+    }
+
     /// Issue #1057 finding 1: a stream whose RESOURCE attributes carry the
     /// declared key as a List and whose SCOPE attributes carry it as a
     /// matching-typed I64 must fall back to the scope value, exactly what the

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -1141,9 +1141,26 @@ struct ColumnAccum {
     /// kind. A record that sets the key overrides its stream's attribute of the
     /// same name, so this suppresses the fallback for that record.
     mention_epoch: u64,
-    /// The epoch of the record this column last took a matching-typed value
-    /// from: first-occurrence-wins within one record.
-    value_epoch: u64,
+    /// The record layer's winner for this column within the record being folded:
+    /// the LAST occurrence of the declared name in [`LogRecord::attrs`],
+    /// whatever its kind. Read only while the column is in
+    /// [`DeclaredStatAccum::touched`], so a value left from an earlier record is
+    /// never folded twice.
+    pending: Option<PendingValue>,
+}
+
+/// One record-layer occurrence of a declared name, reduced to what the stamp
+/// needs: the value when its kind is one a declared column can be stamped at,
+/// and otherwise only the fact that an occurrence exists. A `Str`, `Bytes`,
+/// `F64`, `List` or `Map` occurrence wins the record layer exactly like any
+/// other and then reads NULL for either declarable type, so it is kept as
+/// [`PendingValue::Other`] rather than dropped: dropping it would let a
+/// shadowed same-named I64 or BOOL occurrence claim the row.
+#[derive(Clone, Copy, Debug)]
+enum PendingValue {
+    I64(i64),
+    Bool(bool),
+    Other,
 }
 
 /// The declared eligible columns a compaction output stamps, indexed for the
@@ -1249,7 +1266,8 @@ impl DeclaredSchema {
 /// The per-part fold of declared-column extrema for the compaction output
 /// (ADR-0873 decision 3, the L1 half of wave 5). It mirrors the ingest-side
 /// wave-5a accumulator (`ravel_ingest`'s `DeclaredStatAccum`): eligible I64/BOOL
-/// declared columns only, first-occurrence-wins per record, and a stamp whose
+/// declared columns only, last-occurrence-wins per record (issue #1182), and a
+/// stamp whose
 /// `null_count` is derived as `sample_count - non_null` so the part's own reader
 /// ([`ravel_commit::declared_stats::read_compaction_part`]) never drops it.
 ///
@@ -1277,9 +1295,13 @@ struct DeclaredStatAccum {
     schema: Arc<DeclaredSchema>,
     /// Running extrema, positionally aligned with `schema.cols`.
     cols: Vec<ColumnAccum>,
-    /// Monotonic per-record counter driving the first-occurrence-wins and
-    /// override epochs. Incremented before each record, so a live epoch is
-    /// never 0.
+    /// Indices into `cols` the record being folded mentions, so the pass that
+    /// folds each column's winner costs one step per mention rather than one per
+    /// declared column. Reused across records; cleared as each record's winners
+    /// are folded.
+    touched: Vec<usize>,
+    /// Monotonic per-record counter driving the override epochs. Incremented
+    /// before each record, so a live epoch is never 0.
     epoch: u64,
 }
 
@@ -1294,25 +1316,36 @@ impl DeclaredStatAccum {
         DeclaredStatAccum {
             schema,
             cols,
+            touched: Vec::new(),
             epoch: 0,
         }
     }
 
     /// Fold one record's merged attribute view. Each declared column takes at
-    /// most one non-null row from the record: the first attribute matching its
-    /// name AND its declared value kind wins, and a repeat (or a same-named
-    /// value of the other kind, or an absence with no stream-level value) is a
-    /// NULL for the declaration, so no column's non-null count can exceed the
-    /// part's row count and the derived `null_count` can never go negative.
+    /// most one non-null row from the record: the record layer's single winning
+    /// occurrence of the declared name, which is non-null only when its kind
+    /// matches the declaration. A shadowed occurrence, a winner of the other
+    /// kind, and an absence with no stream-level value are all NULL for the
+    /// declaration, so no column's non-null count can exceed the part's row
+    /// count and the derived `null_count` can never go negative.
+    ///
+    /// Which occurrence wins is LAST-occurrence-wins over
+    /// [`LogRecord::attrs`], the rule docs/log-segment-format.md pins ("Within
+    /// the record layer") and `ravel_sql::rlog_attrs::merged_attrs` implements.
+    /// The list this reads is the one `rebuild_record` produced for the input
+    /// object, so its order already IS the format's resolution order (columnar
+    /// occurrences ascending by FIELD_DIR type byte, then the `attrs_raw`
+    /// overflow occurrences in canonical order): folding it last-wins is the
+    /// reader's answer, not an approximation of it.
     ///
     /// A column the record does not name at all takes its stream's resource or
     /// scope value, when the stream supplies one of the declared kind. A record
     /// that names the column at ANY value kind suppresses that fallback, which
     /// is the reader's override order.
     ///
-    /// Cost is one hash lookup per record attribute plus one pass over the
-    /// record's stream's fallback list, with no String comparison per
-    /// (attribute, column) pair.
+    /// Cost is one hash lookup per record attribute, one pass over the columns
+    /// this record mentions, and one pass over the record's stream's fallback
+    /// list, with no String comparison per (attribute, column) pair.
     fn observe_record(&mut self, r: &LogRecord) {
         if self.cols.is_empty() {
             return;
@@ -1320,9 +1353,11 @@ impl DeclaredStatAccum {
         let Self {
             schema,
             cols,
+            touched,
             epoch,
         } = self;
         *epoch += 1;
+        touched.clear();
         for (name, value) in &r.attrs {
             let Some(&i) = schema.index.get(name.as_str()) else {
                 continue;
@@ -1330,25 +1365,32 @@ impl DeclaredStatAccum {
             let Some(c) = cols.get_mut(i) else {
                 continue;
             };
-            c.mention_epoch = *epoch;
-            if c.value_epoch == *epoch {
-                continue;
+            if c.mention_epoch != *epoch {
+                c.mention_epoch = *epoch;
+                touched.push(i);
             }
-            match (schema.cols[i].1, value) {
-                (DeclaredStatType::I64, AttrValue::I64(v)) => {
-                    match &mut c.i64_run {
-                        Some(run) => run.observe(*v),
-                        None => c.i64_run = Some(Running::start(*v)),
-                    }
-                    c.value_epoch = *epoch;
-                }
-                (DeclaredStatType::Bool, AttrValue::Bool(b)) => {
-                    match &mut c.bool_run {
-                        Some(run) => run.observe(*b),
-                        None => c.bool_run = Some(Running::start(*b)),
-                    }
-                    c.value_epoch = *epoch;
-                }
+            // Last occurrence wins: overwrite whatever an earlier occurrence of
+            // the same name left here.
+            c.pending = Some(match value {
+                AttrValue::I64(v) => PendingValue::I64(*v),
+                AttrValue::Bool(b) => PendingValue::Bool(*b),
+                _ => PendingValue::Other,
+            });
+        }
+        for &i in touched.iter() {
+            let Some(c) = cols.get_mut(i) else {
+                continue;
+            };
+            let winner = c.pending.take();
+            match (schema.cols[i].1, winner) {
+                (DeclaredStatType::I64, Some(PendingValue::I64(v))) => match &mut c.i64_run {
+                    Some(run) => run.observe(v),
+                    None => c.i64_run = Some(Running::start(v)),
+                },
+                (DeclaredStatType::Bool, Some(PendingValue::Bool(b))) => match &mut c.bool_run {
+                    Some(run) => run.observe(b),
+                    None => c.bool_run = Some(Running::start(b)),
+                },
                 _ => {}
             }
         }
@@ -3222,6 +3264,141 @@ mod tests {
             .await
             .expect("put commit");
         bytes
+    }
+
+    /// Issue #1182, consumer 4: the compaction recompute must resolve a record
+    /// that carries one attribute name more than once to the SAME value the
+    /// readers do.
+    ///
+    /// The record table and the resolved values are the ones
+    /// `ravel_sql::logs_scan::columnar_lookup_tests::a_duplicate_key_resolves_last_occurrence_wins_on_both_reader_paths`
+    /// pins for the two reader paths and
+    /// `ravel_ingest::log_declared_stats::tests::duplicate_key_stamp_follows_the_readers_rule`
+    /// pins for the ingest fold:
+    ///
+    /// | record's own attributes         | resolved `k`  |
+    /// |---------------------------------|---------------|
+    /// | `I64(5)` then `Str("x")`        | `I64(5)`      |
+    /// | `Str("x")` then `I64(5)`        | `I64(5)`      |
+    /// | `Bool(true)` then `I64(9)`      | `Bool(true)`  |
+    /// | `I64(1)` then `Bytes([0xab])`   | `Bytes(..)`   |
+    /// | `Str("y")`                      | `Str("y")`    |
+    ///
+    /// The records are written with the real `RlogWriter` and read back with the
+    /// real `RlogReader`, so the attribute list the fold sees is the one
+    /// `rebuild_record` produces for a compaction input, in the order
+    /// docs/log-segment-format.md pins. Nothing here hand-orders the
+    /// occurrences: the writer and reader do, and last-occurrence-wins over
+    /// that list is `merged_attrs`'s answer verbatim.
+    ///
+    /// Prove-the-test: restore the base's first-occurrence-of-the-declared-kind
+    /// rule in `observe_record` -- keep the first `pending` a record sets at a
+    /// declarable kind instead of letting a later occurrence overwrite it -- and
+    /// the I64 stamp reads min 1, max 9, null_count 1: the third and fourth rows
+    /// claim the 9 and the 1 that the Bool and the Bytes occurrence shadow, and
+    /// the first assertion below fails with `left: Some(I64(1))`.
+    #[test]
+    fn duplicate_key_stamp_follows_the_readers_rule() {
+        let cfg = RlogConfig::default();
+        let dup = |ts: i64, attrs: Vec<(String, AttrValue)>| record(1, ts, "b", attrs);
+        let written = vec![
+            dup(
+                100,
+                vec![
+                    ("k".to_string(), AttrValue::I64(5)),
+                    ("k".to_string(), AttrValue::Str("x".into())),
+                ],
+            ),
+            dup(
+                101,
+                vec![
+                    ("k".to_string(), AttrValue::Str("x".into())),
+                    ("k".to_string(), AttrValue::I64(5)),
+                ],
+            ),
+            dup(
+                102,
+                vec![
+                    ("k".to_string(), AttrValue::Bool(true)),
+                    ("k".to_string(), AttrValue::I64(9)),
+                ],
+            ),
+            dup(
+                103,
+                vec![
+                    ("k".to_string(), AttrValue::I64(1)),
+                    ("k".to_string(), AttrValue::Bytes(vec![0xab])),
+                ],
+            ),
+            dup(104, vec![("k".to_string(), AttrValue::Str("y".into()))]),
+        ];
+        let mut w = RlogWriter::new(
+            cfg,
+            ObjectIdentity {
+                tenant_hash: [0; 16],
+                shard: 0,
+                writer_id: [0; 16],
+                writer_epoch: 0,
+                writer_seq: 0,
+            },
+        );
+        for r in &written {
+            w.push(r.clone()).expect("push");
+        }
+        let obj = w.finish().expect("finish");
+        let rebuilt = decode_all(&obj);
+        assert_eq!(rebuilt.len(), written.len(), "every record round-trips");
+
+        let (stream_id, blob) = stream_ident(1);
+        let mut streams = BTreeMap::new();
+        streams.insert(stream_id, blob);
+        // `DeclaredSchema` indexes by name, so each declared type is folded in
+        // its own pass rather than declaring `k` twice in one schema.
+        let stamp_at = |ty: DeclaredStatType| -> DeclaredColumnStat {
+            let schema = Arc::new(DeclaredSchema::build(&[("k".to_string(), ty)], &streams));
+            let mut accum = DeclaredStatAccum::new(schema);
+            for r in &rebuilt {
+                accum.observe_record(r);
+            }
+            let mut stamps = accum.build_stamps(5);
+            assert_eq!(stamps.len(), 1, "one declared column, one stamp");
+            stamps.remove(0)
+        };
+        let stamps = [
+            stamp_at(DeclaredStatType::I64),
+            stamp_at(DeclaredStatType::Bool),
+        ];
+
+        let i64_stat = stamps
+            .iter()
+            .find(|s| s.declared_type() == DeclaredStatType::I64)
+            .expect("I64 stamp");
+        assert_eq!(
+            i64_stat.min(),
+            Some(DeclaredStatValue::I64(5)),
+            "I64 min is the two rows resolving to 5, not the shadowed 1"
+        );
+        assert_eq!(
+            i64_stat.max(),
+            Some(DeclaredStatValue::I64(5)),
+            "I64 max is the two rows resolving to 5, not the shadowed 9"
+        );
+        assert_eq!(
+            i64_stat.null_count(),
+            3,
+            "the Bool, Bytes and Str winners are NULL for a declared I64"
+        );
+        let bool_stat = stamps
+            .iter()
+            .find(|s| s.declared_type() == DeclaredStatType::Bool)
+            .expect("BOOL stamp");
+        assert_eq!(bool_stat.min(), Some(DeclaredStatValue::Bool(true)));
+        assert_eq!(bool_stat.max(), Some(DeclaredStatValue::Bool(true)));
+        assert_eq!(
+            bool_stat.null_count(),
+            4,
+            "only the record whose winner is a Bool is non-null"
+        );
     }
 
     /// Decode every record of an RLOG object (no predicate), in the object's

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -4084,11 +4084,34 @@ impl<'d, 'a> DeclaredPlan<'d, 'a> {
         self.cursors.len() == 1 && self.matching_idx == Some(0)
     }
 
-    /// Whether the record sets the key in any of its FIELD_DIR columns at
-    /// surviving row `i`. Only consulted in the multi-column case; the fused case
-    /// gets the same answer from the single matching read.
-    fn record_sets_key(&self, i: usize) -> bool {
-        self.cursors.iter().any(|c| c.present_at(i))
+    /// The index into [`Self::cols`]/[`Self::cursors`] of the record's WINNING
+    /// occurrence of the key at surviving row `i`, or `None` when the record does
+    /// not set the key at all.
+    ///
+    /// A record that carries one name in several FIELD_DIR columns (a name
+    /// written as both a string and an integer splits into two columns) resolves
+    /// to one value, and which one is fixed by docs/log-segment-format.md
+    /// ("Within the record layer"): `rebuild_record` lays a record's columnar
+    /// occurrences out ascending by FIELD_DIR type byte and `merged_attrs` folds
+    /// that list last-wins, so the occurrence with the highest type byte wins.
+    /// The `attrs_raw` overflow tier, which beats every columnar occurrence,
+    /// cannot appear here: a block carrying an `attrs_raw` page falls the whole
+    /// segment back to the row path before the fast path builds a column.
+    ///
+    /// `max_by_key` returns the LAST maximum, which is the tie-break the same
+    /// paragraph pins; the type byte is read from [`Self::cols`] rather than
+    /// from FIELD_DIR position, so the answer does not depend on the directory's
+    /// sort order.
+    ///
+    /// Only consulted in the multi-column case; the fused case gets the same
+    /// answer from the single matching read.
+    fn winning_idx(&self, i: usize) -> Option<usize> {
+        self.cursors
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.present_at(i))
+            .max_by_key(|(k, _)| self.cols[*k].ty.to_u8())
+            .map(|(k, _)| k)
     }
 }
 
@@ -4140,12 +4163,13 @@ fn resource_attrs<'c>(
 /// `stream_ref`, so it is memoized per `stream_ref`: its scan and the one clone
 /// of its result run once per distinct stream in the block, not once per row.
 ///
-/// The precedence is unchanged (ADR-0090 decision 7): the record's own value
-/// wins if it sets the key in any FIELD_DIR column; a record that sets the key at
-/// a different type yields NULL and does NOT consult the fallback; only a record
-/// that does not set the key at all reads the resource/scope value. The
-/// `single_matching` fast path still treats a `Str` cell that is not valid UTF-8
-/// as absent, falling through to the fallback.
+/// The precedence is ADR-0090 decision 7: the record's own value wins if it sets
+/// the key in any FIELD_DIR column; a record whose winning occurrence
+/// ([`DeclaredPlan::winning_idx`]) is at a different type yields NULL and does
+/// NOT consult the fallback; only a record that does not set the key at all
+/// reads the resource/scope value. The `single_matching` fast path still treats
+/// a `Str` cell that is not valid UTF-8 as absent, falling through to the
+/// fallback.
 struct DeclaredResolver<'p, 'd, 'a> {
     plan: &'p DeclaredPlan<'d, 'a>,
     /// [`DeclaredPlan::single_matching`], resolved once for the block.
@@ -4193,11 +4217,13 @@ impl<'p, 'd, 'a> DeclaredResolver<'p, 'd, 'a> {
     }
 
     /// The merged value of the declared key at surviving row `i`. Returns the
-    /// record-column value when the record sets the key at the declared type;
-    /// `None` when the record sets it at a different type (wrong variant, NULL by
-    /// ADR-0090 decision 7). Only when the record does not set the key at all is
-    /// the resource/scope fallback consulted, whose variant the caller checks
-    /// against the declared type.
+    /// record-column value when the record's WINNING occurrence of the key
+    /// ([`DeclaredPlan::winning_idx`]) is at the declared type; `None` when that
+    /// winner is at a different type (wrong variant, NULL by ADR-0090 decision
+    /// 7), including the case where the record also has a declared-type cell at
+    /// this row that the winner shadows. Only when the record does not set the
+    /// key at all is the resource/scope fallback consulted, whose variant the
+    /// caller checks against the declared type.
     fn merged_value(
         &mut self,
         view: &ColumnarBlockView<'_>,
@@ -4213,11 +4239,17 @@ impl<'p, 'd, 'a> DeclaredResolver<'p, 'd, 'a> {
             if let Some(v) = self.matching_cursor.and_then(|c| c.value_at(i)) {
                 return Ok(Some(v));
             }
-        } else if self.plan.record_sets_key(i) {
-            // Record wins. Its value is the declared-type column's cell, or NULL
-            // when the record set the key only in a different-typed column
-            // (ADR-0090 decision 7); either way the fallback is not consulted.
-            return Ok(self.matching_cursor.and_then(|c| c.value_at(i)));
+        } else if let Some(win) = self.plan.winning_idx(i) {
+            // Record wins. Its value is the cell of the occurrence that wins the
+            // record layer's last-occurrence-wins order
+            // ([`DeclaredPlan::winning_idx`]), or NULL when that winner is of a
+            // type other than the declared one (ADR-0090 decision 7); either way
+            // the fallback is not consulted.
+            return Ok(if Some(win) == self.plan.matching_idx {
+                self.plan.cursors[win].value_at(i)
+            } else {
+                None
+            });
         }
         let Some(stream_ref) = view.stream_ref(i) else {
             return Ok(None);
@@ -4342,13 +4374,17 @@ fn build_declared_str_columnar(
                 })?;
                 let mut keys: Vec<Option<i32>> = Vec::with_capacity(n);
                 for i in start..end {
-                    if plan.record_sets_key(i) {
-                        // Record wins. `id_at` is `Some` only when the record's
-                        // `Str` column has a value at this row; `None` (record set
-                        // the key in another-typed column) is a NULL cell. An `id`
-                        // pointing at a non-UTF-8 (NULL) dictionary value also reads
-                        // NULL, matching the UTF-8 rule on the `Str` cursor.
-                        match col.id_at(i) {
+                    if let Some(win) = plan.winning_idx(i) {
+                        // Record wins. Its value is the winning occurrence's cell
+                        // ([`DeclaredPlan::winning_idx`]); a winner in another-typed
+                        // column of the same key is a NULL cell, even when this row
+                        // also has a `Str` cell the winner shadows. An `id` pointing
+                        // at a non-UTF-8 (NULL) dictionary value also reads NULL,
+                        // matching the UTF-8 rule on the `Str` cursor.
+                        match (Some(win) == plan.matching_idx)
+                            .then(|| col.id_at(i))
+                            .flatten()
+                        {
                             Some(id) => keys.push(Some(i32::try_from(id).map_err(|_| {
                                 DataFusionError::Internal(
                                     "declared Str dictionary id exceeds i32".into(),
@@ -4404,10 +4440,14 @@ fn build_declared_str_columnar(
                         }
                         // A `None` here (absent, or not UTF-8) falls through to
                         // the fallback, matching the row path.
-                    } else if plan.record_sets_key(i) {
-                        // Record wins: its declared-type `Str` cell, or NULL when
-                        // it set the key only in a different-typed column.
-                        match matching_str.and_then(|c| c.str_at(i)) {
+                    } else if let Some(win) = plan.winning_idx(i) {
+                        // Record wins: the winning occurrence's `Str` cell, or NULL
+                        // when that winner sits in a different-typed column of the
+                        // same key ([`DeclaredPlan::winning_idx`]).
+                        match (Some(win) == plan.matching_idx)
+                            .then(|| matching_str.and_then(|c| c.str_at(i)))
+                            .flatten()
+                        {
                             Some(s) => {
                                 values.append_value(s);
                                 keys.push(Some(next));
@@ -4929,7 +4969,7 @@ mod cstat_reconcile_tests {
 #[allow(clippy::expect_used)]
 mod columnar_lookup_tests {
     use super::*;
-    use datafusion::arrow::array::{Array, Int64Array};
+    use datafusion::arrow::array::{Array, BinaryArray, BooleanArray, Int64Array};
     use ravel_logseg::record::stream_attrs_bytes;
     use ravel_logseg::{
         ColumnSelection, LogRecord, ObjectIdentity, Predicate, RlogConfig, RlogReader, RlogWriter,
@@ -5409,6 +5449,268 @@ mod columnar_lookup_tests {
             "one scan per distinct stream across BOTH chunks; a per-chunk \
              resolver would read 6"
         );
+    }
+
+    /// One declared column's cells rendered to a form the two paths can be
+    /// compared in: `None` for NULL, otherwise the value's text (lowercase hex
+    /// for `bytes`). `Str` is a `Dictionary(Int32, Utf8)` on both paths, so its
+    /// keys are resolved through the dictionary values here rather than
+    /// compared as ids: the two paths build different dictionaries for the same
+    /// logical column and only the logical values must match.
+    fn declared_cells(arr: &ArrayRef, ty: DeclaredType) -> Vec<Option<String>> {
+        match ty {
+            DeclaredType::Str => {
+                let d = arr
+                    .as_any()
+                    .downcast_ref::<DictionaryArray<Int32Type>>()
+                    .expect("declared Str dictionary array");
+                let values = d
+                    .values()
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("Utf8 dictionary values");
+                (0..d.len())
+                    .map(|i| {
+                        if d.is_null(i) {
+                            return None;
+                        }
+                        let k = usize::try_from(d.keys().value(i)).expect("non-negative key");
+                        (!values.is_null(k)).then(|| values.value(k).to_string())
+                    })
+                    .collect()
+            }
+            DeclaredType::I64 => {
+                let a = arr
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("declared I64 array");
+                (0..a.len())
+                    .map(|i| (!a.is_null(i)).then(|| a.value(i).to_string()))
+                    .collect()
+            }
+            DeclaredType::Bool => {
+                let a = arr
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .expect("declared Bool array");
+                (0..a.len())
+                    .map(|i| (!a.is_null(i)).then(|| a.value(i).to_string()))
+                    .collect()
+            }
+            DeclaredType::Bytes => {
+                let a = arr
+                    .as_any()
+                    .downcast_ref::<BinaryArray>()
+                    .expect("declared Bytes array");
+                (0..a.len())
+                    .map(|i| (!a.is_null(i)).then(|| hex::encode(a.value(i))))
+                    .collect()
+            }
+        }
+    }
+
+    /// Issue #1182, the reader half: a record carrying one attribute name more
+    /// than once resolves that name to ONE value, and both reader paths must
+    /// pick the same one.
+    ///
+    /// The rule is docs/log-segment-format.md, "Within the record layer": the
+    /// record's columnar occurrences ascending by FIELD_DIR type byte
+    /// (str=1 i64=2 f64=3 bool=4 bytes=5), then its `attrs_raw` overflow
+    /// occurrences ascending by canonical encoded value bytes, last entry wins.
+    /// It is NOT the record's write order, which the on-disk format does not
+    /// preserve. So among the columnar occurrences the HIGHEST type byte wins,
+    /// and the two records below that carry the same pair in opposite write
+    /// orders resolve identically.
+    ///
+    /// Every row is asserted against a literal expected value for each of the
+    /// four declarable types, so a drift names both the consumer and the type.
+    /// The two consumers this can reach in-crate are the row path
+    /// (`declared_column_array` over `merged_attrs` + `find_attr`, already
+    /// correct before #1182) and the columnar fast path
+    /// (`DeclaredResolver::merged_value` + `build_declared_str_columnar`, which
+    /// was first-occurrence-per-(name, type)-wins). The other two consumers of
+    /// the same rule live in crates this one does not depend on and pin the
+    /// SAME table of records and expectations:
+    /// `ravel_ingest::log_declared_stats::tests::duplicate_key_stamp_follows_the_readers_rule`
+    /// and `ravel_maintain::rlog::tests::duplicate_key_stamp_follows_the_readers_rule`.
+    ///
+    /// Prove-the-test: restoring `merged_value`'s `record_sets_key` arm
+    /// (`return Ok(self.matching_cursor.and_then(|c| c.value_at(i)))`) makes the
+    /// declared I64 column read 9 at ts 102 and 1 at ts 103 where the row path
+    /// reads NULL; restoring either `record_sets_key` arm of
+    /// `build_declared_str_columnar` makes the declared Str column read "x" at
+    /// ts 100 and 101 where the row path reads NULL.
+    #[test]
+    fn a_duplicate_key_resolves_last_occurrence_wins_on_both_reader_paths() {
+        let cfg = RlogConfig {
+            block_target_records: 16,
+            max_dynamic_columns: 16,
+            ..RlogConfig::default()
+        };
+        let res = [("svc", AttrValue::Str("a".into()))];
+        let records = vec![
+            // I64 written first, Str second: i64 (2) > str (1), so `k` is 5 and
+            // a declared Str column reads NULL, not "x".
+            rec(
+                1,
+                100,
+                &res,
+                &[("k", AttrValue::I64(5)), ("k", AttrValue::Str("x".into()))],
+            ),
+            // The same pair in the opposite write order: same winner.
+            rec(
+                1,
+                101,
+                &res,
+                &[("k", AttrValue::Str("x".into())), ("k", AttrValue::I64(5))],
+            ),
+            // bool (4) > i64 (2): a declared I64 column reads NULL, not 9.
+            rec(
+                1,
+                102,
+                &res,
+                &[("k", AttrValue::Bool(true)), ("k", AttrValue::I64(9))],
+            ),
+            // bytes (5) beats every other type.
+            rec(
+                1,
+                103,
+                &res,
+                &[
+                    ("k", AttrValue::I64(1)),
+                    ("k", AttrValue::Bytes(vec![0xab])),
+                ],
+            ),
+            // A single occurrence resolves to itself: the Str column is not
+            // simply always NULL, and the I64 column is not simply always set.
+            rec(1, 104, &res, &[("k", AttrValue::Str("y".into()))]),
+        ];
+        // The merged view every consumer must agree on, per record, keyed by ts.
+        let want_merged: Vec<(i64, AttrValue)> = vec![
+            (100, AttrValue::I64(5)),
+            (101, AttrValue::I64(5)),
+            (102, AttrValue::Bool(true)),
+            (103, AttrValue::Bytes(vec![0xab])),
+            (104, AttrValue::Str("y".into())),
+        ];
+        // The same view projected onto each declarable type: a value of another
+        // variant is NULL, never a cast (ADR-0090 decision 7).
+        let want_str = [None, None, None, None, Some("y".to_string())];
+        let want_i64 = [
+            Some("5".to_string()),
+            Some("5".to_string()),
+            None,
+            None,
+            None,
+        ];
+        let want_bool = [None, None, Some("true".to_string()), None, None];
+        let want_bytes = [None, None, None, Some("ab".to_string()), None];
+
+        // Row path (consumer 1, correct before #1182): decode the block's
+        // records, merge, build.
+        let mut obj = Vec::new();
+        let reader = write_and_scan(&records, &cfg, &mut obj);
+        let mut scan = reader
+            .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
+            .expect("scan");
+        let block = scan.next_block(&obj).expect("row exit").expect("one block");
+        assert!(
+            scan.next_block(&obj).expect("row exit").is_none(),
+            "the input fits one block"
+        );
+        let merged: Vec<Vec<(String, AttrValue)>> = block
+            .iter()
+            .map(|r| merged_attrs(r).expect("merge"))
+            .collect();
+        // Consumer 1, field by field: `merged_attrs` + `find_attr` resolve the
+        // winner the format doc pins, for the record with that ts.
+        assert_eq!(block.len(), want_merged.len(), "every record survives");
+        for (r, row) in block.iter().zip(merged.iter()) {
+            let (_, want) = want_merged
+                .iter()
+                .find(|(ts, _)| *ts == r.ts_ns)
+                .expect("a record per expected ts");
+            assert_eq!(
+                find_attr(row, "k"),
+                Some(want),
+                "row path merged view at ts {}",
+                r.ts_ns
+            );
+        }
+
+        // Columnar fast path (consumer 2) over the same object.
+        let mut obj2 = Vec::new();
+        let reader2 = write_and_scan(&records, &cfg, &mut obj2);
+        let mut scan2 = reader2
+            .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
+            .expect("scan");
+        let view = scan2
+            .next_block_columnar(&obj2)
+            .expect("columnar exit")
+            .expect("one block");
+        assert!(
+            !view.has_attrs_raw_page(),
+            "no occurrence overflows, so the columnar path is what a scan takes \
+             here rather than falling back to the row path"
+        );
+        let rows = view.surviving_count();
+        assert_eq!(rows, records.len(), "all records survive in one block");
+
+        for (ty, want) in [
+            (DeclaredType::Str, &want_str),
+            (DeclaredType::I64, &want_i64),
+            (DeclaredType::Bool, &want_bool),
+            (DeclaredType::Bytes, &want_bytes),
+        ] {
+            let dc = DeclaredColumn::new("k", ty);
+            let plan = DeclaredPlan::build(&view, &dc);
+            assert!(
+                !plan.single_matching(),
+                "{ty:?}: `k` has a Str, I64, Bool and Bytes FIELD_DIR column, so \
+                 the multi-column precedence arm is what runs"
+            );
+            let mut cache = HashMap::new();
+            let col = declared_cells(
+                &build_declared_columnar_array(
+                    &view,
+                    &mut DeclaredResolver::new(&plan),
+                    0,
+                    rows,
+                    &mut cache,
+                )
+                .expect("columnar array"),
+                ty,
+            );
+            let row = declared_cells(&declared_column_array(&dc, &merged), ty);
+
+            // Consumer 1 against its literal expectation, in block order.
+            for (i, r) in block.iter().enumerate() {
+                let k = want_merged
+                    .iter()
+                    .position(|(ts, _)| *ts == r.ts_ns)
+                    .expect("a record per expected ts");
+                assert_eq!(
+                    row[i], want[k],
+                    "{ty:?}: row path at ts {} (block position {i})",
+                    r.ts_ns
+                );
+            }
+            // Consumer 2 against consumer 1, cell by cell. Both paths read the
+            // block's surviving rows in the same order, so this compares the
+            // same record on both sides.
+            assert_eq!(
+                col.len(),
+                row.len(),
+                "{ty:?}: the two paths build the same row count"
+            );
+            for i in 0..row.len() {
+                assert_eq!(
+                    col[i], row[i],
+                    "{ty:?}: columnar path disagrees with the row path at block \
+                     position {i}"
+                );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Four consumers of the merged attribute view disagreed when a record carried
the same attribute key more than once, and two of them are reader paths. The
same statement could resolve the same record differently depending on which
path the planner picked, which is a wrong answer independent of the stamps.

docs/log-segment-format.md is normative and pins last-occurrence-wins, with
the traversal order that makes "last" well defined: a name's columnar
occurrences ascending by FIELD_DIR type byte, then its attrs_raw overflow
occurrences ascending by canonical encoded value bytes, last entry wins.

The row path already obeyed it and is unchanged, deliberately: it is the
reference the other three move onto. rlog_attrs.rs is not in this diff at
all, so merged_attrs and find_attr are byte-identical to main.

Moved onto the rule: the SQL columnar path (DeclaredResolver::merged_value),
the ingest fold, and the compaction recompute.

The subtle half is the type-mismatch rule, and it is what most of the new
code is for. The record's own attribute wins when the record sets the key at
ANY value kind, and the resolved value then counts NULL if its type is not
the declared column's. So k=I64(5) followed by k=Str("x") must give NULL for
an I64 column, not 5, and not "x" coerced. A winning Str, Bytes, F64, List
or Map has to OCCUPY the column slot so a shadowed same-named I64 cannot
claim the row, which is what PendingValue::Other exists for. Skipping a
wrong-typed winner and falling back to an earlier right-typed occurrence is
the bug this design forecloses.

A name the record does not carry at all still resolves to the stream's
resource or scope attribute; the fallback path is preserved in all three.

Testing. The differential test drives the columnar path and the row path
over the same five-record fixture and compares them cell by cell, with the
row side asserted against literal expectations so the test cannot be made
green by moving the row path. The fixture writes the key at four distinct
types, and two records carry the same pair in opposite write order and are
asserted to the same value, which defuses the short-input trap where an
unstable order passes by luck.

One coverage gap found in review and closed here: two blocks reaching the
attrs_raw overflow tier through the columnar fold had no test that could
fail, because every record in the existing fixture repeated a name at two
distinct types, which the multi-column rule catches on its own. Added a
single-record, single-type case, I64(7)/I64(-1)/I64(2), which separates
first-occurrence (7), largest-integer (7) and greatest-canonical-encoding
(2). Both blocks demonstrated failing when deleted.

Reported, not fixed here. The ingest fold cannot reproduce the reader's
answer when a name overflows the 1000-column dynamic budget, because the
budget is resolved later at flush and the fold cannot know it; the
preconditions are 1000 distinct dynamic columns in one flush plus a repeated
key on the overflowing name. And stamps already written under
first-occurrence-wins stay wrong on disk with nothing to identify them,
which is a pruning false negative rather than a loose bound; the compaction
recompute heals L1 parts as they are compacted, but existing L0 stamps are
not addressed.

Refs: #1182
