### PR TITLE
fix(iam): scope the KMS grant to tenant keys and close the guard's holes

### DIFF
--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -421,7 +421,10 @@ fn no_kms_statement_grants_every_key_in_the_region() {
                     .collect(),
                 _ => continue,
             };
-            if !actions.iter().any(|a| a.starts_with("kms:")) {
+            if !actions
+                .iter()
+                .any(|a| a.to_ascii_lowercase().starts_with("kms:"))
+            {
                 continue;
             }
             let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
@@ -465,7 +468,10 @@ fn every_kms_statement_names_a_key_id() {
                     .collect(),
                 _ => continue,
             };
-            if !actions.iter().any(|a| a.starts_with("kms:")) {
+            if !actions
+                .iter()
+                .any(|a| a.to_ascii_lowercase().starts_with("kms:"))
+            {
                 continue;
             }
             let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
@@ -488,6 +494,73 @@ fn every_kms_statement_names_a_key_id() {
             }
         }
     }
+}
+
+/// Regression fixture for the case-sensitivity fix above: `KMS:Decrypt` (or any
+/// other capitalization) on `"Resource": "*"` is exactly as fully-permissive as
+/// `kms:Decrypt`, and the case-sensitive `starts_with("kms:")` selection both
+/// guards above used to run would silently skip it -- reporting the templates
+/// safe while a fully-permissive statement sat unexamined. This is not a real
+/// shipped template; it is a synthetic statement built to prove the matcher
+/// itself, independent of what `deploy/iam/*.json` currently contains.
+#[test]
+fn mixed_case_kms_action_is_not_a_bypass() {
+    let stmt = serde_json::json!({
+        "Sid": "MixedCaseFullyPermissive",
+        "Effect": "Allow",
+        "Action": "KMS:Decrypt",
+        "Resource": "*"
+    });
+    let actions: Vec<String> = match &stmt["Action"] {
+        serde_json::Value::String(s) => vec![s.clone()],
+        serde_json::Value::Array(a) => a
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
+        _ => vec![],
+    };
+
+    // Observation 1: the pre-fix selection (case-sensitive) misses the
+    // mixed-case action entirely, exactly the hole this test guards against.
+    let selected_before_fix = actions.iter().any(|a| a.starts_with("kms:"));
+    assert!(
+        !selected_before_fix,
+        "fixture invalid: the pre-fix case-sensitive matcher was expected to \
+         miss \"KMS:Decrypt\" -- if it didn't, this fixture no longer proves \
+         the hole existed"
+    );
+
+    // Observation 2: the post-fix selection (lowercased) catches it.
+    let selected_after_fix = actions
+        .iter()
+        .any(|a| a.to_ascii_lowercase().starts_with("kms:"));
+    assert!(
+        selected_after_fix,
+        "fixture invalid: the post-fix matcher should select \"KMS:Decrypt\""
+    );
+
+    // With the statement selected, the real guard's own assertion (resource
+    // != "*" && !resource.ends_with(":key/*")) must now fire on this
+    // fixture's "Resource": "*". Run it through catch_unwind so this test
+    // reports the panic as an assertion result instead of aborting the binary.
+    let resource = stmt["Resource"]
+        .as_str()
+        .expect("Resource is a string")
+        .to_string();
+    let sid = stmt["Sid"].clone();
+    let guard_result = std::panic::catch_unwind(|| {
+        assert!(
+            resource != "*" && !resource.ends_with(":key/*"),
+            "statement {sid:?} grants a kms: action on {resource:?}, which \
+             covers every key in the account/region"
+        );
+    });
+    assert!(
+        guard_result.is_err(),
+        "the guard must reject \"KMS:Decrypt\" on Resource \"*\" once the \
+         statement is selected -- a mixed-case action must not bypass the \
+         no-account-wide-key assertion"
+    );
 }
 
 #[test]

--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -401,6 +401,95 @@ fn every_role_has_kms_decrypt() {
     }
 }
 
+/// Every statement whose `Action` grants any `kms:` action must not name a
+/// `Resource` that covers every key in the account/region: neither the bare
+/// wildcard `"*"` nor any ARN ending `:key/*`. Pinned as a negation (not an
+/// exact tenant-key ARN) so it survives an operator's post-substitution
+/// value. Widen any of the four templates' KMS `Resource` back to
+/// `arn:aws:kms:us-east-1:111122223333:key/*` and this test fails, naming
+/// the role and the statement `Sid`.
+#[test]
+fn no_kms_statement_grants_every_key_in_the_region() {
+    for role in ALL_ROLES {
+        let policy = load_policy(role);
+        for stmt in policy.statements.as_array().unwrap() {
+            let actions: Vec<String> = match &stmt["Action"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect(),
+                _ => continue,
+            };
+            if !actions.iter().any(|a| a.starts_with("kms:")) {
+                continue;
+            }
+            let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
+            let resources: Vec<String> = match &stmt["Resource"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .map(|v| v.as_str().expect("Resource entry is a string").to_string())
+                    .collect(),
+                other => {
+                    panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
+                }
+            };
+            for resource in &resources {
+                assert!(
+                    resource != "*" && !resource.ends_with(":key/*"),
+                    "{role}: statement {sid:?} grants a kms: action on {resource:?}, \
+                     which covers every key in the account/region"
+                );
+            }
+        }
+    }
+}
+
+/// Every statement whose `Action` grants any `kms:` action must name a
+/// `Resource` that pins a specific key id, so an operator cannot re-widen
+/// the grant to every key by substituting `arn:aws:kms:<region>:<account>:key/*`
+/// (or any other bare-wildcard variant) in place of the placeholder.
+#[test]
+fn every_kms_statement_names_a_key_id() {
+    let key_arn_pattern =
+        regex::Regex::new(r"^arn:aws:kms:[^:]+:[^:]+:key/[^*]+$").expect("valid regex");
+    for role in ALL_ROLES {
+        let policy = load_policy(role);
+        for stmt in policy.statements.as_array().unwrap() {
+            let actions: Vec<String> = match &stmt["Action"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect(),
+                _ => continue,
+            };
+            if !actions.iter().any(|a| a.starts_with("kms:")) {
+                continue;
+            }
+            let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
+            let resources: Vec<String> = match &stmt["Resource"] {
+                serde_json::Value::String(s) => vec![s.clone()],
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .map(|v| v.as_str().expect("Resource entry is a string").to_string())
+                    .collect(),
+                other => {
+                    panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
+                }
+            };
+            for resource in &resources {
+                assert!(
+                    key_arn_pattern.is_match(resource),
+                    "{role}: statement {sid:?} resource {resource:?} does not name a \
+                     specific key id (expected arn:aws:kms:<region>:<account>:key/<id>)"
+                );
+            }
+        }
+    }
+}
+
 #[test]
 fn discovery_prefix_admitted_for_every_discovering_role() {
     for role in ROLES_WITH_DISCOVERY {

--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -159,16 +159,48 @@ fn load_policy(role: &'static str) -> Policy {
     Policy { role, statements }
 }
 
+/// IAM action names are case-insensitive: a statement granting
+/// `KMS:GenerateDataKey*` grants exactly what `kms:GenerateDataKey*` grants.
+/// Every action comparison in this file goes through this helper (or
+/// `action_has_prefix`), in both directions. A case-sensitive positive check
+/// only fails loudly, but a case-sensitive negative check reports a role
+/// unprivileged while it holds the grant.
+fn action_eq(action: &str, expected: &str) -> bool {
+    action.eq_ignore_ascii_case(expected)
+}
+
+/// Case-insensitive prefix match for action names, so `kms:GenerateDataKey`
+/// selects `KMS:GenerateDataKey*` too. Indexed with `get` rather than a slice
+/// so an action name whose bytes do not split on a char boundary at
+/// `prefix.len()` returns false instead of panicking.
+fn action_has_prefix(action: &str, prefix: &str) -> bool {
+    action
+        .get(..prefix.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+}
+
+/// Every action name in a statement's `Action` (a bare string or an array),
+/// with the policy's own capitalization preserved so a failure message quotes
+/// what the template actually says.
+fn statement_actions(stmt: &serde_json::Value) -> Vec<String> {
+    match &stmt["Action"] {
+        serde_json::Value::String(s) => vec![s.clone()],
+        serde_json::Value::Array(a) => a
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// `s3:prefix` patterns from every `s3:ListBucket` statement's
 /// `Condition.StringLike` block.
 fn list_prefix_patterns(policy: &Policy) -> Vec<String> {
     let mut out = Vec::new();
     for stmt in policy.statements.as_array().unwrap() {
-        let action = &stmt["Action"];
-        let is_list = action == "s3:ListBucket"
-            || action
-                .as_array()
-                .is_some_and(|a| a.iter().any(|v| v == "s3:ListBucket"));
+        let is_list = statement_actions(stmt)
+            .iter()
+            .any(|a| action_eq(a, "s3:ListBucket"));
         if !is_list {
             continue;
         }
@@ -186,8 +218,9 @@ fn list_prefix_patterns(policy: &Policy) -> Vec<String> {
 fn resource_key_patterns(policy: &Policy) -> Vec<String> {
     let mut out = Vec::new();
     for stmt in policy.statements.as_array().unwrap() {
-        let action = &stmt["Action"];
-        let is_list_only = action == "s3:ListBucket";
+        let is_list_only = stmt["Action"]
+            .as_str()
+            .is_some_and(|a| action_eq(a, "s3:ListBucket"));
         if is_list_only {
             continue;
         }
@@ -214,11 +247,9 @@ fn resource_key_patterns(policy: &Policy) -> Vec<String> {
 fn put_resource_key_patterns(policy: &Policy) -> Vec<String> {
     let mut out = Vec::new();
     for stmt in policy.statements.as_array().unwrap() {
-        let grants_put = match &stmt["Action"] {
-            serde_json::Value::String(s) => s == "s3:PutObject",
-            serde_json::Value::Array(a) => a.iter().any(|v| v == "s3:PutObject"),
-            _ => false,
-        };
+        let grants_put = statement_actions(stmt)
+            .iter()
+            .any(|a| action_eq(a, "s3:PutObject"));
         if !grants_put {
             continue;
         }
@@ -268,18 +299,53 @@ const WRITE_ROLES: [&str; 3] = ["gateway", "maintain", "query"];
 
 /// `kms:*` action strings appearing anywhere in `policy`'s statements
 /// (`Action` as a bare string or an array), regardless of statement Sid.
+///
+/// Selection is case-insensitive, so `KMS:GenerateDataKey*` is returned; the
+/// strings themselves keep the template's capitalization, so a caller's
+/// failure message shows what the policy said rather than a normalized form
+/// the operator would then grep for in vain. Callers compare with `action_eq`
+/// or `action_has_prefix` rather than against these strings directly.
 fn kms_actions(policy: &Policy) -> Vec<String> {
     let mut out = Vec::new();
     for stmt in policy.statements.as_array().unwrap() {
-        let actions: Vec<String> = match &stmt["Action"] {
+        out.extend(
+            statement_actions(stmt)
+                .into_iter()
+                .filter(|a| action_has_prefix(a, "kms:")),
+        );
+    }
+    out
+}
+
+/// Sid and parsed `Resource` list for every statement carrying a `kms:`
+/// action. Both resource guards below go through this one selection rule, so
+/// a change to it cannot reach one guard and miss the other.
+///
+/// Panics on a `Resource` that is neither a string nor an array, as the
+/// guards did inline: a malformed template must fail the test rather than be
+/// skipped as "no resources to check".
+fn kms_statement_resources(policy: &Policy) -> Vec<(String, Vec<String>)> {
+    let role = policy.role;
+    let mut out = Vec::new();
+    for stmt in policy.statements.as_array().unwrap() {
+        if !statement_actions(stmt)
+            .iter()
+            .any(|a| action_has_prefix(a, "kms:"))
+        {
+            continue;
+        }
+        let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>").to_string();
+        let resources: Vec<String> = match &stmt["Resource"] {
             serde_json::Value::String(s) => vec![s.clone()],
             serde_json::Value::Array(a) => a
                 .iter()
-                .filter_map(|v| v.as_str().map(str::to_string))
+                .map(|v| v.as_str().expect("Resource entry is a string").to_string())
                 .collect(),
-            _ => continue,
+            other => {
+                panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
+            }
         };
-        out.extend(actions.into_iter().filter(|a| a.starts_with("kms:")));
+        out.push((sid, resources));
     }
     out
 }
@@ -298,7 +364,9 @@ fn write_roles_have_kms_generate_data_key() {
         let policy = load_policy(role);
         let actions = kms_actions(&policy);
         assert!(
-            actions.iter().any(|a| a.starts_with("kms:GenerateDataKey")),
+            actions
+                .iter()
+                .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
             "{role}: policy is missing kms:GenerateDataKey* -- its ingest/compaction/\
              catalog-fold PUTs under t/<hash>/... will fail closed against a \
              --tenant-kms-config tenant. Found kms actions: {actions:?}"
@@ -349,13 +417,15 @@ fn roles_writing_routed_objects_have_kms_grant() {
         }
         let actions = kms_actions(&policy);
         assert!(
-            actions.iter().any(|a| a.starts_with("kms:GenerateDataKey")),
+            actions
+                .iter()
+                .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
             "{role}: PUTs routed object class(es) {routed:?} but policy lacks \
              kms:GenerateDataKey* -- those writes fail closed under \
              --tenant-kms-config. Found kms actions: {actions:?}"
         );
         assert!(
-            actions.iter().any(|a| a == "kms:Encrypt"),
+            actions.iter().any(|a| action_eq(a, "kms:Encrypt")),
             "{role}: PUTs routed object class(es) {routed:?} but policy lacks \
              kms:Encrypt -- those writes fail closed under --tenant-kms-config. \
              Found kms actions: {actions:?}"
@@ -374,7 +444,9 @@ fn admin_has_no_kms_generate_data_key() {
     let policy = load_policy("admin");
     let actions = kms_actions(&policy);
     assert!(
-        !actions.iter().any(|a| a.starts_with("kms:GenerateDataKey")),
+        !actions
+            .iter()
+            .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
         "admin: policy must not carry kms:GenerateDataKey* (Decrypt-only per ADR-0055). \
          Found kms actions: {actions:?}"
     );
@@ -393,7 +465,7 @@ fn every_role_has_kms_decrypt() {
         let policy = load_policy(role);
         let actions = kms_actions(&policy);
         assert!(
-            actions.iter().any(|a| a == "kms:Decrypt"),
+            actions.iter().any(|a| action_eq(a, "kms:Decrypt")),
             "{role}: policy is missing kms:Decrypt -- its reads of SSE-KMS objects \
              under a --tenant-kms-config tenant will fail closed. \
              Found kms actions: {actions:?}"
@@ -456,34 +528,15 @@ fn assert_kms_resource_names_a_key_id(role: &str, sid: &str, resource: &str) {
 fn no_kms_statement_grants_every_key_in_the_region() {
     for role in ALL_ROLES {
         let policy = load_policy(role);
-        for stmt in policy.statements.as_array().unwrap() {
-            let actions: Vec<String> = match &stmt["Action"] {
-                serde_json::Value::String(s) => vec![s.clone()],
-                serde_json::Value::Array(a) => a
-                    .iter()
-                    .filter_map(|v| v.as_str().map(str::to_string))
-                    .collect(),
-                _ => continue,
-            };
-            if !actions
-                .iter()
-                .any(|a| a.to_ascii_lowercase().starts_with("kms:"))
-            {
-                continue;
-            }
-            let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
-            let resources: Vec<String> = match &stmt["Resource"] {
-                serde_json::Value::String(s) => vec![s.clone()],
-                serde_json::Value::Array(a) => a
-                    .iter()
-                    .map(|v| v.as_str().expect("Resource entry is a string").to_string())
-                    .collect(),
-                other => {
-                    panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
-                }
-            };
+        let statements = kms_statement_resources(&policy);
+        assert!(
+            !statements.is_empty(),
+            "{role}: no statement carrying a kms: action was found -- this guard \
+             would pass having examined nothing"
+        );
+        for (sid, resources) in statements {
             for resource in &resources {
-                assert_kms_resource_is_not_account_wide(role, sid, resource);
+                assert_kms_resource_is_not_account_wide(role, &sid, resource);
             }
         }
     }
@@ -498,34 +551,15 @@ fn no_kms_statement_grants_every_key_in_the_region() {
 fn every_kms_statement_names_a_key_id() {
     for role in ALL_ROLES {
         let policy = load_policy(role);
-        for stmt in policy.statements.as_array().unwrap() {
-            let actions: Vec<String> = match &stmt["Action"] {
-                serde_json::Value::String(s) => vec![s.clone()],
-                serde_json::Value::Array(a) => a
-                    .iter()
-                    .filter_map(|v| v.as_str().map(str::to_string))
-                    .collect(),
-                _ => continue,
-            };
-            if !actions
-                .iter()
-                .any(|a| a.to_ascii_lowercase().starts_with("kms:"))
-            {
-                continue;
-            }
-            let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
-            let resources: Vec<String> = match &stmt["Resource"] {
-                serde_json::Value::String(s) => vec![s.clone()],
-                serde_json::Value::Array(a) => a
-                    .iter()
-                    .map(|v| v.as_str().expect("Resource entry is a string").to_string())
-                    .collect(),
-                other => {
-                    panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
-                }
-            };
+        let statements = kms_statement_resources(&policy);
+        assert!(
+            !statements.is_empty(),
+            "{role}: no statement carrying a kms: action was found -- this guard \
+             would pass having examined nothing"
+        );
+        for (sid, resources) in statements {
             for resource in &resources {
-                assert_kms_resource_names_a_key_id(role, sid, resource);
+                assert_kms_resource_names_a_key_id(role, &sid, resource);
             }
         }
     }
@@ -546,17 +580,12 @@ fn mixed_case_kms_action_is_not_a_bypass() {
         "Action": "KMS:Decrypt",
         "Resource": "*"
     });
-    let actions: Vec<String> = match &stmt["Action"] {
-        serde_json::Value::String(s) => vec![s.clone()],
-        serde_json::Value::Array(a) => a
-            .iter()
-            .filter_map(|v| v.as_str().map(str::to_string))
-            .collect(),
-        _ => vec![],
-    };
+    let actions = statement_actions(&stmt);
 
-    // Observation 1: the pre-fix selection (case-sensitive) misses the
-    // mixed-case action entirely, exactly the hole this test guards against.
+    // Observation 1 (load-bearing): the pre-fix selection (case-sensitive)
+    // misses the mixed-case action entirely, exactly the hole this test guards
+    // against. Kept as the literal pre-fix expression, not a call into the
+    // fixed code, so it pins that the hole existed.
     let selected_before_fix = actions.iter().any(|a| a.starts_with("kms:"));
     assert!(
         !selected_before_fix,
@@ -565,36 +594,172 @@ fn mixed_case_kms_action_is_not_a_bypass() {
          the hole existed"
     );
 
-    // Observation 2: the post-fix selection (lowercased) catches it.
-    let selected_after_fix = actions
-        .iter()
-        .any(|a| a.to_ascii_lowercase().starts_with("kms:"));
+    // Observation 2: the post-fix selection catches it, through the same
+    // helper the guards use.
+    let selected_after_fix = actions.iter().any(|a| action_has_prefix(a, "kms:"));
     assert!(
         selected_after_fix,
         "fixture invalid: the post-fix matcher should select \"KMS:Decrypt\""
     );
 
-    // With the statement selected, the real guard's own assertion (resource
-    // != "*" && !resource.ends_with(":key/*")) must now fire on this
-    // fixture's "Resource": "*". Run it through catch_unwind so this test
-    // reports the panic as an assertion result instead of aborting the binary.
-    let resource = stmt["Resource"]
-        .as_str()
-        .expect("Resource is a string")
-        .to_string();
-    let sid = stmt["Sid"].clone();
+    // Observation 3: the guard's own function -- not a re-typed copy of its
+    // expression -- must fire on this fixture's "Resource": "*" now that the
+    // statement is selected. Run it through catch_unwind so this test reports
+    // the panic as an assertion result instead of aborting the binary.
+    let resource = stmt["Resource"].as_str().expect("Resource is a string");
+    let sid = stmt["Sid"].as_str().expect("Sid is a string");
     let guard_result = std::panic::catch_unwind(|| {
-        assert!(
-            resource != "*" && !resource.ends_with(":key/*"),
-            "statement {sid:?} grants a kms: action on {resource:?}, which \
-             covers every key in the account/region"
-        );
+        assert_kms_resource_is_not_account_wide("fixture", sid, resource)
     });
     assert!(
         guard_result.is_err(),
         "the guard must reject \"KMS:Decrypt\" on Resource \"*\" once the \
          statement is selected -- a mixed-case action must not bypass the \
          no-account-wide-key assertion"
+    );
+}
+
+/// Regression fixture for the case-sensitivity hole in a NEGATIVE assertion,
+/// which fails silent where the positive ones fail loud. IAM action names are
+/// case-insensitive, so a policy granting `KMS:GenerateDataKey*` holds exactly
+/// the privilege `admin_has_no_kms_generate_data_key` asserts the role does
+/// not hold. Both halves of that assertion used to compare case-sensitively:
+/// `kms_actions` selected on `starts_with("kms:")`, and the caller compared
+/// with `starts_with("kms:GenerateDataKey")`. Either one alone was enough to
+/// report a role Decrypt-only while it could mint ciphertext under every
+/// tenant key the statement names.
+///
+/// Synthetic, not read from `deploy/iam/`: the shipped admin template is
+/// lowercase and correct, so a fixture over it passes whichever way the
+/// matcher behaves and proves nothing about the matcher.
+#[test]
+fn mixed_case_generate_data_key_is_not_missed_by_the_negative_assertion() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "MixedCaseGenerateDataKey",
+            "Effect": "Allow",
+            "Action": ["KMS:GenerateDataKey*", "KMS:Decrypt"],
+            "Resource":
+                "arn:aws:kms:us-east-1:111122223333:key/abcd1234-5678-90ab-cdef-1234567890ab"
+        }]),
+    };
+    let declared: Vec<String> = policy
+        .statements
+        .as_array()
+        .expect("fixture statements are an array")
+        .iter()
+        .flat_map(statement_actions)
+        .collect();
+
+    // Observation 1 (load-bearing): the pre-fix selection saw no kms action at
+    // all, so the negative assertion held over an empty action list while the
+    // grant sat in the policy. Written as the literal pre-fix expressions, so
+    // this pins the hole rather than restating the fix.
+    let selected_before_fix: Vec<&String> =
+        declared.iter().filter(|a| a.starts_with("kms:")).collect();
+    assert!(
+        selected_before_fix.is_empty(),
+        "fixture invalid: the pre-fix selection was expected to miss \
+         \"KMS:GenerateDataKey*\" -- if it saw it, this fixture no longer \
+         proves the hole existed"
+    );
+    assert!(
+        !selected_before_fix
+            .iter()
+            .any(|a| a.starts_with("kms:GenerateDataKey")),
+        "fixture invalid: the pre-fix negative assertion was expected to hold \
+         (reporting the role unprivileged) on a policy that grants the key"
+    );
+    // The second half of the hole, independent of the first: even handed the
+    // action directly, the pre-fix comparison did not recognize it.
+    assert!(
+        !declared
+            .iter()
+            .any(|a| a.starts_with("kms:GenerateDataKey")),
+        "fixture invalid: the pre-fix comparison was expected to miss \
+         \"KMS:GenerateDataKey*\" even when given the action"
+    );
+
+    // Observation 2: the post-fix selection and comparison both see it, so the
+    // negative assertion in admin_has_no_kms_generate_data_key now fires.
+    let actions = kms_actions(&policy);
+    assert!(
+        actions
+            .iter()
+            .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
+        "the post-fix matcher must see KMS:GenerateDataKey* as the \
+         kms:GenerateDataKey* grant it is. Found kms actions: {actions:?}"
+    );
+    assert!(
+        actions.iter().any(|a| action_eq(a, "kms:Decrypt")),
+        "the post-fix matcher must see KMS:Decrypt as kms:Decrypt. \
+         Found kms actions: {actions:?}"
+    );
+
+    // Observation 3: the selected strings keep the template's own
+    // capitalization, so a failure message quotes what the policy says rather
+    // than a normalized form the operator cannot find in the file.
+    assert!(
+        actions.iter().any(|a| a == "KMS:GenerateDataKey*"),
+        "kms_actions must preserve the policy's own spelling for failure \
+         messages. Found kms actions: {actions:?}"
+    );
+}
+
+/// The same case-sensitivity shape on the `s3:PutObject` selection that feeds
+/// `roles_writing_routed_objects_have_kms_grant`. That guard derives the set
+/// of routed PUT patterns from the policy and skips the role outright when the
+/// set is empty, so a case-sensitive match on the action name silently skips
+/// the KMS-grant check for a role that does route writes -- the same
+/// fails-silent shape as the negative assertion above, reached through an
+/// empty derived set instead of an empty action list.
+///
+/// Synthetic for the same reason: the shipped templates spell the action
+/// lowercase.
+#[test]
+fn mixed_case_put_object_still_selects_routed_write_patterns() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "MixedCaseRoutedPut",
+            "Effect": "Allow",
+            "Action": ["S3:PutObject"],
+            "Resource": ["arn:aws:s3:::my-ravel-bucket/t/*/*/l0/*"]
+        }]),
+    };
+
+    // Observation 1 (load-bearing): the pre-fix case-sensitive equality
+    // selected nothing, so the derived routed-PUT set was empty and the guard
+    // continued past this role without checking any KMS grant.
+    let selected_before_fix = policy
+        .statements
+        .as_array()
+        .expect("fixture statements are an array")
+        .iter()
+        .any(|stmt| statement_actions(stmt).iter().any(|a| a == "s3:PutObject"));
+    assert!(
+        !selected_before_fix,
+        "fixture invalid: the pre-fix case-sensitive match was expected to \
+         miss \"S3:PutObject\" -- if it saw it, this fixture no longer proves \
+         the hole existed"
+    );
+
+    // Observation 2: the post-fix selection returns the pattern, and the real
+    // routing predicate confirms it is a routed write, so the guard now
+    // reaches its KMS-grant assertions for this role instead of skipping it.
+    let patterns = put_resource_key_patterns(&policy);
+    assert_eq!(
+        patterns,
+        vec!["t/*/*/l0/*".to_string()],
+        "the post-fix selection must return the statement's PUT pattern"
+    );
+    assert!(
+        patterns
+            .iter()
+            .any(|p| ravel_object_store::routes_through_tenant_key(p)),
+        "fixture invalid: {patterns:?} must route through the tenant key, or \
+         the guard would skip this role for a reason unrelated to the matcher"
     );
 }
 

--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -401,9 +401,53 @@ fn every_role_has_kms_decrypt() {
     }
 }
 
+/// The two wildcard characters IAM resolves inside a `Resource` ARN: `*`
+/// matches any sequence, `?` matches exactly one character. Either one, in
+/// any segment of a KMS ARN, grants more keys than the ARN appears to name:
+/// `key/????????-????-????-????-????????????` covers every key whose id has
+/// the shape of a UUID, and a `?` or `*` in the region or account position
+/// widens the grant the same way.
+const IAM_WILDCARDS: [char; 2] = ['*', '?'];
+
+/// True when `resource` names more than the single key it appears to name.
+fn kms_resource_is_wildcarded(resource: &str) -> bool {
+    resource.contains(IAM_WILDCARDS)
+}
+
+/// The ARN shape a KMS `Resource` must have to pin one key: no IAM wildcard
+/// in any segment, and a key-id segment that cannot span a `/` (so an
+/// `alias/...` or a nested path cannot pose as a key id).
+fn kms_key_arn_pattern() -> regex::Regex {
+    regex::Regex::new(r"^arn:aws:kms:[^:*?/]+:[^:*?/]+:key/[^:*?/]+$").expect("valid regex")
+}
+
+/// The account-wide-grant half of the KMS resource guard, as one function so
+/// the regression fixtures below run the real assertion rather than a copy of
+/// its text.
+fn assert_kms_resource_is_not_account_wide(role: &str, sid: &str, resource: &str) {
+    assert!(
+        !kms_resource_is_wildcarded(resource),
+        "{role}: statement {sid:?} grants a kms: action on {resource:?}, which \
+         contains an IAM wildcard (`*` or `?`) and so covers keys beyond the one \
+         it appears to name"
+    );
+}
+
+/// The names-a-specific-key half of the KMS resource guard, likewise shared
+/// with the fixtures.
+fn assert_kms_resource_names_a_key_id(role: &str, sid: &str, resource: &str) {
+    assert!(
+        kms_key_arn_pattern().is_match(resource),
+        "{role}: statement {sid:?} resource {resource:?} does not name a \
+         specific key id (expected arn:aws:kms:<region>:<account>:key/<id>, \
+         with no `*` or `?` in any segment)"
+    );
+}
+
 /// Every statement whose `Action` grants any `kms:` action must not name a
-/// `Resource` that covers every key in the account/region: neither the bare
-/// wildcard `"*"` nor any ARN ending `:key/*`. Pinned as a negation (not an
+/// `Resource` that covers every key in the account/region: not the bare
+/// wildcard `"*"`, not an ARN ending `:key/*`, and not an ARN carrying an IAM
+/// wildcard character anywhere else either. Pinned as a negation (not an
 /// exact tenant-key ARN) so it survives an operator's post-substitution
 /// value. Widen any of the four templates' KMS `Resource` back to
 /// `arn:aws:kms:us-east-1:111122223333:key/*` and this test fails, naming
@@ -439,11 +483,7 @@ fn no_kms_statement_grants_every_key_in_the_region() {
                 }
             };
             for resource in &resources {
-                assert!(
-                    resource != "*" && !resource.ends_with(":key/*"),
-                    "{role}: statement {sid:?} grants a kms: action on {resource:?}, \
-                     which covers every key in the account/region"
-                );
+                assert_kms_resource_is_not_account_wide(role, sid, resource);
             }
         }
     }
@@ -452,11 +492,10 @@ fn no_kms_statement_grants_every_key_in_the_region() {
 /// Every statement whose `Action` grants any `kms:` action must name a
 /// `Resource` that pins a specific key id, so an operator cannot re-widen
 /// the grant to every key by substituting `arn:aws:kms:<region>:<account>:key/*`
-/// (or any other bare-wildcard variant) in place of the placeholder.
+/// (or any other wildcard variant, in the key id or in the region or account
+/// segment) in place of the placeholder.
 #[test]
 fn every_kms_statement_names_a_key_id() {
-    let key_arn_pattern =
-        regex::Regex::new(r"^arn:aws:kms:[^:]+:[^:]+:key/[^*]+$").expect("valid regex");
     for role in ALL_ROLES {
         let policy = load_policy(role);
         for stmt in policy.statements.as_array().unwrap() {
@@ -486,11 +525,7 @@ fn every_kms_statement_names_a_key_id() {
                 }
             };
             for resource in &resources {
-                assert!(
-                    key_arn_pattern.is_match(resource),
-                    "{role}: statement {sid:?} resource {resource:?} does not name a \
-                     specific key id (expected arn:aws:kms:<region>:<account>:key/<id>)"
-                );
+                assert_kms_resource_names_a_key_id(role, sid, resource);
             }
         }
     }
@@ -561,6 +596,109 @@ fn mixed_case_kms_action_is_not_a_bypass() {
          statement is selected -- a mixed-case action must not bypass the \
          no-account-wide-key assertion"
     );
+}
+
+/// Regression fixture for the single-character-wildcard hole: IAM resolves `?`
+/// inside a `Resource` ARN as exactly one character, so
+/// `key/????????-????-????-????-????????????` grants every key whose id has the
+/// shape of a UUID, and a `?` in the region or account segment widens the grant
+/// the same way. Both pre-fix predicates accepted those ARNs: the direct check
+/// tested only for the two literals `"*"` and a `:key/*` suffix, and the ARN
+/// regex excluded `*` from the key-id segment alone. The guards therefore ran
+/// and reported the templates scoped while an effectively account-wide grant sat
+/// unexamined.
+///
+/// Synthetic statements, not `deploy/iam/*.json`: a fixture read from the config
+/// directory passes for reasons unrelated to the matcher, and goes green the day
+/// someone edits the config. Each case asserts in both directions -- that the
+/// pre-fix predicates did NOT reject the resource (so the test cannot quietly
+/// become a tautology if the predicates are rewritten) and that the post-fix
+/// ones do.
+#[test]
+fn single_character_wildcard_in_kms_resource_is_not_a_bypass() {
+    // The pre-fix ARN shape check, kept verbatim so observation 1 below pins
+    // the hole rather than restating the fix.
+    let pre_fix_key_arn_pattern =
+        regex::Regex::new(r"^arn:aws:kms:[^:]+:[^:]+:key/[^*]+$").expect("valid regex");
+
+    let cases = [
+        (
+            "QuestionMarkKeyId",
+            "arn:aws:kms:us-east-1:111122223333:key/????????-????-????-????-????????????",
+        ),
+        (
+            "QuestionMarkRegionAndAccount",
+            "arn:aws:kms:us-east-?:11112222333?:key/abcd1234-5678-90ab-cdef-1234567890ab",
+        ),
+    ];
+
+    for (sid, resource) in cases {
+        let stmt = serde_json::json!({
+            "Sid": sid,
+            "Effect": "Allow",
+            "Action": ["kms:Decrypt", "kms:Encrypt"],
+            "Resource": [resource],
+        });
+        let resources: Vec<String> = stmt["Resource"]
+            .as_array()
+            .expect("Resource is an array")
+            .iter()
+            .map(|v| v.as_str().expect("Resource entry is a string").to_string())
+            .collect();
+        assert_eq!(
+            resources.len(),
+            1,
+            "fixture invalid: expected exactly one resource for {sid}"
+        );
+        let resource = resources[0].as_str();
+
+        // Observation 1 (load-bearing): neither pre-fix predicate rejected this
+        // resource. If either one does, the fixture no longer proves the hole
+        // existed and must be rewritten rather than deleted.
+        let pre_fix_direct_rejects = resource == "*" || resource.ends_with(":key/*");
+        assert!(
+            !pre_fix_direct_rejects,
+            "fixture invalid: the pre-fix direct check was expected to accept \
+             {resource:?} -- if it rejects it, this fixture no longer proves the \
+             `?` hole existed"
+        );
+        assert!(
+            pre_fix_key_arn_pattern.is_match(resource),
+            "fixture invalid: the pre-fix ARN regex was expected to accept \
+             {resource:?} -- if it rejects it, this fixture no longer proves the \
+             `?` hole existed"
+        );
+
+        // Observation 2: both post-fix predicates reject it.
+        assert!(
+            kms_resource_is_wildcarded(resource),
+            "the post-fix direct check must treat {resource:?} as wildcarded"
+        );
+        assert!(
+            !kms_key_arn_pattern().is_match(resource),
+            "the post-fix ARN regex must reject {resource:?}"
+        );
+
+        // Observation 3: the real guards' own assertions fire on this statement.
+        // Run through catch_unwind so the panic is reported as a result here
+        // instead of aborting the binary.
+        let account_wide_guard = std::panic::catch_unwind(|| {
+            assert_kms_resource_is_not_account_wide("fixture", sid, resource)
+        });
+        assert!(
+            account_wide_guard.is_err(),
+            "no_kms_statement_grants_every_key_in_the_region's assertion must \
+             fire on {resource:?}"
+        );
+        let key_id_guard = std::panic::catch_unwind(|| {
+            assert_kms_resource_names_a_key_id("fixture", sid, resource)
+        });
+        assert!(
+            key_id_guard.is_err(),
+            "every_kms_statement_names_a_key_id's assertion must fire on \
+             {resource:?}"
+        );
+    }
 }
 
 #[test]

--- a/deploy/iam/admin.json
+++ b/deploy/iam/admin.json
@@ -39,7 +39,7 @@
       "Sid": "AdminTenantKms",
       "Effect": "Allow",
       "Action": "kms:Decrypt",
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/deploy/iam/gateway.json
+++ b/deploy/iam/gateway.json
@@ -48,7 +48,7 @@
       "Sid": "GatewayTenantKms",
       "Effect": "Allow",
       "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/deploy/iam/maintain.json
+++ b/deploy/iam/maintain.json
@@ -58,7 +58,7 @@
       "Sid": "MaintainTenantKms",
       "Effect": "Allow",
       "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/deploy/iam/query.json
+++ b/deploy/iam/query.json
@@ -47,7 +47,7 @@
       "Sid": "QueryTenantKms",
       "Effect": "Allow",
       "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
-      "Resource": "arn:aws:kms:us-east-1:111122223333:key/*"
+      "Resource": ["arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID"]
     },
     {
       "Sid": "DenyDeleteProtected",

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -169,11 +169,21 @@ shipped topology does.
 One policy document per role lives in [`deploy/iam/`](../../../deploy/iam/)
 rather than being transcribed here, so a policy edit is a diff that a test
 checks against the real object-key layout in CI. Replace `my-ravel-bucket` with
-your bucket, and `arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID`
-with your tenant key ARN(s), in each file, then attach each document to the
-principal whose access key that role's deployment uses. An operator who
-attaches a template without substituting the KMS ARN gets `AccessDenied` on
-the first KMS-routed PUT: the placeholder names no real key.
+your bucket in each file, then attach each document to the principal whose
+access key that role's deployment uses.
+
+The KMS statement's `Resource` value is a JSON array, shipped with exactly one
+entry: the placeholder `arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID`.
+That single-entry array is correct as shipped only for a deployment with one
+KMS key. `--tenant-kms-config` routes different tenants to different keys (see
+[Encrypting objects with SSE-KMS](#encrypting-objects-with-sse-kms)), and each
+role's policy must authorize every key its own writes and reads can reach:
+for each key you configure in the tenant-KMS file, add its exact ARN as its own
+entry in that array, rather than replacing the single placeholder with your
+one key and calling it done. A configured tenant key missing from the array
+does not fail at startup: the process starts normally, and the gap surfaces
+only when a request first routes to that key, as `AccessDenied` on that KMS
+call, at runtime rather than at deploy time.
 
 Three facts about those documents are worth knowing before you edit them.
 

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -169,8 +169,11 @@ shipped topology does.
 One policy document per role lives in [`deploy/iam/`](../../../deploy/iam/)
 rather than being transcribed here, so a policy edit is a diff that a test
 checks against the real object-key layout in CI. Replace `my-ravel-bucket` with
-your bucket in each file, then attach each document to the principal whose
-access key that role's deployment uses.
+your bucket, and `arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID`
+with your tenant key ARN(s), in each file, then attach each document to the
+principal whose access key that role's deployment uses. An operator who
+attaches a template without substituting the KMS ARN gets `AccessDenied` on
+the first KMS-routed PUT: the placeholder names no real key.
 
 Three facts about those documents are worth knowing before you edit them.
 
@@ -356,8 +359,10 @@ to narrow.
 }
 ```
 
-The matching role-side statement in each `deploy/iam/*.json` template is scoped
-to the tenant key ARNs rather than to every key:
+The matching role-side statement in each `deploy/iam/*.json` template holds a
+placeholder tenant key ARN that you must replace with your own (see
+[the shipped policy documents](#the-shipped-policy-documents)); scoped to a
+real tenant key rather than to every key:
 
 - Gateway and Maintain write tenant data through the routing store and read some
   of what they write, so they hold encrypt, generate-data-key and decrypt.

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -175,15 +175,23 @@ access key that role's deployment uses.
 The KMS statement's `Resource` value is a JSON array, shipped with exactly one
 entry: the placeholder `arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID`.
 That single-entry array is correct as shipped only for a deployment with one
-KMS key. `--tenant-kms-config` routes different tenants to different keys (see
+KMS key. Two independent flags put keys in play (see
 [Encrypting objects with SSE-KMS](#encrypting-objects-with-sse-kms)), and each
-role's policy must authorize every key its own writes and reads can reach:
-for each key you configure in the tenant-KMS file, add its exact ARN as its own
-entry in that array, rather than replacing the single placeholder with your
-one key and calling it done. A configured tenant key missing from the array
+role's policy must authorize every key its own writes and reads can reach, so
+that array needs an exact ARN for each of:
+
+- the key configured with `--s3-kms-key`, if the deployment sets it. It is
+  applied to the default store, so it encrypts every PUT the process makes that
+  no per-tenant key overrides. Omit it and Gateway, Query and Maintain PUTs fail
+  with `AccessDenied`, and reads of objects already written under it fail KMS
+  decryption for every role including Admin.
+- every key configured in the `--tenant-kms-config` file, one entry each.
+
+Add each ARN as its own entry, rather than replacing the single placeholder with
+your one key and calling it done. A configured key missing from the array
 does not fail at startup: the process starts normally, and the gap surfaces
-only when a request first routes to that key, as `AccessDenied` on that KMS
-call, at runtime rather than at deploy time.
+only when a request first uses that key, as `AccessDenied` on that KMS call, at
+runtime rather than at deploy time.
 
 Three facts about those documents are worth knowing before you edit them.
 
@@ -371,8 +379,13 @@ to narrow.
 
 The matching role-side statement in each `deploy/iam/*.json` template holds a
 placeholder tenant key ARN that you must replace with your own (see
-[the shipped policy documents](#the-shipped-policy-documents)); scoped to a
-real tenant key rather than to every key:
+[the shipped policy documents](#the-shipped-policy-documents)); scoped to real
+keys rather than to every key. Replace it with the exact ARN configured with
+`--s3-kms-key`, if the deployment sets that flag, plus one exact ARN for every
+key in the `--tenant-kms-config` file. The two flags are independent: the
+`--s3-kms-key` ARN covers every PUT that no per-tenant key overrides, and its
+absence from a role's array fails that role's PUTs, and every role's reads of
+objects written under it, with `AccessDenied`. With the keys in place:
 
 - Gateway and Maintain write tenant data through the routing store and read some
   of what they write, so they hold encrypt, generate-data-key and decrypt.

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -379,7 +379,7 @@ to narrow.
 
 The matching role-side statement in each `deploy/iam/*.json` template holds a
 placeholder tenant key ARN that you must replace with your own (see
-[the shipped policy documents](#the-shipped-policy-documents)); scoped to real
+[the shipped policy documents](#the-shipped-policy-documents)), scoped to real
 keys rather than to every key. Replace it with the exact ARN configured with
 `--s3-kms-key`, if the deployment sets that flag, plus one exact ARN for every
 key in the `--tenant-kms-config` file. The two flags are independent: the


### PR DESCRIPTION
The shipped IAM templates granted every KMS action on
arn:aws:kms:us-east-1:111122223333:key/*, which is every key in the account and
region. Each role's KMS Resource is now an array holding a placeholder tenant
key ARN for the operator to replace.

The test guard meant to catch that took four rounds, and every failure had one
signature: the guard ran, reported success, and the permissive thing sat
unexamined. It could not read the Resource field at all. Then it matched the
IAM action prefix case-sensitively, so KMS:Decrypt on Resource "*" passed. Then
it accepted ?, which IAM resolves as a single-character wildcard, so
key/????????-????-????-????-???????????? covered every key whose id has the
shape of a UUID. Then, in the commit fixing those three, two more: a shared
helper still selected and compared action names case-sensitively, and a fixture
claiming to run the real guard ran a re-typed copy of it.

The last two were the worst of the set. admin_has_no_kms_generate_data_key is a
NEGATIVE assertion, that the Admin role does not hold kms:GenerateDataKey, and a
policy granting KMS:GenerateDataKey satisfied it while holding the grant, so the
assertion reported the safe answer on the unsafe input. And
mixed_case_kms_action_is_not_a_bypass stated in its own comment that the real
guard's assertion ran inside its catch_unwind while the closure re-implemented
the pre-fix expression, so a regression in the real guard left it green.

Both resource guards now go through one selection helper, action comparisons go
through action_eq and action_has_prefix, and the selected strings keep the
template's own capitalization so a failure message shows what the policy said
rather than a normalized form the operator would grep for in vain. Fixtures call
the guard functions instead of copies of their text.

Four regression fixtures assert in both directions on synthetic statements, not
on the shipped config: that each pre-fix predicate ACCEPTED the input, so a
later rewrite cannot quietly turn the test into a tautology, and that each
post-fix one rejects it.

The operations guide understated which ARNs a role needs. --s3-kms-key is an
independent mode that configures the default store for every PUT no per-tenant
key overrides, verified at services/ravel-server/src/store.rs:395. Omit its ARN
and Gateway, Query and Maintain PUTs fail with AccessDenied, and reads of
objects already written under it fail KMS decryption for every role including
Admin. Both the shipped-documents section and the SSE-KMS summary now require
that ARN plus one exact ARN per key in the tenant-KMS file, and say a missing
key surfaces at first use rather than at startup.

The guards still read only the Resource field, so a statement carrying
NotResource or NotAction is skipped rather than rejected. That is the same shape
again and is tracked in #1346, with a fail-closed-on-unknown-keys suggestion
rather than a fifth targeted patch. The shipped templates use neither key today.

Fixes: #1303
