### PR TITLE
fix(config): refuse dev tenant header off-loopback on all listeners

### DIFF
--- a/docs/adrs/0009-tenant-isolation.md
+++ b/docs/adrs/0009-tenant-isolation.md
@@ -31,3 +31,39 @@ from request bodies.
   keyed tenant hash (ADR-0010 §13).
 - Static token maps are a stopgap; OIDC support follows when the gateway
   hardens.
+
+## Amendment (2026-09-07): the loopback refusal covers every listener the shared resolver backs
+
+The Decision above promised that `--dev-insecure-tenant-header` "refuses to
+enable outside loopback binds". As shipped, `Cli::validate` tested only
+`--listen-http`. But the dev-header resolver joins one shared resolver chain
+(`services/ravel-server/src/tenant.rs`), and that single chain backs every
+public listener: HTTP, remote-write, OTLP gRPC, and Flight SQL (through the
+Flight auth path). So the flag was reachable, unguarded, on a non-loopback
+`--listen-grpc`, letting an unauthenticated `x-ravel-tenant` header forge
+tenant identity on the public gRPC and Flight SQL surfaces (issue #1293).
+
+This is the class of defect the resolver-chain doc comment already names: a
+resolver that trusts an unauthenticated header has no business backing a
+public listener. The ADR's promise is refusal on a reachable port, not
+narrowing.
+
+The guard now refuses the flag unless both `--listen-http` and `--listen-grpc`
+bind loopback addresses. Both defaults are loopback and no shipped manifest
+sets the flag, so the tightened guard breaks nothing that ships.
+
+The clean fix is by construction: exclude the dev-header resolver (and any
+resolver trusting an unauthenticated header) from the gRPC and Flight
+resolver chains entirely, rather than gating a config flag. That was not done
+here because `config.tenant_resolver` is a single `Arc` consumed by five call
+sites and re-wrapped by `DurableBearerResolver` in `lib.rs`; splitting it
+means threading two resolvers through `start()`, `gateway_state`, the Flight
+service, and `FragmentService::new`, which collides with other in-flight
+changes to `lib.rs`. That resolver split is the stated follow-up.
+
+The ingest-router sibling (`services/ravel-ingest-router`) carried the same
+unguarded flag with no loopback check at all. There the resolved tenant is a
+routing key and the proxy forwards the original headers so the upstream
+re-authenticates, so this is forged routing affinity rather than forged
+identity, a lower guard than the gateway's. It now carries the same loopback
+requirement on its bound listeners.

--- a/services/ravel-ingest-router/src/config.rs
+++ b/services/ravel-ingest-router/src/config.rs
@@ -326,6 +326,32 @@ impl Cli {
             KeyConfig::Header(self.header_key_name()?)
         };
 
+        // #1293 sibling: the dev header resolves an `x-ravel-tenant` routing key
+        // from an unauthenticated header. Because the proxy forwards the original
+        // request headers and the upstream gateway re-authenticates, this forges
+        // routing affinity rather than tenant identity, which is why it is a
+        // lower guard than the gateway's. It must still never be reachable off
+        // loopback: require every bound listener to be loopback when the flag is
+        // set. Reaching here with the flag set means the key source is
+        // canonical-tenant; a non-canonical source already failed in
+        // `reject_canonical_only_flags` above.
+        if self.dev_insecure_tenant_header {
+            if !self.listen_http.ip().is_loopback() {
+                anyhow::bail!(
+                    "--dev-insecure-tenant-header refuses to enable unless --listen-http binds a \
+                     loopback address"
+                );
+            }
+            if let Some(grpc) = self.listen_grpc
+                && !grpc.ip().is_loopback()
+            {
+                anyhow::bail!(
+                    "--dev-insecure-tenant-header refuses to enable unless --listen-grpc binds a \
+                     loopback address"
+                );
+            }
+        }
+
         Ok(RouterConfig {
             gateway_service_name: self.gateway_service_name,
             gateway_service_namespace: self.gateway_service_namespace,
@@ -609,6 +635,66 @@ mod tests {
             }
             other => panic!("expected canonical key config, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn dev_insecure_tenant_header_on_non_loopback_listen_fails_validate() {
+        // Default --listen-http is 0.0.0.0:8080, a non-loopback bind. The dev
+        // header resolves an x-ravel-tenant routing key from an unauthenticated
+        // header, so it must refuse to enable off loopback (#1293 sibling).
+        let err = cli(&[
+            "--key-source",
+            "canonical-tenant",
+            "--dev-insecure-tenant-header",
+        ])
+        .into_config()
+        .expect_err("non-loopback --listen-http with the dev header must refuse startup");
+        assert!(
+            err.to_string().contains("--dev-insecure-tenant-header"),
+            "error names the flag: {err}"
+        );
+        assert!(
+            err.to_string().contains("--listen-http"),
+            "error names the listener: {err}"
+        );
+    }
+
+    #[test]
+    fn dev_insecure_tenant_header_on_loopback_listen_validates() {
+        // Positive control so the guard is not vacuous: both bound listeners
+        // loopback validates.
+        cli(&[
+            "--key-source",
+            "canonical-tenant",
+            "--dev-insecure-tenant-header",
+            "--listen-http",
+            "127.0.0.1:8080",
+            "--listen-grpc",
+            "127.0.0.1:8081",
+        ])
+        .into_config()
+        .expect("both listeners loopback with the dev header is fine");
+    }
+
+    #[test]
+    fn dev_insecure_tenant_header_on_non_loopback_grpc_fails_validate() {
+        // --listen-http loopback but --listen-grpc public: the gRPC proxy
+        // listener carries the forged affinity too, so refuse.
+        let err = cli(&[
+            "--key-source",
+            "canonical-tenant",
+            "--dev-insecure-tenant-header",
+            "--listen-http",
+            "127.0.0.1:8080",
+            "--listen-grpc",
+            "0.0.0.0:8081",
+        ])
+        .into_config()
+        .expect_err("non-loopback --listen-grpc with the dev header must refuse startup");
+        assert!(
+            err.to_string().contains("--listen-grpc"),
+            "error names the gRPC listener: {err}"
+        );
     }
 
     #[test]

--- a/services/ravel-ingest-router/src/config.rs
+++ b/services/ravel-ingest-router/src/config.rs
@@ -111,7 +111,10 @@ pub struct Cli {
     #[arg(long = "tenant-token", value_name = "TOKEN=TENANT")]
     pub tenant_tokens: Vec<String>,
 
-    /// Dev-only tenant resolution via the `x-ravel-tenant` header.
+    /// Dev-only tenant resolution via the `x-ravel-tenant` header. Refuses to
+    /// enable unless every bound listener (`--listen-http` and, when set,
+    /// `--listen-grpc`) is loopback: the dev header resolves an unauthenticated
+    /// routing key on every bound listener, not just HTTP.
     #[arg(long)]
     pub dev_insecure_tenant_header: bool,
 

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -3351,10 +3351,21 @@ impl Cli {
             );
         }
 
-        if self.dev_insecure_tenant_header && !self.listen_http.ip().is_loopback() {
+        // The dev header resolver trusts an unauthenticated `x-ravel-tenant`
+        // header, and the single resolver chain it joins backs every public
+        // listener: HTTP, remote-write, OTLP gRPC, and Flight SQL (via the
+        // flight auth path). Guarding `--listen-http` alone left the flag
+        // reachable on a non-loopback `--listen-grpc`, forging tenant identity
+        // on the public gRPC/Flight surfaces (issue #1293). ADR-0009 promises
+        // refusal on any reachable port, so require both listeners loopback.
+        if self.dev_insecure_tenant_header
+            && (!self.listen_http.ip().is_loopback() || !self.listen_grpc.ip().is_loopback())
+        {
             anyhow::bail!(
-                "--dev-insecure-tenant-header refuses to enable unless --listen-http binds a \
-                 loopback address"
+                "--dev-insecure-tenant-header refuses to enable unless both --listen-http and \
+                 --listen-grpc bind loopback addresses: the dev header resolver trusts an \
+                 unauthenticated x-ravel-tenant header and backs every public listener (HTTP, \
+                 OTLP gRPC, and Flight SQL), not just HTTP"
             );
         }
 
@@ -3376,6 +3387,28 @@ impl Cli {
                 "--mtls-enabled requires --mtls-listener: the mTLS resolver is only installed on \
                  its own dedicated listener (ADR-0050 section 1), never on the public HTTP or \
                  gRPC/Flight listeners."
+            );
+        }
+
+        // Issue #94: the ADR-0071 fragment surface (the `SeriesFetch` service,
+        // its listener, and the coordinator fan-out) is constructed only by a
+        // query-serving process. `fragment_service` in lib.rs is gated on
+        // `matches!(config.mode, Mode::All | Mode::Query)`, so under gateway-only
+        // or maintain mode no fragment surface is ever built and no listener
+        // binds. Both `--distributed-query` and `--fragment-listener` are then
+        // silently inert. This is a diagnostic, not a security fix: refuse them
+        // so an operator cannot believe distribution is on when nothing serves
+        // it. The supported set is derived from that `Mode::All | Mode::Query`
+        // guard, not guessed.
+        if !matches!(self.mode, Mode::All | Mode::Query)
+            && (self.distributed_query || self.fragment_listener.is_some())
+        {
+            anyhow::bail!(
+                "--distributed-query and --fragment-listener are only supported under \
+                 --mode all or --mode query: the ADR-0071 fragment SeriesFetch surface is \
+                 constructed only by a query-serving process, so under --mode {:?} these flags \
+                 would be silently inert. Drop them, or run --mode all or --mode query.",
+                self.mode
             );
         }
 
@@ -7448,6 +7481,103 @@ mod tests {
         ])
         .validate()
         .expect("loopback --listen-http with the dev header is fine");
+    }
+
+    #[test]
+    fn dev_insecure_tenant_header_on_non_loopback_grpc_fails_validate() {
+        // --listen-http stays loopback; only --listen-grpc is public. The dev
+        // header resolver backs the gRPC/Flight listener too, so this must
+        // refuse startup even though HTTP alone was fine (issue #1293).
+        let err = cli(&[
+            "--dev-insecure-tenant-header",
+            "--listen-http",
+            "127.0.0.1:4318",
+            "--listen-grpc",
+            "0.0.0.0:4317",
+        ])
+        .validate()
+        .expect_err("non-loopback --listen-grpc with the dev header must refuse startup");
+        assert!(
+            err.to_string().contains("--dev-insecure-tenant-header"),
+            "error names the flag: {err}"
+        );
+        assert!(
+            err.to_string().contains("--listen-grpc"),
+            "error names the gRPC listener: {err}"
+        );
+    }
+
+    #[test]
+    fn dev_insecure_tenant_header_on_loopback_grpc_validates() {
+        // Positive control so the grpc half of the guard cannot be vacuous:
+        // both listeners loopback validates.
+        cli(&[
+            "--dev-insecure-tenant-header",
+            "--listen-http",
+            "127.0.0.1:4318",
+            "--listen-grpc",
+            "127.0.0.1:4317",
+        ])
+        .validate()
+        .expect("both listeners loopback with the dev header is fine");
+    }
+
+    #[test]
+    fn fragment_flags_under_gateway_mode_fail_validate() {
+        // Issue #94: fragment_service is built only under Mode::All | Mode::Query
+        // (lib.rs), so --distributed-query under gateway mode is silently inert.
+        // Refuse it, naming the supported modes.
+        let key = tempfile::NamedTempFile::new().expect("temp key file");
+        std::fs::write(key.path(), format!("{}\n", "ab".repeat(32))).expect("write key");
+        let err = cli(&[
+            "--mode",
+            "gateway",
+            "--distributed-query",
+            "--fragment-key-file",
+            key.path().to_str().expect("utf8 path"),
+        ])
+        .validate()
+        .expect_err("--distributed-query under gateway mode must refuse startup");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--mode all") && msg.contains("--mode query"),
+            "error names the supported modes: {err}"
+        );
+    }
+
+    #[test]
+    fn fragment_listener_under_maintain_mode_fails_validate() {
+        // Same rule for --fragment-listener under a non-query-serving mode.
+        let err = cli(&[
+            "--mode",
+            "maintain",
+            "--fragment-listener",
+            "127.0.0.1:4319",
+        ])
+        .validate()
+        .expect_err("--fragment-listener under maintain mode must refuse startup");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--mode all") && msg.contains("--mode query"),
+            "error names the supported modes: {err}"
+        );
+    }
+
+    #[test]
+    fn distributed_query_under_query_mode_validates() {
+        // Positive control: under a fragment-serving mode the flag validates,
+        // so the #94 guard is not vacuously rejecting the flag everywhere.
+        let key = tempfile::NamedTempFile::new().expect("temp key file");
+        std::fs::write(key.path(), format!("{}\n", "ab".repeat(32))).expect("write key");
+        cli(&[
+            "--mode",
+            "query",
+            "--distributed-query",
+            "--fragment-key-file",
+            key.path().to_str().expect("utf8 path"),
+        ])
+        .validate()
+        .expect("--distributed-query under query mode is fine");
     }
 
     #[test]

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -137,7 +137,9 @@ pub struct Cli {
     pub maintain_tenants: Vec<String>,
 
     /// Dev-only tenant resolution via the `x-ravel-tenant` header. Refuses to
-    /// enable unless `--listen-http` binds a loopback address.
+    /// enable unless both `--listen-http` and `--listen-grpc` bind loopback
+    /// addresses: the dev header resolver backs every public listener (HTTP,
+    /// OTLP gRPC, and Flight SQL), not just HTTP.
     #[arg(long)]
     pub dev_insecure_tenant_header: bool,
 

--- a/services/ravel-server/tests/real_authn_e2e.rs
+++ b/services/ravel-server/tests/real_authn_e2e.rs
@@ -29,6 +29,9 @@ use ravel_query::http::{OidcJwksCache, OidcResolver, TenantResolver};
 use ravel_server::config::AuthResolverSettings;
 use ravel_server::tenant::FallbackResolver;
 use ravel_server::{FoldTaskConfig, Mode, MtlsListenerConfig, ServerConfig};
+use ravel_types::TenantId;
+
+const DEV_TENANT_HEADER: &str = "x-ravel-tenant";
 
 const ISSUER: &str = "https://issuer.example.com";
 const KID: &str = "itest-key";
@@ -54,6 +57,17 @@ async fn start_with_mtls(
     resolver: Arc<dyn TenantResolver>,
     mtls_resolver: Option<Arc<dyn TenantResolver>>,
 ) -> ravel_server::Running {
+    let (running, _store) = start_returning_store(resolver, mtls_resolver).await;
+    running
+}
+
+/// Same as [`start_with_mtls`] but also hands back the backing `MemoryStore`,
+/// so a test can count objects before and after a request to prove a rejected
+/// request wrote nothing durable.
+async fn start_returning_store(
+    resolver: Arc<dyn TenantResolver>,
+    mtls_resolver: Option<Arc<dyn TenantResolver>>,
+) -> (ravel_server::Running, Arc<MemoryStore>) {
     let store = Arc::new(MemoryStore::new());
     let config = ServerConfig {
         query_budgets: Default::default(),
@@ -105,7 +119,7 @@ async fn start_with_mtls(
             1024,
         ),
     };
-    ravel_server::start(
+    let running = ravel_server::start(
         config,
         store.clone(),
         store.clone(),
@@ -113,7 +127,8 @@ async fn start_with_mtls(
         None,
     )
     .await
-    .expect("server starts")
+    .expect("server starts");
+    (running, store)
 }
 
 async fn start_with_resolver(resolver: Arc<dyn TenantResolver>) -> ravel_server::Running {
@@ -177,6 +192,121 @@ fn mtls_bundle() -> (Arc<dyn TenantResolver>, Arc<dyn TenantResolver>) {
         .mtls_resolver
         .expect("mtls_header was set above, so build_auth_resolver returns Some");
     (bundle.resolver, mtls_resolver)
+}
+
+/// The production resolver chain with the dev header flag OFF: the static
+/// bearer map only, exactly what `build_auth_resolver(tokens, false, ..)`
+/// produces when `--dev-insecure-tenant-header` is not passed. Two genuinely
+/// distinct tenants, each with its own bearer credential, so a forged
+/// `x-ravel-tenant` naming one of them carries no legitimate token.
+fn bearer_only_resolver() -> Arc<dyn TenantResolver> {
+    let mut tokens = HashMap::new();
+    tokens.insert("victim-token".to_string(), TenantId::new("victim-tenant"));
+    tokens.insert(
+        "attacker-token".to_string(),
+        TenantId::new("attacker-tenant"),
+    );
+    ravel_server::tenant::build_auth_resolver(
+        tokens,
+        false,
+        AuthResolverSettings {
+            oidc: None,
+            mtls_header: None,
+        },
+    )
+    .expect("resolver builds")
+    .resolver
+}
+
+async fn store_key_count(store: &MemoryStore) -> usize {
+    ravel_object_store::list_all(store, "")
+        .await
+        .expect("list store")
+        .len()
+}
+
+/// With `--dev-insecure-tenant-header` OFF, an OTLP gRPC export carrying only
+/// the `x-ravel-tenant` header for a victim tenant (no bearer credential) is
+/// Unauthenticated on the public gRPC listener, and writes nothing durable.
+/// This exercises the running listener through `start()`, not the config-level
+/// `validate()` predicate: `main.rs` is the only caller of `Cli::validate` and
+/// `start()` never re-validates, so a config guard alone proves nothing about
+/// the listener (issue #1293).
+#[tokio::test]
+async fn forged_tenant_header_rejected_on_public_grpc_and_writes_nothing() {
+    use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+    use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_client::MetricsServiceClient;
+
+    let (running, store) = start_returning_store(bearer_only_resolver(), None).await;
+    let before = store_key_count(&store).await;
+
+    let grpc_addr = running.grpc_addr.expect("gRPC listener binds in All mode");
+    let mut client = MetricsServiceClient::connect(format!("http://{grpc_addr}"))
+        .await
+        .expect("gRPC client connects");
+    let mut request = tonic::Request::new(ExportMetricsServiceRequest {
+        resource_metrics: Vec::new(),
+    });
+    request.metadata_mut().insert(
+        DEV_TENANT_HEADER,
+        "victim-tenant".parse().expect("ascii metadata"),
+    );
+    let status = client
+        .export(request)
+        .await
+        .expect_err("x-ravel-tenant must not authenticate on the public gRPC listener");
+    assert_eq!(status.code(), tonic::Code::Unauthenticated);
+
+    let after = store_key_count(&store).await;
+    assert_eq!(
+        after, before,
+        "a rejected export must write no object: store held {before} keys before and \
+         {after} after"
+    );
+
+    running.shutdown().await.expect("clean shutdown");
+}
+
+/// The Flight SQL sibling of the above: a `get_flight_info` carrying only the
+/// `x-ravel-tenant` metadata, with the dev header flag OFF, is Unauthenticated
+/// on the public Flight listener. `get_flight_info` is the authenticated Flight
+/// entry point (it resolves the tenant before planning); the Flight `Handshake`
+/// RPC has no default implementation in arrow-flight and never reaches the
+/// resolver, so it cannot demonstrate the auth boundary.
+#[cfg(feature = "flight-sql")]
+#[tokio::test]
+async fn forged_tenant_header_rejected_on_public_flight() {
+    use arrow_flight::FlightDescriptor;
+    use arrow_flight::flight_service_client::FlightServiceClient;
+    use arrow_flight::sql::{CommandStatementQuery, ProstMessageExt};
+    use prost::Message as _;
+
+    let (running, _store) = start_returning_store(bearer_only_resolver(), None).await;
+    let grpc_addr = running.grpc_addr.expect("gRPC listener binds in All mode");
+    let channel = tonic::transport::Channel::from_shared(format!("http://{grpc_addr}"))
+        .expect("valid endpoint uri")
+        .connect()
+        .await
+        .expect("Flight client connects");
+    let mut client = FlightServiceClient::new(channel);
+
+    let command = CommandStatementQuery {
+        query: "SELECT 1".to_string(),
+        transaction_id: None,
+    };
+    let descriptor = FlightDescriptor::new_cmd(command.as_any().encode_to_vec());
+    let mut request = tonic::Request::new(descriptor);
+    request.metadata_mut().insert(
+        DEV_TENANT_HEADER,
+        "victim-tenant".parse().expect("ascii metadata"),
+    );
+    let status = client
+        .get_flight_info(request)
+        .await
+        .expect_err("x-ravel-tenant must not authenticate on the public Flight listener");
+    assert_eq!(status.code(), tonic::Code::Unauthenticated);
+
+    running.shutdown().await.expect("clean shutdown");
 }
 
 #[tokio::test]

--- a/services/ravel-server/tests/real_authn_e2e.rs
+++ b/services/ravel-server/tests/real_authn_e2e.rs
@@ -225,16 +225,73 @@ async fn store_key_count(store: &MemoryStore) -> usize {
         .len()
 }
 
-/// With `--dev-insecure-tenant-header` OFF, an OTLP gRPC export carrying only
-/// the `x-ravel-tenant` header for a victim tenant (no bearer credential) is
-/// Unauthenticated on the public gRPC listener, and writes nothing durable.
-/// This exercises the running listener through `start()`, not the config-level
-/// `validate()` predicate: `main.rs` is the only caller of `Cli::validate` and
-/// `start()` never re-validates, so a config guard alone proves nothing about
-/// the listener (issue #1293).
-#[tokio::test]
-async fn forged_tenant_header_rejected_on_public_grpc_and_writes_nothing() {
+/// A minimal but non-empty OTLP metrics export: one resource, one gauge point
+/// under one series for `victim-tenant`. Sent with a real bearer this produces
+/// durable objects (the positive control below proves it); the negative test
+/// sends the exact same payload with only a forged `x-ravel-tenant` header, so
+/// its unchanged-key-count assertion measures a request the server would have
+/// written had it accepted it. An empty `resource_metrics` would make that
+/// assertion vacuous: an accepted-but-empty export writes nothing either, so
+/// before == after could not tell rejection from a no-op.
+fn victim_metrics_export_request()
+-> opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest {
     use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+    use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValueVariant;
+    use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
+    use opentelemetry_proto::tonic::metrics::v1::metric::Data as MetricData;
+    use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+    use opentelemetry_proto::tonic::metrics::v1::{
+        Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics,
+    };
+    use opentelemetry_proto::tonic::resource::v1::Resource;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let ts_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_nanos() as u64;
+    ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(AnyValue {
+                        value: Some(AnyValueVariant::StringValue("authn-e2e".to_string())),
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            scope_metrics: vec![ScopeMetrics {
+                metrics: vec![Metric {
+                    name: "authn_e2e_gauge".to_string(),
+                    data: Some(MetricData::Gauge(Gauge {
+                        data_points: vec![NumberDataPoint {
+                            time_unix_nano: ts_ns,
+                            value: Some(NumberValue::AsDouble(1.0)),
+                            ..Default::default()
+                        }],
+                    })),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    }
+}
+
+/// Positive control for
+/// [`forged_tenant_header_rejected_on_public_grpc_and_writes_nothing`]: the
+/// same non-empty payload, exported with the victim tenant's real bearer
+/// token, must be accepted and write durable objects. Strict ingest (the
+/// default, no `x-ravel-ingest-mode` header) blocks the export until the
+/// flush's commit ack, so a completed `export` already guarantees the objects
+/// are on the store. Without this control the negative test's before/after
+/// assertion proves nothing: it could pass because the payload never writes
+/// anything, credential or not.
+#[tokio::test]
+async fn valid_bearer_metric_export_writes_durable_objects() {
     use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_client::MetricsServiceClient;
 
     let (running, store) = start_returning_store(bearer_only_resolver(), None).await;
@@ -244,9 +301,67 @@ async fn forged_tenant_header_rejected_on_public_grpc_and_writes_nothing() {
     let mut client = MetricsServiceClient::connect(format!("http://{grpc_addr}"))
         .await
         .expect("gRPC client connects");
-    let mut request = tonic::Request::new(ExportMetricsServiceRequest {
-        resource_metrics: Vec::new(),
-    });
+    let mut request = tonic::Request::new(victim_metrics_export_request());
+    request.metadata_mut().insert(
+        "authorization",
+        "Bearer victim-token".parse().expect("ascii metadata"),
+    );
+    client
+        .export(request)
+        .await
+        .expect("a valid bearer must authenticate and the export must be accepted");
+
+    let after = store_key_count(&store).await;
+    assert_eq!(
+        after - before,
+        DURABLE_OBJECTS_PER_METRIC_EXPORT,
+        "a valid non-empty metric export must write exactly \
+         {DURABLE_OBJECTS_PER_METRIC_EXPORT} durable object(s): store held {before} keys before \
+         and {after} after"
+    );
+
+    let metric_prefix = format!("t/{}/m/l0/", TenantId::new("victim-tenant").hash().to_hex());
+    let metric_objects = ravel_object_store::list_all(store.as_ref(), &metric_prefix)
+        .await
+        .expect("list metric data objects")
+        .len();
+    assert_eq!(
+        metric_objects, 1,
+        "the accepted export must land exactly one metric data object under {metric_prefix}"
+    );
+
+    running.shutdown().await.expect("clean shutdown");
+}
+
+/// The exact number of durable objects a single non-empty metric export writes
+/// through one shard's one flush: one data object, one commit record, one
+/// catalog manifest. Pinned so the negative test's before == after assertion
+/// is read against a payload known to move this count when accepted.
+const DURABLE_OBJECTS_PER_METRIC_EXPORT: usize = 3;
+
+/// With `--dev-insecure-tenant-header` OFF, an OTLP gRPC export carrying only
+/// the `x-ravel-tenant` header for a victim tenant (no bearer credential) is
+/// Unauthenticated on the public gRPC listener, and writes nothing durable.
+/// This exercises the running listener through `start()`, not the config-level
+/// `validate()` predicate: `main.rs` is the only caller of `Cli::validate` and
+/// `start()` never re-validates, so a config guard alone proves nothing about
+/// the listener (issue #1293).
+#[tokio::test]
+async fn forged_tenant_header_rejected_on_public_grpc_and_writes_nothing() {
+    use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_client::MetricsServiceClient;
+
+    let (running, store) = start_returning_store(bearer_only_resolver(), None).await;
+    let before = store_key_count(&store).await;
+
+    let grpc_addr = running.grpc_addr.expect("gRPC listener binds in All mode");
+    let mut client = MetricsServiceClient::connect(format!("http://{grpc_addr}"))
+        .await
+        .expect("gRPC client connects");
+    // A non-empty payload, the same one the positive control proves DOES write
+    // durable objects with a real credential. With only the forged header the
+    // before == after assertion below now distinguishes rejection from an
+    // accepted no-op.
+    let mut request = tonic::Request::new(victim_metrics_export_request());
     request.metadata_mut().insert(
         DEV_TENANT_HEADER,
         "victim-tenant".parse().expect("ascii metadata"),


### PR DESCRIPTION
The dev tenant header resolver trusts an unauthenticated x-ravel-tenant header.
Its loopback guard tested only the HTTP listen address, while the single shared
resolver chain also backs remote-write, OTLP gRPC, Flight SQL and the fragment
service. A process bound to a public gRPC address with the dev flag set accepted
a forged tenant on every one of those surfaces. ADR-0009 promises refusal of an
untrusted resolver on a reachable port, not narrowing.

Cli::validate now refuses the flag unless both the HTTP and gRPC listen
addresses are loopback. Both defaults are loopback and no shipped manifest sets
the flag, so nothing that ships changes behaviour. The by-construction fix,
excluding the dev resolver from the gRPC and Flight chains, is deliberately not
taken: the resolver is one shared value consumed at five call sites and
re-wrapped by the durable bearer resolver, so splitting it threads two resolvers
through startup, the gateway state, the Flight service and the fragment service,
which collides with two other in-flight changes to the same file. The ADR
amendment records that split as the follow-up.

The ingest router had no loopback guard at all for its own copy of the flag.
Its resolved tenant is a routing key and the proxy forwards the original headers
so the upstream re-authenticates, which makes this forged affinity rather than
forged identity, and the same requirement now applies there.

Issue #94 lives in the same function and is folded in: --distributed-query and
--fragment-listener were accepted under modes that never construct the fragment
service, so the flags were silently inert. Validation now refuses them there and
names the supporting modes, derived from the code that builds the service rather
than guessed. That part is a diagnostic, not a security fix.

The decisive test runs through start rather than the config predicate, because
main is the only caller of validate and start does not re-validate: with the dev
flag off, a gRPC export carrying only the tenant header for a victim tenant is
Unauthenticated, and the store key count is exactly unchanged. The Flight test
uses the authenticated entry point rather than the handshake, because this
service version leaves the handshake unimplemented and it never reaches tenant
resolution. Every guard is demonstrated by removing it and recording the
observed failure, with a positive control beside each so the guard cannot be
vacuous.

Review caught the decisive test being vacuous as first written: the rejected
gRPC export carried no payload, so its exact-equality key count could not tell
rejection from an accepted empty request. It now sends a real metric export
that a positive control proves writes exactly three objects with a valid
credential, and with the dev resolver re-enabled the negative test fails on the
count, three objects written against zero expected, not on the status. A sweep
of every negative test in the two e2e files that claims nothing was written
found that one, and only that one, made the claim without a payload. The help
text for the flag in both binaries now states the loopback requirement covers
every bound listener.

Fixes: #1293
Fixes: #94
