### PR TITLE
feat(operator): harden rendered pods and narrow operator secret RBAC

### DIFF
--- a/deploy/k8s/operator/rbac.yaml
+++ b/deploy/k8s/operator/rbac.yaml
@@ -10,9 +10,16 @@
 #     the Gateway API exposure routes (ADR-0080 decision 2). Delete is what lets
 #     gateway.exposure be removed without leaving an orphan route attached to
 #     the Gateway.
+#   - PodDisruptionBudgets (policy): full lifecycle, for the per-tier PDBs the
+#     operator renders (issue #126, ADR-0034 hardening amendment). Delete is what
+#     converges maintain's PDB away when maintain.enabled goes back to false.
 #   - RavelCluster (and its status subresource): watch the spec, write status.
-#   - Secrets: get only. The operator reads the credentials and tenant-token
-#     Secrets to resolve tenant names; it never lists, writes, or watches them.
+#   - Secrets: get only, and granted by a NAMESPACED Role, not this ClusterRole
+#     (issue #126). The operator reads the credentials, tenant-token, and
+#     deployment-key Secrets to resolve tenant names; it never lists, writes, or
+#     watches them. The cluster-wide secrets rule is gone; the least-privilege
+#     Role/RoleBinding at the bottom of this file grants the read in ravel-system
+#     only. See that block for the per-namespace follow-up.
 #   - ServiceAccounts, Roles, and RoleBindings: the same lifecycle, for the
 #     ravel-native ingest router's own ServiceAccount and its namespaced,
 #     least-privilege Role/RoleBinding (ADR-0080 decision 3). The operator's own
@@ -72,9 +79,9 @@ rules:
   - apiGroups: ["ravel.nofire.ai"]
     resources: ["ravelclusters/status"]
     verbs: ["get", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -87,6 +94,51 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: ravel-operator
+subjects:
+  - kind: ServiceAccount
+    name: ravel-operator
+    namespace: ravel-system
+---
+# Secrets: get only, and namespaced rather than cluster-wide (issue #126). The
+# operator reads the credentials, tenant-token, and deployment-key Secrets a
+# RavelCluster references (crate::controller resolves them via
+# Api::<Secret>::namespaced on the RavelCluster's OWN namespace) to resolve
+# tenant names and stamp resource versions; it never lists, writes, or watches
+# them. The Secret names are user-chosen CRD fields
+# (credentialsSecretRef/tenantTokensSecretRef/deploymentKeySecretRef and the
+# per-tier credential overrides), not a fixed set, so resourceNames cannot
+# enumerate them; a namespaced Role is the tightest grant that still works.
+#
+# This Role+RoleBinding grants the read only in ravel-system. A RavelCluster in
+# another namespace needs one RoleBinding of this Role (or an equivalent Role)
+# in that namespace; running the operator cluster-wide over many namespaces is a
+# follow-up. Scoping the read to a Role here removes the operator's standing
+# ability to read every Secret in the cluster, which was the finding.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ravel-operator-secrets
+  namespace: ravel-system
+  labels:
+    app.kubernetes.io/name: ravel-operator
+    app.kubernetes.io/managed-by: ravel-operator
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ravel-operator-secrets
+  namespace: ravel-system
+  labels:
+    app.kubernetes.io/name: ravel-operator
+    app.kubernetes.io/managed-by: ravel-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ravel-operator-secrets
 subjects:
   - kind: ServiceAccount
     name: ravel-operator

--- a/deploy/k8s/operator/rbac.yaml
+++ b/deploy/k8s/operator/rbac.yaml
@@ -14,12 +14,18 @@
 #     operator renders (issue #126, ADR-0034 hardening amendment). Delete is what
 #     converges maintain's PDB away when maintain.enabled goes back to false.
 #   - RavelCluster (and its status subresource): watch the spec, write status.
-#   - Secrets: get only, and granted by a NAMESPACED Role, not this ClusterRole
+#   - Secrets: get only, and NEVER granted by this cluster-wide ClusterRole
 #     (issue #126). The operator reads the credentials, tenant-token, and
 #     deployment-key Secrets to resolve tenant names; it never lists, writes, or
-#     watches them. The cluster-wide secrets rule is gone; the least-privilege
-#     Role/RoleBinding at the bottom of this file grants the read in ravel-system
-#     only. See that block for the per-namespace follow-up.
+#     watches them. The cluster-wide secrets rule is gone. The read is carried by
+#     a separate ravel-operator-secrets ClusterRole bound ONLY by namespaced
+#     RoleBindings (never a ClusterRoleBinding), so the grant is per namespace:
+#     the block at the bottom of this file binds it in ravel-system, and
+#     deploy/k8s/operator/secrets-rolebinding.yaml is the template to copy into
+#     every other namespace a served RavelCluster lives in. A RavelCluster in a
+#     namespace with no such RoleBinding 403s on Secret resolution and the
+#     operator reports a SecretsUnreadable condition on it (see
+#     crate::controller::secret_error).
 #   - ServiceAccounts, Roles, and RoleBindings: the same lifecycle, for the
 #     ravel-native ingest router's own ServiceAccount and its namespaced,
 #     least-privilege Role/RoleBinding (ADR-0080 decision 3). The operator's own
@@ -99,26 +105,32 @@ subjects:
     name: ravel-operator
     namespace: ravel-system
 ---
-# Secrets: get only, and namespaced rather than cluster-wide (issue #126). The
-# operator reads the credentials, tenant-token, and deployment-key Secrets a
+# Secrets: get only, granted per namespace and never cluster-wide (issue #126).
+# The operator reads the credentials, tenant-token, and deployment-key Secrets a
 # RavelCluster references (crate::controller resolves them via
 # Api::<Secret>::namespaced on the RavelCluster's OWN namespace) to resolve
 # tenant names and stamp resource versions; it never lists, writes, or watches
 # them. The Secret names are user-chosen CRD fields
 # (credentialsSecretRef/tenantTokensSecretRef/deploymentKeySecretRef and the
 # per-tier credential overrides), not a fixed set, so resourceNames cannot
-# enumerate them; a namespaced Role is the tightest grant that still works.
+# enumerate them; a bare `secrets get` bound per namespace is the tightest grant
+# that still works.
 #
-# This Role+RoleBinding grants the read only in ravel-system. A RavelCluster in
-# another namespace needs one RoleBinding of this Role (or an equivalent Role)
-# in that namespace; running the operator cluster-wide over many namespaces is a
-# follow-up. Scoping the read to a Role here removes the operator's standing
-# ability to read every Secret in the cluster, which was the finding.
+# The rule lives in a ClusterRole so a single definition can be reused in every
+# served namespace (a RoleBinding cannot reference a Role in another namespace,
+# only a same-namespace Role or a ClusterRole). Binding it with a RoleBinding
+# grants the rule ONLY within that RoleBinding's namespace, so this ClusterRole
+# confers no cluster-wide reach on its own; a ClusterRoleBinding to it would, and
+# must never be created (the operator's own lint asserts this). The RoleBinding
+# below grants the read in ravel-system, the operator's own namespace, so a
+# default install works. Every other namespace a served RavelCluster lives in
+# needs a copy of deploy/k8s/operator/secrets-rolebinding.yaml with its
+# namespace filled in; without it that RavelCluster reports a SecretsUnreadable
+# condition instead of reconciling.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: ravel-operator-secrets
-  namespace: ravel-system
   labels:
     app.kubernetes.io/name: ravel-operator
     app.kubernetes.io/managed-by: ravel-operator
@@ -137,7 +149,7 @@ metadata:
     app.kubernetes.io/managed-by: ravel-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: ravel-operator-secrets
 subjects:
   - kind: ServiceAccount

--- a/deploy/k8s/operator/secrets-rolebinding.yaml
+++ b/deploy/k8s/operator/secrets-rolebinding.yaml
@@ -1,0 +1,33 @@
+# Per-namespace secrets RoleBinding template (issue #126).
+#
+# The operator watches RavelCluster cluster-wide but is granted `secrets get`
+# only in namespaces where this RoleBinding is applied (rbac.yaml removed the
+# cluster-wide grant and left only a ravel-operator-secrets ClusterRole, which
+# grants nothing until a RoleBinding binds it in a namespace). To serve a
+# RavelCluster in a namespace other than ravel-system, copy this file, replace
+# REPLACE_WITH_TARGET_NAMESPACE with that namespace, and apply it:
+#
+#   sed 's/REPLACE_WITH_TARGET_NAMESPACE/team-a/' \
+#     deploy/k8s/operator/secrets-rolebinding.yaml | kubectl apply -f -
+#
+# Until it is applied, a RavelCluster in that namespace 403s on Secret
+# resolution and the operator reports a Degraded condition with reason
+# SecretsUnreadable naming the namespace and Secret, rather than reconciling
+# silently. A RoleBinding to a ClusterRole grants the rule only within this
+# RoleBinding's namespace, so this restores no cluster-wide Secret read.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ravel-operator-secrets
+  namespace: REPLACE_WITH_TARGET_NAMESPACE
+  labels:
+    app.kubernetes.io/name: ravel-operator
+    app.kubernetes.io/managed-by: ravel-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ravel-operator-secrets
+subjects:
+  - kind: ServiceAccount
+    name: ravel-operator
+    namespace: ravel-system

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -234,24 +234,60 @@ the same pure render path as everything else in decision 3:
   second replica.
 - The operator renders one PodDisruptionBudget per tier
   (`maxUnavailable: 1`), applied and swept exactly like the Deployments,
-  so a node drain cannot take a whole tier down and a manual patch does
-  not survive a reconcile.
-- The cluster-wide `secrets` grant is removed. The operator reads only
-  the Secrets a RavelCluster references, in the RavelCluster's own
-  namespace, so the read is now a namespaced Role+RoleBinding in
-  `ravel-system`. The Secret names are user-chosen CRD fields, not a
-  fixed set, so `resourceNames` cannot enumerate them and a namespaced
-  Role is the tightest grant that still works. Running the operator over
-  RavelClusters in other namespaces needs one RoleBinding per namespace;
-  that is a follow-up.
+  so a manual patch does not survive a reconcile. The budget protects a
+  multi-replica tier during a voluntary disruption (a node drain): the
+  eviction of a second pod is blocked once it would breach
+  `maxUnavailable: 1`, so at least one replica keeps serving. A
+  single-replica tier (the maintain default) is not protected and can
+  still be drained to zero, which is intentional: `maxUnavailable: 1`
+  permits evicting the one pod, and the operator does not force two
+  replicas (the same reason the anti-affinity above is preferred, not
+  required).
+- The cluster-wide `secrets` grant is removed. The operator keeps its
+  cluster-wide `RavelCluster` watch (decision 3) and reads each object's
+  referenced Secrets in that object's own namespace, so `secrets get` is
+  granted per namespace, never cluster-wide. The rule lives in a
+  `ravel-operator-secrets` ClusterRole (a reusable definition that grants
+  nothing on its own) bound by a namespaced RoleBinding in each served
+  namespace; `ravel-system` ships bound, and
+  `deploy/k8s/operator/secrets-rolebinding.yaml` is the template for every
+  other namespace. A RoleBinding to a ClusterRole grants the rule only
+  within that RoleBinding's namespace, so this confers no cluster-wide
+  reach; a ClusterRoleBinding to it would, and the rbac lint asserts none
+  exists. The Secret names are user-chosen CRD fields, not a fixed set, so
+  `resourceNames` cannot enumerate them; a bare `secrets get` bound per
+  namespace is the tightest grant that still works.
+
+  Shipping the narrowing without the per-namespace binding was a
+  regression, not a follow-up (issue #126): before this change the operator
+  read Secrets for a RavelCluster in any namespace, and narrowing to a
+  Role in `ravel-system` alone silently 403'd every RavelCluster elsewhere.
+  Of the two remedies the finding offered, option (b) is taken here: keep
+  the cluster-wide watch and bind per namespace, rather than option (a),
+  restricting the watch to `ravel-system`. Option (b) preserves the
+  multi-namespace reconcile the controller already implements (`Api::all`
+  plus namespaced reads per object) and keeps the operator install guide's
+  "watches RavelCluster cluster-wide and manages Deployments and Services in
+  whatever namespace each RavelCluster lives in" true. Its cost is that a
+  served namespace now carries an out-of-band precondition (the
+  RoleBinding); so it does not fail silently, the reconciler maps a 403 on
+  Secret resolution to a `Degraded` condition with reason `SecretsUnreadable`
+  naming the namespace and Secret (`crate::controller::secret_error`),
+  rather than a bare reconcile failure.
 
 The container/pod SecurityContext, the PDB count, and the anti-affinity
 shape are asserted at render level in `reconcile.rs` tests; a manifest
 lint there (a text scan of `deploy/k8s/operator/rbac.yaml`, run by
-`cargo test -p ravel-operator`) asserts the ClusterRole grants no
-`secrets`. The runtime effect (a pod actually rejected for a missing
-capability, a drain actually blocked) is left to the k8s CI lane
-(decision 8).
+`cargo test -p ravel-operator`) asserts the cluster-wide ClusterRole
+grants no `secrets` and that the secrets read is bound only per namespace,
+and a `controller.rs` test asserts the 403-to-`SecretsUnreadable` mapping.
+The runtime behavior is left to the k8s CI lane (decision 8), and it is a
+runtime behavior, not an admission one: Kubernetes admits a hardened pod,
+and an operation that needs a dropped capability fails when it is attempted
+at runtime, exactly as a write under `readOnlyRootFilesystem` fails at
+runtime; nothing rejects the pod for the dropped capability. What the kind
+lane actually proves is that the hardened pods reach readiness and complete
+an OTLP round trip, not that a missing capability is rejected.
 
 ## Rejected alternatives
 

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -212,6 +212,47 @@ exists for disk-hungry jobs.
    `services/*` in the doc map), an index entry in `docs/README.md`,
    and a README.md pointer.
 
+**Amendment (2026-09-07): pod and RBAC hardening are the operator's
+responsibility (issue #126).** The rendered objects this ADR describes
+shipped with no workload hardening, and the operator's ServiceAccount
+held a cluster-wide `secrets` read. Both are now the operator's job, in
+the same pure render path as everything else in decision 3:
+
+- Every rendered container carries a SecurityContext: `runAsNonRoot`,
+  `allowPrivilegeEscalation: false`, all Linux capabilities dropped, and
+  a read-only root filesystem. The read-only root is correct because
+  object storage is the only durable backend (no process writes local
+  disk on any path the operator renders): the sole opt-in local write is
+  the ADR-0046 disk cache, which the operator renders no `--cache-dir`
+  flag for, so every rendered container runs RAM-only. A future CRD field
+  that wires `--cache-dir` must add its own writable volume mount.
+- Every rendered PodSpec carries a pod SecurityContext (`runAsNonRoot`
+  and the `RuntimeDefault` seccomp profile) and preferred (soft), never
+  required, pod anti-affinity spreading a tier's replicas across nodes.
+  Preferred because a required rule would leave a single-node `kind`
+  cluster (the reference environment, decision 6) unable to schedule a
+  second replica.
+- The operator renders one PodDisruptionBudget per tier
+  (`maxUnavailable: 1`), applied and swept exactly like the Deployments,
+  so a node drain cannot take a whole tier down and a manual patch does
+  not survive a reconcile.
+- The cluster-wide `secrets` grant is removed. The operator reads only
+  the Secrets a RavelCluster references, in the RavelCluster's own
+  namespace, so the read is now a namespaced Role+RoleBinding in
+  `ravel-system`. The Secret names are user-chosen CRD fields, not a
+  fixed set, so `resourceNames` cannot enumerate them and a namespaced
+  Role is the tightest grant that still works. Running the operator over
+  RavelClusters in other namespaces needs one RoleBinding per namespace;
+  that is a follow-up.
+
+The container/pod SecurityContext, the PDB count, and the anti-affinity
+shape are asserted at render level in `reconcile.rs` tests; a manifest
+lint there (a text scan of `deploy/k8s/operator/rbac.yaml`, run by
+`cargo test -p ravel-operator`) asserts the ClusterRole grants no
+`secrets`. The runtime effect (a pod actually rejected for a missing
+capability, a drain actually blocked) is left to the k8s CI lane
+(decision 8).
+
 ## Rejected alternatives
 
 1. **Go operator (kubebuilder/controller-runtime).** The larger example

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -15,6 +15,7 @@ use futures::StreamExt;
 use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::{Secret, Service, ServiceAccount};
 use k8s_openapi::api::networking::v1::Ingress;
+use k8s_openapi::api::policy::v1::PodDisruptionBudget;
 use k8s_openapi::api::rbac::v1::{Role, RoleBinding};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::api::{DeleteParams, Patch, PatchParams};
@@ -39,7 +40,8 @@ use crate::reconcile::{
     GcBootstrapGate, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
     WAITING_FOR_GC_BOOTSTRAP_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_REASON, desired_objects,
     grpcroute_api_resource, httproute_api_resource, possible_gateway_route_names,
-    possible_ingest_ingress_names, possible_router_object_names,
+    possible_ingest_ingress_names, possible_pod_disruption_budget_names,
+    possible_router_object_names,
 };
 
 /// Server-side-apply field manager name.
@@ -1181,6 +1183,28 @@ async fn reconcile_inner(
     query_svc.metadata.namespace = Some(namespace.to_string());
     query_svc.metadata.owner_references = owner.clone();
     apply(&services, &child(instance, "query"), &query_svc).await?;
+
+    // Pod disruption budgets (issue #126, deliverable 4): apply one per rendered
+    // tier, then delete every possible PDB name the render did not produce, so
+    // disabling `maintain` removes its PDB instead of orphaning one that guards a
+    // Deployment that no longer exists. Applied and swept here (owned like the
+    // Deployments, with the same field manager and owner references) so a manual
+    // patch does not survive a reconcile.
+    let disruption_budgets: Api<PodDisruptionBudget> = Api::namespaced(client.clone(), namespace);
+    let mut desired_pdb_names: BTreeSet<String> = BTreeSet::new();
+    for mut pdb in desired.pod_disruption_budgets {
+        let name = pdb.name_any();
+        pdb.metadata.namespace = Some(namespace.to_string());
+        pdb.metadata.owner_references = owner.clone();
+        apply(&disruption_budgets, &name, &pdb).await?;
+        desired_pdb_names.insert(name);
+    }
+    for name in possible_pod_disruption_budget_names(instance) {
+        if desired_pdb_names.contains(&name) {
+            continue;
+        }
+        delete_if_present(&disruption_budgets, &name).await?;
+    }
 
     // The three Deployments, in exactly the order `gc_bootstrap` names and no
     // other.

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -91,6 +91,25 @@ pub enum Error {
         reason: String,
     },
 
+    /// The operator is forbidden (HTTP 403) from reading a Secret the spec
+    /// references in its namespace. Under the per-namespace secrets grant
+    /// (ADR-0034 hardening amendment, issue #126) the operator watches
+    /// `RavelCluster` cluster-wide but is granted `secrets get` only in
+    /// namespaces where the `ravel-operator-secrets` RoleBinding is applied, so
+    /// a RavelCluster in an unbound namespace 403s here. Surfaced as a
+    /// `Degraded` status condition with reason `SecretsUnreadable`, naming the
+    /// namespace and Secret, so `kubectl describe` shows exactly which
+    /// RoleBinding is missing rather than a bare reconcile failure.
+    #[error("secret {name} in namespace {namespace} is not readable: {reason}")]
+    SecretsUnreadable {
+        /// The Secret the operator could not read.
+        name: String,
+        /// The namespace the read was attempted in (the RavelCluster's own).
+        namespace: String,
+        /// Why the read was refused, including which RoleBinding to apply.
+        reason: String,
+    },
+
     /// A Kubernetes API call failed.
     #[error("kube API error: {0}")]
     Kube(#[from] kube::Error),
@@ -187,7 +206,7 @@ async fn resolve_token_secret(
     let secret = api
         .get(&secret_ref.name)
         .await
-        .map_err(|err| secret_error(err, &secret_ref.name, "tenantTokensSecretRef"))?;
+        .map_err(|err| secret_error(err, &secret_ref.name, namespace, "tenantTokensSecretRef"))?;
     let resource_version = secret.resource_version();
     let mut token_values: BTreeMap<String, Vec<u8>> = BTreeMap::new();
     if let Some(data) = &secret.data {
@@ -221,7 +240,7 @@ async fn secret_resource_version(
     let secret = api
         .get(name)
         .await
-        .map_err(|err| secret_error(err, name, field))?;
+        .map_err(|err| secret_error(err, name, namespace, field))?;
     Ok(secret.resource_version())
 }
 
@@ -285,13 +304,26 @@ async fn resolve_credential_resource_versions(
 }
 
 /// Map a Secret `get` error: a 404 becomes [`Error::SecretNotFound`] naming the
-/// Secret and the spec field that referenced it; anything else stays a
-/// [`Error::Kube`].
-fn secret_error(err: kube::Error, name: &str, field: &str) -> Error {
+/// Secret and the spec field that referenced it; a 403 becomes
+/// [`Error::SecretsUnreadable`] naming the namespace, Secret, and the
+/// RoleBinding to apply (the per-namespace secrets grant, issue #126); anything
+/// else stays a [`Error::Kube`].
+fn secret_error(err: kube::Error, name: &str, namespace: &str, field: &str) -> Error {
     if is_not_found(&err) {
         Error::SecretNotFound {
             name: name.to_string(),
             reason: format!("referenced by spec.{field} but absent from the namespace"),
+        }
+    } else if is_forbidden(&err) {
+        Error::SecretsUnreadable {
+            name: name.to_string(),
+            namespace: namespace.to_string(),
+            reason: format!(
+                "the operator's ServiceAccount is forbidden from reading it (referenced by \
+                 spec.{field}); bind the ravel-operator-secrets ClusterRole in namespace \
+                 {namespace} with a RoleBinding (see \
+                 deploy/k8s/operator/secrets-rolebinding.yaml)"
+            ),
         }
     } else {
         Error::Kube(err)
@@ -360,7 +392,7 @@ async fn resolve_deployment_key(
     let secret = api
         .get(&secret_ref.name)
         .await
-        .map_err(|err| secret_error(err, &secret_ref.name, "deploymentKeySecretRef"))?;
+        .map_err(|err| secret_error(err, &secret_ref.name, namespace, "deploymentKeySecretRef"))?;
     let resource_version = secret.resource_version();
     let raw = secret_value(&secret, DEPLOYMENT_KEY_SECRET_KEY).ok_or_else(|| {
         Error::InvalidSecretValue {
@@ -393,10 +425,14 @@ async fn resolve_s3_credentials(
     secret_ref: &LocalSecretRef,
 ) -> Result<(String, String), Error> {
     let api: Api<Secret> = Api::namespaced(client.clone(), namespace);
-    let secret = api
-        .get(&secret_ref.name)
-        .await
-        .map_err(|err| secret_error(err, &secret_ref.name, "storage.s3.credentialsSecretRef"))?;
+    let secret = api.get(&secret_ref.name).await.map_err(|err| {
+        secret_error(
+            err,
+            &secret_ref.name,
+            namespace,
+            "storage.s3.credentialsSecretRef",
+        )
+    })?;
     let field = |key: &str| -> Result<String, Error> {
         let raw = secret_value(&secret, key).ok_or_else(|| Error::InvalidSecretValue {
             name: secret_ref.name.clone(),
@@ -1458,6 +1494,14 @@ fn is_not_found(err: &kube::Error) -> bool {
     matches!(err, kube::Error::Api(response) if response.code == 404)
 }
 
+/// Whether a kube error is a 403 Forbidden. A Secret read that returns this is
+/// the missing-per-namespace-RoleBinding case (issue #126): the operator
+/// watches `RavelCluster` cluster-wide but holds `secrets get` only where the
+/// `ravel-operator-secrets` RoleBinding is applied.
+fn is_forbidden(err: &kube::Error) -> bool {
+    matches!(err, kube::Error::Api(response) if response.code == 403)
+}
+
 /// `<instance>-<component>`, matching [`crate::reconcile`]'s naming.
 fn child(instance: &str, component: &str) -> String {
     format!("{instance}-{component}")
@@ -1686,6 +1730,14 @@ fn degraded_reason(err: &Error) -> (String, String) {
         } => (
             "InvalidSecretValue".to_string(),
             format!("Secret \"{name}\" field \"{field}\": {reason}"),
+        ),
+        Error::SecretsUnreadable {
+            name,
+            namespace,
+            reason,
+        } => (
+            "SecretsUnreadable".to_string(),
+            format!("Secret \"{name}\" in namespace \"{namespace}\" is not readable: {reason}"),
         ),
         Error::Render(RenderError::RouterImageMissing) => {
             ("RouterImageMissing".to_string(), err.to_string())
@@ -1955,6 +2007,52 @@ mod tests {
         let (reason, message) = degraded_reason(&err);
         assert_eq!(reason, "SecretNotFound");
         assert!(message.contains("ravel-tokens"), "message names the Secret");
+    }
+
+    #[test]
+    fn forbidden_secret_read_surfaces_secrets_unreadable_condition() {
+        // A 403 on the namespaced Secret GET is the missing-per-namespace-
+        // RoleBinding case (issue #126, ADR-0034 hardening amendment): the
+        // operator watches RavelCluster cluster-wide but holds `secrets get`
+        // only where the ravel-operator-secrets RoleBinding is applied. It must
+        // map to a named SecretsUnreadable condition carrying the exact
+        // namespace and Secret, never a bare ReconcileError, so the missing
+        // binding is visible on the RavelCluster.
+        let err = kube::Error::Api(Box::new(kube::core::Status {
+            code: 403,
+            reason: "Forbidden".to_string(),
+            message: "secrets \"team-a-tokens\" is forbidden".to_string(),
+            ..Default::default()
+        }));
+        let mapped = secret_error(err, "team-a-tokens", "team-a", "tenantTokensSecretRef");
+        match &mapped {
+            Error::SecretsUnreadable {
+                name,
+                namespace,
+                reason,
+            } => {
+                assert_eq!(name, "team-a-tokens", "names the exact Secret");
+                assert_eq!(namespace, "team-a", "names the exact namespace");
+                assert!(
+                    reason.contains("secrets-rolebinding.yaml"),
+                    "reason points at the RoleBinding template: {reason}"
+                );
+            }
+            other => panic!("403 must map to SecretsUnreadable, got {other:?}"),
+        }
+        let (reason, message) = degraded_reason(&mapped);
+        assert_eq!(
+            reason, "SecretsUnreadable",
+            "condition reason is the named one"
+        );
+        assert!(
+            message.contains("team-a-tokens"),
+            "condition message names the Secret: {message}"
+        );
+        assert!(
+            message.contains("team-a"),
+            "condition message names the namespace: {message}"
+        );
     }
 
     #[test]

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -5079,13 +5079,16 @@ mod tests {
     }
 
     #[test]
-    fn rbac_manifest_carries_no_cluster_wide_secrets_rule() {
-        // Deliverable 5, manifest lint. A dependency-free text scan of the
-        // shipped rbac.yaml, run by the existing `cargo test -p ravel-operator`
-        // gate: the operator's ClusterRole must NOT grant `secrets`, and the
-        // read must instead come from a namespaced Role. It fails on the current
-        // rbac.yaml before the narrowing lands, which is exactly the
-        // prove-the-test demonstration.
+    fn rbac_manifest_never_grants_secrets_cluster_wide() {
+        // Issue #126 manifest lint. A dependency-free text scan of the shipped
+        // rbac.yaml, run by the existing `cargo test -p ravel-operator` gate.
+        // The operator must hold no standing cluster-wide Secret read: the
+        // cluster-wide ClusterRole (ravel-operator, the one the
+        // ClusterRoleBinding binds) grants no `secrets`, the secrets read lives
+        // in a separate ravel-operator-secrets ClusterRole, and NO
+        // ClusterRoleBinding may reference that secrets ClusterRole (a
+        // ClusterRoleBinding would make it cluster-wide; only RoleBindings, which
+        // are namespace-scoped, may bind it).
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../deploy/k8s/operator/rbac.yaml");
         let manifest = std::fs::read_to_string(&path)
@@ -5093,28 +5096,54 @@ mod tests {
 
         // Split into YAML documents and classify each by its `kind:` line. A
         // ClusterRoleBinding also contains the text "ClusterRole", so match the
-        // kind line exactly rather than with a substring.
+        // kind line exactly rather than with a substring. `has_name` matches a
+        // metadata (or roleRef) name line exactly, so `ravel-operator` does not
+        // also match `ravel-operator-secrets`.
         let docs: Vec<&str> = manifest.split("\n---").collect();
         let kind_is =
             |doc: &str, kind: &str| doc.lines().any(|l| l.trim() == format!("kind: {kind}"));
+        let has_name =
+            |doc: &str, name: &str| doc.lines().any(|l| l.trim() == format!("name: {name}"));
 
-        let cluster_role = docs
+        // No ClusterRoleBinding may bind the secrets ClusterRole cluster-wide.
+        for doc in &docs {
+            if kind_is(doc, "ClusterRoleBinding") {
+                assert!(
+                    !doc.contains("ravel-operator-secrets"),
+                    "the secrets read must never be bound cluster-wide by a \
+                     ClusterRoleBinding; bind it per namespace with a RoleBinding"
+                );
+            }
+        }
+
+        // The cluster-wide operator ClusterRole grants no secrets.
+        let main_cluster_role = docs
             .iter()
-            .find(|d| kind_is(d, "ClusterRole"))
-            .expect("rbac.yaml defines a ClusterRole");
+            .find(|d| kind_is(d, "ClusterRole") && has_name(d, "ravel-operator"))
+            .expect("rbac.yaml defines the ravel-operator ClusterRole");
         assert!(
-            !cluster_role.contains("secrets"),
-            "the operator ClusterRole must not grant a cluster-wide secrets rule; \
-             narrow it to a namespaced Role"
+            !main_cluster_role.contains("secrets"),
+            "the cluster-wide ravel-operator ClusterRole must not grant a secrets rule"
         );
 
-        let secrets_role = docs
+        // The secrets read lives in its own ClusterRole, get only, bound per
+        // namespace by a RoleBinding (ravel-system ships one).
+        let secrets_cluster_role = docs
             .iter()
-            .find(|d| kind_is(d, "Role") && d.contains("secrets"))
-            .expect("a namespaced Role must grant the secrets read");
+            .find(|d| kind_is(d, "ClusterRole") && has_name(d, "ravel-operator-secrets"))
+            .expect("rbac.yaml defines the ravel-operator-secrets ClusterRole");
         assert!(
-            secrets_role.contains("verbs: [\"get\"]"),
-            "the namespaced secrets Role grants get only"
+            secrets_cluster_role.contains("secrets")
+                && secrets_cluster_role.contains("verbs: [\"get\"]"),
+            "the ravel-operator-secrets ClusterRole grants secrets get only"
+        );
+        let secrets_binding = docs
+            .iter()
+            .find(|d| kind_is(d, "RoleBinding") && d.contains("ravel-operator-secrets"))
+            .expect("a RoleBinding binds the secrets ClusterRole in a namespace");
+        assert!(
+            secrets_binding.contains("namespace: ravel-system"),
+            "the shipped secrets RoleBinding binds ravel-system, the operator's own namespace"
         );
     }
 }

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -15,14 +15,17 @@ use std::time::Duration;
 
 use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy};
 use k8s_openapi::api::core::v1::{
-    Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction, KeyToPath, PodSpec,
-    PodTemplateSpec, Probe, ResourceRequirements, SecretKeySelector, SecretVolumeSource, Service,
-    ServiceAccount, ServicePort, ServiceSpec, Volume, VolumeMount,
+    Affinity, Capabilities, Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction,
+    KeyToPath, PodAffinityTerm, PodAntiAffinity, PodSecurityContext, PodSpec, PodTemplateSpec,
+    Probe, ResourceRequirements, SeccompProfile, SecretKeySelector, SecretVolumeSource,
+    SecurityContext, Service, ServiceAccount, ServicePort, ServiceSpec, Volume, VolumeMount,
+    WeightedPodAffinityTerm,
 };
 use k8s_openapi::api::networking::v1::{
     HTTPIngressPath, HTTPIngressRuleValue, Ingress, IngressBackend, IngressRule,
     IngressServiceBackend, IngressSpec, IngressTLS, ServiceBackendPort,
 };
+use k8s_openapi::api::policy::v1::{PodDisruptionBudget, PodDisruptionBudgetSpec};
 use k8s_openapi::api::rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject};
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
@@ -476,6 +479,75 @@ fn probes_on(port: i32) -> (Probe, Probe) {
     (liveness, readiness)
 }
 
+/// The hardened container-level SecurityContext stamped on every container the
+/// operator renders (issue #126, ADR-0034 hardening amendment). Runs non-root,
+/// forbids privilege escalation, drops every Linux capability, and mounts the
+/// root filesystem read-only.
+///
+/// `read_only_root_filesystem` is correct for every container the operator
+/// renders: ravel-server's only local-disk write path is the opt-in ADR-0046
+/// disk cache tier (`--cache-dir`), which the operator renders no flag for, so
+/// the server and the ingest-router run RAM-only and write nothing outside the
+/// read-only mounts the pod already carries (the deployment-key Secret, mounted
+/// read-only). Object storage is the only durable backend, so no rendered
+/// container needs a writable root. A future CRD field that wires `--cache-dir`
+/// must back it with its own writable volume mount, which is writable
+/// independently of the root filesystem.
+fn container_security_context() -> SecurityContext {
+    SecurityContext {
+        run_as_non_root: Some(true),
+        allow_privilege_escalation: Some(false),
+        read_only_root_filesystem: Some(true),
+        capabilities: Some(Capabilities {
+            drop: Some(vec!["ALL".to_string()]),
+            add: None,
+        }),
+        ..Default::default()
+    }
+}
+
+/// The hardened pod-level SecurityContext stamped on every PodSpec the operator
+/// renders (issue #126): run as non-root and confine every container to the
+/// `RuntimeDefault` seccomp profile.
+fn pod_security_context() -> PodSecurityContext {
+    PodSecurityContext {
+        run_as_non_root: Some(true),
+        seccomp_profile: Some(SeccompProfile {
+            type_: "RuntimeDefault".to_string(),
+            localhost_profile: None,
+        }),
+        ..Default::default()
+    }
+}
+
+/// Preferred (soft) pod anti-affinity spreading a component's replicas across
+/// nodes (issue #126). Preferred, never required: a required rule leaves a
+/// single-node cluster (a `kind` dev cluster, the reference environment) unable
+/// to schedule a second replica, wedging every multi-replica tier. The term
+/// selects the component's own pods by the standard `instance`+`component`
+/// labels and spreads on `kubernetes.io/hostname`.
+fn pod_anti_affinity(instance: &str, component: &str) -> Affinity {
+    Affinity {
+        pod_anti_affinity: Some(PodAntiAffinity {
+            preferred_during_scheduling_ignored_during_execution: Some(vec![
+                WeightedPodAffinityTerm {
+                    weight: 100,
+                    pod_affinity_term: PodAffinityTerm {
+                        label_selector: Some(LabelSelector {
+                            match_labels: Some(labels(instance, component)),
+                            ..Default::default()
+                        }),
+                        topology_key: "kubernetes.io/hostname".to_string(),
+                        ..Default::default()
+                    },
+                },
+            ]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
 /// Build a Deployment for `component` from its rendered args, env, container
 /// ports, replica count, and strategy. The single place the common container
 /// shape (image, probes, resources) is assembled, so gateway/query/maintain
@@ -508,6 +580,7 @@ fn deployment(
         readiness_probe: Some(readiness),
         resources: resources(resources_spec),
         volume_mounts: volume_mount.map(|m| vec![m]),
+        security_context: Some(container_security_context()),
         ..Default::default()
     };
     Deployment {
@@ -540,6 +613,8 @@ fn deployment(
                 spec: Some(PodSpec {
                     containers: vec![container],
                     volumes: volume.map(|v| vec![v]),
+                    security_context: Some(pod_security_context()),
+                    affinity: Some(pod_anti_affinity(instance, component)),
                     ..Default::default()
                 }),
             },
@@ -1302,6 +1377,7 @@ pub fn desired_router_deployment(
         }]),
         liveness_probe: Some(liveness),
         readiness_probe: Some(readiness),
+        security_context: Some(container_security_context()),
         ..Default::default()
     };
     Ok(Some(Deployment {
@@ -1330,6 +1406,8 @@ pub fn desired_router_deployment(
                     // The router reads EndpointSlices/Services under its own
                     // least-privilege ServiceAccount (deliverable 7).
                     service_account_name: Some(child_name(instance, ROUTER_COMPONENT)),
+                    security_context: Some(pod_security_context()),
+                    affinity: Some(pod_anti_affinity(instance, ROUTER_COMPONENT)),
                     ..Default::default()
                 }),
             },
@@ -1828,6 +1906,75 @@ pub fn gc_bootstrap_plan(spec: &RavelClusterSpec) -> GcBootstrapPlan {
     }
 }
 
+/// A tier's PodDisruptionBudget (issue #126, deliverable 4), capping how many of
+/// its pods a voluntary disruption (a node drain, a cluster upgrade) may take
+/// down at once.
+///
+/// `maxUnavailable: 1` rather than a `minAvailable`: it protects a multi-replica
+/// tier (gateway/query) during a rolling node drain while never blocking a drain
+/// on a single-replica tier (maintain, or a one-replica gateway on a single-node
+/// `kind` cluster). A `minAvailable` equal to the replica count would wedge a
+/// node drain on such a cluster, the same failure the preferred (not required)
+/// anti-affinity avoids. The selector matches the tier's own pods by the
+/// standard `instance`+`component` labels, exactly as its Deployment selector
+/// does.
+fn pod_disruption_budget(instance: &str, component: &str) -> PodDisruptionBudget {
+    let labels = labels(instance, component);
+    PodDisruptionBudget {
+        metadata: ObjectMeta {
+            name: Some(child_name(instance, component)),
+            labels: Some(labels.clone()),
+            ..Default::default()
+        },
+        spec: Some(PodDisruptionBudgetSpec {
+            max_unavailable: Some(IntOrString::Int(1)),
+            selector: Some(LabelSelector {
+                match_labels: Some(labels),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        status: None,
+    }
+}
+
+/// One PodDisruptionBudget per rendered tier (issue #126, deliverable 4): always
+/// gateway and query, plus maintain when `maintain.enabled`. The count equals
+/// the number of tiers the reconcile renders a Deployment for. The controller
+/// applies and sweeps these exactly like the Deployments, so a manual patch does
+/// not survive a reconcile. The router is an optional affinity backend, not a
+/// tier, and gets no PDB (its Deployment is swept as a unit with its other
+/// objects when the backend is switched away).
+pub fn desired_pod_disruption_budgets(
+    spec: &RavelClusterSpec,
+    instance: &str,
+) -> Vec<PodDisruptionBudget> {
+    let mut tiers = vec![DeploymentTier::Gateway, DeploymentTier::Query];
+    if spec.maintain.enabled {
+        tiers.push(DeploymentTier::Maintain);
+    }
+    tiers
+        .into_iter()
+        .map(|tier| pod_disruption_budget(instance, tier.component()))
+        .collect()
+}
+
+/// Every PodDisruptionBudget name the render can produce for `instance`, in a
+/// fixed order, whether or not the current spec renders that tier. The
+/// controller applies the ones [`desired_pod_disruption_budgets`] returns and
+/// deletes every other name here, so disabling `maintain` removes its PDB
+/// instead of orphaning one that guards a Deployment that no longer exists.
+pub fn possible_pod_disruption_budget_names(instance: &str) -> Vec<String> {
+    [
+        DeploymentTier::Gateway,
+        DeploymentTier::Query,
+        DeploymentTier::Maintain,
+    ]
+    .into_iter()
+    .map(|tier| child_name(instance, tier.component()))
+    .collect()
+}
+
 /// Everything one `RavelCluster` reconcile applies, rendered in one place.
 ///
 /// [`crate::controller`] builds this and applies exactly its contents, so a
@@ -1876,6 +2023,10 @@ pub struct DesiredObjects {
     /// The maintain Deployment, or `None` when `maintain.enabled` is false (the
     /// controller deletes it in that case).
     pub maintain_deployment: Option<Deployment>,
+    /// One PodDisruptionBudget per rendered tier (issue #126, deliverable 4).
+    /// The controller applies and sweeps these like the Deployments, so a manual
+    /// patch does not survive a reconcile.
+    pub pod_disruption_budgets: Vec<PodDisruptionBudget>,
     /// The order this pass applies the three Deployments in, and the condition
     /// it records while an ordering constraint holds the request-serving tiers
     /// back.
@@ -1949,6 +2100,7 @@ pub fn desired_objects(
         query_deployment: desired_query_deployment(spec, instance, ctx),
         query_service: desired_query_service(spec, instance),
         maintain_deployment: desired_maintain_deployment(spec, instance, ctx)?,
+        pod_disruption_budgets: desired_pod_disruption_budgets(spec, instance),
         gc_bootstrap,
     })
 }
@@ -4709,5 +4861,260 @@ mod tests {
         // The name the previous mode created is still in the sweep list, so the
         // controller deletes it on this pass.
         assert!(possible_router_object_names("prod").contains(&"prod-ingest-router".to_string()));
+    }
+
+    /// Every Deployment the reconciler can render for a fully-populated spec,
+    /// paired with a label naming its container: the three tiers plus the
+    /// ravel-native ingest router. The hardening sweeps assert over this exact
+    /// set, so a newly added rendered container or pod cannot escape the
+    /// SecurityContext unnoticed. `AuthorizationHeader` affinity is used because
+    /// it needs no tenant-token resolver, so the router renders even with
+    /// `tenant_tokens_secret_ref` cleared.
+    fn every_rendered_deployment() -> Vec<(&'static str, Deployment)> {
+        let mut spec = ravel_native_spec(3, AffinityKeySource::AuthorizationHeader);
+        spec.maintain.enabled = true;
+        let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
+        let deployments = vec![
+            ("gateway", objects.gateway_deployment),
+            ("query", objects.query_deployment),
+            (
+                "maintain",
+                objects
+                    .maintain_deployment
+                    .expect("maintain.enabled renders a maintain Deployment"),
+            ),
+            (
+                "ingest-router",
+                objects
+                    .router_deployment
+                    .expect("ravelNative renders a router Deployment"),
+            ),
+        ];
+        // Guard against a future render path silently dropping out of this
+        // enumeration: the four names above are every container the operator
+        // ships today.
+        assert_eq!(
+            deployments.len(),
+            4,
+            "expected exactly four rendered Deployments to sweep"
+        );
+        deployments
+    }
+
+    fn pod_spec_of(dep: &Deployment) -> &PodSpec {
+        dep.spec
+            .as_ref()
+            .expect("deployment spec")
+            .template
+            .spec
+            .as_ref()
+            .expect("pod spec")
+    }
+
+    #[test]
+    fn every_rendered_container_drops_all_capabilities_and_runs_non_root() {
+        // Deliverable 1: the container-level SecurityContext is on EVERY
+        // container the reconciler can render, not just the shared tier builder.
+        // Render-level assertion: it checks the object the operator applies, not
+        // a live pod (the k8s CI lane covers the runtime effect).
+        for (tier, dep) in every_rendered_deployment() {
+            for container in &pod_spec_of(&dep).containers {
+                let sc = container
+                    .security_context
+                    .as_ref()
+                    .unwrap_or_else(|| panic!("{tier}: container has no SecurityContext"));
+                assert_eq!(
+                    sc.run_as_non_root,
+                    Some(true),
+                    "{tier}: runAsNonRoot must be true"
+                );
+                assert_eq!(
+                    sc.allow_privilege_escalation,
+                    Some(false),
+                    "{tier}: allowPrivilegeEscalation must be false"
+                );
+                assert_eq!(
+                    sc.read_only_root_filesystem,
+                    Some(true),
+                    "{tier}: readOnlyRootFilesystem must be true"
+                );
+                let dropped = sc
+                    .capabilities
+                    .as_ref()
+                    .and_then(|c| c.drop.as_ref())
+                    .unwrap_or_else(|| panic!("{tier}: capabilities.drop unset"));
+                assert_eq!(
+                    dropped,
+                    &vec!["ALL".to_string()],
+                    "{tier}: every capability must be dropped"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_rendered_pod_spec_sets_a_non_root_security_context() {
+        // Deliverable 2: the pod-level SecurityContext (runAsNonRoot + the
+        // RuntimeDefault seccomp profile) is on EVERY rendered PodSpec.
+        // Render-level assertion.
+        for (tier, dep) in every_rendered_deployment() {
+            let pod = pod_spec_of(&dep);
+            let sc = pod
+                .security_context
+                .as_ref()
+                .unwrap_or_else(|| panic!("{tier}: PodSpec has no securityContext"));
+            assert_eq!(
+                sc.run_as_non_root,
+                Some(true),
+                "{tier}: pod runAsNonRoot must be true"
+            );
+            let profile = sc
+                .seccomp_profile
+                .as_ref()
+                .unwrap_or_else(|| panic!("{tier}: no seccompProfile"));
+            assert_eq!(
+                profile.type_, "RuntimeDefault",
+                "{tier}: seccompProfile must be RuntimeDefault"
+            );
+        }
+    }
+
+    #[test]
+    fn each_tier_renders_a_pod_disruption_budget_and_anti_affinity() {
+        // Deliverable 3 and 4, render-level. The PDB count equals the number of
+        // tiers the reconcile renders a Deployment for, and every tier PodSpec
+        // carries preferred (soft) anti-affinity keyed on its own labels.
+        //
+        // With maintain enabled: three tiers, three PDBs. Disabling maintain
+        // drops it to two, proving the count tracks the rendered tiers rather
+        // than a constant.
+        let mut spec = base_spec();
+        spec.maintain.enabled = true;
+        let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
+        assert_eq!(
+            objects.pod_disruption_budgets.len(),
+            3,
+            "one PDB per rendered tier (gateway, query, maintain)"
+        );
+        // Each PDB caps voluntary disruption at one pod and selects its tier's
+        // own labels.
+        for (pdb, component) in objects
+            .pod_disruption_budgets
+            .iter()
+            .zip(["gateway", "query", "maintain"])
+        {
+            let pdb_spec = pdb.spec.as_ref().expect("pdb spec");
+            assert_eq!(
+                pdb_spec.max_unavailable,
+                Some(IntOrString::Int(1)),
+                "{component}: maxUnavailable must be 1"
+            );
+            assert_eq!(
+                pdb.metadata.name.as_deref(),
+                Some(child_name("prod", component).as_str()),
+                "{component}: PDB name must match the tier"
+            );
+            assert_eq!(
+                pdb_spec
+                    .selector
+                    .as_ref()
+                    .and_then(|s| s.match_labels.clone()),
+                Some(labels("prod", component)),
+                "{component}: PDB selects its tier labels"
+            );
+        }
+
+        // Preferred, not required: a required term would wedge scheduling on a
+        // single-node cluster. Assert the preferred list is populated and the
+        // required list is empty, on every tier.
+        for (tier, dep) in [
+            ("gateway", objects.gateway_deployment),
+            ("query", objects.query_deployment),
+            (
+                "maintain",
+                objects.maintain_deployment.expect("maintain enabled"),
+            ),
+        ] {
+            let anti = pod_spec_of(&dep)
+                .affinity
+                .as_ref()
+                .and_then(|a| a.pod_anti_affinity.as_ref())
+                .unwrap_or_else(|| panic!("{tier}: no podAntiAffinity"));
+            assert!(
+                anti.required_during_scheduling_ignored_during_execution
+                    .as_ref()
+                    .map(|r| r.is_empty())
+                    .unwrap_or(true),
+                "{tier}: anti-affinity must be preferred, never required"
+            );
+            let preferred = anti
+                .preferred_during_scheduling_ignored_during_execution
+                .as_ref()
+                .unwrap_or_else(|| panic!("{tier}: no preferred anti-affinity term"));
+            assert_eq!(preferred.len(), 1, "{tier}: one preferred term");
+            assert_eq!(
+                preferred[0].pod_affinity_term.topology_key, "kubernetes.io/hostname",
+                "{tier}: spread across nodes"
+            );
+            assert_eq!(
+                preferred[0]
+                    .pod_affinity_term
+                    .label_selector
+                    .as_ref()
+                    .and_then(|s| s.match_labels.clone()),
+                Some(labels("prod", tier)),
+                "{tier}: term selects the tier's own pods"
+            );
+        }
+
+        // Disabling maintain drops its PDB, proving the count tracks tiers.
+        let mut disabled = base_spec();
+        disabled.maintain.enabled = false;
+        let objects = desired_objects(&disabled, "prod", "default", &ctx()).expect("render");
+        assert_eq!(
+            objects.pod_disruption_budgets.len(),
+            2,
+            "maintain disabled: only gateway and query PDBs"
+        );
+    }
+
+    #[test]
+    fn rbac_manifest_carries_no_cluster_wide_secrets_rule() {
+        // Deliverable 5, manifest lint. A dependency-free text scan of the
+        // shipped rbac.yaml, run by the existing `cargo test -p ravel-operator`
+        // gate: the operator's ClusterRole must NOT grant `secrets`, and the
+        // read must instead come from a namespaced Role. It fails on the current
+        // rbac.yaml before the narrowing lands, which is exactly the
+        // prove-the-test demonstration.
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../deploy/k8s/operator/rbac.yaml");
+        let manifest = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+        // Split into YAML documents and classify each by its `kind:` line. A
+        // ClusterRoleBinding also contains the text "ClusterRole", so match the
+        // kind line exactly rather than with a substring.
+        let docs: Vec<&str> = manifest.split("\n---").collect();
+        let kind_is =
+            |doc: &str, kind: &str| doc.lines().any(|l| l.trim() == format!("kind: {kind}"));
+
+        let cluster_role = docs
+            .iter()
+            .find(|d| kind_is(d, "ClusterRole"))
+            .expect("rbac.yaml defines a ClusterRole");
+        assert!(
+            !cluster_role.contains("secrets"),
+            "the operator ClusterRole must not grant a cluster-wide secrets rule; \
+             narrow it to a namespaced Role"
+        );
+
+        let secrets_role = docs
+            .iter()
+            .find(|d| kind_is(d, "Role") && d.contains("secrets"))
+            .expect("a namespaced Role must grant the secrets read");
+        assert!(
+            secrets_role.contains("verbs: [\"get\"]"),
+            "the namespaced secrets Role grants get only"
+        );
     }
 }


### PR DESCRIPTION
The operator rendered every pod with no security context, no anti-affinity and
no disruption budget, and its cluster role granted secrets read cluster-wide
with no resource names and no namespace, while the file's own comment claimed
narrower behaviour.

Every rendered container now runs as non-root with privilege escalation
disabled, all capabilities dropped and a read-only root filesystem. The last of
those was the one field to verify before enabling: the operator renders no cache
directory, which is the only opt-in local write, object storage is the sole
durable backend, and the only rendered volume is a read-only secret mount, so
nothing writes outside a mount. Every pod sets a non-root security context with
the runtime default seccomp profile.

Each tier gets preferred anti-affinity across hostnames, preferred rather than
required because a required rule makes the single-node kind cluster that
scripts/kind-up.sh creates unschedulable. Each tier gets a disruption budget
allowing one unavailable, rendered and owned by the reconciler like every other
object so a manual patch is not reverted on the next reconcile. That ownership
is the apply-and-sweep in the controller, which is why that file changed.

The cluster-wide secrets rule is gone, and review caught that the first
replacement was a regression: a Role bound in the operator's own namespace,
while the controller watches clusters in every namespace and reads each one's
secrets there, so a cluster anywhere else got 403 on secret resolution and
could not reconcile where it worked before. The secrets rule now lives in its
own ClusterRole that is bound only by namespaced RoleBindings, which grant it in
that namespace alone; no ClusterRoleBinding references it and a manifest lint
asserts that. The operator's namespace ships bound and a per-namespace binding
template ships beside it. Restricting the watch instead was considered and
rejected because it would reduce what the operator already does and leave the
Kubernetes guide's description of it false. A 403 on a secret read now
surfaces as a SecretsUnreadable status condition naming the namespace and the
secret, proven by flipping the status mapping, rather than a bare reconcile
failure. Resource names were considered and rejected because the secrets the
reconciler reads are user-chosen CRD fields, so no fixed list can enumerate
them. A sweep of every namespaced API the controller uses shows secrets are the
only permission not already granted cluster-wide.

The amendment no longer claims a drain cannot take a tier down: the budget
protects multi-replica tiers, and a single-replica tier can still be drained,
which is intentional. It also no longer claims Kubernetes rejects a pod needing a
dropped capability; the pod is admitted and the operation fails at runtime, and
the kind lane proves readiness and an OTLP round trip rather than rejection.

The tests enumerate every container and pod the reconciler can render rather
than sampling one, assert the exact count of disruption budgets against the
number of enabled tiers, and a manifest scan fails if a cluster-wide secrets
rule ever returns. Each is demonstrated by removing what it guards. They are
render-level; the runtime effect is left to the k8s integration lane.

Issue #36, the qualification job, is a separate change that rebases onto this
hardened pod spec.

Fixes: #126
