### PR TITLE
feat(sql): carry the query I/O shape through the SQL executor

### DIFF
--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -2496,6 +2496,14 @@ fn combine_phase_accounting(
 /// every figure here is a pure function of the resolved `Snapshot` and the
 /// query's own configuration, computable before a single segment fetch
 /// starts.
+///
+/// Delegates to [`crate::io_shape::io_shape_for_resolve_with_fanouts`],
+/// passing `concurrency` as both the outer and inner fan-out width -- the
+/// single-fanout special case that function's own docs describe -- and
+/// extracting `resolve_list_requests` from `accounting` here, since
+/// `PhaseAccounting` is a PromQL-engine-specific type the shared function
+/// does not depend on (issue #1250 needed a second entry point that
+/// `ravel-sql`'s single-pool `QueryAccounting` could also drive).
 #[allow(clippy::too_many_arguments)]
 fn io_shape_for_resolve(
     snapshot: &Snapshot,
@@ -2507,33 +2515,22 @@ fn io_shape_for_resolve(
     accounting: &PhaseAccounting,
     unfolded_segments_resolved: u64,
 ) -> QueryIoShape {
-    let mut counts = IoShapeCounts::default();
-    let depth = snapshot
-        .segments
-        .iter()
-        .map(|seg| crate::io_shape::depth_for_object(seg.object_size, whole_object_threshold))
-        .max()
-        .unwrap_or(0);
-    counts.record_dependency_chain(depth);
-    counts.record_service_batches(crate::io_shape::service_batches_over_plan_waves(
-        snapshot.segments.len() as u64,
-        service_fetch_multiplier,
-        concurrency,
-        shared_get_permits,
-    ));
     let resolve_list_requests = accounting
         .resolve()
         .snapshot()
         .s3_requests(AccountedOp::List);
-    counts.record_list_pages(resolve_list_requests.min(u64::from(u32::MAX)) as u32);
-    let plan_class = if metadata_only {
-        PlanClass::MetadataOnly
-    } else if snapshot.segments_pruned > 0 {
-        PlanClass::SelectiveIndexed
-    } else {
-        PlanClass::ExhaustiveScan
-    };
-    counts.into_shape(unfolded_segments_resolved, plan_class)
+    crate::io_shape::io_shape_for_resolve_with_fanouts(
+        snapshot,
+        metadata_only,
+        whole_object_threshold,
+        snapshot.segments.len() as u64,
+        service_fetch_multiplier,
+        concurrency,
+        concurrency,
+        shared_get_permits,
+        resolve_list_requests,
+        unfolded_segments_resolved,
+    )
 }
 
 /// A locally-scoped series identity for a log-derived series returned from

--- a/crates/ravel-query/src/io_shape.rs
+++ b/crates/ravel-query/src/io_shape.rs
@@ -160,7 +160,7 @@
 //! recording sequences and assert on the resulting [`IoShapeCounts`], with no
 //! dependency on a live catalog or object store.
 
-use ravel_catalog::SegmentOrigin;
+use ravel_catalog::{SegmentOrigin, Snapshot};
 
 /// Coarse pre-execution classification of a query's expected access pattern,
 /// decided once, before any segment is opened.
@@ -370,18 +370,121 @@ pub fn service_batches_over_plan_waves(
     fanout: u64,
     shared_permits: u64,
 ) -> u32 {
-    let fanout = fanout.max(1);
+    // PromQL's engine has one fan-out knob per level (`promql_fetch_fanout`),
+    // reused for both the OUTER admission width and the INNER per-plan
+    // concurrency (see the module docs' `service_batches` entry). That is the
+    // single-fanout special case of the two-width model below.
+    service_batches_over_plan_waves_with_fanouts(
+        segments,
+        distinct_plans,
+        fanout,
+        fanout,
+        shared_permits,
+    )
+}
+
+/// [`service_batches_over_plan_waves`], generalized to a caller whose OUTER
+/// admission width (how many plans run at once) and INNER per-plan
+/// concurrency (how many of one plan's segments fetch at once) are two
+/// genuinely different numbers, rather than the one `promql_fetch_fanout`
+/// PromQL's engine reuses for both. `ravel-sql`'s `SqlExecutor` is exactly
+/// such a caller: `outer_fanout` is the effective DataFusion partition count
+/// (`target_partitions`, clamped to the segment count), all of which run
+/// concurrently with no shared limiter admitting them in waves, while
+/// `inner_fanout` is 1, because each partition's own segments fetch strictly
+/// sequentially (`RsegScanExec::prepare_partition`'s per-partition loop is
+/// genuinely sequential, `crates/ravel-sql/src/scan.rs`). Passing
+/// `outer_fanout == inner_fanout == fanout` reduces this exactly to
+/// [`service_batches_over_plan_waves`]'s own formula, which is how that
+/// function is now implemented.
+///
+/// `waves = ceil(distinct_plans / outer_fanout)`. For 0-based wave `w`,
+/// `active_w = min(outer_fanout, distinct_plans - w * outer_fanout)` plans
+/// are admitted, `capacity_w = min(inner_fanout * active_w, shared_permits)`
+/// is that wave's binding concurrency (each admitted plan contributes up to
+/// `inner_fanout` concurrent requests, not `outer_fanout`), and `batches_w =
+/// service_batches(segments * active_w, capacity_w)` is that wave's own
+/// serial round count. `outer_fanout` and `distinct_plans` are each clamped
+/// to at least 1, matching [`service_batches`]'s own concurrency clamp.
+pub fn service_batches_over_plan_waves_with_fanouts(
+    segments: u64,
+    distinct_plans: u64,
+    outer_fanout: u64,
+    inner_fanout: u64,
+    shared_permits: u64,
+) -> u32 {
+    let outer_fanout = outer_fanout.max(1);
     let distinct_plans = distinct_plans.max(1);
-    let waves = distinct_plans.div_ceil(fanout);
+    let waves = distinct_plans.div_ceil(outer_fanout);
     let mut total: u64 = 0;
     for w in 0..waves {
-        let admitted_before = w.saturating_mul(fanout);
-        let active = fanout.min(distinct_plans.saturating_sub(admitted_before));
-        let capacity = fanout.saturating_mul(active).min(shared_permits);
+        let admitted_before = w.saturating_mul(outer_fanout);
+        let active = outer_fanout.min(distinct_plans.saturating_sub(admitted_before));
+        let capacity = inner_fanout.saturating_mul(active).min(shared_permits);
         let batches = service_batches(segments.saturating_mul(active), capacity);
         total = total.saturating_add(u64::from(batches));
     }
     total.min(u64::from(u32::MAX)) as u32
+}
+
+/// Assembles a complete [`QueryIoShape`] from fully explicit primitives, with
+/// no dependency on `ravel-query`'s own `PhaseAccounting` (`engine.rs`'s
+/// private `io_shape_for_resolve` wraps this, extracting
+/// `resolve_list_requests` from its `&PhaseAccounting` before calling
+/// through) and no assumption that one fan-out width serves both the OUTER
+/// and INNER levels of `service_batches_over_plan_waves_with_fanouts`
+/// (issue #1250: `ravel-sql`'s DataFusion partition fan-out and per-partition
+/// sequential fetch need two independent widths, which the PromQL-shaped
+/// `io_shape_for_resolve` cannot express without pulling in a
+/// `PhaseAccounting`-shaped argument it has no equivalent of).
+///
+/// `metadata_only` and `whole_object_threshold` behave exactly as in
+/// `io_shape_for_resolve`. `segments` is the segment count the
+/// `service_batches` model should charge per admitted plan (for `ravel-sql`,
+/// the busiest DataFusion partition's segment count, not the query's total);
+/// `distinct_plans`, `outer_fanout`, and `inner_fanout` feed
+/// [`service_batches_over_plan_waves_with_fanouts`] directly.
+/// `resolve_list_requests` and `unfolded_segments_resolved` are each computed
+/// by the caller from its own resolve step (a `QueryAccountingSnapshot` LIST
+/// count and [`count_unfolded_segments`] respectively), since neither type is
+/// shared between the PromQL and SQL resolve paths.
+#[allow(clippy::too_many_arguments)]
+pub fn io_shape_for_resolve_with_fanouts(
+    snapshot: &Snapshot,
+    metadata_only: bool,
+    whole_object_threshold: u64,
+    segments: u64,
+    distinct_plans: u64,
+    outer_fanout: u64,
+    inner_fanout: u64,
+    shared_get_permits: u64,
+    resolve_list_requests: u64,
+    unfolded_segments_resolved: u64,
+) -> QueryIoShape {
+    let mut counts = IoShapeCounts::default();
+    let depth = snapshot
+        .segments
+        .iter()
+        .map(|seg| depth_for_object(seg.object_size, whole_object_threshold))
+        .max()
+        .unwrap_or(0);
+    counts.record_dependency_chain(depth);
+    counts.record_service_batches(service_batches_over_plan_waves_with_fanouts(
+        segments,
+        distinct_plans,
+        outer_fanout,
+        inner_fanout,
+        shared_get_permits,
+    ));
+    counts.record_list_pages(resolve_list_requests.min(u64::from(u32::MAX)) as u32);
+    let plan_class = if metadata_only {
+        PlanClass::MetadataOnly
+    } else if snapshot.segments_pruned > 0 {
+        PlanClass::SelectiveIndexed
+    } else {
+        PlanClass::ExhaustiveScan
+    };
+    counts.into_shape(unfolded_segments_resolved, plan_class)
 }
 
 /// Accumulates the three fan-out-shaped `QueryIoShape` fields
@@ -654,6 +757,63 @@ mod tests {
             count_unfolded_segments(&origins.origins),
             4,
             "4 segments (1 L0 + 3 L1 parts) from only 2 underlying commit/compaction records"
+        );
+    }
+
+    /// [`service_batches_over_plan_waves`] must keep computing exactly what
+    /// it did before it became a thin wrapper around
+    /// [`service_batches_over_plan_waves_with_fanouts`]: passing the same
+    /// `fanout` value for both the two-width function's `outer_fanout` and
+    /// `inner_fanout` must reproduce the single-fanout formula's answer on
+    /// the module docs' own worked examples. Flip the wrapper to pass `1` as
+    /// `inner_fanout` instead of `fanout` to watch this fail.
+    #[test]
+    fn single_fanout_wrapper_matches_the_two_width_formula() {
+        // 18 distinct plans of 1 segment each, outer fan-out 17, 16 shared
+        // permits (the module docs' reviewer's case): wave 0 admits 17 plans
+        // (capacity min(17*17,16)=16, batches ceil(17/16)=2), wave 1 admits
+        // the last plan (capacity min(17*1,16)=16, batches 1): total 3.
+        assert_eq!(service_batches_over_plan_waves(1, 18, 17, 16), 3);
+        assert_eq!(
+            service_batches_over_plan_waves_with_fanouts(1, 18, 17, 17, 16),
+            3
+        );
+        // 64 segments, fanout 8, 2 distinct plans, 16 permits: one wave,
+        // active 2, capacity min(16,16)=16, batches ceil(128/16)=8.
+        assert_eq!(service_batches_over_plan_waves(64, 2, 8, 16), 8);
+        assert_eq!(
+            service_batches_over_plan_waves_with_fanouts(64, 2, 8, 8, 16),
+            8
+        );
+    }
+
+    /// The shape `ravel-sql`'s executor actually needs: `inner_fanout == 1`
+    /// because a DataFusion partition's segments fetch strictly sequentially
+    /// (`RsegScanExec::prepare_partition`), while `outer_fanout ==
+    /// distinct_plans` because every partition runs concurrently with no
+    /// shared limiter admitting them in waves. With `shared_permits` set to
+    /// `u64::MAX` (no `GetLimiter` on the SQL path), this must reduce to
+    /// exactly the busiest partition's own segment count: one wave, capacity
+    /// `1 * active` always covers `segments * active` with `active` full
+    /// batches of size `segments`, i.e. `segments` batches, unaffected by how
+    /// many partitions there are. Flip `inner_fanout` to `outer_fanout` (the
+    /// single-fanout model) to watch this fail: it would instead report
+    /// `ceil(segments / distinct_plans)`, undercounting the real sequential
+    /// depth of the busiest partition.
+    #[test]
+    fn two_width_formula_models_sql_s_sequential_per_partition_fetch() {
+        let segments_per_partition = 5;
+        let distinct_partitions = 3;
+        assert_eq!(
+            service_batches_over_plan_waves_with_fanouts(
+                segments_per_partition,
+                distinct_partitions,
+                distinct_partitions,
+                1,
+                u64::MAX,
+            ),
+            5,
+            "with no shared limiter, the busiest partition's sequential depth is the batch count"
         );
     }
 

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -1158,8 +1158,8 @@ impl SqlExecutor {
     ///   permit pool across partitions.
     /// - `whole_object_threshold` has no single SQL-wide knob; it is read
     ///   per target signal: `self.fetcher` (metrics) and `self.log_fetcher`
-    ///   (logs/alerts/audit, sharing the RLOG funnel per ADR-1101 decision
-    ///   1) each expose their configured threshold directly.
+    ///   (logs/alerts/audit, sharing the RLOG funnel per ADR-1101 decision 1)
+    ///   each expose their configured threshold directly.
     ///   [`crate::spans_fetcher::SpanSegmentFetcher`] has no threshold
     ///   concept at all -- it always issues one unconditional whole-object
     ///   GET -- so spans report `u64::MAX` rather than reusing a

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -91,8 +91,11 @@ use futures::{Stream, StreamExt};
 use ravel_catalog::{Catalog, Snapshot};
 use ravel_memory::MemoryBudget;
 use ravel_promql::{LabelMatcher, MatchOp};
+use ravel_query::io_shape::{
+    QueryIoShape, count_unfolded_segments, io_shape_for_resolve_with_fanouts,
+};
 use ravel_query::{LogSegmentFetcher, QueryError, SegmentFetcher, admit};
-use ravel_types::accounting::{CostEstimate, QueryAccounting, QueryAccountingSnapshot};
+use ravel_types::accounting::{AccountedOp, CostEstimate, QueryAccounting, QueryAccountingSnapshot};
 use ravel_types::{CommitToken, METRIC_NAME_LABEL, Signal, TenantHash, TimeRange};
 
 use crate::alerts_provider::AlertsTableProvider;
@@ -223,6 +226,13 @@ pub struct SqlStats {
     /// that wrote it lives on [`SqlOutcome::spill_by_operator`], which does not
     /// have to stay `Copy`.
     pub spill: SpillCounts,
+    /// This query's I/O dependency shape (issue #1250), computed at the same
+    /// resolve site that sets `segments`, so a SQL statement reports the same
+    /// `io` block a PromQL query does. See
+    /// [`SqlExecutor::io_shape_for_resolve`] (called from
+    /// [`SqlExecutor::resolve`]) for how each field is derived from a SQL
+    /// statement's own knobs.
+    pub io_shape: ravel_query::io_shape::QueryIoShape,
 }
 
 /// The `LogsScanExec` block counters, summed over a plan tree.
@@ -610,10 +620,11 @@ impl SqlExecutor {
             // deadline trip reflects exactly this attempt's issued cost and
             // never a discarded prior attempt's.
             live.install(&accounting);
-            let (snapshot, estimate) = self.resolve(tenant_hash, req, &accounting).await?;
+            let (snapshot, estimate, io_shape) = self.resolve(tenant_hash, req, &accounting).await?;
             stats.resolves += 1;
             stats.attempts += 1;
             stats.segments = snapshot.segments.len();
+            stats.io_shape = io_shape;
 
             let (result, emitted, blocks, spill, spill_by_operator) = self
                 .attempt(tenant_hash, req, snapshot, &accounting, &declared)
@@ -669,12 +680,19 @@ impl SqlExecutor {
     /// `accounting` receives this resolve's store counters; the returned
     /// [`CostEstimate`] is the two-part estimate for the query this snapshot
     /// will be planned against.
+    ///
+    /// Also returns this resolve's [`QueryIoShape`] (issue #1250). Flight SQL
+    /// does not currently render a stats surface on either RPC, so
+    /// `get_flight_info_statement` discards it; it is kept in the return
+    /// type anyway so both transports share exactly one resolve-site
+    /// computation rather than `run` recomputing it from this method's other
+    /// return values.
     pub async fn resolve_snapshot(
         &self,
         tenant_hash: TenantHash,
         req: &SqlRequest,
         accounting: &QueryAccounting,
-    ) -> Result<(Snapshot, CostEstimate), SqlError> {
+    ) -> Result<(Snapshot, CostEstimate, QueryIoShape), SqlError> {
         self.resolve(tenant_hash, req, accounting).await
     }
 
@@ -1043,7 +1061,7 @@ impl SqlExecutor {
         tenant_hash: TenantHash,
         req: &SqlRequest,
         accounting: &QueryAccounting,
-    ) -> Result<(Snapshot, CostEstimate), SqlError> {
+    ) -> Result<(Snapshot, CostEstimate, QueryIoShape), SqlError> {
         // Idle-tenant eviction last-touch (ADR-0069 decision 2): stamp this
         // tenant's activity with the request's injected clock before resolving.
         // This is the one funnel both the HTTP (`execute`/`run`) and Flight SQL
@@ -1085,6 +1103,15 @@ impl SqlExecutor {
                 accounting,
             )
             .await?;
+        // Sampled here, before `admit()` and before any scan or fetch has
+        // started, so this counts only the resolve above's own LIST calls
+        // (issue #1250). PromQL's equivalent is `PhaseAccounting::resolve()`
+        // (`ravel_query::engine::io_shape_for_resolve`); SQL has no
+        // phase-split accounting type, so the same isolation is achieved by
+        // timing, against the single-pool `QueryAccounting` every SQL query
+        // already carries.
+        let resolve_list_requests = accounting.snapshot().s3_requests(AccountedOp::List);
+        let unfolded_segments_resolved = count_unfolded_segments(&origins.origins);
         // Sealed, below-watermark segments count against `max_segments`;
         // recent and token-resolved segments are exempt (ADR-0073 decision
         // 2), the same seam `ravel_query::engine::resolve_bounded` uses for
@@ -1101,7 +1128,73 @@ impl SqlExecutor {
             }
             TargetSignal::Spans => estimate_spans_cost(&snapshot, catalog_requests),
         };
-        Ok((snapshot, estimate))
+        let io_shape = self.io_shape_for_resolve(
+            target,
+            &snapshot,
+            resolve_list_requests,
+            unfolded_segments_resolved,
+        );
+        Ok((snapshot, estimate, io_shape))
+    }
+
+    /// Assembles this resolve's [`QueryIoShape`] (issue #1250), reusing
+    /// `ravel-query`'s shared assembly function so a SQL statement reports
+    /// the same `io` block a PromQL query does, built from SQL's own fan-out
+    /// knobs in place of PromQL's:
+    ///
+    /// - The outer wave width is DataFusion's `target_partitions`
+    ///   ([`crate::config::EngineConfig::sql_partition_count`] via
+    ///   `self.config.engine`), clamped to the segment count like
+    ///   [`crate::scan::RsegScanExec`] clamps its own partition count.
+    /// - The inner fan-out is `1`: [`crate::scan::RsegScanExec`] fetches each
+    ///   partition's segments strictly sequentially, so the busiest
+    ///   partition's own segment count (`segments.div_ceil(partitions)`) is
+    ///   the whole inner depth.
+    /// - `shared_get_permits` is `u64::MAX`: unlike PromQL's fetchers
+    ///   (ADR-1195's `GetLimiter`), nothing in `ravel-sql` shares a GET
+    ///   permit pool across partitions.
+    /// - `whole_object_threshold` has no single SQL-wide knob; it is read
+    ///   per target signal: `self.fetcher` (metrics) and `self.log_fetcher`
+    ///   (logs/alerts/audit, sharing the RLOG funnel per ADR-1101 decision
+    ///   1) each expose their configured threshold directly.
+    ///   [`crate::spans_fetcher::SpanSegmentFetcher`] has no threshold
+    ///   concept at all -- it always issues one unconditional whole-object
+    ///   GET -- so spans report `u64::MAX` rather than reusing a
+    ///   metrics/logs number that would not apply.
+    fn io_shape_for_resolve(
+        &self,
+        target: TargetSignal,
+        snapshot: &Snapshot,
+        resolve_list_requests: u64,
+        unfolded_segments_resolved: u64,
+    ) -> QueryIoShape {
+        let whole_object_threshold = match target {
+            TargetSignal::Metrics => self.fetcher.whole_object_threshold(),
+            TargetSignal::Logs | TargetSignal::Alerts | TargetSignal::Audit => {
+                self.log_fetcher.block_range_threshold()
+            }
+            TargetSignal::Spans => u64::MAX,
+        };
+        let total_segments = snapshot.segments.len() as u64;
+        let partitions = self
+            .config
+            .engine
+            .sql_partition_count()
+            .max(1)
+            .min(total_segments.max(1) as usize) as u64;
+        let segments_per_plan = total_segments.div_ceil(partitions);
+        io_shape_for_resolve_with_fanouts(
+            snapshot,
+            false,
+            whole_object_threshold,
+            segments_per_plan,
+            partitions,
+            partitions,
+            1,
+            u64::MAX,
+            resolve_list_requests,
+            unfolded_segments_resolved,
+        )
     }
 
     /// The equality `__name__` value a metrics query's pushed-down predicates

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -92,7 +92,7 @@ use ravel_catalog::{Catalog, Snapshot};
 use ravel_memory::MemoryBudget;
 use ravel_promql::{LabelMatcher, MatchOp};
 use ravel_query::io_shape::{
-    QueryIoShape, count_unfolded_segments, io_shape_for_resolve_with_fanouts,
+    QueryIoShape, count_unfolded_segments, io_shape_for_resolve_with_fanouts, service_batches,
 };
 use ravel_query::{LogSegmentFetcher, QueryError, SegmentFetcher, admit};
 use ravel_types::accounting::{
@@ -1147,15 +1147,56 @@ impl SqlExecutor {
     ///
     /// - The outer wave width is DataFusion's `target_partitions`
     ///   ([`crate::config::EngineConfig::sql_partition_count`] via
-    ///   `self.config.engine`), clamped to the segment count like
-    ///   [`crate::scan::RsegScanExec`] clamps its own partition count.
-    /// - The inner fan-out is `1`: [`crate::scan::RsegScanExec`] fetches each
-    ///   partition's segments strictly sequentially, so the busiest
-    ///   partition's own segment count (`segments.div_ceil(partitions)`) is
-    ///   the whole inner depth.
-    /// - `shared_get_permits` is `u64::MAX`: unlike PromQL's fetchers
-    ///   (ADR-1195's `GetLimiter`), nothing in `ravel-sql` shares a GET
-    ///   permit pool across partitions.
+    ///   `self.config.engine`). For `Metrics` and `Spans` this is clamped to
+    ///   the resolved segment count the same way [`crate::scan::RsegScanExec`]
+    ///   clamps its own partition count (both fetch strictly sequentially, one
+    ///   partition per segment). For `Logs`/`Alerts`/`Audit` the shape
+    ///   depends on whether `self.log_fetcher` (a [`LogSegmentFetcher`])
+    ///   carries ADR-0046's read cache ([`LogSegmentFetcher::has_cache`]):
+    ///   un-cached, `logs_scan.rs`'s `LogsScanExec` assigns segments the same
+    ///   segment-granular way and the same clamp applies; cache-wired (the
+    ///   server's default absent `--disable-cache`), `LogsScanExec` stripes
+    ///   every segment's surviving blocks across `target_partitions`
+    ///   unclamped by segment count, so this reports `target_partitions`
+    ///   itself, matching `LogsScanExec`'s own declared partition count.
+    /// - The segment count charged per admitted plan is the busiest
+    ///   partition's own share (`total_segments.div_ceil(partitions)`) for
+    ///   every segment-granular shape (`Metrics`, `Spans`, un-cached logs),
+    ///   where each segment is opened by exactly one partition. For
+    ///   cache-wired logs it is `total_segments` itself: block striping can
+    ///   spread any one segment's blocks across every active partition, so
+    ///   the busiest partition can end up opening every relevant segment.
+    ///   This is a real upper bound (never exceeded, since there are only
+    ///   `total_segments` segments to open) rather than an exact figure,
+    ///   because the true per-partition segment count depends on each
+    ///   segment's surviving block count, which is not resolvable here
+    ///   without an extra fetch (see `logs_scan.rs`'s module doc).
+    /// - The inner fan-out is `1` for every signal: every scan
+    ///   (`RsegScanExec`, the spans scan, and `LogsScanExec` in either mode)
+    ///   fetches its owned work strictly sequentially within one partition.
+    /// - `shared_get_permits` is
+    ///   [`EngineConfig::store_get_concurrency`](ravel_query::EngineConfig::store_get_concurrency)
+    ///   via `self.config.engine`: the real, resolved size of the one
+    ///   `GetLimiter` the server builds and shares across every fetcher it
+    ///   constructs, including all three of this executor's, the same shared
+    ///   pool ADR-1195 gives PromQL's fetchers -- not an unbounded
+    ///   `u64::MAX`.
+    /// - `Logs`/`Alerts`/`Audit` additionally serialize a plan-read phase on
+    ///   top of the scan phase: `logs_scan.rs`'s `compute_plan_counts` runs
+    ///   one plan probe per relevant segment at
+    ///   `buffer_unordered(target_partitions)` (itself bound by the same
+    ///   shared GET permits), and no scan partition drains until that whole
+    ///   pass completes (issue #691). This is added as a second
+    ///   `service_batches` term on top of the scan term rather than folded
+    ///   into it, since the two phases run strictly one after the other on
+    ///   the critical path. The term is charged even on a resolve whose later
+    ///   scan will take the predicate-free whole-segment fast path
+    ///   (`LogsScanExec::whole_segment_fast_path`, which skips the real plan
+    ///   phase entirely): this function runs at resolve time, before the
+    ///   query's predicates are available to it, so it cannot tell the fast
+    ///   path will apply, and charging the phase unconditionally is a
+    ///   documented upper-bound bias (it can overcount that case), never an
+    ///   undercount.
     /// - `whole_object_threshold` has no single SQL-wide knob; it is read
     ///   per target signal: `self.fetcher` (metrics) and `self.log_fetcher`
     ///   (logs/alerts/audit, sharing the RLOG funnel per ADR-1101 decision 1)
@@ -1164,6 +1205,9 @@ impl SqlExecutor {
     ///   concept at all -- it always issues one unconditional whole-object
     ///   GET -- so spans report `u64::MAX` rather than reusing a
     ///   metrics/logs number that would not apply.
+    /// - `metadata_only` is always `false`: no SQL statement plans a
+    ///   metadata-only class today (unlike PromQL's labels/label-values
+    ///   lane), not because one was considered here and ruled out.
     fn io_shape_for_resolve(
         &self,
         target: TargetSignal,
@@ -1179,14 +1223,29 @@ impl SqlExecutor {
             TargetSignal::Spans => u64::MAX,
         };
         let total_segments = snapshot.segments.len() as u64;
-        let partitions = self
-            .config
-            .engine
-            .sql_partition_count()
-            .max(1)
-            .min(total_segments.max(1) as usize) as u64;
-        let segments_per_plan = total_segments.div_ceil(partitions);
-        io_shape_for_resolve_with_fanouts(
+        let configured_partitions = self.config.engine.sql_partition_count().max(1) as u64;
+        let shared_get_permits = self.config.engine.store_get_concurrency().max(1) as u64;
+
+        let (segments_per_plan, partitions, plan_phase_batches) = match target {
+            TargetSignal::Metrics | TargetSignal::Spans => {
+                let partitions = configured_partitions.min(total_segments.max(1));
+                (total_segments.div_ceil(partitions), partitions, 0u32)
+            }
+            TargetSignal::Logs | TargetSignal::Alerts | TargetSignal::Audit => {
+                let (segments_per_plan, partitions, plan_partitions) =
+                    if self.log_fetcher.has_cache() {
+                        (total_segments, configured_partitions, configured_partitions)
+                    } else {
+                        let partitions = configured_partitions.min(total_segments.max(1));
+                        (total_segments.div_ceil(partitions), partitions, partitions)
+                    };
+                let plan_phase_batches =
+                    service_batches(total_segments, plan_partitions.min(shared_get_permits));
+                (segments_per_plan, partitions, plan_phase_batches)
+            }
+        };
+
+        let mut io_shape = io_shape_for_resolve_with_fanouts(
             snapshot,
             false,
             whole_object_threshold,
@@ -1194,10 +1253,12 @@ impl SqlExecutor {
             partitions,
             partitions,
             1,
-            u64::MAX,
+            shared_get_permits,
             resolve_list_requests,
             unfolded_segments_resolved,
-        )
+        );
+        io_shape.service_batches = io_shape.service_batches.saturating_add(plan_phase_batches);
+        io_shape
     }
 
     /// The equality `__name__` value a metrics query's pushed-down predicates

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -95,7 +95,9 @@ use ravel_query::io_shape::{
     QueryIoShape, count_unfolded_segments, io_shape_for_resolve_with_fanouts,
 };
 use ravel_query::{LogSegmentFetcher, QueryError, SegmentFetcher, admit};
-use ravel_types::accounting::{AccountedOp, CostEstimate, QueryAccounting, QueryAccountingSnapshot};
+use ravel_types::accounting::{
+    AccountedOp, CostEstimate, QueryAccounting, QueryAccountingSnapshot,
+};
 use ravel_types::{CommitToken, METRIC_NAME_LABEL, Signal, TenantHash, TimeRange};
 
 use crate::alerts_provider::AlertsTableProvider;
@@ -620,7 +622,8 @@ impl SqlExecutor {
             // deadline trip reflects exactly this attempt's issued cost and
             // never a discarded prior attempt's.
             live.install(&accounting);
-            let (snapshot, estimate, io_shape) = self.resolve(tenant_hash, req, &accounting).await?;
+            let (snapshot, estimate, io_shape) =
+                self.resolve(tenant_hash, req, &accounting).await?;
             stats.resolves += 1;
             stats.attempts += 1;
             stats.segments = snapshot.segments.len();

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -1147,33 +1147,40 @@ impl SqlExecutor {
     ///
     /// - The outer wave width is DataFusion's `target_partitions`
     ///   ([`crate::config::EngineConfig::sql_partition_count`] via
-    ///   `self.config.engine`). For `Metrics` and `Spans` this is clamped to
-    ///   the resolved segment count the same way [`crate::scan::RsegScanExec`]
-    ///   clamps its own partition count (both fetch strictly sequentially, one
-    ///   partition per segment). For `Logs`/`Alerts`/`Audit` the shape
-    ///   depends on whether `self.log_fetcher` (a [`LogSegmentFetcher`])
-    ///   carries ADR-0046's read cache ([`LogSegmentFetcher::has_cache`]):
-    ///   un-cached, `logs_scan.rs`'s `LogsScanExec` assigns segments the same
-    ///   segment-granular way and the same clamp applies; cache-wired (the
-    ///   server's default absent `--disable-cache`), `LogsScanExec` stripes
-    ///   every segment's surviving blocks across `target_partitions`
-    ///   unclamped by segment count, so this reports `target_partitions`
-    ///   itself, matching `LogsScanExec`'s own declared partition count.
+    ///   `self.config.engine`). For `Metrics`, `Spans`, `Alerts`, and `Audit`
+    ///   this is clamped to the resolved segment count the same way
+    ///   [`crate::scan::RsegScanExec`] clamps its own partition count (all
+    ///   four fetch strictly sequentially, one partition per segment):
+    ///   `AlertsScanExec` (`alerts_scan.rs`) and `AuditScanExec`
+    ///   (`audit_scan.rs`) both assign segments round-robin over
+    ///   `min(target_partitions, segments.len())` unconditionally, with no
+    ///   cache-dependent striping and no separate plan-read phase, so they
+    ///   share `Metrics`/`Spans`'s exact segment-granular shape rather than
+    ///   `Logs`'s. Only `Logs` alone depends on whether `self.log_fetcher` (a
+    ///   [`LogSegmentFetcher`]) carries ADR-0046's read cache
+    ///   ([`LogSegmentFetcher::has_cache`]): un-cached, `logs_scan.rs`'s
+    ///   `LogsScanExec` assigns segments the same segment-granular way and
+    ///   the same clamp applies; cache-wired (the server's default absent
+    ///   `--disable-cache`), `LogsScanExec` stripes every segment's surviving
+    ///   blocks across `target_partitions` unclamped by segment count, so
+    ///   this reports `target_partitions` itself, matching `LogsScanExec`'s
+    ///   own declared partition count.
     /// - The segment count charged per admitted plan is the busiest
     ///   partition's own share (`total_segments.div_ceil(partitions)`) for
-    ///   every segment-granular shape (`Metrics`, `Spans`, un-cached logs),
-    ///   where each segment is opened by exactly one partition. For
-    ///   cache-wired logs it is `total_segments` itself: block striping can
-    ///   spread any one segment's blocks across every active partition, so
-    ///   the busiest partition can end up opening every relevant segment.
-    ///   This is a real upper bound (never exceeded, since there are only
-    ///   `total_segments` segments to open) rather than an exact figure,
-    ///   because the true per-partition segment count depends on each
-    ///   segment's surviving block count, which is not resolvable here
-    ///   without an extra fetch (see `logs_scan.rs`'s module doc).
+    ///   every segment-granular shape (`Metrics`, `Spans`, `Alerts`, `Audit`,
+    ///   un-cached logs), where each segment is opened by exactly one
+    ///   partition. For cache-wired logs it is `total_segments` itself: block
+    ///   striping can spread any one segment's blocks across every active
+    ///   partition, so the busiest partition can end up opening every
+    ///   relevant segment. This is a real upper bound (never exceeded, since
+    ///   there are only `total_segments` segments to open) rather than an
+    ///   exact figure, because the true per-partition segment count depends
+    ///   on each segment's surviving block count, which is not resolvable
+    ///   here without an extra fetch (see `logs_scan.rs`'s module doc).
     /// - The inner fan-out is `1` for every signal: every scan
-    ///   (`RsegScanExec`, the spans scan, and `LogsScanExec` in either mode)
-    ///   fetches its owned work strictly sequentially within one partition.
+    ///   (`RsegScanExec`, the spans scan, `AlertsScanExec`, `AuditScanExec`,
+    ///   and `LogsScanExec` in either mode) fetches its owned work strictly
+    ///   sequentially within one partition.
     /// - `shared_get_permits` is
     ///   [`EngineConfig::store_get_concurrency`](ravel_query::EngineConfig::store_get_concurrency)
     ///   via `self.config.engine`: the real, resolved size of the one
@@ -1181,8 +1188,10 @@ impl SqlExecutor {
     ///   constructs, including all three of this executor's, the same shared
     ///   pool ADR-1195 gives PromQL's fetchers -- not an unbounded
     ///   `u64::MAX`.
-    /// - `Logs`/`Alerts`/`Audit` additionally serialize a plan-read phase on
-    ///   top of the scan phase: `logs_scan.rs`'s `compute_plan_counts` runs
+    /// - `Logs` alone additionally serializes a plan-read phase on top of
+    ///   the scan phase; `Alerts` and `Audit` do not, since neither
+    ///   `AlertsScanExec` nor `AuditScanExec` runs one: `logs_scan.rs`'s
+    ///   `compute_plan_counts` runs
     ///   one plan probe per relevant segment at
     ///   `buffer_unordered(target_partitions)` (itself bound by the same
     ///   shared GET permits), and no scan partition drains until that whole
@@ -1227,11 +1236,14 @@ impl SqlExecutor {
         let shared_get_permits = self.config.engine.store_get_concurrency().max(1) as u64;
 
         let (segments_per_plan, partitions, plan_phase_batches) = match target {
-            TargetSignal::Metrics | TargetSignal::Spans => {
+            TargetSignal::Metrics
+            | TargetSignal::Spans
+            | TargetSignal::Alerts
+            | TargetSignal::Audit => {
                 let partitions = configured_partitions.min(total_segments.max(1));
                 (total_segments.div_ceil(partitions), partitions, 0u32)
             }
-            TargetSignal::Logs | TargetSignal::Alerts | TargetSignal::Audit => {
+            TargetSignal::Logs => {
                 let (segments_per_plan, partitions, plan_partitions) =
                     if self.log_fetcher.has_cache() {
                         (total_segments, configured_partitions, configured_partitions)

--- a/crates/ravel-sql/src/flight/service.rs
+++ b/crates/ravel-sql/src/flight/service.rs
@@ -331,7 +331,10 @@ impl FlightSqlService for RavelFlightSqlService {
         // DoGet records its actual with a zero estimate so the two folds sum to
         // one whole-query estimate beside the summed whole-query actual.
         let accounting = QueryAccounting::new();
-        let (snapshot, estimate) = self
+        // The third element is this resolve's `QueryIoShape` (issue #1250);
+        // Flight SQL renders no stats surface on either RPC, so it is
+        // discarded here rather than threaded through `FlightInfo`.
+        let (snapshot, estimate, _io_shape) = self
             .executor
             .resolve_snapshot(tenant, &req, &accounting)
             .await

--- a/crates/ravel-sql/tests/flight_distributed.rs
+++ b/crates/ravel-sql/tests/flight_distributed.rs
@@ -933,7 +933,7 @@ async fn multi_endpoint_tickets_partition_pinned_snapshot() {
     let (service, executor, tenant) = service_over_two_shards().await;
 
     // The whole pinned segment set, resolved once as the source of truth.
-    let (snapshot, estimate) = executor
+    let (snapshot, estimate, _io_shape) = executor
         .resolve_snapshot(tenant.hash(), &request(SQL), &QueryAccounting::new())
         .await
         .expect("resolve");
@@ -1067,7 +1067,7 @@ async fn single_client_endpoint_even_when_distributed() {
     // one slice. So the single client endpoint is the deliberate contract, not
     // an artifact of a snapshot that happens not to distribute. Those slices are
     // the INTERNAL coordinator-to-worker plan, never endpoints.
-    let (snapshot, estimate) = executor
+    let (snapshot, estimate, _io_shape) = executor
         .resolve_snapshot(tenant.hash(), &request(SQL), &QueryAccounting::new())
         .await
         .expect("resolve");

--- a/crates/ravel-sql/tests/flight_erasure.rs
+++ b/crates/ravel-sql/tests/flight_erasure.rs
@@ -319,7 +319,7 @@ async fn distributed_slice_do_get_excludes_what_the_resolve_saw_pending() {
 
     let (service, executor) = build_shard_service(Arc::clone(&backend), &tenant).await;
 
-    let (snapshot, estimate) = executor
+    let (snapshot, estimate, _io_shape) = executor
         .resolve_snapshot(
             tenant.hash(),
             &util::request(QUERY),

--- a/crates/ravel-sql/tests/group_by_string_keys.rs
+++ b/crates/ravel-sql/tests/group_by_string_keys.rs
@@ -219,7 +219,7 @@ async fn declared_str_group_by_groups_on_views_and_returns_its_declared_type() {
     let declared = executor
         .resolve_declared_columns(tenant().hash(), request(&sql).now_ns)
         .await;
-    let (snapshot, _) = executor
+    let (snapshot, _, _) = executor
         .resolve_snapshot(tenant().hash(), &request(&sql), &accounting)
         .await
         .expect("snapshot resolves");

--- a/crates/ravel-sql/tests/io_shape.rs
+++ b/crates/ravel-sql/tests/io_shape.rs
@@ -15,7 +15,8 @@ use ravel_query::io_shape::PlanClass;
 use ravel_query::{EngineConfig, LogSegmentFetcher};
 use ravel_sql::SqlConfig;
 use util::{
-    Fixture, SegSpec, SeriesSpec, build_read_cache, publish_logs_segments, request, tenant_id,
+    Fixture, SegSpec, SeriesSpec, build_read_cache, publish_alerts_segments, publish_logs_segments,
+    request, tenant_id,
 };
 
 fn segment(index: i64, metric: &str) -> SegSpec {
@@ -275,7 +276,11 @@ async fn uncached_logs_scan_adds_the_plan_phase_to_the_scan_phase() {
 ///
 /// Flip-line proof: with the `has_cache()` branch removed (falling through
 /// to the uncached clamp unconditionally), this assertion (`4`) fails and
-/// reads `1` instead.
+/// reads `2` instead -- not `1`: the plan-phase term survives that edit
+/// (`plan_partitions` becomes the uncached branch's `partitions = min(8, 3) =
+/// 3`, so `service_batches(3, min(3,50)=3) = ceil(3/3) = 1`), and only the
+/// scan-phase term collapses (`active = 3`, `capacity = min(1*3,50) = 3`,
+/// `service_batches = ceil(1*3/3) = 1`), for a total of `1 + 1 = 2`.
 #[tokio::test]
 async fn cached_logs_scan_is_not_clamped_by_segment_count() {
     const TARGET_PARTITIONS: usize = 8;
@@ -318,5 +323,79 @@ async fn cached_logs_scan_is_not_clamped_by_segment_count() {
         outcome.stats.io_shape.service_batches, 4,
         "cached logs: plan phase ceil(3/min(8,50))=1 plus scan phase \
          ceil(3*8/8)=3, total 4, not the old segment-clamped model's 1"
+    );
+}
+
+/// `alerts` is segment-granular, matching `Metrics`/`Spans`, with NO
+/// plan-read phase (issue #1250 review round 3 regression fix):
+/// `AlertsScanExec` (`alerts_scan.rs`) assigns segments round-robin over
+/// `min(target_partitions, segments.len())` unconditionally -- no
+/// `has_cache()` branch, no `compute_plan_counts` probe -- so it never touches
+/// the cache-dependent, plan-phase-charging shape `logs_scan.rs`'s
+/// `LogsScanExec` uses. Round 2 wrongly grouped `Alerts` (and `Audit`) under
+/// that `Logs` shape, which always overcounts for these two signals since
+/// they never run a plan phase at all.
+///
+/// This fixture publishes 10 alert segments with `sql_partition_count = 4`
+/// and `store_get_concurrency = 8` (ample, so it never binds):
+///
+/// Fixed model: `partitions = min(4, 10) = 4`, `segments_per_plan =
+/// ceil(10/4) = 3`, one wave (`distinct_plans == outer_fanout == partitions
+/// == 4`), `active = 4`, `capacity = min(1*4, 8) = 4`, `service_batches =
+/// ceil(3*4/4) = 3`. No plan-phase term.
+///
+/// Buggy (round 2) model, alerts grouped under `Logs`'s uncached shape:
+/// scan phase unchanged at `3` (the uncached branch's clamp is the same
+/// formula), but it also charges a plan phase: `plan_partitions =
+/// partitions = 4`, `plan_phase_batches = service_batches(10, min(4,8)=4) =
+/// ceil(10/4) = 3`. Buggy total: `3 (plan) + 3 (scan) = 6`.
+///
+/// Flip-line proof: with `TargetSignal::Alerts` moved back into the `Logs`
+/// arm of `io_shape_for_resolve`'s match on `target` (reverting this fix),
+/// this assertion (`3`) fails and reads `6` instead.
+///
+/// Only `alerts` gets this test, not `audit`: both `AlertsScanExec` and
+/// `AuditScanExec` share the identical unconditional round-robin
+/// segment-granular assignment (same `let n = target_partitions.max(1)
+/// .min(segments.len().max(1))` shape, no cache, no plan phase), so one
+/// exact-value regression test through the real `SqlExecutor` proves the
+/// shared arm is correct for both; a second copy over `audit` would just
+/// re-run the same arithmetic against a different table name.
+#[tokio::test]
+async fn alerts_scan_is_segment_granular_with_no_plan_phase() {
+    const TARGET_PARTITIONS: usize = 4;
+    const STORE_GET_CONCURRENCY: usize = 8;
+    const ALERT_SEGMENTS: usize = 10;
+    let tenant = tenant_id("io-shape-alerts");
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    publish_alerts_segments(store.as_ref(), &tenant, ALERT_SEGMENTS).await;
+
+    let config = SqlConfig {
+        engine: EngineConfig {
+            sql_partition_count: Some(TARGET_PARTITIONS),
+            store_get_concurrency: Some(STORE_GET_CONCURRENCY),
+            ..EngineConfig::default()
+        },
+        ..SqlConfig::default()
+    };
+    let fixture = Fixture::build(Arc::clone(&store), &[], config, 1 << 30).await;
+
+    let outcome = fixture
+        .executor
+        .execute(
+            tenant.hash(),
+            &request("SELECT ts_ns, alert_id FROM alerts"),
+        )
+        .await
+        .expect("alerts query");
+
+    assert_eq!(
+        outcome.stats.segments, ALERT_SEGMENTS,
+        "sanity: all 10 resolve"
+    );
+    assert_eq!(
+        outcome.stats.io_shape.service_batches, 3,
+        "alerts is segment-granular with no plan phase: ceil(10/4) = 3, not \
+         the buggy Logs-shaped model's 3 (plan) + 3 (scan) = 6"
     );
 }

--- a/crates/ravel-sql/tests/io_shape.rs
+++ b/crates/ravel-sql/tests/io_shape.rs
@@ -1,0 +1,121 @@
+//! Acceptance tests for issue #1250: a SQL statement's `stats.io_shape`,
+//! computed at `SqlExecutor::resolve`'s resolve site
+//! (`crates/ravel-sql/src/executor.rs`), matches PromQL's own `QueryIoShape`
+//! contract exactly rather than reporting a placeholder.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod util;
+
+use ravel_query::EngineConfig;
+use ravel_query::io_shape::PlanClass;
+use ravel_sql::SqlConfig;
+use util::{Fixture, SegSpec, SeriesSpec, request, tenant_id};
+
+fn segment(index: i64, metric: &str) -> SegSpec {
+    SegSpec::new(
+        index,
+        1,
+        index as u64,
+        vec![SeriesSpec::new(
+            metric,
+            vec![(1, index as f64), (2, (index * 2) as f64)],
+        )],
+    )
+}
+
+/// `unfolded_segments_resolved` and `plan_class` must reflect the real
+/// resolve, not a placeholder: every segment published here is fresh (no
+/// fold has run), so every one of them resolves through the `Recent`
+/// listing path, and a scan with no predicate leaves `segments_pruned == 0`,
+/// so the classification is `ExhaustiveScan`.
+///
+/// Flip-line proof: add a fifth entry to `specs` below (e.g. `segment(5,
+/// "m4")`) without touching the two `assert_eq!(.., 4, ..)` calls below, and
+/// both fail: `outcome.stats.segments` and
+/// `outcome.stats.io_shape.unfolded_segments_resolved` each read 5, not the
+/// pinned 4.
+#[tokio::test]
+async fn a_multi_segment_scan_reports_its_exact_unfolded_count_and_plan_class() {
+    let tenant = tenant_id("io-shape-multi-segment");
+    let specs = vec![
+        segment(1, "m0"),
+        segment(2, "m1"),
+        segment(3, "m2"),
+        segment(4, "m3"),
+    ];
+    let fixture = Fixture::memory(&[(&tenant, &specs)]).await;
+
+    let outcome = fixture
+        .executor
+        .execute(tenant.hash(), &request("SELECT ts, value FROM samples"))
+        .await
+        .expect("multi-segment query");
+
+    assert_eq!(
+        outcome.stats.segments, 4,
+        "sanity: every published segment must resolve"
+    );
+    assert_eq!(
+        outcome.stats.io_shape.unfolded_segments_resolved, 4,
+        "every segment is fresh (no fold has run), so all of them must count \
+         as unfolded"
+    );
+    assert_eq!(
+        outcome.stats.io_shape.plan_class,
+        PlanClass::ExhaustiveScan,
+        "no predicate prunes any segment, so the whole listed window is scanned"
+    );
+}
+
+/// `service_batches` for `ravel-sql` is a deterministic function of the
+/// resolved segment count and the configured `target_partitions`
+/// (`EngineConfig::sql_partition_count`), clamped to the segment count and
+/// floored at 1 (`SqlExecutor::io_shape_for_resolve`): with `inner_fanout ==
+/// 1` and `shared_get_permits == u64::MAX`, the model reduces to the busiest
+/// partition's own segment count, `ceil(total_segments / partitions)`.
+///
+/// This fixture publishes 7 segments with `sql_partition_count` set to 3:
+/// `partitions = min(3, 7) = 3`, so segments split 3/2/2 round-robin across
+/// partitions, and the busiest partition holds `ceil(7 / 3) = 3` segments.
+/// `service_batches` must therefore read exactly 3.
+///
+/// Flip-line proof: add three more entries to `specs` (10 segments total)
+/// without touching `TARGET_PARTITIONS` or the `service_batches, 3`
+/// assertion below: `ceil(10 / 3) = 4`, so the pinned `3` fails.
+#[tokio::test]
+async fn service_batches_matches_the_busiest_partition_s_segment_count() {
+    const TARGET_PARTITIONS: usize = 3;
+    let tenant = tenant_id("io-shape-service-batches");
+    let specs = vec![
+        segment(1, "m0"),
+        segment(2, "m1"),
+        segment(3, "m2"),
+        segment(4, "m3"),
+        segment(5, "m4"),
+        segment(6, "m5"),
+        segment(7, "m6"),
+    ];
+    let config = SqlConfig {
+        engine: EngineConfig {
+            sql_partition_count: Some(TARGET_PARTITIONS),
+            ..EngineConfig::default()
+        },
+        ..SqlConfig::default()
+    };
+    let store: std::sync::Arc<dyn ravel_object_store::ObjectStoreBackend> =
+        std::sync::Arc::new(ravel_object_store::memory::MemoryStore::new());
+    let fixture = Fixture::build(store, &[(&tenant, &specs)], config, 1 << 30).await;
+
+    let outcome = fixture
+        .executor
+        .execute(tenant.hash(), &request("SELECT ts, value FROM samples"))
+        .await
+        .expect("multi-segment query");
+
+    assert_eq!(outcome.stats.segments, 7, "sanity: all 7 resolve");
+    assert_eq!(
+        outcome.stats.io_shape.service_batches, 3,
+        "7 segments over 3 partitions: the busiest partition holds ceil(7/3) = 3"
+    );
+}

--- a/crates/ravel-sql/tests/io_shape.rs
+++ b/crates/ravel-sql/tests/io_shape.rs
@@ -7,10 +7,16 @@
 
 mod util;
 
-use ravel_query::EngineConfig;
+use std::sync::Arc;
+
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
 use ravel_query::io_shape::PlanClass;
+use ravel_query::{EngineConfig, LogSegmentFetcher};
 use ravel_sql::SqlConfig;
-use util::{Fixture, SegSpec, SeriesSpec, request, tenant_id};
+use util::{
+    Fixture, SegSpec, SeriesSpec, build_read_cache, publish_logs_segments, request, tenant_id,
+};
 
 fn segment(index: i64, metric: &str) -> SegSpec {
     SegSpec::new(
@@ -178,5 +184,139 @@ async fn shared_get_permits_reflects_store_get_concurrency_not_u64_max() {
         outcome.stats.io_shape.service_batches, 3,
         "8 segments, 8 partitions, but only 3 shared GET permits: \
          ceil(8/min(8,3)) = 3, not the u64::MAX model's ceil(8/8) = 1"
+    );
+}
+
+/// Uncached Logs/Alerts/Audit is segment-granular, matching `RsegScanExec`
+/// (issue #1250 review fix, finding 2a) -- but the old model charged only
+/// the scan phase and missed `compute_plan_counts`'s own uncounted
+/// `buffer_unordered(target_partitions)` plan-probe pass (issue #691), which
+/// gates every scan partition and never overlaps with it.
+///
+/// This fixture publishes 5 log segments with `sql_partition_count = 2` and
+/// the default `store_get_concurrency` (8):
+///
+/// Scan phase (unchanged by this fix, both models agree here):
+/// `partitions = min(2, 5) = 2`, `segments_per_plan = ceil(5/2) = 3`, one
+/// wave (`distinct_plans == outer_fanout == partitions == 2`), `active = 2`,
+/// `capacity = min(1*2, 8) = 2`, `service_batches = ceil(3*2/2) = 3`.
+///
+/// Plan phase (the old model's omission): one probe per segment at
+/// `buffer_unordered(plan_partitions.min(shared_get_permits)) =
+/// buffer_unordered(min(2,8)=2)`, so `service_batches = ceil(5/2) = 3`.
+///
+/// Total, fixed model: `3 (plan) + 3 (scan) = 6`. Old (Metrics-shaped, no
+/// plan-phase term) model: `3`.
+///
+/// Flip-line proof: with the plan-phase `saturating_add` removed (or
+/// `plan_phase_batches` fixed at 0), this assertion (`6`) fails and reads `3`
+/// instead.
+#[tokio::test]
+async fn uncached_logs_scan_adds_the_plan_phase_to_the_scan_phase() {
+    const TARGET_PARTITIONS: usize = 2;
+    const LOG_SEGMENTS: usize = 5;
+    let tenant = tenant_id("io-shape-logs-uncached");
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    publish_logs_segments(store.as_ref(), &tenant, LOG_SEGMENTS).await;
+
+    let config = SqlConfig {
+        engine: EngineConfig {
+            sql_partition_count: Some(TARGET_PARTITIONS),
+            ..EngineConfig::default()
+        },
+        ..SqlConfig::default()
+    };
+    let fixture = Fixture::build(Arc::clone(&store), &[], config, 1 << 30).await;
+
+    let outcome = fixture
+        .executor
+        .execute(tenant.hash(), &request("SELECT ts, body FROM logs"))
+        .await
+        .expect("logs query");
+
+    assert_eq!(
+        outcome.stats.segments, LOG_SEGMENTS,
+        "sanity: all 5 resolve"
+    );
+    assert_eq!(
+        outcome.stats.io_shape.service_batches, 6,
+        "uncached logs: plan phase ceil(5/min(2,8))=3 plus scan phase \
+         ceil(3*2/2)=3, total 6, not the old Metrics-shaped model's 3 \
+         (scan phase alone)"
+    );
+}
+
+/// Cache-wired Logs/Alerts/Audit block-strides across `min(target_partitions,
+/// total_block_count)` partitions, unclamped by segment count -- the exact
+/// opposite of the uncached shape above (issue #1250 review fix, finding
+/// 2b). The old model applied the uncached (`RsegScanExec`-style) clamp
+/// uniformly, which badly undercounts here since a segment count far below
+/// the partition count no longer bounds the outer width once the cache is
+/// wired in.
+///
+/// This fixture publishes 3 log segments with `sql_partition_count = 8` and
+/// `store_get_concurrency = 50`, and wires a read cache into the
+/// `LogSegmentFetcher` so `has_cache() == true`.
+///
+/// Fixed model: `total_block_count` is not resolvable at resolve time
+/// without extra I/O (`SegmentRef` carries no block-count field), so
+/// `segments_per_plan` is upper-bounded at `total_segments = 3` and
+/// `partitions` at the configured `8` (both legitimate, never-exceeded
+/// bounds since there are only 3 segments and DataFusion never plans more
+/// than 8 partitions). Plan phase: `service_batches(3, min(8,50)=8) =
+/// ceil(3/8) = 1`. Scan phase: one wave (`distinct_plans == outer_fanout ==
+/// 8`), `active = 8`, `capacity = min(1*8, 50) = 8`,
+/// `service_batches = ceil(3*8/8) = 3`. Total: `1 + 3 = 4`.
+///
+/// Old (uncached-shaped) model: `partitions = min(8, 3) = 3` (wrongly
+/// clamped by segment count), `segments_per_plan = ceil(3/3) = 1`, one wave,
+/// `active = 3`, `capacity = min(3,50) = 3`, `service_batches = ceil(1*3/3)
+/// = 1`, no plan-phase term. Old total: `1`.
+///
+/// Flip-line proof: with the `has_cache()` branch removed (falling through
+/// to the uncached clamp unconditionally), this assertion (`4`) fails and
+/// reads `1` instead.
+#[tokio::test]
+async fn cached_logs_scan_is_not_clamped_by_segment_count() {
+    const TARGET_PARTITIONS: usize = 8;
+    const STORE_GET_CONCURRENCY: usize = 50;
+    const LOG_SEGMENTS: usize = 3;
+    let tenant = tenant_id("io-shape-logs-cached");
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    publish_logs_segments(store.as_ref(), &tenant, LOG_SEGMENTS).await;
+
+    let cache = build_read_cache(64 << 20);
+    let log_fetcher = LogSegmentFetcher::new(Arc::clone(&store)).with_cache(cache);
+    assert!(
+        log_fetcher.has_cache(),
+        "this fixture must exercise the cache-wired path"
+    );
+
+    let config = SqlConfig {
+        engine: EngineConfig {
+            sql_partition_count: Some(TARGET_PARTITIONS),
+            store_get_concurrency: Some(STORE_GET_CONCURRENCY),
+            ..EngineConfig::default()
+        },
+        ..SqlConfig::default()
+    };
+    let fixture =
+        Fixture::build_with_log_fetcher(Arc::clone(&store), &[], config, 1 << 30, log_fetcher)
+            .await;
+
+    let outcome = fixture
+        .executor
+        .execute(tenant.hash(), &request("SELECT ts, body FROM logs"))
+        .await
+        .expect("logs query");
+
+    assert_eq!(
+        outcome.stats.segments, LOG_SEGMENTS,
+        "sanity: all 3 resolve"
+    );
+    assert_eq!(
+        outcome.stats.io_shape.service_batches, 4,
+        "cached logs: plan phase ceil(3/min(8,50))=1 plus scan phase \
+         ceil(3*8/8)=3, total 4, not the old segment-clamped model's 1"
     );
 }

--- a/crates/ravel-sql/tests/io_shape.rs
+++ b/crates/ravel-sql/tests/io_shape.rs
@@ -119,3 +119,64 @@ async fn service_batches_matches_the_busiest_partition_s_segment_count() {
         "7 segments over 3 partitions: the busiest partition holds ceil(7/3) = 3"
     );
 }
+
+/// `shared_get_permits` must be the real, resolved
+/// `EngineConfig::store_get_concurrency` -- the size of the one `GetLimiter`
+/// the server shares across every fetcher it builds -- not `u64::MAX`
+/// (issue #1250 review fix, finding 1). `u64::MAX` silently drops the
+/// concurrency clamp whenever the configured GET permits are fewer than the
+/// configured partitions, which is exactly the case this fixture sets up:
+/// `sql_partition_count = 8`, `store_get_concurrency = 3`.
+///
+/// This fixture publishes 8 segments with `partitions = min(8, 8) = 8`, so
+/// `segments_per_plan = ceil(8/8) = 1`, one wave (`distinct_plans ==
+/// outer_fanout == 8`), `active = 8`.
+///
+/// Under the WRONG `u64::MAX` model: `capacity = min(1 * 8, u64::MAX) = 8`,
+/// `service_batches = ceil(1 * 8 / 8) = 1`.
+///
+/// Under the FIXED model: `capacity = min(1 * 8, 3) = 3`,
+/// `service_batches = ceil(1 * 8 / 3) = 3`.
+///
+/// Flip-line proof: with `shared_get_permits` reverted to `u64::MAX`, this
+/// assertion (`3`) fails and reads `1` instead.
+#[tokio::test]
+async fn shared_get_permits_reflects_store_get_concurrency_not_u64_max() {
+    const TARGET_PARTITIONS: usize = 8;
+    const STORE_GET_CONCURRENCY: usize = 3;
+    let tenant = tenant_id("io-shape-shared-get-permits");
+    let specs = vec![
+        segment(1, "m0"),
+        segment(2, "m1"),
+        segment(3, "m2"),
+        segment(4, "m3"),
+        segment(5, "m4"),
+        segment(6, "m5"),
+        segment(7, "m6"),
+        segment(8, "m7"),
+    ];
+    let config = SqlConfig {
+        engine: EngineConfig {
+            sql_partition_count: Some(TARGET_PARTITIONS),
+            store_get_concurrency: Some(STORE_GET_CONCURRENCY),
+            ..EngineConfig::default()
+        },
+        ..SqlConfig::default()
+    };
+    let store: std::sync::Arc<dyn ravel_object_store::ObjectStoreBackend> =
+        std::sync::Arc::new(ravel_object_store::memory::MemoryStore::new());
+    let fixture = Fixture::build(store, &[(&tenant, &specs)], config, 1 << 30).await;
+
+    let outcome = fixture
+        .executor
+        .execute(tenant.hash(), &request("SELECT ts, value FROM samples"))
+        .await
+        .expect("multi-segment query");
+
+    assert_eq!(outcome.stats.segments, 8, "sanity: all 8 resolve");
+    assert_eq!(
+        outcome.stats.io_shape.service_batches, 3,
+        "8 segments, 8 partitions, but only 3 shared GET permits: \
+         ceil(8/min(8,3)) = 3, not the u64::MAX model's ceil(8/8) = 1"
+    );
+}

--- a/crates/ravel-sql/tests/util/mod.rs
+++ b/crates/ravel-sql/tests/util/mod.rs
@@ -36,17 +36,21 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use ravel_cache::{Cache, CacheLimits};
 use ravel_catalog::{Catalog, CatalogConfig, Snapshot};
 use ravel_commit::publish::RetryPolicy;
 use ravel_commit::record::NewCommitRecord;
 use ravel_commit::{keys, publish, record};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
-use ravel_query::{EngineConfig, LogSegmentFetcher, SegmentFetcher};
+use ravel_query::{CacheFetchError, EngineConfig, LogSegmentFetcher, SegmentFetcher};
 use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
 use ravel_sql::{SqlConfig, SqlExecutor, SqlRequest};
 use ravel_types::{
     CommitToken, Label, LabelSet, Sample, SeriesId, Signal, TenantHash, TenantId, TimeRange,
+    logstream,
 };
 use uuid::Uuid;
 
@@ -201,6 +205,103 @@ pub async fn publish_segment(
     (token, data_key)
 }
 
+/// Publish `count` real RLOG objects, each its own `Signal::Logs` commit
+/// record, so a `logs`/`alerts`/`audit`-target query resolves `count`
+/// distinct segments (mirrors tests/query_accounting.rs's `publish_logs`,
+/// parameterized by segment index so each one gets a distinct writer_seq,
+/// content_hash, and ts window instead of a single fixed segment).
+pub async fn publish_logs_segments(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantId,
+    count: usize,
+) {
+    const RECORDS_PER_SEGMENT: usize = 4;
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("io-shape-logs".to_string()),
+    )];
+    let stream_id = logstream::log_stream_id(&resource, "scope", "1.0", &[]);
+    let stream_attrs = stream_attrs_bytes(&resource, "scope", "1.0", &[]);
+
+    for seg in 0..count {
+        let writer_id = Uuid::from_u128(20_000 + seg as u128);
+        let mut writer = RlogWriter::new(
+            RlogConfig::default(),
+            ObjectIdentity {
+                tenant_hash: tenant.hash().0,
+                shard: 0,
+                writer_id: *writer_id.as_bytes(),
+                writer_epoch: 1,
+                writer_seq: seg as u64 + 1,
+            },
+        );
+        let base_ts = 1_000 + (seg as i64) * (RECORDS_PER_SEGMENT as i64);
+        for i in 0..RECORDS_PER_SEGMENT {
+            let ts_ns = base_ts + i as i64;
+            writer
+                .push(LogRecord {
+                    stream_id,
+                    stream_attrs: stream_attrs.clone(),
+                    ts_ns,
+                    observed_ts_ns: ts_ns,
+                    severity_num: 9,
+                    severity_text: "INFO".to_string(),
+                    body: format!("io-shape logs segment {seg} record {i}"),
+                    trace_id: None,
+                    span_id: None,
+                    flags: 0,
+                    attrs: Vec::new(),
+                })
+                .expect("push log record");
+        }
+        let bytes = writer.finish().expect("finish rlog object");
+
+        let mut content_hash = [0u8; 32];
+        content_hash[0] = 100 + seg as u8;
+        let new_record = NewCommitRecord {
+            tenant_hash: tenant.hash(),
+            signal: Signal::Logs,
+            shard: 0,
+            writer_id,
+            writer_epoch: 1,
+            writer_seq: seg as u64 + 1,
+            object_size: bytes.len() as u64,
+            content_hash,
+            sample_count: RECORDS_PER_SEGMENT as u64,
+            series_count: 1,
+            min_event_ts_ns: base_ts,
+            max_event_ts_ns: base_ts + RECORDS_PER_SEGMENT as i64 - 1,
+            min_ingest_ts_ns: base_ts,
+            max_ingest_ts_ns: base_ts + RECORDS_PER_SEGMENT as i64 - 1,
+            segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+            created_unix_ns: 10 + seg as i64,
+            ingest_hour_bucket: 0,
+        };
+        let rec = record::build(new_record).expect("valid logs commit record");
+        let data_key = keys::reconstruct_data_key(&rec).expect("logs data key");
+        store
+            .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put rlog object");
+        publish::publish(store, &rec, &RetryPolicy::default())
+            .await
+            .expect("publish logs commit record");
+    }
+}
+
+/// Build ADR-0046's RAM read cache (mirrors
+/// tests/logs_uncached_assignment.rs's `build_read_cache`): the whole budget
+/// as the per-entry cap so no small fixture object is rejected, one entry per
+/// 4 KiB of budget floored at 64.
+pub fn build_read_cache(cache_bytes: u64) -> Arc<Cache<CacheFetchError>> {
+    let max_entries = (cache_bytes / 4096).max(64) as usize;
+    Arc::new(Cache::new(CacheLimits::new(
+        cache_bytes,
+        max_entries,
+        cache_bytes,
+    )))
+}
+
 /// A running stack: store, catalog, fetcher, and executor.
 pub struct Fixture {
     pub store: Arc<dyn ObjectStoreBackend>,
@@ -218,6 +319,28 @@ impl Fixture {
         config: SqlConfig,
         max_tenant_bytes: usize,
     ) -> Self {
+        Fixture::build_with_log_fetcher(
+            store.clone(),
+            tenants,
+            config,
+            max_tenant_bytes,
+            LogSegmentFetcher::new(store),
+        )
+        .await
+    }
+
+    /// Same as [`Fixture::build`], but with the caller's own
+    /// [`LogSegmentFetcher`] wired into the executor instead of a fresh
+    /// uncached one -- the only way to exercise the cache-wired logs scan
+    /// path (`LogSegmentFetcher::has_cache() == true`) through a real
+    /// `SqlExecutor`.
+    pub async fn build_with_log_fetcher(
+        store: Arc<dyn ObjectStoreBackend>,
+        tenants: &[(&TenantId, &[SegSpec])],
+        config: SqlConfig,
+        max_tenant_bytes: usize,
+        log_fetcher: LogSegmentFetcher,
+    ) -> Self {
         let mut data_keys: HashMap<String, Vec<String>> = HashMap::new();
         for (tenant, specs) in tenants {
             for (i, spec) in specs.iter().enumerate() {
@@ -234,7 +357,7 @@ impl Fixture {
         let executor = SqlExecutor::new(
             Arc::clone(&catalog),
             fetcher.clone(),
-            LogSegmentFetcher::new(Arc::clone(&store)),
+            log_fetcher,
             ravel_sql::SpanSegmentFetcher::new(Arc::clone(&store)),
             config,
             max_tenant_bytes,

--- a/crates/ravel-sql/tests/util/mod.rs
+++ b/crates/ravel-sql/tests/util/mod.rs
@@ -205,20 +205,25 @@ pub async fn publish_segment(
     (token, data_key)
 }
 
-/// Publish `count` real RLOG objects, each its own `Signal::Logs` commit
-/// record, so a `logs`/`alerts`/`audit`-target query resolves `count`
+/// Publish `count` real RLOG objects, each its own commit record under
+/// `signal`, so a `logs`/`alerts`/`audit`-target query resolves `count`
 /// distinct segments (mirrors tests/query_accounting.rs's `publish_logs`,
 /// parameterized by segment index so each one gets a distinct writer_seq,
-/// content_hash, and ts window instead of a single fixed segment).
-pub async fn publish_logs_segments(
+/// content_hash, and ts window instead of a single fixed segment). Shared by
+/// [`publish_logs_segments`] and [`publish_alerts_segments`]: alerts ride RLOG
+/// v1 verbatim (ADR-0040 decision 2) and resolve through the same shard-0
+/// commit-record shape as logs, only the `signal` tag differs.
+async fn publish_rlog_segments(
     store: &dyn ObjectStoreBackend,
     tenant: &TenantId,
     count: usize,
+    signal: Signal,
+    resource_name: &str,
 ) {
     const RECORDS_PER_SEGMENT: usize = 4;
     let resource = vec![(
         "service.name".to_string(),
-        AttrValue::Str("io-shape-logs".to_string()),
+        AttrValue::Str(resource_name.to_string()),
     )];
     let stream_id = logstream::log_stream_id(&resource, "scope", "1.0", &[]);
     let stream_attrs = stream_attrs_bytes(&resource, "scope", "1.0", &[]);
@@ -246,7 +251,7 @@ pub async fn publish_logs_segments(
                     observed_ts_ns: ts_ns,
                     severity_num: 9,
                     severity_text: "INFO".to_string(),
-                    body: format!("io-shape logs segment {seg} record {i}"),
+                    body: format!("io-shape {resource_name} segment {seg} record {i}"),
                     trace_id: None,
                     span_id: None,
                     flags: 0,
@@ -260,7 +265,7 @@ pub async fn publish_logs_segments(
         content_hash[0] = 100 + seg as u8;
         let new_record = NewCommitRecord {
             tenant_hash: tenant.hash(),
-            signal: Signal::Logs,
+            signal,
             shard: 0,
             writer_id,
             writer_epoch: 1,
@@ -277,16 +282,37 @@ pub async fn publish_logs_segments(
             created_unix_ns: 10 + seg as i64,
             ingest_hour_bucket: 0,
         };
-        let rec = record::build(new_record).expect("valid logs commit record");
-        let data_key = keys::reconstruct_data_key(&rec).expect("logs data key");
+        let rec = record::build(new_record).expect("valid commit record");
+        let data_key = keys::reconstruct_data_key(&rec).expect("data key");
         store
             .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
             .await
             .expect("put rlog object");
         publish::publish(store, &rec, &RetryPolicy::default())
             .await
-            .expect("publish logs commit record");
+            .expect("publish commit record");
     }
+}
+
+/// [`publish_rlog_segments`] under `Signal::Logs`.
+pub async fn publish_logs_segments(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantId,
+    count: usize,
+) {
+    publish_rlog_segments(store, tenant, count, Signal::Logs, "io-shape-logs").await
+}
+
+/// [`publish_rlog_segments`] under `Signal::Alerts`, shard 0 -- the same shard
+/// `AlertsTableProvider`'s own acceptance fixture (tests/alerts_provider.rs)
+/// uses; unlike `Signal::Audit`, alerts carries no dedicated query shard
+/// (`QUERY_AUDIT_SHARD`) to route through.
+pub async fn publish_alerts_segments(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantId,
+    count: usize,
+) {
+    publish_rlog_segments(store, tenant, count, Signal::Alerts, "io-shape-alerts").await
 }
 
 /// Build ADR-0046's RAM read cache (mirrors

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1945,6 +1945,43 @@ cannot understate a lane that did, and the log lane's `unclassified` result
 cannot fabricate a worse classification than a metrics lane that pruned
 correctly.
 
+#### SQL statements
+
+A SQL statement's `stats.io` is the same `QueryIoShape` type and the same
+`stats.io` wire block a PromQL query reports, computed at `SqlExecutor`'s own
+resolve site (`crates/ravel-sql/src/executor.rs`) rather than left as a
+placeholder. `unfoldedSegmentsResolved` and the resolve's own `dependencyDepth`
+inputs are read directly off that resolve, exactly as the PromQL lane reads
+them. `serviceBatches` differs because `ravel-sql` has no `GetLimiter` and no
+outer/inner `buffer_unordered` nesting: `crates/ravel-sql/src/scan.rs`'s
+`RsegScanExec` assigns segments to partitions round-robin and fetches each
+partition's own segments strictly sequentially, so the wave-synchronous model
+above collapses to a single wave:
+
+- The outer fan-out width is DataFusion's `target_partitions`
+  (`EngineConfig::sql_partition_count`, read through the SQL statement's own
+  `SqlConfig.engine`), clamped to the resolved segment count the same way
+  `RsegScanExec` clamps its own partition count.
+- The inner fan-out is always `1`: a partition's segments are fetched one
+  after another, never concurrently, so the busiest partition's own segment
+  count (`total_segments.div_ceil(partitions)`) is the whole per-partition
+  depth.
+- `sharedGetPermits` is always `u64::MAX`: nothing in `ravel-sql` shares a GET
+  permit pool across partitions the way ADR-1195's limiter does for PromQL.
+
+With those three inputs, the model reduces to `ceil(total_segments /
+partitions)`: the busiest partition's segment count is the whole story, since
+there is no shared pool to bind concurrency below the partition count and no
+second fan-out level to add rounds.
+
+`dependencyDepth`'s `whole_object_threshold` has no single SQL-wide knob
+either; it is read per target signal, matching whichever fetcher that
+signal's scan actually uses: the metrics fetcher's own configured threshold
+for `metrics`, the log fetcher's block-range threshold for `logs`, `alerts`,
+and `audit` (they share the RLOG funnel, ADR-1101 decision 1), and `u64::MAX`
+for `spans`, because the span fetcher always issues one unconditional
+whole-object GET and has no threshold concept to report.
+
 `stats.io` carries no object keys, field values, predicates, or index
 terms: every figure is a structural count.
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1952,27 +1952,60 @@ A SQL statement's `stats.io` is the same `QueryIoShape` type and the same
 resolve site (`crates/ravel-sql/src/executor.rs`) rather than left as a
 placeholder. `unfoldedSegmentsResolved` and the resolve's own `dependencyDepth`
 inputs are read directly off that resolve, exactly as the PromQL lane reads
-them. `serviceBatches` differs because `ravel-sql` has no `GetLimiter` and no
-outer/inner `buffer_unordered` nesting: `crates/ravel-sql/src/scan.rs`'s
-`RsegScanExec` assigns segments to partitions round-robin and fetches each
-partition's own segments strictly sequentially, so the wave-synchronous model
-above collapses to a single wave:
+them.
 
-- The outer fan-out width is DataFusion's `target_partitions`
-  (`EngineConfig::sql_partition_count`, read through the SQL statement's own
-  `SqlConfig.engine`), clamped to the resolved segment count the same way
-  `RsegScanExec` clamps its own partition count.
-- The inner fan-out is always `1`: a partition's segments are fetched one
-  after another, never concurrently, so the busiest partition's own segment
-  count (`total_segments.div_ceil(partitions)`) is the whole per-partition
-  depth.
-- `sharedGetPermits` is always `u64::MAX`: nothing in `ravel-sql` shares a GET
-  permit pool across partitions the way ADR-1195's limiter does for PromQL.
+`sharedGetPermits` is the real, resolved `EngineConfig::store_get_concurrency`
+(the same source `sql_partition_count` reads), because `ravel-sql` does share
+a GET permit pool across partitions: `services/ravel-server/src/lib.rs` builds
+one `Arc<GetLimiter>` (ADR-1195) shared process-wide across every fetcher it
+constructs, including all three of the SQL executor's fetchers, not only
+PromQL's.
 
-With those three inputs, the model reduces to `ceil(total_segments /
-partitions)`: the busiest partition's segment count is the whole story, since
-there is no shared pool to bind concurrency below the partition count and no
-second fan-out level to add rounds.
+The outer/inner fan-out shape splits by target signal, because
+`metrics`/`spans` and `logs`/`alerts`/`audit` are scanned by different
+executors with different partition-assignment rules:
+
+- **`metrics` and `spans`**: `crates/ravel-sql/src/scan.rs`'s `RsegScanExec`
+  assigns segments to partitions round-robin and fetches each partition's own
+  segments strictly sequentially, so the wave-synchronous model above
+  collapses to a single wave. The outer fan-out width is DataFusion's
+  `target_partitions` (`EngineConfig::sql_partition_count`), clamped to the
+  resolved segment count the same way `RsegScanExec` clamps its own partition
+  count; the inner fan-out is always `1`, so the busiest partition's own
+  segment count (`total_segments.div_ceil(partitions)`) is the whole
+  per-partition depth. With `sharedGetPermits` folded in, the model is
+  `ceil(total_segments.div_ceil(partitions) * partitions /
+  min(partitions, sharedGetPermits))`.
+- **`logs`, `alerts`, and `audit`** (`crates/ravel-sql/src/logs_scan.rs`'s
+  `LogsScanExec`): the shape depends on `LogSegmentFetcher::has_cache()`,
+  because the cache changes how blocks are assigned to partitions, not just
+  whether a re-fetch is free.
+  - Uncached: segment-granular, matching `RsegScanExec` above (the outer
+    fan-out is `target_partitions` clamped to the segment count, one
+    partition per segment).
+  - Cached: intra-segment block striping spreads a single segment's blocks
+    across `min(target_partitions, total_block_count)` partitions, so a
+    partition can open every segment rather than one partition per segment.
+    The outer fan-out is therefore `target_partitions`, unclamped by segment
+    count. `SegmentRef` carries no block-count field, so `total_block_count`
+    is not resolvable at `io_shape_for_resolve`'s resolve-time call site
+    without extra I/O; the model instead upper-bounds a partition's segment
+    count at `total_segments` (a legitimate bound: there are only that many
+    segments to open at all). This is a documented over-estimate of
+    `serviceBatches` whenever a segment's blocks do not actually reach every
+    partition.
+
+  Both cases add a **plan-phase** term the scan-phase model above does not
+  capture: `LogsScanExec::compute_plan_counts` runs one plan probe per
+  relevant segment at `buffer_unordered(target_partitions)` before any scan
+  partition drains, contributing
+  `ceil(total_segments / min(target_partitions, sharedGetPermits))`
+  `serviceBatches` on top of the scan-phase figure, added rather than
+  maxed (the two phases run strictly serially, matching the federated-lane
+  ADD rule above). This plan-phase probe is skipped entirely by a
+  predicate-free whole-segment fast path, but predicate information is not
+  available at `io_shape_for_resolve`'s resolve-time call site, so the model
+  charges the plan phase unconditionally -- another documented over-estimate.
 
 `dependencyDepth`'s `whole_object_threshold` has no single SQL-wide knob
 either; it is read per target signal, matching whichever fetcher that
@@ -1981,6 +2014,10 @@ for `metrics`, the log fetcher's block-range threshold for `logs`, `alerts`,
 and `audit` (they share the RLOG funnel, ADR-1101 decision 1), and `u64::MAX`
 for `spans`, because the span fetcher always issues one unconditional
 whole-object GET and has no threshold concept to report.
+
+`metadataOnly` is always `false`: no SQL statement plans a metadata-only
+class today (unlike PromQL's labels/label-values lane), not because one was
+considered here and ruled out.
 
 `stats.io` carries no object keys, field values, predicates, or index
 terms: every figure is a structural count.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1962,24 +1962,27 @@ constructs, including all three of the SQL executor's fetchers, not only
 PromQL's.
 
 The outer/inner fan-out shape splits by target signal, because
-`metrics`/`spans` and `logs`/`alerts`/`audit` are scanned by different
+`metrics`/`spans`/`alerts`/`audit` and `logs` are scanned by different
 executors with different partition-assignment rules:
 
-- **`metrics` and `spans`**: `crates/ravel-sql/src/scan.rs`'s `RsegScanExec`
-  assigns segments to partitions round-robin and fetches each partition's own
-  segments strictly sequentially, so the wave-synchronous model above
-  collapses to a single wave. The outer fan-out width is DataFusion's
-  `target_partitions` (`EngineConfig::sql_partition_count`), clamped to the
-  resolved segment count the same way `RsegScanExec` clamps its own partition
-  count; the inner fan-out is always `1`, so the busiest partition's own
-  segment count (`total_segments.div_ceil(partitions)`) is the whole
-  per-partition depth. With `sharedGetPermits` folded in, the model is
+- **`metrics`, `spans`, `alerts`, and `audit`**: `crates/ravel-sql/src/scan.rs`'s
+  `RsegScanExec`, `alerts_scan.rs`'s `AlertsScanExec`, and `audit_scan.rs`'s
+  `AuditScanExec` all assign segments to partitions round-robin
+  (`min(target_partitions, segments.len())` partitions, unconditionally, with
+  no cache-dependent striping and no plan-read phase) and fetch each
+  partition's own segments strictly sequentially, so the wave-synchronous
+  model above collapses to a single wave. The outer fan-out width is
+  DataFusion's `target_partitions` (`EngineConfig::sql_partition_count`),
+  clamped to the resolved segment count the same way `RsegScanExec` clamps its
+  own partition count; the inner fan-out is always `1`, so the busiest
+  partition's own segment count (`total_segments.div_ceil(partitions)`) is the
+  whole per-partition depth. With `sharedGetPermits` folded in, the model is
   `ceil(total_segments.div_ceil(partitions) * partitions /
-  min(partitions, sharedGetPermits))`.
-- **`logs`, `alerts`, and `audit`** (`crates/ravel-sql/src/logs_scan.rs`'s
-  `LogsScanExec`): the shape depends on `LogSegmentFetcher::has_cache()`,
-  because the cache changes how blocks are assigned to partitions, not just
-  whether a re-fetch is free.
+  min(partitions, sharedGetPermits))`. This figure is exact, not an
+  upper bound, for all four signals.
+- **`logs`** (`crates/ravel-sql/src/logs_scan.rs`'s `LogsScanExec`): the shape
+  depends on `LogSegmentFetcher::has_cache()`, because the cache changes how
+  blocks are assigned to partitions, not just whether a re-fetch is free.
   - Uncached: segment-granular, matching `RsegScanExec` above (the outer
     fan-out is `target_partitions` clamped to the segment count, one
     partition per segment).
@@ -1995,8 +1998,8 @@ executors with different partition-assignment rules:
     `serviceBatches` whenever a segment's blocks do not actually reach every
     partition.
 
-  Both cases add a **plan-phase** term the scan-phase model above does not
-  capture: `LogsScanExec::compute_plan_counts` runs one plan probe per
+  Both `logs` cases add a **plan-phase** term the scan-phase model above does
+  not capture: `LogsScanExec::compute_plan_counts` runs one plan probe per
   relevant segment at `buffer_unordered(target_partitions)` before any scan
   partition drains, contributing
   `ceil(total_segments / min(target_partitions, sharedGetPermits))`
@@ -2006,6 +2009,8 @@ executors with different partition-assignment rules:
   predicate-free whole-segment fast path, but predicate information is not
   available at `io_shape_for_resolve`'s resolve-time call site, so the model
   charges the plan phase unconditionally -- another documented over-estimate.
+  `alerts` and `audit` never add this term: neither `AlertsScanExec` nor
+  `AuditScanExec` runs a plan-read phase at all.
 
 `dependencyDepth`'s `whole_object_threshold` has no single SQL-wide knob
 either; it is read per target signal, matching whichever fetcher that

--- a/services/ravel-server/src/sql.rs
+++ b/services/ravel-server/src/sql.rs
@@ -375,7 +375,31 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
         outcome.stats.blocks_pruned_by_postings,
     );
 
-    let stats = crate::query::accounting_stats_json(&outcome.accounting, &outcome.estimate);
+    let mut stats = crate::query::accounting_stats_json(&outcome.accounting, &outcome.estimate);
+    // The same `io` block a PromQL query's `stats` carries (issue #1250),
+    // added beside `accounting`/`estimate` rather than folded into
+    // `accounting_stats_json` itself: that helper is shared with
+    // `/api/v1/analytics`, which has no `QueryIoShape` to render.
+    //
+    // These field names and renames are kept byte-identical to
+    // `ravel_query::http::json::IoShapeJson`'s `Serialize` impl by hand
+    // rather than by reusing that type directly: the `json` module it lives
+    // in is private to `ravel-query` (no `pub use` re-exports it), and this
+    // task's out-of-scope allowance covers only a second `io_shape.rs` entry
+    // point, not a second edit to export a type from a different module.
+    if let Some(object) = stats.as_object_mut() {
+        let shape = outcome.stats.io_shape;
+        object.insert(
+            "io".to_string(),
+            serde_json::json!({
+                "dependencyDepth": shape.dependency_depth,
+                "listPageDepth": shape.list_page_depth,
+                "serviceBatches": shape.service_batches,
+                "unfoldedSegmentsResolved": shape.unfolded_segments_resolved,
+                "planClass": shape.plan_class.name(),
+            }),
+        );
+    }
     encode(&headers, &outcome, tenant_hash, stats)
 }
 

--- a/services/ravel-server/src/sql.rs
+++ b/services/ravel-server/src/sql.rs
@@ -376,19 +376,23 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
     );
 
     let mut stats = crate::query::accounting_stats_json(&outcome.accounting, &outcome.estimate);
-    // The same `io` block a PromQL query's `stats` carries (issue #1250),
-    // added beside `accounting`/`estimate` rather than folded into
-    // `accounting_stats_json` itself: that helper is shared with
-    // `/api/v1/analytics`, which has no `QueryIoShape` to render.
-    //
-    // These field names and renames are kept byte-identical to
-    // `ravel_query::http::json::IoShapeJson`'s `Serialize` impl by hand
-    // rather than by reusing that type directly: the `json` module it lives
-    // in is private to `ravel-query` (no `pub use` re-exports it), and this
-    // task's out-of-scope allowance covers only a second `io_shape.rs` entry
-    // point, not a second edit to export a type from a different module.
+    attach_io_shape(&mut stats, outcome.stats.io_shape);
+    encode(&headers, &outcome, tenant_hash, stats)
+}
+
+/// Inserts the same `io` block a PromQL query's `stats` carries (issue
+/// #1250) beside `accounting`/`estimate`, rather than folding it into
+/// `crate::query::accounting_stats_json` itself: that helper is shared with
+/// `/api/v1/analytics`, which has no `QueryIoShape` to render.
+///
+/// These field names and renames are kept byte-identical to
+/// `ravel_query::http::json::IoShapeJson`'s `Serialize` impl by hand rather
+/// than by reusing that type directly: the `json` module it lives in is
+/// private to `ravel-query` (no `pub use` re-exports it), and this task's
+/// out-of-scope allowance covers only a second `io_shape.rs` entry point,
+/// not a second edit to export a type from a different module.
+fn attach_io_shape(stats: &mut serde_json::Value, shape: ravel_query::io_shape::QueryIoShape) {
     if let Some(object) = stats.as_object_mut() {
-        let shape = outcome.stats.io_shape;
         object.insert(
             "io".to_string(),
             serde_json::json!({
@@ -400,7 +404,6 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
             }),
         );
     }
-    encode(&headers, &outcome, tenant_hash, stats)
 }
 
 /// Submit the query-audit event for one request through the shared sink and
@@ -664,6 +667,57 @@ mod tests {
     }
 
     const MAX: Duration = Duration::from_secs(30);
+
+    /// Mirrors `ravel_query::http::json`'s
+    /// `stats_json_io_object_has_each_figure_present_exactly_once_in_the_wire_text`
+    /// (issue #1250): counts key occurrences in the raw serialized JSON TEXT.
+    ///
+    /// This module's `io` block is built by inserting into a
+    /// `serde_json::Value`/`Map` (`attach_io_shape`), not by a
+    /// `#[derive(Serialize)]` struct serialized straight to a string writer
+    /// like `IoShapeJson` is. A `Map` cannot hold two entries under one key by
+    /// construction, so literally duplicating a `serde_json::json!` key (the
+    /// PromQL precedent's flip-line) is absorbed at macro-expansion time and
+    /// never reaches the wire -- confirmed empirically, not asserted: doing so
+    /// here still serializes each key exactly once. The reachable failure
+    /// mode for THIS shape is a figure silently dropped from the literal,
+    /// e.g. an edit that deletes the `"unfoldedSegmentsResolved"` line from
+    /// `attach_io_shape`'s `json!` block. Flip-line proof: delete that line
+    /// and `occurrences("unfoldedSegmentsResolved")` reads 0, not 1.
+    #[test]
+    fn attach_io_shape_writes_each_figure_exactly_once_in_the_wire_text() {
+        let shape = ravel_query::io_shape::QueryIoShape {
+            dependency_depth: 2,
+            list_page_depth: 13,
+            service_batches: 4,
+            unfolded_segments_resolved: 2_500,
+            plan_class: ravel_query::io_shape::PlanClass::SelectiveIndexed,
+        };
+        let mut stats = serde_json::json!({ "accounting": {}, "estimate": {} });
+        attach_io_shape(&mut stats, shape);
+        let text = serde_json::to_string(&stats).expect("serializes");
+
+        let io_start = text
+            .find("\"io\":{")
+            .expect("io object present in wire text");
+        let io_rest = &text[io_start..];
+        let io_end = io_rest.find('}').map(|i| i + 1).expect("io object closes");
+        let io_text = &io_rest[..io_end];
+
+        for key in [
+            "\"dependencyDepth\"",
+            "\"listPageDepth\"",
+            "\"serviceBatches\"",
+            "\"unfoldedSegmentsResolved\"",
+            "\"planClass\"",
+        ] {
+            let occurrences = io_text.matches(key).count();
+            assert_eq!(
+                occurrences, 1,
+                "io.{key} must be present exactly once in the wire text, found {occurrences}"
+            );
+        }
+    }
 
     #[test]
     fn an_absent_window_defaults_to_the_last_hour_ending_now() {


### PR DESCRIPTION
feat(sql): carry the query I/O shape through the SQL executor

The io block (planClass, dependencyDepth, listPageDepth, serviceBatches,
unfoldedSegmentsResolved) existed only on the PromQL path. SqlStats now
carries the same QueryIoShape, computed at the point the executor
resolves the catalog and rendered as stats.io in the HTTP SQL response,
with the same field names PromQL uses.

The computation is a single shared function, io_shape_for_resolve_with_
fanouts in ravel-query, that both the PromQL engine and the SQL executor
call with their own fan-out inputs, so the two paths cannot drift apart
the way a second hand-written formula would let them.

SQL's fan-out inputs differ by target signal, verified against each
scan executor's real partitioning rather than assumed:

- Metrics, Spans, Alerts, and Audit are segment-granular: partitions
  are DataFusion's target_partitions clamped to the segment count, one
  partition per segment, no serial plan phase. AlertsScanExec and
  AuditScanExec partition this way unconditionally.
- Logs alone has a different shape, because LogsScanExec does: uncached,
  it is segment-granular like the others; cache-wired (the server
  default), it stripes blocks across partitions and a segment can be
  opened by more than one partition, and a serial plan-read phase
  (compute_plan_counts) always runs before any scan partition drains,
  charged as a second service_batches term on top of the scan term.
- shared_get_permits reads the real process-wide GetLimiter size
  (EngineConfig::store_get_concurrency), the same limiter every SQL
  fetcher and every PromQL fetcher share, not an unbounded value.

Every exact-value test goes through the real SqlExecutor, states its
arithmetic by hand in the comment, and is demonstrated failing against
the wrong model it replaces. docs/query-engine.md states which paths
produce the block and how each SQL term is derived.

Fixes: #1250
Refs: #1199
