### PR TITLE
fix(maintain): count a loser-only L0 input as below the format floor

### DIFF
--- a/crates/ravel-maintain/src/migrate.rs
+++ b/crates/ravel-maintain/src/migrate.rs
@@ -18,8 +18,9 @@
 //!    it costs a rescan, never correctness. The cursor lets a huge migration
 //!    run across many bounded invocations, each resuming exactly where the last
 //!    stopped, never reprocessing an already-migrated bucket (the pre-migration
-//!    per-bucket compaction-record check makes reprocessing a no-op even if the
-//!    cursor is lost) and never skipping one (the walk order is total and the
+//!    per-bucket raw-served check makes reprocessing a no-op even if the cursor
+//!    is lost: the migration's own record names every input it rewrote) and
+//!    never skipping one (the walk order is total and the
 //!    cursor only ever moves forward). The cursor exists only to carry an
 //!    unfinished walk across invocations, so a walk that drains clears it: it
 //!    is a position in one walk, not a permanent high-water mark, and a
@@ -49,20 +50,30 @@
 //! re-audit deliberately counts every live commit and compaction record
 //! regardless of seal state: a fresh, still-unsealed below-target record the
 //! walk could not yet migrate still blocks the raise, which is exactly the
-//! guarantee the floor must carry. "Live" excludes an L0 commit record that a
-//! compaction or rewrite record names in its input list
-//! ([`count_below_target`], keyed on the same predicate sweep rule 2 deletes
-//! by): those are sweepable leftovers of a rewrite this same walk may just
-//! have performed, not stragglers, so migrating a bucket and then re-auditing
-//! it in the same invocation converges without needing an interleaved `sweep`
-//! in between. The exclusion asks the input-set question
+//! guarantee the floor must carry. "Live" excludes an L0 commit record that an
+//! AUTHORITATIVE compaction record, or a rewrite record, names in its input
+//! list ([`count_below_target`], keyed on the same predicate sweep rule 2
+//! deletes by): those are sweepable leftovers of a rewrite this same walk may
+//! just have performed, not stragglers, so migrating a bucket and then
+//! re-auditing it in the same invocation converges without needing an
+//! interleaved `sweep` in between. The exclusion asks the input-set question
 //! directly rather than "does this record's bucket carry a compaction record",
 //! so the re-audit confirms coverage instead of assuming the seal invariant
 //! that makes the two equivalent.
+//!
+//! Authority is what makes that exclusion sound when two compaction records
+//! over one bucket overlap: they resolve to one winner per overlap component
+//! ([`ravel_catalog::select_authoritative_compaction_records`], the rule the
+//! resolver, the index fold, the sweep and the erasure completion gate share),
+//! the losers' parts are served from nowhere, and an input only a loser names
+//! is served raw by `Catalog::resolve`. Both the walk's eligibility check and
+//! the re-audit ask the question through that rule, so such an input is
+//! visited by one and counted by the other, rather than being invisible to
+//! both -- which is the false durable claim the floor must never make.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use ravel_catalog::current_floor_from_store;
+use ravel_catalog::{current_floor_from_store, select_authoritative_compaction_records};
 use ravel_commit::{keys, record};
 use ravel_object_store::{
     GetRange, ObjectStoreBackend, PutMode, PutOptions, StoreError, UploadChecksum, Version,
@@ -75,7 +86,7 @@ use crate::bucket::Bucket;
 use crate::clock::Clock;
 use crate::config::CompactorConfig;
 use crate::error::{MaintainError, Result};
-use crate::read::{list_bucket, load_inputs};
+use crate::read::{BucketListing, list_bucket, load_inputs};
 use crate::rewrite::{MigrateOutcome, migrate_bucket_format};
 use crate::sweep::superseded_input_commit_keys;
 
@@ -135,9 +146,9 @@ pub enum Verification {
     /// that landed after the walk passed, or that the walk could not migrate --
     /// so the floor was left untouched. `l0` counts below-target commit records
     /// still live (a bucket's pre-rewrite commit records already superseded by
-    /// a compaction/rewrite record for that bucket are excluded, not counted
-    /// here: [`count_below_target`]), `l1` counts below-target compaction
-    /// parts.
+    /// an authoritative compaction record, or by a rewrite record, are
+    /// excluded, not counted here: [`count_below_target`]), `l1` counts
+    /// below-target compaction parts.
     Stragglers { l0: usize, l1: usize },
 }
 
@@ -157,6 +168,20 @@ pub struct FamilyMigrateReport {
     pub buckets_migrated: usize,
     /// L0 records migrated this invocation (the budget spend).
     pub records_migrated: u64,
+    /// Buckets this invocation found still serving a below-target L0 record raw
+    /// that the rewrite primitive refused, because the bucket already carries a
+    /// compaction or rewrite record set.
+    ///
+    /// The load-bearing case is a bucket whose overlapping compaction records
+    /// resolve to a winner and a loser: every input only the loser names is
+    /// served as a raw L0 segment, is live, and cannot be migrated by rewriting
+    /// that subset (a new record over it would join the same overlap component
+    /// and lose to the existing winner). Such a bucket makes
+    /// [`count_below_target`] report stragglers on every invocation, so the
+    /// floor for the family stays unraised until the overlap itself is
+    /// resolved. A nonzero value here names that condition instead of leaving
+    /// an operator to infer it from a straggler count that never drains.
+    pub buckets_blocked: usize,
     /// The `(shard, ingest_hour)` the cursor was persisted at, when this
     /// invocation stopped on its budget. `None` once the walk completes: a
     /// drained walk clears the cursor rather than leaving a position behind.
@@ -342,6 +367,22 @@ async fn list_shard_hours(
 /// the still-live, un-migrated remainder and raise the floor over data below
 /// the target, a false claim about durable state; the input-set predicate
 /// excludes exactly the records that were actually superseded.
+///
+/// Only an AUTHORITATIVE compaction record's inputs are excluded. Compaction
+/// records whose input sets overlap resolve to one winner per overlap
+/// component ([`select_authoritative_compaction_records`], the rule the
+/// resolver, the index fold, the superseded-input sweep and the erasure
+/// completion gate all share); a loser's parts are served from nowhere, so an
+/// input only a loser names is still served as a raw L0 segment by
+/// `Catalog::resolve` and is exactly the live, below-target object the floor
+/// would be falsely raised over. Excluding a loser's whole input set is
+/// therefore the same false durable claim this predicate exists to prevent,
+/// one step further in: the record would be neither migrated by the walk nor
+/// counted here.
+///
+/// Rewrite records are not part of that selection: ADR-0064 decision 3 point 5
+/// keeps one record set per bucket, so a live rewrite record has no overlapping
+/// peer to lose to and its whole input list supersedes.
 pub async fn count_below_target(
     store: &dyn ObjectStoreBackend,
     tenant_hash: &TenantHash,
@@ -363,11 +404,17 @@ pub async fn count_below_target(
         // keys it explicitly supersedes. A record must be read for its parts
         // anyway, so deriving the supersession set from its `inputs` list here
         // adds no store read over the bucket-membership version this replaced;
-        // commit records are deferred to the second pass because the full
+        // commit records are deferred to the third pass because the full
         // supersession set is only known once every record in the shard has
-        // been seen.
+        // been seen. Compaction records are additionally held per ingest-hour
+        // bucket rather than resolved inline: an overlap component is a
+        // property of one bucket (the unit the resolver reads), so which of
+        // them are authoritative is only decidable once the whole bucket's set
+        // is in hand.
         let mut commit_keys = Vec::with_capacity(metas.len());
         let mut superseded_commits: HashSet<String> = HashSet::new();
+        let mut compaction_by_bucket: HashMap<u32, Vec<(String, CompactionRecord)>> =
+            HashMap::new();
         for meta in metas {
             let entry = keys::partition_bucket_entry(&meta.key).map_err(MaintainError::Key)?;
             let key = meta.key;
@@ -386,12 +433,10 @@ pub async fn count_below_target(
                             l1_below += 1;
                         }
                     }
-                    superseded_commits.extend(superseded_input_commit_keys(
-                        tenant_hash,
-                        signal,
-                        shard,
-                        &rec,
-                    )?);
+                    compaction_by_bucket
+                        .entry(rec.ingest_hour_bucket)
+                        .or_default()
+                        .push((key, rec));
                 }
                 // A rewrite record (selective erasure, ADR-0064) carries the
                 // same CompactionPart parts as a compaction record; its
@@ -427,6 +472,26 @@ pub async fn count_below_target(
             }
         }
 
+        // Second pass: resolve each bucket's compaction records to one
+        // authoritative record per overlap component and take only a winner's
+        // inputs as superseded. An input a loser alone names has no live
+        // successor -- the loser's parts are ignored -- so it is still served
+        // raw and still counts below the target.
+        for records in compaction_by_bucket.values() {
+            let losing = select_authoritative_compaction_records(records);
+            for (key, rec) in records {
+                if losing.contains(key.as_str()) {
+                    continue;
+                }
+                superseded_commits.extend(superseded_input_commit_keys(
+                    tenant_hash,
+                    signal,
+                    shard,
+                    rec,
+                )?);
+            }
+        }
+
         for key in commit_keys {
             if superseded_commits.contains(&key) {
                 continue;
@@ -441,6 +506,86 @@ pub async fn count_below_target(
     Ok((l0_below, l1_below))
 }
 
+/// The commit keys of `listing`'s L0 records that its compaction and rewrite
+/// records leave served RAW, in listing order: the ones `Catalog::resolve`
+/// still returns as L0 segments because no authoritative record covers them.
+///
+/// This is the walk's eligibility question, asked with the same predicate
+/// [`count_below_target`] verifies with, rather than "does this bucket carry a
+/// compaction record at all". The two differ exactly where two overlapping
+/// compaction records resolve to a winner and a loser
+/// ([`select_authoritative_compaction_records`]): an input only the loser names
+/// is served raw, so a bucket carrying compaction records can still hold live,
+/// un-migrated L0. Skipping the whole bucket on record presence hides that
+/// record from the walk while the re-audit counts it, which is a migration
+/// that can never converge; counting it in neither is the false floor raise.
+///
+/// A bucket with no compaction or rewrite record answers from the listing
+/// alone, so the ordinary path pays no extra store read; a bucket that carries
+/// records pays one GET per record, which is what deciding authority requires.
+async fn raw_served_commit_keys(
+    store: &dyn ObjectStoreBackend,
+    bucket: &Bucket,
+    listing: &BucketListing,
+) -> Result<Vec<String>> {
+    use prost::Message;
+
+    if listing.compaction_record_keys.is_empty() && listing.rewrite_record_keys.is_empty() {
+        return Ok(listing.commit_keys.clone());
+    }
+
+    let mut compaction_records: Vec<(String, CompactionRecord)> =
+        Vec::with_capacity(listing.compaction_record_keys.len());
+    for key in &listing.compaction_record_keys {
+        let got = store.get(key, GetRange::Full).await?;
+        let rec = CompactionRecord::decode(got.data.as_ref()).map_err(|err| {
+            MaintainError::Invariant(format!(
+                "compaction record {key} is corrupt during the migrate walk: {err}"
+            ))
+        })?;
+        compaction_records.push((key.clone(), rec));
+    }
+
+    let mut superseded: HashSet<String> = HashSet::new();
+    let losing = select_authoritative_compaction_records(&compaction_records);
+    for (key, rec) in &compaction_records {
+        if losing.contains(key.as_str()) {
+            continue;
+        }
+        superseded.extend(superseded_input_commit_keys(
+            &bucket.tenant_hash,
+            bucket.signal,
+            bucket.shard,
+            rec,
+        )?);
+    }
+
+    // A rewrite record has no overlapping peer to lose to (ADR-0064 decision 3
+    // point 5 keeps one record set per bucket), so its whole input list
+    // supersedes, exactly as the re-audit treats it.
+    for key in &listing.rewrite_record_keys {
+        let got = store.get(key, GetRange::Full).await?;
+        let rec = RewriteRecord::decode(got.data.as_ref()).map_err(|err| {
+            MaintainError::Invariant(format!(
+                "rewrite record {key} is corrupt during the migrate walk: {err}"
+            ))
+        })?;
+        superseded.extend(superseded_input_commit_keys(
+            &bucket.tenant_hash,
+            bucket.signal,
+            bucket.shard,
+            &rec,
+        )?);
+    }
+
+    Ok(listing
+        .commit_keys
+        .iter()
+        .filter(|key| !superseded.contains(*key))
+        .cloned()
+        .collect())
+}
+
 /// Migrate one `(tenant, signal, family)` toward `target_version`, resuming from
 /// the durable cursor, bounded by `budget`, and -- once the walk drains --
 /// verifying fresh and raising the format floor.
@@ -450,10 +595,13 @@ pub async fn count_below_target(
 /// 1. resolves the generation-aware shard range (fail-closed) and reads the
 ///    advisory cursor;
 /// 2. walks buckets in `(shard, ingest_hour)` order, skipping everything at or
-///    below the cursor, and for each sealed, un-tombstoned, not-yet-compacted
-///    bucket carrying a below-target L0 record, rewrites its whole live L0 set
-///    to the target via [`migrate_bucket_format`] (the rewrite primitive),
-///    advancing the cursor past every examined bucket;
+///    below the cursor, and for each sealed, un-tombstoned bucket that still
+///    serves a below-target L0 record raw ([`raw_served_commit_keys`], not the
+///    presence of a compaction record), rewrites its whole live L0 set to the
+///    target via [`migrate_bucket_format`] (the rewrite primitive), advancing
+///    the cursor past every examined bucket. A bucket the primitive refuses
+///    because it already carries a record set counts into
+///    [`FamilyMigrateReport::buckets_blocked`];
 /// 3. stops early once `budget` is spent (persisting the cursor and returning
 ///    with `walk_complete == false` so the caller re-invokes), or runs the
 ///    verify-and-raise step once the walk reaches its end within budget;
@@ -510,28 +658,26 @@ pub async fn migrate_family(
 
             // Discover eligibility exactly as the audit walk does: from the
             // commit records' recorded format version, never a data-object GET.
-            // Only a sealed, un-tombstoned, not-yet-compacted bucket carrying a
-            // below-target L0 record is rewritten here; a compacted bucket's L1
-            // parts are the rewrite-on-touch scope, and the re-audit below
-            // still refuses the floor raise if any such L1 straggler survives.
-            // A bucket holding a live erasure rewrite record is skipped for the
-            // same reason `migrate_bucket_format` refuses it: a second record
-            // set over the same inputs would make the catalog serve both
-            // (ADR-0064 decision 3 point 5).
+            // Only a sealed, un-tombstoned bucket that still serves at least
+            // one below-target L0 record RAW is a candidate here; a compacted
+            // bucket's L1 parts are the rewrite-on-touch scope, and the
+            // re-audit below still refuses the floor raise if any such L1
+            // straggler survives.
+            //
+            // "Still served raw" is asked through the shared authority rule
+            // ([`raw_served_commit_keys`]), not answered from the presence of a
+            // compaction record. A bucket whose overlapping compaction records
+            // resolve to a winner and a loser leaves every loser-only input
+            // served as a raw L0 segment, so record presence would skip a live
+            // below-target record that the re-audit rightly counts.
             let listing = list_bucket(store, &bucket).await?;
             if bucket.is_sealed(now, config)
                 && listing.tombstone_key.is_none()
-                && listing.compaction_record_keys.is_empty()
-                && listing.rewrite_record_keys.is_empty()
                 && !listing.commit_keys.is_empty()
             {
-                let inputs = load_inputs(
-                    store,
-                    &bucket,
-                    &listing.commit_keys,
-                    config.input_read_concurrency,
-                )
-                .await?;
+                let served = raw_served_commit_keys(store, &bucket, &listing).await?;
+                let inputs =
+                    load_inputs(store, &bucket, &served, config.input_read_concurrency).await?;
                 let l0_below = inputs
                     .iter()
                     .filter(|i| i.record.segment_format_version < target_version)
@@ -545,14 +691,28 @@ pub async fn migrate_family(
                             report.records_migrated += l0_below;
                             spent += l0_below;
                         }
-                        // A concurrent compaction/tombstone/rewrite landed
-                        // between our listing and the call: harmless, the other
-                        // actor's result stands and the re-audit still gates the
-                        // floor.
+                        // The rewrite primitive serves one record set per
+                        // bucket, so it refuses a bucket that already carries
+                        // compaction or rewrite records. Reached two ways, and
+                        // recorded rather than dropped either way: a concurrent
+                        // compaction or erasure landed between our listing and
+                        // the call (harmless, the other actor's result stands),
+                        // or the bucket holds overlapping compaction records
+                        // whose loser-only inputs are still served raw and
+                        // below the target. The second case cannot be migrated
+                        // by rewriting a subset -- a new record over those
+                        // inputs would join the same overlap component and lose
+                        // to the existing winner -- so the re-audit's straggler
+                        // refusal is the correct end state, and this counter is
+                        // what tells the operator which buckets it is waiting
+                        // on.
+                        MigrateOutcome::AlreadyCompacted | MigrateOutcome::RewritePresent => {
+                            report.buckets_blocked += 1;
+                        }
+                        // A concurrent tombstone or a bucket already at the
+                        // target: nothing to migrate and nothing to report.
                         MigrateOutcome::NotSealed
                         | MigrateOutcome::Tombstoned
-                        | MigrateOutcome::AlreadyCompacted
-                        | MigrateOutcome::RewritePresent
                         | MigrateOutcome::UpToDate => {}
                     }
                 }
@@ -1622,6 +1782,254 @@ mod tests {
              (l0_below == 1) even though its bucket carries a compaction record: only \
              the record that compaction actually named is superseded. Counting 0 here \
              is a false floor raise over live un-migrated data"
+        );
+    }
+
+    /// Build and PUT one compaction record at `(shard, hour)` naming the L0
+    /// inputs seeded at `input_seqs` (the same `seq` [`seed_at`] takes, which
+    /// fixes the input's writer identity). `hash_seed` fills `input_set_hash`
+    /// independently of `inputs`, so a test controls both the record key and
+    /// the selection rule's hash tie-break. Every part is stamped at
+    /// `part_version`, so a test can keep `l1_below` out of the figure it is
+    /// pinning. No part data objects are written: neither
+    /// [`count_below_target`] nor the walk's eligibility check reads them.
+    async fn put_compaction_record(
+        store: &dyn ObjectStoreBackend,
+        shard: u32,
+        hour: u32,
+        input_seqs: &[u64],
+        hash_seed: u8,
+        part_version: u32,
+    ) -> String {
+        use prost::Message;
+        use ravel_proto::commit::v1::{CompactionInputIdentity, CompactionPart};
+
+        let th = tenant_hash();
+        let created = i64::from(hour) * NS_PER_HOUR;
+        let input_set_hash = vec![hash_seed; 32];
+        let record = CompactionRecord {
+            format_version: 1,
+            tenant_hash: th.0.to_vec(),
+            signal: ravel_commit::signal::to_proto(Signal::Metrics) as i32,
+            shard,
+            ingest_hour_bucket: hour,
+            level: 1,
+            inputs: input_seqs
+                .iter()
+                .map(|seq| CompactionInputIdentity {
+                    writer_id: Uuid::from_u128(u128::from(*seq)).to_string(),
+                    writer_epoch: EPOCH,
+                    writer_seq: *seq,
+                })
+                .collect(),
+            input_set_hash: input_set_hash.clone(),
+            parts: vec![CompactionPart {
+                part_index: 0,
+                first_series_id: vec![0u8; 16],
+                last_series_id: vec![0xff; 16],
+                content_hash: vec![hash_seed; 32],
+                object_size: 4096,
+                sample_count: 1,
+                series_count: 1,
+                run_count: 1,
+                min_event_ts_ns: created,
+                max_event_ts_ns: created + 100,
+                segment_format_version: part_version,
+                declared_column_stats: Vec::new(),
+            }],
+            created_unix_ns: created,
+        };
+        let hash16: String = input_set_hash[..8]
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        let key = keys::compaction_record_key(&th, Signal::Metrics, shard, hour, &hash16)
+            .expect("compaction record key");
+        store
+            .put(
+                &key,
+                record.encode_to_vec().into(),
+                PutOptions::create_if_absent(),
+            )
+            .await
+            .expect("put compaction record");
+        key
+    }
+
+    /// Seed the overlap fixture: one bucket at `(0, 100)` holding four
+    /// below-target L0 records and two OVERLAPPING compaction records, plus a
+    /// plain uncompacted below-target bucket at `(0, 101)` so the asserted
+    /// figure is a sum over two independent contributions rather than a
+    /// single-record 0-or-1 flip.
+    ///
+    /// The winner names `winner_seqs`; the loser always names `{2, 3}`, so the
+    /// two overlap on input 2 and form one component. Caller picks whether
+    /// input 3 is also named by the winner, which is the whole variable under
+    /// test. Part versions are stamped at the target so `l1_below` is 0 and the
+    /// pinned figure is purely the L0 count.
+    async fn seed_overlapping_records(store: &dyn ObjectStoreBackend, winner_seqs: &[u64]) {
+        for (seq, metric) in [(1u64, "alpha"), (2, "beta"), (3, "gamma"), (4, "delta")] {
+            seed_at(store, 0, 100, seq, metric, VERSION_V7 as u32).await;
+        }
+        // An unrelated below-target bucket with no compaction record at all:
+        // always a straggler, in every scenario.
+        seed_at(store, 0, 101, 5, "epsilon", VERSION_V7 as u32).await;
+
+        // 0x11 sorts below 0x22, so the winner also wins the hash tie-break;
+        // the input-set cardinality already decides it, and pinning the
+        // fallback too keeps the fixture from depending on which term fired.
+        put_compaction_record(store, 0, 100, winner_seqs, 0x11, FUTURE_VERSION).await;
+        put_compaction_record(store, 0, 100, &[2, 3], 0x22, FUTURE_VERSION).await;
+    }
+
+    /// Regression (issue #1156): the re-audit must take an L0 input as
+    /// superseded only where an AUTHORITATIVE compaction record names it.
+    ///
+    /// Two compaction records over one bucket overlap on input 2, so they form
+    /// one overlap component and `select_authoritative_compaction_records`
+    /// keeps exactly one. The loser's parts are served from nowhere, so input
+    /// 3 -- which only the loser names -- is still served as a raw L0 segment
+    /// by `Catalog::resolve`, is still below the target, and must still count.
+    ///
+    /// Both directions are asserted here rather than described: the same
+    /// fixture is built twice, once with the winner naming `{1, 2, 4}` (input 3
+    /// loser-only, so it counts) and once with the winner naming `{1, 2, 3, 4}`
+    /// (input 3 named by the winner, so it does not). The figures are pinned
+    /// exactly, and they differ, so neither a predicate that excludes
+    /// everything nor one that excludes nothing passes.
+    ///
+    /// The flipped line is `count_below_target`'s authority filter: drop the
+    /// `select_authoritative_compaction_records` pass and extend
+    /// `superseded_commits` from every compaction record (the pre-fix
+    /// `superseded_commits.extend(superseded_input_commit_keys(tenant_hash,
+    /// signal, shard, &rec)?)` inside the `CompactionRecord` arm) and the
+    /// loser-only case fails with `l0_below == 1`: input 3 is excluded on the
+    /// strength of a record whose parts nothing serves, and `migrate_family`
+    /// raises the format floor over an object the resolver still returns raw.
+    #[tokio::test]
+    async fn a_loser_only_l0_input_still_counts_below_the_target() {
+        // Winner names {1, 2, 4}; input 3 is named by the loser alone.
+        let store = MemoryStore::new();
+        seed_overlapping_records(&store, &[1, 2, 4]).await;
+
+        // The selection rule itself, on this exact fixture: the smaller
+        // overlapping record is the loser, so its parts are not served and its
+        // exclusive input is not superseded.
+        let bucket = Bucket::new(tenant_hash(), Signal::Metrics, 0, 100);
+        let listing = list_bucket(&store, &bucket).await.expect("list bucket");
+        let served = raw_served_commit_keys(&store, &bucket, &listing)
+            .await
+            .expect("raw-served set");
+        let expected_raw = keys::commit_key(
+            &tenant_hash(),
+            Signal::Metrics,
+            0,
+            100,
+            Uuid::from_u128(3),
+            EPOCH,
+            3,
+        )
+        .expect("commit key");
+        assert_eq!(
+            served,
+            vec![expected_raw],
+            "exactly the loser-only input is left served raw: the winner's three inputs \
+             are inside its parts, and the loser's parts are served from nowhere"
+        );
+
+        let (l0_below, l1_below) =
+            count_below_target(&store, &tenant_hash(), Signal::Metrics, 1, FUTURE_VERSION)
+                .await
+                .expect("re-audit");
+        assert_eq!(
+            (l0_below, l1_below),
+            (2, 0),
+            "exactly two below-target L0 records are live: the loser-only input 3, still \
+             served raw, and the uncompacted bucket's input 5. Counting 1 here excludes \
+             input 3 on a losing record's say-so and raises the floor over an object \
+             Catalog::resolve still serves raw"
+        );
+
+        // Same fixture, one variable changed: the winner now names input 3 too,
+        // so it IS superseded and must drop out of the count.
+        let store = MemoryStore::new();
+        seed_overlapping_records(&store, &[1, 2, 3, 4]).await;
+
+        let listing = list_bucket(&store, &bucket).await.expect("list bucket");
+        let served = raw_served_commit_keys(&store, &bucket, &listing)
+            .await
+            .expect("raw-served set");
+        assert!(
+            served.is_empty(),
+            "the winner names every input of the bucket, so nothing is served raw: {served:?}"
+        );
+
+        let (l0_below, l1_below) =
+            count_below_target(&store, &tenant_hash(), Signal::Metrics, 1, FUTURE_VERSION)
+                .await
+                .expect("re-audit");
+        assert_eq!(
+            (l0_below, l1_below),
+            (1, 0),
+            "only the uncompacted bucket's input 5 is left: an input the AUTHORITATIVE \
+             record names is superseded and must not count"
+        );
+    }
+
+    /// Regression (issue #1156), the walk half: a bucket whose compaction
+    /// records leave a below-target L0 served raw must be VISITED, not skipped
+    /// on the mere presence of a compaction record.
+    ///
+    /// The rewrite primitive still refuses it (one record set per bucket, and a
+    /// new record over the loser-only subset would join the same overlap
+    /// component and lose to the existing winner), so the correct end state is
+    /// a reported blocked bucket and a refused floor raise, not a silent skip
+    /// followed by a raise. The uncompacted bucket at `(0, 101)` is migrated in
+    /// the same walk, which is what shows the visit is selective rather than a
+    /// blanket refusal.
+    ///
+    /// The flipped line is the walk's eligibility gate: restore
+    /// `listing.compaction_record_keys.is_empty() &&
+    /// listing.rewrite_record_keys.is_empty()` to the `if` in `migrate_family`
+    /// and `buckets_blocked` is 0 -- the bucket is never examined past its
+    /// listing.
+    #[tokio::test]
+    async fn the_walk_visits_a_bucket_whose_losing_record_leaves_raw_l0_served() {
+        let store = MemoryStore::new();
+        provision(&store, 1).await;
+        seed_overlapping_records(&store, &[1, 2, 4]).await;
+
+        let clock = FixedClock::new(sealed_now_ns_for(101));
+        let report = migrate_family(
+            &store,
+            &clock,
+            &CompactorConfig::default(),
+            tenant_hash(),
+            Signal::Metrics,
+            FAMILY,
+            FUTURE_VERSION,
+            1,
+            MigrateBudget::unlimited(),
+            "test",
+        )
+        .await
+        .expect("migrate");
+
+        assert_eq!(
+            report.buckets_blocked, 1,
+            "the overlap bucket still serves a below-target L0 raw and the rewrite \
+             primitive refuses it: the walk must report it, not skip it"
+        );
+        assert_eq!(
+            report.buckets_migrated, 1,
+            "the uncompacted bucket at hour 101 is still migrated in the same walk"
+        );
+        assert_eq!(
+            report.verification,
+            Some(Verification::Stragglers { l0: 1, l1: 1 }),
+            "the floor is not raised: the loser-only L0 input is still below the target \
+             (l0 == 1), and hour 101's freshly written L1 part is below the fictional \
+             FUTURE_VERSION target exactly as in the other tests here (l1 == 1)"
         );
     }
 }

--- a/crates/ravel-maintain/src/migrate.rs
+++ b/crates/ravel-maintain/src/migrate.rs
@@ -533,11 +533,14 @@ pub async fn count_below_target(
 ///
 /// Permanence needs BOTH halves and neither implies the other:
 ///
-/// - a record still present to cause the refusal. If retention removed every
-///   record in the meantime, [`raw_served_commit_keys`] short-circuits and
-///   returns every commit as served raw, which is indistinguishable from the
-///   overlap case by inputs alone -- yet that bucket migrates on the next run,
-///   because the rewrite finds nothing to refuse on;
+/// - a record actually READ, not merely listed. If retention removed every
+///   record in the meantime, `raw_served_commit_keys` returns every commit as
+///   served raw, which is indistinguishable from the overlap case by inputs
+///   alone -- yet that bucket migrates on the next run, because the rewrite
+///   finds nothing to refuse on. A listing does not settle this: a record can
+///   go between the list and the GET, and the helper skips a vanished record
+///   rather than failing the walk, so `records_read` is the only honest
+///   evidence that a refusal cause survived;
 /// - an input that record leaves served raw and below the target. A bucket
 ///   whose records supersede everything is refused for reasons that do not
 ///   block the floor.
@@ -548,28 +551,46 @@ async fn refusal_is_permanent(
     target_version: u32,
 ) -> Result<bool> {
     let fresh = list_bucket(store, bucket).await?;
-    if fresh.compaction_record_keys.is_empty() && fresh.rewrite_record_keys.is_empty() {
+    let served = raw_served_commit_keys(store, bucket, &fresh).await?;
+    if served.records_read == 0 {
         return Ok(false);
     }
-    let served = raw_served_commit_keys(store, bucket, &fresh).await?;
     Ok(
-        load_inputs(store, bucket, &served, config.input_read_concurrency)
+        load_inputs(store, bucket, &served.keys, config.input_read_concurrency)
             .await?
             .iter()
             .any(|i| i.record.segment_format_version < target_version),
     )
 }
 
+/// What [`raw_served_commit_keys`] resolved, plus how many records it actually
+/// READ.
+///
+/// The read count is not a statistic. A listing is not evidence that a record
+/// still exists: retention can delete one between the list and the GET, and
+/// this helper skips a vanished record rather than failing the walk. So a
+/// caller asking "is a record still here to refuse the next rewrite" must ask
+/// this, not the listing it passed in.
+#[derive(Debug)]
+struct RawServed {
+    keys: Vec<String>,
+    records_read: usize,
+}
+
 async fn raw_served_commit_keys(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,
     listing: &BucketListing,
-) -> Result<Vec<String>> {
+) -> Result<RawServed> {
     use prost::Message;
 
     if listing.compaction_record_keys.is_empty() && listing.rewrite_record_keys.is_empty() {
-        return Ok(listing.commit_keys.clone());
+        return Ok(RawServed {
+            keys: listing.commit_keys.clone(),
+            records_read: 0,
+        });
     }
+    let mut records_read = 0usize;
 
     let mut compaction_records: Vec<(String, CompactionRecord)> =
         Vec::with_capacity(listing.compaction_record_keys.len());
@@ -592,6 +613,7 @@ async fn raw_served_commit_keys(
                 "compaction record {key} is corrupt during the migrate walk: {err}"
             ))
         })?;
+        records_read += 1;
         compaction_records.push((key.clone(), rec));
     }
 
@@ -624,6 +646,7 @@ async fn raw_served_commit_keys(
                 "rewrite record {key} is corrupt during the migrate walk: {err}"
             ))
         })?;
+        records_read += 1;
         superseded.extend(superseded_input_commit_keys(
             &bucket.tenant_hash,
             bucket.signal,
@@ -632,12 +655,15 @@ async fn raw_served_commit_keys(
         )?);
     }
 
-    Ok(listing
-        .commit_keys
-        .iter()
-        .filter(|key| !superseded.contains(*key))
-        .cloned()
-        .collect())
+    Ok(RawServed {
+        keys: listing
+            .commit_keys
+            .iter()
+            .filter(|key| !superseded.contains(*key))
+            .cloned()
+            .collect(),
+        records_read,
+    })
 }
 
 /// Migrate one `(tenant, signal, family)` toward `target_version`, resuming from
@@ -731,7 +757,8 @@ pub async fn migrate_family(
             {
                 let served = raw_served_commit_keys(store, &bucket, &listing).await?;
                 let inputs =
-                    load_inputs(store, &bucket, &served, config.input_read_concurrency).await?;
+                    load_inputs(store, &bucket, &served.keys, config.input_read_concurrency)
+                        .await?;
                 let l0_below = inputs
                     .iter()
                     .filter(|i| i.record.segment_format_version < target_version)
@@ -2047,11 +2074,18 @@ mod tests {
             .await
             .expect("a vanished record must not abort the walk");
         assert_eq!(
-            served.len(),
+            served.keys.len(),
             4,
             "with both records gone nothing supersedes, so all four inputs are served \
              raw: the conservative direction, which refuses a floor raise rather than \
              raising it over an object that is still served"
+        );
+        assert_eq!(
+            served.records_read, 0,
+            "the listing still NAMES two records, so a caller trusting the listing would \
+             conclude a refusal cause survives. Only the read count distinguishes a record \
+             that is there from one that was there when we listed, which is why \
+             refusal_is_permanent asks this rather than the listing it passed in"
         );
     }
 
@@ -2080,7 +2114,7 @@ mod tests {
         )
         .expect("commit key");
         assert_eq!(
-            served,
+            served.keys,
             vec![expected_raw],
             "exactly the loser-only input is left served raw: the winner's three inputs \
              are inside its parts, and the loser's parts are served from nowhere"
@@ -2109,7 +2143,7 @@ mod tests {
             .await
             .expect("raw-served set");
         assert!(
-            served.is_empty(),
+            served.keys.is_empty(),
             "the winner names every input of the bucket, so nothing is served raw: {served:?}"
         );
 

--- a/crates/ravel-maintain/src/migrate.rs
+++ b/crates/ravel-maintain/src/migrate.rs
@@ -523,6 +523,43 @@ pub async fn count_below_target(
 /// A bucket with no compaction or rewrite record answers from the listing
 /// alone, so the ordinary path pays no extra store read; a bucket that carries
 /// records pays one GET per record, which is what deciding authority requires.
+/// Whether a rewrite refusal on this bucket is permanent, asked against
+/// CURRENT state rather than inferred from the refusal.
+///
+/// `AlreadyCompacted` and `RewritePresent` are returned on nothing more than
+/// the bucket carrying a record when the rewrite re-lists, so the outcome
+/// alone cannot separate a permanent overlap from a concurrent compaction or
+/// erasure that landed underneath the walk and converges on a later run.
+///
+/// Permanence needs BOTH halves and neither implies the other:
+///
+/// - a record still present to cause the refusal. If retention removed every
+///   record in the meantime, [`raw_served_commit_keys`] short-circuits and
+///   returns every commit as served raw, which is indistinguishable from the
+///   overlap case by inputs alone -- yet that bucket migrates on the next run,
+///   because the rewrite finds nothing to refuse on;
+/// - an input that record leaves served raw and below the target. A bucket
+///   whose records supersede everything is refused for reasons that do not
+///   block the floor.
+async fn refusal_is_permanent(
+    store: &dyn ObjectStoreBackend,
+    bucket: &Bucket,
+    config: &CompactorConfig,
+    target_version: u32,
+) -> Result<bool> {
+    let fresh = list_bucket(store, bucket).await?;
+    if fresh.compaction_record_keys.is_empty() && fresh.rewrite_record_keys.is_empty() {
+        return Ok(false);
+    }
+    let served = raw_served_commit_keys(store, bucket, &fresh).await?;
+    Ok(
+        load_inputs(store, bucket, &served, config.input_read_concurrency)
+            .await?
+            .iter()
+            .any(|i| i.record.segment_format_version < target_version),
+    )
+}
+
 async fn raw_served_commit_keys(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,
@@ -730,19 +767,7 @@ pub async fn migrate_family(
                         // also counted a raced-past bucket would send an
                         // operator looking for an overlap that is not there.
                         MigrateOutcome::AlreadyCompacted | MigrateOutcome::RewritePresent => {
-                            let fresh = list_bucket(store, &bucket).await?;
-                            let still_served =
-                                raw_served_commit_keys(store, &bucket, &fresh).await?;
-                            let still_below = load_inputs(
-                                store,
-                                &bucket,
-                                &still_served,
-                                config.input_read_concurrency,
-                            )
-                            .await?
-                            .iter()
-                            .any(|i| i.record.segment_format_version < target_version);
-                            if still_below {
+                            if refusal_is_permanent(store, &bucket, config, target_version).await? {
                                 report.buckets_blocked += 1;
                             }
                         }
@@ -1943,6 +1968,49 @@ mod tests {
     /// loser-only case fails with `l0_below == 1`: input 3 is excluded on the
     /// strength of a record whose parts nothing serves, and `migrate_family`
     /// raises the format floor over an object the resolver still returns raw.
+    /// `buckets_blocked` must not claim permanence when the refusal cause is
+    /// gone. Both halves of the predicate, on one fixture with one variable
+    /// changed.
+    ///
+    /// The transient half is the one the counter got wrong before: with every
+    /// record deleted, `raw_served_commit_keys` short-circuits and returns
+    /// EVERY commit as served raw, so an inputs-only test reads exactly like
+    /// the overlap case. That bucket migrates on the next run, and reporting
+    /// it as permanently blocked sends an operator looking for an overlap that
+    /// is not there, against a guide that tells them re-running will not help.
+    ///
+    /// Prove-the-test: drop the empty-records early return in
+    /// `refusal_is_permanent` and the second assertion reads true.
+    #[tokio::test]
+    async fn a_refusal_is_permanent_only_while_its_cause_survives() {
+        let store = MemoryStore::new();
+        seed_overlapping_records(&store, &[1, 2, 4]).await;
+        let bucket = Bucket::new(tenant_hash(), Signal::Metrics, 0, 100);
+        let config = CompactorConfig::default();
+
+        assert!(
+            refusal_is_permanent(&store, &bucket, &config, FUTURE_VERSION)
+                .await
+                .expect("permanence check"),
+            "the overlap survives and leaves input 3 served raw and below target"
+        );
+
+        // Retention removes the records that caused the refusal.
+        let listing = list_bucket(&store, &bucket).await.expect("list bucket");
+        for key in &listing.compaction_record_keys {
+            store.delete(key).await.expect("delete record");
+        }
+
+        assert!(
+            !refusal_is_permanent(&store, &bucket, &config, FUTURE_VERSION)
+                .await
+                .expect("permanence check"),
+            "with no record left to refuse on, the next run migrates this bucket: the \
+             inputs are still below target and still served raw, so an inputs-only \
+             check would wrongly call this permanent"
+        );
+    }
+
     /// A record listed and then deleted before it is read must not abort the
     /// walk. Retention can remove a compaction record between the listing and
     /// the read, and propagating `NotFound` would fail `migrate_family` before

--- a/crates/ravel-maintain/src/migrate.rs
+++ b/crates/ravel-maintain/src/migrate.rs
@@ -537,7 +537,19 @@ async fn raw_served_commit_keys(
     let mut compaction_records: Vec<(String, CompactionRecord)> =
         Vec::with_capacity(listing.compaction_record_keys.len());
     for key in &listing.compaction_record_keys {
-        let got = store.get(key, GetRange::Full).await?;
+        // Retention can delete a record between the listing and this read.
+        // Propagating NotFound would abort the whole walk before the cursor
+        // advances, losing a long migration's progress to an unrelated
+        // concurrent pass; the rest of this crate already treats a vanished
+        // object as absent rather than as an error. Skipping is also the
+        // fail-safe direction here: a record that is gone supersedes nothing,
+        // so its inputs stay counted as served raw and the floor raise is
+        // refused rather than wrongly allowed.
+        let got = match store.get(key, GetRange::Full).await {
+            Ok(got) => got,
+            Err(ravel_object_store::StoreError::NotFound) => continue,
+            Err(err) => return Err(err.into()),
+        };
         let rec = CompactionRecord::decode(got.data.as_ref()).map_err(|err| {
             MaintainError::Invariant(format!(
                 "compaction record {key} is corrupt during the migrate walk: {err}"
@@ -564,7 +576,12 @@ async fn raw_served_commit_keys(
     // point 5 keeps one record set per bucket), so its whole input list
     // supersedes, exactly as the re-audit treats it.
     for key in &listing.rewrite_record_keys {
-        let got = store.get(key, GetRange::Full).await?;
+        // Same race and same reasoning as the compaction records above.
+        let got = match store.get(key, GetRange::Full).await {
+            Ok(got) => got,
+            Err(ravel_object_store::StoreError::NotFound) => continue,
+            Err(err) => return Err(err.into()),
+        };
         let rec = RewriteRecord::decode(got.data.as_ref()).map_err(|err| {
             MaintainError::Invariant(format!(
                 "rewrite record {key} is corrupt during the migrate walk: {err}"
@@ -1926,6 +1943,50 @@ mod tests {
     /// loser-only case fails with `l0_below == 1`: input 3 is excluded on the
     /// strength of a record whose parts nothing serves, and `migrate_family`
     /// raises the format floor over an object the resolver still returns raw.
+    /// A record listed and then deleted before it is read must not abort the
+    /// walk. Retention can remove a compaction record between the listing and
+    /// the read, and propagating `NotFound` would fail `migrate_family` before
+    /// the cursor advances, losing a long migration's progress to an unrelated
+    /// concurrent pass.
+    ///
+    /// The stale listing IS the race: it still names a key whose object is
+    /// gone, which is exactly the state the walk holds when retention runs
+    /// underneath it.
+    ///
+    /// Prove-the-test: restore `store.get(key, GetRange::Full).await?` in
+    /// `raw_served_commit_keys` and this returns `Err(NotFound)` instead of a
+    /// served set. The assertion on the result also pins the fail-safe
+    /// direction: a vanished record supersedes nothing, so its inputs come
+    /// back as served raw rather than being silently excluded.
+    #[tokio::test]
+    async fn a_record_deleted_after_the_listing_does_not_abort_the_walk() {
+        let store = MemoryStore::new();
+        seed_overlapping_records(&store, &[1, 2, 4]).await;
+        let bucket = Bucket::new(tenant_hash(), Signal::Metrics, 0, 100);
+        let listing = list_bucket(&store, &bucket).await.expect("list bucket");
+        assert_eq!(
+            listing.compaction_record_keys.len(),
+            2,
+            "the fixture must carry both overlapping records, or this proves nothing"
+        );
+
+        // Retention removes one of them while the walk still holds the listing.
+        for key in &listing.compaction_record_keys {
+            store.delete(key).await.expect("delete record");
+        }
+
+        let served = raw_served_commit_keys(&store, &bucket, &listing)
+            .await
+            .expect("a vanished record must not abort the walk");
+        assert_eq!(
+            served.len(),
+            4,
+            "with both records gone nothing supersedes, so all four inputs are served \
+             raw: the conservative direction, which refuses a floor raise rather than \
+             raising it over an object that is still served"
+        );
+    }
+
     #[tokio::test]
     async fn a_loser_only_l0_input_still_counts_below_the_target() {
         // Winner names {1, 2, 4}; input 3 is named by the loser alone.

--- a/crates/ravel-maintain/src/migrate.rs
+++ b/crates/ravel-maintain/src/migrate.rs
@@ -693,21 +693,41 @@ pub async fn migrate_family(
                         }
                         // The rewrite primitive serves one record set per
                         // bucket, so it refuses a bucket that already carries
-                        // compaction or rewrite records. Reached two ways, and
-                        // recorded rather than dropped either way: a concurrent
-                        // compaction or erasure landed between our listing and
-                        // the call (harmless, the other actor's result stands),
-                        // or the bucket holds overlapping compaction records
-                        // whose loser-only inputs are still served raw and
-                        // below the target. The second case cannot be migrated
-                        // by rewriting a subset -- a new record over those
-                        // inputs would join the same overlap component and lose
-                        // to the existing winner -- so the re-audit's straggler
-                        // refusal is the correct end state, and this counter is
-                        // what tells the operator which buckets it is waiting
-                        // on.
+                        // compaction or rewrite records. Two different things
+                        // reach this arm and only one of them is permanent:
+                        // a concurrent compaction or erasure landed between our
+                        // listing and the call, which is harmless and converges
+                        // on a later run; or the bucket holds overlapping
+                        // compaction records whose loser-only inputs are still
+                        // served raw and below the target, which no rewrite can
+                        // migrate, because a new record over those inputs joins
+                        // the same overlap component and loses to the existing
+                        // winner.
+                        //
+                        // The outcome alone cannot tell them apart: both are
+                        // returned on nothing more than the bucket carrying a
+                        // record at re-list time. So ask the question again
+                        // against current state rather than counting the
+                        // refusal. `buckets_blocked` claims the permanent case
+                        // on both the CLI and in the guide, and a counter that
+                        // also counted a raced-past bucket would send an
+                        // operator looking for an overlap that is not there.
                         MigrateOutcome::AlreadyCompacted | MigrateOutcome::RewritePresent => {
-                            report.buckets_blocked += 1;
+                            let fresh = list_bucket(store, &bucket).await?;
+                            let still_served =
+                                raw_served_commit_keys(store, &bucket, &fresh).await?;
+                            let still_below = load_inputs(
+                                store,
+                                &bucket,
+                                &still_served,
+                                config.input_read_concurrency,
+                            )
+                            .await?
+                            .iter()
+                            .any(|i| i.record.segment_format_version < target_version);
+                            if still_below {
+                                report.buckets_blocked += 1;
+                            }
                         }
                         // A concurrent tombstone or a bucket already at the
                         // target: nothing to migrate and nothing to report.

--- a/docs/guides/operations/maintenance.md
+++ b/docs/guides/operations/maintenance.md
@@ -334,6 +334,15 @@ Because the refusal alone cannot tell the two apart, the walk re-reads the
 bucket after a refusal and counts it only when a below-target record is still
 served raw.
 
+There is no command that forces the overlap to resolve. The block clears on its
+own when the loser-only inputs stop being served raw, which happens when a
+later authoritative compaction covers them or when retention ages them out.
+Until one of those occurs the floor stays where it is, which is the correct
+outcome rather than a fault: raising it would claim a format floor over an
+object the resolver still returns. The walk's output identifies the shard and
+ingest hour, so the affected bucket is known even though no command resolves
+the overlap for you.
+
 The re-audit's liveness definition excludes a bucket's pre-rewrite L0 commit
 records once an authoritative compaction or rewrite record supersedes them.
 Those records are dead, sweepable leftovers of a rewrite this same invocation may have

--- a/docs/guides/operations/maintenance.md
+++ b/docs/guides/operations/maintenance.md
@@ -307,8 +307,10 @@ ravel-cli maintain migrate --tenant <t> --signal <metrics|logs|spans> \
 target on-object format version. One invocation:
 
 1. walks buckets in shard and ingest-hour order from a durable cursor, rewriting
-   every sealed, un-tombstoned, not-yet-compacted bucket that still has an L0
-   commit record below the target version. This reuses the compaction rewrite
+   every sealed, un-tombstoned bucket that still has an L0 commit record below
+   the target version and served raw. A bucket that already carries a compaction
+   or rewrite record is visited too, because a record can leave an input served
+   raw. This reuses the compaction rewrite
    primitive, so the rewrite is bucket-atomic and produces a compaction record
    exactly as compaction does;
 2. stops early and persists the cursor once `--budget-records` is spent (`0`,
@@ -317,13 +319,17 @@ target on-object format version. One invocation:
    below the target.
 
 A refused raise, reported as "FOUND STRAGGLERS", means the fresh re-audit found
-genuine live data still below the target: a bucket too recently landed to be
-sealed and migrated yet, or data that arrived after the walk passed. Re-run
-`migrate`; that data migrates once it is sealed.
+genuine live data still below the target. Whether re-running helps depends on
+why. A bucket too recently landed to be sealed, or data that arrived after the
+walk passed, migrates on a later run. But an L0 input that only a losing
+compaction record names is served raw and the walk cannot migrate it, so that
+refusal is permanent until the overlap itself is resolved and re-running reports
+the same count forever. `buckets_blocked` in the report counts the buckets in
+that state; when it is non-zero, re-running is not the remedy.
 
-The re-audit's liveness definition already excludes a bucket's pre-rewrite L0
-commit records once that bucket carries a compaction or rewrite record. Those
-records are dead, sweepable leftovers of a rewrite this same invocation may have
+The re-audit's liveness definition excludes a bucket's pre-rewrite L0 commit
+records once an authoritative compaction or rewrite record supersedes them.
+Those records are dead, sweepable leftovers of a rewrite this same invocation may have
 just performed, not stragglers. Because of that, a clean migration converges and
 raises the floor in one invocation, and running `sweep` in between is never
 required for it to converge. The sweeper's superseded-input rule still deletes

--- a/docs/guides/operations/maintenance.md
+++ b/docs/guides/operations/maintenance.md
@@ -327,6 +327,13 @@ refusal is permanent until the overlap itself is resolved and re-running reports
 the same count forever. `buckets_blocked` in the report counts the buckets in
 that state; when it is non-zero, re-running is not the remedy.
 
+The counter is narrowed to that case deliberately. The rewrite primitive also
+refuses a bucket when a concurrent compaction or erasure lands between the
+walk's listing and its own, which is harmless and converges on a later run.
+Because the refusal alone cannot tell the two apart, the walk re-reads the
+bucket after a refusal and counts it only when a below-target record is still
+served raw.
+
 The re-audit's liveness definition excludes a bucket's pre-rewrite L0 commit
 records once an authoritative compaction or rewrite record supersedes them.
 Those records are dead, sweepable leftovers of a rewrite this same invocation may have

--- a/services/ravel-cli/src/maintain.rs
+++ b/services/ravel-cli/src/maintain.rs
@@ -1267,12 +1267,16 @@ fn signal_current_version(signal: Signal) -> anyhow::Result<u32> {
 /// within budget, migrate re-audits fresh and raises the floor only if nothing
 /// below the target survives; if a straggler is found the floor is left
 /// untouched and this exits nonzero, reporting what it found. The re-audit
-/// already excludes a bucket's pre-rewrite commit records once that bucket
-/// carries a compaction/rewrite record (dead, sweepable leftovers of a
-/// rewrite this same invocation may have just performed, not stragglers),
-/// so a clean migration converges and raises the floor in one
-/// invocation -- no interleaved `sweep` required. A reported straggler is
-/// therefore genuine below-target live data still to migrate.
+/// excludes a bucket's pre-rewrite commit records once an AUTHORITATIVE
+/// compaction or rewrite record supersedes them (dead, sweepable leftovers of a
+/// rewrite this same invocation may have just performed, not stragglers). An
+/// input named only by a LOSING record of an overlap is not superseded: the
+/// resolver still serves it raw, so it stays counted. A clean migration
+/// therefore converges and raises the floor in one invocation, with no
+/// interleaved `sweep` required, but a below-target loser-only input is a
+/// straggler the walk cannot migrate, so that refusal is permanent until the
+/// overlap itself is resolved. `buckets_blocked` reports how many buckets are
+/// in that state.
 ///
 /// `target_version` defaults to the signal's current supported version
 /// ([`signal_current_version`]); `family` defaults to the signal's canonical
@@ -1332,6 +1336,7 @@ pub async fn migrate(
     println!("budget_records: {budget_records} (0 = unlimited)");
     println!("buckets_examined: {}", report.buckets_examined);
     println!("buckets_migrated: {}", report.buckets_migrated);
+    println!("buckets_blocked: {}", report.buckets_blocked);
     println!("records_migrated: {}", report.records_migrated);
     if let Some((shard, hour)) = report.cursor_advanced_to {
         println!("cursor_advanced_to: shard={shard} hour={hour}");
@@ -1364,8 +1369,14 @@ pub async fn migrate(
                  finishing and the floor raise, or is not yet migratable -- e.g. still \
                  unsealed). These are genuinely live: a bucket's own pre-rewrite commit records \
                  are already excluded from this count once that bucket has been migrated, so a \
-                 `sweep` will not make this converge. The floor was NOT raised; re-run migrate \
-                 once the stragglers are at or above the target."
+                 `sweep` will not make this converge. The floor was NOT raised.\n\n\
+                 Whether re-running helps depends on why they are below target. Data that is \
+                 merely not yet sealed migrates on a later run. But a below-target L0 that only \
+                 a LOSING compaction record names is served raw by the resolver and is not \
+                 migratable by the walk, so that straggler is permanent until the overlap \
+                 itself is resolved, and re-running will report the same count forever. \
+                 buckets_blocked above counts the buckets in that state: if it is non-zero, \
+                 re-running is not the remedy."
             )
         }
         None => {


### PR DESCRIPTION
Overlapping compaction records resolve to one authoritative record per
overlap component, so an L0 input that only a LOSING record names is still
served raw by Catalog::resolve. The format-floor migration did not know
that. It built its superseded set from every compaction record's inputs,
losers included, and the walk skipped any bucket that carried a compaction
record at all.

So a served, below-target, loser-only L0 was neither migrated by the walk
nor counted by the re-audit, and migrate_family could raise the format floor
over an object the resolver still returns raw. That is the false durable
claim count_below_target's own doc comment says the predicate exists to
prevent.

The superseded set is now derived through
select_authoritative_compaction_records, the same rule the resolver, the
fold, the superseded-input sweep and the erasure completion gate already
share, rather than a second selection written here that would drift from the
resolver later. The walk visits a bucket whose records leave a raw L0
served, while still short-circuiting when the bucket has no L0 commit
records at all, so the ordinary compacted bucket costs the same as before.

The harm fixed is a false claim about durable state, not a read failure or
data loss: migrate_family runs from the CLI maintain command rather than the
automatic maintenance loop, and no reader drops an old decoder today.

The refusal this creates is PERMANENT, which the operator surfaces did not
say. A loser-only below-target input is not migratable by the walk, so
re-running reports the same count forever, where an unsealed straggler
migrates on a later run. The CLI now prints buckets_blocked, separates those
two cases in its error text, and points at the counter as the way to tell
them apart. Three claims in the maintenance guide and one in the command's
doc comment were made false by this change and are corrected in the same
commit: the walk no longer skips a bucket carrying a compaction record, and
the re-audit excludes pre-rewrite records only when an authoritative record
supersedes them.

The tests pin exact counts rather than a floor. A fixture with a winner
naming inputs 1, 2 and 4 and a loser naming 2 and 3 asserts (l0_below,
l1_below) is exactly (2, 0), and a control arm where the winner names all
four asserts exactly (1, 0). Two different exact tuples from one fixture
with one variable changed, so neither "exclude everything" nor "exclude
nothing" passes.

Reported, not fixed here: count_below_target still counts a losing record's
PARTS, which the resolver also never serves. That is the same shape one
level up on the l1 half, is pre-existing, and over-counts rather than
under-counts, so it refuses a raise that could proceed rather than allowing
one that should not. Filed as #1341.

Refs: #1156
