### PR TITLE
docs: add ADR-1374 first-party MCP server and query service layer

### DIFF
--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -231,7 +231,7 @@ Every tool returns one envelope:
   "visibility": {"snapshot_id": "", "watermark_hour": "", "pinned": false, "min_commit_tokens_applied": []},
   "coverage": {"complete": true, "partial": false, "fragments": [], "unindexed_predicates": []},
   "accuracy": {"exact": true, "approximation": null, "lower_bound_count": false},
-  "presentation": {"max_rows": 200, "row_cap_hit": false, "bytes_cap_hit": false, "rows_omitted": 0, "cells_truncated": 0, "metadata_elided": 0, "cursor": null},
+  "presentation": {"max_rows": 200, "row_cap_hit": false, "bytes_cap_hit": false, "rows_omitted": 0, "cells_truncated": 0, "metadata_elided": 0, "effective_max_response_bytes": 524288, "floor_applied": false, "cursor": null},
   "budget": {"effective": {}, "actual": {}, "estimate": {}, "estimate_is_upper_envelope": true},
   "evidence": [{"ref": "", "covers": "data.rows", "sha256": ""}],
   "warnings": [],
@@ -258,36 +258,53 @@ rows are then reachable on the next page. When it has no total order, the
 status is `ok_bounded`.
 
 A page always keeps its first row when the query produced one. When the
-first row alone does not fit under the cap, the server keeps the row. It
-shortens each string cell of that row to at most 4 KiB and appends a
-trailing marker to each shortened cell. `presentation.cells_truncated`
-carries the count of shortened cells. The evidence hash covers the full
-canonical row, not the shortened one. So `data.rows` is never empty while `rows_omitted` is
-positive, and a cursor always has a last kept row. A test feeds a row with a
-64 KiB body under the floor cap and asserts one row, one truncated cell, and
-zero omitted rows.
+first row alone does not fit under the cap, the server keeps the row and
+shortens its cells. The cell budget is `max(256 B, (cap - fixed_part) /
+column_count)`, where `fixed_part` is the serialized size of the envelope
+without `data.rows`. The rule applies to every cell type. A number, a
+timestamp, a boolean, or a hex binary id never exceeds 64 B and is never
+shortened. A string cell longer than the budget is cut to the budget,
+including the trailing marker. A map cell or another structured cell that
+exceeds the budget is serialized to its JSON text first. That text is cut
+the same way and returned as a string. `presentation.cells_truncated` carries the count
+of shortened cells. The evidence hash covers the full canonical row, not
+the shortened one. So `data.rows` is never empty while `rows_omitted` is
+positive, a retained row always fits, and a cursor always has a last kept
+row. Two tests cover this rule: a row with a 1 MiB body and a row with a
+1 MiB map, each under the floor cap. Each asserts one row, one truncated
+cell, zero omitted rows, and the exact serialized size under the cap.
 
 The fixed part of the envelope is bounded so that it always fits. The server
-floors `max_response_bytes` at 64 KiB: a caller value below the floor is
-raised to the floor, and the envelope says so. This floor is a minimum on
-the presentation cap and is not a raise of any query budget. Every
-variable-length field outside `data.rows` has a count bound and a string
-bound:
+floors `max_response_bytes` at 256 KiB, and the default is 512 KiB. A caller
+value below the floor is raised to the floor.
+`presentation.effective_max_response_bytes` carries the cap in force and
+`presentation.floor_applied` says if the floor raised it. This floor is a
+minimum on the presentation cap and is not a raise of any query budget.
+Every variable-length field outside `data.rows` has a count bound and a
+per-entry serialized-size bound:
 
-- `data.columns`: at most 512 entries of 256 bytes each
+- `data.columns`: at most 256 entries of 160 B each (name, type, and JSON
+  overhead), 40 KiB in total
 - `scope.predicates_applied` and `scope.order_by`: at most 16 entries of
-  512 bytes each
-- `visibility.min_commit_tokens_applied`: at most 64 entries
-- `coverage.fragments`: at most 64 entries
-- `coverage.unindexed_predicates`: at most 16 entries
+  512 B each, 16 KiB in total
+- `visibility.min_commit_tokens_applied`: at most 64 entries of 128 B each,
+  8 KiB in total
+- `coverage.fragments`: at most 64 entries of 160 B each, 10 KiB in total
+- `coverage.unindexed_predicates`: at most 16 entries of 256 B each, 4 KiB
+  in total
 - `warnings`: at most 16 entries, `next_steps`: at most 8 entries,
-  `evidence`: at most 16 entries, each entry at most 512 bytes
+  `evidence`: at most 16 entries, each entry at most 512 B, 20 KiB in total
+- the scalar fields together: at most 4 KiB
 
-When a list exceeds its bound, the server keeps the first entries and sets
-`presentation.metadata_elided` to the number of dropped entries. A test
-serializes an
-envelope with zero rows and every field at its bound and asserts the exact
-size stays under 64 KiB. The byte cap, the row cap, and analytic
+The sum of these bounds is 102 KiB. That is less than half of the 256 KiB
+floor, so a retained row always has at least 154 KiB. A projection wider
+than 256 columns is an `invalid_argument` failure whose `next_steps` says to
+name the columns. When a list exceeds its bound, the server keeps the first
+entries and sets `presentation.metadata_elided` to the number of dropped
+entries. A test serializes an envelope with zero rows and every field at its
+bound. The test asserts the exact size, which must be less than 106,496
+bytes.
+The byte cap, the row cap, and analytic
 downsampling are three separate facts in the envelope. A downsampled
 analytic sets `exact: false` and names the method.
 Missing coverage sets `complete: false` and names the reason. A budget
@@ -378,9 +395,10 @@ cross-replica control, and the envelope says so. Usage is reported as
 requests and bytes by kind: wire, cache-served, decompressed. Usage is never
 reported as money.
 
-Defaults: `max_rows` 200 with a ceiling of 5,000, `max_response_bytes`
-256 KiB, 100 metric families per describe page, and 2,000 segments for label
-resolution. The evaluation can change these values.
+Defaults: `max_rows` 200 with a ceiling of 5,000. `max_response_bytes`
+512 KiB with a floor of 256 KiB (D4). 100 metric families per describe
+page. 2,000 segments for label resolution. The evaluation can change these
+values.
 
 An investigation-wide budget across calls is Phase 2. A caller-supplied
 bundle id is not trustworthy.

--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -182,10 +182,14 @@ The `tools/list` result for the nine tools must serialize in less than
 
 ### D3. Engine and server prerequisites
 
-1. `RequestBudgets` in `ravel-query`: `max_bytes_scanned`, `max_s3_requests`,
-   and `max_segments`, each optional. `clamp` can only lower a ceiling. The
-   admission and scan checks read the clamped value. PromQL entry points take
-   `Option<RequestBudgets>`. `None` keeps the current behavior.
+1. `RequestBudgets` in `ravel-query`: `max_bytes_scanned`,
+   `max_store_requests`, and `max_segments`, each optional. The name
+   `max_store_requests` is the one canonical name on the wire, in the tool
+   schemas, and in the envelope. It maps to the existing
+   `EngineConfig::max_s3_requests` ceiling, which keeps its name. A schema
+   test asserts the serialized field name. `clamp` can only lower a ceiling.
+   The admission and scan checks read the clamped value. PromQL entry points
+   take `Option<RequestBudgets>`. `None` keeps the current behavior.
 2. `SqlRequest::row_window`, default `false`. When `true`, each table
    provider applies `ts_col >= start AND ts_col < end` above the scan. The
    column is `ts` for `samples` and `logs`, `start_ts` for `spans`, and
@@ -198,7 +202,13 @@ The `tools/list` result for the nine tools must serialize in less than
    outcome reports `row_cap_hit`.
 5. A query service layer in `services/ravel-server/src/service/`. Analytics
    and exemplars gain an admission permit. PromQL gains cost on cancel.
-   `labels` and `label_values` gain the audit seam.
+   `labels` and `label_values` gain the audit seam. The service layer
+   finalizes usage before it maps any outcome to an error. The outcomes are
+   an audit failure, a partial-result refusal, an evaluation failure, a
+   deadline, and a cancellation. A drop guard in the pattern of
+   `sql.rs::CostGuard` records the spend on every path. As a result, the
+   D6 usage figures and the D7 cancelled-spend figure are never omitted.
+   One test per path asserts the recorded figures.
 6. `AuditPipeline::spawn` in `lib.rs::start` for query modes. Flags
    `--audit-mode required|best-effort` (default `required`) and
    `--audit-text`. This closes #1187. MCP tool calls submit
@@ -231,18 +241,32 @@ query with zero matches is `ok`. A query whose `LIMIT` the data did not fill
 is `ok`. `ok_bounded` means that the row cap stopped the result, more rows
 exist, and no cursor exists because the statement has no total order.
 `ok_page` means that the row cap stopped the result and a cursor exists.
-`bytes_cap_hit` reports a shortened rendering and is separate from the row
-cap. A downsampled analytic sets `exact: false` and names the method.
+
+`max_response_bytes` bounds the serialized `structuredContent`, that is, the
+whole envelope as JSON. When the envelope exceeds the cap, the server drops
+rows from the end of `data.rows` until the envelope fits. `data.row_count`
+keeps the count of rows that the query produced. `presentation.bytes_cap_hit`
+becomes `true` and `presentation.rows_omitted` carries the number of dropped
+rows. The text block is rendered from the truncated `data`, so the two
+representations never differ. When the statement has a total order, the
+cursor points at the last kept row, so the omitted rows are reachable on the
+next page. When it has no total order, the status is `ok_bounded`. The byte
+cap, the row cap, and analytic downsampling are three separate facts in the
+envelope. A downsampled analytic sets `exact: false` and names the method.
 Missing coverage sets `complete: false` and names the reason. A budget
 failure or a deadline is an `error`. The server never returns a partial exact
 aggregate as `ok`. A `COUNT` over `logs` or `spans` sets
 `lower_bound_count: true`, because ingest is at-least-once.
 
-Time. Every data tool requires `time_range`. An absent range is a
-`missing_argument` failure. There is no default window. Inputs are RFC 3339
-strings or integer nanoseconds as strings. Intervals are half-open. Outputs
-carry timestamps as nanosecond strings. The `scope` block reports the 5 m
-metric lookback and the step alignment.
+Time. Every data tool requires a time input. There is no default window.
+Inputs are RFC 3339 strings or integer nanoseconds as strings. Range tools
+take `time_range`, a half-open interval. `ravel_query_promql` has two modes.
+Range mode takes `time_range` and `step`. Instant mode takes
+`evaluation_time`, one instant, and no `time_range`. A request with both
+fields, or with neither, is an `invalid_argument` failure. A test covers
+both modes. An absent time input on any other data tool is a
+`missing_argument` failure. Outputs carry timestamps as nanosecond strings.
+The `scope` block reports the 5 m metric lookback and the step alignment.
 
 Precision. Integers and timestamps are JSON strings, because nanosecond epochs
 exceed 2^53. Floats keep `NaN`, `+Inf`, and `-Inf` as strings. Finite floats
@@ -280,9 +304,19 @@ routing as the option for a load balancer.
 `ravel_query_sql` mints a cursor only when the `ORDER BY`, plus a
 deterministic tiebreak that the tool appends, is a total order over the
 projection. `ravel_search_logs` orders by
-`(ts, observed_ts, trace_id, span_id, body_hash)`, because `logs` has no
-unique key, and it reports remaining ties as possible duplicates.
-`ravel_get_trace` orders by `(start_ts, span_id)`.
+`(ts, observed_ts, trace_id, span_id, body_hash)`. That tuple is not unique,
+because `logs` has no row identity and ingest is at-least-once. A strict
+keyset predicate would skip an equal row on the next page. So a page never
+ends inside a group of equal tuples. The tool fetches `k + 1` rows. When
+the last kept tuple equals the first omitted tuple, the tool drops that
+whole equal group from the page. The cursor then points at the last
+complete group.
+If no complete group fits in the page, the status is `ok_bounded` with no
+cursor and a `next_steps` entry that says to narrow `time_range`. The same
+rule applies to `ravel_query_sql` when its appended tiebreak is not unique.
+`ravel_get_trace` orders by `(start_ts, span_id)`. A test paginates a
+fixture with equal tuples across a page boundary and asserts that every row
+appears exactly once.
 
 An evidence reference is a token of the same family. It adds the sha256 of
 the canonical row bytes. Redemption re-executes against the pin while the pin
@@ -323,12 +357,18 @@ bundle id is not trustworthy.
   default profile has read tools only. The fold route, ingest, erasure,
   legal holds, retention, alert rules, and maintenance are not reachable
   through MCP. An operator profile needs a principal model and its own ADR.
-- Transport: `POST /mcp` only. The server validates `MCP-Protocol-Version`,
-  `Mcp-Method`, and `Mcp-Name`. It validates `Origin` against
+- Transport: `POST /mcp` only. The server validates `Origin` against
   `--mcp-allowed-origins` and answers 403 on a mismatch. The body cap is
   1 MiB. Each tool call takes one admission permit. The deadline is clamped.
-  Legacy clients use the in-memory session manager of `rmcp`, and each
-  request re-authenticates. An `initialize` without a credential is refused.
+  Header validation is per revision. For a `2026-07-28` request, the server
+  requires `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name`, and answers
+  400 on a mismatch with the body. For a `2025-11-25` request, the server
+  requires neither `Mcp-Method` nor `Mcp-Name`, accepts `initialize`, and
+  handles `Mcp-Session-Id` with the in-memory session manager of `rmcp`.
+  Each legacy request re-authenticates. An `initialize` without a
+  credential is refused. One test sends a `2025-11-25` `initialize` and one
+  test sends a `2026-07-28` `tools/call`, and each asserts its own header
+  rule.
 - Phase 1 uses the bearer chain. Phase 2 serves the RFC 9728 document when
   an OIDC resolver is configured, after a check that `OidcResolver` validates
   the audience claim.
@@ -394,7 +434,13 @@ asserts snapshot identity per page.
 
 ### D9. Packaging and rollout
 
-The cargo feature `mcp` implies `sql`. The published image builds
+The cargo feature `mcp` implies `sql`. The cursor codec of D5 reuses the
+Flight pin codec (`flight_ticket.rs`, `TicketKey`), which `ravel-sql` gates
+behind `flight-sql` today. `ravel-sql` gains a smaller feature, `pin-codec`,
+that carries only that module and no `arrow-flight` dependency. Both
+`flight-sql` and `mcp` enable `pin-codec`. A CI build check compiles
+`ravel-server` with `sql,mcp` and without `flight-sql`, so an `mcp` build
+never depends on Flight. The published image builds
 `sql,flight-sql,otap,mcp`. The operator needs no new Service port. The flag
 `--mcp` is off by default. `--mcp-allowed-origins` is required when `--mcp`
 is set on a non-loopback listener, or startup fails. The server serves
@@ -443,7 +489,6 @@ the catalog by a drift test, a README section, the `/mcp` row in
   - resources and prompts stay minimal
   - audit records carry `query.language = mcp:<tool>`
 - Recorded uncertainties:
-  - if `flight_ticket.rs` compiles without the `flight-sql` feature
   - if `OidcResolver` checks the `aud` claim
   - the `rmcp` attribute syntax for output schemas
   - the exact `tools/list` byte figure. The first serialization sets it and

--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -231,7 +231,7 @@ Every tool returns one envelope:
   "visibility": {"snapshot_id": "", "watermark_hour": "", "pinned": false, "min_commit_tokens_applied": []},
   "coverage": {"complete": true, "partial": false, "fragments": [], "unindexed_predicates": []},
   "accuracy": {"exact": true, "approximation": null, "lower_bound_count": false},
-  "presentation": {"max_rows": 200, "row_cap_hit": false, "bytes_cap_hit": false, "rows_omitted": 0, "cursor": null},
+  "presentation": {"max_rows": 200, "row_cap_hit": false, "bytes_cap_hit": false, "rows_omitted": 0, "cells_truncated": 0, "metadata_elided": 0, "cursor": null},
   "budget": {"effective": {}, "actual": {}, "estimate": {}, "estimate_is_upper_envelope": true},
   "evidence": [{"ref": "", "covers": "data.rows", "sha256": ""}],
   "warnings": [],
@@ -257,18 +257,39 @@ cursor points at the last kept row and the status is `ok_page`. The omitted
 rows are then reachable on the next page. When it has no total order, the
 status is `ok_bounded`.
 
+A page always keeps its first row when the query produced one. When the
+first row alone does not fit under the cap, the server keeps the row. It
+shortens each string cell of that row to at most 4 KiB and appends a
+trailing marker to each shortened cell. `presentation.cells_truncated`
+carries the count of shortened cells. The evidence hash covers the full
+canonical row, not the shortened one. So `data.rows` is never empty while `rows_omitted` is
+positive, and a cursor always has a last kept row. A test feeds a row with a
+64 KiB body under the floor cap and asserts one row, one truncated cell, and
+zero omitted rows.
+
 The fixed part of the envelope is bounded so that it always fits. The server
-floors `max_response_bytes` at 16 KiB: a caller value below the floor is
+floors `max_response_bytes` at 64 KiB: a caller value below the floor is
 raised to the floor, and the envelope says so. This floor is a minimum on
-the presentation cap and is not a raise of any query budget. The metadata
-lists are bounded by count: at most 16 `warnings`, 8 `next_steps`, and 16
-`evidence` entries, each with a bounded string length. A test serializes an
-envelope with zero rows and every metadata list at its maximum and asserts
-that it fits under 16 KiB. When the rendering still cannot fit, which the
-test makes impossible, the result is an `error` with class `internal`. The
-byte cap, the row cap, and analytic downsampling are three separate facts in
-the envelope. A downsampled analytic sets `exact: false` and names the
-method.
+the presentation cap and is not a raise of any query budget. Every
+variable-length field outside `data.rows` has a count bound and a string
+bound:
+
+- `data.columns`: at most 512 entries of 256 bytes each
+- `scope.predicates_applied` and `scope.order_by`: at most 16 entries of
+  512 bytes each
+- `visibility.min_commit_tokens_applied`: at most 64 entries
+- `coverage.fragments`: at most 64 entries
+- `coverage.unindexed_predicates`: at most 16 entries
+- `warnings`: at most 16 entries, `next_steps`: at most 8 entries,
+  `evidence`: at most 16 entries, each entry at most 512 bytes
+
+When a list exceeds its bound, the server keeps the first entries and sets
+`presentation.metadata_elided` to the number of dropped entries. A test
+serializes an
+envelope with zero rows and every field at its bound and asserts the exact
+size stays under 64 KiB. The byte cap, the row cap, and analytic
+downsampling are three separate facts in the envelope. A downsampled
+analytic sets `exact: false` and names the method.
 Missing coverage sets `complete: false` and names the reason. A budget
 failure or a deadline is an `error`. The server never returns a partial exact
 aggregate as `ok`. A `COUNT` over `logs` or `spans` sets

--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -1,0 +1,458 @@
+# ADR-1374: A first-party MCP server, a shared query service layer, and an agent result contract
+
+Status: Proposed
+Date: 2026-09-07
+Epic: #1374
+Reviewed revision: `2b8c2a51ddcd844e3362ad4513d314c01fa35b6f`
+
+## Context
+
+An AI agent that investigates an incident or a security event needs four
+things from a telemetry database. It needs to find what data exists without a
+guess. It needs to run bounded queries with a known cost. It needs to move
+between metrics, logs, and traces on exact identifiers. It needs to hand back
+a finding that a person can check again. Ravel has the query engines for this
+work. It does not have an agent-facing surface, and several controls that an
+agent would depend on are not in place for human callers either.
+
+The facts below were checked by symbol at the reviewed revision. Each row
+names the path and symbol, never a line number.
+
+### What exists
+
+| Capability | State | Evidence |
+|---|---|---|
+| Tenant authentication: static bearer, OIDC JWT, durable `sys/auth`, mTLS proxy header | shipped | `crates/ravel-tenant-resolve/src/lib.rs::TenantResolver::resolve` |
+| SQL statement gate: one `SELECT`, no DDL, no DML, no `COPY`, no `CREATE EXTERNAL TABLE`, no `EXPLAIN`, no `SET` | shipped, structural | `crates/ravel-sql/src/validate.rs::validate`, `::reject_writes_in_query` |
+| Empty table-function registry, empty object-store registry, `information_schema` off | shipped | `crates/ravel-sql/src/session.rs::build_session`, `::EmptyObjectStoreRegistry` |
+| Five SQL tables, one table per statement | gated (`sql`) | `crates/ravel-sql/src/session.rs::SessionTable`, `executor.rs::SqlExecutor::target_signal` |
+| Declared typed attribute columns, 60 s refresh horizon | shipped, CLI-declared | `services/ravel-server/src/declared_columns.rs::TenantConfigDeclaredColumns` |
+| Metric metadata (type, unit, help), one object per tenant | shipped | `crates/ravel-query/src/http/metadata_cache.rs::MetadataCache::get` |
+| Metric name postings under `__name__` equality | shipped | `crates/ravel-catalog/src/catalog.rs::resolve_fanout` |
+| Exemplars, window applied to rows | shipped | `services/ravel-server/src/exemplars.rs::run` |
+| Trace by id through the `spans` table, skip index per block | shipped | `crates/ravel-sql/src/spans_pushdown.rs::extract_spans`, `crates/ravel-rspan/src/skip_index.rs::SkipIndex::candidate_blocks` |
+| Analytics `change_point` and `summary` over PromQL range results | shipped | `services/ravel-server/src/analytics.rs::run`, `crates/ravel-analytics/src/lib.rs` |
+| Per-query budgets: segments, store requests, series, samples, deadline, SQL memory. Each one is a typed error, never a truncation | shipped | `crates/ravel-query/src/segment_admission.rs::admit`, `::request_budget_exceeded` |
+| Cost estimate as an upper envelope, reported after the query | shipped | `crates/ravel-sql/src/cost.rs`, `ravel_types::accounting::CostEstimate` |
+| Fleet-global query concurrency ceiling | shipped | `crates/ravel-query/src/query_admission.rs::QueryAdmissionController::try_admit` |
+| Cancellation by future drop, no spawn between transport and engine | shipped | `services/ravel-server/src/sql.rs::CostGuard` |
+| Read-your-write lower bound (`min_commit_token`) | shipped, except exemplars | `crates/ravel-query/src/http/params.rs::decode_commit_tokens` |
+| Snapshot pinned across two requests | Flight ticket only, MAC, deadline-bound, process-local key | `crates/ravel-sql/src/flight_ticket.rs::FlightTicket`, `::TicketKey` |
+| Partial-coverage flag with a consent gate | PromQL and analytics only | `crates/ravel-query/src/http/handlers.rs::gate_partial` |
+| Per-phase cost split | PromQL only. SQL reports pooled counters | `crates/ravel-query/src/http/json.rs::phase_costs` |
+
+### What is missing
+
+| Gap | Evidence |
+|---|---|
+| Authorization below the tenant. `resolve` returns a bare `TenantId`. `AuthError` cannot say "authenticated, not permitted" | `crates/ravel-tenant-resolve/src/lib.rs::TenantResolver` |
+| Operator identity. Any tenant token can trigger a fold | `services/ravel-server/src/fold_on_demand.rs::run` |
+| SQL `start`/`end` as a row filter. The window reaches only `Catalog::resolve`. No provider constructor receives it. An absent window means the last hour | `crates/ravel-sql/src/executor.rs::SqlRequest::window`, `services/ravel-server/src/sql.rs::build_request` |
+| A cost estimate before the query runs. `EXPLAIN` is refused. The plan text exists only in the bench | `crates/ravel-sql/src/executor.rs::PinnedQuery::create_physical_plan` |
+| A budget that a caller can lower, other than the deadline | `services/ravel-server/src/sql.rs::SqlBody` |
+| Per-tenant query budgets. The `--limits-file` entries are parsed and inert | `services/ravel-server/src/config.rs::LimitsConfig` |
+| Effective schema over HTTP. Only a Flight statement returns the declared columns | `crates/ravel-sql/src/flight/service.rs::get_flight_info_statement` |
+| Enumeration of log attribute keys or values | no map-key function in `crates/ravel-sql/src/session.rs::ADMITTED_SCALARS` |
+| Query audit records. Every sink is `NoopQueryAuditSink`. `AuditPipeline::spawn` has no non-test caller. No `--audit-mode` flag (#1187) | `services/ravel-server/src/query.rs::build_sql_state`, `crates/ravel-maintain/src/audit_pipeline.rs` |
+| Row ordering, row identity, pagination, row cap. The scan declares no order. `logs` has no unique key. HTTP buffers the whole result | `crates/ravel-sql/src/output.rs::QueryOutput`, `crates/ravel-sql/src/logs_schema.rs::logs_fields` |
+| Missing-parent disclosure on traces | `docs/guides/traces.md`, "Incomplete traces" |
+| Pruning on `logs.trace_id`. It is a fixed column with a residual filter only | `crates/ravel-sql/src/logs_pushdown.rs::FIXED_LOG_COLUMNS` |
+| A service layer. Handlers call the engines. Analytics, exemplars, and the fold route take no admission permit. Two PromQL routes have no audit seam. Exemplars record no cost | `services/ravel-server/src/lib.rs::start`, no `.layer` on either `axum::serve` |
+| Any MCP server. The only MCP in the tree is the `graft` development tool configuration | `gh issue list --search MCP` returns nothing related |
+
+### The protocol and the SDK
+
+The current MCP specification is `2026-07-28`. It has no `initialize`
+handshake, no protocol session, no GET stream, and no SSE resumption. Each
+request carries its protocol version in `_meta` and in the
+`MCP-Protocol-Version` header. A server must validate the `Origin` header.
+On Streamable HTTP, a closed stream is a cancellation. Stateful tools mint an
+explicit handle and bind that handle to the authenticated user. The legacy
+revision `2025-11-25` still uses `initialize` and `Mcp-Session-Id`, and most
+deployed clients speak that revision. Authorization is optional in the
+specification. When a server uses OAuth 2.1, it must publish protected
+resource metadata (RFC 9728) and must bind tokens to its own audience.
+
+The Rust SDK `rmcp` 3.2.0 serves both revisions. It mounts on axum 0.8 as a
+tower service. It delivers cancellation through `on_cancelled`. Its `auth`
+feature is an OAuth client, not a token validator. Its versions of tokio,
+serde, and schemars match the workspace.
+
+Reference servers give three lessons. The Grafana server lists 110 tools at
+about 44,000 tokens and tracks that as a defect. The ClickHouse server
+enforces read-only at the engine (`readonly=1`) and marks its regex gate as
+advisory. The Elastic Agent Builder binds the tenant scope at authoring time,
+never through an agent argument.
+
+## Decision
+
+### D1. One service layer, one tool layer, one native adapter
+
+Ravel gets a transport-independent tool layer in a new crate, `ravel-mcp`. It
+gets a shared application-service layer in `services/ravel-server/src/service/`.
+The MCP adapter mounts `rmcp::StreamableHttpService` on the query router at
+`POST /mcp`, behind the cargo feature `mcp` and the flag `--mcp`. Both are off
+by default. The HTTP handlers keep their parsing and encoding. They call the
+service layer for admission, tenant resolution, deadline and budget clamps,
+audit submit-and-await, cost recording, partial-coverage consent, and error
+redaction. The MCP tools call the same service layer.
+
+The service layer comes first because the handlers already differ. A new
+transport that calls the engines directly makes one more copy of the policy.
+
+The adapter is native, not a standalone binary. Every missing capability that
+an agent needs lives below the HTTP surface. These capabilities are the
+explain path, the effective schema, the row cap, cost on cancel, budget
+lowering, and audit. A standalone server needs those server changes too. It also adds a second credential hop.
+In-process, the MCP endpoint is the resource server and the tenant credential
+is the token.
+
+```mermaid
+flowchart LR
+  subgraph client["Agent host (untrusted)"]
+    A[MCP client]
+  end
+  subgraph proxy["Reverse proxy / TLS (deployment)"]
+    P[TLS termination, Origin policy]
+  end
+  subgraph server["ravel-server, mode all|query, feature mcp, flag --mcp"]
+    direction TB
+    H["HTTP handlers<br/>/api/v1/*"]
+    M["MCP adapter<br/>POST /mcp (rmcp StreamableHttpService)<br/>TenantResolver per request, body cap, Origin check"]
+    T["ravel-mcp tool layer<br/>schemas, envelope, cursor codec, SQL synthesis, compact output"]
+    S["service layer<br/>services/ravel-server/src/service/<br/>admit, resolve tenant, clamp deadline and budgets,<br/>audit submit-and-await, record cost, redact"]
+    E["engines<br/>SqlExecutor, QueryEngine, Catalog, analytics"]
+    H --> S
+    M --> T --> S
+    S --> E
+  end
+  subgraph store["Object store (the only durable state)"]
+    O[(bucket)]
+  end
+  A -- "Bearer tenant credential<br/>MCP-Protocol-Version" --> P --> M
+  E --> O
+  S -- "audit RLOG object and commit record<br/>(audit_mode=required)" --> O
+```
+
+Trust boundaries. The agent host is untrusted. Every argument, cursor, and
+evidence reference is data until the server checks it against the credential.
+The tenant credential is the only authority. A cursor is a name, not a
+capability. The server compares the tenant hash inside a cursor with the
+resolved tenant on every call. The tool layer never touches the store. Only
+the engines touch the store, through the budgets of the service layer.
+Telemetry content is untrusted text. The server returns it inside typed
+fields and never interprets it.
+
+### D2. Nine tools, three resources, two prompts
+
+The default profile is read-only. Tool names carry the `ravel_` prefix. Each
+tool declares an input schema and an output schema. The `structuredContent`
+of each result is the envelope of D4. The text block is a compact rendering
+of the same data, not a second copy of the rows. Every tool carries the
+annotations `readOnlyHint: true`, `destructiveHint: false`, and
+`openWorldHint: false`. Annotations are hints and carry no authority.
+
+| Tool | Purpose | Prerequisite |
+|---|---|---|
+| `ravel_capabilities` | Protocol and server version, enabled tools, effective budget ceilings, dialect summaries, tenant hash, enabled signals. Zero store reads | none |
+| `ravel_describe_data` | Per signal: effective schema (fixed and declared columns), indexed keys, metric families with type and unit (one bounded page), freshness watermark, coverage window, exact catalog row counts where they exist | D3 explain path, `MetadataCache`, one resolve per signal |
+| `ravel_find_labels` | Metric names for a selector, label names, or label values for one label under a selector. The result says if the list is declared, observed, or exact. An unfiltered tenant-wide list is refused, and the refusal names the bounded form | label machinery through the service layer |
+| `ravel_explain_query` | Validate SQL or PromQL, resolve the snapshot, return the target table, the effective schema, the admitted segment count, the estimate against the effective budget, and the plan shape. No scan | D3 `SqlExecutor::explain` |
+| `ravel_query_sql` | One `SELECT` over one table, with a required `time_range` applied as a row filter, `max_rows`, budgets that can only be lowered, and a keyset cursor | D3 |
+| `ravel_query_promql` | Instant or range evaluation, partial-coverage consent, step alignment, the two log pseudo-metrics | `QueryEngine` through the service layer |
+| `ravel_search_logs` | Typed log search compiled to SQL. Uses indexed and declared predicates, `has_word`, severity, and trace id. Orders by `ts`. Groups rows by attribute set and hoists shared attributes once | D3 |
+| `ravel_get_trace` | Spans of one trace id inside a required window, the span tree, the missing parents, and the orphans. An optional logs leg, reported as an unindexed scan with its own cost | `spans_pushdown` fast path |
+| `ravel_analyze_timeseries` | `change_point` or `summary` over a PromQL range result. The output says "heuristic", the minimum point count, and if it was downsampled | `analytics.rs::run` through the service layer, which adds admission |
+
+Phase 2 tools: `ravel_compare_windows` and `ravel_correlate_signals`
+(exemplar to trace to logs, exact ids only).
+
+Rejected tool candidates: `ravel_find_metrics` and `ravel_find_label_values`
+(merged into `ravel_find_labels`), `ravel_read_result` (a cursor lives on the
+tool that made it), and the three operator tools (they need an operator
+principal, and they show process-wide state).
+
+Resources: `ravel://dialect/sql`, `ravel://dialect/promql`, and the template
+`ravel://schema/{signal}`. Prompts: `incident_triage` and `entity_timeline`.
+Each prompt names its version and its tools. No resource or prompt carries
+data that a tool cannot return.
+
+The `tools/list` result for the nine tools must serialize in less than
+24 KiB. A test pins the exact byte band. Tools are listed in a fixed order.
+
+### D3. Engine and server prerequisites
+
+1. `RequestBudgets` in `ravel-query`: `max_bytes_scanned`, `max_s3_requests`,
+   and `max_segments`, each optional. `clamp` can only lower a ceiling. The
+   admission and scan checks read the clamped value. PromQL entry points take
+   `Option<RequestBudgets>`. `None` keeps the current behavior.
+2. `SqlRequest::row_window`, default `false`. When `true`, each table
+   provider applies `ts_col >= start AND ts_col < end` above the scan. The
+   column is `ts` for `samples` and `logs`, `start_ts` for `spans`, and
+   `ts_ns` for `alerts` and `audit`. The outcome reports the applied
+   predicate. The HTTP body keeps `false` until a client opts in.
+3. `SqlExecutor::explain`: validate, resolve, admit, compute the effective
+   schema, run the estimator with `unknown` components, and render the plan
+   text. No data GET. A test asserts the data GET count.
+4. `SqlRequest::max_rows`. The stream stops after `max_rows + 1` rows. The
+   outcome reports `row_cap_hit`.
+5. A query service layer in `services/ravel-server/src/service/`. Analytics
+   and exemplars gain an admission permit. PromQL gains cost on cancel.
+   `labels` and `label_values` gain the audit seam.
+6. `AuditPipeline::spawn` in `lib.rs::start` for query modes. Flags
+   `--audit-mode required|best-effort` (default `required`) and
+   `--audit-text`. This closes #1187. MCP tool calls submit
+   `query.language = mcp:<tool>`.
+
+### D4. The result envelope
+
+Every tool returns one envelope:
+
+```json
+{
+  "status": "ok | ok_bounded | ok_page | error",
+  "failure": null,
+  "data": {"columns": [], "rows": [], "row_count": 0},
+  "scope": {"signal": "", "table": "", "time_range": {}, "predicates_applied": [], "order_by": []},
+  "ids": {"query_id": "", "audit_ref": ""},
+  "visibility": {"snapshot_id": "", "watermark_hour": "", "pinned": false, "min_commit_tokens_applied": []},
+  "coverage": {"complete": true, "partial": false, "fragments": [], "unindexed_predicates": []},
+  "accuracy": {"exact": true, "approximation": null, "lower_bound_count": false},
+  "presentation": {"max_rows": 200, "row_cap_hit": false, "bytes_cap_hit": false, "cursor": null},
+  "budget": {"effective": {}, "actual": {}, "estimate": {}, "estimate_is_upper_envelope": true},
+  "evidence": [{"ref": "", "covers": "data.rows", "sha256": ""}],
+  "warnings": [],
+  "next_steps": [{"action": "", "detail": ""}]
+}
+```
+
+The four status values are different facts. `ok` is a complete query. A
+query with zero matches is `ok`. A query whose `LIMIT` the data did not fill
+is `ok`. `ok_bounded` means that the row cap stopped the result, more rows
+exist, and no cursor exists because the statement has no total order.
+`ok_page` means that the row cap stopped the result and a cursor exists.
+`bytes_cap_hit` reports a shortened rendering and is separate from the row
+cap. A downsampled analytic sets `exact: false` and names the method.
+Missing coverage sets `complete: false` and names the reason. A budget
+failure or a deadline is an `error`. The server never returns a partial exact
+aggregate as `ok`. A `COUNT` over `logs` or `spans` sets
+`lower_bound_count: true`, because ingest is at-least-once.
+
+Time. Every data tool requires `time_range`. An absent range is a
+`missing_argument` failure. There is no default window. Inputs are RFC 3339
+strings or integer nanoseconds as strings. Intervals are half-open. Outputs
+carry timestamps as nanosecond strings. The `scope` block reports the 5 m
+metric lookback and the step alignment.
+
+Precision. Integers and timestamps are JSON strings, because nanosecond epochs
+exceed 2^53. Floats keep `NaN`, `+Inf`, and `-Inf` as strings. Finite floats
+are numbers with the sign of zero preserved (the rule of
+`output.rs::float_to_json`). Binary is hex. Maps are objects.
+
+Failure classes: `unauthorized`, `invalid_argument`, `validation` (the engine
+text, safe to echo), `unsupported`, `budget_estimate_exceeds_ceiling`,
+`budget_exceeded` (with the counter that tripped), `deadline`, `unavailable`
+(retryable), `snapshot_invalidated` (retryable once), `cursor_expired`,
+`cursor_invalid`, and `internal` (fixed message). A failure is a tool result
+with `isError: true`, so the model can correct itself. Protocol errors are
+for malformed JSON-RPC and unknown tools only. Every failure carries
+`next_steps`.
+
+### D5. Consistency, cursors, and evidence references
+
+Each call resolves its own snapshot. Two calls share a snapshot only when the
+second call carries a cursor from the first. The cursor pin is valid until
+`min(remaining query deadline, protection_horizon - grace)`. This is the
+Flight ticket rule. The envelope reports `snapshot_id` (a hash of the pinned
+segment set), the watermark hour, the applied commit tokens, and `pinned`. A
+commit token is a read-your-write lower bound. It is not a snapshot identity.
+
+A cursor is a token with a keyed MAC, minted with a process-local key in the
+`TicketKey` pattern. It carries the tenant hash, the tool, the argument hash,
+the keyset position, and the deadline. It also carries the pinned segment
+set, with the pending erasure predicates and the declared columns. The server
+stores nothing. A page
+re-executes the statement against the pin with a keyset predicate. A cursor
+from a dead process fails with `cursor_expired`. Only the process that minted
+a cursor can redeem it. The documentation says this, and it names sticky
+routing as the option for a load balancer.
+
+`ravel_query_sql` mints a cursor only when the `ORDER BY`, plus a
+deterministic tiebreak that the tool appends, is a total order over the
+projection. `ravel_search_logs` orders by
+`(ts, observed_ts, trace_id, span_id, body_hash)`, because `logs` has no
+unique key, and it reports remaining ties as possible duplicates.
+`ravel_get_trace` orders by `(start_ts, span_id)`.
+
+An evidence reference is a token of the same family. It adds the sha256 of
+the canonical row bytes. Redemption re-executes against the pin while the pin
+is valid and compares hashes. After the deadline, redemption re-executes
+fresh, reports `pinned: false`, and reports if the hash matched. A matching
+hash proves identical bytes and nothing more. No reference carries an object
+key, a tenant name, or a credential.
+
+### D6. Budgets
+
+The effective budget is the minimum of the server ceiling, the enforced
+tenant ceiling, and the caller value. A caller can lower `deadline`,
+`max_rows`, `max_bytes_scanned`, `max_store_requests`, and
+`max_response_bytes`. A caller cannot raise a ceiling.
+`ravel_explain_query` returns the estimate beside the effective budget. When
+the estimate exceeds the budget, the tool returns
+`budget_estimate_exceeds_ceiling` and the factor to narrow by. An `unknown`
+estimate component is not zero and does not pass. Retries and snapshot
+re-resolution run inside the same deadline and their cost is added.
+Enforcement is process-local. The fleet concurrency ceiling is the only
+cross-replica control, and the envelope says so. Usage is reported as
+requests and bytes by kind: wire, cache-served, decompressed. Usage is never
+reported as money.
+
+Defaults: `max_rows` 200 with a ceiling of 5,000, `max_response_bytes`
+256 KiB, 100 metric families per describe page, and 2,000 segments for label
+resolution. The evaluation can change these values.
+
+An investigation-wide budget across calls is Phase 2. A caller-supplied
+bundle id is not trustworthy.
+
+### D7. Security
+
+- The `TenantResolver` chain of the deployment authenticates every MCP
+  request on the headers of that request. No session, cursor, or reference
+  replaces this step. No tool argument names a tenant.
+- Authorization is at the tenant level, because that is what exists. The
+  default profile has read tools only. The fold route, ingest, erasure,
+  legal holds, retention, alert rules, and maintenance are not reachable
+  through MCP. An operator profile needs a principal model and its own ADR.
+- Transport: `POST /mcp` only. The server validates `MCP-Protocol-Version`,
+  `Mcp-Method`, and `Mcp-Name`. It validates `Origin` against
+  `--mcp-allowed-origins` and answers 403 on a mismatch. The body cap is
+  1 MiB. Each tool call takes one admission permit. The deadline is clamped.
+  Legacy clients use the in-memory session manager of `rmcp`, and each
+  request re-authenticates. An `initialize` without a credential is refused.
+- Phase 1 uses the bearer chain. Phase 2 serves the RFC 9728 document when
+  an OIDC resolver is configured, after a check that `OidcResolver` validates
+  the audience claim.
+- SQL text passes through `validate.rs` unchanged. The MCP layer adds no
+  second gate. A test tries each escape route through the tool.
+- Telemetry text is returned inside typed fields only. The server never puts
+  it into a tool description, a prompt, or `next_steps`. The documentation
+  says that no server-side sanitization makes a model immune to injection.
+- No tool fetches a URL, runs a shell, reads a file, or connects to a
+  caller-supplied address.
+- The only writes are audit records and cost metrics. With
+  `audit_mode=required`, a failed audit write fails the call.
+- The adapter must not `tokio::spawn` between the transport and the engine.
+  A dropped tool future is the cancellation. `CostGuard` records the spend
+  of a cancelled call. Progress notifications go out at phase boundaries
+  when the client supplied a `progressToken`.
+
+### D8. Validation
+
+Protocol tests use an `rmcp` client against the real router for both
+revisions. Every output schema validates every fixture result. A build
+without the `mcp` feature serves no `/mcp`. Before the epic closes, the MCP
+Inspector and one production client are run by hand, and the versions go
+into the ledger.
+
+Adversarial tests cover these cases:
+
+- parity with `/api/v1/sql`, the row window, and schema drift between two
+  pages
+- tenant isolation with two hashes on every path, and cursor replay across
+  tenants
+- expired and revoked credentials during pagination, and malformed arguments
+- budget enforcement, where `unknown` is not equal to zero
+- cancellation, and audit write faults with the `FaultStore` counter asserted
+- redaction, and precision at 2^53, `-0.0`, and NaN payloads
+- pagination under fold and compaction, late data, missing spans, and partial
+  federation
+- hostile telemetry content
+
+Each regression test is shown to fail first. The executor report names the
+flipped line.
+
+The agent evaluation is a set of hypotheses, not results. A corpus of at
+least 24 investigations over a known fixture includes cases whose correct
+answer is "no data in scope" and "not visible yet". Two profiles run on the
+same engine, budgets, model, and tasks: a baseline with the two raw query
+tools and `ravel_capabilities`, and the full profile. The runner records
+correctness, evidence completeness, completion, tool calls, and invalid
+queries. It also records wall time, store requests and bytes, and response
+bytes. Each record names the model and version, 5 runs, and cold and warm
+conditions. Targets: half the invalid
+queries and one third fewer store requests per completed task, with equal or
+better correctness. No result goes into this ADR before it is measured.
+
+No new TLA+ model. Cursors and evidence references are process-local tokens
+with no durable state and no cross-process protocol. The suite models
+durable protocols. A pinned snapshot can outlive its deadline while GC
+advances. That case is the in-flight reader case that `LifecycleGC` already
+covers. The cursor deadline uses the same protection-horizon rule as Flight
+tickets.
+A `ravel-sim` scenario paginates through fold, compaction, and sweep and
+asserts snapshot identity per page.
+
+### D9. Packaging and rollout
+
+The cargo feature `mcp` implies `sql`. The published image builds
+`sql,flight-sql,otap,mcp`. The operator needs no new Service port. The flag
+`--mcp` is off by default. `--mcp-allowed-origins` is required when `--mcp`
+is set on a non-loopback listener, or startup fails. The server serves
+protocol revisions `2026-07-28` and `2025-11-25`. The new external
+dependency is `rmcp` 3.2 with `rmcp-macros`. No persistent format changes.
+The HTTP `/api/v1/sql` behavior is unchanged unless a client sends the new
+optional body fields.
+
+Documentation: `docs/guides/agents.md`, `docs/reference/mcp.md` rendered from
+the catalog by a drift test, a README section, the `/mcp` row in
+`docs/reference/http-api.md`, and one transport line in
+`docs/architecture.md`.
+
+## Rejected alternatives
+
+| Alternative | Reason it lost |
+|---|---|
+| Native MCP without a service layer | The handlers already differ on admission, audit, and cost recording. A third copy of the policy repeats the defect that the inventory found. |
+| A standalone Rust MCP server over `/api/v1/*` | It needs every engine and server prerequisite of D3. It adds a credential hop that the MCP authorization rules treat as token passthrough, unless the server keeps its own user-to-tenant map, which is new durable state. It stays a Phase 2 option for a Ravel that cannot be rebuilt. |
+| Flight SQL as the execution path | Flight is gRPC only. The operator's query Service exposes HTTP only. Issue #1293 leaves its resolver chain without the loopback guard. Flight stays the source of the pin codec. |
+| One `ravel_query` tool with a `language` field | Reference servers that merged query languages report worse tool selection. SQL and PromQL have different time contracts. |
+| One tool per endpoint | The Grafana server tracks 110 tools at about 44,000 tokens as a defect. |
+| The MCP Tasks extension | Every Phase 1 call ends inside the query deadline or fails typed. The extension is optional and most clients do not support it. |
+| Durable result handles in the bucket | A new object family, a sweeper, an erasure inventory entry, and a GC interaction for every call. Inline results and MAC'd re-execution cursors cover Phase 1. |
+| A text-level SQL allowlist in the MCP layer | `validate.rs` is a structural gate. A second regex gate is the advisory check that ClickHouse marks as "not a security boundary". |
+| stdio as a Phase 1 transport | An in-process stdio server runs with object-store credentials, which is the cross-tenant trust model of the CLI. A stdio bridge to the HTTP endpoint is a client and is Phase 2. |
+| A separate listener for MCP | A listener is a trust boundary only when it terminates TLS. The mTLS listener does not. A listener becomes useful with a separate credential class. |
+
+## Consequences
+
+- HTTP callers get the row-window fix, the explain path, lowerable budgets,
+  and audit records, because the service layer serves both transports.
+- `ravel-server` gains one crate dependency (`rmcp`) behind a feature, and
+  one new workspace crate (`ravel-mcp`).
+- Analytics, exemplars, and the two label routes change behavior: they take
+  an admission permit and submit an audit event. This is a fix of a gap, not
+  a regression, and the ADR names it here.
+- The decomposition has nine waves. High-risk tasks (T1, T2a, T4) ride
+  alone. The task table and the wave plan are in the epic issue.
+- Open decisions, each with a default:
+  - the endpoint is on the public listener
+  - Phase 1 uses bearer credentials only
+  - legacy session mode is on by default
+  - the numeric defaults of D6 apply
+  - `time_range` is required and has no default
+  - resources and prompts stay minimal
+  - audit records carry `query.language = mcp:<tool>`
+- Recorded uncertainties:
+  - if `flight_ticket.rs` compiles without the `flight-sql` feature
+  - if `OidcResolver` checks the `aud` claim
+  - the `rmcp` attribute syntax for output schemas
+  - the exact `tools/list` byte figure. The first serialization sets it and
+    a test then pins it
+- Pre-existing defects to work around: #1293, #1296, #362, #1187, #1306,
+  #1304.
+- Documentation drift found during the review is reported in the epic
+  issue and is not fixed here. The three items that mislead an agent are:
+  - the SQL `start`/`end` marked required in `docs/reference/http-api.md`
+  - the `audit` table described as "including the query-audit trail"
+  - the global "one snapshot per query" statement in
+    `docs/consistency-model.md`

--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -203,12 +203,15 @@ The `tools/list` result for the nine tools must serialize in less than
 5. A query service layer in `services/ravel-server/src/service/`. Analytics
    and exemplars gain an admission permit. PromQL gains cost on cancel.
    `labels` and `label_values` gain the audit seam. The service layer
-   finalizes usage before it maps any outcome to an error. The outcomes are
-   an audit failure, a partial-result refusal, an evaluation failure, a
-   deadline, and a cancellation. A drop guard in the pattern of
-   `sql.rs::CostGuard` records the spend on every path. As a result, the
-   D6 usage figures and the D7 cancelled-spend figure are never omitted.
-   One test per path asserts the recorded figures.
+   finalizes usage before it maps an outcome to an error. The outcomes that
+   map to an error are an audit failure, a partial-result refusal, an
+   evaluation failure, and a deadline. A cancellation is transport-level:
+   the tool future is dropped, no envelope is produced, and the usage
+   record is its only result. A drop guard in the pattern of
+   `sql.rs::CostGuard` records the spend on every path, including the
+   dropped one. As a result, the D6 usage figures and the D7
+   cancelled-spend figure are never omitted. One test per path asserts the
+   recorded figures.
 6. `AuditPipeline::spawn` in `lib.rs::start` for query modes. Flags
    `--audit-mode required|best-effort` (default `required`) and
    `--audit-text`. This closes #1187. MCP tool calls submit
@@ -228,7 +231,7 @@ Every tool returns one envelope:
   "visibility": {"snapshot_id": "", "watermark_hour": "", "pinned": false, "min_commit_tokens_applied": []},
   "coverage": {"complete": true, "partial": false, "fragments": [], "unindexed_predicates": []},
   "accuracy": {"exact": true, "approximation": null, "lower_bound_count": false},
-  "presentation": {"max_rows": 200, "row_cap_hit": false, "bytes_cap_hit": false, "cursor": null},
+  "presentation": {"max_rows": 200, "row_cap_hit": false, "bytes_cap_hit": false, "rows_omitted": 0, "cursor": null},
   "budget": {"effective": {}, "actual": {}, "estimate": {}, "estimate_is_upper_envelope": true},
   "evidence": [{"ref": "", "covers": "data.rows", "sha256": ""}],
   "warnings": [],
@@ -240,7 +243,8 @@ The four status values are different facts. `ok` is a complete query. A
 query with zero matches is `ok`. A query whose `LIMIT` the data did not fill
 is `ok`. `ok_bounded` means that the row cap stopped the result, more rows
 exist, and no cursor exists because the statement has no total order.
-`ok_page` means that the row cap stopped the result and a cursor exists.
+`ok_page` means that a cap stopped the result and a cursor exists. The cap
+is the row cap, the byte cap, or both, and `presentation` says which.
 
 `max_response_bytes` bounds the serialized `structuredContent`, that is, the
 whole envelope as JSON. When the envelope exceeds the cap, the server drops
@@ -249,10 +253,22 @@ keeps the count of rows that the query produced. `presentation.bytes_cap_hit`
 becomes `true` and `presentation.rows_omitted` carries the number of dropped
 rows. The text block is rendered from the truncated `data`, so the two
 representations never differ. When the statement has a total order, the
-cursor points at the last kept row, so the omitted rows are reachable on the
-next page. When it has no total order, the status is `ok_bounded`. The byte
-cap, the row cap, and analytic downsampling are three separate facts in the
-envelope. A downsampled analytic sets `exact: false` and names the method.
+cursor points at the last kept row and the status is `ok_page`. The omitted
+rows are then reachable on the next page. When it has no total order, the
+status is `ok_bounded`.
+
+The fixed part of the envelope is bounded so that it always fits. The server
+floors `max_response_bytes` at 16 KiB: a caller value below the floor is
+raised to the floor, and the envelope says so. This floor is a minimum on
+the presentation cap and is not a raise of any query budget. The metadata
+lists are bounded by count: at most 16 `warnings`, 8 `next_steps`, and 16
+`evidence` entries, each with a bounded string length. A test serializes an
+envelope with zero rows and every metadata list at its maximum and asserts
+that it fits under 16 KiB. When the rendering still cannot fit, which the
+test makes impossible, the result is an `error` with class `internal`. The
+byte cap, the row cap, and analytic downsampling are three separate facts in
+the envelope. A downsampled analytic sets `exact: false` and names the
+method.
 Missing coverage sets `complete: false` and names the reason. A budget
 failure or a deadline is an `error`. The server never returns a partial exact
 aggregate as `ok`. A `COUNT` over `logs` or `spans` sets

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -147,3 +147,4 @@ the reservation commit that used to work around it.
 | [1195](1195-unbundle-fetch-concurrency.md) | Unbundle `--fetch-concurrency`, and make GET concurrency a process-wide limit | Proposed |
 | [1196](1196-fetch-objective-cost-first-default-latency-first-policy.md) | Keep the cost-first fetch default, add a latency-first policy | Proposed |
 | [1199](1199-bounded-query-io-and-tail-checkpoints.md) | Bounded query I/O accounting, and a pre-registered measured gate deciding whether an L0.5 tail checkpoint gets built at all | Proposed |
+| [1374](1374-agent-mcp-server.md) | A first-party MCP server behind a shared query service layer, with a bounded, evidence-bearing agent result contract | Proposed |


### PR DESCRIPTION
Adds ADR-1374, the design record for epic #1374: a first-party MCP server behind a shared query service layer, with a bounded, evidence-bearing agent result contract. Docs-only change; the ADR index gains one row.

Refs: #1374
