### PR TITLE
feat(query,sql): request budgets, SQL row window, explain, and row cap

### DIFF
--- a/crates/ravel-bench/src/bin/flight_sql_egress.rs
+++ b/crates/ravel-bench/src/bin/flight_sql_egress.rs
@@ -374,6 +374,9 @@ async fn json_egress_bytes(executor: &SqlExecutor, tenant: TenantHash) -> u64 {
         min_tokens: Vec::new(),
         now_ns: NOW_NS,
         deadline: Duration::from_secs(30),
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     };
     let outcome = executor.execute(tenant, &req).await.expect("execute query");
     let json = outcome.output.to_json().expect("encode json");

--- a/crates/ravel-bench/src/groupby_scaling.rs
+++ b/crates/ravel-bench/src/groupby_scaling.rs
@@ -458,6 +458,9 @@ async fn run_combo(
         min_tokens: Vec::new(),
         now_ns: NOW_NS,
         deadline,
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     };
 
     // Observe the physical plan this combination actually produces, before the
@@ -1095,6 +1098,9 @@ async fn run_distinct_combo(
         min_tokens: Vec::new(),
         now_ns: NOW_NS,
         deadline,
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     };
     let start = Instant::now();
     let outcome = match executor.execute(tenant_hash, &request).await {

--- a/crates/ravel-bench/src/logs_scan_scaling.rs
+++ b/crates/ravel-bench/src/logs_scan_scaling.rs
@@ -726,6 +726,9 @@ async fn run_combo(
         min_tokens: Vec::new(),
         now_ns: NOW_NS,
         deadline,
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     };
 
     // Observe the physical plan's scan fan-out before the timed runs. Planning

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -1676,6 +1676,9 @@ pub async fn measure_corpus(
             min_tokens: Vec::new(),
             now_ns,
             deadline,
+            row_window: false,
+            max_rows: None,
+            budgets: None,
         };
 
         // EXPLAIN side artifact, before any timed run and never counted in the
@@ -3890,6 +3893,9 @@ mod tests {
             min_tokens: Vec::new(),
             now_ns: NOW_NS,
             deadline: Duration::from_secs(30),
+            row_window: false,
+            max_rows: None,
+            budgets: None,
         };
 
         // Fetcher cache ON: a fresh executor (cold catalog byte cache, cold

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -38,6 +38,7 @@ use crate::limiter::GetLimiter;
 use crate::log_fetcher::{DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LogFetchError, LogSegmentFetcher};
 use crate::log_series;
 use crate::phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot};
+use crate::request_budgets::RequestBudgets;
 use crate::segment_admission;
 
 /// Which evaluation shape a prefetch is being computed for: an instant
@@ -476,6 +477,34 @@ impl QueryEngine {
         &self.config
     }
 
+    /// This engine scoped to one request's lowered budgets (ADR-1374
+    /// decision 3): the same catalog, fetchers, limiter, and fan-out
+    /// contexts, with `config`'s three budget fields replaced by
+    /// [`RequestBudgets::clamp`]'s output.
+    ///
+    /// Substituting the config rather than threading an extra parameter is
+    /// what makes every enforcement site read the effective budget without
+    /// each one having to consult a second value: `admit`, the three
+    /// bytes-scanned checks, and the request-budget check all already read
+    /// `self.config`. The clone is cheap and shares state by construction:
+    /// [`SegmentFetcher`] and [`LogSegmentFetcher`] both share their cache
+    /// and their [`GetLimiter`] across clones, so a scoped engine draws
+    /// permits from the same limiter and hits the same cache entries as the
+    /// engine it came from. It must stay that way; a fetcher clone that
+    /// forked its limiter would turn one query's budget scope into a second
+    /// concurrency allowance.
+    fn scoped_to(&self, budgets: &RequestBudgets) -> QueryEngine {
+        QueryEngine {
+            catalog: Arc::clone(&self.catalog),
+            fetcher: self.fetcher.clone(),
+            log_fetcher: self.log_fetcher.clone(),
+            get_limiter: Arc::clone(&self.get_limiter),
+            config: budgets.clamp(&self.config).applied_to(&self.config),
+            distributed: self.distributed.clone(),
+            federation: self.federation.clone(),
+        }
+    }
+
     /// The [`GetLimiter`] this engine's `fetcher` and `log_fetcher` currently
     /// share. Test-only: production code has no reason to reach behind the
     /// engine at its fetchers' shared limiter, only to replace it wholesale
@@ -551,6 +580,52 @@ impl QueryEngine {
         )
         .await;
         unify_deadline(outcome, deadline)
+    }
+
+    /// [`Self::instant_with_stats_annotated`] under one request's
+    /// caller-supplied budgets (ADR-1374 decision 3).
+    ///
+    /// `budgets` can only LOWER this engine's configured ceilings; see
+    /// [`RequestBudgets::clamp`]. `None` delegates to
+    /// [`Self::instant_with_stats_annotated`] unchanged, which is what every
+    /// HTTP handler passes: the agent surface (#1381) is the caller that
+    /// supplies budgets.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn instant_with_budgets(
+        &self,
+        tenant_hash: TenantHash,
+        query: &str,
+        t_ms: i64,
+        min_tokens: &[CommitToken],
+        now_ns: i64,
+        deadline: Duration,
+        budgets: Option<&RequestBudgets>,
+    ) -> Result<(Value, Annotations, QueryStats), QueryError> {
+        match budgets {
+            None => {
+                self.instant_with_stats_annotated(
+                    tenant_hash,
+                    query,
+                    t_ms,
+                    min_tokens,
+                    now_ns,
+                    deadline,
+                )
+                .await
+            }
+            Some(budgets) => {
+                self.scoped_to(budgets)
+                    .instant_with_stats_annotated(
+                        tenant_hash,
+                        query,
+                        t_ms,
+                        min_tokens,
+                        now_ns,
+                        deadline,
+                    )
+                    .await
+            }
+        }
     }
 
     async fn instant_inner(
@@ -705,6 +780,54 @@ impl QueryEngine {
         unify_deadline(outcome, deadline)
     }
 
+    /// [`Self::range_hist_with_stats_annotated`] under one request's
+    /// caller-supplied budgets (ADR-1374 decision 3). Same contract as
+    /// [`Self::instant_with_budgets`]: lowering only, and `None` is the
+    /// existing method unchanged.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn range_hist_with_budgets(
+        &self,
+        tenant_hash: TenantHash,
+        query: &str,
+        start_ms: i64,
+        end_ms: i64,
+        step_ms: i64,
+        min_tokens: &[CommitToken],
+        now_ns: i64,
+        deadline: Duration,
+        budgets: Option<&RequestBudgets>,
+    ) -> Result<(RangeValue, Annotations, QueryStats), QueryError> {
+        match budgets {
+            None => {
+                self.range_hist_with_stats_annotated(
+                    tenant_hash,
+                    query,
+                    start_ms,
+                    end_ms,
+                    step_ms,
+                    min_tokens,
+                    now_ns,
+                    deadline,
+                )
+                .await
+            }
+            Some(budgets) => {
+                self.scoped_to(budgets)
+                    .range_hist_with_stats_annotated(
+                        tenant_hash,
+                        query,
+                        start_ms,
+                        end_ms,
+                        step_ms,
+                        min_tokens,
+                        now_ns,
+                        deadline,
+                    )
+                    .await
+            }
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn range_inner(
         &self,
@@ -785,6 +908,48 @@ impl QueryEngine {
         )
         .await
         .map_err(|_| QueryError::DeadlineExceeded { deadline })?
+    }
+
+    /// [`Self::resolve_series_with_stats`] under one request's
+    /// caller-supplied budgets (ADR-1374 decision 3). Same contract as
+    /// [`Self::instant_with_budgets`]: lowering only, and `None` is the
+    /// existing method unchanged.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn resolve_series_with_budgets(
+        &self,
+        tenant_hash: TenantHash,
+        matchers: &[LabelMatcher],
+        window: TimeRange,
+        min_tokens: &[CommitToken],
+        now_ns: i64,
+        deadline: Duration,
+        budgets: Option<&RequestBudgets>,
+    ) -> Result<(Vec<(SeriesId, LabelSet)>, QueryStats), QueryError> {
+        match budgets {
+            None => {
+                self.resolve_series_with_stats(
+                    tenant_hash,
+                    matchers,
+                    window,
+                    min_tokens,
+                    now_ns,
+                    deadline,
+                )
+                .await
+            }
+            Some(budgets) => {
+                self.scoped_to(budgets)
+                    .resolve_series_with_stats(
+                        tenant_hash,
+                        matchers,
+                        window,
+                        min_tokens,
+                        now_ns,
+                        deadline,
+                    )
+                    .await
+            }
+        }
     }
 
     async fn resolve_series_inner(

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -1290,6 +1290,17 @@ impl QueryEngine {
             )
             .await?;
 
+        // Checked here, right after the log lane's own resolve returns, for
+        // the same reason the metrics lane checks in `resolve_snapshot_with_retry`
+        // do: a log selector whose snapshot resolves to zero segments never
+        // reaches the incremental checks in the log fetch loop below.
+        if let Some(err) = segment_admission::request_budget_exceeded(
+            log_accounting.snapshot().pooled().total_s3_requests(),
+            self.config.max_s3_requests,
+        ) {
+            return Err(err);
+        }
+
         // ADR-1103 decision 4 step 4: a query with both a metrics and a log
         // selector must not spend two full `max_segments` budgets. Each
         // `resolve_bounded` call above already checked its OWN sealed-segment
@@ -1956,6 +1967,18 @@ impl QueryEngine {
                 first_accounting.resolve(),
             )
             .await?;
+        // Checked here, right after the resolve returns, not only at the
+        // segment-fetch boundaries below: a query whose snapshot resolves to
+        // zero segments never reaches those checks, so a caller with a
+        // lowered `max_s3_requests` (ADR-1374 decision 3) must still be
+        // stopped from completing on the strength of the resolve's own
+        // catalog requests alone.
+        if let Some(err) = segment_admission::request_budget_exceeded(
+            first_accounting.snapshot().pooled().total_s3_requests(),
+            self.config.max_s3_requests,
+        ) {
+            return Err(err);
+        }
         let first_estimate = estimate_cost(&first, fetch_multiplier, catalog_requests);
         let first_segments = first.segments.len() as u64;
         let first_pruned = first.segments_pruned;
@@ -1986,6 +2009,12 @@ impl QueryEngine {
                         second_accounting.resolve(),
                     )
                     .await?;
+                if let Some(err) = segment_admission::request_budget_exceeded(
+                    second_accounting.snapshot().pooled().total_s3_requests(),
+                    self.config.max_s3_requests,
+                ) {
+                    return Err(err);
+                }
                 let second_estimate = estimate_cost(&second, fetch_multiplier, catalog_requests);
                 let second_segments = second.segments.len() as u64;
                 let second_pruned = second.segments_pruned;
@@ -4790,6 +4819,78 @@ mod tests {
     use ravel_types::{Label, LabelSet, SeriesId};
 
     use super::*;
+
+    /// CodeRabbit finding on PR #1424 (comment 3952989200): a query whose
+    /// snapshot resolves to zero segments never enters the segment-fetch
+    /// loop, so the incremental `max_s3_requests` check there never runs. A
+    /// caller-lowered budget of zero (ADR-1374 decision 3) must still be
+    /// enforced on the strength of the resolve's own catalog requests, and
+    /// the server default ceiling (far above any resolve cost) must not
+    /// change behavior for the same fixture.
+    #[tokio::test]
+    async fn lowered_request_budget_is_enforced_after_resolve() {
+        let store: Arc<dyn ObjectStoreBackend> =
+            Arc::new(ravel_object_store::memory::MemoryStore::new());
+        let catalog = ravel_catalog::Catalog::new(
+            Arc::clone(&store),
+            ravel_catalog::CatalogConfig::default(),
+        )
+        .expect("catalog");
+        let engine = QueryEngine::new(Arc::new(catalog), store, EngineConfig::default());
+        let tenant_hash = ravel_types::TenantId::new("acme").hash();
+        // No segments are ever published to this store, so the window is
+        // arbitrary: the snapshot resolves empty regardless of its bounds.
+        let window = TimeRange {
+            start_ns: 0,
+            end_ns: 60 * 1_000_000_000,
+        };
+        let now_ns = window.end_ns;
+        let deadline = Duration::from_secs(30);
+
+        let budgets = RequestBudgets {
+            max_store_requests: Some(RequestLimit::Bounded(0)),
+            ..Default::default()
+        };
+        let err = engine
+            .resolve_series_with_budgets(
+                tenant_hash,
+                &[],
+                window,
+                &[],
+                now_ns,
+                deadline,
+                Some(&budgets),
+            )
+            .await
+            .expect_err("a zero store-request budget must trip even on an empty snapshot");
+        let QueryError::RequestBudgetExceeded { requests, max } = err else {
+            panic!("expected QueryError::RequestBudgetExceeded, got {err:?}");
+        };
+        assert_eq!(
+            max, 0,
+            "the caller's lowered ceiling must be reported exactly"
+        );
+        // Pinned: an empty-snapshot resolve against a fresh `MemoryStore`
+        // issues exactly 3 catalog requests. A regression that changes the
+        // resolve's own request count is exactly what this bound catches.
+        assert_eq!(
+            requests, 3,
+            "the resolve's own catalog request count must be exact, not just nonzero"
+        );
+
+        // Control: the server's default ceiling is far above any resolve
+        // cost, so the identical fixture succeeds under it, and the
+        // accounted request count is the same exact number.
+        let (_series, stats) = engine
+            .resolve_series_with_budgets(tenant_hash, &[], window, &[], now_ns, deadline, None)
+            .await
+            .expect("the server default ceiling must not trip on the resolve's own cost");
+        assert_eq!(
+            stats.accounting.total_s3_requests(),
+            requests,
+            "the default-ceiling control must account the same resolve cost as the trip"
+        );
+    }
 
     /// Issue #529: the labels/series HTTP endpoints
     /// (`http/handlers.rs`'s `match[]` parameter) reach `parse_selector`

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -1294,8 +1294,22 @@ impl QueryEngine {
         // the same reason the metrics lane checks in `resolve_snapshot_with_retry`
         // do: a log selector whose snapshot resolves to zero segments never
         // reaches the incremental checks in the log fetch loop below.
+        //
+        // Combined with the metrics lane's own already-spent total
+        // (`stats.phase_accounting`, populated by `prefetch_metric_plans`
+        // above), not the log lane's total alone: the two lanes share ONE
+        // query-wide `max_s3_requests` ceiling (the same reasoning
+        // `requests_remaining` below applies to the log fetch loop itself),
+        // so a metrics lane that already spent most of the budget must not
+        // let the log lane's resolve alone re-check against the whole
+        // ceiling as if the metrics spend never happened.
+        let combined_requests_so_far = stats
+            .phase_accounting
+            .pooled()
+            .total_s3_requests()
+            .saturating_add(log_accounting.snapshot().pooled().total_s3_requests());
         if let Some(err) = segment_admission::request_budget_exceeded(
-            log_accounting.snapshot().pooled().total_s3_requests(),
+            combined_requests_so_far,
             self.config.max_s3_requests,
         ) {
             return Err(err);
@@ -4889,6 +4903,102 @@ mod tests {
             stats.accounting.total_s3_requests(),
             requests,
             "the default-ceiling control must account the same resolve cost as the trip"
+        );
+    }
+
+    /// Round 2, CodeRabbit finding on PR #1424: the log lane's post-resolve
+    /// budget check added in `prefetch` (see
+    /// `lowered_request_budget_is_enforced_after_resolve` above) compared
+    /// only the log lane's OWN resolve cost against the ceiling, ignoring
+    /// whatever the metrics lane had already spent. A mixed metrics+logs
+    /// query must be checked against the COMBINED total right after the log
+    /// lane's resolve, the same way the log fetch loop's own incremental
+    /// checks already account for the metrics lane's prior spend
+    /// (`requests_remaining` below in `prefetch`).
+    #[tokio::test]
+    async fn mixed_metrics_and_log_lanes_share_the_request_budget_after_resolve() {
+        let store: Arc<dyn ObjectStoreBackend> =
+            Arc::new(ravel_object_store::memory::MemoryStore::new());
+        let catalog = ravel_catalog::Catalog::new(
+            Arc::clone(&store),
+            ravel_catalog::CatalogConfig::default(),
+        )
+        .expect("catalog");
+        let engine = QueryEngine::new(Arc::new(catalog), store, EngineConfig::default());
+        let tenant_hash = ravel_types::TenantId::new("acme-mixed").hash();
+        let now_ns = 60 * 1_000_000_000;
+        let t_ms = now_ns / 1_000_000;
+        let deadline = Duration::from_secs(30);
+        // `or` is PromQL's set operator (tolerates label-set mismatch,
+        // matching `two_log_selectors_share_one_request_budget` in
+        // tests/log_series_engine.rs): the metrics lane ("m") and the log
+        // lane (`ravel_log_lines`) both resolve empty snapshots against this
+        // fresh, unpublished store.
+        let query = r#"m or count_over_time(ravel_log_lines{job="x"}[1h])"#;
+
+        // Pinned: the metrics lane alone spends exactly 3 catalog requests
+        // resolving an empty snapshot (the same fixed cost
+        // `lowered_request_budget_is_enforced_after_resolve` pins for a lone
+        // empty-snapshot resolve), and the log lane spends exactly 3 more.
+        const METRICS_LANE_REQUESTS: u64 = 3;
+        const LOG_LANE_REQUESTS: u64 = 3;
+
+        let budgets = RequestBudgets {
+            max_store_requests: Some(RequestLimit::Bounded(METRICS_LANE_REQUESTS)),
+            ..Default::default()
+        };
+        let err = engine
+            .instant_with_budgets(
+                tenant_hash,
+                query,
+                t_ms,
+                &[],
+                now_ns,
+                deadline,
+                Some(&budgets),
+            )
+            .await
+            .expect_err(
+                "a budget sized for the metrics lane alone must still trip once the log \
+                 lane's own resolve is added",
+            );
+        let QueryError::RequestBudgetExceeded { requests, max } = err else {
+            panic!("expected QueryError::RequestBudgetExceeded, got {err:?}");
+        };
+        assert_eq!(
+            max, METRICS_LANE_REQUESTS,
+            "the caller's lowered ceiling must be reported exactly"
+        );
+        assert_eq!(
+            requests,
+            METRICS_LANE_REQUESTS + LOG_LANE_REQUESTS,
+            "the trip must report the COMBINED total, not the log lane's total alone"
+        );
+
+        // Control: a budget sized for both lanes' combined resolve cost
+        // succeeds, and accounts the same combined total the trip reported.
+        let combined_budgets = RequestBudgets {
+            max_store_requests: Some(RequestLimit::Bounded(
+                METRICS_LANE_REQUESTS + LOG_LANE_REQUESTS,
+            )),
+            ..Default::default()
+        };
+        let (_value, _annotations, stats) = engine
+            .instant_with_budgets(
+                tenant_hash,
+                query,
+                t_ms,
+                &[],
+                now_ns,
+                deadline,
+                Some(&combined_budgets),
+            )
+            .await
+            .expect("a budget sized for the combined resolve cost must succeed");
+        assert_eq!(
+            stats.accounting.total_s3_requests(),
+            METRICS_LANE_REQUESTS + LOG_LANE_REQUESTS,
+            "the combined-budget control must account the same combined resolve cost as the trip"
         );
     }
 

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -16,6 +16,7 @@ mod log_fetcher;
 pub mod log_series;
 mod phase_accounting;
 mod query_admission;
+mod request_budgets;
 mod segment_admission;
 pub mod span_fetcher;
 #[cfg(test)]
@@ -50,5 +51,6 @@ pub use query_admission::{
     QueryAdmissionController, QueryConcurrencyLimit, QueryPermit, QueryRejected,
     query_admission_snapshot_key, reconcile_query_admission_once,
 };
+pub use request_budgets::{EffectiveBudgets, RequestBudgets};
 pub use segment_admission::{SegmentAdmission, admit, request_budget_exceeded};
 pub use span_fetcher::{SpanFetchError, SpanFetchOutput, SpanRow, SpanSegmentFetcher};

--- a/crates/ravel-query/src/request_budgets.rs
+++ b/crates/ravel-query/src/request_budgets.rs
@@ -1,0 +1,283 @@
+//! Per-request budget overrides a caller may attach to one query (ADR-1374
+//! decision 3, prerequisite 1).
+//!
+//! A caller never sets a budget: it lowers one. The server's [`EngineConfig`]
+//! is the ceiling, and [`RequestBudgets::clamp`] resolves a caller's wishes
+//! against it into the [`EffectiveBudgets`] the query actually runs under. A
+//! value above the ceiling resolves to the ceiling, an absent value resolves to
+//! the ceiling, and `Unlimited` from a caller cannot lift a bounded ceiling.
+//! That direction is the whole point: the agent surface ADR-1374 describes
+//! hands untrusted callers a budget knob, and a knob that can only turn one way
+//! needs no separate authorization check.
+//!
+//! `max_store_requests` is the one canonical wire name for the store-request
+//! budget (ADR-1374 decision 3). It maps onto the existing
+//! [`EngineConfig::max_s3_requests`] ceiling, which keeps its name: the ceiling
+//! is an operator-facing knob that has shipped, and renaming it would break
+//! deployed configuration to no end.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::config::{ByteLimit, EngineConfig, RequestLimit};
+
+/// The string form of an unbounded limit on the wire, matching the
+/// `max_bytes_scanned = "unlimited"` spelling operators already write in
+/// `ravel-server`'s limits file.
+const UNLIMITED: &str = "unlimited";
+
+/// What one request asks its budgets to be lowered to. Every field is
+/// optional; an absent field leaves the server ceiling in place.
+///
+/// Deserialized from an agent- or client-supplied request body, so the field
+/// names here are a wire contract:
+/// `request_budget_field_names_are_the_wire_contract` pins them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RequestBudgets {
+    /// Lowers [`EngineConfig::max_bytes_scanned`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_bytes_scanned: Option<ByteLimit>,
+    /// Lowers [`EngineConfig::max_s3_requests`]. The wire name is
+    /// `max_store_requests`; the ceiling it lowers keeps its shipped name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_store_requests: Option<RequestLimit>,
+    /// Lowers [`EngineConfig::max_segments`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_segments: Option<usize>,
+}
+
+/// The budgets a query actually runs under: the caller's wishes resolved
+/// against the server ceiling. Every field is concrete, so no enforcement site
+/// has to reason about an absent value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EffectiveBudgets {
+    pub max_bytes_scanned: ByteLimit,
+    pub max_store_requests: RequestLimit,
+    pub max_segments: usize,
+}
+
+impl RequestBudgets {
+    /// Resolve these budgets against the server `ceiling`. Lowering only: for
+    /// every field the result is the more restrictive of the caller's value and
+    /// the ceiling, and an absent caller value is the ceiling.
+    pub fn clamp(&self, ceiling: &EngineConfig) -> EffectiveBudgets {
+        EffectiveBudgets {
+            max_bytes_scanned: lower_bytes(self.max_bytes_scanned, ceiling.max_bytes_scanned),
+            max_store_requests: lower_requests(self.max_store_requests, ceiling.max_s3_requests),
+            max_segments: match self.max_segments {
+                Some(requested) => requested.min(ceiling.max_segments),
+                None => ceiling.max_segments,
+            },
+        }
+    }
+
+    /// [`Self::clamp`] for an optional caller: `None` is exactly the ceiling,
+    /// which is what every pre-ADR-1374 call site runs under.
+    pub fn clamp_optional(
+        budgets: Option<&RequestBudgets>,
+        ceiling: &EngineConfig,
+    ) -> EffectiveBudgets {
+        match budgets {
+            Some(budgets) => budgets.clamp(ceiling),
+            None => EffectiveBudgets::from_ceiling(ceiling),
+        }
+    }
+}
+
+impl EffectiveBudgets {
+    /// The ceiling itself, with nothing lowered.
+    pub fn from_ceiling(ceiling: &EngineConfig) -> Self {
+        EffectiveBudgets {
+            max_bytes_scanned: ceiling.max_bytes_scanned,
+            max_store_requests: ceiling.max_s3_requests,
+            max_segments: ceiling.max_segments,
+        }
+    }
+
+    /// `ceiling` with these three budgets substituted in.
+    ///
+    /// This is how a lowered budget reaches every enforcement site at once. The
+    /// sites read `config.max_bytes_scanned`, `config.max_s3_requests`, and
+    /// `config.max_segments`; handing them a config whose three fields are
+    /// already the effective values is what makes "the check reads the
+    /// effective budget" true structurally rather than by each site
+    /// remembering to consult a second value.
+    pub fn applied_to(&self, ceiling: &EngineConfig) -> EngineConfig {
+        EngineConfig {
+            max_bytes_scanned: self.max_bytes_scanned,
+            max_s3_requests: self.max_store_requests,
+            max_segments: self.max_segments,
+            ..*ceiling
+        }
+    }
+}
+
+/// The more restrictive of a caller's byte limit and the ceiling. An absent
+/// caller value, and a caller asking for `Unlimited` under a bounded ceiling,
+/// both resolve to the ceiling.
+fn lower_bytes(requested: Option<ByteLimit>, ceiling: ByteLimit) -> ByteLimit {
+    match (requested, ceiling) {
+        (None, ceiling) => ceiling,
+        (Some(ByteLimit::Unlimited), ceiling) => ceiling,
+        (Some(ByteLimit::Bounded(v)), ByteLimit::Unlimited) => ByteLimit::Bounded(v),
+        (Some(ByteLimit::Bounded(v)), ByteLimit::Bounded(c)) => ByteLimit::Bounded(v.min(c)),
+    }
+}
+
+/// [`lower_bytes`] for the store-request budget.
+fn lower_requests(requested: Option<RequestLimit>, ceiling: RequestLimit) -> RequestLimit {
+    match (requested, ceiling) {
+        (None, ceiling) => ceiling,
+        (Some(RequestLimit::Unlimited), ceiling) => ceiling,
+        (Some(RequestLimit::Bounded(v)), RequestLimit::Unlimited) => RequestLimit::Bounded(v),
+        (Some(RequestLimit::Bounded(v)), RequestLimit::Bounded(c)) => {
+            RequestLimit::Bounded(v.min(c))
+        }
+    }
+}
+
+/// A limit on the wire: a plain number for a bound, the string `"unlimited"`
+/// for none. Shared by [`ByteLimit`] and [`RequestLimit`] so both spell an
+/// unbounded budget the same way an operator already spells it in the limits
+/// file.
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum LimitWire {
+    Bounded(u64),
+    Unlimited(String),
+}
+
+impl Serialize for ByteLimit {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            ByteLimit::Bounded(v) => serializer.serialize_u64(*v),
+            ByteLimit::Unlimited => serializer.serialize_str(UNLIMITED),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ByteLimit {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match LimitWire::deserialize(deserializer)? {
+            LimitWire::Bounded(v) => Ok(ByteLimit::Bounded(v)),
+            LimitWire::Unlimited(s) if s == UNLIMITED => Ok(ByteLimit::Unlimited),
+            LimitWire::Unlimited(s) => Err(serde::de::Error::custom(format!(
+                "expected a byte count or {UNLIMITED:?}, got {s:?}"
+            ))),
+        }
+    }
+}
+
+impl Serialize for RequestLimit {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            RequestLimit::Bounded(v) => serializer.serialize_u64(*v),
+            RequestLimit::Unlimited => serializer.serialize_str(UNLIMITED),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RequestLimit {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match LimitWire::deserialize(deserializer)? {
+            LimitWire::Bounded(v) => Ok(RequestLimit::Bounded(v)),
+            LimitWire::Unlimited(s) if s == UNLIMITED => Ok(RequestLimit::Unlimited),
+            LimitWire::Unlimited(s) => Err(serde::de::Error::custom(format!(
+                "expected a request count or {UNLIMITED:?}, got {s:?}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// ADR-1374 decision 3 prerequisite 1 names `max_store_requests` as the one
+    /// canonical wire name for the store-request budget. The ceiling it lowers
+    /// is still spelled `max_s3_requests`, so nothing but this assertion stops
+    /// the wire name from drifting back to the internal one.
+    #[test]
+    fn request_budget_field_names_are_the_wire_contract() {
+        let budgets = RequestBudgets {
+            max_bytes_scanned: Some(ByteLimit::Bounded(4096)),
+            max_store_requests: Some(RequestLimit::Bounded(12)),
+            max_segments: Some(7),
+        };
+        let json = serde_json::to_string(&budgets).expect("serialize");
+        assert_eq!(
+            json,
+            r#"{"max_bytes_scanned":4096,"max_store_requests":12,"max_segments":7}"#
+        );
+
+        let parsed: RequestBudgets = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, budgets);
+    }
+
+    /// An unbounded budget is the string form on both sides, so a caller can
+    /// spell "no bound of my own" the same way the limits file does. It still
+    /// cannot lift a bounded ceiling; that is
+    /// `request_budget_cannot_be_raised_above_server_ceiling`.
+    #[test]
+    fn unlimited_round_trips_as_the_operator_spelling() {
+        let budgets = RequestBudgets {
+            max_bytes_scanned: Some(ByteLimit::Unlimited),
+            max_store_requests: Some(RequestLimit::Unlimited),
+            max_segments: None,
+        };
+        let json = serde_json::to_string(&budgets).expect("serialize");
+        assert_eq!(
+            json,
+            r#"{"max_bytes_scanned":"unlimited","max_store_requests":"unlimited"}"#
+        );
+        let parsed: RequestBudgets = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, budgets);
+    }
+
+    /// A limit string that is not `"unlimited"` is a typed deserialization
+    /// error, never a silently-unbounded budget.
+    #[test]
+    fn an_unknown_limit_string_is_rejected() {
+        let err = serde_json::from_str::<RequestBudgets>(r#"{"max_bytes_scanned":"none"}"#)
+            .expect_err("must reject");
+        assert!(
+            err.to_string().contains("unlimited"),
+            "the error must name the accepted spelling, got {err}"
+        );
+    }
+
+    /// `applied_to` substitutes exactly the three budget fields and leaves the
+    /// rest of the ceiling alone: a lowered budget must not silently reset an
+    /// unrelated knob.
+    #[test]
+    fn applied_to_changes_only_the_three_budget_fields() {
+        let ceiling = EngineConfig {
+            max_segments: 100,
+            max_bytes_scanned: ByteLimit::Bounded(10_000),
+            max_s3_requests: RequestLimit::Bounded(500),
+            ..EngineConfig::default()
+        };
+        let lowered = RequestBudgets {
+            max_bytes_scanned: Some(ByteLimit::Bounded(10)),
+            max_store_requests: Some(RequestLimit::Bounded(5)),
+            max_segments: Some(3),
+        }
+        .clamp(&ceiling)
+        .applied_to(&ceiling);
+
+        assert_eq!(lowered.max_bytes_scanned, ByteLimit::Bounded(10));
+        assert_eq!(lowered.max_s3_requests, RequestLimit::Bounded(5));
+        assert_eq!(lowered.max_segments, 3);
+        assert_eq!(
+            EngineConfig {
+                max_segments: ceiling.max_segments,
+                max_bytes_scanned: ceiling.max_bytes_scanned,
+                max_s3_requests: ceiling.max_s3_requests,
+                ..lowered
+            },
+            ceiling,
+            "every field outside the three budgets must be the ceiling's"
+        );
+    }
+}

--- a/crates/ravel-query/src/segment_admission.rs
+++ b/crates/ravel-query/src/segment_admission.rs
@@ -66,11 +66,19 @@ pub fn request_budget_exceeded(
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use std::time::Duration;
 
-    use super::request_budget_exceeded;
-    use crate::config::{RequestLimit, derive_max_s3_requests};
+    use ravel_catalog::{
+        DeclaredColumnStats, SegmentLevel, SegmentOrigin, SegmentOrigins, Snapshot,
+    };
+    use uuid::Uuid;
+
+    use super::{admit, request_budget_exceeded};
+    use crate::config::{ByteLimit, EngineConfig, RequestLimit, derive_max_s3_requests};
+    use crate::error::QueryError;
+    use crate::request_budgets::RequestBudgets;
 
     /// The shard count a `ravel-server` process runs with by default
     /// (`services/ravel-server`'s `--shards`, `default_value_t = 4`). Named
@@ -166,5 +174,131 @@ mod tests {
         let open_hour_4 = 4 * (3_600_000u64 / 500);
         assert!(!RequestLimit::Bounded(four).is_exceeded_by(open_hour_4));
         assert!(RequestLimit::Bounded(OLD_FLAT_CAP).is_exceeded_by(open_hour_4));
+    }
+
+    /// A snapshot of `sealed` sealed, below-watermark segments and one recent
+    /// (exempt) one, with `origins` parallel to `segments` as `admit`'s
+    /// debug assertion requires.
+    fn snapshot_with_sealed(sealed: usize) -> (Snapshot, SegmentOrigins) {
+        let segment = ravel_catalog::SegmentRef {
+            data_object_key: "irrelevant".to_string(),
+            object_size: 4_096,
+            min_event_ts_ns: 0,
+            max_event_ts_ns: 1,
+            ingest_hour_bucket: 0,
+            sample_count: 1,
+            series_count: 1,
+            shard: 0,
+            content_hash: [0u8; 32],
+            writer_id: Uuid::nil(),
+            writer_epoch: 0,
+            writer_seq: 0,
+            created_unix_ns: 0,
+            level: SegmentLevel::L0,
+            segment_format_version: 1,
+            declared_column_stats: DeclaredColumnStats::default(),
+        };
+        let mut origins = SegmentOrigins::default();
+        for _ in 0..sealed {
+            origins.push(SegmentOrigin::SealedBelowWatermark);
+        }
+        origins.push(SegmentOrigin::Recent);
+        let snapshot = Snapshot {
+            segments: vec![segment; sealed + 1],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        (snapshot, origins)
+    }
+
+    /// ADR-1374 decision 3: a caller-supplied [`RequestBudgets`] can only
+    /// LOWER a server ceiling. A value above the ceiling resolves to the
+    /// ceiling, a value below it resolves to itself, and an absent value
+    /// leaves the ceiling untouched.
+    ///
+    /// Asserted through the two enforcement seams, not only through `clamp`:
+    /// the clamped values are what `admit` and `request_budget_exceeded`
+    /// actually read, so a clamp that computed the right number but never
+    /// reached the check would pass a `clamp`-only test.
+    #[test]
+    fn request_budget_cannot_be_raised_above_server_ceiling() {
+        let ceiling = EngineConfig {
+            max_segments: 10,
+            max_bytes_scanned: ByteLimit::Bounded(1_000),
+            max_s3_requests: RequestLimit::Bounded(100),
+            ..EngineConfig::default()
+        };
+
+        // Above the ceiling in every field: each one clamps down to the
+        // ceiling's exact value, never the caller's.
+        let raised = RequestBudgets {
+            max_bytes_scanned: Some(ByteLimit::Bounded(1_000_000)),
+            max_store_requests: Some(RequestLimit::Bounded(50_000)),
+            max_segments: Some(9_999),
+        }
+        .clamp(&ceiling);
+        assert_eq!(raised.max_bytes_scanned, ByteLimit::Bounded(1_000));
+        assert_eq!(raised.max_store_requests, RequestLimit::Bounded(100));
+        assert_eq!(raised.max_segments, 10);
+
+        // `Unlimited` is the strongest possible ask and still cannot lift a
+        // bounded ceiling.
+        let unbounded = RequestBudgets {
+            max_bytes_scanned: Some(ByteLimit::Unlimited),
+            max_store_requests: Some(RequestLimit::Unlimited),
+            max_segments: None,
+        }
+        .clamp(&ceiling);
+        assert_eq!(unbounded.max_bytes_scanned, ByteLimit::Bounded(1_000));
+        assert_eq!(unbounded.max_store_requests, RequestLimit::Bounded(100));
+        assert_eq!(unbounded.max_segments, 10);
+
+        // Below the ceiling: the caller's own value, exactly.
+        let lowered = RequestBudgets {
+            max_bytes_scanned: Some(ByteLimit::Bounded(256)),
+            max_store_requests: Some(RequestLimit::Bounded(7)),
+            max_segments: Some(2),
+        }
+        .clamp(&ceiling);
+        assert_eq!(lowered.max_bytes_scanned, ByteLimit::Bounded(256));
+        assert_eq!(lowered.max_store_requests, RequestLimit::Bounded(7));
+        assert_eq!(lowered.max_segments, 2);
+
+        // Absent entirely: byte-identical to the pre-ADR-1374 behavior.
+        let absent = RequestBudgets::default().clamp(&ceiling);
+        assert_eq!(absent.max_bytes_scanned, ceiling.max_bytes_scanned);
+        assert_eq!(absent.max_store_requests, ceiling.max_s3_requests);
+        assert_eq!(absent.max_segments, ceiling.max_segments);
+        assert_eq!(absent, RequestBudgets::clamp_optional(None, &ceiling));
+
+        // The request-budget check reads the effective value. 50 requests is
+        // under the ceiling of 100 and over the lowered 7.
+        assert!(request_budget_exceeded(50, raised.max_store_requests).is_none());
+        assert!(request_budget_exceeded(50, absent.max_store_requests).is_none());
+        match request_budget_exceeded(50, lowered.max_store_requests) {
+            Some(QueryError::RequestBudgetExceeded { requests, max }) => {
+                assert_eq!(requests, 50);
+                assert_eq!(max, 7);
+            }
+            other => panic!("a lowered request budget must reject 50 requests, got {other:?}"),
+        }
+
+        // `admit` reads the effective segment count the same way: 5 sealed
+        // segments fit the ceiling of 10 and the raise-attempt's clamped 10,
+        // and are rejected under the lowered 2.
+        let (snapshot, origins) = snapshot_with_sealed(5);
+        for effective in [raised, absent] {
+            let admitted = admit(&snapshot, &origins, &effective.applied_to(&ceiling))
+                .expect("5 sealed segments fit a ceiling of 10");
+            assert_eq!(admitted.sealed_count, 5);
+            assert_eq!(admitted.exempt_count, 1);
+        }
+        match admit(&snapshot, &origins, &lowered.applied_to(&ceiling)) {
+            Err(QueryError::TooManySegments { count, max }) => {
+                assert_eq!(count, 5);
+                assert_eq!(max, 2);
+            }
+            other => panic!("a lowered max_segments must reject 5 sealed segments, got {other:?}"),
+        }
     }
 }

--- a/crates/ravel-sql/Cargo.toml
+++ b/crates/ravel-sql/Cargo.toml
@@ -166,6 +166,11 @@ flight-sql = [
 ]
 
 [dev-dependencies]
+# test-util for `#[tokio::test(start_paused = true)]`: the explain deadline
+# test holds a commit-record GET open and asserts the typed
+# `DeadlineExceeded`, which needs the runtime's injected clock rather than a
+# real 50 ms wait on a loaded machine. Same workspace pin, one added feature.
+tokio = { workspace = true, features = ["test-util"] }
 proptest = { workspace = true }
 uuid = { workspace = true }
 bytes = { workspace = true }

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -849,20 +849,12 @@ impl SqlExecutor {
     ) -> Result<ExplainReport, SqlError> {
         let target = Self::target_signal(&req.sql)?;
         let declared = self.resolve_declared_columns(tenant_hash, req.now_ns).await;
+        // `resolve_admitted` itself checks the effective `max_s3_requests`
+        // right after resolve returns, so `explain` gets that enforcement
+        // for free here without ever reaching the segment-fetch loop in
+        // scan.rs (which it never runs: explain issues no data GET).
         let (snapshot, admission, estimate) =
             self.resolve_admitted(tenant_hash, req, accounting).await?;
-        // Checked here too (mirrors `Self::run` above): `explain` resolves and
-        // plans a statement without ever reaching the segment-fetch loop in
-        // scan.rs, so a caller's lowered `max_s3_requests` (ADR-1374 decision
-        // 3) is only enforceable against the resolve's own catalog requests.
-        if let Some(QueryError::RequestBudgetExceeded { requests, max }) = request_budget_exceeded(
-            accounting.snapshot().total_s3_requests(),
-            self.effective_config(req.budgets.as_ref())
-                .engine
-                .max_s3_requests,
-        ) {
-            return Err(SqlError::RequestBudgetExceeded { requests, max });
-        }
         let segments_resolved = snapshot.segments.len();
 
         let planned = self
@@ -934,23 +926,12 @@ impl SqlExecutor {
             // deadline trip reflects exactly this attempt's issued cost and
             // never a discarded prior attempt's.
             live.install(&accounting);
+            // `resolve` (via `resolve_admitted`) itself checks the effective
+            // `max_s3_requests` right after resolve returns, so a statement
+            // whose snapshot resolves to zero segments cannot slip past this
+            // ceiling on the strength that it never reaches the
+            // segment-fetch loop in scan.rs.
             let (snapshot, estimate) = self.resolve(tenant_hash, req, &accounting).await?;
-            // Checked here, right after resolve returns, not only in the
-            // segment-fetch loop in scan.rs: a statement whose snapshot
-            // resolves to zero segments never reaches that loop, so a
-            // caller's lowered `max_s3_requests` (ADR-1374 decision 3) must
-            // still be enforced on the strength of the resolve's own
-            // catalog requests alone.
-            if let Some(QueryError::RequestBudgetExceeded { requests, max }) =
-                request_budget_exceeded(
-                    accounting.snapshot().total_s3_requests(),
-                    self.effective_config(req.budgets.as_ref())
-                        .engine
-                        .max_s3_requests,
-                )
-            {
-                return Err(SqlError::RequestBudgetExceeded { requests, max });
-            }
             stats.resolves += 1;
             stats.attempts += 1;
             stats.segments = snapshot.segments.len();
@@ -1512,6 +1493,23 @@ impl SqlExecutor {
             }
             TargetSignal::Spans => estimate_spans_cost(&snapshot, catalog_requests),
         };
+        // Checked here, in the one resolve path `execute`, `explain`, and the
+        // Flight SQL `resolve_snapshot` all funnel through, right after
+        // resolve returns and not only in the segment-fetch loop in scan.rs:
+        // a statement whose snapshot resolves to zero segments never reaches
+        // that loop, so a caller's lowered `max_s3_requests` (ADR-1374
+        // decision 3) must still be enforced on the strength of the
+        // resolve's own catalog requests alone. Checked once here rather
+        // than once per caller, so a fourth resolve entry point cannot be
+        // added later without this check automatically covering it too.
+        if let Some(QueryError::RequestBudgetExceeded { requests, max }) = request_budget_exceeded(
+            accounting.snapshot().total_s3_requests(),
+            self.effective_config(req.budgets.as_ref())
+                .engine
+                .max_s3_requests,
+        ) {
+            return Err(SqlError::RequestBudgetExceeded { requests, max });
+        }
         Ok((snapshot, admission, estimate))
     }
 
@@ -3337,9 +3335,12 @@ mod tests {
     /// statement whose snapshot resolves to zero segments never reaches the
     /// segment-fetch loop in scan.rs, so the incremental `max_s3_requests`
     /// check there never runs. A caller-lowered budget of zero (ADR-1374
-    /// decision 3) must still be enforced right after resolve, on both the
-    /// `execute` and `explain` paths, and the server default ceiling must
-    /// not change behavior for the same fixture.
+    /// decision 3) must still be enforced right after resolve, on the
+    /// `execute`, `explain`, and Flight SQL `resolve_snapshot` paths alike --
+    /// round 2 moved the check into `resolve_admitted`, the one resolve path
+    /// all three funnel through, so this covers all three with one shared
+    /// check instead of one copy per caller -- and the server default
+    /// ceiling must not change behavior for the same fixture.
     #[tokio::test]
     async fn lowered_request_budget_is_enforced_after_resolve() {
         let tenant_hash = TenantId::new("acme-sql-budget").hash();
@@ -3397,6 +3398,33 @@ mod tests {
         assert_eq!(
             explain_requests, 3,
             "explain's resolve must issue the same exact catalog request count as execute's"
+        );
+
+        // resolve_snapshot(): the Flight SQL resolve path, which used to
+        // return right after `resolve` with no post-resolution check of its
+        // own. It shares `resolve_admitted` with `execute` and `explain`, so
+        // it must trip on the identical fixture with the identical pinned
+        // cost.
+        let mut snapshot_req = sql_request(sql, window);
+        snapshot_req.budgets = budgets;
+        let snapshot_executor = executor_over(empty_store());
+        let snapshot_accounting = QueryAccounting::new();
+        let snapshot_err = snapshot_executor
+            .resolve_snapshot(tenant_hash, &snapshot_req, &snapshot_accounting)
+            .await
+            .expect_err("resolve_snapshot must also trip on a zero store-request budget");
+        let SqlError::RequestBudgetExceeded {
+            requests: snapshot_requests,
+            max: snapshot_max,
+        } = snapshot_err
+        else {
+            panic!("expected SqlError::RequestBudgetExceeded, got {snapshot_err:?}");
+        };
+        assert_eq!(snapshot_max, 0);
+        assert_eq!(
+            snapshot_requests, 3,
+            "resolve_snapshot's resolve must issue the same exact catalog request count \
+             as execute's and explain's"
         );
 
         // Control: the server's default ceiling is far above any resolve

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -3278,6 +3278,8 @@ mod tests {
     use ravel_commit::publish::RetryPolicy;
     use ravel_commit::record::NewCommitRecord;
     use ravel_commit::{keys, publish, record};
+    use ravel_logseg::writer::ObjectIdentity as LogObjectIdentity;
+    use ravel_logseg::{LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
     use ravel_object_store::StoreError;
     use ravel_object_store::fault::{
         FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
@@ -3286,6 +3288,9 @@ mod tests {
     use ravel_object_store::memory::MemoryStore;
     use ravel_object_store::{ObjectStoreBackend, PutOptions};
     use ravel_query::FetchError;
+    use ravel_rspan::{
+        ObjectIdentity as SpanObjectIdentity, RspanConfig, RspanWriter, SpanRecord, StatusCode,
+    };
     use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
     use ravel_types::{Label, LabelSet, Sample, SeriesId, TenantId};
     use uuid::Uuid;
@@ -4266,6 +4271,166 @@ mod tests {
         (store, tenant_hash, data_key)
     }
 
+    /// One published RSPAN segment holding `count` spans whose `start_ts` is
+    /// `0, 100, 200, ...`, under the same instrumented store the metrics
+    /// fixture uses. Published as a real `Signal::Spans` commit record, so the
+    /// executor resolves it exactly as a production caller would.
+    async fn one_spans_segment(
+        tenant_name: &str,
+        count: i64,
+    ) -> (Arc<InstrumentedStore<FaultStore<MemoryStore>>>, TenantHash) {
+        let tenant = TenantId::new(tenant_name.to_string());
+        let tenant_hash = tenant.hash();
+        let writer_id = Uuid::from_u128(1_376);
+        let records: Vec<SpanRecord> = (0..count)
+            .map(|i| SpanRecord {
+                trace_id: [1u8; 16],
+                span_id: [u8::try_from(i).unwrap_or(u8::MAX); 8],
+                parent_span_id: None,
+                name: "op".to_string(),
+                start_ts_ns: i * 100,
+                end_ts_ns: i * 100 + 10,
+                status_code: StatusCode::Ok,
+                status_message: None,
+                attrs: vec![("service.name".to_string(), "checkout".to_string())],
+            })
+            .collect();
+
+        let identity = SpanObjectIdentity {
+            tenant_hash: tenant_hash.0,
+            shard: 0,
+            writer_id: *writer_id.as_bytes(),
+            writer_epoch: 1,
+            writer_seq: 1,
+        };
+        let mut writer = RspanWriter::new(RspanConfig::default(), identity);
+        for record in &records {
+            writer.push(record.clone());
+        }
+        let bytes = writer.finish().expect("finish span object");
+
+        let min = records.iter().map(|r| r.start_ts_ns).min().expect("rows");
+        let max = records.iter().map(|r| r.end_ts_ns).max().expect("rows");
+        let store = publish_one_segment(
+            tenant_hash,
+            Signal::Spans,
+            writer_id,
+            bytes,
+            records.len() as u64,
+            min,
+            max,
+            1,
+        )
+        .await;
+        (store, tenant_hash)
+    }
+
+    /// One published RLOG segment on the audit stream holding `count` records
+    /// whose `ts_ns` is `0, 100, 200, ...`. The RLOG footer carries a tenant
+    /// hash the read path checks, so the identity below names the same tenant
+    /// the query resolves as.
+    async fn one_audit_segment(
+        tenant_name: &str,
+        count: i64,
+    ) -> (Arc<InstrumentedStore<FaultStore<MemoryStore>>>, TenantHash) {
+        let tenant = TenantId::new(tenant_name.to_string());
+        let tenant_hash = tenant.hash();
+        let writer_id = Uuid::from_u128(1_376);
+        let records: Vec<LogRecord> = (0..count)
+            .map(|i| LogRecord {
+                stream_id: ravel_types::logstream::log_stream_id(&[], "audit", "1", &[]),
+                stream_attrs: stream_attrs_bytes(&[], "audit", "1", &[]),
+                ts_ns: i * 100,
+                observed_ts_ns: i * 100,
+                severity_num: 0,
+                severity_text: "INFO".to_string(),
+                body: "query".to_string(),
+                trace_id: None,
+                span_id: None,
+                flags: 0,
+                attrs: Vec::new(),
+            })
+            .collect();
+
+        let identity = LogObjectIdentity {
+            tenant_hash: tenant_hash.0,
+            shard: 0,
+            writer_id: *writer_id.as_bytes(),
+            writer_epoch: 1,
+            writer_seq: 1,
+        };
+        let mut writer = RlogWriter::new(RlogConfig::default(), identity);
+        for record in &records {
+            writer.push(record.clone()).expect("push audit record");
+        }
+        let bytes = writer.finish().expect("finish audit object");
+
+        let min = records.iter().map(|r| r.ts_ns).min().expect("rows");
+        let max = records.iter().map(|r| r.ts_ns).max().expect("rows");
+        let store = publish_one_segment(
+            tenant_hash,
+            Signal::Audit,
+            writer_id,
+            bytes,
+            records.len() as u64,
+            min,
+            max,
+            u32::from(ravel_logseg::footer::VERSION),
+        )
+        .await;
+        (store, tenant_hash)
+    }
+
+    /// Put one already-encoded data object and publish its commit record, then
+    /// wrap the store the way [`one_metrics_segment`] does.
+    #[allow(clippy::too_many_arguments)]
+    async fn publish_one_segment(
+        tenant_hash: TenantHash,
+        signal: Signal,
+        writer_id: Uuid,
+        bytes: Vec<u8>,
+        row_count: u64,
+        min_event_ts_ns: i64,
+        max_event_ts_ns: i64,
+        segment_format_version: u32,
+    ) -> Arc<InstrumentedStore<FaultStore<MemoryStore>>> {
+        let new_record = NewCommitRecord {
+            tenant_hash,
+            signal,
+            shard: 0,
+            writer_id,
+            writer_epoch: 1,
+            writer_seq: 1,
+            object_size: bytes.len() as u64,
+            content_hash: *blake3::hash(&bytes).as_bytes(),
+            sample_count: row_count,
+            series_count: 0,
+            min_event_ts_ns,
+            max_event_ts_ns,
+            min_ingest_ts_ns: min_event_ts_ns,
+            max_ingest_ts_ns: max_event_ts_ns,
+            segment_format_version,
+            created_unix_ns: 1,
+            ingest_hour_bucket: 0,
+        };
+        let rec = record::build(new_record).expect("valid commit record");
+        let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+
+        let memory = MemoryStore::new();
+        memory
+            .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put data object");
+        publish::publish(&memory, &rec, &RetryPolicy::default())
+            .await
+            .expect("publish");
+
+        Arc::new(InstrumentedStore::new(FaultStore::new(
+            memory,
+            FaultPlan::empty(),
+        )))
+    }
+
     fn executor_over(store: Arc<InstrumentedStore<FaultStore<MemoryStore>>>) -> SqlExecutor {
         let catalog =
             Arc::new(Catalog::new(store.clone(), CatalogConfig::default()).expect("catalog"));
@@ -4281,9 +4446,16 @@ mod tests {
 
     /// The `ts` column of a metrics result, as raw nanoseconds.
     fn ts_values(output: &QueryOutput) -> Vec<i64> {
+        ts_column_values(output, "ts")
+    }
+
+    /// The named event-time column of a result, as raw nanoseconds. Every
+    /// table's event-time column is `Timestamp(Nanosecond, None)`, so the same
+    /// reader serves `ts`, `start_ts`, and `ts_ns`.
+    fn ts_column_values(output: &QueryOutput, name: &str) -> Vec<i64> {
         let mut values = Vec::new();
         for batch in output.batches() {
-            let column = batch.column_by_name("ts").expect("ts column");
+            let column = batch.column_by_name(name).expect("event-time column");
             let ts = column
                 .as_any()
                 .downcast_ref::<TimestampNanosecondArray>()
@@ -4293,7 +4465,9 @@ mod tests {
         values
     }
 
-    fn samples_request(sql: &str, window: TimeRange) -> SqlRequest {
+    /// A request carrying the T1 defaults off: the struct names no table, so
+    /// the statement is the only thing that selects one.
+    fn sql_request(sql: &str, window: TimeRange) -> SqlRequest {
         SqlRequest {
             sql: sql.to_string(),
             window,
@@ -4325,7 +4499,7 @@ mod tests {
             start_ns: 200,
             end_ns: 500,
         };
-        let base = samples_request("SELECT ts, value FROM samples", window);
+        let base = sql_request("SELECT ts, value FROM samples", window);
 
         let before = store.metrics().snapshot();
         let unfiltered = executor_over(store.clone())
@@ -4446,7 +4620,7 @@ mod tests {
                 tenant_hash,
                 &SqlRequest {
                     row_window: true,
-                    ..samples_request(
+                    ..sql_request(
                         "SELECT ts FROM samples WHERE value > (SELECT avg(value) FROM samples)",
                         window,
                     )
@@ -4472,7 +4646,7 @@ mod tests {
                 tenant_hash,
                 &SqlRequest {
                     row_window: true,
-                    ..samples_request(
+                    ..sql_request(
                         "SELECT ts FROM samples WHERE ts IN (SELECT ts FROM samples WHERE value >= 400)",
                         window,
                     )
@@ -4514,7 +4688,7 @@ mod tests {
 
         let request = SqlRequest {
             row_window: true,
-            ..samples_request(
+            ..sql_request(
                 "SELECT ts, value FROM samples",
                 TimeRange {
                     start_ns: 200,
@@ -4607,7 +4781,7 @@ mod tests {
             .hold(Op::Get, Some(".cmt".to_string()), Occurrence::Nth(1));
         let executor = executor_over(store);
 
-        let request = samples_request(
+        let request = sql_request(
             "SELECT ts, value FROM samples",
             TimeRange {
                 start_ns: 0,
@@ -4656,7 +4830,7 @@ mod tests {
             one_metrics_segment("max-rows-1376", 1_000, FaultPlan::empty()).await;
         let executor = executor_over(store);
 
-        let base = samples_request(
+        let base = sql_request(
             "SELECT ts, value FROM samples",
             TimeRange {
                 start_ns: 0,
@@ -4706,5 +4880,153 @@ mod tests {
             .expect("execute with no cap");
         assert_eq!(uncapped.output.num_rows(), 1_000);
         assert!(!uncapped.stats.row_cap_hit);
+
+        // The two boundaries, where an off-by-one lives. At `max_rows` exactly
+        // equal to the result size the stream drains and nothing was cut: the
+        // cap-plus-one'th row does not exist. One row lower, the extra row does
+        // exist, so the same `max_rows + 1` rows come back and the flag is set.
+        // The two cases return the SAME row count (1_000) and differ only in
+        // the flag, which is what makes the flag the only usable signal.
+        let exact = executor
+            .execute(
+                tenant_hash,
+                &SqlRequest {
+                    max_rows: Some(1_000),
+                    ..base.clone()
+                },
+            )
+            .await
+            .expect("execute under a cap equal to the result size");
+        assert_eq!(exact.output.num_rows(), 1_000);
+        assert!(
+            !exact.stats.row_cap_hit,
+            "a cap equal to the result size cuts nothing"
+        );
+
+        let one_short = executor
+            .execute(
+                tenant_hash,
+                &SqlRequest {
+                    max_rows: Some(999),
+                    ..base.clone()
+                },
+            )
+            .await
+            .expect("execute under a cap one row below the result size");
+        assert_eq!(
+            one_short.output.num_rows(),
+            1_000,
+            "max_rows + 1 rows, which here is the whole result"
+        );
+        assert!(
+            one_short.stats.row_cap_hit,
+            "the 1000th row is the cap-plus-one'th, so the result is reported cut"
+        );
+    }
+
+    /// Finding 6. The window column is per table, and only `samples` was
+    /// covered. `spans` filters on `start_ts` and `audit` on `ts_ns`, so a
+    /// wrong entry in [`window_ts_column`] for either would plan a predicate on
+    /// a column that is not in scope, or on the wrong one. Both fixtures
+    /// straddle the window, so widen-only pruning returns every row without
+    /// `row_window` and exactly the in-window rows with it.
+    #[tokio::test]
+    async fn row_window_applies_to_spans_start_ts_and_audit_ts_ns() {
+        let window = TimeRange {
+            start_ns: 200,
+            end_ns: 500,
+        };
+
+        let (spans_store, spans_tenant) = one_spans_segment("row-window-spans-1376", 10).await;
+        let spans_sql = "SELECT start_ts FROM spans";
+        let spans_base = sql_request(spans_sql, window);
+
+        let spans_unfiltered = executor_over(spans_store.clone())
+            .execute(spans_tenant, &spans_base)
+            .await
+            .expect("execute spans without the row window");
+        assert_eq!(
+            spans_unfiltered.output.num_rows(),
+            10,
+            "widen-only pruning returns the whole overlapping span segment"
+        );
+        assert_eq!(spans_unfiltered.stats.window_predicate, None);
+
+        let spans_filtered = executor_over(spans_store)
+            .execute(
+                spans_tenant,
+                &SqlRequest {
+                    row_window: true,
+                    ..spans_base
+                },
+            )
+            .await
+            .expect("execute spans with the row window");
+        assert_eq!(
+            spans_filtered.stats.window_predicate.as_deref(),
+            Some(
+                window_filter_expr(&TableReference::bare("spans"), "start_ts", window)
+                    .to_string()
+                    .as_str()
+            )
+        );
+        let mut spans_kept = ts_column_values(&spans_filtered.output, "start_ts");
+        spans_kept.sort_unstable();
+        assert_eq!(
+            spans_kept,
+            vec![200, 300, 400],
+            "exactly the spans starting inside [200, 500)"
+        );
+        assert_eq!(
+            spans_unfiltered.output.num_rows() - spans_filtered.output.num_rows(),
+            7,
+            "the seven spans starting outside the window are excluded"
+        );
+
+        let (audit_store, audit_tenant) = one_audit_segment("row-window-audit-1376", 10).await;
+        let audit_sql = "SELECT ts_ns FROM audit";
+        let audit_base = sql_request(audit_sql, window);
+
+        let audit_unfiltered = executor_over(audit_store.clone())
+            .execute(audit_tenant, &audit_base)
+            .await
+            .expect("execute audit without the row window");
+        assert_eq!(
+            audit_unfiltered.output.num_rows(),
+            10,
+            "widen-only pruning returns the whole overlapping audit segment"
+        );
+        assert_eq!(audit_unfiltered.stats.window_predicate, None);
+
+        let audit_filtered = executor_over(audit_store)
+            .execute(
+                audit_tenant,
+                &SqlRequest {
+                    row_window: true,
+                    ..audit_base
+                },
+            )
+            .await
+            .expect("execute audit with the row window");
+        assert_eq!(
+            audit_filtered.stats.window_predicate.as_deref(),
+            Some(
+                window_filter_expr(&TableReference::bare("audit"), "ts_ns", window)
+                    .to_string()
+                    .as_str()
+            )
+        );
+        let mut audit_kept = ts_column_values(&audit_filtered.output, "ts_ns");
+        audit_kept.sort_unstable();
+        assert_eq!(
+            audit_kept,
+            vec![200, 300, 400],
+            "exactly the audit records inside [200, 500)"
+        );
+        assert_eq!(
+            audit_unfiltered.output.num_rows() - audit_filtered.output.num_rows(),
+            7,
+            "the seven audit records outside the window are excluded"
+        );
     }
 }

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -230,6 +230,15 @@ pub struct SqlRequest {
     /// Per-request budgets for this statement, which can only LOWER the
     /// server's configured ceilings (ADR-1374 decision 3, prerequisite 1).
     /// `None` runs under the server config unchanged.
+    ///
+    /// Which knob binds depends on the table. Only the `samples` (metrics)
+    /// provider reads the effective `max_bytes_scanned` and
+    /// `max_store_requests` at scan time; the `logs`, `spans`, `alerts`, and
+    /// `audit` providers do not. For those four tables only `max_segments` is
+    /// lowered today, through the catalog resolve every table shares. A bytes
+    /// or request ceiling set for one of them is clamped and then never
+    /// consulted. That is a pre-existing gap in those providers, tracked as
+    /// issue #1409, not a property of the budgets themselves.
     pub budgets: Option<RequestBudgets>,
 }
 
@@ -4302,11 +4311,15 @@ mod tests {
     /// carries no time predicate, and the request window only bounded which
     /// segments were listed. `row_window` is what turns that window into a row
     /// filter, and the two executions below differ in nothing else.
+    ///
+    /// Each run gets its own executor over the one shared store, so both
+    /// resolve and fetch cold and their request counts are comparable: reusing
+    /// one executor would let the second run read the first's caches, and the
+    /// second run's lower count would say nothing about pruning.
     #[tokio::test]
     async fn row_window_excludes_rows_outside_range_inside_overlapping_segment() {
         let (store, tenant_hash, _data_key) =
             one_metrics_segment("row-window-1376", 1_000, FaultPlan::empty()).await;
-        let executor = executor_over(store);
 
         let window = TimeRange {
             start_ns: 200,
@@ -4314,10 +4327,12 @@ mod tests {
         };
         let base = samples_request("SELECT ts, value FROM samples", window);
 
-        let unfiltered = executor
+        let before = store.metrics().snapshot();
+        let unfiltered = executor_over(store.clone())
             .execute(tenant_hash, &base)
             .await
             .expect("execute without the row window");
+        let after_unfiltered = store.metrics().snapshot();
         assert_eq!(
             unfiltered.stats.segments, 1,
             "the fixture is one segment straddling the window"
@@ -4329,7 +4344,7 @@ mod tests {
         );
         assert_eq!(unfiltered.stats.window_predicate, None);
 
-        let filtered = executor
+        let filtered = executor_over(store.clone())
             .execute(
                 tenant_hash,
                 &SqlRequest {
@@ -4339,6 +4354,24 @@ mod tests {
             )
             .await
             .expect("execute with the row window");
+        let after_filtered = store.metrics().snapshot();
+
+        // The injected filter is pushed down like any predicate the statement
+        // itself carried, so pruning with the row window is a SUBSET of pruning
+        // without it: never more work, and sound either way because the
+        // provider reports `Inexact` and the filter is re-applied above the
+        // scan. Both counts are pinned exactly, so a run that started reading
+        // more (or that pruned an object it still needed) fails here rather
+        // than passing an inequality that holds for the wrong reason.
+        let unfiltered_gets = after_unfiltered.get.calls - before.get.calls;
+        let filtered_gets = after_filtered.get.calls - after_unfiltered.get.calls;
+        assert!(
+            filtered_gets <= unfiltered_gets,
+            "the row window must never make the run read more: \
+             {filtered_gets} > {unfiltered_gets}"
+        );
+        assert_eq!(unfiltered_gets, ROW_WINDOW_RUN_GETS);
+        assert_eq!(filtered_gets, ROW_WINDOW_RUN_GETS);
 
         // What was applied, before what it did: the reported text is the
         // display of the expression the rewrite built, not an independently
@@ -4371,6 +4404,15 @@ mod tests {
         assert_eq!(kept.last().copied(), Some(499), "end is exclusive");
         assert_eq!(kept, (200..500).collect::<Vec<i64>>());
     }
+
+    /// Every GET one whole `SELECT ts, value FROM samples` run issues against
+    /// the one-segment fixture from a cold executor: the resolve's
+    /// [`EXPLAIN_RESOLVE_GETS`] catalog reads plus the data object's own. The
+    /// same figure holds with and without the row window on this fixture, which
+    /// is the point: one segment overlaps the window, so the tightened pruning
+    /// the injected filter allows cannot drop it, and the run still reads it
+    /// whole and filters by row.
+    const ROW_WINDOW_RUN_GETS: u64 = 3;
 
     /// The exact predicate text a `[200, 500)` row window on `samples` reports,
     /// pinned so a change to the rendering (a dropped qualifier, a literal

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -96,6 +96,7 @@ use ravel_memory::MemoryBudget;
 use ravel_promql::{LabelMatcher, MatchOp};
 use ravel_query::{
     LogSegmentFetcher, QueryError, RequestBudgets, SegmentAdmission, SegmentFetcher, admit,
+    request_budget_exceeded,
 };
 use ravel_types::accounting::{CostEstimate, QueryAccounting, QueryAccountingSnapshot};
 use ravel_types::{CommitToken, METRIC_NAME_LABEL, Signal, TenantHash, TimeRange};
@@ -850,6 +851,18 @@ impl SqlExecutor {
         let declared = self.resolve_declared_columns(tenant_hash, req.now_ns).await;
         let (snapshot, admission, estimate) =
             self.resolve_admitted(tenant_hash, req, accounting).await?;
+        // Checked here too (mirrors `Self::run` above): `explain` resolves and
+        // plans a statement without ever reaching the segment-fetch loop in
+        // scan.rs, so a caller's lowered `max_s3_requests` (ADR-1374 decision
+        // 3) is only enforceable against the resolve's own catalog requests.
+        if let Some(QueryError::RequestBudgetExceeded { requests, max }) = request_budget_exceeded(
+            accounting.snapshot().total_s3_requests(),
+            self.effective_config(req.budgets.as_ref())
+                .engine
+                .max_s3_requests,
+        ) {
+            return Err(SqlError::RequestBudgetExceeded { requests, max });
+        }
         let segments_resolved = snapshot.segments.len();
 
         let planned = self
@@ -922,6 +935,22 @@ impl SqlExecutor {
             // never a discarded prior attempt's.
             live.install(&accounting);
             let (snapshot, estimate) = self.resolve(tenant_hash, req, &accounting).await?;
+            // Checked here, right after resolve returns, not only in the
+            // segment-fetch loop in scan.rs: a statement whose snapshot
+            // resolves to zero segments never reaches that loop, so a
+            // caller's lowered `max_s3_requests` (ADR-1374 decision 3) must
+            // still be enforced on the strength of the resolve's own
+            // catalog requests alone.
+            if let Some(QueryError::RequestBudgetExceeded { requests, max }) =
+                request_budget_exceeded(
+                    accounting.snapshot().total_s3_requests(),
+                    self.effective_config(req.budgets.as_ref())
+                        .engine
+                        .max_s3_requests,
+                )
+            {
+                return Err(SqlError::RequestBudgetExceeded { requests, max });
+            }
             stats.resolves += 1;
             stats.attempts += 1;
             stats.segments = snapshot.segments.len();
@@ -3296,6 +3325,96 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+
+    fn empty_store() -> Arc<InstrumentedStore<FaultStore<MemoryStore>>> {
+        Arc::new(InstrumentedStore::new(FaultStore::new(
+            MemoryStore::new(),
+            FaultPlan::empty(),
+        )))
+    }
+
+    /// CodeRabbit finding on PR #1424 (comment 3952989200), SQL side: a
+    /// statement whose snapshot resolves to zero segments never reaches the
+    /// segment-fetch loop in scan.rs, so the incremental `max_s3_requests`
+    /// check there never runs. A caller-lowered budget of zero (ADR-1374
+    /// decision 3) must still be enforced right after resolve, on both the
+    /// `execute` and `explain` paths, and the server default ceiling must
+    /// not change behavior for the same fixture.
+    #[tokio::test]
+    async fn lowered_request_budget_is_enforced_after_resolve() {
+        let tenant_hash = TenantId::new("acme-sql-budget").hash();
+        let window = TimeRange {
+            start_ns: 0,
+            end_ns: 60_000_000_000,
+        };
+        let sql = "SELECT ts, value FROM samples";
+        let budgets = Some(ravel_query::RequestBudgets {
+            max_store_requests: Some(ravel_query::RequestLimit::Bounded(0)),
+            ..Default::default()
+        });
+
+        // execute(): the attempt path in `run`.
+        let mut exec_req = sql_request(sql, window);
+        exec_req.budgets = budgets;
+        let executor = executor_over(empty_store());
+        let err = executor
+            .execute(tenant_hash, &exec_req)
+            .await
+            .expect_err("a zero store-request budget must trip even on an empty snapshot");
+        let SqlError::RequestBudgetExceeded { requests, max } = err else {
+            panic!("expected SqlError::RequestBudgetExceeded, got {err:?}");
+        };
+        assert_eq!(
+            max, 0,
+            "the caller's lowered ceiling must be reported exactly"
+        );
+        // Pinned: an empty-snapshot resolve against a fresh `MemoryStore`
+        // issues exactly 3 catalog requests, on both the execute and
+        // explain paths (both funnel through `resolve_admitted`).
+        assert_eq!(
+            requests, 3,
+            "the resolve's own catalog request count must be exact, not just nonzero"
+        );
+
+        // explain(): the same check in `explain_inner`, against a fresh
+        // store/executor so the two paths' resolves are not comparing a warm
+        // cache against a cold one.
+        let mut explain_req = sql_request(sql, window);
+        explain_req.budgets = budgets;
+        let explain_executor = executor_over(empty_store());
+        let explain_err = explain_executor
+            .explain(tenant_hash, &explain_req)
+            .await
+            .expect_err("explain must also trip on a zero store-request budget");
+        let SqlError::RequestBudgetExceeded {
+            requests: explain_requests,
+            max: explain_max,
+        } = explain_err
+        else {
+            panic!("expected SqlError::RequestBudgetExceeded, got {explain_err:?}");
+        };
+        assert_eq!(explain_max, 0);
+        assert_eq!(
+            explain_requests, 3,
+            "explain's resolve must issue the same exact catalog request count as execute's"
+        );
+
+        // Control: the server's default ceiling is far above any resolve
+        // cost, so the identical fixture succeeds under it, and the
+        // accounted request count is the same exact number both budgeted
+        // attempts tripped on.
+        let control_req = sql_request(sql, window);
+        let control_executor = executor_over(empty_store());
+        let outcome = control_executor
+            .execute(tenant_hash, &control_req)
+            .await
+            .expect("the server default ceiling must not trip on the resolve's own cost");
+        assert_eq!(
+            outcome.accounting.total_s3_requests(),
+            requests,
+            "the default-ceiling control must account the same resolve cost as the trip"
+        );
+    }
 
     fn not_found() -> SqlError {
         SqlError::Fetch(FetchError::Store {

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -802,6 +802,11 @@ impl SqlExecutor {
 
     /// [`Self::explain`] with a caller-owned [`QueryAccounting`], so the
     /// resolve's own store spend is attributable.
+    ///
+    /// Bounded by [`SqlRequest::deadline`] exactly as [`Self::execute_accounted`]
+    /// is. Explain issues no data GET, but it does issue the resolve's catalog
+    /// LISTs and GETs, and a store that stops answering would otherwise hang
+    /// this call for as long as the transport allowed.
     pub async fn explain_accounted(
         &self,
         tenant_hash: TenantHash,
@@ -809,8 +814,29 @@ impl SqlExecutor {
         accounting: &QueryAccounting,
     ) -> Result<ExplainReport, SqlError> {
         // Same order as `execute`: the security gate first, so a rejected
-        // statement costs no catalog LIST here either.
+        // statement costs no catalog LIST here either, and it runs outside the
+        // timeout because a rejection is not a thing that can time out.
         validate(&req.sql)?;
+
+        let millis = u64::try_from(req.deadline.as_millis()).unwrap_or(u64::MAX);
+        tokio::time::timeout(
+            req.deadline,
+            self.explain_inner(tenant_hash, req, accounting),
+        )
+        .await
+        .unwrap_or(Err(SqlError::DeadlineExceeded { millis }))
+    }
+
+    /// The resolve-and-plan body behind [`Self::explain_accounted`], minus
+    /// validation and the deadline. Separate so the timeout wraps exactly the
+    /// work that can block, matching how [`Self::run`] sits under
+    /// [`Self::execute_accounted`].
+    async fn explain_inner(
+        &self,
+        tenant_hash: TenantHash,
+        req: &SqlRequest,
+        accounting: &QueryAccounting,
+    ) -> Result<ExplainReport, SqlError> {
         let target = Self::target_signal(&req.sql)?;
         let declared = self.resolve_declared_columns(tenant_hash, req.now_ns).await;
         let (snapshot, admission, estimate) =
@@ -4523,6 +4549,62 @@ mod tests {
     /// here, rather than becoming a larger number nobody compares.
     const EXPLAIN_RESOLVE_LISTS: u64 = 2;
     const EXPLAIN_RESOLVE_GETS: u64 = 2;
+
+    /// Finding 2. `explain` never opens a data object, but it does issue the
+    /// resolve's catalog reads, so it needs the same wall bound `execute` has.
+    /// A hold gate on the first commit-record GET stops the resolve inside the
+    /// call and never yields (a `MemoryStore` answers every read, so nothing
+    /// else here is slow), and the clock is the runtime's injected one: the
+    /// test parks, tokio advances to the timer, and no wall time passes.
+    #[tokio::test(start_paused = true)]
+    async fn explain_honors_the_request_deadline() {
+        let (store, tenant_hash, _data_key) =
+            one_metrics_segment("explain-deadline-1376", 1_000, FaultPlan::empty()).await;
+        let held = store
+            .inner()
+            .hold(Op::Get, Some(".cmt".to_string()), Occurrence::Nth(1));
+        let executor = executor_over(store);
+
+        let request = samples_request(
+            "SELECT ts, value FROM samples",
+            TimeRange {
+                start_ns: 0,
+                end_ns: 2_000,
+            },
+        );
+        let request = SqlRequest {
+            deadline: Duration::from_millis(50),
+            ..request
+        };
+
+        // The outer guard is 1200x the request deadline and exists only so a
+        // regression that drops the wrapper fails here instead of hanging the
+        // suite. Under the paused clock both are virtual: the runtime advances
+        // to the earliest timer, which is the 50 ms one whenever it is armed.
+        let err = tokio::time::timeout(
+            Duration::from_secs(60),
+            executor.explain(tenant_hash, &request),
+        )
+        .await
+        .expect("explain must return under its own deadline rather than run unbounded")
+        .expect_err("the held commit-record GET must trip the deadline");
+        assert!(
+            matches!(err, SqlError::DeadlineExceeded { millis: 50 }),
+            "explain must report the typed deadline error: {err:?}"
+        );
+
+        // Non-vacuity: the gate matched exactly one call, and it is the
+        // commit-record GET, so the deadline tripped on the resolve being held
+        // and not on some unrelated stall.
+        let details = held.held_details();
+        assert_eq!(details.len(), 1, "the gate held exactly one call");
+        assert_eq!(details[0].1, Op::Get);
+        assert!(
+            details[0].2.ends_with(".cmt"),
+            "the held call is the commit-record GET: {}",
+            details[0].2
+        );
+    }
 
     /// Prerequisite 4. The cap stops the stream at `max_rows + 1` rows: the
     /// extra row is the evidence that more existed, reported as `row_cap_hit`.

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -68,6 +68,7 @@
 //! reserved bytes (crate::memory); partial state is discarded,
 //! never returned (docs/query-engine.md "Budgets").
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -77,21 +78,25 @@ use std::time::{Duration, Instant};
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::error::ArrowError;
-use datafusion::common::DFSchema;
-use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
+use datafusion::common::{Column, DFSchema, ScalarValue};
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::execution::disk_manager::DiskManager;
 use datafusion::execution::memory_pool::{MemoryLimit, MemoryPool, UnboundedMemoryPool};
-use datafusion::logical_expr::{Aggregate, Distinct, Expr, ExprSchemable, LogicalPlan};
+use datafusion::logical_expr::{
+    Aggregate, Distinct, Expr, ExprSchemable, Filter, LogicalPlan, lit,
+};
 use datafusion::physical_plan::{ExecutionPlan, execute_stream};
 use datafusion::prelude::SessionContext;
 use futures::{Stream, StreamExt};
 use ravel_catalog::{Catalog, Snapshot};
 use ravel_memory::MemoryBudget;
 use ravel_promql::{LabelMatcher, MatchOp};
-use ravel_query::{LogSegmentFetcher, QueryError, SegmentFetcher, admit};
+use ravel_query::{
+    LogSegmentFetcher, QueryError, RequestBudgets, SegmentAdmission, SegmentFetcher, admit,
+};
 use ravel_types::accounting::{CostEstimate, QueryAccounting, QueryAccountingSnapshot};
 use ravel_types::{CommitToken, METRIC_NAME_LABEL, Signal, TenantHash, TimeRange};
 
@@ -121,7 +126,7 @@ use crate::validate::{referenced_base_tables, validate};
 /// variant the SQL surface has no table for, and the executor must never
 /// resolve or register that.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum TargetSignal {
+pub enum TargetSignal {
     /// The `samples` table, resolved against `Signal::Metrics`.
     Metrics,
     /// The `logs` table, resolved against `Signal::Logs`.
@@ -174,6 +179,13 @@ struct PlanExtras {
     /// or `None` to run the samples scan locally.
     #[cfg(feature = "flight-sql")]
     distributed: Option<DistributedScan>,
+    /// Apply this window as a row filter above every scan
+    /// ([`SqlRequest::row_window`]). `None` leaves the plan untouched, which is
+    /// what every pre-ADR-1374 caller gets.
+    row_window: Option<TimeRange>,
+    /// This request's lowered budgets ([`SqlRequest::budgets`]). `None` plans
+    /// under the executor's own configuration unchanged.
+    budgets: Option<RequestBudgets>,
 }
 
 /// One SQL request, fully resolved from its transport.
@@ -192,10 +204,35 @@ pub struct SqlRequest {
     pub now_ns: i64,
     /// Wall deadline for the whole call, retry included.
     pub deadline: Duration,
+    /// Apply `window` as a row filter above the scan, not only as the
+    /// segment-listing bound (ADR-1374 decision 3, prerequisite 2). Off by
+    /// default, which is the shipped behavior: `window` widens to whole
+    /// segments, so a segment overlapping the window contributes every row it
+    /// holds unless the statement itself says otherwise.
+    ///
+    /// An agent writing SQL against a window it did not choose cannot know to
+    /// add that predicate, so the caller that chose the window opts in here
+    /// instead. See [`window_predicate_for`] for the column each table filters
+    /// on and [`SqlStats::window_predicate`] for what was applied.
+    pub row_window: bool,
+    /// Stop the stream once this many rows have been emitted, plus one
+    /// (ADR-1374 decision 3, prerequisite 4). The extra row is deliberate: it
+    /// is what lets a caller distinguish "this is the whole result" from "this
+    /// result was cut", reported as [`SqlStats::row_cap_hit`]. `None` (the
+    /// default) drains the plan to completion.
+    pub max_rows: Option<usize>,
+    /// Per-request budgets for this statement, which can only LOWER the
+    /// server's configured ceilings (ADR-1374 decision 3, prerequisite 1).
+    /// `None` runs under the server config unchanged.
+    pub budgets: Option<RequestBudgets>,
 }
 
 /// What the executor actually did, for tests and operator metrics.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// Not `Copy`: [`Self::window_predicate`] carries the applied predicate text,
+/// and reporting the predicate that ran (rather than a flag saying one did) is
+/// what lets a caller check the executor filtered on the column it meant.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SqlStats {
     /// `Catalog::resolve` calls. 1 normally, 2 when the retry contract fired.
     pub resolves: u32,
@@ -223,6 +260,15 @@ pub struct SqlStats {
     /// that wrote it lives on [`SqlOutcome::spill_by_operator`], which does not
     /// have to stay `Copy`.
     pub spill: SpillCounts,
+    /// The row filter [`SqlRequest::row_window`] applied above each scan, in
+    /// the form `"<ts_col> >= <start_ns> AND <ts_col> < <end_ns>"`. `None`
+    /// when the request did not ask for one, which is the default.
+    pub window_predicate: Option<String>,
+    /// Whether [`SqlRequest::max_rows`] cut this result: true when the plan
+    /// produced the cap-plus-one'th row, meaning at least one more row
+    /// existed. False both when no cap was set and when the whole result fit
+    /// inside it.
+    pub row_cap_hit: bool,
 }
 
 /// The `LogsScanExec` block counters, summed over a plan tree.
@@ -248,6 +294,121 @@ fn accumulate_block_counts(plan: &Arc<dyn ExecutionPlan>, counts: &mut BlockCoun
     }
     for child in plan.children() {
         accumulate_block_counts(child, counts);
+    }
+}
+
+/// The event-time column [`SqlRequest::row_window`] filters each table on.
+///
+/// One column per table, not a guess: `samples` and `logs` both carry `ts`,
+/// a span's event time is its `start_ts` (`end_ts` is when it finished), and
+/// the two RLOG-backed tables carry `ts_ns`. All five are
+/// `Timestamp(Nanosecond, None)`, so one literal type serves them all.
+fn window_ts_column(target: TargetSignal) -> &'static str {
+    match target {
+        TargetSignal::Metrics | TargetSignal::Logs => "ts",
+        TargetSignal::Spans => "start_ts",
+        TargetSignal::Alerts | TargetSignal::Audit => "ts_ns",
+    }
+}
+
+/// The predicate text [`SqlStats::window_predicate`] reports for `target`
+/// filtered to `window`. Half-open on the right, matching `TimeRange` and the
+/// segment-listing bound the same window already drives.
+fn window_predicate_for(target: TargetSignal, window: TimeRange) -> String {
+    let ts = window_ts_column(target);
+    format!("{ts} >= {} AND {ts} < {}", window.start_ns, window.end_ns)
+}
+
+/// A nanosecond event-time literal, in the column's own Arrow type so the
+/// comparison needs no cast.
+fn ts_literal(ns: i64) -> Expr {
+    lit(ScalarValue::TimestampNanosecond(Some(ns), None))
+}
+
+/// Insert `ts_col >= window.start_ns AND ts_col < window.end_ns` directly
+/// above every `TableScan` in `plan` (ADR-1374 decision 3, prerequisite 2).
+///
+/// Rewrites the UNOPTIMIZED logical plan, which is what keeps this from
+/// interfering with pruning. At this stage a `TableScan` still carries no
+/// projection, so the event-time column is always in scope; the optimizer then
+/// pushes projections and filters down over the rewritten plan exactly as it
+/// would over the original. The provider still returns `Inexact` for every
+/// filter it is offered, so this predicate arrives at the scan as a widen-only
+/// hint and is re-applied above it: no segment or block is pruned that the
+/// statement alone would not have pruned, and a segment straddling the window
+/// is still read whole and filtered by row.
+///
+/// A `Filter` preserves its input's schema, so the planned result schema is
+/// unchanged and the caller's `DataFrame` can be rebuilt around the new plan.
+fn apply_row_window(
+    plan: LogicalPlan,
+    ts_col: &str,
+    window: TimeRange,
+) -> Result<LogicalPlan, SqlError> {
+    plan.transform_up(|node| {
+        if let LogicalPlan::TableScan(scan) = &node {
+            // Qualified by the scan's own relation: an unqualified column
+            // would be ambiguous the moment a plan carries two scans.
+            let ts = Expr::Column(Column::new(Some(scan.table_name.clone()), ts_col));
+            let predicate = ts
+                .clone()
+                .gt_eq(ts_literal(window.start_ns))
+                .and(ts.lt(ts_literal(window.end_ns)));
+            // An unresolvable column surfaces here as a typed plan error,
+            // never as a silently unfiltered scan.
+            let filter = Filter::try_new(predicate, Arc::new(node))?;
+            return Ok(Transformed::yes(LogicalPlan::Filter(filter)));
+        }
+        Ok(Transformed::no(node))
+    })
+    .map(|transformed| transformed.data)
+    .map_err(plan_error)
+}
+
+/// What [`SqlExecutor::explain`] found out about a statement without reading
+/// any of its data (ADR-1374 decision 3, prerequisite 3).
+#[derive(Debug, Clone)]
+pub struct ExplainReport {
+    /// The signal the validated statement targets, chosen from its `FROM`
+    /// clause the same way execution chooses it.
+    pub target: TargetSignal,
+    /// The effective result schema, declared typed columns (ADR-0090)
+    /// included.
+    pub schema: SchemaRef,
+    /// Segments the resolve returned, of every origin.
+    pub segments_resolved: usize,
+    /// Of those, the sealed below-watermark segments checked against
+    /// `max_segments` (ADR-0073 decision 2).
+    pub segments_admitted: u64,
+    /// Of those, the recent and token-resolved segments exempt from
+    /// `max_segments`, whose cost the request budget bounds instead.
+    pub segments_recent_exempt: u64,
+    /// The pre-execution cost estimate (ADR-0044 "3."), from this resolve.
+    pub estimate: CostEstimate,
+    /// [`CostEstimate`] fields the estimator cannot bound for this target,
+    /// named so a caller does not read a structural zero as a real estimate of
+    /// zero. Empty for a metrics query, which the estimator bounds fully.
+    pub unbounded_components: Vec<&'static str>,
+    /// The row filter [`SqlRequest::row_window`] would apply, or `None`.
+    pub window_predicate: Option<String>,
+    /// The physical plan, rendered as DataFusion's indented display.
+    pub plan_text: String,
+}
+
+/// Which [`CostEstimate`] components the estimator cannot bound for `target`.
+///
+/// `estimate_logs_cost` and `estimate_spans_cost` both pass a literal zero for
+/// `estimated_decompressed_bytes`: the RLOG and RSPAN funnels never call
+/// `add_decompressed_bytes`, so that zero is a statement about where the
+/// accounting lives, not a claim that no bytes are decompressed. Reporting it
+/// as an estimate of zero would be a wrong answer to a question a caller
+/// budgeting a query is entitled to ask, so it is named as unknown instead.
+fn unbounded_estimate_components(target: TargetSignal) -> Vec<&'static str> {
+    match target {
+        TargetSignal::Metrics => Vec::new(),
+        TargetSignal::Logs | TargetSignal::Spans | TargetSignal::Alerts | TargetSignal::Audit => {
+            vec!["estimated_decompressed_bytes"]
+        }
     }
 }
 
@@ -580,6 +741,88 @@ impl SqlExecutor {
             .unwrap_or(Err(SqlError::DeadlineExceeded { millis }))
     }
 
+    /// Answer "what would this statement do?" without reading a single data
+    /// object (ADR-1374 decision 3, prerequisite 3).
+    ///
+    /// Runs the same first half [`Self::execute`] runs -- validate, resolve
+    /// the target signal's snapshot, admit it, estimate its cost, build the
+    /// session and plan -- and stops before execution. The catalog reads the
+    /// resolve issues are real (a plan over an imagined snapshot would answer
+    /// a different question than the one asked); no segment is fetched,
+    /// because nothing polls a stream.
+    ///
+    /// The returned schema is the effective one, declared typed columns
+    /// (ADR-0090) included, because those widen the `logs` table and a caller
+    /// deciding which columns to select has to see them.
+    /// `tenant_hash` is a separate argument rather than a [`SqlRequest`]
+    /// field, matching [`Self::execute`]: the tenant is an authenticated
+    /// property of the connection, and putting it inside the request body
+    /// would let a transport that deserializes one name any tenant it liked.
+    pub async fn explain(
+        &self,
+        tenant_hash: TenantHash,
+        req: &SqlRequest,
+    ) -> Result<ExplainReport, SqlError> {
+        self.explain_accounted(tenant_hash, req, &QueryAccounting::new())
+            .await
+    }
+
+    /// [`Self::explain`] with a caller-owned [`QueryAccounting`], so the
+    /// resolve's own store spend is attributable.
+    pub async fn explain_accounted(
+        &self,
+        tenant_hash: TenantHash,
+        req: &SqlRequest,
+        accounting: &QueryAccounting,
+    ) -> Result<ExplainReport, SqlError> {
+        // Same order as `execute`: the security gate first, so a rejected
+        // statement costs no catalog LIST here either.
+        validate(&req.sql)?;
+        let target = Self::target_signal(&req.sql)?;
+        let declared = self.resolve_declared_columns(tenant_hash, req.now_ns).await;
+        let (snapshot, admission, estimate) =
+            self.resolve_admitted(tenant_hash, req, accounting).await?;
+        let segments_resolved = snapshot.segments.len();
+
+        let planned = self
+            .plan_pinned_with(
+                tenant_hash,
+                snapshot,
+                &req.sql,
+                accounting,
+                PlanExtras {
+                    declared,
+                    #[cfg(feature = "flight-sql")]
+                    distributed: None,
+                    row_window: req.row_window.then_some(req.window),
+                    budgets: req.budgets,
+                },
+            )
+            .await?;
+        let schema = planned.schema();
+        let window_predicate = planned.window_predicate().map(str::to_string);
+        // Physical, not logical: the shapes worth linting (which columns a
+        // TopK's input scan decodes, whether a repartition fans the final
+        // aggregate out) exist only after physical planning. Building it polls
+        // nothing, so it issues no data GET.
+        let plan = planned.create_physical_plan().await?;
+        let plan_text = datafusion::physical_plan::displayable(plan.as_ref())
+            .indent(true)
+            .to_string();
+
+        Ok(ExplainReport {
+            target,
+            schema,
+            segments_resolved,
+            segments_admitted: admission.sealed_count,
+            segments_recent_exempt: admission.exempt_count,
+            estimate,
+            unbounded_components: unbounded_estimate_components(target),
+            window_predicate,
+            plan_text,
+        })
+    }
+
     /// The resolve/plan/execute loop, minus validation and the deadline.
     async fn run(
         &self,
@@ -615,10 +858,15 @@ impl SqlExecutor {
             stats.attempts += 1;
             stats.segments = snapshot.segments.len();
 
-            let (result, emitted, blocks, spill, spill_by_operator) = self
+            let (result, emitted, blocks, spill, spill_by_operator, caps) = self
                 .attempt(tenant_hash, req, snapshot, &accounting, &declared)
                 .await;
             stats.batches_emitted += emitted;
+            // Overwritten per attempt, like `spill` below: these describe the
+            // attempt that just ran, and a retry's values replace the
+            // discarded attempt's rather than accumulating with them.
+            stats.window_predicate = caps.window_predicate;
+            stats.row_cap_hit = caps.row_cap_hit;
             // Recorded for the failing attempt too: a spill that happened
             // before the failure is a fact about this query, and a retried
             // attempt overwrites it with its own, matching how the block
@@ -715,6 +963,8 @@ impl SqlExecutor {
                 // be a needless update on the single-field local build.
                 #[cfg(feature = "flight-sql")]
                 distributed: None,
+                row_window: None,
+                budgets: None,
             },
         )
         .await
@@ -748,6 +998,8 @@ impl SqlExecutor {
             PlanExtras {
                 declared: declared.to_vec(),
                 distributed,
+                row_window: None,
+                budgets: None,
             },
         )
         .await
@@ -765,9 +1017,13 @@ impl SqlExecutor {
         accounting: &QueryAccounting,
         extras: PlanExtras,
     ) -> Result<PinnedQuery, SqlError> {
-        let (pool, breach) = self
-            .config
-            .query_pool(self.tenant_budget(tenant_hash), accounting.clone());
+        // Every read of the executor's configuration below goes through this
+        // one binding, so a request's lowered budgets reach the memory pool,
+        // the metrics provider's scan limits, and the session together. `None`
+        // borrows the executor's own config and clones nothing.
+        let effective = self.effective_config(extras.budgets.as_ref());
+        let config: &SqlConfig = &effective;
+        let (pool, breach) = config.query_pool(self.tenant_budget(tenant_hash), accounting.clone());
         // ADR-0094 decision 1/2: classify the query's aggregates and GROUP BY
         // keys before the real session is built, right here at the one call site
         // that funnels into `build_session`. The result flips
@@ -787,14 +1043,14 @@ impl SqlExecutor {
         // ADR-0954: the spill eligibility predicate reads the same analyzed
         // plan, so a configured-spill deployment is a third consumer of it
         // rather than a second analyze pass.
-        let wants_spill_gate = self.config.spill.is_some();
-        let analyzed =
-            if self.config.parallel_final_aggregation || wants_stats_gate || wants_spill_gate {
-                self.analyzed_classification_plan(tenant_hash, sql, &extras.declared)
-                    .await
-            } else {
-                None
-            };
+        let wants_spill_gate = config.spill.is_some();
+        let analyzed = if config.parallel_final_aggregation || wants_stats_gate || wants_spill_gate
+        {
+            self.analyzed_classification_plan(tenant_hash, sql, &extras.declared)
+                .await
+        } else {
+            None
+        };
         // ADR-0954: spill needs BOTH an operator-configured scratch area and a
         // plan whose every aggregate is exact under a changed folding order.
         // Fail closed the same way: an unbuildable plan is not eligible, so it
@@ -804,7 +1060,7 @@ impl SqlExecutor {
         // or unwritable spill area is a typed `SpillUnavailable` raised with
         // nothing written and no operator started, rather than an opaque IO
         // failure from inside a spilling operator half way through a query.
-        let scratch = match &self.config.spill {
+        let scratch = match &config.spill {
             Some(spill) if analyzed.as_ref().is_some_and(plan_is_spill_eligible) => {
                 Some((SpillScratch::create(spill)?, spill.max_bytes))
             }
@@ -821,19 +1077,20 @@ impl SqlExecutor {
         // still computed here so the two decisions stay independent and the
         // override lives in exactly one place (`crate::session::
         // repartition_free`).
-        let exact_typed_aggregates = self.config.parallel_final_aggregation
-            && analyzed.as_ref().is_some_and(plan_is_exact_typed);
+        let exact_typed_aggregates =
+            config.parallel_final_aggregation && analyzed.as_ref().is_some_and(plan_is_exact_typed);
         // Build the one table the query targets over the snapshot resolved for
         // its signal. `resolve` already resolved `snapshot` against exactly
         // this signal, so the provider and the snapshot always agree.
-        let table = match Self::target_signal(sql)? {
+        let target = Self::target_signal(sql)?;
+        let table = match target {
             TargetSignal::Metrics => {
                 #[cfg_attr(not(feature = "flight-sql"), allow(unused_mut))]
                 let mut provider = RavelTableProvider::new(
                     snapshot,
                     tenant_hash,
                     self.fetcher.clone(),
-                    self.config.clone(),
+                    config.clone(),
                     accounting.clone(),
                 );
                 // Install the distributed samples scan for this query only, when
@@ -929,9 +1186,26 @@ impl SqlExecutor {
             },
             None => SpillDecision::Disabled,
         };
-        let ctx = build_session(&self.config, pool, table, exact_typed_aggregates, decision)
+        let ctx = build_session(config, pool, table, exact_typed_aggregates, decision)
             .map_err(plan_error)?;
-        let frame = ctx.sql(sql).await.map_err(plan_error)?;
+        let mut frame = ctx.sql(sql).await.map_err(plan_error)?;
+        // The row window (ADR-1374 decision 3, prerequisite 2), inserted into
+        // the plan `ctx.sql` just produced -- before any optimizer pass, and
+        // before the schema is read, so the reported schema is the one the
+        // statement asked for either way (a `Filter` preserves its input's
+        // schema).
+        let window_predicate = match extras.row_window {
+            Some(window) => {
+                let plan = apply_row_window(
+                    frame.logical_plan().clone(),
+                    window_ts_column(target),
+                    window,
+                )?;
+                frame = DataFrame::new(ctx.state(), plan);
+                Some(window_predicate_for(target, window))
+            }
+            None => None,
+        };
         let schema = frame.schema().inner().clone();
         Ok(PinnedQuery {
             ctx,
@@ -939,6 +1213,8 @@ impl SqlExecutor {
             schema,
             breach,
             scratch: scratch.map(|(scratch, _)| scratch),
+            row_cap: None,
+            window_predicate,
         })
     }
 
@@ -1044,6 +1320,36 @@ impl SqlExecutor {
         req: &SqlRequest,
         accounting: &QueryAccounting,
     ) -> Result<(Snapshot, CostEstimate), SqlError> {
+        let (snapshot, _admission, estimate) =
+            self.resolve_admitted(tenant_hash, req, accounting).await?;
+        Ok((snapshot, estimate))
+    }
+
+    /// This executor's configuration with `budgets` applied (ADR-1374
+    /// decision 3). A caller's budgets can only lower the configured ceilings,
+    /// so the result is never more permissive than `self.config`.
+    ///
+    /// `None` borrows: the overwhelmingly common request carries no budgets
+    /// and must not pay a config clone for the feature's existence.
+    fn effective_config(&self, budgets: Option<&RequestBudgets>) -> Cow<'_, SqlConfig> {
+        match budgets {
+            None => Cow::Borrowed(&self.config),
+            Some(budgets) => {
+                let mut config = self.config.clone();
+                config.engine = budgets.clamp(&config.engine).applied_to(&config.engine);
+                Cow::Owned(config)
+            }
+        }
+    }
+
+    /// [`Self::resolve`] keeping the [`SegmentAdmission`] counts, for
+    /// [`Self::explain`], which reports them.
+    async fn resolve_admitted(
+        &self,
+        tenant_hash: TenantHash,
+        req: &SqlRequest,
+        accounting: &QueryAccounting,
+    ) -> Result<(Snapshot, SegmentAdmission, CostEstimate), SqlError> {
         // Idle-tenant eviction last-touch (ADR-0069 decision 2): stamp this
         // tenant's activity with the request's injected clock before resolving.
         // This is the one funnel both the HTTP (`execute`/`run`) and Flight SQL
@@ -1090,7 +1396,15 @@ impl SqlExecutor {
         // 2), the same seam `ravel_query::engine::resolve_bounded` uses for
         // PromQL. Their cost is bounded separately by the
         // request budget checked incrementally during fetch (see scan.rs).
-        admit(&snapshot, &origins, &self.config.engine).map_err(admission_error_to_sql)?;
+        //
+        // Checked against the request's EFFECTIVE `max_segments`: a caller's
+        // lowered budget is a smaller ceiling here, never a larger one.
+        let admission = admit(
+            &snapshot,
+            &origins,
+            &self.effective_config(req.budgets.as_ref()).engine,
+        )
+        .map_err(admission_error_to_sql)?;
         let estimate = match target {
             TargetSignal::Metrics => estimate_metrics_cost(&snapshot, catalog_requests),
             // The `alerts` and `audit` scans fetch through the same RLOG funnel
@@ -1101,7 +1415,7 @@ impl SqlExecutor {
             }
             TargetSignal::Spans => estimate_spans_cost(&snapshot, catalog_requests),
         };
-        Ok((snapshot, estimate))
+        Ok((snapshot, admission, estimate))
     }
 
     /// The equality `__name__` value a metrics query's pushed-down predicates
@@ -1434,9 +1748,22 @@ impl SqlExecutor {
         BlockCounts,
         SpillCounts,
         Vec<OperatorSpill>,
+        AttemptCaps,
     ) {
         let planned = match self
-            .plan_pinned(tenant_hash, snapshot, &req.sql, accounting, declared)
+            .plan_pinned_with(
+                tenant_hash,
+                snapshot,
+                &req.sql,
+                accounting,
+                PlanExtras {
+                    declared: declared.to_vec(),
+                    #[cfg(feature = "flight-sql")]
+                    distributed: None,
+                    row_window: req.row_window.then_some(req.window),
+                    budgets: req.budgets,
+                },
+            )
             .await
         {
             Ok(planned) => planned,
@@ -1447,12 +1774,17 @@ impl SqlExecutor {
                     BlockCounts::default(),
                     SpillCounts::default(),
                     Vec::new(),
+                    AttemptCaps::default(),
                 );
             }
         };
         let schema = planned.schema();
+        // Read before `execute` consumes the planned query. Reported even on
+        // the paths below that fail: the filter was applied to the plan that
+        // failed, and saying otherwise would misreport what ran.
+        let window_predicate = planned.window_predicate().map(str::to_string);
 
-        let mut stream = match planned.execute().await {
+        let mut stream = match planned.with_row_cap(req.max_rows).execute().await {
             Ok(stream) => stream,
             Err(e) => {
                 return (
@@ -1461,6 +1793,10 @@ impl SqlExecutor {
                     BlockCounts::default(),
                     SpillCounts::default(),
                     Vec::new(),
+                    AttemptCaps {
+                        window_predicate,
+                        row_cap_hit: false,
+                    },
                 );
             }
         };
@@ -1480,7 +1816,17 @@ impl SqlExecutor {
                 // failure was still written, so they are read on both paths.
                 Err(e) => {
                     let (spill, by_operator) = stream.spill_counts();
-                    return (Err(e), emitted, BlockCounts::default(), spill, by_operator);
+                    return (
+                        Err(e),
+                        emitted,
+                        BlockCounts::default(),
+                        spill,
+                        by_operator,
+                        AttemptCaps {
+                            window_predicate,
+                            row_cap_hit: stream.row_cap_hit(),
+                        },
+                    );
                 }
             }
         }
@@ -1495,8 +1841,22 @@ impl SqlExecutor {
             blocks,
             spill,
             by_operator,
+            AttemptCaps {
+                window_predicate,
+                row_cap_hit: stream.row_cap_hit(),
+            },
         )
     }
+}
+
+/// What one [`SqlExecutor::attempt`] applied on top of the statement itself:
+/// the row-window predicate and whether the row cap cut the result. Carried
+/// out separately from [`SqlStats`] because an attempt that is later discarded
+/// by the retry must not leave its values behind.
+#[derive(Debug, Clone, Default)]
+struct AttemptCaps {
+    window_predicate: Option<String>,
+    row_cap_hit: bool,
 }
 
 /// A query planned against one pinned snapshot, not yet executing.
@@ -1519,12 +1879,35 @@ pub struct PinnedQuery {
     /// inside it, and moved into the [`PinnedStream`] on execute so a query
     /// abandoned mid-stream still removes its scratch.
     scratch: Option<SpillScratch>,
+    /// [`SqlRequest::max_rows`], moved into the [`PinnedStream`] on execute.
+    row_cap: Option<usize>,
+    /// The row filter [`SqlRequest::row_window`] put above each scan, for
+    /// [`SqlStats::window_predicate`]. `None` when none was requested.
+    window_predicate: Option<String>,
 }
 
 impl PinnedQuery {
     /// The planned result schema.
     pub fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
+    }
+
+    /// Stop this query's stream once `max_rows` rows have been emitted, plus
+    /// one (ADR-1374 decision 3, prerequisite 4). `None` drains to completion.
+    ///
+    /// The extra row is the point: with it, the caller can tell a complete
+    /// result from a cut one without a second query, which is what
+    /// [`SqlStats::row_cap_hit`] reports.
+    #[must_use]
+    pub fn with_row_cap(mut self, max_rows: Option<usize>) -> Self {
+        self.row_cap = max_rows;
+        self
+    }
+
+    /// The row filter [`SqlRequest::row_window`] applied above each scan, or
+    /// `None` when the request did not ask for one.
+    pub fn window_predicate(&self) -> Option<&str> {
+        self.window_predicate.as_deref()
     }
 
     /// Build the physical plan for this query without consuming it or starting
@@ -1549,6 +1932,8 @@ impl PinnedQuery {
             schema,
             breach,
             scratch,
+            row_cap,
+            window_predicate: _,
         } = self;
         // Build the physical plan explicitly rather than through
         // `frame.execute_stream()` (which does the same two steps internally)
@@ -1557,7 +1942,10 @@ impl PinnedQuery {
         // are equivalent: `execute_stream` is `create_physical_plan` then
         // `execute_stream(plan, task_ctx)`.
         let plan = frame.create_physical_plan().await.map_err(plan_error)?;
-        PinnedStream::start_with_scratch(ctx, plan, schema, breach, scratch)
+        Ok(
+            PinnedStream::start_with_scratch(ctx, plan, schema, breach, scratch)?
+                .with_row_cap(row_cap),
+        )
     }
 }
 
@@ -1598,6 +1986,14 @@ pub struct PinnedStream {
     /// session's disk manager is disabled -- which is every query on the
     /// default configuration, so the default path pays nothing for this.
     spill: Option<SpillState>,
+    /// [`SqlRequest::max_rows`]: stop after this many rows plus one. `None`
+    /// drains the plan, which is every pre-ADR-1374 caller.
+    row_cap: Option<usize>,
+    /// Rows emitted so far, counted only while `row_cap` is set.
+    rows_emitted: usize,
+    /// Set once the cap-plus-one'th row was emitted, meaning the plan had more
+    /// rows than the caller asked for.
+    row_cap_hit: bool,
     /// This query's scratch directory. Declared LAST so it drops after `_ctx`:
     /// the session's `RuntimeEnv` owns the spill files inside it and must
     /// release them first. Removing the directory here is what makes cleanup
@@ -1681,8 +2077,32 @@ impl PinnedStream {
             panicked: false,
             pool,
             spill,
+            row_cap: None,
+            rows_emitted: 0,
+            row_cap_hit: false,
             _scratch: scratch,
         })
+    }
+
+    /// Stop this stream after `max_rows` rows plus one (ADR-1374 decision 3,
+    /// prerequisite 4). `None` is byte-identical to an uncapped stream.
+    ///
+    /// Ending early drops `inner` with the stream, which is the existing
+    /// cancellation path: every operator's `MemoryReservation` drops with it
+    /// and shrinks back through `TenantDelegatingPool` into the tenant
+    /// accountant, exactly as on a normal end of stream. There is no separate
+    /// release step to get wrong, and adding one would double-count.
+    #[must_use]
+    pub fn with_row_cap(mut self, max_rows: Option<usize>) -> Self {
+        self.row_cap = max_rows;
+        self
+    }
+
+    /// Whether the cap set by [`Self::with_row_cap`] cut this result: true
+    /// once the cap-plus-one'th row was emitted. Always false for an uncapped
+    /// stream and for a result that fit inside its cap.
+    pub fn row_cap_hit(&self) -> bool {
+        self.row_cap_hit
     }
 
     /// The stream's schema, identical to the planned schema.
@@ -1736,6 +2156,35 @@ impl PinnedStream {
             }
             _ => {}
         }
+    }
+
+    /// Apply the row cap to one emitted batch (ADR-1374 decision 3,
+    /// prerequisite 4).
+    ///
+    /// The budget is `cap + 1` rows, not `cap`: the extra row is what tells
+    /// the caller the result was cut rather than complete. A batch that
+    /// crosses the budget is sliced to it, so the emitted total is exactly
+    /// `cap + 1` and never a whole batch more.
+    fn cap_batch(&mut self, batch: RecordBatch) -> Option<Result<RecordBatch, SqlError>> {
+        let Some(cap) = self.row_cap else {
+            return Some(Ok(batch));
+        };
+        let allowance = cap.saturating_add(1).saturating_sub(self.rows_emitted);
+        if allowance == 0 {
+            self.row_cap_hit = true;
+            return None;
+        }
+        let batch = if batch.num_rows() > allowance {
+            batch.slice(0, allowance)
+        } else {
+            batch
+        };
+        self.rows_emitted += batch.num_rows();
+        // Strictly greater: a result that exactly fills the cap was not cut.
+        if self.rows_emitted > cap {
+            self.row_cap_hit = true;
+        }
+        Some(Ok(batch))
     }
 
     /// Map an execution error, classifying the two spill-specific failures
@@ -1854,6 +2303,13 @@ impl Stream for PinnedStream {
         if self.panicked {
             return Poll::Ready(None);
         }
+        // The row cap (ADR-1374 decision 3, prerequisite 4) has already
+        // yielded its cap-plus-one'th row: stop without polling the plan
+        // again. `inner` is dropped undrained with this stream, which releases
+        // every reservation through the pool exactly as a full drain does.
+        if self.row_cap_hit {
+            return Poll::Ready(None);
+        }
         // The panic boundary (issue #737). A panic raised inside a DataFusion
         // operator, or inside an arrow kernel it calls, unwinds through this
         // poll: an `i32` offset overflow while a group-by table is decoded is
@@ -1881,7 +2337,7 @@ impl Stream for PinnedStream {
                     Poll::Ready(Some(Err(err))) => {
                         Poll::Ready(Some(Err(self.map_execution_error(err))))
                     }
-                    Poll::Ready(Some(Ok(batch))) => Poll::Ready(Some(Ok(batch))),
+                    Poll::Ready(Some(Ok(batch))) => Poll::Ready(self.cap_batch(batch)),
                     Poll::Ready(None) => Poll::Ready(None),
                     Poll::Pending => Poll::Pending,
                 }
@@ -2749,8 +3205,22 @@ mod name_filter_tests {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
+    use datafusion::arrow::array::TimestampNanosecondArray;
+    use ravel_catalog::CatalogConfig;
+    use ravel_commit::publish::RetryPolicy;
+    use ravel_commit::record::NewCommitRecord;
+    use ravel_commit::{keys, publish, record};
     use ravel_object_store::StoreError;
+    use ravel_object_store::fault::{
+        FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+    };
+    use ravel_object_store::instrument::InstrumentedStore;
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_object_store::{ObjectStoreBackend, PutOptions};
     use ravel_query::FetchError;
+    use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
+    use ravel_types::{Label, LabelSet, Sample, SeriesId, TenantId};
+    use uuid::Uuid;
 
     use super::*;
 
@@ -3015,6 +3485,9 @@ mod tests {
             min_tokens: Vec::new(),
             now_ns: 2_000,
             deadline: Duration::from_secs(30),
+            row_window: false,
+            max_rows: None,
+            budgets: None,
         };
 
         let before = store.metrics().snapshot();
@@ -3601,6 +4074,9 @@ mod tests {
             min_tokens: Vec::new(),
             now_ns: 2_000,
             deadline: Duration::from_secs(30),
+            row_window: false,
+            max_rows: None,
+            budgets: None,
         };
 
         let before = store.metrics().snapshot();
@@ -3632,5 +4108,360 @@ mod tests {
              observe_intermediate_bytes, so this \
              is not always zero"
         );
+    }
+
+    /// One published metrics segment holding `count` samples at `ts_ns`
+    /// `0..count`, under a store that both counts requests and can refuse one
+    /// by key. Returns the store, the tenant hash, and the data object's key.
+    ///
+    /// The segment is written and published against the bare `MemoryStore`, so
+    /// the counters and the fault plan see only what the query does.
+    async fn one_metrics_segment(
+        tenant_name: &str,
+        count: i64,
+        plan: FaultPlan,
+    ) -> (
+        Arc<InstrumentedStore<FaultStore<MemoryStore>>>,
+        TenantHash,
+        String,
+    ) {
+        let tenant = TenantId::new(tenant_name.to_string());
+        let tenant_hash = tenant.hash();
+        let labels = LabelSet::new(vec![Label {
+            name: "__name__".to_string(),
+            value: "m".to_string(),
+        }])
+        .expect("valid labels");
+        let series_id = SeriesId::compute(&tenant, "m", &labels).expect("series id");
+        let samples: Vec<Sample> = (0..count)
+            .map(|i| Sample {
+                ts_ns: i,
+                value: i as f64,
+            })
+            .collect();
+
+        let writer_id = Uuid::from_u128(1_376);
+        let identity = SegmentIdentity {
+            tenant_hash: tenant_hash.0,
+            shard: 0,
+            writer_id: writer_id.to_string(),
+            writer_epoch: 1,
+            writer_seq: 1,
+        };
+        let bounds = IngestBounds {
+            min_ingest_ts_ns: 0,
+            max_ingest_ts_ns: 0,
+        };
+        let written = SegmentWriter::write(
+            vec![SeriesInput {
+                series_id,
+                labels,
+                samples,
+            }],
+            identity,
+            bounds,
+        )
+        .expect("write segment");
+
+        let new_record = NewCommitRecord {
+            tenant_hash,
+            signal: Signal::Metrics,
+            shard: 0,
+            writer_id,
+            writer_epoch: 1,
+            writer_seq: 1,
+            object_size: written.bytes.len() as u64,
+            content_hash: written.summary.blake3,
+            sample_count: written.summary.sample_count,
+            series_count: written.summary.series_count,
+            min_event_ts_ns: written.summary.min_event_ts_ns,
+            max_event_ts_ns: written.summary.max_event_ts_ns,
+            min_ingest_ts_ns: written.summary.min_event_ts_ns,
+            max_ingest_ts_ns: written.summary.max_event_ts_ns,
+            segment_format_version: 1,
+            created_unix_ns: 1,
+            ingest_hour_bucket: 0,
+        };
+        let rec = record::build(new_record).expect("valid commit record");
+        let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+
+        let memory = MemoryStore::new();
+        memory
+            .put(&data_key, written.bytes, PutOptions::default())
+            .await
+            .expect("put data object");
+        publish::publish(&memory, &rec, &RetryPolicy::default())
+            .await
+            .expect("publish");
+
+        let store = Arc::new(InstrumentedStore::new(FaultStore::new(memory, plan)));
+        (store, tenant_hash, data_key)
+    }
+
+    fn executor_over(store: Arc<InstrumentedStore<FaultStore<MemoryStore>>>) -> SqlExecutor {
+        let catalog =
+            Arc::new(Catalog::new(store.clone(), CatalogConfig::default()).expect("catalog"));
+        SqlExecutor::new(
+            catalog,
+            SegmentFetcher::new(store.clone()),
+            LogSegmentFetcher::new(store.clone()),
+            SpanSegmentFetcher::new(store),
+            SqlConfig::default(),
+            1 << 30,
+        )
+    }
+
+    /// The `ts` column of a metrics result, as raw nanoseconds.
+    fn ts_values(output: &QueryOutput) -> Vec<i64> {
+        let mut values = Vec::new();
+        for batch in output.batches() {
+            let column = batch.column_by_name("ts").expect("ts column");
+            let ts = column
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .expect("ts is Timestamp(Nanosecond)");
+            values.extend(ts.values().iter().copied());
+        }
+        values
+    }
+
+    fn samples_request(sql: &str, window: TimeRange) -> SqlRequest {
+        SqlRequest {
+            sql: sql.to_string(),
+            window,
+            min_tokens: Vec::new(),
+            now_ns: 2_000,
+            deadline: Duration::from_secs(30),
+            row_window: false,
+            max_rows: None,
+            budgets: None,
+        }
+    }
+
+    /// Prerequisite 2. Segment pruning is widen-only, so ONE segment whose rows
+    /// straddle the window contributes every row it holds: the statement itself
+    /// carries no time predicate, and the request window only bounded which
+    /// segments were listed. `row_window` is what turns that window into a row
+    /// filter, and the two executions below differ in nothing else.
+    #[tokio::test]
+    async fn row_window_excludes_rows_outside_range_inside_overlapping_segment() {
+        let (store, tenant_hash, _data_key) =
+            one_metrics_segment("row-window-1376", 1_000, FaultPlan::empty()).await;
+        let executor = executor_over(store);
+
+        let window = TimeRange {
+            start_ns: 200,
+            end_ns: 500,
+        };
+        let base = samples_request("SELECT ts, value FROM samples", window);
+
+        let unfiltered = executor
+            .execute(tenant_hash, &base)
+            .await
+            .expect("execute without the row window");
+        assert_eq!(
+            unfiltered.stats.segments, 1,
+            "the fixture is one segment straddling the window"
+        );
+        assert_eq!(
+            unfiltered.output.num_rows(),
+            1_000,
+            "widen-only pruning returns the whole overlapping segment"
+        );
+        assert_eq!(unfiltered.stats.window_predicate, None);
+
+        let filtered = executor
+            .execute(
+                tenant_hash,
+                &SqlRequest {
+                    row_window: true,
+                    ..base.clone()
+                },
+            )
+            .await
+            .expect("execute with the row window");
+
+        assert_eq!(
+            filtered.stats.segments, 1,
+            "the row filter sits above the scan, so it changes no pruning"
+        );
+        assert_eq!(filtered.output.num_rows(), 300);
+        assert_eq!(
+            unfiltered.output.num_rows() - filtered.output.num_rows(),
+            700,
+            "exactly the rows outside [200, 500) are excluded"
+        );
+        assert_eq!(
+            filtered.stats.window_predicate.as_deref(),
+            Some("ts >= 200 AND ts < 500")
+        );
+
+        let mut kept = ts_values(&filtered.output);
+        kept.sort_unstable();
+        assert_eq!(kept.len(), 300);
+        assert_eq!(kept.first().copied(), Some(200), "start is inclusive");
+        assert_eq!(kept.last().copied(), Some(499), "end is exclusive");
+        assert_eq!(kept, (200..500).collect::<Vec<i64>>());
+    }
+
+    /// Prerequisite 3. `explain` resolves, admits, and plans; it must never
+    /// open a data object. The fault rule below refuses any GET whose key names
+    /// an RSEG, which is exactly the data objects: if `explain` read one it
+    /// would fire.
+    #[tokio::test]
+    async fn explain_resolves_without_issuing_data_gets() {
+        let plan = FaultPlan::empty().with_rule(
+            Rule::new(
+                Op::Get,
+                ScriptedFault::Permanent("data object read in explain".to_string()),
+            )
+            .with_key_contains(".rseg")
+            .with_occurrence(Occurrence::Nth(1)),
+        );
+        let (store, tenant_hash, data_key) = one_metrics_segment("explain-1376", 1_000, plan).await;
+        assert!(
+            data_key.ends_with(".rseg"),
+            "the rule's key pattern must match the data object: {data_key}"
+        );
+        let executor = executor_over(store.clone());
+
+        let request = SqlRequest {
+            row_window: true,
+            ..samples_request(
+                "SELECT ts, value FROM samples",
+                TimeRange {
+                    start_ns: 200,
+                    end_ns: 500,
+                },
+            )
+        };
+
+        let before = store.metrics().snapshot();
+        let report = executor
+            .explain(tenant_hash, &request)
+            .await
+            .expect("explain");
+        let after = store.metrics().snapshot();
+
+        assert_eq!(
+            store.inner().fault_count(Op::Get, FaultKind::Permanent),
+            0,
+            "explain opened a data object"
+        );
+        assert_eq!(after.head.calls - before.head.calls, 0);
+        assert_eq!(
+            after.list.calls - before.list.calls,
+            EXPLAIN_RESOLVE_LISTS,
+            "explain's LIST count is the resolve's alone"
+        );
+        assert_eq!(
+            after.get.calls - before.get.calls,
+            EXPLAIN_RESOLVE_GETS,
+            "explain's GET count is the resolve's commit-record reads alone"
+        );
+
+        assert_eq!(report.target, TargetSignal::Metrics);
+        assert_eq!(
+            report.schema.fields().len(),
+            2,
+            "the effective schema is the statement's projection"
+        );
+        assert_eq!(report.segments_resolved, 1);
+        assert_eq!(
+            report.segments_admitted + report.segments_recent_exempt,
+            1,
+            "every resolved segment is either admitted or exempt"
+        );
+        assert!(
+            report.unbounded_components.is_empty(),
+            "the estimator bounds a metrics query fully"
+        );
+        assert_eq!(
+            report.window_predicate.as_deref(),
+            Some("ts >= 200 AND ts < 500")
+        );
+        assert!(
+            report.plan_text.contains("RsegScanExec"),
+            "the report carries the physical plan: {}",
+            report.plan_text
+        );
+
+        // Non-vacuity: the rule is armed and it does match this fixture's data
+        // object. Executing the same request fires it, so the zero above is
+        // explain's doing and not a pattern that never matched.
+        let _ = executor.execute(tenant_hash, &request).await;
+        assert_eq!(
+            store.inner().fault_count(Op::Get, FaultKind::Permanent),
+            1,
+            "executing the same request does open the data object"
+        );
+    }
+
+    /// The resolve's own request counts against the one-segment fixture: two
+    /// commit-record listings and two catalog object reads, none of them a data
+    /// object (the fault rule in the test proves that part). Pinned exactly so
+    /// a regression that made `explain` read more than the catalog needs fails
+    /// here, rather than becoming a larger number nobody compares.
+    const EXPLAIN_RESOLVE_LISTS: u64 = 2;
+    const EXPLAIN_RESOLVE_GETS: u64 = 2;
+
+    /// Prerequisite 4. The cap stops the stream at `max_rows + 1` rows: the
+    /// extra row is the evidence that more existed, reported as `row_cap_hit`.
+    #[tokio::test]
+    async fn max_rows_stops_stream_after_cap_plus_one() {
+        let (store, tenant_hash, _data_key) =
+            one_metrics_segment("max-rows-1376", 1_000, FaultPlan::empty()).await;
+        let executor = executor_over(store);
+
+        let base = samples_request(
+            "SELECT ts, value FROM samples",
+            TimeRange {
+                start_ns: 0,
+                end_ns: 2_000,
+            },
+        );
+
+        let capped = executor
+            .execute(
+                tenant_hash,
+                &SqlRequest {
+                    max_rows: Some(10),
+                    ..base.clone()
+                },
+            )
+            .await
+            .expect("execute under a row cap");
+        assert_eq!(
+            capped.output.num_rows(),
+            11,
+            "the cap emits max_rows + 1 rows and no more"
+        );
+        assert!(
+            capped.stats.row_cap_hit,
+            "the cap-plus-one'th row existed, so the result was cut"
+        );
+
+        let uncut = executor
+            .execute(
+                tenant_hash,
+                &SqlRequest {
+                    max_rows: Some(5_000),
+                    ..base.clone()
+                },
+            )
+            .await
+            .expect("execute under a cap the result fits inside");
+        assert_eq!(uncut.output.num_rows(), 1_000);
+        assert!(
+            !uncut.stats.row_cap_hit,
+            "the whole result fit inside the cap"
+        );
+
+        let uncapped = executor
+            .execute(tenant_hash, &base)
+            .await
+            .expect("execute with no cap");
+        assert_eq!(uncapped.output.num_rows(), 1_000);
+        assert!(!uncapped.stats.row_cap_hit);
     }
 }

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -79,7 +79,7 @@ use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::error::ArrowError;
 use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
-use datafusion::common::{Column, DFSchema, ScalarValue};
+use datafusion::common::{Column, DFSchema, ScalarValue, TableReference};
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
@@ -212,8 +212,14 @@ pub struct SqlRequest {
     ///
     /// An agent writing SQL against a window it did not choose cannot know to
     /// add that predicate, so the caller that chose the window opts in here
-    /// instead. See [`window_predicate_for`] for the column each table filters
-    /// on and [`SqlStats::window_predicate`] for what was applied.
+    /// instead. See [`window_ts_column`] for the column each table filters on
+    /// and [`SqlStats::window_predicate`] for what was applied.
+    ///
+    /// The row filter is half-open, `[start, end)` (ADR-1374 decision 4), while
+    /// the same `window` selects segments on the closed `[start, end]` bound
+    /// `TimeRange` carries. The two differ on purpose: a listing bound may only
+    /// widen, and a row bound must be exact. A request whose `start` equals its
+    /// `end` therefore returns zero rows under `row_window`, by definition.
     pub row_window: bool,
     /// Stop the stream once this many rows have been emitted, plus one
     /// (ADR-1374 decision 3, prerequisite 4). The extra row is deliberate: it
@@ -260,9 +266,11 @@ pub struct SqlStats {
     /// that wrote it lives on [`SqlOutcome::spill_by_operator`], which does not
     /// have to stay `Copy`.
     pub spill: SpillCounts,
-    /// The row filter [`SqlRequest::row_window`] applied above each scan, in
-    /// the form `"<ts_col> >= <start_ns> AND <ts_col> < <end_ns>"`. `None`
-    /// when the request did not ask for one, which is the default.
+    /// The row filter [`SqlRequest::row_window`] applied above each scan, as
+    /// the display of the [`Expr`] that was actually planted
+    /// ([`window_filter_expr`]) rather than a separately formatted description
+    /// of it. `None` when the request did not ask for one, which is the
+    /// default, and when the plan carried no scan to filter.
     pub window_predicate: Option<String>,
     /// Whether [`SqlRequest::max_rows`] cut this result: true when the plan
     /// produced the cap-plus-one'th row, meaning at least one more row
@@ -311,12 +319,24 @@ fn window_ts_column(target: TargetSignal) -> &'static str {
     }
 }
 
-/// The predicate text [`SqlStats::window_predicate`] reports for `target`
-/// filtered to `window`. Half-open on the right, matching `TimeRange` and the
-/// segment-listing bound the same window already drives.
-fn window_predicate_for(target: TargetSignal, window: TimeRange) -> String {
-    let ts = window_ts_column(target);
-    format!("{ts} >= {} AND {ts} < {}", window.start_ns, window.end_ns)
+/// The row-window predicate for one scan: `ts_col >= start AND ts_col < end`,
+/// with the column qualified by the scan's own `relation` (an unqualified
+/// column would be ambiguous the moment a plan carries two scans).
+///
+/// Half-open on the right, per ADR-1374 decision 4, and deliberately NOT the
+/// bound the same window drives on segment listing: `TimeRange` is closed
+/// (`[start, end]`) where it selects segments, because that bound may only
+/// widen. A request with `start == end` therefore lists the segments covering
+/// that instant and, under `row_window`, returns zero rows.
+///
+/// This is the one place the predicate is built, and
+/// [`SqlStats::window_predicate`] reports this expression's own display, so the
+/// reported text cannot drift from the filter that ran.
+fn window_filter_expr(relation: &TableReference, ts_col: &str, window: TimeRange) -> Expr {
+    let ts = Expr::Column(Column::new(Some(relation.clone()), ts_col));
+    ts.clone()
+        .gt_eq(ts_literal(window.start_ns))
+        .and(ts.lt(ts_literal(window.end_ns)))
 }
 
 /// A nanosecond event-time literal, in the column's own Arrow type so the
@@ -328,41 +348,54 @@ fn ts_literal(ns: i64) -> Expr {
 /// Insert `ts_col >= window.start_ns AND ts_col < window.end_ns` directly
 /// above every `TableScan` in `plan` (ADR-1374 decision 3, prerequisite 2).
 ///
-/// Rewrites the UNOPTIMIZED logical plan, which is what keeps this from
-/// interfering with pruning. At this stage a `TableScan` still carries no
-/// projection, so the event-time column is always in scope; the optimizer then
-/// pushes projections and filters down over the rewritten plan exactly as it
-/// would over the original. The provider still returns `Inexact` for every
-/// filter it is offered, so this predicate arrives at the scan as a widen-only
-/// hint and is re-applied above it: no segment or block is pruned that the
-/// statement alone would not have pruned, and a segment straddling the window
-/// is still read whole and filtered by row.
+/// Rewrites the UNOPTIMIZED logical plan. At this stage a `TableScan` still
+/// carries no projection, so the event-time column is always in scope; the
+/// optimizer then pushes projections and filters down over the rewritten plan
+/// exactly as it would over a predicate the statement itself carried. Pruning
+/// therefore tightens: the injected filter is offered to the provider like any
+/// other, and the result stays sound because every provider reports `Inexact`,
+/// so DataFusion re-applies the filter above the scan and a segment straddling
+/// the window is read whole and filtered by row.
+///
+/// The traversal descends into subqueries embedded in expressions
+/// (`Expr::ScalarSubquery`, `Expr::InSubquery`, `Expr::Exists`) as well as into
+/// plan children, so a statement whose `WHERE` clause carries its own `SELECT`
+/// gets the window on that scan too. A plain `transform_up` walks only the plan
+/// tree, which would leave the inner scan reading the whole overlapping segment
+/// while the reported predicate claimed the window had been applied.
 ///
 /// A `Filter` preserves its input's schema, so the planned result schema is
 /// unchanged and the caller's `DataFrame` can be rebuilt around the new plan.
+///
+/// Returns the rewritten plan and the display of the predicate actually built,
+/// which is what [`SqlStats::window_predicate`] reports; `None` when the plan
+/// carries no `TableScan` at all and nothing was filtered.
 fn apply_row_window(
     plan: LogicalPlan,
     ts_col: &str,
     window: TimeRange,
-) -> Result<LogicalPlan, SqlError> {
-    plan.transform_up(|node| {
-        if let LogicalPlan::TableScan(scan) = &node {
-            // Qualified by the scan's own relation: an unqualified column
-            // would be ambiguous the moment a plan carries two scans.
-            let ts = Expr::Column(Column::new(Some(scan.table_name.clone()), ts_col));
-            let predicate = ts
-                .clone()
-                .gt_eq(ts_literal(window.start_ns))
-                .and(ts.lt(ts_literal(window.end_ns)));
-            // An unresolvable column surfaces here as a typed plan error,
-            // never as a silently unfiltered scan.
-            let filter = Filter::try_new(predicate, Arc::new(node))?;
-            return Ok(Transformed::yes(LogicalPlan::Filter(filter)));
-        }
-        Ok(Transformed::no(node))
-    })
-    .map(|transformed| transformed.data)
-    .map_err(plan_error)
+) -> Result<(LogicalPlan, Option<String>), SqlError> {
+    let mut applied: Option<String> = None;
+    let rewritten = plan
+        .transform_up_with_subqueries(|node| {
+            if let LogicalPlan::TableScan(scan) = &node {
+                let predicate = window_filter_expr(&scan.table_name, ts_col, window);
+                // Rendered from the expression that is about to be planted, so
+                // the reported text cannot describe a different filter than the
+                // one that ran. A session registers exactly one table provider
+                // (crate::session::build_session), so every scan in a plan
+                // names the same relation and renders identically.
+                applied = Some(predicate.to_string());
+                // An unresolvable column surfaces here as a typed plan error,
+                // never as a silently unfiltered scan.
+                let filter = Filter::try_new(predicate, Arc::new(node))?;
+                return Ok(Transformed::yes(LogicalPlan::Filter(filter)));
+            }
+            Ok(Transformed::no(node))
+        })
+        .map(|transformed| transformed.data)
+        .map_err(plan_error)?;
+    Ok((rewritten, applied))
 }
 
 /// What [`SqlExecutor::explain`] found out about a statement without reading
@@ -1196,13 +1229,13 @@ impl SqlExecutor {
         // schema).
         let window_predicate = match extras.row_window {
             Some(window) => {
-                let plan = apply_row_window(
+                let (plan, predicate) = apply_row_window(
                     frame.logical_plan().clone(),
                     window_ts_column(target),
                     window,
                 )?;
                 frame = DataFrame::new(ctx.state(), plan);
-                Some(window_predicate_for(target, window))
+                predicate
             }
             None => None,
         };
@@ -4281,19 +4314,28 @@ mod tests {
             .await
             .expect("execute with the row window");
 
+        // What was applied, before what it did: the reported text is the
+        // display of the expression the rewrite built, not an independently
+        // formatted description of it, and it is pinned to an exact string so a
+        // changed bound cannot leave the report intact.
         assert_eq!(
-            filtered.stats.segments, 1,
-            "the row filter sits above the scan, so it changes no pruning"
+            filtered.stats.window_predicate.as_deref(),
+            Some(
+                window_filter_expr(&TableReference::bare("samples"), "ts", window)
+                    .to_string()
+                    .as_str()
+            )
         );
+        assert_eq!(
+            filtered.stats.window_predicate.as_deref(),
+            Some(ROW_WINDOW_200_500_PREDICATE)
+        );
+
         assert_eq!(filtered.output.num_rows(), 300);
         assert_eq!(
             unfiltered.output.num_rows() - filtered.output.num_rows(),
             700,
             "exactly the rows outside [200, 500) are excluded"
-        );
-        assert_eq!(
-            filtered.stats.window_predicate.as_deref(),
-            Some("ts >= 200 AND ts < 500")
         );
 
         let mut kept = ts_values(&filtered.output);
@@ -4302,6 +4344,83 @@ mod tests {
         assert_eq!(kept.first().copied(), Some(200), "start is inclusive");
         assert_eq!(kept.last().copied(), Some(499), "end is exclusive");
         assert_eq!(kept, (200..500).collect::<Vec<i64>>());
+    }
+
+    /// The exact predicate text a `[200, 500)` row window on `samples` reports,
+    /// pinned so a change to the rendering (a dropped qualifier, a literal
+    /// printed in another unit) fails here rather than silently changing what
+    /// `SqlStats::window_predicate` promises a caller.
+    const ROW_WINDOW_200_500_PREDICATE: &str = "samples.ts >= TimestampNanosecond(200, None) AND \
+         samples.ts < TimestampNanosecond(500, None)";
+
+    /// Finding 1. A subquery embedded in an expression is not a plan child, so
+    /// a plain `transform_up` never reaches its `TableScan`: the outer scan
+    /// would be windowed, the inner one would read the whole overlapping
+    /// segment, and `window_predicate` would still report the window as
+    /// applied. Both statements below are answerable only if BOTH scans are
+    /// filtered.
+    #[tokio::test]
+    async fn row_window_reaches_scans_inside_expression_subqueries() {
+        let (store, tenant_hash, _data_key) =
+            one_metrics_segment("row-window-subquery-1376", 1_000, FaultPlan::empty()).await;
+        let executor = executor_over(store);
+
+        let window = TimeRange {
+            start_ns: 200,
+            end_ns: 500,
+        };
+
+        // value == ts, so the windowed inner AVG is (200 + 499) / 2 = 349.5 and
+        // the outer scan keeps ts 350..500. Unwindowed, the inner AVG over the
+        // whole segment is 499.5 and the outer result is empty.
+        let scalar = executor
+            .execute(
+                tenant_hash,
+                &SqlRequest {
+                    row_window: true,
+                    ..samples_request(
+                        "SELECT ts FROM samples WHERE value > (SELECT avg(value) FROM samples)",
+                        window,
+                    )
+                },
+            )
+            .await
+            .expect("execute the scalar-subquery statement under the row window");
+        assert_eq!(
+            scalar.output.num_rows(),
+            150,
+            "the windowed inner average is 349.5, so ts 350..500 survives"
+        );
+        let mut kept = ts_values(&scalar.output);
+        kept.sort_unstable();
+        assert_eq!(kept.first().copied(), Some(350));
+        assert_eq!(kept.last().copied(), Some(499));
+
+        // An IN subquery is the other expression-embedded shape: the inner
+        // scan's own predicate keeps ts 400..1000, and the window cuts it to
+        // 400..500.
+        let in_list = executor
+            .execute(
+                tenant_hash,
+                &SqlRequest {
+                    row_window: true,
+                    ..samples_request(
+                        "SELECT ts FROM samples WHERE ts IN (SELECT ts FROM samples WHERE value >= 400)",
+                        window,
+                    )
+                },
+            )
+            .await
+            .expect("execute the IN-subquery statement under the row window");
+        assert_eq!(
+            in_list.output.num_rows(),
+            100,
+            "the window bounds the inner scan too, so ts 400..500 survives"
+        );
+        let mut kept = ts_values(&in_list.output);
+        kept.sort_unstable();
+        assert_eq!(kept.first().copied(), Some(400));
+        assert_eq!(kept.last().copied(), Some(499));
     }
 
     /// Prerequisite 3. `explain` resolves, admits, and plans; it must never
@@ -4378,7 +4497,7 @@ mod tests {
         );
         assert_eq!(
             report.window_predicate.as_deref(),
-            Some("ts >= 200 AND ts < 500")
+            Some(ROW_WINDOW_200_500_PREDICATE)
         );
         assert!(
             report.plan_text.contains("RsegScanExec"),

--- a/crates/ravel-sql/src/flight/request.rs
+++ b/crates/ravel-sql/src/flight/request.rs
@@ -104,6 +104,9 @@ pub(super) fn sql_request(
         min_tokens,
         now_ns,
         deadline,
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     })
 }
 

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -125,7 +125,8 @@ pub use error::{
     MSG_SPILL_QUOTA_MARKER, MSG_SPILL_UNAVAILABLE, MSG_UNAVAILABLE, MSG_UNSATISFIABLE, SqlError,
 };
 pub use executor::{
-    LiveAccounting, PinnedQuery, PinnedStream, SqlExecutor, SqlOutcome, SqlRequest, SqlStats,
+    ExplainReport, LiveAccounting, PinnedQuery, PinnedStream, SqlExecutor, SqlOutcome, SqlRequest,
+    SqlStats, TargetSignal,
 };
 #[cfg(feature = "flight-sql")]
 pub use flight::{

--- a/crates/ravel-sql/tests/admission_parity.rs
+++ b/crates/ravel-sql/tests/admission_parity.rs
@@ -128,6 +128,9 @@ fn sql_request(sql: &str, window: TimeRange, now_ns: i64) -> SqlRequest {
         min_tokens: Vec::new(),
         now_ns,
         deadline: Duration::from_secs(30),
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     }
 }
 

--- a/crates/ravel-sql/tests/deadline.rs
+++ b/crates/ravel-sql/tests/deadline.rs
@@ -66,6 +66,9 @@ fn request_with_deadline(sql: &str, deadline: Duration) -> ravel_sql::SqlRequest
         min_tokens: Vec::new(),
         now_ns: NOW_NS,
         deadline,
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     }
 }
 

--- a/crates/ravel-sql/tests/group_by_string_keys.rs
+++ b/crates/ravel-sql/tests/group_by_string_keys.rs
@@ -77,6 +77,9 @@ fn request(sql: &str) -> SqlRequest {
         min_tokens: Vec::new(),
         now_ns: 1_000_000,
         deadline: Duration::from_secs(60),
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     }
 }
 

--- a/crates/ravel-sql/tests/logs_declared_columns.rs
+++ b/crates/ravel-sql/tests/logs_declared_columns.rs
@@ -157,6 +157,9 @@ fn request(sql: &str) -> SqlRequest {
         min_tokens: Vec::new(),
         now_ns: 1_000_000,
         deadline: Duration::from_secs(30),
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     }
 }
 

--- a/crates/ravel-sql/tests/parallel_final_default.rs
+++ b/crates/ravel-sql/tests/parallel_final_default.rs
@@ -357,6 +357,9 @@ fn request(sql: &str) -> SqlRequest {
         min_tokens: Vec::new(),
         now_ns: 1_000_000,
         deadline: Duration::from_secs(30),
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     }
 }
 

--- a/crates/ravel-sql/tests/util/mod.rs
+++ b/crates/ravel-sql/tests/util/mod.rs
@@ -270,6 +270,9 @@ pub fn request(sql: &str) -> SqlRequest {
         min_tokens: Vec::new(),
         now_ns: NOW_NS,
         deadline: Duration::from_secs(30),
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     }
 }
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1049,7 +1049,10 @@ into a scoped copy of the engine configuration, so `segment_admission::admit`,
 lowered numbers through the same fields they already read. A tripped
 per-request budget is the same typed error as a tripped server ceiling
 (`TooManySegments`, `RequestBudgetExceeded`, `TooManyBytesScanned`, all HTTP
-422), never a truncated result.
+422), never a truncated result. The store-request budget is checked once
+right after catalog resolution and then again at every fetch boundary, so a
+resolve alone can trip a lowered budget even when the resolved snapshot has
+no segments left to fetch.
 
 On the PromQL side, `QueryEngine::instant_with_budgets`,
 `range_hist_with_budgets`, and `resolve_series_with_budgets` are the entry

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1060,18 +1060,25 @@ points that take `Option<&RequestBudgets>`; passing `None` is exactly the
 pre-existing method. On the SQL side, `SqlRequest::budgets` carries them.
 
 Enforcement on the SQL side is not yet uniform across the five tables, and a
-caller has to know which knob binds where. Only the `samples` (metrics)
-provider reads the effective `max_bytes_scanned` and `max_store_requests` at
-scan time; the `logs`, `spans`, `alerts`, and `audit` providers do not. For
-those four tables, only `max_segments` is lowered today: it binds in
-`segment_admission::admit`, which runs on the catalog resolve every table
-shares, so a per-request `max_segments` does refuse an over-wide scan on any
-of them. A per-request bytes or request ceiling set alongside it is accepted
-and clamped, and then never consulted by those four scans. This is a
-pre-existing gap in the providers, not something the per-request budgets
-introduced; enforcing the lowered byte and store-request budgets on the
-`logs`, `spans`, `alerts`, and `audit` providers is tracked as follow-up
-work and is not implemented yet, and is out of scope here.
+caller has to know which knob binds where. The effective `max_store_requests`
+ceiling IS checked for every target signal, once, immediately after
+`resolve_admitted`'s catalog resolve: a caller cannot finish a query above a
+lowered request budget on any of the five tables merely because its snapshot
+resolved empty. `max_segments` is enforced the same way, on the same shared
+resolve, via `segment_admission::admit`.
+
+What is not yet uniform is INCREMENTAL, scan-time enforcement. Only the
+`samples` (metrics) provider re-checks the running total against
+`max_bytes_scanned` and `max_store_requests` as it fetches segments (scan.rs);
+the `logs`, `spans`, `alerts`, and `audit` providers do not. A lowered request
+budget on one of those four tables therefore only ever traps once, at resolve,
+never again as the scan itself keeps issuing GETs. The byte budget fares
+worse: `max_bytes_scanned` is not consulted at all for those four tables,
+neither at resolve nor during the scan. This is a pre-existing gap in the
+providers, not something the per-request budgets introduced; enforcing the
+lowered byte budget, and the request budget's incremental scan-time re-check,
+on the `logs`, `spans`, `alerts`, and `audit` providers is tracked as
+follow-up work and is not implemented yet, and is out of scope here.
 
 ### The agent query knobs on `SqlRequest` (ADR-1374)
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1056,6 +1056,18 @@ On the PromQL side, `QueryEngine::instant_with_budgets`,
 points that take `Option<&RequestBudgets>`; passing `None` is exactly the
 pre-existing method. On the SQL side, `SqlRequest::budgets` carries them.
 
+Enforcement on the SQL side is not yet uniform across the five tables, and a
+caller has to know which knob binds where. Only the `samples` (metrics)
+provider reads the effective `max_bytes_scanned` and `max_store_requests` at
+scan time; the `logs`, `spans`, `alerts`, and `audit` providers do not. For
+those four tables, only `max_segments` is lowered today: it binds in
+`segment_admission::admit`, which runs on the catalog resolve every table
+shares, so a per-request `max_segments` does refuse an over-wide scan on any
+of them. A per-request bytes or request ceiling set alongside it is accepted
+and clamped, and then simply never consulted by those four scans. This is a
+pre-existing gap in the providers, not something the per-request budgets
+introduced; it is tracked as issue #1409 and is out of scope here.
+
 ### The agent query knobs on `SqlRequest` (ADR-1374)
 
 Three request fields exist for a caller that composes SQL on someone else's
@@ -1073,11 +1085,37 @@ each table scan in the unoptimized logical plan, on that table's event-time
 column: `ts` for `samples` and `logs`, `start_ts` for `spans`, `ts_ns` for
 `alerts` and `audit`. The rewrite happens before optimization, where the
 scan carries no projection, so the column is always in scope, and `Filter`
-preserves the schema, so the result schema is unchanged. The optimizer then
-pushes the predicate down normally, so the `Inexact` widen-only pushdown
-contract is untouched and pruning is unaffected. The rewrite runs inside the
-attempt, so it survives the snapshot retry. The applied predicate text is
-reported as `SqlStats::window_predicate`.
+preserves the schema, so the result schema is unchanged. The rewrite runs
+inside the attempt, so it survives the snapshot retry.
+
+The two bounds the one `window` drives are deliberately different.
+`ravel_types::TimeRange` is **closed**, `[start_ns, end_ns]`, and that is the
+bound `Catalog::resolve` prunes segments on; a listing bound may only widen,
+so an inclusive end can never drop a segment that holds a matching row. The
+row window is **half-open**, `[start_ns, end_ns)`, per ADR-1374 decision 4,
+because a row bound must be exact and adjacent windows must not both claim
+the instant on their shared edge. One consequence follows directly and is
+not a defect: a request whose `start_ns` equals its `end_ns` lists the
+segments covering that instant and, under `row_window`, returns zero rows.
+
+The traversal that plants the filter descends into subqueries embedded in
+expressions (`Expr::ScalarSubquery`, `Expr::InSubquery`, `Expr::Exists`) as
+well as into plan children, so every `TableScan` in the statement is
+filtered, including the scans of CTEs, set operations, self-joins, and a
+`WHERE` clause's own `SELECT`. Filtering only the outer scan would answer
+`SELECT ... WHERE value > (SELECT avg(value) FROM samples)` from an average
+over rows the caller excluded.
+
+The optimizer then pushes the injected predicate down exactly as it pushes
+one the statement itself carried, so **pruning tightens**: the provider is
+offered a filter it would not otherwise have seen, and it may skip segments
+and blocks the bare statement would have read. That is sound rather than a
+correctness risk because every provider reports `Inexact` for the filters it
+accepts, so DataFusion re-applies the predicate above the scan; a segment
+straddling the window is still read whole and cut by row. `SqlStats::
+window_predicate` reports the applied predicate as the display of the
+expression that was actually planted, so the reported text cannot describe a
+different filter than the one that ran.
 
 `max_rows: Option<usize>` stops the stream once `max_rows + 1` rows have
 been emitted. The extra row is deliberate: it is what distinguishes "this is

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1064,9 +1064,11 @@ those four tables, only `max_segments` is lowered today: it binds in
 `segment_admission::admit`, which runs on the catalog resolve every table
 shares, so a per-request `max_segments` does refuse an over-wide scan on any
 of them. A per-request bytes or request ceiling set alongside it is accepted
-and clamped, and then simply never consulted by those four scans. This is a
+and clamped, and then never consulted by those four scans. This is a
 pre-existing gap in the providers, not something the per-request budgets
-introduced; it is tracked as issue #1409 and is out of scope here.
+introduced; enforcing the lowered byte and store-request budgets on the
+`logs`, `spans`, `alerts`, and `audit` providers is tracked as follow-up
+work and is not implemented yet, and is out of scope here.
 
 ### The agent query knobs on `SqlRequest` (ADR-1374)
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1011,6 +1011,95 @@ output size: every matched series in every matched segment is still fully
 fetched and SoA-decoded before the merge runs, so peak fetch/decode memory
 scales with the query's matched input, not with `max_samples`.
 
+## Per-request budgets (ADR-1374)
+
+Every budget above is a server ceiling, configured once at startup and the
+same for every request. A caller that knows its own query is cheap, or that
+wants a cheap query to fail fast rather than run long, can tighten those
+ceilings for one request through `ravel_query::RequestBudgets`:
+
+```rust
+pub struct RequestBudgets {
+    pub max_bytes_scanned: Option<ByteLimit>,
+    pub max_store_requests: Option<RequestLimit>,
+    pub max_segments: Option<usize>,
+}
+```
+
+`RequestBudgets::clamp(&EngineConfig)` returns the `EffectiveBudgets` a
+request actually runs under. It can only lower: a value above the server
+ceiling yields the ceiling, `Unlimited` cannot lift a bounded ceiling, and
+`None` (for one field or for the whole struct) yields the ceiling unchanged.
+This is the same rule the `timeout` parameter already follows for the wall
+deadline, and it is what makes the budgets safe to accept from a request
+body: the worst a caller can do to the server is ask for less.
+
+`max_store_requests` is the wire name for the ceiling
+`EngineConfig::max_s3_requests` holds. The two names differ deliberately.
+The config field keeps its name because renaming a frozen operator-facing
+knob is a breaking change with no benefit; the wire name drops the `s3`
+because a caller of a request API is not addressing a specific object-store
+implementation, and the field name is a contract a client can hard-code. A
+serde test pins the three serialized names, so a rename fails there rather
+than at a client.
+
+Enforcement adds no new check. The three effective values are substituted
+into a scoped copy of the engine configuration, so `segment_admission::admit`,
+`request_budget_exceeded`, and the three bytes-scanned check sites read the
+lowered numbers through the same fields they already read. A tripped
+per-request budget is the same typed error as a tripped server ceiling
+(`TooManySegments`, `RequestBudgetExceeded`, `TooManyBytesScanned`, all HTTP
+422), never a truncated result.
+
+On the PromQL side, `QueryEngine::instant_with_budgets`,
+`range_hist_with_budgets`, and `resolve_series_with_budgets` are the entry
+points that take `Option<&RequestBudgets>`; passing `None` is exactly the
+pre-existing method. On the SQL side, `SqlRequest::budgets` carries them.
+
+### The agent query knobs on `SqlRequest` (ADR-1374)
+
+Three request fields exist for a caller that composes SQL on someone else's
+behalf. All three default to the values that reproduce the shipped behavior,
+and the HTTP surface (`ravel-server`'s `build_request`) sets exactly those
+defaults, so an HTTP query is unaffected by any of them.
+
+`row_window: bool` applies the request's own time window as a row filter,
+not only as the segment-listing bound. Segment pruning is widen-only, so a
+segment overlapping the window contributes every row it holds; a statement
+that carries no time predicate of its own therefore returns rows outside the
+window the caller asked for. With `row_window` set, the executor inserts
+`<ts_col> >= window.start_ns AND <ts_col> < window.end_ns` directly above
+each table scan in the unoptimized logical plan, on that table's event-time
+column: `ts` for `samples` and `logs`, `start_ts` for `spans`, `ts_ns` for
+`alerts` and `audit`. The rewrite happens before optimization, where the
+scan carries no projection, so the column is always in scope, and `Filter`
+preserves the schema, so the result schema is unchanged. The optimizer then
+pushes the predicate down normally, so the `Inexact` widen-only pushdown
+contract is untouched and pruning is unaffected. The rewrite runs inside the
+attempt, so it survives the snapshot retry. The applied predicate text is
+reported as `SqlStats::window_predicate`.
+
+`max_rows: Option<usize>` stops the stream once `max_rows + 1` rows have
+been emitted. The extra row is deliberate: it is what distinguishes "this is
+the whole result" from "this result was cut", reported as
+`SqlStats::row_cap_hit`. The service layer above trims it. Stopping early
+drops the inner stream on the existing cancellation path, so memory
+reservations release exactly as they do at a normal end of stream.
+
+`SqlExecutor::explain` validates, resolves, admits, computes the effective
+schema (declared typed columns included), runs the cost estimator, and
+renders the physical plan, without opening a single data object. It reports
+the target table, that schema, the resolved/admitted/recent-exempt segment
+counts, the `CostEstimate`, the row-window predicate it would apply, and the
+plan text. Where the estimator cannot bound a component for the target it
+names that component in `unbounded_components` rather than reporting a
+structural zero a caller would read as a real estimate of zero:
+`estimated_decompressed_bytes` is unbounded for the RLOG- and RSPAN-backed
+tables, whose funnels never call the decompressor the metrics estimate
+counts. The plan is physical, not logical, because the shapes worth linting
+(which columns a TopK's input scan decodes, whether a repartition fans the
+final aggregate out) exist only after physical planning.
+
 ## Intra-cluster read fan-out (ADR-0071)
 
 Within one cluster, a read can be spread across peer query nodes so more than

--- a/services/ravel-cli/tests/load.rs
+++ b/services/ravel-cli/tests/load.rs
@@ -94,6 +94,9 @@ async fn logs_query_rows(
         min_tokens: min_tokens.to_vec(),
         now_ns: CLOCK_NS + 1_000,
         deadline: Duration::from_secs(30),
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     };
     let outcome = executor
         .execute(TenantId::new(tenant).hash(), &req)

--- a/services/ravel-server/src/alerting.rs
+++ b/services/ravel-server/src/alerting.rs
@@ -896,6 +896,9 @@ impl AlertEvaluator {
             min_tokens: Vec::new(),
             now_ns,
             deadline: self.query_deadline,
+            row_window: false,
+            max_rows: None,
+            budgets: None,
         };
         let outcome = executor.execute(self.tenant, &request).await?;
         Ok(QueryResultSummary::RowCount(

--- a/services/ravel-server/src/sql.rs
+++ b/services/ravel-server/src/sql.rs
@@ -488,6 +488,12 @@ fn build_request(
         min_tokens,
         now_ns,
         deadline,
+        // The HTTP surface never opts into the MCP-only request knobs
+        // (#1376): no row window, no row cap, no per-request budgets, so
+        // the server ceilings alone govern an HTTP query.
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     })
 }
 

--- a/services/ravel-server/src/tests.rs
+++ b/services/ravel-server/src/tests.rs
@@ -347,6 +347,9 @@ async fn query_result_is_byte_identical_with_and_without_accounting() {
         min_tokens: Vec::new(),
         now_ns: NOW_NS,
         deadline: Duration::from_secs(30),
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     };
     let outcome = h
         .executor

--- a/services/ravel-server/tests/logs_fetch_policy_e2e.rs
+++ b/services/ravel-server/tests/logs_fetch_policy_e2e.rs
@@ -273,6 +273,9 @@ async fn run(argv: &[&str]) -> Routed {
                 min_tokens: Vec::new(),
                 now_ns: NOW_NS,
                 deadline: Duration::from_secs(120),
+                row_window: false,
+                max_rows: None,
+                budgets: None,
             },
         )
         .await

--- a/services/ravel-server/tests/recent_hours_reachability_e2e.rs
+++ b/services/ravel-server/tests/recent_hours_reachability_e2e.rs
@@ -534,6 +534,9 @@ async fn post_compaction_bits(
                 min_tokens: vec![],
                 now_ns: seal_now_ns,
                 deadline: Duration::from_secs(30),
+                row_window: false,
+                max_rows: None,
+                budgets: None,
             },
         )
         .await


### PR DESCRIPTION
T1 of epic #1374 (ADR-1374 D3). ravel-query gains RequestBudgets, a
per-request budget that can only lower the server ceilings, applied by
cloning the engine with the effective config; the PromQL entry points gain
*_with_budgets siblings and the existing signatures stay unchanged.
ravel-sql gains SqlRequest::row_window (an opt-in row filter on the
request window, inserted above each table scan on the signal's timestamp
column), SqlRequest::max_rows (the stream stops after max_rows + 1 rows and
SqlStats::row_cap_hit says whether the sentinel existed), and
SqlExecutor::explain (validate, resolve, admit, effective schema, estimate,
plan text, no data GET). Every existing construction site sets the three
new fields to today's behavior, so no shipped surface changes; the MCP
adapter (#1381) is the caller that sets them. docs/query-engine.md
documents the new section.

Fixes: #1376
Refs: #1374
