### PR TITLE
fix(catalog): accept format_version {1,2} on CAS-mutable sys records

### DIFF
--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -56,7 +56,8 @@ pub use key_epoch::{
 pub use metrics_meta::{
     DEFAULT_METRICS_META_ENTRY_CAP, MAX_METRICS_META_DECOMPRESSED_BYTES,
     METRICS_META_FORMAT_VERSION, MergeOutcome, MetricKind, MetricMetadataEntry, MetricsMetaDefect,
-    MetricsMetaError, merge_entries, metrics_meta_key, read_metrics_meta, write_metrics_meta,
+    MetricsMetaError, merge_entries, metrics_meta_key, read_metrics_meta,
+    read_metrics_meta_for_serve, write_metrics_meta,
 };
 pub use provisioning::{
     AbsentPolicy, DEFAULT_SCAN_SLACK_HOURS, FLUSH_BOUND_SLACK_HOURS, FloorDefect,

--- a/crates/ravel-catalog/src/metrics_meta.rs
+++ b/crates/ravel-catalog/src/metrics_meta.rs
@@ -71,6 +71,15 @@ pub const METRICS_META_FORMAT_VERSION: u32 = 1;
 /// fleet-wide.
 pub const METRICS_META_MAX_READ_VERSION: u32 = 2;
 
+/// Lowest record version the decode gate accepts: the supported read set is a
+/// closed interval `METRICS_META_MIN_READ_VERSION..=METRICS_META_MAX_READ_VERSION`,
+/// a set with a floor and not a ceiling. Version 0 is an unstamped record from a
+/// writer that never set `format_version`; admitting it would let a valid-shaped
+/// but unstamped record be served as this tenant's metadata and rewritten as
+/// version 1 by the CAS-loser re-merge, so it is refused with the same
+/// `UnsupportedVersion` error the ceiling uses (ADR-0066 decision 4).
+pub const METRICS_META_MIN_READ_VERSION: u32 = 1;
+
 /// zstd level for the record body. 3 is the level
 /// [`crate::snapshot_format`] already uses for its compressed bodies and zstd's
 /// own default; a single fixed level (never a caller-chosen one) is what makes
@@ -451,7 +460,9 @@ fn decode_record(
     key: &str,
     tenant_hash: &TenantHash,
 ) -> Result<Vec<MetricMetadataEntry>, MetricsMetaError> {
-    if record.format_version > METRICS_META_MAX_READ_VERSION {
+    if record.format_version < METRICS_META_MIN_READ_VERSION
+        || record.format_version > METRICS_META_MAX_READ_VERSION
+    {
         return Err(MetricsMetaError::UnsupportedVersion {
             key: key.to_string(),
             got: record.format_version,
@@ -628,6 +639,34 @@ pub async fn read_metrics_meta(
                     got: format_version,
                 });
             }
+            Ok(Some((entries, outcome.version)))
+        }
+        Err(StoreError::NotFound) => Ok(None),
+        Err(err) => Err(MetricsMetaError::store(&key, err)),
+    }
+}
+
+/// Read a tenant's metric metadata for a read-only serve caller (the query
+/// metadata cache), returning the decoded entries and the store version.
+///
+/// Unlike [`read_metrics_meta`], this does NOT apply the rewrite refusal
+/// (ADR-0066 decision 5): a serve caller never writes the record back, so a
+/// version-2 record it cannot reproduce byte-for-byte is still safe to read for
+/// the v1 fields this build models. The decode gate is the shared `decode_body`,
+/// so the accepted read set is the full
+/// `METRICS_META_MIN_READ_VERSION..=METRICS_META_MAX_READ_VERSION`.
+/// [`read_metrics_meta`] stays strict for the CAS-loser re-merge rewrite, which
+/// does feed a whole-record re-encode and must refuse a version it would strip.
+/// Without this split the shared reader would turn every version-2 record into an
+/// empty metadata snapshot for one horizon during the writer rollout (R2).
+pub async fn read_metrics_meta_for_serve(
+    store: &dyn ObjectStoreBackend,
+    tenant_hash: &TenantHash,
+) -> Result<Option<(Vec<MetricMetadataEntry>, Version)>, MetricsMetaError> {
+    let key = metrics_meta_key(tenant_hash);
+    match store.get(&key, GetRange::Full).await {
+        Ok(outcome) => {
+            let (entries, _format_version) = decode_body(outcome.data.as_ref(), &key, tenant_hash)?;
             Ok(Some((entries, outcome.version)))
         }
         Err(StoreError::NotFound) => Ok(None),
@@ -1246,12 +1285,14 @@ mod tests {
         zstd::bulk::compress(&record.encode_to_vec(), ZSTD_LEVEL).expect("compress")
     }
 
-    /// The decode gate's supported set is {1, 2}: a version-1 and a version-2 body
-    /// both decode through `decode_body`; a version-3 body is refused with a typed
-    /// UnsupportedVersion. Pins ADR-0066 decision 4 for the metrics-metadata reader
-    /// gate (decode_record, exercised through decode_body).
+    /// The decode gate's supported set is exactly {1, 2}, a set with a floor and a
+    /// ceiling: a version-1 and a version-2 body both decode through `decode_body`;
+    /// both a version-0 body (below the floor: an unstamped record from a writer
+    /// that never set format_version) and a version-3 body (above the ceiling) are
+    /// refused with a typed UnsupportedVersion. Pins ADR-0066 decision 4 for the
+    /// metrics-metadata reader gate (decode_record, exercised through decode_body).
     #[test]
-    fn reader_accepts_version_one_and_two_and_refuses_three() {
+    fn reader_accepts_version_one_and_two_and_refuses_zero_and_three() {
         let key = metrics_meta_key(&tenant());
         let entries = vec![entry("a", MetricKind::Counter, "h", "", 1)];
 
@@ -1271,6 +1312,61 @@ mod tests {
         assert!(
             matches!(err, MetricsMetaError::UnsupportedVersion { got: 3, .. }),
             "got: {err}"
+        );
+
+        // Version 0 (below the floor: an unstamped record) is refused too. A
+        // supported set has a floor as well as a ceiling.
+        let body = body_at_version(0, &entries);
+        let err = decode_body(&body, &key, &tenant()).expect_err("version 0 must be refused");
+        assert!(
+            matches!(err, MetricsMetaError::UnsupportedVersion { got: 0, .. }),
+            "got: {err}"
+        );
+    }
+
+    /// ADR-0066 item 2: the read-only serve reader and the strict rewrite reader
+    /// split on a version-2 record. `read_metrics_meta_for_serve` (the query
+    /// metadata cache's read) decodes a version-2 record's v1 fields and returns
+    /// them; `read_metrics_meta` (the read that feeds the CAS-loser re-merge
+    /// rewrite) refuses the same record with `RefusingToRewriteNewerRecord`. This
+    /// is what keeps the cache from serving an empty snapshot for one horizon once
+    /// a writer emits version 2 (R2), while the rewrite path stays fail-closed.
+    #[tokio::test]
+    async fn serve_reader_accepts_version_two_while_strict_reader_refuses_it() {
+        let store = mem();
+        let key = metrics_meta_key(&tenant());
+        let entries = vec![entry("a", MetricKind::Counter, "h", "u", 1)];
+        let seeded = body_at_version(2, &entries);
+        store
+            .put(&key, seeded.clone().into(), PutOptions::default())
+            .await
+            .expect("seed a version-2 record");
+
+        let (served, _version) = read_metrics_meta_for_serve(store.as_ref(), &tenant())
+            .await
+            .expect("serve reader must not error on a version-2 record")
+            .expect("a present record is Some");
+        assert_eq!(
+            served, entries,
+            "the serve reader returns the version-2 record's v1 entries"
+        );
+
+        let err = read_metrics_meta(store.as_ref(), &tenant())
+            .await
+            .expect_err("the strict rewrite reader must refuse a version-2 record");
+        assert!(
+            matches!(
+                err,
+                MetricsMetaError::RefusingToRewriteNewerRecord { got: 2, .. }
+            ),
+            "got: {err}"
+        );
+
+        let after = store.get(&key, GetRange::Full).await.expect("re-read").data;
+        assert_eq!(
+            after.as_ref(),
+            seeded.as_slice(),
+            "neither read mutated the stored record"
         );
     }
 

--- a/crates/ravel-catalog/src/metrics_meta.rs
+++ b/crates/ravel-catalog/src/metrics_meta.rs
@@ -47,11 +47,29 @@ use ravel_proto::sys::v1 as sysproto;
 use ravel_types::TenantHash;
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Format floor written into every metadata record this build emits, and the
-/// highest record version it understands. A record declaring a higher version is
-/// refused rather than misread under this layout, matching the `config` / `prov`
-/// / `enc` records' version guards.
+/// Format floor written into every metadata record this build emits: the writer,
+/// including the CAS-loser re-merge rewrite, stamps exactly this. It is also the
+/// highest version the read-merge-write rewrite can reproduce byte-for-byte, so
+/// [`read_metrics_meta`] (the read that feeds that rewrite) refuses any record
+/// declaring a version above it rather than let a whole-record re-encode strip a
+/// field it does not model (ADR-0066 decision 5).
 pub const METRICS_META_FORMAT_VERSION: u32 = 1;
+
+/// Highest record version the decode gate accepts: the supported read set is
+/// `1..=METRICS_META_MAX_READ_VERSION` (ADR-0066 decision 4). A record declaring
+/// a higher version is refused rather than misread under this layout, matching
+/// the `config` / `prov` / `enc` records' version guards.
+///
+/// This exceeds [`METRICS_META_FORMAT_VERSION`] on purpose: the decode gate
+/// accepts the next version before any writer emits it (readers-before-writers),
+/// so a future serve-only reader that models only the v1 fields reads a v2
+/// record's v1 fields rather than failing closed. Note that [`read_metrics_meta`]
+/// itself is stricter: because it returns the CAS version a caller writes back
+/// with, it doubles as the read for the CAS-loser re-merge rewrite and refuses a
+/// version above [`METRICS_META_FORMAT_VERSION`] (decision 5). The writer bump to
+/// 2 (R2) is a separate later change, sequenced after this decode gate accepts 2
+/// fleet-wide.
+pub const METRICS_META_MAX_READ_VERSION: u32 = 2;
 
 /// zstd level for the record body. 3 is the level
 /// [`crate::snapshot_format`] already uses for its compressed bodies and zstd's
@@ -220,9 +238,23 @@ pub enum MetricsMetaError {
     },
     #[error(
         "metadata record {key:?} declares format_version {got}, but this build only understands \
-         version {METRICS_META_FORMAT_VERSION}: refusing rather than misread a future record format"
+         versions 1..={METRICS_META_MAX_READ_VERSION}: refusing rather than misread a future record \
+         format"
     )]
     UnsupportedVersion { key: String, got: u32 },
+    /// [`read_metrics_meta`] read a record declaring a version this build's writer
+    /// cannot reproduce (> [`METRICS_META_FORMAT_VERSION`]). That read feeds the
+    /// CAS-loser re-merge, which re-encodes the whole record through this build's
+    /// field set, so a field a newer writer added would be silently dropped on the
+    /// write-back; the read is refused so the merge never runs and nothing is
+    /// stripped (ADR-0066 decision 5). The decode gate itself still accepts the
+    /// record up to [`METRICS_META_MAX_READ_VERSION`] for a read-only serve path.
+    #[error(
+        "metadata record {key:?} declares format_version {got}, newer than this build's writer \
+         version {METRICS_META_FORMAT_VERSION}: refusing to read it for a whole-record rewrite that \
+         would strip fields this build does not model (ADR-0066 decision 5)"
+    )]
+    RefusingToRewriteNewerRecord { key: String, got: u32 },
     /// The record records a different tenant than the key it was read under. It
     /// is another tenant's metadata misfiled here; serving it would leak one
     /// tenant's metric names to another, so it is refused (the
@@ -419,7 +451,7 @@ fn decode_record(
     key: &str,
     tenant_hash: &TenantHash,
 ) -> Result<Vec<MetricMetadataEntry>, MetricsMetaError> {
-    if record.format_version > METRICS_META_FORMAT_VERSION {
+    if record.format_version > METRICS_META_MAX_READ_VERSION {
         return Err(MetricsMetaError::UnsupportedVersion {
             key: key.to_string(),
             got: record.format_version,
@@ -522,12 +554,16 @@ fn decompress_body(key: &str, body: &[u8]) -> Result<Vec<u8>, MetricsMetaError> 
     Ok(out)
 }
 
-/// Decode a stored body into domain entries: decompress, prost-decode, validate.
+/// Decode a stored body into domain entries plus the record's declared
+/// `format_version`: decompress, prost-decode, validate. The version is returned
+/// alongside the entries so a rewrite caller can refuse a record newer than it
+/// can reproduce (ADR-0066 decision 5); the entry validation here accepts the
+/// full supported read set (up to [`METRICS_META_MAX_READ_VERSION`]).
 fn decode_body(
     body: &[u8],
     key: &str,
     tenant_hash: &TenantHash,
-) -> Result<Vec<MetricMetadataEntry>, MetricsMetaError> {
+) -> Result<(Vec<MetricMetadataEntry>, u32), MetricsMetaError> {
     let raw = decompress_body(key, body)?;
     let record = sysproto::MetricMetadataRecord::decode(raw.as_slice()).map_err(|source| {
         MetricsMetaError::Decode {
@@ -535,7 +571,9 @@ fn decode_body(
             source,
         }
     })?;
-    decode_record(&record, key, tenant_hash)
+    let format_version = record.format_version;
+    let entries = decode_record(&record, key, tenant_hash)?;
+    Ok((entries, format_version))
 }
 
 /// Refuse an entry set that would make a corrupt record before it is written. A
@@ -576,7 +614,20 @@ pub async fn read_metrics_meta(
     let key = metrics_meta_key(tenant_hash);
     match store.get(&key, GetRange::Full).await {
         Ok(outcome) => {
-            let entries = decode_body(outcome.data.as_ref(), &key, tenant_hash)?;
+            let (entries, format_version) = decode_body(outcome.data.as_ref(), &key, tenant_hash)?;
+            // Rewrite refusal (ADR-0066 decision 5): the returned version is what a
+            // caller CAS-writes back against after a re-merge, so this read feeds a
+            // whole-record rewrite. A record a newer writer wrote may carry a field
+            // this build does not model, which the re-encode would strip; refuse it
+            // here so the merge never runs. A read failure makes the sink drop the
+            // window (no write, no strip) and the serve path fall back to an empty
+            // record for one horizon, both fail-safe.
+            if format_version > METRICS_META_FORMAT_VERSION {
+                return Err(MetricsMetaError::RefusingToRewriteNewerRecord {
+                    key,
+                    got: format_version,
+                });
+            }
             Ok(Some((entries, outcome.version)))
         }
         Err(StoreError::NotFound) => Ok(None),
@@ -1176,31 +1227,86 @@ mod tests {
         assert_eq!(out.merged, out2.merged, "order-independent, byte-stable");
     }
 
-    /// A record declaring a future format_version is refused rather than misread
-    /// under this layout.
+    /// ADR-0066 R1: the writer still stamps 1 while the decode gate accepts
+    /// {1, 2}. A premature writer bump (R2) would flip these pins.
+    #[test]
+    fn writer_stamps_one_while_reader_accepts_two() {
+        let built = build_record(&tenant(), &[entry("a", MetricKind::Counter, "h", "", 1)]);
+        assert_eq!(built.format_version, 1, "writer stamps version 1 (R1)");
+        assert_eq!(METRICS_META_FORMAT_VERSION, 1);
+        assert_eq!(METRICS_META_MAX_READ_VERSION, 2);
+    }
+
+    /// Compress a record at an explicit `format_version` into a stored body,
+    /// bypassing the writer's version stamp, so a test can seed exactly the record
+    /// a newer or too-new writer would leave on disk.
+    fn body_at_version(version: u32, entries: &[MetricMetadataEntry]) -> Vec<u8> {
+        let mut record = build_record(&tenant(), entries);
+        record.format_version = version;
+        zstd::bulk::compress(&record.encode_to_vec(), ZSTD_LEVEL).expect("compress")
+    }
+
+    /// The decode gate's supported set is {1, 2}: a version-1 and a version-2 body
+    /// both decode through `decode_body`; a version-3 body is refused with a typed
+    /// UnsupportedVersion. Pins ADR-0066 decision 4 for the metrics-metadata reader
+    /// gate (decode_record, exercised through decode_body).
+    #[test]
+    fn reader_accepts_version_one_and_two_and_refuses_three() {
+        let key = metrics_meta_key(&tenant());
+        let entries = vec![entry("a", MetricKind::Counter, "h", "", 1)];
+
+        for version in [1u32, 2u32] {
+            let body = body_at_version(version, &entries);
+            let (decoded, fv) = decode_body(&body, &key, &tenant())
+                .unwrap_or_else(|e| panic!("version {version} must decode: {e}"));
+            assert_eq!(
+                decoded, entries,
+                "version {version} entries decode unchanged"
+            );
+            assert_eq!(fv, version, "decode reports the record's own version");
+        }
+
+        let body = body_at_version(3, &entries);
+        let err = decode_body(&body, &key, &tenant()).expect_err("version 3 must be refused");
+        assert!(
+            matches!(err, MetricsMetaError::UnsupportedVersion { got: 3, .. }),
+            "got: {err}"
+        );
+    }
+
+    /// The merge-and-rewrite equivalent of the tenant-config test: reading a
+    /// version-2 record for the CAS-loser re-merge is REFUSED, not decoded into
+    /// entries a version-1 writer would re-encode and strip. `read_metrics_meta`
+    /// returns the CAS version a caller writes back with, so it is the read that
+    /// feeds the rewrite; it refuses the newer record. The stored bytes must be
+    /// exactly unchanged (the read errored before any merge or write). Named per
+    /// ADR-0066 R1 (decision 5).
     #[tokio::test]
-    async fn read_rejects_future_format_version() {
+    async fn rewrite_refuses_a_version_two_record_from_a_version_one_writer() {
         let store = mem();
-        let mut record = build_record(&tenant(), &[entry("a", MetricKind::Counter, "h", "", 1)]);
-        record.format_version = METRICS_META_FORMAT_VERSION + 1;
-        let body = zstd::bulk::compress(&record.encode_to_vec(), ZSTD_LEVEL).expect("compress");
+        let key = metrics_meta_key(&tenant());
+        let seeded = body_at_version(2, &[entry("a", MetricKind::Counter, "h", "u", 1)]);
         store
-            .put(
-                &metrics_meta_key(&tenant()),
-                body.into(),
-                PutOptions::default(),
-            )
+            .put(&key, seeded.clone().into(), PutOptions::default())
             .await
-            .expect("seed future record");
+            .expect("seed a version-2 record");
+
         let err = read_metrics_meta(store.as_ref(), &tenant())
             .await
-            .expect_err("a future format_version must be refused");
+            .expect_err("reading a newer record for a rewrite must be refused");
         assert!(
             matches!(
                 err,
-                MetricsMetaError::UnsupportedVersion { got, .. } if got == METRICS_META_FORMAT_VERSION + 1
+                MetricsMetaError::RefusingToRewriteNewerRecord { got: 2, .. }
             ),
             "got: {err}"
+        );
+
+        let after = store.get(&key, GetRange::Full).await.expect("re-read").data;
+        assert_eq!(
+            after.as_ref(),
+            seeded.as_slice(),
+            "the stored version-2 record must be byte-for-byte unchanged"
         );
     }
 
@@ -1466,8 +1572,9 @@ mod tests {
         fn encode_decode_round_trip_is_identity(entries in entries_strategy(24)) {
             let key = metrics_meta_key(&tenant());
             let body = encode_body(&tenant(), &entries, &key).expect("encode");
-            let decoded = decode_body(&body, &key, &tenant()).expect("decode");
+            let (decoded, format_version) = decode_body(&body, &key, &tenant()).expect("decode");
             prop_assert_eq!(decoded, entries);
+            prop_assert_eq!(format_version, METRICS_META_FORMAT_VERSION);
         }
 
         /// The merge is idempotent: applying the same incoming set to its own

--- a/crates/ravel-catalog/src/provisioning.rs
+++ b/crates/ravel-catalog/src/provisioning.rs
@@ -62,6 +62,15 @@ pub const PROVISIONING_FORMAT_VERSION: u32 = 1;
 /// 2 fleet-wide.
 pub const PROVISIONING_MAX_READ_VERSION: u32 = 2;
 
+/// Lowest record version a reader accepts: the supported read set is a closed
+/// interval `PROVISIONING_MIN_READ_VERSION..=PROVISIONING_MAX_READ_VERSION`, a
+/// set with a floor and not a ceiling. Version 0 is an unstamped record from a
+/// writer that never set `format_version`; admitting it would let a valid-shaped
+/// but unstamped record enter shard routing and be rewritten as version 1 by a
+/// CAS path, so it is refused with the same `UnsupportedVersion` error the
+/// ceiling uses (ADR-0066 decision 4).
+pub const PROVISIONING_MIN_READ_VERSION: u32 = 1;
+
 /// Object key for a (tenant, signal) provisioning record: `t/<hex>/<sig>/prov`.
 /// Under the tenant's own prefix, alongside its `l0/` and `c/` shard data, not
 /// a bucket-root `sys/` object (ADR-0050 section 5).
@@ -849,7 +858,9 @@ pub fn read_generations_checked(
     tenant_hash: &TenantHash,
     signal: Signal,
 ) -> Result<Vec<ShardGeneration>, ProvisioningError> {
-    if record.format_version > PROVISIONING_MAX_READ_VERSION {
+    if record.format_version < PROVISIONING_MIN_READ_VERSION
+        || record.format_version > PROVISIONING_MAX_READ_VERSION
+    {
         return Err(ProvisioningError::UnsupportedVersion {
             key: key.to_string(),
             got: record.format_version,
@@ -1121,7 +1132,9 @@ fn validate_record(
     signal: Signal,
     shard_count: u32,
 ) -> Result<(), ProvisioningError> {
-    if record.format_version > PROVISIONING_MAX_READ_VERSION {
+    if record.format_version < PROVISIONING_MIN_READ_VERSION
+        || record.format_version > PROVISIONING_MAX_READ_VERSION
+    {
         return Err(ProvisioningError::UnsupportedVersion {
             key: key.to_string(),
             got: record.format_version,
@@ -1631,7 +1644,9 @@ pub fn read_floors_checked(
     tenant_hash: &TenantHash,
     signal: Signal,
 ) -> Result<Vec<FormatFloor>, ProvisioningError> {
-    if record.format_version > PROVISIONING_MAX_READ_VERSION {
+    if record.format_version < PROVISIONING_MIN_READ_VERSION
+        || record.format_version > PROVISIONING_MAX_READ_VERSION
+    {
         return Err(ProvisioningError::UnsupportedVersion {
             key: key.to_string(),
             got: record.format_version,
@@ -2354,7 +2369,7 @@ pub(crate) mod tests {
         let mut record = build_record(&tenant(), Signal::Metrics, 4, 1_000);
         // A version past the supported read set (3, above PROVISIONING_MAX_READ_VERSION
         // = 2). Version 2 is now inside the read set and is accepted on the read
-        // path (see reader_accepts_version_one_and_two_and_refuses_three).
+        // path (see reader_accepts_version_one_and_two_and_refuses_zero_and_three).
         record.format_version = PROVISIONING_MAX_READ_VERSION + 1;
         store
             .put(&key, record.encode_to_vec().into(), PutOptions::default())
@@ -3305,7 +3320,7 @@ pub(crate) mod tests {
     /// (version 3, above PROVISIONING_MAX_READ_VERSION) before ever trusting its
     /// generation history, matching the guard [`validate_record`] applies on the
     /// [`validate_or_adopt`] path. Version 2 is inside the set and is accepted
-    /// (see reader_accepts_version_one_and_two_and_refuses_three).
+    /// (see reader_accepts_version_one_and_two_and_refuses_zero_and_three).
     #[test]
     fn read_generations_checked_rejects_future_format_version() {
         let record = sysproto::ProvisioningRecord {
@@ -4069,13 +4084,16 @@ pub(crate) mod tests {
         }
     }
 
-    /// The read-side supported set is {1, 2}: a version-1 and a version-2 record
-    /// are both accepted at every reader gate (validate_or_adopt's validate_record,
-    /// read_generations_checked, read_floors_checked), and a version-3 record is
-    /// refused at each with a typed UnsupportedVersion. Pins ADR-0066 decision 4's
-    /// "accepting {1, 2} and refusing 3" for the three provisioning reader sites.
+    /// The read-side supported set is exactly {1, 2}, a closed set with a floor
+    /// and a ceiling: a version-1 and a version-2 record are both accepted at
+    /// every reader gate (validate_or_adopt's validate_record,
+    /// read_generations_checked, read_floors_checked), while both a version-0
+    /// record (below the floor: an unstamped record from a writer that never set
+    /// format_version) and a version-3 record (above the ceiling) are refused at
+    /// each with a typed UnsupportedVersion. Pins ADR-0066 decision 4's supported
+    /// set for the three provisioning reader sites.
     #[tokio::test]
-    async fn reader_accepts_version_one_and_two_and_refuses_three() {
+    async fn reader_accepts_version_one_and_two_and_refuses_zero_and_three() {
         let key = provisioning_key(&tenant(), Signal::Metrics);
 
         for version in [1u32, 2u32] {
@@ -4143,6 +4161,48 @@ pub(crate) mod tests {
                 Err(ProvisioningError::UnsupportedVersion { got: 3, .. })
             ),
             "validate_record must refuse version 3"
+        );
+
+        // Version 0 (below the floor: an unstamped record from a writer that
+        // never set format_version) is refused at each gate. A supported set has
+        // a floor as well as a ceiling: admitting version 0 would let a
+        // valid-shaped but unstamped record enter shard routing and later be
+        // rewritten as version 1 by a CAS path.
+        let mut v0 = build_record(&tenant(), Signal::Metrics, 4, 1_000);
+        v0.format_version = 0;
+        assert!(
+            matches!(
+                read_generations_checked(&v0, &key, &tenant(), Signal::Metrics),
+                Err(ProvisioningError::UnsupportedVersion { got: 0, .. })
+            ),
+            "read_generations_checked must refuse version 0"
+        );
+        assert!(
+            matches!(
+                read_floors_checked(&v0, &key, &tenant(), Signal::Metrics),
+                Err(ProvisioningError::UnsupportedVersion { got: 0, .. })
+            ),
+            "read_floors_checked must refuse version 0"
+        );
+        let store = mem();
+        store
+            .put(&key, v0.encode_to_vec().into(), PutOptions::default())
+            .await
+            .expect("seed v0");
+        assert!(
+            matches!(
+                validate_or_adopt(
+                    store.as_ref(),
+                    &tenant(),
+                    Signal::Metrics,
+                    4,
+                    1_000,
+                    AbsentPolicy::CheckOnly,
+                )
+                .await,
+                Err(ProvisioningError::UnsupportedVersion { got: 0, .. })
+            ),
+            "validate_record must refuse version 0"
         );
     }
 

--- a/crates/ravel-catalog/src/provisioning.rs
+++ b/crates/ravel-catalog/src/provisioning.rs
@@ -38,11 +38,29 @@ use ravel_object_store::{
 use ravel_proto::sys::v1 as sysproto;
 use ravel_types::{Signal, TenantHash};
 
-/// Format floor written into every provisioning record this build emits, and
-/// the highest record version it understands. A record declaring a higher
-/// version is refused rather than misread under this layout (ADR-0050 section
-/// 5), matching the `sys/tenancy` marker's version guard.
+/// Format floor written into every provisioning record this build emits: every
+/// writer, including the CAS rewrite paths ([`append_generation`],
+/// [`raise_format_floor`]), stamps exactly this. It is also the highest version
+/// a rewrite path can reproduce byte-for-byte, so a rewrite refuses any record
+/// declaring a version above it rather than strip a field it does not model
+/// (ADR-0066 decision 5).
 pub const PROVISIONING_FORMAT_VERSION: u32 = 1;
+
+/// Highest record version a reader accepts: the supported read set is
+/// `1..=PROVISIONING_MAX_READ_VERSION` (ADR-0066 decision 4). A record declaring
+/// a higher version is refused rather than misread under this layout, matching
+/// the `sys/tenancy` marker's version guard.
+///
+/// This exceeds [`PROVISIONING_FORMAT_VERSION`] on purpose: readers accept the
+/// next version before any writer emits it (readers-before-writers), so a
+/// lagging binary meeting a record a newer peer wrote halts nowhere on the read
+/// path. This record is read on the ingest hot path by `GenerationSwitch`, which
+/// fails a flush closed on a read failure, so a single-release bump that refused
+/// the newer version would be a fleet-wide ingest outage during any rolling
+/// upgrade; the two-release readers-then-writers split avoids it. The writer
+/// bump to 2 (R2) is a separate later change, sequenced after this reader accepts
+/// 2 fleet-wide.
+pub const PROVISIONING_MAX_READ_VERSION: u32 = 2;
 
 /// Object key for a (tenant, signal) provisioning record: `t/<hex>/<sig>/prov`.
 /// Under the tenant's own prefix, alongside its `l0/` and `c/` shard data, not
@@ -97,10 +115,23 @@ pub enum ProvisioningError {
     },
     #[error(
         "provisioning record {key:?} declares format_version {got}, but this build only \
-         understands version {PROVISIONING_FORMAT_VERSION}: refusing rather than misread a future \
-         record format"
+         understands versions 1..={PROVISIONING_MAX_READ_VERSION}: refusing rather than misread a \
+         future record format"
     )]
     UnsupportedVersion { key: String, got: u32 },
+    /// A CAS rewrite path ([`append_generation`], [`raise_format_floor`]) read a
+    /// record declaring a version this build's writer cannot reproduce
+    /// (> [`PROVISIONING_FORMAT_VERSION`]). Rewriting it whole would re-encode
+    /// through this build's field set and silently drop any field a newer writer
+    /// added, so the rewrite is refused and nothing is written (ADR-0066 decision
+    /// 5). A read-only path still accepts the record (up to
+    /// [`PROVISIONING_MAX_READ_VERSION`]); only a rewrite is refused.
+    #[error(
+        "provisioning record {key:?} declares format_version {got}, newer than this build's writer \
+         version {PROVISIONING_FORMAT_VERSION}: refusing to rewrite it whole and strip fields this \
+         build does not model (ADR-0066 decision 5)"
+    )]
+    RefusingToRewriteNewerRecord { key: String, got: u32 },
     #[error(
         "provisioning record {key:?} is misfiled: it records {field} {actual}, but the key it was \
          read under expects {expected}"
@@ -818,7 +849,7 @@ pub fn read_generations_checked(
     tenant_hash: &TenantHash,
     signal: Signal,
 ) -> Result<Vec<ShardGeneration>, ProvisioningError> {
-    if record.format_version > PROVISIONING_FORMAT_VERSION {
+    if record.format_version > PROVISIONING_MAX_READ_VERSION {
         return Err(ProvisioningError::UnsupportedVersion {
             key: key.to_string(),
             got: record.format_version,
@@ -1090,7 +1121,7 @@ fn validate_record(
     signal: Signal,
     shard_count: u32,
 ) -> Result<(), ProvisioningError> {
-    if record.format_version > PROVISIONING_FORMAT_VERSION {
+    if record.format_version > PROVISIONING_MAX_READ_VERSION {
         return Err(ProvisioningError::UnsupportedVersion {
             key: key.to_string(),
             got: record.format_version,
@@ -1408,6 +1439,20 @@ pub async fn append_generation(
         Err(err) => return Err(ProvisioningError::store(&key, err)),
     };
 
+    // Rewrite refusal (ADR-0066 decision 5): this appends and writes the record
+    // back whole, re-encoding through this build's field set. A record a newer
+    // writer wrote (version above what this build stamps) may carry a field this
+    // build does not model, which a whole-record rewrite would silently strip. A
+    // read-only path tolerates such a record (up to PROVISIONING_MAX_READ_VERSION);
+    // a rewrite must refuse it. Checked before read_generations_checked, which
+    // accepts the wider read set and so would let a newer record through here.
+    if record.format_version > PROVISIONING_FORMAT_VERSION {
+        return Err(ProvisioningError::RefusingToRewriteNewerRecord {
+            key,
+            got: record.format_version,
+        });
+    }
+
     // Version, misfile, and history-corruption guard, then normalize the
     // existing history (fail closed on any of these) before extending it. A
     // record misfiled under the wrong tenant or signal must never be extended
@@ -1586,7 +1631,7 @@ pub fn read_floors_checked(
     tenant_hash: &TenantHash,
     signal: Signal,
 ) -> Result<Vec<FormatFloor>, ProvisioningError> {
-    if record.format_version > PROVISIONING_FORMAT_VERSION {
+    if record.format_version > PROVISIONING_MAX_READ_VERSION {
         return Err(ProvisioningError::UnsupportedVersion {
             key: key.to_string(),
             got: record.format_version,
@@ -1722,6 +1767,18 @@ pub async fn raise_format_floor(
         }
         Err(err) => return Err(ProvisioningError::store(&key, err)),
     };
+
+    // Rewrite refusal (ADR-0066 decision 5): raising a floor writes the record
+    // back whole, so a record a newer writer wrote may carry a field this build
+    // does not model that the rewrite would strip. A read-only path tolerates it
+    // (up to PROVISIONING_MAX_READ_VERSION); this rewrite refuses it, before
+    // read_floors_checked lets the wider read set through.
+    if record.format_version > PROVISIONING_FORMAT_VERSION {
+        return Err(ProvisioningError::RefusingToRewriteNewerRecord {
+            key,
+            got: record.format_version,
+        });
+    }
 
     // Version, misfile, and history-corruption guard, then normalize the
     // existing floor history (fail closed on any of these) before extending it.
@@ -2295,7 +2352,10 @@ pub(crate) mod tests {
         let store = mem();
         let key = provisioning_key(&tenant(), Signal::Metrics);
         let mut record = build_record(&tenant(), Signal::Metrics, 4, 1_000);
-        record.format_version = PROVISIONING_FORMAT_VERSION + 1;
+        // A version past the supported read set (3, above PROVISIONING_MAX_READ_VERSION
+        // = 2). Version 2 is now inside the read set and is accepted on the read
+        // path (see reader_accepts_version_one_and_two_and_refuses_three).
+        record.format_version = PROVISIONING_MAX_READ_VERSION + 1;
         store
             .put(&key, record.encode_to_vec().into(), PutOptions::default())
             .await
@@ -3241,13 +3301,15 @@ pub(crate) mod tests {
         assert_eq!(gens[0].activation_hour, 0);
     }
 
-    /// [`read_generations_checked`] refuses a record from a future format
-    /// version before ever trusting its generation history, matching the guard
-    /// [`validate_record`] already applies on the [`validate_or_adopt`] path.
+    /// [`read_generations_checked`] refuses a record past the supported read set
+    /// (version 3, above PROVISIONING_MAX_READ_VERSION) before ever trusting its
+    /// generation history, matching the guard [`validate_record`] applies on the
+    /// [`validate_or_adopt`] path. Version 2 is inside the set and is accepted
+    /// (see reader_accepts_version_one_and_two_and_refuses_three).
     #[test]
     fn read_generations_checked_rejects_future_format_version() {
         let record = sysproto::ProvisioningRecord {
-            format_version: PROVISIONING_FORMAT_VERSION + 1,
+            format_version: PROVISIONING_MAX_READ_VERSION + 1,
             tenant_hash: tenant().0.to_vec(),
             signal: sysproto::Signal::Metrics as i32,
             shard_count: 4,
@@ -3973,9 +4035,254 @@ pub(crate) mod tests {
             built.format_floors.is_empty(),
             "a freshly built record carries no floors"
         );
+        // ADR-0066 R1: the writer still stamps 1 while readers accept {1, 2}. A
+        // premature writer bump (R2) would flip these pins.
+        assert_eq!(built.format_version, 1, "writer stamps version 1 (R1)");
+        assert_eq!(PROVISIONING_FORMAT_VERSION, 1);
+        assert_eq!(PROVISIONING_MAX_READ_VERSION, 2);
         let key = provisioning_key(&tenant(), Signal::Metrics);
         let floors = read_floors(&built, &key).expect("empty floor history is valid");
         assert!(floors.is_empty(), "empty history reads as no floors");
         assert_eq!(current_floor(&floors, RSEG), None);
+    }
+
+    // ---- ADR-0066 R1: reader supported set {1, 2}, rewrite refuses newer ----
+
+    /// A version-2 record shaped exactly like one a newer writer would persist:
+    /// generation 0's implicit count plus a raised format floor in field 7,
+    /// stamped `format_version = 2`. `raise_unix`/`raised_by` are pinned so the
+    /// encoded bytes are deterministic for the exact-bytes preservation check.
+    fn version_two_record_with_floor() -> sysproto::ProvisioningRecord {
+        sysproto::ProvisioningRecord {
+            format_version: 2,
+            tenant_hash: tenant().0.to_vec(),
+            signal: sysproto::Signal::Metrics as i32,
+            shard_count: 4,
+            created_unix_ns: 1_000,
+            generations: Vec::new(),
+            format_floors: vec![sysproto::FormatFloor {
+                family: "rseg".to_string(),
+                floor_version: 6,
+                raised_unix_ns: 2_000,
+                raised_by: "migrate".to_string(),
+            }],
+        }
+    }
+
+    /// The read-side supported set is {1, 2}: a version-1 and a version-2 record
+    /// are both accepted at every reader gate (validate_or_adopt's validate_record,
+    /// read_generations_checked, read_floors_checked), and a version-3 record is
+    /// refused at each with a typed UnsupportedVersion. Pins ADR-0066 decision 4's
+    /// "accepting {1, 2} and refusing 3" for the three provisioning reader sites.
+    #[tokio::test]
+    async fn reader_accepts_version_one_and_two_and_refuses_three() {
+        let key = provisioning_key(&tenant(), Signal::Metrics);
+
+        for version in [1u32, 2u32] {
+            let mut record = build_record(&tenant(), Signal::Metrics, 4, 1_000);
+            record.format_version = version;
+
+            // read_generations_checked (site 1) accepts it.
+            read_generations_checked(&record, &key, &tenant(), Signal::Metrics)
+                .unwrap_or_else(|e| panic!("version {version} must be read-accepted: {e}"));
+            // read_floors_checked (site 3) accepts it.
+            read_floors_checked(&record, &key, &tenant(), Signal::Metrics)
+                .unwrap_or_else(|e| panic!("version {version} floors must be accepted: {e}"));
+
+            // validate_record via validate_or_adopt's CheckOnly path (site 2).
+            let store = mem();
+            store
+                .put(&key, record.encode_to_vec().into(), PutOptions::default())
+                .await
+                .expect("seed record");
+            validate_or_adopt(
+                store.as_ref(),
+                &tenant(),
+                Signal::Metrics,
+                4,
+                1_000,
+                AbsentPolicy::CheckOnly,
+            )
+            .await
+            .unwrap_or_else(|e| panic!("version {version} must pass validate_record: {e}"));
+        }
+
+        // Version 3 (one past the read set) is refused at each gate.
+        let mut v3 = build_record(&tenant(), Signal::Metrics, 4, 1_000);
+        v3.format_version = 3;
+        assert!(
+            matches!(
+                read_generations_checked(&v3, &key, &tenant(), Signal::Metrics),
+                Err(ProvisioningError::UnsupportedVersion { got: 3, .. })
+            ),
+            "read_generations_checked must refuse version 3"
+        );
+        assert!(
+            matches!(
+                read_floors_checked(&v3, &key, &tenant(), Signal::Metrics),
+                Err(ProvisioningError::UnsupportedVersion { got: 3, .. })
+            ),
+            "read_floors_checked must refuse version 3"
+        );
+        let store = mem();
+        store
+            .put(&key, v3.encode_to_vec().into(), PutOptions::default())
+            .await
+            .expect("seed v3");
+        assert!(
+            matches!(
+                validate_or_adopt(
+                    store.as_ref(),
+                    &tenant(),
+                    Signal::Metrics,
+                    4,
+                    1_000,
+                    AbsentPolicy::CheckOnly,
+                )
+                .await,
+                Err(ProvisioningError::UnsupportedVersion { got: 3, .. })
+            ),
+            "validate_record must refuse version 3"
+        );
+    }
+
+    /// A version-2 record carrying a format floor (field 7) put through the
+    /// old-shaped `append_generation` rewrite is REFUSED, not stripped: the
+    /// rewrite re-encodes the whole record through this build's field set, which
+    /// would drop a field a newer writer added. The stored bytes must be exactly
+    /// unchanged after the refusal (no CAS write happened at all). Named per the
+    /// ADR-0066 R1 spec; field 7 is one this build does model, so the refusal is
+    /// version-driven (a v2 record may carry a field this build does NOT model),
+    /// not field-driven.
+    #[tokio::test]
+    async fn append_generation_preserves_format_floors_written_by_a_newer_writer() {
+        let store = mem();
+        let key = provisioning_key(&tenant(), Signal::Metrics);
+        let seeded = version_two_record_with_floor().encode_to_vec();
+        store
+            .put(&key, seeded.clone().into(), PutOptions::default())
+            .await
+            .expect("seed a version-2 record with a format floor");
+
+        // Reshard append onto a version-2 record: refused, not stripped.
+        let err = append_generation(store.as_ref(), &tenant(), Signal::Metrics, 8, 1_000_000, 0)
+            .await
+            .expect_err("appending onto a newer record must be refused");
+        assert!(
+            matches!(
+                err,
+                ProvisioningError::RefusingToRewriteNewerRecord { got: 2, .. }
+            ),
+            "got: {err}"
+        );
+
+        // Exact-bytes: nothing was written back, the newer record is intact.
+        let after = store.get(&key, GetRange::Full).await.expect("re-read").data;
+        assert_eq!(
+            after.as_ref(),
+            seeded.as_slice(),
+            "the stored version-2 record must be byte-for-byte unchanged"
+        );
+    }
+
+    /// The sibling rewrite path: `raise_format_floor` refuses a version-2 record
+    /// too, leaving its bytes exactly unchanged. Sweeps the rule across both CAS
+    /// rewrite paths of this record, not only the one the spec named.
+    #[tokio::test]
+    async fn raise_format_floor_refuses_a_version_two_record_from_a_version_one_writer() {
+        let store = mem();
+        let key = provisioning_key(&tenant(), Signal::Metrics);
+        let seeded = version_two_record_with_floor().encode_to_vec();
+        store
+            .put(&key, seeded.clone().into(), PutOptions::default())
+            .await
+            .expect("seed a version-2 record");
+
+        let err = raise_format_floor(
+            store.as_ref(),
+            &tenant(),
+            Signal::Metrics,
+            "rseg",
+            9,
+            "job",
+            3_000,
+        )
+        .await
+        .expect_err("raising a floor on a newer record must be refused");
+        assert!(
+            matches!(
+                err,
+                ProvisioningError::RefusingToRewriteNewerRecord { got: 2, .. }
+            ),
+            "got: {err}"
+        );
+
+        let after = store.get(&key, GetRange::Full).await.expect("re-read").data;
+        assert_eq!(
+            after.as_ref(),
+            seeded.as_slice(),
+            "the stored version-2 record must be byte-for-byte unchanged"
+        );
+    }
+
+    /// Decode fails closed with a typed error, never a panic or wrong data, on
+    /// three malformed inputs through the raw-store read path: an unknown
+    /// (too-new) format version, a truncated body, and a corrupted body. Covers
+    /// ADR-0066's "typed error, never a panic" for the provisioning decode gate.
+    #[tokio::test]
+    async fn decode_rejects_truncated_and_corrupt_record() {
+        let key = provisioning_key(&tenant(), Signal::Metrics);
+
+        // 1. Unknown (too-new) version: a well-formed record stamped past the read
+        //    set is a typed UnsupportedVersion, surfaced through the checked read.
+        let mut future = build_record(&tenant(), Signal::Metrics, 4, 1_000);
+        future.format_version = PROVISIONING_MAX_READ_VERSION + 1;
+        let store = mem();
+        store
+            .put(&key, future.encode_to_vec().into(), PutOptions::default())
+            .await
+            .expect("seed future record");
+        let err = read_generations_from_store(store.as_ref(), &tenant(), Signal::Metrics)
+            .await
+            .expect_err("an unknown version must be a typed error");
+        assert!(
+            matches!(err, ProvisioningError::UnsupportedVersion { got, .. } if got == PROVISIONING_MAX_READ_VERSION + 1),
+            "got: {err}"
+        );
+
+        // 2. Truncated body: a valid record encoding cut in half is a typed Decode
+        //    error, not a panic.
+        let full = build_record(&tenant(), Signal::Metrics, 4, 1_000).encode_to_vec();
+        let truncated = full[..full.len() / 2].to_vec();
+        let store = mem();
+        store
+            .put(&key, truncated.into(), PutOptions::default())
+            .await
+            .expect("seed truncated body");
+        let err = read_generations_from_store(store.as_ref(), &tenant(), Signal::Metrics)
+            .await
+            .expect_err("a truncated body must be a typed error");
+        assert!(
+            matches!(err, ProvisioningError::Decode { .. }),
+            "got: {err}"
+        );
+
+        // 3. Corrupted body: arbitrary garbage bytes are a typed Decode error.
+        let store = mem();
+        store
+            .put(
+                &key,
+                vec![0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x42].into(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("seed garbage body");
+        let err = read_generations_from_store(store.as_ref(), &tenant(), Signal::Metrics)
+            .await
+            .expect_err("a corrupt body must be a typed error");
+        assert!(
+            matches!(err, ProvisioningError::Decode { .. }),
+            "got: {err}"
+        );
     }
 }

--- a/crates/ravel-catalog/src/tenant_config.rs
+++ b/crates/ravel-catalog/src/tenant_config.rs
@@ -38,11 +38,26 @@ use ravel_object_store::{GetRange, ObjectStoreBackend, PutMode, PutOptions, Stor
 use ravel_proto::sys::v1 as sysproto;
 use ravel_types::TenantHash;
 
-/// Format floor written into every config record this build emits, and the
-/// highest record version it understands. A record declaring a higher version is
-/// refused rather than misread under this layout, matching the `prov` / `enc`
-/// records' version guards (both other `t/<hash>/` records in this crate).
+/// Format floor written into every config record this build emits: the writer,
+/// including the CAS-replace rewrite in [`set_tenant_config`], stamps exactly
+/// this. It is also the highest version a rewrite can reproduce byte-for-byte, so
+/// a rewrite refuses any record declaring a version above it rather than strip a
+/// field it does not model (ADR-0066 decision 5).
 pub const TENANT_CONFIG_FORMAT_VERSION: u32 = 1;
+
+/// Highest record version a reader accepts: the supported read set is
+/// `1..=TENANT_CONFIG_MAX_READ_VERSION` (ADR-0066 decision 4). A record declaring
+/// a higher version is refused rather than misread under this layout, matching
+/// the `prov` / `enc` records' version guards.
+///
+/// This exceeds [`TENANT_CONFIG_FORMAT_VERSION`] on purpose: readers accept the
+/// next version before any writer emits it (readers-before-writers), so a lagging
+/// binary reading a record a newer peer wrote does not fail closed. The lifecycle
+/// refresh loop reads this record on a bounded-staleness horizon; a single-release
+/// bump that refused the newer version would break that refresh across a rolling
+/// upgrade. The writer bump to 2 (R2) is a separate later change, sequenced after
+/// this reader accepts 2 fleet-wide.
+pub const TENANT_CONFIG_MAX_READ_VERSION: u32 = 2;
 
 /// Object key for a tenant's config record: `t/<hex>/config`. Tenant-scoped, not
 /// per-signal (ADR-0066 decision 6). Under the tenant's own prefix, alongside its
@@ -318,9 +333,22 @@ pub enum TenantConfigError {
     },
     #[error(
         "config record {key:?} declares format_version {got}, but this build only understands \
-         version {TENANT_CONFIG_FORMAT_VERSION}: refusing rather than misread a future record format"
+         versions 1..={TENANT_CONFIG_MAX_READ_VERSION}: refusing rather than misread a future \
+         record format"
     )]
     UnsupportedVersion { key: String, got: u32 },
+    /// [`set_tenant_config`] read a record declaring a version this build's writer
+    /// cannot reproduce (> [`TENANT_CONFIG_FORMAT_VERSION`]). The whole-record
+    /// CAS-replace rebuilds the body from this build's field set, so a field a
+    /// newer writer added would be silently dropped; the write is refused and
+    /// nothing is persisted (ADR-0066 decision 5). A read-only path still accepts
+    /// the record (up to [`TENANT_CONFIG_MAX_READ_VERSION`]).
+    #[error(
+        "config record {key:?} declares format_version {got}, newer than this build's writer \
+         version {TENANT_CONFIG_FORMAT_VERSION}: refusing to rewrite it whole and strip fields this \
+         build does not model (ADR-0066 decision 5)"
+    )]
+    RefusingToRewriteNewerRecord { key: String, got: u32 },
     #[error(
         "config record {key:?} is misfiled: it records {field} {actual}, but the key it was read \
          under expects {expected}"
@@ -388,7 +416,7 @@ fn decode_record(
     key: &str,
     tenant_hash: &TenantHash,
 ) -> Result<TenantConfig, TenantConfigError> {
-    if record.format_version > TENANT_CONFIG_FORMAT_VERSION {
+    if record.format_version > TENANT_CONFIG_MAX_READ_VERSION {
         return Err(TenantConfigError::UnsupportedVersion {
             key: key.to_string(),
             got: record.format_version,
@@ -575,6 +603,18 @@ pub async fn set_tenant_config(
             // persists the record, so trusting a misfiled or future-format read
             // would durably corrupt it.
             decode_record(&existing, &key, tenant_hash)?;
+            // Rewrite refusal (ADR-0066 decision 5): the CAS-replace below rebuilds
+            // the body from this build's field set. A record a newer writer wrote
+            // (version above what this build stamps) may carry a field this build
+            // does not model, which the rebuild would strip. decode_record above
+            // accepts the wider read set, so this narrower check refuses the
+            // rewrite explicitly. Nothing is written.
+            if existing.format_version > TENANT_CONFIG_FORMAT_VERSION {
+                return Err(TenantConfigError::RefusingToRewriteNewerRecord {
+                    key,
+                    got: existing.format_version,
+                });
+            }
             let created_unix_ns = existing.created_unix_ns;
             let record = build_record(tenant_hash, config, created_unix_ns, now_ns);
             match store
@@ -884,7 +924,10 @@ mod tests {
         ));
     }
 
-    /// A future format_version is refused rather than misread under this layout.
+    /// A record past the supported read set (version 3, above
+    /// TENANT_CONFIG_MAX_READ_VERSION) is refused rather than misread. Version 2
+    /// is inside the set and accepted (see
+    /// reader_accepts_version_one_and_two_and_refuses_three).
     #[tokio::test]
     async fn read_rejects_future_format_version() {
         let store = mem();
@@ -894,7 +937,7 @@ mod tests {
             0,
             0,
         );
-        record.format_version = TENANT_CONFIG_FORMAT_VERSION + 1;
+        record.format_version = TENANT_CONFIG_MAX_READ_VERSION + 1;
         store
             .put(
                 &config_key(&tenant()),
@@ -907,6 +950,107 @@ mod tests {
             .await
             .expect_err("a future format_version must be refused");
         assert!(matches!(err, TenantConfigError::UnsupportedVersion { .. }));
+    }
+
+    /// The read-side supported set is {1, 2}: a version-1 and a version-2 record
+    /// both read back through `read_config`; a version-3 record is refused with a
+    /// typed UnsupportedVersion. Pins ADR-0066 decision 4 for the tenant-config
+    /// reader gate (decode_record).
+    #[tokio::test]
+    async fn reader_accepts_version_one_and_two_and_refuses_three() {
+        for version in [1u32, 2u32] {
+            let store = mem();
+            let mut record = build_record(
+                &tenant(),
+                &TenantConfig::new(TenantLifecycleState::Active),
+                0,
+                0,
+            );
+            record.format_version = version;
+            store
+                .put(
+                    &config_key(&tenant()),
+                    record.encode_to_vec().into(),
+                    PutOptions::default(),
+                )
+                .await
+                .expect("seed record");
+            let read = read_config(store.as_ref(), &tenant())
+                .await
+                .unwrap_or_else(|e| panic!("version {version} must read-accept: {e}"));
+            assert!(read.is_some(), "version {version} decodes to a config");
+        }
+
+        let store = mem();
+        let mut v3 = build_record(
+            &tenant(),
+            &TenantConfig::new(TenantLifecycleState::Active),
+            0,
+            0,
+        );
+        v3.format_version = 3;
+        store
+            .put(
+                &config_key(&tenant()),
+                v3.encode_to_vec().into(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("seed v3");
+        let err = read_config(store.as_ref(), &tenant())
+            .await
+            .expect_err("version 3 must be refused");
+        assert!(
+            matches!(err, TenantConfigError::UnsupportedVersion { got: 3, .. }),
+            "got: {err}"
+        );
+    }
+
+    /// A version-2 config record put through `set_tenant_config`'s whole-record
+    /// CAS-replace is REFUSED, not rebuilt at version 1: the rebuild names every
+    /// field explicitly and would drop any field a newer writer added. The stored
+    /// bytes must be exactly unchanged. Named per ADR-0066 R1 (decision 5).
+    #[tokio::test]
+    async fn set_tenant_config_refuses_a_version_two_record_from_a_version_one_writer() {
+        let store = mem();
+        let key = config_key(&tenant());
+        // A version-2 record on disk (as a newer writer would leave it).
+        let mut seeded_record = build_record(
+            &tenant(),
+            &TenantConfig::new(TenantLifecycleState::Suspended),
+            1_000,
+            1_000,
+        );
+        seeded_record.format_version = 2;
+        let seeded = seeded_record.encode_to_vec();
+        store
+            .put(&key, seeded.clone().into(), PutOptions::default())
+            .await
+            .expect("seed a version-2 config record");
+
+        // A version-1 writer tries to overwrite it: refused, nothing written.
+        let err = set_tenant_config(
+            store.as_ref(),
+            &tenant(),
+            &TenantConfig::new(TenantLifecycleState::Active),
+            2_000,
+        )
+        .await
+        .expect_err("overwriting a newer record must be refused");
+        assert!(
+            matches!(
+                err,
+                TenantConfigError::RefusingToRewriteNewerRecord { got: 2, .. }
+            ),
+            "got: {err}"
+        );
+
+        let after = store.get(&key, GetRange::Full).await.expect("re-read").data;
+        assert_eq!(
+            after.as_ref(),
+            seeded.as_slice(),
+            "the stored version-2 record must be byte-for-byte unchanged"
+        );
     }
 
     /// An UNSPECIFIED (0) lifecycle state is a corrupt record refused on decode,
@@ -968,6 +1112,12 @@ mod tests {
         assert_eq!(
             TENANT_CONFIG_FORMAT_VERSION, 1,
             "typed_attr_columns is additive; ADR-0090 forbids a format-version bump"
+        );
+        // ADR-0066 R1: the writer still stamps 1 while readers accept {1, 2}. A
+        // premature writer bump (R2) here would flip this pin.
+        assert_eq!(
+            TENANT_CONFIG_MAX_READ_VERSION, 2,
+            "readers accept versions 1 and 2 (ADR-0066 decision 4); writer stays at 1 until R2"
         );
     }
 

--- a/crates/ravel-catalog/src/tenant_config.rs
+++ b/crates/ravel-catalog/src/tenant_config.rs
@@ -59,6 +59,15 @@ pub const TENANT_CONFIG_FORMAT_VERSION: u32 = 1;
 /// this reader accepts 2 fleet-wide.
 pub const TENANT_CONFIG_MAX_READ_VERSION: u32 = 2;
 
+/// Lowest record version a reader accepts: the supported read set is a closed
+/// interval `TENANT_CONFIG_MIN_READ_VERSION..=TENANT_CONFIG_MAX_READ_VERSION`, a
+/// set with a floor and not a ceiling. Version 0 is an unstamped record from a
+/// writer that never set `format_version`; admitting it would let a valid-shaped
+/// but unstamped record be applied by `read_config` and rewritten as version 1
+/// by the CAS `set_tenant_config` path, so it is refused with the same
+/// `UnsupportedVersion` error the ceiling uses (ADR-0066 decision 4).
+pub const TENANT_CONFIG_MIN_READ_VERSION: u32 = 1;
+
 /// Object key for a tenant's config record: `t/<hex>/config`. Tenant-scoped, not
 /// per-signal (ADR-0066 decision 6). Under the tenant's own prefix, alongside its
 /// per-signal `<sig>/prov` and tenant-scoped `enc` records, never a bucket-root
@@ -416,7 +425,9 @@ fn decode_record(
     key: &str,
     tenant_hash: &TenantHash,
 ) -> Result<TenantConfig, TenantConfigError> {
-    if record.format_version > TENANT_CONFIG_MAX_READ_VERSION {
+    if record.format_version < TENANT_CONFIG_MIN_READ_VERSION
+        || record.format_version > TENANT_CONFIG_MAX_READ_VERSION
+    {
         return Err(TenantConfigError::UnsupportedVersion {
             key: key.to_string(),
             got: record.format_version,
@@ -927,7 +938,7 @@ mod tests {
     /// A record past the supported read set (version 3, above
     /// TENANT_CONFIG_MAX_READ_VERSION) is refused rather than misread. Version 2
     /// is inside the set and accepted (see
-    /// reader_accepts_version_one_and_two_and_refuses_three).
+    /// reader_accepts_version_one_and_two_and_refuses_zero_and_three).
     #[tokio::test]
     async fn read_rejects_future_format_version() {
         let store = mem();
@@ -952,12 +963,14 @@ mod tests {
         assert!(matches!(err, TenantConfigError::UnsupportedVersion { .. }));
     }
 
-    /// The read-side supported set is {1, 2}: a version-1 and a version-2 record
-    /// both read back through `read_config`; a version-3 record is refused with a
-    /// typed UnsupportedVersion. Pins ADR-0066 decision 4 for the tenant-config
-    /// reader gate (decode_record).
+    /// The read-side supported set is exactly {1, 2}, a set with a floor and a
+    /// ceiling: a version-1 and a version-2 record both read back through
+    /// `read_config`; both a version-0 record (below the floor: an unstamped
+    /// record from a writer that never set format_version) and a version-3 record
+    /// (above the ceiling) are refused with a typed UnsupportedVersion. Pins
+    /// ADR-0066 decision 4 for the tenant-config reader gate (decode_record).
     #[tokio::test]
-    async fn reader_accepts_version_one_and_two_and_refuses_three() {
+    async fn reader_accepts_version_one_and_two_and_refuses_zero_and_three() {
         for version in [1u32, 2u32] {
             let store = mem();
             let mut record = build_record(
@@ -1002,6 +1015,32 @@ mod tests {
             .expect_err("version 3 must be refused");
         assert!(
             matches!(err, TenantConfigError::UnsupportedVersion { got: 3, .. }),
+            "got: {err}"
+        );
+
+        // Version 0 (below the floor: an unstamped record) is refused too. A
+        // supported set has a floor as well as a ceiling.
+        let store = mem();
+        let mut v0 = build_record(
+            &tenant(),
+            &TenantConfig::new(TenantLifecycleState::Active),
+            0,
+            0,
+        );
+        v0.format_version = 0;
+        store
+            .put(
+                &config_key(&tenant()),
+                v0.encode_to_vec().into(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("seed v0");
+        let err = read_config(store.as_ref(), &tenant())
+            .await
+            .expect_err("version 0 must be refused");
+        assert!(
+            matches!(err, TenantConfigError::UnsupportedVersion { got: 0, .. }),
             "got: {err}"
         );
     }

--- a/crates/ravel-catalog/tests/sys_proto_format_version_classification.rs
+++ b/crates/ravel-catalog/tests/sys_proto_format_version_classification.rs
@@ -1,0 +1,226 @@
+//! Enumeration guard for ADR-0066 decision 4 (the format-migration classes).
+//!
+//! Every message in `proto/ravel/sys.proto` that carries a `format_version`
+//! field must be classified in the table below as either rewritten-under-CAS
+//! (a lagging writer could strip an additive field, so every additive change
+//! MUST bump `format_version`, sequenced readers-before-writers) or
+//! never-rewritten (written once and immutable, or overwritten wholesale from a
+//! sole writer's live state, so no peer ever reads-and-rewrites its bytes and a
+//! strip cannot happen). A new versioned message that lands without a table
+//! entry fails this test, so a message cannot be added to the frozen sys schema
+//! without a deliberate classification.
+//!
+//! Why this lives in `crates/ravel-catalog/tests/` rather than a unit module:
+//! the invariant spans every message in the shared sys proto, whose readers and
+//! writers are owned by four crates (ravel-catalog, ravel-ingest, ravel-maintain,
+//! ravel-server), so it belongs to no single module. An integration test parses
+//! the checked-in proto TEXT (via `CARGO_MANIFEST_DIR`), which is exactly the
+//! artifact a new message is added to, rather than the generated Rust types --
+//! so a message that never got a Rust reader is still caught. It is scoped to
+//! ravel-catalog because that crate owns three of the versioned records and its
+//! test gate (`cargo test -p ravel-catalog`) always runs it.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// How a versioned sys/* record is mutated, and the read-version set its readers
+/// accept today. The vocabulary of ADR-0066 decision 4.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Class {
+    /// Read-modify-write under CAS (or a sole-record CAS-replace that rebuilds
+    /// the body from a decoded view): a lagging writer that re-encodes through an
+    /// older field set silently strips any additive field a newer writer added.
+    /// Every additive change to such a record MUST bump `format_version`,
+    /// sequenced readers-before-writers, and its rewrite paths refuse a record
+    /// newer than the writer can reproduce (ADR-0066 decision 5). The slice is
+    /// the supported read-version set its readers accept today.
+    CasMutable(&'static [u32]),
+    /// Never rewritten by a peer: either written once with `CreateIfAbsent` and
+    /// immutable, or overwritten wholesale by its single owning writer from that
+    /// writer's own live state (`PutMode::Overwrite`, no prior bytes read). A
+    /// strip cannot happen because nothing reads-and-rewrites the object. The
+    /// slice is the supported read-version set its readers accept today.
+    Immutable(&'static [u32]),
+}
+
+/// The checked-in classification of every `format_version`-carrying message in
+/// `proto/ravel/sys.proto`. Adding a versioned message without adding it here
+/// fails `classification_is_complete`.
+fn classification_table() -> BTreeMap<&'static str, Class> {
+    use Class::{CasMutable, Immutable};
+    BTreeMap::from([
+        // Written once with CreateIfAbsent, then immutable.
+        ("TenancyMarker", Immutable(&[1])),
+        ("TenantRecoveryManifest", Immutable(&[1])),
+        // Sole-writer PutMode::Overwrite snapshots: each write is a fresh dump of
+        // the owning process's live state, never a read-modify-write of prior
+        // bytes, so a lagging binary cannot strip a sibling's additive field.
+        ("AdmissionUsageSnapshot", Immutable(&[1])),
+        ("WorkerHeartbeat", Immutable(&[1])),
+        // Read-modify-write under CAS. ProvisioningRecord / TenantConfigRecord /
+        // MetricMetadataRecord accept {1, 2} after ADR-0066 R1 (this change);
+        // AuthTokenMap already accepts {1, 2} (managed_by, ADR-0072 #897). The
+        // rest still accept {1}: their reader gates are unchanged here because
+        // their crates are in flight under other work (reported, not fixed).
+        ("ProvisioningRecord", CasMutable(&[1, 2])),
+        ("TenantConfigRecord", CasMutable(&[1, 2])),
+        ("MetricMetadataRecord", CasMutable(&[1, 2])),
+        ("AuthTokenMap", CasMutable(&[1, 2])),
+        ("GcConfig", CasMutable(&[1])),
+        ("CompactionClaim", CasMutable(&[1])),
+        ("KeyEpochRecord", CasMutable(&[1])),
+    ])
+}
+
+/// The checked-in proto text this guard classifies.
+fn sys_proto_text() -> String {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../proto/ravel/sys.proto");
+    std::fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read sys.proto at {path}: {e}"))
+}
+
+/// The set of top-level `message` names in `proto` that declare a `format_version`
+/// field. Parses the proto text (not generated types) so a message that was never
+/// given a Rust reader is still enumerated. Messages here are flat (no nested
+/// messages), so a brace-depth scan that resets the current message at depth 0 is
+/// sufficient; a `format_version` field is recognized by the field declaration
+/// `uint32 format_version = <n>;`, distinct from the many doc comments that
+/// mention the word.
+fn messages_with_format_version(proto: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut current: Option<String> = None;
+    let mut depth: i32 = 0;
+
+    for raw in proto.lines() {
+        // Drop any trailing `// ...` comment so a commented mention of
+        // `format_version` or a stray brace inside a comment is ignored.
+        let line = match raw.find("//") {
+            Some(idx) => &raw[..idx],
+            None => raw,
+        };
+        let trimmed = line.trim();
+
+        if depth == 0
+            && let Some(rest) = trimmed.strip_prefix("message ")
+        {
+            let name = rest
+                .split_whitespace()
+                .next()
+                .unwrap_or("")
+                .trim_end_matches('{')
+                .to_string();
+            if !name.is_empty() {
+                current = Some(name);
+            }
+        }
+
+        if let Some(name) = &current
+            && trimmed.starts_with("uint32 format_version")
+        {
+            out.insert(name.clone());
+        }
+
+        depth += trimmed.matches('{').count() as i32;
+        depth -= trimmed.matches('}').count() as i32;
+        if depth <= 0 {
+            depth = 0;
+            current = None;
+        }
+    }
+
+    out
+}
+
+/// Every `format_version`-carrying message in the proto is classified, and the
+/// table lists no message the proto does not have. This is the enumeration guard:
+/// a new versioned message added to the frozen sys schema without a table entry
+/// fails here.
+#[test]
+fn classification_is_complete() {
+    let proto = sys_proto_text();
+    let in_proto = messages_with_format_version(&proto);
+    let classified: BTreeSet<String> = classification_table()
+        .keys()
+        .map(|s| s.to_string())
+        .collect();
+
+    let unclassified: Vec<&String> = in_proto.difference(&classified).collect();
+    assert!(
+        unclassified.is_empty(),
+        "sys.proto messages carrying format_version with no ADR-0066 classification: {unclassified:?}. \
+         Classify each in classification_table() as CasMutable (a lagging writer could strip an \
+         additive field, so bump format_version on every additive change) or Immutable (never \
+         rewritten by a peer)."
+    );
+
+    let stale: Vec<&String> = classified.difference(&in_proto).collect();
+    assert!(
+        stale.is_empty(),
+        "classification_table() names messages not in sys.proto (renamed or removed?): {stale:?}"
+    );
+
+    // Sanity: the eleven versioned messages ADR-0066 enumerates are all present,
+    // so a parser regression that silently found none is itself caught.
+    assert_eq!(
+        in_proto.len(),
+        11,
+        "expected 11 versioned sys.proto messages (ADR-0066 decision 4); found {}: {in_proto:?}",
+        in_proto.len()
+    );
+}
+
+/// Every CasMutable supported set is non-empty and includes version 1 (the
+/// original floor); no Immutable record advertises a wider read set than {1}
+/// today. Pins the table's own shape so a typo (an empty set, a missing 1)
+/// cannot pass.
+#[test]
+fn classification_table_is_well_formed() {
+    for (name, class) in classification_table() {
+        match class {
+            Class::CasMutable(versions) => {
+                assert!(!versions.is_empty(), "{name}: CasMutable set is empty");
+                assert!(
+                    versions.contains(&1),
+                    "{name}: supported set must include 1"
+                );
+            }
+            Class::Immutable(versions) => {
+                assert_eq!(
+                    versions,
+                    &[1],
+                    "{name}: an immutable record reads only {{1}}"
+                );
+            }
+        }
+    }
+}
+
+/// The guard bites: a fake versioned message appended to a COPY of the proto is
+/// enumerated and, because it is absent from the table, would fail
+/// `classification_is_complete`. Proves the enumeration actually detects a new
+/// message rather than trivially passing.
+#[test]
+fn a_new_versioned_message_is_detected_as_unclassified() {
+    let mut proto = sys_proto_text();
+    proto.push_str(
+        "\nmessage FutureThing {\n  uint32 format_version = 1;\n  bytes payload = 2;\n}\n",
+    );
+
+    let in_proto = messages_with_format_version(&proto);
+    assert!(
+        in_proto.contains("FutureThing"),
+        "the parser must enumerate a newly added versioned message"
+    );
+
+    let classified: BTreeSet<String> = classification_table()
+        .keys()
+        .map(|s| s.to_string())
+        .collect();
+    assert!(
+        !classified.contains("FutureThing"),
+        "the fake message must be absent from the table, so the completeness check would fail"
+    );
+    // And the completeness relation the real test asserts would now be violated.
+    assert!(
+        in_proto.difference(&classified).next().is_some(),
+        "an unclassified message must make the completeness difference non-empty"
+    );
+}

--- a/crates/ravel-query/src/http/metadata_cache.rs
+++ b/crates/ravel-query/src/http/metadata_cache.rs
@@ -38,7 +38,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use ravel_cache::Clock;
-use ravel_catalog::{MetricMetadataEntry, read_metrics_meta};
+use ravel_catalog::{MetricMetadataEntry, read_metrics_meta, read_metrics_meta_for_serve};
 use ravel_object_store::{ObjectStoreBackend, Version};
 use ravel_types::TenantHash;
 
@@ -312,7 +312,7 @@ async fn fetch_snapshot(
     shared: &Shared,
     tenant_hash: TenantHash,
 ) -> (MetadataSnapshot, Option<Version>) {
-    match read_metrics_meta(shared.store.as_ref(), &tenant_hash).await {
+    match read_metrics_meta_for_serve(shared.store.as_ref(), &tenant_hash).await {
         Ok(Some((entries, version))) => (Arc::new(entries), Some(version)),
         Ok(None) => (Arc::new(Vec::new()), None),
         Err(err) => {

--- a/docs/adrs/0066-format-migration-machinery.md
+++ b/docs/adrs/0066-format-migration-machinery.md
@@ -101,7 +101,7 @@ A recorded floor F for family X asserts that no live object of family X below ve
 
 **Class B — derived catalog objects (.csnap, .npost, HEAD).** Rebuildable from commit records by construction; the fold rewrites them continuously. A version bump needs no migration tool: the upgraded fold emits the new version, supersession GCs the old parts, and dual-read is needed only across the rolling-upgrade window. Multi-part fold (ADR-0063) is exactly such a bump and is this rule's first consumer.
 
-**Class C — immutable metadata records (commit records, compaction records, tombstones, sys/* objects, idempotency markers).** Never rewritten; commit-record immutability is a repo invariant and migration machinery gets no exemption. Default evolution is additive protobuf change (frozen field numbers, new fields only — the ADR-0052 precedent, now normative). A genuinely incompatible change requires a new record kind under a new key suffix, dual-listed alongside the old kind until retention tombstones the old records' hour buckets; the reader-floor `format_version` these records already carry keeps an incompatible in-place edit detectable and refused.
+**Class C — immutable metadata records (commit records, compaction records, tombstones, sys/* objects, idempotency markers).** Never rewritten; commit-record immutability is a repo invariant and migration machinery gets no exemption. Default evolution is additive protobuf change (frozen field numbers, new fields only — the ADR-0052 precedent, now normative). A genuinely incompatible change requires a new record kind under a new key suffix, dual-listed alongside the old kind until retention tombstones the old records' hour buckets; the reader-floor `format_version` these records already carry keeps an incompatible in-place edit detectable and refused. **(Corrected by the R1 amendment below: "never rewritten" holds for the commit-family records and the write-once sys/* markers, NOT for the several sys/* records that ARE rewritten whole under CAS. For those, additive-only is unsafe without a version bump.)**
 
 **Class D — identity and domain-hash encodings (series-identity domain string, tenant-hash scheme, commit-token version).** Not migratable by generic machinery: a bump splits identity rather than failing a decode. The obligation here is containment, not migration: the active version is pinned per bucket in a durable control object — the `sys/tenancy` `TenantHashScheme` pattern, extended to record the series-identity domain and token version — and a process whose build disagrees refuses to start. An actual identity re-key is out of scope here; each such event is its own ADR (as the unkeyed-tenant-hash re-key already is).
 
@@ -178,3 +178,111 @@ existing one) addable without a proto change, matching the additive-evolution
 discipline the rest of this record follows. Decoding enforces `family` is
 non-empty and lowercase, fail-closed on either violation, so the field is not
 an unconstrained string in practice — see `ravel_catalog::provisioning::FloorDefect`.
+
+## Amendment (R1, #1300): the CAS-mutable sys/* records version on every additive change
+
+Decision 4's Class C filed every sys/* object as "never rewritten, so
+additive-only evolution is safe without a `format_version` bump." That premise
+is false for a subset of them, and the additive-only rule applied to that subset
+licenses a real data-loss bug: a lagging writer strips fields a newer writer
+added.
+
+**The mechanism.** Three sys/* records are rewritten WHOLE under CAS: a reader
+reads the record, this build re-encodes it through the field set THIS build
+knows, and writes it back. `prost` drops fields it does not know on decode, so a
+binary that predates an additive field re-emits the record without it. The
+existing reader gates were all the permissive `format_version > CONSTANT` form,
+so a lagging binary happily read a newer record, dropped the unknown field, and
+CAS-wrote the stripped record back. Three additive fields shipped this way with
+no version bump: `ProvisioningRecord.generations` (f6) and `format_floors` (f7),
+and `TenantConfigRecord.typed_attr_columns` (f12). The `generations` reasoning
+copied into the proto (from ADR-0052) proves only that an old *reader* reads a
+new record correctly; it never considered an old *writer* rewriting one.
+
+**Classification of every `format_version`-carrying sys/* message** (enforced by
+the enumeration test `crates/ravel-catalog/tests/sys_proto_format_version_classification.rs`,
+which fails if a new versioned message lands unclassified):
+
+| Message | Class | Writer / rewrite site | Read set today |
+|---|---|---|---|
+| `TenancyMarker` | never rewritten (write-once) | `sys/tenancy`, CreateIfAbsent | {1} |
+| `TenantRecoveryManifest` | never rewritten (write-once) | `sys/t/<h>`, CreateIfAbsent | {1} |
+| `AdmissionUsageSnapshot` | never rewritten (sole-writer Overwrite, fresh dump) | ADR-0057 snapshot, `PutMode::Overwrite` | {1} |
+| `WorkerHeartbeat` | never rewritten (sole-writer Overwrite, fresh dump) | ADR-0065 heartbeat, `PutMode::Overwrite` | {1} |
+| `ProvisioningRecord` | **CAS-mutable** | `provisioning::append_generation`, `raise_format_floor` | **{1, 2}** |
+| `TenantConfigRecord` | **CAS-mutable** | `tenant_config::set_tenant_config` | **{1, 2}** |
+| `MetricMetadataRecord` | **CAS-mutable** | ingest metadata sink read→`merge_entries`→write | **{1, 2}** |
+| `AuthTokenMap` | **CAS-mutable** | `sys/auth` CAS-replace | {1, 2} (already, managed_by) |
+| `GcConfig` | **CAS-mutable** | `ravel-maintain::gc_config::set_gc_config` | {1} |
+| `CompactionClaim` | **CAS-mutable** | ADR-1029 claim renew/steal/complete | {1} |
+| `KeyEpochRecord` | **CAS-mutable** | `ravel-catalog::key_epoch` append-epoch CAS | {1} |
+
+"Never rewritten" covers the write-once markers AND the sole-writer
+`PutMode::Overwrite` snapshots (`AdmissionUsageSnapshot`, `WorkerHeartbeat`): each
+of those is a fresh dump of the owning process's live state, never a
+read-modify-write of prior bytes, so no peer strips them. The CAS-mutable rows
+are the ones the false premise endangered.
+
+**The rule.** A CAS-mutable sys/* record bumps `format_version` on every additive
+change, sequenced readers-before-writers: the release that TEACHES readers to
+accept version N+1 ships and rolls out fully BEFORE any writer emits N+1, and a
+rewrite path refuses a record newer than the writer can reproduce byte-for-byte
+rather than strip it. This is exactly the precedent `AuthTokenMap` set for
+`managed_by` (ADR-0072 decision 4 amendment, #897): a purely additive `optional`
+field still bumped the map's `format_version` to 2 and required every
+`ravel-server` to understand 2 before any writer stamped it, precisely so a
+lagging reader fails closed instead of silently mishandling the record. The
+generalization here is that a CAS-mutable record must do this even though the
+field is additive, because the danger is not an old *reader* misreading the
+layout (additive fields are safe for that) but an old *writer* re-encoding the
+record without the field.
+
+**R1 (this change, #1300).** The reader half, for the three records whose gates
+were permissive: `ProvisioningRecord`, `TenantConfigRecord`, `MetricMetadataRecord`
+now accept the read set {1, 2} and refuse 3, and their CAS rewrite paths refuse a
+record whose version exceeds what this build's writer stamps (still 1),
+preventing the strip before any version-2 writer exists. The two-release split is
+not optional: `ProvisioningRecord` is read on the ingest hot path by
+`GenerationSwitch`, which fails a flush CLOSED on a read failure, so a
+single-release reader-and-writer bump would be a fleet-wide ingest outage during
+any rolling upgrade. R1 is the readers; **R2** (a later task, after this reader
+is fleet-wide) is the writer flip that stamps 2 with a new additive field and
+models it.
+
+**R2's obligation.** When R2 adds the version-2 field, it models that field in
+these readers and re-encoders, so a version-2 record is then read AND rewritten
+without loss — the read set stays {1, 2} but the rewrite paths stop refusing 2.
+Until R2, a version-2 record cannot exist (every writer stamps 1), so R1's
+refusals only ever fire during a mixed-version window a future R2 rollout opens.
+
+**A note on `MetricMetadataRecord`'s serve path.** Its record is read by two
+callers through one function, `read_metrics_meta`: the ingest sink (which merges
+and CAS-writes it back — a rewrite) and the query `/api/v1/metadata` cache (a
+read-only serve). Because that function returns the CAS version a caller writes
+back with, R1 makes it refuse a version-2 record, which keeps the sink from
+stripping. The serve cache treats any read error as "serve an empty record for
+one horizon" (best-effort, logged), so on a version-2 record during an R2 rollout
+it degrades to empty metadata for a horizon rather than a hard failure — an
+accepted, bounded cost, and one that does not exist until R2. The decode gate
+itself (`decode_record`) accepts {1, 2}, so a future R2 serve-only reader that
+models the new field needs no gate change.
+
+**The four never-audited records, reported not fixed here (their crates are in
+flight under other work):** `TenantRecoveryManifest` and `AdmissionUsageSnapshot`
+are never-rewritten (write-once and sole-writer-overwrite respectively), so they
+carry no strip risk. `GcConfig` (ravel-maintain) and `KeyEpochRecord`
+(ravel-catalog `key_epoch`) ARE CAS-mutable and still carry the permissive reader
+gate; neither has an additive field shipped past version 1 today, so neither is a
+*live* strip instance, but both would be if an additive field lands before their
+gate is widened. `CompactionClaim` (ADR-1029) is likewise CAS-mutable with a
+permissive gate and no post-v1 additive field. These are flagged for their owning
+tasks; this change does not touch their gates.
+
+**Rejected R1 alternatives** (and why the reader-set-plus-rewrite-refusal shape
+won): an unknown-tail bytes field to carry unmodeled fields across a rewrite (its
+own format decision, hand-rolled decoders for three messages, and a new field
+number on a frozen schema — a bigger change than the bug); a recorded-floor write
+gate (a durable read on every CAS path, and it cannot protect the first write
+after a bump); and prospective-only (bump only future writers), which leaves f6,
+f7, and f12 strippable by every already-deployed binary — the live half of the
+bug.

--- a/docs/adrs/0066-format-migration-machinery.md
+++ b/docs/adrs/0066-format-migration-machinery.md
@@ -239,9 +239,16 @@ record without the field.
 
 **R1 (this change, #1300).** The reader half, for the three records whose gates
 were permissive: `ProvisioningRecord`, `TenantConfigRecord`, `MetricMetadataRecord`
-now accept the read set {1, 2} and refuse 3, and their CAS rewrite paths refuse a
+now accept the read set exactly {1, 2} and their CAS rewrite paths refuse a
 record whose version exceeds what this build's writer stamps (still 1),
-preventing the strip before any version-2 writer exists. The two-release split is
+preventing the strip before any version-2 writer exists. The accepted set is a
+set with a floor, not a ceiling: each reader gate rejects a version below 1 with
+the same typed `UnsupportedVersion` error it uses for a version above 2. A
+version-0 record — a valid-shaped record from a writer that never stamped
+`format_version` — is therefore refused rather than admitted and later rewritten
+as version 1 by a CAS path; whether any pre-release binary ever wrote such a
+record into a live bucket is unknown, which is exactly why the gate is a set and
+not a ceiling. The two-release split is
 not optional: `ProvisioningRecord` is read on the ingest hot path by
 `GenerationSwitch`, which fails a flush CLOSED on a read failure, so a
 single-release reader-and-writer bump would be a fleet-wide ingest outage during
@@ -256,16 +263,22 @@ Until R2, a version-2 record cannot exist (every writer stamps 1), so R1's
 refusals only ever fire during a mixed-version window a future R2 rollout opens.
 
 **A note on `MetricMetadataRecord`'s serve path.** Its record is read by two
-callers through one function, `read_metrics_meta`: the ingest sink (which merges
-and CAS-writes it back — a rewrite) and the query `/api/v1/metadata` cache (a
-read-only serve). Because that function returns the CAS version a caller writes
-back with, R1 makes it refuse a version-2 record, which keeps the sink from
-stripping. The serve cache treats any read error as "serve an empty record for
-one horizon" (best-effort, logged), so on a version-2 record during an R2 rollout
-it degrades to empty metadata for a horizon rather than a hard failure — an
-accepted, bounded cost, and one that does not exist until R2. The decode gate
-itself (`decode_record`) accepts {1, 2}, so a future R2 serve-only reader that
-models the new field needs no gate change.
+callers with opposite obligations: the ingest sink merges and CAS-writes it back
+(a rewrite, which must stay strict) and the query `/api/v1/metadata` cache serves
+it read-only (which must not fail closed on a version it will never rewrite). R1
+splits the read accordingly rather than forcing both through one function.
+`read_metrics_meta` stays strict: it returns the CAS version a caller writes back
+with, so it refuses a version-2 record and keeps the sink from stripping.
+`read_metrics_meta_for_serve` is the read-only decoder for the cache; it applies
+the shared `decode_body` gate ({1, 2}) and does NOT apply the rewrite refusal, so
+a version-2 record's v1 fields are served rather than turned into an empty
+snapshot. The query metadata cache's fetch calls the serve reader. An earlier
+draft of this amendment accepted "serve an empty record for one horizon" on a
+version-2 record during an R2 rollout as a bounded cost; the split removes that
+degradation, so it is no longer a trade-off this ADR accepts. (The single
+background-refresh caller in that cache still uses the strict reader; widening it
+is follow-up work outside #1300's permitted scope and does not reintroduce the
+serve-empty horizon on the inline fetch path.)
 
 **The four never-audited records, reported not fixed here (their crates are in
 flight under other work):** `TenantRecoveryManifest` and `AdmissionUsageSnapshot`

--- a/proto/ravel/sys.proto
+++ b/proto/ravel/sys.proto
@@ -90,14 +90,25 @@ enum Signal {
 message ProvisioningRecord {
   // Format floor: the minimum reader version that understands this record. A
   // reader that only knows a lower version refuses rather than misreading a
-  // future layout as v1 (matching TenancyMarker's format_version guard). = 1.
+  // future layout as v1 (matching TenancyMarker's format_version guard).
   //
-  // Adding `generations` (field 6) is additive and does NOT bump this floor:
-  // a pre-ADR-0052 reader that skips the unknown field 6 still reads the
-  // scalar `shard_count` as generation 0's count, and a post-0052 reader with
-  // an empty `generations` list reads exactly the same single implicit
-  // generation. There is no layout a v1 reader would misread, so the floor
-  // stays 1 (ADR-0052 section 1, "Sequencing with EC5").
+  // Writers stamp 1. Readers accept the SET {1, 2}: this record is CAS-mutable
+  // (append_generation, raise_format_floor rewrite it whole), so per the
+  // ADR-0066 R1 amendment its readers accept the next version before any writer
+  // emits it (readers-before-writers), and its rewrite paths REFUSE a record
+  // whose version exceeds what this build's writer stamps rather than re-encode
+  // it through an older field set and strip a field a newer writer added. This
+  // is why the ADR-0052 note below, which reasons only about an old READER, is
+  // not sufficient on its own for a CAS-mutable record: an old WRITER rewriting
+  // a newer record is the hazard the SET and the rewrite refusal close.
+  //
+  // Adding `generations` (field 6) is additive and does NOT bump the version a
+  // WRITER stamps: a pre-ADR-0052 reader that skips the unknown field 6 still
+  // reads the scalar `shard_count` as generation 0's count, and a post-0052
+  // reader with an empty `generations` list reads exactly the same single
+  // implicit generation. There is no layout a v1 reader would misread
+  // (ADR-0052 section 1, "Sequencing with EC5"). The remaining hazard the R1
+  // amendment addresses is the old-writer rewrite, not the old-reader read.
   uint32 format_version = 1;
   bytes tenant_hash = 2;       // 16 bytes; the `t/<tenant_hash>/` prefix owner
   Signal signal = 3;
@@ -125,13 +136,22 @@ message ProvisioningRecord {
   // format version's read support is legal only when every bucket's floor for
   // that family exceeds the retired version.
   //
-  // Adding this field is additive and does NOT bump `format_version` (field 1),
-  // for the identical reason `generations` (field 6) did not: a reader that
-  // skips this unknown field still reads every earlier field exactly as before,
-  // and a reader that understands it sees an empty list on every pre-EM record,
-  // which reads identically to "no floors raised". There is no layout a v1
-  // reader would misread, so the floor stays 1 (ADR-0066 decision 3, citing the
-  // ADR-0052 `generations` precedent verbatim).
+  // Adding this field is additive and does NOT bump the version a WRITER stamps
+  // (field 1), for the identical reason `generations` (field 6) did not: a
+  // reader that skips this unknown field still reads every earlier field exactly
+  // as before, and a reader that understands it sees an empty list on every
+  // pre-EM record, which reads identically to "no floors raised". There is no
+  // layout a v1 reader would misread (ADR-0066 decision 3, citing the ADR-0052
+  // `generations` precedent).
+  //
+  // That old-READER reasoning is necessary but not sufficient for this
+  // CAS-mutable record: an old WRITER that rewrites a record a newer writer
+  // stamped (append_generation, raise_format_floor) would re-encode it without a
+  // field it does not model and strip it. The R1 amendment (ADR-0066, #1300)
+  // closes that: readers accept the version SET {1, 2}, and the rewrite paths
+  // refuse a record newer than the writer stamps. Any additive field added after
+  // this one still follows the CAS-mutable rule: bump the version, ship the
+  // reader that accepts it fleet-wide, THEN flip the writer.
   //
   // Decode enforces, per family, that floor_version is strictly increasing in
   // append order (floors raised only); a later entry for a family at or below an
@@ -511,7 +531,15 @@ message TypedAttrColumnConfig {
 message TenantConfigRecord {
   // Format floor: the minimum reader version that understands this record. A
   // reader that only knows a lower version refuses rather than misreading a
-  // future layout, matching every other durable record's version guard. = 1.
+  // future layout, matching every other durable record's version guard.
+  //
+  // Writers stamp 1. Readers accept the SET {1, 2}: this record is CAS-mutable
+  // (set_tenant_config rebuilds it whole under CasVersion, naming every field it
+  // knows), so per the ADR-0066 R1 amendment its reader accepts the next version
+  // before any writer emits it, and set_tenant_config REFUSES to rewrite a record
+  // newer than this build's writer stamps rather than rebuild it at the older
+  // field set and strip a field a newer writer added (e.g. a field past
+  // `typed_attr_columns`).
   uint32 format_version = 1;
   bytes tenant_hash = 2;              // 16 bytes; the `t/<tenant_hash>/` prefix owner
   TenantLifecycleState lifecycle_state = 3;
@@ -535,8 +563,12 @@ message TenantConfigRecord {
   // present-but-empty vs absent distinction). Additive field: a reader that
   // skips this unknown field reads every earlier field exactly as before, and a
   // reader that understands it sees an absent sub-message on every pre-ADR-0090
-  // record, identical to "no override". No format_version bump (ADR-0090
-  // Consequences).
+  // record, identical to "no override". No writer version bump for THIS field
+  // (ADR-0090 Consequences). But note this record is CAS-mutable: any field
+  // added AFTER this one must follow the CAS-mutable rule (ADR-0066 R1
+  // amendment) -- bump the version, ship the reader that accepts it fleet-wide,
+  // then flip the writer -- because set_tenant_config rewrites the record whole
+  // and a lagging writer would otherwise strip the new field.
   TypedAttrColumnConfig typed_attr_columns = 12;
 }
 
@@ -694,7 +726,17 @@ message MetricMetadataEntry {
 message MetricMetadataRecord {
   // Format floor: the minimum reader version that understands this record. A
   // reader that only knows a lower version refuses rather than misreading a
-  // future layout, matching every other durable record's version guard. = 1.
+  // future layout, matching every other durable record's version guard.
+  //
+  // Writers stamp 1. The decode gate accepts the SET {1, 2}: this record is
+  // CAS-mutable (the ingest sink reads it, field-wise re-merges via
+  // merge_entries, and CAS-writes it back), so per the ADR-0066 R1 amendment the
+  // decode gate accepts the next version before any writer emits it. The read
+  // that FEEDS that rewrite (read_metrics_meta, which returns the CAS version a
+  // caller writes back with) is stricter: it REFUSES a record newer than this
+  // build's writer stamps, so a lagging binary drops the merge window rather than
+  // re-encoding the record through an older field set and stripping a field a
+  // newer writer added.
   uint32 format_version = 1;
   // One entry per metric family name. Decode enforces: every family_name is
   // non-empty, no family_name repeats (a duplicate would make a

--- a/services/ravel-server/src/lifecycle_refresh.rs
+++ b/services/ravel-server/src/lifecycle_refresh.rs
@@ -724,6 +724,86 @@ mod tests {
         assert!(admitted.rejected.is_empty());
     }
 
+    /// Reachability for ADR-0066 R1: the lifecycle refresh reads a version-2
+    /// tenant config record and applies it. A version-2 record is what an R2
+    /// writer will leave once the writer flip ships; this R1 reader must already
+    /// accept it (readers-before-writers), so the refresh loop keeps applying
+    /// durable caps across a rolling upgrade instead of failing closed on a peer's
+    /// newer record. Seeded directly (bypassing set_tenant_config's version-1
+    /// stamp) and observed through real admission: the record's cap of 5 admits
+    /// five series where the startup base cap of 2 would admit two.
+    #[tokio::test]
+    async fn refresh_reads_a_version_two_tenant_config() {
+        use prost::Message;
+        use ravel_catalog::config_key;
+        use ravel_ingest::{CountLimit, RateLimit};
+        use ravel_object_store::{PutOptions, memory::MemoryStore};
+        use ravel_types::SeriesId;
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new("acme");
+        let hash = tenant.hash();
+
+        // A version-2 config record on disk, raising the active-series cap to 5.
+        let record = ravel_proto::sys::v1::TenantConfigRecord {
+            format_version: 2,
+            tenant_hash: hash.0.to_vec(),
+            lifecycle_state: ravel_proto::sys::v1::TenantLifecycleState::Active as i32,
+            max_active_series: Some(5),
+            max_active_streams: None,
+            max_ingest_byte_rate: None,
+            max_series_creation_rate: None,
+            retention_ns: None,
+            indexed_fields: None,
+            created_unix_ns: 1_000,
+            updated_unix_ns: 1_000,
+            typed_attr_columns: None,
+        };
+        store
+            .put(
+                &config_key(&hash),
+                record.encode_to_vec().into(),
+                PutOptions::create_if_absent(),
+            )
+            .await
+            .expect("seed a version-2 tenant config");
+
+        let base = AdmissionLimits {
+            max_active_series: CountLimit::Bounded(2),
+            max_active_streams: CountLimit::Unlimited,
+            ingest_byte_rate: RateLimit::Unlimited,
+            series_creation_rate: RateLimit::Unlimited,
+        };
+        let admission = AdmissionController::new(Arc::new(SystemClock), base);
+        admission.set_tenant_limits(tenant.clone(), base);
+
+        // The refresh decodes the version-2 record and applies its cap.
+        let applied = refresh_tenant_limits_once(&admission, store.as_ref(), &tenant, base)
+            .await
+            .expect("refresh reads the version-2 config");
+        assert!(
+            applied.is_some(),
+            "the refresh decoded the version-2 record rather than failing closed"
+        );
+        assert_eq!(
+            applied.expect("config present").max_active_series,
+            Some(5),
+            "the version-2 record's cap reached the refresh"
+        );
+
+        let admitted = admission.admit_series(
+            &tenant,
+            (1u8..=5).map(|b| SeriesId([b; 16])),
+            SystemClock.now_ns(),
+        );
+        assert_eq!(
+            admitted.admitted.len(),
+            5,
+            "the version-2 config's cap of 5 is in force (base cap 2 would admit two)"
+        );
+        assert!(admitted.rejected.is_empty());
+    }
+
     /// The `TenantResolver` surface: a hard-stale or unknown-token request is an
     /// `AuthError` (so the fallback chain moves on), and a header with no bearer
     /// token is an `AuthError` too (this resolver claims only bearer requests).


### PR DESCRIPTION
Three sys records are rewritten whole under compare-and-swap: the provisioning
record through append_generation and raise_format_floor, the tenant config
record through a builder that names every field explicitly, and the metric
metadata record whose CAS loser re-merges onto the winner field by field. Three
additive fields shipped on them without a version bump. Every reader gate was the
permissive form that accepts anything at or below the constant, so a lagging
binary reads a record written by a newer one, drops the fields it does not
know, and writes the stripped record back. No test covered preservation across a
rewrite.

The root cause is a classification error rather than a prost property. ADR-0066
files sys records under a class whose premise is that they are never rewritten.
These are. The additive-only rule is sound for immutable records and licenses
exactly this strip when applied to mutable ones. The amendment corrects the
premise, states the rule for CAS-mutable records, bumps on every additive change
sequenced readers before writers, and cites the auth token map as the record
that already did it right.

This is the readers release. The five gates accept versions one and two and
refuse three. Writers still stamp one. Each rewrite path refuses a record newer
than it can model rather than stripping it, and the preservation tests assert
the stored bytes are byte-for-byte unchanged. The split is not optional: the
provisioning record is read on the ingest hot path by the generation switch,
which fails a flush closed on a read failure, so a single-release bump is a
fleet-wide ingest outage during any rolling upgrade.

Every versioned message in sys.proto, eleven today, is now classified in a
checked-in table, and a test that parses the proto text fails when a new
versioned message appears without an entry. Of the four records never audited
before, two are write-once and carry no strip risk, and two, the GC config and
the key epoch record, are CAS-mutable behind permissive gates but have no field
past version one yet. Latent rather than live, and now on record.

Review caught the supported set implemented as a ceiling: anything at or below
the constant passed every reader gate, including an unstamped version-zero
record, which the research left open as possibly present in a live bucket. A
set has a floor. Every gate for the three records now rejects a version below
one with the same typed error, each shown admitting version zero under the
ceiling-only check. A sweep of every version comparison in the crate found the
same ceiling-only shape on two records outside this change, the auth token map
and the key epoch record, which are recorded on the issue for the writer half.

The serve-path trade-off is gone rather than deferred. The metric metadata sink
keeps the strict reader that refuses a version-two record so it never strips one
by rewriting, and the query metadata cache now reads through a serve-only decoder
that accepts the supported set, so an old binary serves real metadata during the
writer rollout instead of an empty snapshot for a horizon. The cache change is
one call in a file no other open change touches.

HEAD and the snapshot head are a different class owned by #855 and are
untouched. No field number, key layout or on-disk byte shape changes; the proto
file gains comments only.

This is the readers half of #1300; the writer flip follows a fleet roll and does
not land here.

Refs: #1300
