### PR TITLE
feat(logseg,query): count decompressed bytes on the RLOG read paths

### DIFF
--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -872,6 +872,7 @@ pub struct DecodedBlock {
     pages_skipped: usize,
     page_bytes_fetched: u64,
     page_bytes_decoded: u64,
+    decompressed_bytes: u64,
 }
 
 impl DecodedBlock {
@@ -908,6 +909,16 @@ impl DecodedBlock {
     /// decode; strictly less whenever a projection skipped any present page.
     pub fn page_bytes_decoded(&self) -> u64 {
         self.page_bytes_decoded
+    }
+
+    /// Bytes zstd produced decompressing this block's pages: the sum, over
+    /// every page this decode actually decompressed (a raw/`COMP_NONE` page
+    /// counts nothing, it was never decompressed), of the decompressed buffer's
+    /// own length. A projection that skips a page decompresses nothing for it,
+    /// so this follows the column filter exactly as `page_bytes_decoded` does,
+    /// but in decompressed rather than stored units (issue #1401).
+    pub fn decompressed_bytes(&self) -> u64 {
+        self.decompressed_bytes
     }
 
     /// Whether this block carries any page for the `attrs_raw` overflow column.
@@ -1180,6 +1191,10 @@ pub struct PageCounters {
     pub skipped: usize,
     pub bytes_fetched: u64,
     pub bytes_decoded: u64,
+    /// Bytes zstd produced decompressing this block's pages (issue #1401). Only
+    /// a `COMP_ZSTD` page contributes, and it contributes its decompressed
+    /// buffer's actual length, so a short frame is counted as what it produced.
+    pub decompressed_bytes: u64,
 }
 
 /// Turns a block's page descriptors and their decompressed bytes into a
@@ -1231,6 +1246,7 @@ fn decode_columns(
         pages_skipped: counters.skipped,
         page_bytes_fetched: counters.bytes_fetched,
         page_bytes_decoded: counters.bytes_decoded,
+        decompressed_bytes: counters.decompressed_bytes,
     };
 
     for column_id in order {
@@ -1409,6 +1425,7 @@ mod tests {
                 pages_skipped: 0,
                 page_bytes_fetched: 0,
                 page_bytes_decoded: 0,
+                decompressed_bytes: 0,
             }
         }
 

--- a/crates/ravel-logseg/src/lib.rs
+++ b/crates/ravel-logseg/src/lib.rs
@@ -49,7 +49,7 @@ pub use footer::{SuffixOutcome, open_from_suffix};
 pub use ranged::{RlogRangeReader, StreamBlockLoc, StreamBlockRows, StreamBlockSpan};
 pub use reader::{
     BlockScan, RlogReader, ScanStats, decode_section, decode_section_accounted, read_section,
-    stream_attr_pairs,
+    read_section_accounted, stream_attr_pairs,
 };
 pub use record::{FieldSel, FieldType, LogRecord, Predicate, stream_attrs_bytes};
 pub use writer::{ObjectIdentity, RlogConfig, RlogWriter};

--- a/crates/ravel-logseg/src/lib.rs
+++ b/crates/ravel-logseg/src/lib.rs
@@ -48,7 +48,8 @@ pub use error::LogSegError;
 pub use footer::{SuffixOutcome, open_from_suffix};
 pub use ranged::{RlogRangeReader, StreamBlockLoc, StreamBlockRows, StreamBlockSpan};
 pub use reader::{
-    BlockScan, RlogReader, ScanStats, decode_section, read_section, stream_attr_pairs,
+    BlockScan, RlogReader, ScanStats, decode_section, decode_section_accounted, read_section,
+    stream_attr_pairs,
 };
 pub use record::{FieldSel, FieldType, LogRecord, Predicate, stream_attrs_bytes};
 pub use writer::{ObjectIdentity, RlogConfig, RlogWriter};

--- a/crates/ravel-logseg/src/postings.rs
+++ b/crates/ravel-logseg/src/postings.rs
@@ -538,18 +538,33 @@ impl<'a> PostingsSection<'a> {
     ///   prune on this arm) but should also record that a corruption was
     ///   seen, mirroring `bloom_degraded`.
     pub fn probe(&self, column_id: u32, term: &[u8]) -> Result<Option<Vec<u32>>, LogSegError> {
+        self.probe_accounted(column_id, term)
+            .map(|(blocks, _)| blocks)
+    }
+
+    /// [`PostingsSection::probe`], additionally returning the bytes zstd
+    /// produced decompressing the term block this probe touched (issue
+    /// #1401 finding 1). Zero when the probe resolved without decompressing
+    /// a block: an uncapped field with no entry, a capped field, an empty
+    /// dictionary, or a term that sorts before the first block's
+    /// `first_term`.
+    pub fn probe_accounted(
+        &self,
+        column_id: u32,
+        term: &[u8],
+    ) -> Result<(Option<Vec<u32>>, u64), LogSegError> {
         let Ok(idx) = self
             .fields
             .binary_search_by(|f| f.column_id.cmp(&column_id))
         else {
-            return Ok(None);
+            return Ok((None, 0));
         };
         let field = &self.fields[idx];
         if field.capped {
-            return Ok(None);
+            return Ok((None, 0));
         }
         if field.blocks.is_empty() {
-            return Ok(Some(Vec::new()));
+            return Ok((Some(Vec::new()), 0));
         }
         // The last block whose first_term <= term; if term sorts before the
         // very first block's first_term, it cannot be in the dictionary.
@@ -558,7 +573,7 @@ impl<'a> PostingsSection<'a> {
             .binary_search_by(|b| b.first_term.as_slice().cmp(term))
         {
             Ok(i) => i,
-            Err(0) => return Ok(Some(Vec::new())),
+            Err(0) => return Ok((Some(Vec::new()), 0)),
             Err(i) => i - 1,
         };
         let block = &field.blocks[block_idx];
@@ -584,7 +599,24 @@ impl<'a> PostingsSection<'a> {
                 "postings block decompressed length".into(),
             ));
         }
+        let decompressed_len = payload.len() as u64;
         find_term_in_block(&payload, term, &block.first_term, upper_bound)
+            .map(|blocks| (blocks, decompressed_len))
+    }
+
+    /// Test-only: the sum of every term block's `uncompressed_len` across
+    /// every field in the section, read straight from the parsed sparse-index
+    /// headers rather than through `probe`'s block-selection or decompression
+    /// path. A fixture with one indexed field and few enough distinct terms to
+    /// fit inside one `DEFAULT_STRIDE`-sized term block makes this exactly the
+    /// byte count one probe into that field decompresses (issue #1401).
+    #[cfg(test)]
+    pub(crate) fn total_block_uncompressed_len(&self) -> u64 {
+        self.fields
+            .iter()
+            .flat_map(|f| f.blocks.iter())
+            .map(|b| b.uncompressed_len as u64)
+            .sum()
     }
 }
 

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -1740,32 +1740,33 @@ mod tests {
         &obj[start..start + desc.len as usize]
     }
 
-    /// An object wide enough that its directory sections clear the writer's
-    /// compression floor and are stored `COMP_ZSTD`, so decoding one produces
+    /// An object whose directory sections AND block pages clear the writer's
+    /// compression floor and are stored `COMP_ZSTD`, so decoding either produces
     /// strictly more bytes than it read: 200 distinct streams (a distinct
-    /// `service.name` each) with repetitive bodies. Returned with its footer
-    /// so a test can read a section descriptor's `uncomp_len` back.
+    /// `service.name` each), each with a long, highly compressible body so its
+    /// `body` page is well over the 512-byte page floor and zstd-encoded.
     fn object_with_zstd_dirs() -> Vec<u8> {
         let cfg = RlogConfig::default();
+        let body = "log message body ".repeat(200);
         let mut recs = Vec::new();
         for s in 0..200u8 {
-            recs.push(rec(s, i64::from(s), "hello world log body message repeated"));
+            recs.push(rec(s, i64::from(s), &body));
         }
         build(cfg, recs)
     }
 
     /// A section descriptor of `kind`, asserted to be zstd-compressed so its
-    /// `uncomp_len` is the exact byte count one decode produces.
+    /// `uncomp_len` is the exact byte count one decode produces. (The writer
+    /// stores every whole-read directory section `COMP_ZSTD` unconditionally, so
+    /// this holds for any object; `uncomp_len` may be below `len` for a tiny
+    /// section zstd could not shrink, which does not change what one decode
+    /// produces.)
     fn zstd_section(obj: &[u8], k: u32) -> SectionDesc {
         let footer = open(obj).expect("open");
         let desc = *footer.section(k).expect("section present");
         assert_eq!(
             desc.comp, COMP_ZSTD,
             "fixture section {k} must be zstd-compressed for this test"
-        );
-        assert!(
-            desc.uncomp_len > desc.len,
-            "a zstd section decodes to strictly more than it stores"
         );
         desc
     }
@@ -1828,25 +1829,25 @@ mod tests {
     }
 
     /// A raw (`COMP_NONE`) section decodes without decompression, so it charges
-    /// nothing: the counter is bytes zstd PRODUCED, not bytes copied.
+    /// nothing: the counter is bytes zstd PRODUCED, not bytes copied. The writer
+    /// always zstd-compresses whole-read sections, so this synthesizes a raw
+    /// section descriptor (the shape `decode_section`'s `COMP_NONE` branch and a
+    /// ranged reader over an uncompressed section both accept).
     #[test]
     fn decode_section_accounted_charges_nothing_for_raw_section() {
-        // A tiny object leaves its directory sections below the compression
-        // floor, so they are stored raw.
-        let obj = build(RlogConfig::default(), vec![rec(0, 1, "x")]);
-        let footer = open(&obj).expect("open");
         let cfg = RlogConfig::default();
+        let payload = b"an uncompressed section body".to_vec();
+        let desc = SectionDesc {
+            kind: kind::STREAM_DIR,
+            offset: 0,
+            len: payload.len() as u64,
+            crc32c: crc32c::crc32c(&payload),
+            comp: crate::footer::COMP_NONE,
+            uncomp_len: payload.len() as u64,
+        };
         let acct = QueryAccounting::new();
-        let mut saw_raw = false;
-        for k in [kind::STREAM_DIR, kind::FIELD_DIR, kind::SKIP_IDX] {
-            let desc = *footer.section(k).expect("section");
-            if desc.comp == crate::footer::COMP_NONE {
-                saw_raw = true;
-                decode_section_accounted(section_stored(&obj, &desc), &desc, &cfg, &acct)
-                    .expect("decode raw");
-            }
-        }
-        assert!(saw_raw, "the tiny fixture must store some directory raw");
+        let raw = decode_section_accounted(&payload, &desc, &cfg, &acct).expect("decode raw");
+        assert_eq!(raw, payload, "a raw section decodes to its own bytes");
         assert_eq!(
             acct.snapshot().decompressed_bytes,
             0,

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -1683,6 +1683,7 @@ mod tests {
     use super::*;
     use crate::record::LogRecord;
     use crate::writer::{ObjectIdentity, RlogWriter};
+    use ravel_types::accounting::QueryAccounting;
     use ravel_types::logstream::{AttrValue, LogStreamId};
 
     fn identity() -> ObjectIdentity {
@@ -1731,6 +1732,174 @@ mod tests {
             w.push(r).expect("push");
         }
         w.finish().expect("finish")
+    }
+
+    /// The on-object stored bytes of a section (`[offset, offset+len)`).
+    fn section_stored<'a>(obj: &'a [u8], desc: &SectionDesc) -> &'a [u8] {
+        let start = desc.offset as usize;
+        &obj[start..start + desc.len as usize]
+    }
+
+    /// An object wide enough that its directory sections clear the writer's
+    /// compression floor and are stored `COMP_ZSTD`, so decoding one produces
+    /// strictly more bytes than it read: 200 distinct streams (a distinct
+    /// `service.name` each) with repetitive bodies. Returned with its footer
+    /// so a test can read a section descriptor's `uncomp_len` back.
+    fn object_with_zstd_dirs() -> Vec<u8> {
+        let cfg = RlogConfig::default();
+        let mut recs = Vec::new();
+        for s in 0..200u8 {
+            recs.push(rec(s, i64::from(s), "hello world log body message repeated"));
+        }
+        build(cfg, recs)
+    }
+
+    /// A section descriptor of `kind`, asserted to be zstd-compressed so its
+    /// `uncomp_len` is the exact byte count one decode produces.
+    fn zstd_section(obj: &[u8], k: u32) -> SectionDesc {
+        let footer = open(obj).expect("open");
+        let desc = *footer.section(k).expect("section present");
+        assert_eq!(
+            desc.comp, COMP_ZSTD,
+            "fixture section {k} must be zstd-compressed for this test"
+        );
+        assert!(
+            desc.uncomp_len > desc.len,
+            "a zstd section decodes to strictly more than it stores"
+        );
+        desc
+    }
+
+    /// One `decode_section_accounted` charges exactly the section's `uncomp_len`
+    /// (the bytes zstd produced), and N calls charge exactly N times it. The
+    /// pre-fix `decode_section` charged nothing, so this reads 0 there; the
+    /// flipped line is the `add_decompressed_bytes` call in
+    /// `decode_section_accounted` (issue #1401).
+    #[test]
+    fn decode_section_accounted_charges_uncomp_len_per_read() {
+        let obj = object_with_zstd_dirs();
+        let cfg = RlogConfig::default();
+        let desc = zstd_section(&obj, kind::STREAM_DIR);
+        let stored = section_stored(&obj, &desc);
+        let acct = QueryAccounting::new();
+
+        let raw = decode_section_accounted(stored, &desc, &cfg, &acct).expect("decode");
+        assert_eq!(raw.len() as u64, desc.uncomp_len, "decode produces uncomp_len");
+        assert_eq!(
+            acct.snapshot().decompressed_bytes,
+            desc.uncomp_len,
+            "one section read charges exactly the section's uncomp_len"
+        );
+
+        // Four more reads: the counter is exactly five times the section.
+        for _ in 0..4 {
+            decode_section_accounted(stored, &desc, &cfg, &acct).expect("decode");
+        }
+        assert_eq!(
+            acct.snapshot().decompressed_bytes,
+            desc.uncomp_len * 5,
+            "N reads charge exactly N times the section's uncomp_len"
+        );
+    }
+
+    /// Two sections of DIFFERENT uncompressed size sum to the byte, so a counter
+    /// that charged the wrong section, `desc.len` instead of `uncomp_len`, or
+    /// double-charged one would miss the exact total (issue #1401).
+    #[test]
+    fn decode_section_accounted_sums_two_distinct_sections() {
+        let obj = object_with_zstd_dirs();
+        let cfg = RlogConfig::default();
+        let stream_desc = zstd_section(&obj, kind::STREAM_DIR);
+        let field_desc = zstd_section(&obj, kind::FIELD_DIR);
+        assert_ne!(
+            stream_desc.uncomp_len, field_desc.uncomp_len,
+            "the two sections must differ in uncompressed size for this test"
+        );
+        let acct = QueryAccounting::new();
+        decode_section_accounted(section_stored(&obj, &stream_desc), &stream_desc, &cfg, &acct)
+            .expect("decode stream_dir");
+        decode_section_accounted(section_stored(&obj, &field_desc), &field_desc, &cfg, &acct)
+            .expect("decode field_dir");
+        assert_eq!(
+            acct.snapshot().decompressed_bytes,
+            stream_desc.uncomp_len + field_desc.uncomp_len,
+            "two distinct sections sum to the byte"
+        );
+    }
+
+    /// A raw (`COMP_NONE`) section decodes without decompression, so it charges
+    /// nothing: the counter is bytes zstd PRODUCED, not bytes copied.
+    #[test]
+    fn decode_section_accounted_charges_nothing_for_raw_section() {
+        // A tiny object leaves its directory sections below the compression
+        // floor, so they are stored raw.
+        let obj = build(RlogConfig::default(), vec![rec(0, 1, "x")]);
+        let footer = open(&obj).expect("open");
+        let cfg = RlogConfig::default();
+        let acct = QueryAccounting::new();
+        let mut saw_raw = false;
+        for k in [kind::STREAM_DIR, kind::FIELD_DIR, kind::SKIP_IDX] {
+            let desc = *footer.section(k).expect("section");
+            if desc.comp == crate::footer::COMP_NONE {
+                saw_raw = true;
+                decode_section_accounted(section_stored(&obj, &desc), &desc, &cfg, &acct)
+                    .expect("decode raw");
+            }
+        }
+        assert!(saw_raw, "the tiny fixture must store some directory raw");
+        assert_eq!(
+            acct.snapshot().decompressed_bytes,
+            0,
+            "a raw section was copied, not decompressed, so it charges nothing"
+        );
+    }
+
+    /// A whole-object scan's `ScanStats.decompressed_bytes` is the object's
+    /// zstd directory total plus every zstd block page it decodes, and it grows
+    /// only as blocks are drained: opening the reader seeds the directory total,
+    /// each `next_block` adds that block's produced page bytes. A second scan of
+    /// the same reader reports the same figure, proving the seed is per-scan and
+    /// not accumulated across scans (issue #1401).
+    #[test]
+    fn scan_stats_decompressed_bytes_covers_open_and_pages() {
+        let obj = object_with_zstd_dirs();
+        let cfg = RlogConfig::default();
+        let reader = RlogReader::new(&obj, &cfg).expect("open");
+
+        // The seed equals the sum of the object's zstd directory sections.
+        let footer = open(&obj).expect("open");
+        let mut open_total = 0u64;
+        for k in [kind::STREAM_DIR, kind::FIELD_DIR, kind::SKIP_IDX, kind::PAGE_DIR] {
+            let desc = *footer.section(k).expect("section");
+            if desc.comp == COMP_ZSTD {
+                open_total += desc.uncomp_len;
+            }
+        }
+        assert!(open_total > 0, "fixture must have at least one zstd directory");
+
+        let mut cursor = reader
+            .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
+            .expect("scan");
+        // Before any block is decoded the figure is exactly the open-time total.
+        assert_eq!(cursor.stats().decompressed_bytes, open_total);
+        while cursor.next_block(&obj).expect("next").is_some() {}
+        let total = cursor.stats().decompressed_bytes;
+        assert!(
+            total > open_total,
+            "draining blocks adds their decompressed page bytes on top of the open total"
+        );
+
+        // A second, independent scan reports the identical figure: the seed is
+        // per-scan, not accumulated onto the reader.
+        let mut again = reader
+            .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
+            .expect("scan");
+        while again.next_block(&obj).expect("next").is_some() {}
+        assert_eq!(
+            again.stats().decompressed_bytes,
+            total,
+            "a re-scan of the same reader charges the same, not double"
+        );
     }
 
     /// A record carrying `cols` int columns and `cols` string columns, all

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -69,6 +69,15 @@ pub struct ScanStats {
     /// filtering. Equal to `page_bytes_fetched` for an all-columns scan; the
     /// gap to it is the column-filtering waste (ADR-0107 decision 4).
     pub page_bytes_decoded: u64,
+    /// Bytes zstd produced decompressing this object's sections for this scan:
+    /// the directory sections opened at [`RlogReader::new`] plus every block
+    /// page the scan decoded (issue #1401). Seeded at scan construction with the
+    /// open-time directory total and grown as blocks are decoded, so a
+    /// partially-drained [`BlockScan`] reports the directories plus what it has
+    /// decoded so far. A raw/`COMP_NONE` section or page contributes nothing (it
+    /// was never decompressed); a zstd one contributes its decompressed buffer's
+    /// actual length. Decompressed, not stored or wire, bytes.
+    pub decompressed_bytes: u64,
 }
 
 /// An opened RLOG object ready to scan.
@@ -92,6 +101,12 @@ pub struct RlogReader<'a> {
     /// Absent when the object was written with no indexed fields
     /// (docs/log-segment-format.md: POSTINGS is an optional section).
     postings: Option<SectionDesc>,
+    /// Bytes zstd produced decompressing the directory sections this open
+    /// decompressed (STREAM_DIR, FIELD_DIR, SKIP_IDX, PAGE_DIR), summed at
+    /// [`Self::new`] (issue #1401). A directory stored raw contributes nothing.
+    /// Each scan seeds its [`ScanStats::decompressed_bytes`] with this so the
+    /// figure counts opening the object as well as decoding its blocks.
+    open_decompressed_bytes: u64,
 }
 
 impl<'a> RlogReader<'a> {
@@ -101,11 +116,18 @@ impl<'a> RlogReader<'a> {
     /// degrade: without it no block can be located.
     pub fn new(bytes: &'a [u8], cfg: &RlogConfig) -> Result<Self, LogSegError> {
         let footer = open(bytes)?;
-        let stream_raw = read_section(bytes, section(&footer, kind::STREAM_DIR)?, cfg)?;
+        let mut open_decompressed_bytes = 0u64;
+        let stream_desc = *section(&footer, kind::STREAM_DIR)?;
+        let stream_raw = read_section(bytes, &stream_desc, cfg)?;
+        open_decompressed_bytes += section_decompressed_len(&stream_desc, &stream_raw);
         let stream_dir = StreamDir::decode(&stream_raw, MAX_STREAMS)?;
-        let field_raw = read_section(bytes, section(&footer, kind::FIELD_DIR)?, cfg)?;
+        let field_desc = *section(&footer, kind::FIELD_DIR)?;
+        let field_raw = read_section(bytes, &field_desc, cfg)?;
+        open_decompressed_bytes += section_decompressed_len(&field_desc, &field_raw);
         let field_dir = FieldDir::decode(&field_raw, MAX_FIELDS)?;
-        let skip_raw = read_section(bytes, section(&footer, kind::SKIP_IDX)?, cfg)?;
+        let skip_desc = *section(&footer, kind::SKIP_IDX)?;
+        let skip_raw = read_section(bytes, &skip_desc, cfg)?;
+        open_decompressed_bytes += section_decompressed_len(&skip_desc, &skip_raw);
         let skip = SkipIndex::decode(&skip_raw, MAX_BLOCKS)?;
         let blocks = *section(&footer, kind::BLOCKS)?;
         let bloom = *section(&footer, kind::BLOOM)?;
@@ -116,10 +138,11 @@ impl<'a> RlogReader<'a> {
         // is refused rather than read under a guessed layout, which would
         // decode another block's bytes as this one's.
         let page_dir = {
-            let desc = footer
+            let desc = *footer
                 .section(kind::PAGE_DIR)
                 .ok_or_else(|| LogSegError::Corrupted("missing PAGE_DIR section".into()))?;
-            let raw = read_section(bytes, desc, cfg)?;
+            let raw = read_section(bytes, &desc, cfg)?;
+            open_decompressed_bytes += section_decompressed_len(&desc, &raw);
             Arc::new(PageDir::decode_validated(&raw, blocks.len, skip.l0.len())?)
         };
         Ok(RlogReader {
@@ -131,6 +154,7 @@ impl<'a> RlogReader<'a> {
             page_dir,
             bloom,
             postings,
+            open_decompressed_bytes,
         })
     }
 
@@ -242,6 +266,10 @@ impl<'a> RlogReader<'a> {
     ) -> Result<BlockScan, LogSegError> {
         let mut stats = ScanStats {
             blocks_total: self.skip.l0.len() as u32,
+            // Opening the object already decompressed its directory sections;
+            // seed the scan with that so the figure counts the open plus the
+            // block pages the scan goes on to decode (issue #1401).
+            decompressed_bytes: self.open_decompressed_bytes,
             ..ScanStats::default()
         };
 
@@ -924,6 +952,10 @@ impl BlockScan {
             .stats
             .page_bytes_decoded
             .saturating_add(decoded.page_bytes_decoded());
+        self.stats.decompressed_bytes = self
+            .stats
+            .decompressed_bytes
+            .saturating_add(decoded.decompressed_bytes());
 
         for row in 0..decoded.record_count() {
             if eval(
@@ -1008,7 +1040,15 @@ pub(crate) fn decode_v4_block(
             )));
         }
         block_crc = crc32c::crc32c_append(block_crc, stored);
-        page_bytes.push(Some(read_page(stored, &p.desc, DEFAULT_MAX_UNCOMP)?));
+        let produced = read_page(stored, &p.desc, DEFAULT_MAX_UNCOMP)?;
+        // Only a zstd page was decompressed; count what it actually produced
+        // (equal to `uncomp_len` for a valid page, which `read_page` already
+        // checked). A raw page was copied, not decompressed (issue #1401).
+        if p.desc.comp == crate::page::COMP_ZSTD {
+            counters.decompressed_bytes =
+                counters.decompressed_bytes.saturating_add(produced.len() as u64);
+        }
+        page_bytes.push(Some(produced));
         counters.decoded += 1;
         counters.bytes_decoded = counters.bytes_decoded.saturating_add(p.desc.len);
     }
@@ -1338,6 +1378,39 @@ pub fn decode_section(
         }
         Ok(stored.to_vec())
     }
+}
+
+/// Bytes zstd produced decoding one section: the produced buffer's own length
+/// for a `COMP_ZSTD` section, zero for one stored raw (nothing was
+/// decompressed). Used both by [`RlogReader::new`] for the directory sections
+/// it opens and by [`decode_section_accounted`] (issue #1401).
+fn section_decompressed_len(desc: &SectionDesc, produced: &[u8]) -> u64 {
+    if desc.comp == COMP_ZSTD {
+        produced.len() as u64
+    } else {
+        0
+    }
+}
+
+/// [`decode_section`], additionally charging the bytes zstd produced to
+/// `accounting` (issue #1401).
+///
+/// The charge is the returned buffer's actual length, not `desc.uncomp_len`,
+/// for a `COMP_ZSTD` section, and nothing for a raw section (which was copied,
+/// not decompressed). `decode_section` has already checked the two are equal for
+/// a valid section, so a short or corrupt frame is charged as what it produced
+/// only in the error paths it also rejects. Callers pass the phase handle for
+/// the phase the read belongs to (`PhaseAccounting::scan`/`plan`), the same way
+/// the surrounding fetch already charges its GET requests and bytes.
+pub fn decode_section_accounted(
+    stored: &[u8],
+    desc: &SectionDesc,
+    cfg: &RlogConfig,
+    accounting: &ravel_types::accounting::QueryAccounting,
+) -> Result<Vec<u8>, LogSegError> {
+    let produced = decode_section(stored, desc, cfg)?;
+    accounting.add_decompressed_bytes(section_decompressed_len(desc, &produced));
+    Ok(produced)
 }
 
 fn flatten<'p>(pred: &'p Predicate, out: &mut Vec<&'p Predicate>) {

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -1921,6 +1921,29 @@ mod tests {
             "fixture must have at least one zstd directory"
         );
 
+        // Independent reference for the page total below (issue #1401 finding
+        // 4): every page PAGE_DIR lists, across every group and chunk, summed
+        // by its own `uncomp_len` when it is stored COMP_ZSTD and contributing
+        // nothing when it is raw -- read straight from the directory rather
+        // than through `decode_v4_block`'s own counters, and gated on each
+        // page's own `comp` field rather than assumed, so a charge that only
+        // covers the first page of each block (which would still clear a bare
+        // `> open_total` bound) is caught by the sum falling short.
+        let page_desc = *footer.section(kind::PAGE_DIR).expect("PAGE_DIR section");
+        let page_dir_raw = read_section(&obj, &page_desc, &cfg).expect("decode PAGE_DIR");
+        let page_dir = PageDir::decode(&page_dir_raw).expect("parse PAGE_DIR");
+        let mut page_total = 0u64;
+        for group in &page_dir.groups {
+            for chunk in &group.chunks {
+                for page in &chunk.pages {
+                    if page.comp == COMP_ZSTD {
+                        page_total += page.uncomp_len;
+                    }
+                }
+            }
+        }
+        assert!(page_total > 0, "fixture must decode at least one zstd page");
+
         let mut cursor = reader
             .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
             .expect("scan");
@@ -1928,9 +1951,11 @@ mod tests {
         assert_eq!(cursor.stats().decompressed_bytes, open_total);
         while cursor.next_block(&obj).expect("next").is_some() {}
         let total = cursor.stats().decompressed_bytes;
-        assert!(
-            total > open_total,
-            "draining blocks adds their decompressed page bytes on top of the open total"
+        assert_eq!(
+            total,
+            open_total + page_total,
+            "draining every block adds exactly the zstd pages PAGE_DIR lists, \
+             on top of the open total"
         );
 
         // A second, independent scan reports the identical figure: the seed is

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -371,13 +371,18 @@ impl<'a> RlogReader<'a> {
                             let mut postings_arms = content_arms;
                             postings_arms.extend(prune_arms);
                             for (cid, term) in &postings_arms {
-                                match section.probe(*cid, term) {
-                                    Ok(Some(blocks)) => {
+                                match section.probe_accounted(*cid, term) {
+                                    Ok((Some(blocks), decompressed)) => {
+                                        stats.decompressed_bytes =
+                                            stats.decompressed_bytes.saturating_add(decompressed);
                                         let allowed: std::collections::HashSet<usize> =
                                             blocks.iter().map(|&b| b as usize).collect();
                                         candidates.retain(|b| allowed.contains(b));
                                     }
-                                    Ok(None) => {}
+                                    Ok((None, decompressed)) => {
+                                        stats.decompressed_bytes =
+                                            stats.decompressed_bytes.saturating_add(decompressed);
+                                    }
                                     Err(_) => stats.postings_degraded = true,
                                 }
                             }
@@ -1045,8 +1050,9 @@ pub(crate) fn decode_v4_block(
         // (equal to `uncomp_len` for a valid page, which `read_page` already
         // checked). A raw page was copied, not decompressed (issue #1401).
         if p.desc.comp == crate::page::COMP_ZSTD {
-            counters.decompressed_bytes =
-                counters.decompressed_bytes.saturating_add(produced.len() as u64);
+            counters.decompressed_bytes = counters
+                .decompressed_bytes
+                .saturating_add(produced.len() as u64);
         }
         page_bytes.push(Some(produced));
         counters.decoded += 1;
@@ -1785,7 +1791,11 @@ mod tests {
         let acct = QueryAccounting::new();
 
         let raw = decode_section_accounted(stored, &desc, &cfg, &acct).expect("decode");
-        assert_eq!(raw.len() as u64, desc.uncomp_len, "decode produces uncomp_len");
+        assert_eq!(
+            raw.len() as u64,
+            desc.uncomp_len,
+            "decode produces uncomp_len"
+        );
         assert_eq!(
             acct.snapshot().decompressed_bytes,
             desc.uncomp_len,
@@ -1817,8 +1827,13 @@ mod tests {
             "the two sections must differ in uncompressed size for this test"
         );
         let acct = QueryAccounting::new();
-        decode_section_accounted(section_stored(&obj, &stream_desc), &stream_desc, &cfg, &acct)
-            .expect("decode stream_dir");
+        decode_section_accounted(
+            section_stored(&obj, &stream_desc),
+            &stream_desc,
+            &cfg,
+            &acct,
+        )
+        .expect("decode stream_dir");
         decode_section_accounted(section_stored(&obj, &field_desc), &field_desc, &cfg, &acct)
             .expect("decode field_dir");
         assert_eq!(
@@ -1870,13 +1885,21 @@ mod tests {
         // The seed equals the sum of the object's zstd directory sections.
         let footer = open(&obj).expect("open");
         let mut open_total = 0u64;
-        for k in [kind::STREAM_DIR, kind::FIELD_DIR, kind::SKIP_IDX, kind::PAGE_DIR] {
+        for k in [
+            kind::STREAM_DIR,
+            kind::FIELD_DIR,
+            kind::SKIP_IDX,
+            kind::PAGE_DIR,
+        ] {
             let desc = *footer.section(k).expect("section");
             if desc.comp == COMP_ZSTD {
                 open_total += desc.uncomp_len;
             }
         }
-        assert!(open_total > 0, "fixture must have at least one zstd directory");
+        assert!(
+            open_total > 0,
+            "fixture must have at least one zstd directory"
+        );
 
         let mut cursor = reader
             .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
@@ -2668,6 +2691,69 @@ mod tests {
         assert_eq!(stats.blocks_after_postings, 4);
         assert_eq!(stats.blocks_scanned, 4);
         assert!(!stats.postings_degraded);
+    }
+
+    /// A postings-eligible prune arm decompresses one POSTINGS term block
+    /// (`PostingsSection::probe_accounted`), and that block's bytes must land
+    /// in `ScanStats.decompressed_bytes` alongside the open-time directory
+    /// total: before this fix nothing on the postings path charged
+    /// `decompressed_bytes` at all (issue #1401 finding 1). Three distinct
+    /// `svc` values fit inside one `DEFAULT_STRIDE` (128) term block, so the
+    /// section holds exactly one postings term block and
+    /// `total_block_uncompressed_len` names its exact byte count independent
+    /// of `probe_accounted`'s own block selection. Read right after
+    /// `scan_blocks` returns, before any block page is decoded, so no page
+    /// bytes are in the figure to account for.
+    #[test]
+    fn scan_blocks_charges_postings_probe_decompression() {
+        let cfg = RlogConfig {
+            block_target_records: 5,
+            ..RlogConfig::default()
+        };
+        let mut recs = Vec::new();
+        for i in 0..60i64 {
+            let block = i / 5;
+            recs.push(rec_with_svc(i, &format!("s{}", block % 3)));
+        }
+        let obj = build_indexed(cfg, recs, &["svc"]);
+        let reader = RlogReader::new(&obj, &cfg).expect("open");
+
+        let footer = open(&obj).expect("open");
+        let mut open_total = 0u64;
+        for k in [
+            kind::STREAM_DIR,
+            kind::FIELD_DIR,
+            kind::SKIP_IDX,
+            kind::PAGE_DIR,
+        ] {
+            let desc = *footer.section(k).expect("section");
+            if desc.comp == COMP_ZSTD {
+                open_total += desc.uncomp_len;
+            }
+        }
+
+        let postings_bytes = postings_bytes_of(&obj);
+        let section = PostingsSection::parse(&postings_bytes).expect("parse postings");
+        let postings_total = section.total_block_uncompressed_len();
+        assert!(
+            postings_total > 0,
+            "fixture must produce at least one postings term block"
+        );
+
+        let prune = [Predicate::Equals {
+            field: FieldSel::Attr("svc".into()),
+            value: AttrValue::Str("s0".into()),
+        }];
+        let cursor = reader
+            .scan_blocks(&Predicate::And(Vec::new()), &prune, &ColumnSelection::all())
+            .expect("scan");
+
+        assert_eq!(
+            cursor.stats().decompressed_bytes,
+            open_total + postings_total,
+            "scan_blocks charges the postings probe's decompressed term block \
+             on top of the open-time directory total"
+        );
     }
 
     /// An attribute the POSTINGS index does not cover prunes nothing. `region`

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -1329,6 +1329,27 @@ pub fn read_section(
     desc: &SectionDesc,
     cfg: &RlogConfig,
 ) -> Result<Vec<u8>, LogSegError> {
+    decode_section(section_slice(bytes, desc)?, desc, cfg)
+}
+
+/// [`read_section`], additionally charging the bytes zstd produced to
+/// `accounting` (issue #1401 finding 3), the same way
+/// [`decode_section_accounted`] does for a caller that has already sliced the
+/// section's stored bytes out of an assembled buffer.
+pub fn read_section_accounted(
+    bytes: &[u8],
+    desc: &SectionDesc,
+    cfg: &RlogConfig,
+    accounting: &ravel_types::accounting::QueryAccounting,
+) -> Result<Vec<u8>, LogSegError> {
+    decode_section_accounted(section_slice(bytes, desc)?, desc, cfg, accounting)
+}
+
+/// The section's stored bytes, sliced out of a whole-object buffer at
+/// `[desc.offset, desc.offset + desc.len)`. Shared by [`read_section`] and
+/// [`read_section_accounted`], which differ only in whether the decode that
+/// follows charges `decompressed_bytes`.
+fn section_slice<'b>(bytes: &'b [u8], desc: &SectionDesc) -> Result<&'b [u8], LogSegError> {
     let start = usize::try_from(desc.offset)
         .map_err(|_| LogSegError::Corrupted("section offset range".into()))?;
     let len = usize::try_from(desc.len)
@@ -1336,10 +1357,9 @@ pub fn read_section(
     let end = start
         .checked_add(len)
         .ok_or_else(|| LogSegError::Corrupted("section range overflow".into()))?;
-    let stored = bytes
+    bytes
         .get(start..end)
-        .ok_or_else(|| LogSegError::Corrupted("section out of bounds".into()))?;
-    decode_section(stored, desc, cfg)
+        .ok_or_else(|| LogSegError::Corrupted("section out of bounds".into()))
 }
 
 /// The crc-and-decompress half of [`read_section`], taking a section's stored

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -449,6 +449,13 @@ impl LogSegmentScan {
             .add_page_bytes_fetched(stats.page_bytes_fetched);
         self.accounting
             .add_page_bytes_decoded(stats.page_bytes_decoded);
+        // Bytes zstd produced opening this object's directory sections and
+        // decoding its scanned block pages (issue #1401). This is the scan
+        // funnel's decompressed-byte output; charged to the `scan` phase, the
+        // same handle its page-byte figures land on, so a warm-cache scan that
+        // moves no wire bytes still reports the decode work it did.
+        self.accounting
+            .add_decompressed_bytes(stats.decompressed_bytes);
     }
 }
 
@@ -1428,6 +1435,7 @@ impl LogSegmentFetcher {
                     pages_skipped: 0,
                     page_bytes_fetched: 0,
                     page_bytes_decoded: 0,
+                    decompressed_bytes: 0,
                     bloom_degraded: false,
                     postings_degraded: false,
                 };
@@ -1663,6 +1671,7 @@ impl LogSegmentFetcher {
             pages_skipped: 0,
             page_bytes_fetched: 0,
             page_bytes_decoded: 0,
+            decompressed_bytes: 0,
             bloom_degraded: false,
             postings_degraded: false,
         };

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -65,8 +65,8 @@ use ravel_logseg::skip_index::{Level0Entry, NumRangeArm, SkipIndex, merge_stats}
 use ravel_logseg::stream_dir::StreamDir;
 use ravel_logseg::{
     AttrValue, BlockScan, ColumnSelection, ColumnarBlockView, LogRecord, LogSegError, LogStreamId,
-    Predicate, RlogConfig, RlogReader, ScanStats, SuffixOutcome, decode_section,
-    decode_section_accounted, open_from_suffix, read_section,
+    Predicate, RlogConfig, RlogReader, ScanStats, SuffixOutcome, decode_section_accounted,
+    open_from_suffix, read_section_accounted,
 };
 use ravel_object_store::{Etag, GetOutcome, GetRange, ObjectStoreBackend, StoreError};
 use ravel_types::TenantHash;
@@ -939,12 +939,17 @@ impl LogSegmentFetcher {
     /// limitation in its user-facing query semantics. Silently inheriting this
     /// over-approximation into a user-facing query would violate the "exact
     /// semantics by default, approximation is opt-in and visible" invariant.
+    ///
+    /// `accounting` receives the STREAM_DIR decompression this decode performs
+    /// (issue #1401 finding 3); `bytes` is assumed already fetched and its wire
+    /// bytes already charged by the caller.
     pub fn matching_streams(
         &self,
         bytes: &[u8],
         filters: &[StreamAttrEquals],
+        accounting: &QueryAccounting,
     ) -> Result<Vec<LogStreamId>, LogSegError> {
-        let dir = self.decode_stream_dir(bytes)?;
+        let dir = self.decode_stream_dir(bytes, accounting)?;
         let needles: Vec<Vec<u8>> = filters.iter().map(stream_attr_needle).collect();
         let mut out = Vec::new();
         for entry in dir.entries() {
@@ -1073,7 +1078,7 @@ impl LogSegmentFetcher {
             // This funnel issues exactly one whole-object GET per call.
             fetch_span.record("s3_requests", 1u64);
             fetch_span.record("s3_bytes", got.data.len() as u64);
-            self.decode_spanned(key, &got.data, query)
+            self.decode_spanned(key, &got.data, query, accounting)
         }
         .await;
         caller_accounting.merge_snapshot(&phase.snapshot().pooled());
@@ -1138,7 +1143,7 @@ impl LogSegmentFetcher {
             else {
                 return Ok(None);
             };
-            self.decode_spanned(&seg_ref.data_object_key, &bytes, query)
+            self.decode_spanned(&seg_ref.data_object_key, &bytes, query, accounting)
         }
         .await;
         caller_accounting.merge_snapshot(&phase.snapshot().pooled());
@@ -1209,7 +1214,7 @@ impl LogSegmentFetcher {
         };
         let key = &seg_ref.data_object_key;
         let span = decode_span();
-        let scan = span.in_scope(|| self.open_scan(key, &bytes, query, columns))?;
+        let scan = span.in_scope(|| self.open_scan(key, &bytes, query, columns, accounting))?;
         Ok(Some(LogSegmentScan {
             bytes,
             scan,
@@ -1264,7 +1269,7 @@ impl LogSegmentFetcher {
             .await?;
         let key = &seg_ref.data_object_key;
         let span = decode_span();
-        let scan = span.in_scope(|| self.open_scan(key, &bytes, query, columns))?;
+        let scan = span.in_scope(|| self.open_scan(key, &bytes, query, columns, accounting))?;
         Ok(Some(LogSegmentScan {
             bytes,
             scan,
@@ -1480,7 +1485,7 @@ impl LogSegmentFetcher {
             };
             let key = &seg_ref.data_object_key;
             let span = decode_span();
-            let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &all))?;
+            let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &all, accounting))?;
             // This fallback read fetched blocks iff `tenant_bytes` resolved at
             // least one (ranged path) or read the whole object (`None`, every
             // block present). A ranged read that pruned every block resolved zero
@@ -1857,7 +1862,8 @@ impl LogSegmentFetcher {
         };
         let key = &seg_ref.data_object_key;
         let span = decode_span();
-        let scan = span.in_scope(|| self.open_scan_subset(key, &bytes, query, columns, indices))?;
+        let scan = span
+            .in_scope(|| self.open_scan_subset(key, &bytes, query, columns, indices, accounting))?;
         Ok(Some(LogSegmentScan {
             bytes,
             scan,
@@ -2253,9 +2259,10 @@ impl LogSegmentFetcher {
         key: &str,
         bytes: &Bytes,
         query: &LogQuery,
+        accounting: &QueryAccounting,
     ) -> Result<Option<LogFetchOutput>, LogFetchError> {
         let span = decode_span();
-        let out = span.in_scope(|| self.scan_bytes(key, bytes, query))?;
+        let out = span.in_scope(|| self.scan_bytes(key, bytes, query, accounting))?;
         if let Some(output) = &out {
             span.record("blocks_scanned", output.stats.blocks_scanned);
             span.record("blocks_total", output.stats.blocks_total);
@@ -2272,8 +2279,9 @@ impl LogSegmentFetcher {
         key: &str,
         bytes: &Bytes,
         query: &LogQuery,
+        accounting: &QueryAccounting,
     ) -> Result<Option<LogFetchOutput>, LogFetchError> {
-        let mut scan = self.open_scan(key, bytes, query, &ColumnSelection::all())?;
+        let mut scan = self.open_scan(key, bytes, query, &ColumnSelection::all(), accounting)?;
         let mut records = Vec::new();
         loop {
             let block = scan.next_block(bytes).map_err(|s| corrupt(key, s))?;
@@ -2310,8 +2318,9 @@ impl LogSegmentFetcher {
         bytes: &Bytes,
         query: &LogQuery,
         columns: &ColumnSelection,
+        accounting: &QueryAccounting,
     ) -> Result<BlockScan, LogFetchError> {
-        let pred = self.combined_predicate(key, bytes, query)?;
+        let pred = self.combined_predicate(key, bytes, query, accounting)?;
         let reader = RlogReader::new(bytes, &self.cfg).map_err(|source| corrupt(key, source))?;
         // `prune` is passed as the reader's prune-only channel, never folded
         // into `pred`: an arm there would become an exact per-row filter and
@@ -2337,8 +2346,9 @@ impl LogSegmentFetcher {
         query: &LogQuery,
         columns: &ColumnSelection,
         indices: &[usize],
+        accounting: &QueryAccounting,
     ) -> Result<BlockScan, LogFetchError> {
-        let pred = self.combined_predicate(key, bytes, query)?;
+        let pred = self.combined_predicate(key, bytes, query, accounting)?;
         let reader = RlogReader::new(bytes, &self.cfg).map_err(|source| corrupt(key, source))?;
         reader
             .scan_blocks_subset(&pred, &query.prune, columns, indices)
@@ -2355,12 +2365,13 @@ impl LogSegmentFetcher {
         key: &str,
         bytes: &Bytes,
         query: &LogQuery,
+        accounting: &QueryAccounting,
     ) -> Result<Predicate, LogFetchError> {
         let stream_ids = if query.stream_attrs.is_empty() {
             None
         } else {
             Some(
-                self.matching_streams(bytes, &query.stream_attrs)
+                self.matching_streams(bytes, &query.stream_attrs, accounting)
                     .map_err(|source| corrupt(key, source))?,
             )
         };
@@ -2477,7 +2488,7 @@ impl LogSegmentFetcher {
             match footer.section(kind::STREAM_DIR).copied() {
                 None => None,
                 Some(desc) => {
-                    let raw = read_section(&bytes, &desc, &self.cfg)
+                    let raw = read_section_accounted(&bytes, &desc, &self.cfg, accounting)
                         .map_err(|source| corrupt(key, source))?;
                     Some(
                         StreamDir::decode(&raw, MAX_STREAMS)
@@ -2498,12 +2509,21 @@ impl LogSegmentFetcher {
     /// descriptor, using the crate's public whole-section reader.
     /// This does not go through [`RlogReader`], which decodes STREAM_DIR
     /// internally but exposes no accessor for it.
-    fn decode_stream_dir(&self, bytes: &[u8]) -> Result<StreamDir, LogSegError> {
+    ///
+    /// Charges the bytes zstd produced to `accounting` (issue #1401 finding 3):
+    /// `bytes` was already fetched by the caller, so this is the one
+    /// in-memory decompression this method itself performs, and it lands
+    /// under whichever phase handle the caller is threading.
+    fn decode_stream_dir(
+        &self,
+        bytes: &[u8],
+        accounting: &QueryAccounting,
+    ) -> Result<StreamDir, LogSegError> {
         let footer = footer::open(bytes)?;
         let desc = footer
             .section(kind::STREAM_DIR)
             .ok_or_else(|| LogSegError::Corrupted("missing STREAM_DIR section".into()))?;
-        let raw = read_section(bytes, desc, &self.cfg)?;
+        let raw = read_section_accounted(bytes, desc, &self.cfg, accounting)?;
         StreamDir::decode(&raw, MAX_STREAMS)
     }
 }
@@ -4627,8 +4647,11 @@ impl BlockRangeFetcher {
         .await?;
 
         // Decode the skip index (now resident) and resolve the candidate blocks.
+        // A ranged read of this shape, so charged to whichever phase handle the
+        // caller passed in (issue #1401 finding 3): `decode_section_accounted`
+        // has no phase tag of its own, only the handle it is given.
         let skip_stored = asm.slice(key, skip_desc.offset, skip_desc.len)?;
-        let skip_raw = decode_section(skip_stored, skip_desc, &self.cfg)
+        let skip_raw = decode_section_accounted(skip_stored, skip_desc, &self.cfg, accounting)
             .map_err(|source| corrupt(key, source))?;
         let skip =
             SkipIndex::decode(&skip_raw, MAX_BLOCKS).map_err(|source| corrupt(key, source))?;
@@ -4932,10 +4955,10 @@ impl BlockRangeFetcher {
             &mut stats,
         )
         .await?;
-        let skip_raw = self.placed_section_raw(key, &asm, &skip_desc)?;
+        let skip_raw = self.placed_section_raw(key, &asm, &skip_desc, accounting)?;
         let skip =
             SkipIndex::decode(&skip_raw, MAX_BLOCKS).map_err(|source| corrupt(key, source))?;
-        let page_raw = self.placed_section_raw(key, &asm, &page_desc)?;
+        let page_raw = self.placed_section_raw(key, &asm, &page_desc, accounting)?;
         let page_dir = PageDir::decode(&page_raw).map_err(|source| corrupt(key, source))?;
         page_dir
             .validate_extents(blocks_desc.len)
@@ -5216,15 +5239,20 @@ impl BlockRangeFetcher {
     }
 
     /// Decode one whole-compressed section out of the assembled buffer, where an
-    /// earlier `place_*` call already put its stored bytes.
+    /// earlier `place_*` call already put its stored bytes. Charges the bytes
+    /// zstd produced to `accounting` (issue #1401 finding 3): a ranged read's
+    /// SKIP_IDX and PAGE_DIR decode, so its callers pass the same handle their
+    /// GETs are charged against.
     fn placed_section_raw(
         &self,
         key: &str,
         asm: &ObjectAssembler,
         desc: &SectionDesc,
+        accounting: &QueryAccounting,
     ) -> Result<Vec<u8>, LogFetchError> {
         let stored = asm.slice(key, desc.offset, desc.len)?;
-        decode_section(stored, desc, &self.cfg).map_err(|source| corrupt(key, source))
+        decode_section_accounted(stored, desc, &self.cfg, accounting)
+            .map_err(|source| corrupt(key, source))
     }
 
     /// Resolve each candidate block index (from `skip.candidate_blocks`) to its
@@ -5379,8 +5407,8 @@ impl BlockRangeFetcher {
         )
         .await?;
         let stored = asm.slice(key, desc.offset, desc.len)?;
-        let raw =
-            decode_section(stored, &desc, &self.cfg).map_err(|source| corrupt(key, source))?;
+        let raw = decode_section_accounted(stored, &desc, &self.cfg, accounting)
+            .map_err(|source| corrupt(key, source))?;
         FieldDir::decode(&raw, MAX_FIELDS).map_err(|source| corrupt(key, source))
     }
 
@@ -7902,6 +7930,22 @@ mod fetch_stream_dir_tests {
         let total = bytes.len() as u64;
         let seg = seg_ref(total, &records);
 
+        // Independent ground truth for the decompressed-byte pins below (issue
+        // #1401 finding 3): STREAM_DIR is a whole-read directory section, always
+        // stored COMP_ZSTD, so its uncomp_len is the exact bytes one decode of it
+        // produces, read straight from the footer rather than through either
+        // branch under test.
+        let stream_desc = *footer::open(&bytes)
+            .expect("open")
+            .section(kind::STREAM_DIR)
+            .expect("STREAM_DIR present");
+        assert_eq!(
+            stream_desc.comp,
+            footer::COMP_ZSTD,
+            "fixture STREAM_DIR must be zstd for this test"
+        );
+        let expected = stream_desc.uncomp_len;
+
         let below_store = store_with_object(bytes.clone()).await;
         let below = LogSegmentFetcher::new(below_store);
         assert!(
@@ -7914,6 +7958,11 @@ mod fetch_stream_dir_tests {
             .await
             .expect("fetch_stream_dir (below threshold)")
             .expect("STREAM_DIR present");
+        assert_eq!(
+            below_acc.snapshot().decompressed_bytes,
+            expected,
+            "below-threshold branch charges exactly STREAM_DIR's zstd uncomp_len"
+        );
 
         let above_store = store_with_object(bytes).await;
         let above = fetcher_above_threshold(above_store);
@@ -7923,6 +7972,11 @@ mod fetch_stream_dir_tests {
             .await
             .expect("fetch_stream_dir (above threshold)")
             .expect("STREAM_DIR present");
+        assert_eq!(
+            above_acc.snapshot().decompressed_bytes,
+            expected,
+            "above-threshold branch charges exactly STREAM_DIR's zstd uncomp_len"
+        );
 
         below_entries.sort_by_key(|(id, _)| *id);
         above_entries.sort_by_key(|(id, _)| *id);

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -440,6 +440,8 @@ impl LogSegmentScan {
         let stats = self.scan.stats();
         self.span.record("blocks_scanned", stats.blocks_scanned);
         self.span.record("blocks_total", stats.blocks_total);
+        self.span
+            .record("decompressed_bytes", stats.decompressed_bytes);
         // Decode-time column-filtering accounting (ADR-0107 decision 4), folded
         // once at exhaustion into the query's handle: page_bytes_fetched vs.
         // page_bytes_decoded expose how much of each fetched block a narrow
@@ -1119,10 +1121,11 @@ impl LogSegmentFetcher {
         // whole-object GET) and the block-range path it falls through to
         // above threshold both do data reads with no separate plan step of
         // their own here, so this funnel's GETs are charged to `scan`.
-        // `decode_spanned` (below) records no accounting of its own -- unlike
-        // the `LogSegmentScan`-returning funnels below, this one fully
-        // decodes and returns before this function returns, so buffering into
-        // a disposable `PhaseAccounting` and merging once is safe here.
+        // `decode_spanned` (below) charges only the decode's decompressed
+        // bytes (issue #1401) -- unlike the `LogSegmentScan`-returning funnels
+        // below, this one fully decodes and returns before this function
+        // returns, so buffering into a disposable `PhaseAccounting` and
+        // merging once is safe here.
         let phase = PhaseAccounting::new();
         let accounting = phase.scan();
         // This funnel's decode (`scan_bytes`) reads every column, so the fetch
@@ -1486,6 +1489,13 @@ impl LogSegmentFetcher {
             let key = &seg_ref.data_object_key;
             let span = decode_span();
             let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &all, accounting))?;
+            // Opening the scan decoded the four directory sections over the
+            // fetched buffer (and ran the POSTINGS probe for an eligible prune
+            // arm); those bytes sit in the reader's own stats, not on any
+            // handle, so charge them to the plan phase here (issue #1401). No
+            // block is decoded on this branch: the scan exists for its
+            // survivor count.
+            accounting.add_decompressed_bytes(scan.stats().decompressed_bytes);
             // This fallback read fetched blocks iff `tenant_bytes` resolved at
             // least one (ranged path) or read the whole object (`None`, every
             // block present). A ranged read that pruned every block resolved zero
@@ -2235,25 +2245,21 @@ impl LogSegmentFetcher {
     /// Runs [`scan_bytes`](Self::scan_bytes) inside the log path's `decode`
     /// span, recording the reader's block-scan counts on it afterward.
     ///
-    /// # Why this span's field set diverges from the metric path's `decode`
+    /// # How this span's field set relates to the metric path's `decode`
     ///
     /// The metric path's `decode` span (`crate::fetcher`) carries `page_kind`,
     /// `series_count`, and `decompressed_bytes`. This one carries `signal =
-    /// "logs"` plus `blocks_scanned`/`blocks_total`, and no `decompressed_bytes`
-    /// (documented in docs/guides/tracing.md). No decompressed-byte
-    /// count is cheaply available here: [`ScanStats`] carries block counts, not
-    /// bytes, and decompression happens per block inside
-    /// [`RlogReader::scan_pruned`] (`read_block`) where the total is never
-    /// summed. Surfacing one would need a new `ScanStats` field and a structural
-    /// change to `ravel-logseg`, out of scope for that fix.
+    /// "logs"`, `blocks_scanned`/`blocks_total`, and `decompressed_bytes`
+    /// (documented in docs/guides/tracing.md). The byte figure is
+    /// [`ScanStats::decompressed_bytes`]: what zstd produced opening the
+    /// object's directory sections, probing POSTINGS, and decoding the drained
+    /// blocks, the same total `scan_bytes` charges to the accounting handle.
     ///
-    /// `blocks_scanned`/`blocks_total` are instead a real, already-computed
-    /// pruning-effectiveness signal -- how much of the object's block index the
-    /// scan actually had to touch after skip-index, POSTINGS, and bloom pruning
-    /// -- analogous to the metric path's `catalog_resolve` `segments_pruned`,
-    /// which is likewise a pruning count rather than a byte count. Every phase
-    /// span in the codebase carries at least one count field; before this the
-    /// logs `decode` span carried none.
+    /// `blocks_scanned`/`blocks_total` are a pruning-effectiveness signal --
+    /// how much of the object's block index the scan actually had to touch
+    /// after skip-index, POSTINGS, and bloom pruning -- analogous to the
+    /// metric path's `catalog_resolve` `segments_pruned`, which is likewise a
+    /// pruning count rather than a byte count.
     fn decode_spanned(
         &self,
         key: &str,
@@ -2262,43 +2268,57 @@ impl LogSegmentFetcher {
         accounting: &QueryAccounting,
     ) -> Result<Option<LogFetchOutput>, LogFetchError> {
         let span = decode_span();
-        let out = span.in_scope(|| self.scan_bytes(key, bytes, query, accounting))?;
-        if let Some(output) = &out {
-            span.record("blocks_scanned", output.stats.blocks_scanned);
-            span.record("blocks_total", output.stats.blocks_total);
-        }
-        Ok(out)
+        span.in_scope(|| self.scan_bytes(key, bytes, query, accounting, &span))
     }
 
     /// Shared tail of both fetch entry points: open the pruned scan and drain
     /// every block of it. This is [`LogSegmentScan`] collected eagerly, so the
     /// two paths cannot drift: same predicate, same prune channel, same
     /// per-record erasure exclusion, same order.
+    ///
+    /// `span` is the `decode` span this runs inside; its counters are recorded
+    /// here, at the same point the accounting handle is charged, so a drain
+    /// that stops on a corrupt block still reports what it did before the
+    /// error rather than leaving the span's fields empty.
     fn scan_bytes(
         &self,
         key: &str,
         bytes: &Bytes,
         query: &LogQuery,
         accounting: &QueryAccounting,
+        span: &tracing::Span,
     ) -> Result<Option<LogFetchOutput>, LogFetchError> {
         let mut scan = self.open_scan(key, bytes, query, &ColumnSelection::all(), accounting)?;
         let mut records = Vec::new();
-        loop {
-            let block = scan.next_block(bytes).map_err(|s| corrupt(key, s))?;
-            let Some(mut rows) = block else { break };
-            // Selective-erasure exclusion (ADR-0064 decision 2): drop every
-            // row a pending erasure predicate matches. Applied here, on the
-            // decoded records, so it excludes rows identically whether `bytes`
-            // came from the store or from a cache hit -- the whole point of
-            // filtering after fetch and after cache. A no-op when
-            // `query.erasure` is empty.
-            crate::erasure::retain_log_records(&mut rows, &query.erasure);
-            records.extend(rows);
-        }
-        Ok(Some(LogFetchOutput {
-            records,
-            stats: scan.stats(),
-        }))
+        let drained = loop {
+            match scan.next_block(bytes) {
+                Ok(Some(mut rows)) => {
+                    // Selective-erasure exclusion (ADR-0064 decision 2): drop
+                    // every row a pending erasure predicate matches. Applied
+                    // here, on the decoded records, so it excludes rows
+                    // identically whether `bytes` came from the store or from
+                    // a cache hit -- the whole point of filtering after fetch
+                    // and after cache. A no-op when `query.erasure` is empty.
+                    crate::erasure::retain_log_records(&mut rows, &query.erasure);
+                    records.extend(rows);
+                }
+                Ok(None) => break Ok(()),
+                Err(source) => break Err(corrupt(key, source)),
+            }
+        };
+        // The eager counterpart of `LogSegmentScan::finish`: the bytes zstd
+        // produced opening the directories, probing POSTINGS, and decoding the
+        // drained blocks are charged once, to the handle this funnel's GET
+        // already landed on, whether the drain finished or stopped on a
+        // corrupt block (issue #1401). Work done before an error is still work
+        // done.
+        let stats = scan.stats();
+        accounting.add_decompressed_bytes(stats.decompressed_bytes);
+        span.record("blocks_scanned", stats.blocks_scanned);
+        span.record("blocks_total", stats.blocks_total);
+        span.record("decompressed_bytes", stats.decompressed_bytes);
+        drained?;
+        Ok(Some(LogFetchOutput { records, stats }))
     }
 
     /// Resolve stream-attribute equalities against STREAM_DIR
@@ -6041,6 +6061,7 @@ fn decode_span() -> tracing::Span {
         signal = "logs",
         blocks_scanned = tracing::field::Empty,
         blocks_total = tracing::field::Empty,
+        decompressed_bytes = tracing::field::Empty,
     )
 }
 

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -65,8 +65,8 @@ use ravel_logseg::skip_index::{Level0Entry, NumRangeArm, SkipIndex, merge_stats}
 use ravel_logseg::stream_dir::StreamDir;
 use ravel_logseg::{
     AttrValue, BlockScan, ColumnSelection, ColumnarBlockView, LogRecord, LogSegError, LogStreamId,
-    Predicate, RlogConfig, RlogReader, ScanStats, SuffixOutcome, decode_section, open_from_suffix,
-    read_section,
+    Predicate, RlogConfig, RlogReader, ScanStats, SuffixOutcome, decode_section,
+    decode_section_accounted, open_from_suffix, read_section,
 };
 use ravel_object_store::{Etag, GetOutcome, GetRange, ObjectStoreBackend, StoreError};
 use ravel_types::TenantHash;
@@ -4183,7 +4183,13 @@ impl BlockRangeFetcher {
                 bytes
             }
         };
-        decode_section(&stored, desc, &self.cfg).map_err(|source| corrupt(key, source))
+        // A planning read decompresses this directory section to count survivors
+        // or resolve columns; charge what zstd produced to the phase handle this
+        // read belongs to (issue #1401), the same handle its GETs are charged
+        // against above. Separate from the scan's own directory decode in
+        // `RlogReader::new`, which the scan phase charges through `ScanStats`.
+        decode_section_accounted(&stored, desc, &self.cfg, accounting)
+            .map_err(|source| corrupt(key, source))
     }
 
     /// Read the footer, SKIP_IDX, and FIELD_DIR for one segment and decode all

--- a/crates/ravel-query/tests/e2e.rs
+++ b/crates/ravel-query/tests/e2e.rs
@@ -24,7 +24,7 @@ use ravel_object_store::{
     ObjectStoreBackend, PageToken, PutOptions, PutOutcome, StoreError,
 };
 use ravel_query::http::{AppState, StaticBearerTokenResolver, router};
-use ravel_query::{EngineConfig, LogQuery, LogSegmentFetcher, QueryEngine};
+use ravel_query::{EngineConfig, LogFetchError, LogQuery, LogSegmentFetcher, QueryEngine};
 use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput, WrittenSegment};
 use ravel_types::accounting::QueryAccounting;
 use ravel_types::logstream::log_stream_id;
@@ -284,8 +284,8 @@ struct CapturedSpan {
     s3_requests: Option<u64>,
     s3_bytes: Option<u64>,
     decompressed_bytes: Option<u64>,
-    /// The logs `decode` span's block-scan counts. The metric
-    /// `decode` span records `decompressed_bytes` here instead.
+    /// The logs `decode` span's block-scan counts, beside the
+    /// `decompressed_bytes` both paths' `decode` spans record.
     blocks_scanned: Option<u64>,
     blocks_total: Option<u64>,
 }
@@ -482,13 +482,22 @@ async fn instant_query_emits_all_six_phase_spans() {
 
 /// Writes a small single-stream RLOG object (12 records) onto a fresh
 /// `MemoryStore` and returns it with a matching L0 `SegmentRef`, mirroring the
-/// recipe `cache_correctness.rs` uses. The `decode`-span test below scans it
-/// through `LogSegmentFetcher::fetch_accounted` and asserts the logs `decode`
-/// span records real block-scan counts.
-async fn write_log_segment_for_span_test() -> (Arc<MemoryStore>, SegmentRef) {
+/// recipe `cache_correctness.rs` uses. The `decode`-span tests below scan it
+/// through `LogSegmentFetcher::fetch_accounted` and assert what the logs
+/// `decode` span records.
+///
+/// `cfg` and `service` shape the object (block count, STREAM_DIR size) so two
+/// tests sharing the process-global span collector can each pick out their
+/// own span by its figures; `mutate` runs over the finished object before it
+/// is stored, so a test can corrupt it.
+async fn write_log_segment_for_span_test(
+    cfg: RlogConfig,
+    service: &str,
+    mutate: impl FnOnce(&mut Vec<u8>),
+) -> (Arc<MemoryStore>, SegmentRef) {
     let resource = vec![(
         "service.name".to_string(),
-        AttrValue::Str("logs-span-test".to_string()),
+        AttrValue::Str(service.to_string()),
     )];
     let stream_id = log_stream_id(&resource, "scope", "1.0", &[]);
     let stream_attrs = stream_attrs_bytes(&resource, "scope", "1.0", &[]);
@@ -515,11 +524,12 @@ async fn write_log_segment_for_span_test() -> (Arc<MemoryStore>, SegmentRef) {
         writer_epoch: 1,
         writer_seq: 1,
     };
-    let mut writer = RlogWriter::new(RlogConfig::default(), identity);
+    let mut writer = RlogWriter::new(cfg, identity);
     for record in &records {
         writer.push(record.clone()).expect("push record");
     }
-    let bytes = writer.finish().expect("finish rlog object");
+    let mut bytes = writer.finish().expect("finish rlog object");
+    mutate(&mut bytes);
     let size = bytes.len() as u64;
 
     let store = Arc::new(MemoryStore::new());
@@ -552,17 +562,18 @@ async fn write_log_segment_for_span_test() -> (Arc<MemoryStore>, SegmentRef) {
 
 /// The logs read path's `decode` span must record a real, non-empty count
 /// field, unlike a phase span that carried only `signal = "logs"`. It records
-/// `blocks_scanned` and
-/// `blocks_total` from the reader's `ScanStats` (a decompressed-byte count is not
-/// cheaply available on this path; see `log_fetcher.rs` and
+/// `blocks_scanned` and `blocks_total` from the reader's `ScanStats`, and
+/// `decompressed_bytes` from the same stats (see `log_fetcher.rs` and
 /// docs/guides/tracing.md). This scans a real RLOG object through
 /// `LogSegmentFetcher::fetch_accounted` and asserts the logs-signal `decode`
-/// span captured non-empty block counts.
+/// span captured non-empty block counts and the exact byte figure the scan
+/// reported and the funnel charged.
 #[tokio::test]
 async fn logs_decode_span_records_block_scan_counts() {
     let collector = install_span_collector();
 
-    let (store, seg_ref) = write_log_segment_for_span_test().await;
+    let (store, seg_ref) =
+        write_log_segment_for_span_test(RlogConfig::default(), "logs-span-test", |_| {}).await;
     let fetcher = LogSegmentFetcher::new(store);
     let query = LogQuery::new(0, 11);
     let accounting = QueryAccounting::new();
@@ -581,14 +592,21 @@ async fn logs_decode_span_records_block_scan_counts() {
         "at least one block was scanned"
     );
 
-    // Isolate this scan's logs `decode` span from any sibling metric-path
-    // `decode` span in the shared global collector: only the logs path sets
-    // `signal = "logs"` and records the block counts.
+    // Isolate this scan's logs `decode` span in the shared global collector:
+    // only the logs path sets `signal = "logs"`, and the sibling corrupt-block
+    // span test writes a differently shaped object (four blocks, a longer
+    // STREAM_DIR), so this scan's own block total and byte figure single out
+    // its span.
     let logs_decode: Vec<CapturedSpan> = {
         let completed = collector.completed.lock().expect("completed lock");
         completed
             .iter()
-            .filter(|s| s.name == "decode" && s.signal.as_deref() == Some("logs"))
+            .filter(|s| {
+                s.name == "decode"
+                    && s.signal.as_deref() == Some("logs")
+                    && s.blocks_total == Some(u64::from(out.stats.blocks_total))
+                    && s.decompressed_bytes == Some(out.stats.decompressed_bytes)
+            })
             .cloned()
             .collect()
     };
@@ -615,10 +633,119 @@ async fn logs_decode_span_records_block_scan_counts() {
             "logs decode span must record non-empty block counts, got \
              blocks_scanned={scanned} blocks_total={total}"
         );
-        // The metric path's `decode` field must not leak onto the logs span.
-        assert!(
-            span.decompressed_bytes.is_none(),
-            "logs decode span carries no decompressed_bytes field"
+        // The byte figure is the scan's own total, which the collecting
+        // funnel also charged to the handle: one number, three places.
+        let decompressed = span
+            .decompressed_bytes
+            .expect("logs decode span records decompressed_bytes");
+        assert_eq!(
+            decompressed, out.stats.decompressed_bytes,
+            "logs decode span records exactly the scan's decompressed_bytes"
+        );
+        assert_eq!(
+            decompressed,
+            accounting.snapshot().decompressed_bytes,
+            "the funnel charged the same figure the span recorded"
+        );
+    }
+}
+
+/// When the eager drain stops on a corrupt block, the logs `decode` span still
+/// records what the scan did before the error: the counters and the bytes
+/// zstd produced opening the object, which the accounting handle was charged.
+/// A byte flipped at the start of BLOCKS breaks block 0's first page crc, so no
+/// block decodes and the only decompression is the reader's open, the four
+/// directory sections' `uncomp_len` read from the footer. The object has four
+/// blocks and a longer STREAM_DIR than the clean sibling test's, which is how
+/// its span is told apart in the shared collector.
+#[tokio::test]
+async fn logs_decode_span_records_counts_when_the_drain_stops_on_a_corrupt_block() {
+    let collector = install_span_collector();
+
+    let cfg = RlogConfig {
+        block_target_records: 3,
+        ..RlogConfig::default()
+    };
+    let (store, seg_ref) =
+        write_log_segment_for_span_test(cfg, "logs-span-test-corrupt", |bytes| {
+            let blocks = *ravel_logseg::footer::open(bytes)
+                .expect("open footer")
+                .section(ravel_logseg::footer::kind::BLOCKS)
+                .expect("BLOCKS present");
+            bytes[blocks.offset as usize] ^= 0xff;
+        })
+        .await;
+    let bytes = store
+        .get(&seg_ref.data_object_key, GetRange::Full)
+        .await
+        .expect("get object")
+        .data;
+    let footer = ravel_logseg::footer::open(&bytes).expect("open footer");
+    let mut expected = 0u64;
+    for k in [
+        ravel_logseg::footer::kind::STREAM_DIR,
+        ravel_logseg::footer::kind::FIELD_DIR,
+        ravel_logseg::footer::kind::SKIP_IDX,
+        ravel_logseg::footer::kind::PAGE_DIR,
+    ] {
+        let desc = *footer.section(k).expect("section present");
+        assert_eq!(
+            desc.comp,
+            ravel_logseg::footer::COMP_ZSTD,
+            "fixture directory section {k} must be zstd for this test"
+        );
+        expected += desc.uncomp_len;
+    }
+    let blocks_total = footer.block_count;
+
+    let fetcher = LogSegmentFetcher::new(store);
+    let query = LogQuery::new(0, 11);
+    let accounting = QueryAccounting::new();
+
+    let err = fetcher
+        .fetch_accounted(&seg_ref, &query, &accounting)
+        .await
+        .expect_err("a corrupt first page must not decode");
+    assert!(
+        matches!(err, LogFetchError::Corrupt { .. }),
+        "expected Corrupt, got {err:?}"
+    );
+    assert_eq!(
+        accounting.snapshot().decompressed_bytes,
+        expected,
+        "the handle is charged exactly the reader's four directory decodes"
+    );
+
+    let logs_decode: Vec<CapturedSpan> = {
+        let completed = collector.completed.lock().expect("completed lock");
+        completed
+            .iter()
+            .filter(|s| {
+                s.name == "decode"
+                    && s.signal.as_deref() == Some("logs")
+                    && s.blocks_total == Some(blocks_total)
+                    && s.decompressed_bytes == Some(expected)
+            })
+            .cloned()
+            .collect()
+    };
+    assert!(
+        !logs_decode.is_empty(),
+        "expected a logs-signal `decode` span recording blocks_total={blocks_total} \
+         decompressed_bytes={expected} on the error path; captured decode spans: {:?}",
+        collector
+            .completed
+            .lock()
+            .expect("completed lock")
+            .iter()
+            .filter(|s| s.name == "decode")
+            .collect::<Vec<_>>()
+    );
+    for span in &logs_decode {
+        assert_eq!(
+            span.blocks_scanned,
+            Some(0),
+            "no block decoded before the corrupt first page"
         );
     }
 }

--- a/crates/ravel-query/tests/log_fetcher.rs
+++ b/crates/ravel-query/tests/log_fetcher.rs
@@ -18,10 +18,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use async_trait::async_trait;
 use ravel_cache::{Cache, CacheLimits};
 use ravel_catalog::{SegmentLevel, SegmentRef};
+use ravel_logseg::page_dir::PageDir;
 use ravel_logseg::writer::ObjectIdentity;
 use ravel_logseg::{
     AttrValue, ColumnSelection, FieldSel, FieldType, LogRecord, LogStreamId, Predicate, RlogConfig,
-    RlogWriter, stream_attrs_bytes,
+    RlogWriter, read_section, stream_attrs_bytes,
 };
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{
@@ -520,6 +521,91 @@ async fn matching_streams_over_approximates_nested_map_values() {
         )
         .expect("resolve");
     assert!(none.is_empty(), "no stream carries service.name=absent");
+}
+
+/// The collecting funnel (`fetch_accounted`, the same `scan_bytes` drain the
+/// tenant-aware `fetch_accounted_with_tenant` uses for the alerts and audit
+/// scans) charges the decode's decompressed bytes to the handle it was given:
+/// what zstd produced opening the object's four directory sections plus every
+/// page of every block a ts-only query scans. Both halves are derived here
+/// from the footer and PAGE_DIR, not read back from the fetcher, so a funnel
+/// that charged one page per block, or the directories alone, fails.
+#[tokio::test]
+async fn fetch_accounted_charges_the_decode_decompression() {
+    let mem = MemoryStore::new();
+    // Bodies long and repetitive enough that each block's body page clears the
+    // page writer's 512-byte compression floor and zstd wins, so the fixture
+    // carries zstd pages for the oracle's page half to count. The tiny scalar
+    // columns stay raw and contribute nothing, which the per-page gate below
+    // mirrors.
+    let body = "request served from cache in 3ms; ".repeat(32);
+    let recs: Vec<LogRecord> = (100..=110).map(|ts| record("api", ts, &body)).collect();
+    let seg = write_object(&mem, "logs/acct.rlog", &recs).await;
+    let bytes = mem
+        .get("logs/acct.rlog", GetRange::Full)
+        .await
+        .expect("get")
+        .data;
+
+    let f = ravel_logseg::footer::open(&bytes).expect("open");
+    let mut expected = 0u64;
+    for k in [
+        ravel_logseg::footer::kind::STREAM_DIR,
+        ravel_logseg::footer::kind::FIELD_DIR,
+        ravel_logseg::footer::kind::SKIP_IDX,
+        ravel_logseg::footer::kind::PAGE_DIR,
+    ] {
+        let desc = *f.section(k).expect("section present");
+        if desc.comp == ravel_logseg::footer::COMP_ZSTD {
+            expected += desc.uncomp_len;
+        }
+    }
+    let page_dir_desc = *f
+        .section(ravel_logseg::footer::kind::PAGE_DIR)
+        .expect("PAGE_DIR present");
+    let page_dir_raw = read_section(&bytes, &page_dir_desc, &small_blocks()).expect("PAGE_DIR");
+    let page_dir = PageDir::decode(&page_dir_raw).expect("decode PAGE_DIR");
+    let mut page_total = 0u64;
+    for group in &page_dir.groups {
+        for chunk in &group.chunks {
+            for page in &chunk.pages {
+                if page.comp == ravel_logseg::footer::COMP_ZSTD {
+                    page_total += page.uncomp_len;
+                }
+            }
+        }
+    }
+    assert_ne!(
+        page_total, 0,
+        "fixture precondition: at least one zstd page, or the page half of the \
+         oracle proves nothing"
+    );
+    expected += page_total;
+
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(mem);
+    let fetcher = LogSegmentFetcher::new(store);
+    let query = LogQuery::new(i64::MIN, i64::MAX);
+    let accounting = QueryAccounting::new();
+    let out = fetcher
+        .fetch_accounted(&seg, &query, &accounting)
+        .await
+        .expect("fetch")
+        .expect("in range");
+    assert_eq!(
+        out.records.len(),
+        recs.len(),
+        "a ts-only query scans and returns every record"
+    );
+    assert_eq!(
+        accounting.snapshot().decompressed_bytes,
+        expected,
+        "the collecting funnel charges exactly the four directory opens plus \
+         every decoded page"
+    );
+    assert_eq!(
+        out.stats.decompressed_bytes, expected,
+        "the returned scan stats carry the same figure"
+    );
 }
 
 #[tokio::test]

--- a/crates/ravel-query/tests/log_fetcher.rs
+++ b/crates/ravel-query/tests/log_fetcher.rs
@@ -483,6 +483,7 @@ async fn matching_streams_over_approximates_nested_map_values() {
 
     let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
     let fetcher = LogSegmentFetcher::new(store);
+    let accounting = QueryAccounting::new();
     let mut matched = fetcher
         .matching_streams(
             &bytes,
@@ -490,6 +491,7 @@ async fn matching_streams_over_approximates_nested_map_values() {
                 "service.name",
                 AttrValue::Str("api".into()),
             )],
+            &accounting,
         )
         .expect("resolve");
     matched.sort();
@@ -514,6 +516,7 @@ async fn matching_streams_over_approximates_nested_map_values() {
                 "service.name",
                 AttrValue::Str("absent".into()),
             )],
+            &accounting,
         )
         .expect("resolve");
     assert!(none.is_empty(), "no stream carries service.name=absent");
@@ -533,6 +536,22 @@ async fn matching_streams_resolves_ids_from_stream_dir() {
     let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
     let fetcher = LogSegmentFetcher::new(store);
 
+    // Independent ground truth for the decompressed-byte pin below (issue
+    // #1401 finding 3): STREAM_DIR is a whole-read directory section, always
+    // stored COMP_ZSTD, so its uncomp_len is the exact bytes one decode of it
+    // produces, read from the footer rather than through `matching_streams`
+    // itself.
+    let stream_desc = *ravel_logseg::footer::open(&bytes)
+        .expect("open")
+        .section(ravel_logseg::footer::kind::STREAM_DIR)
+        .expect("STREAM_DIR present");
+    assert_eq!(
+        stream_desc.comp,
+        ravel_logseg::footer::COMP_ZSTD,
+        "fixture STREAM_DIR must be zstd for this test"
+    );
+
+    let accounting = QueryAccounting::new();
     let (api_id, _) = stream("api");
     let matched = fetcher
         .matching_streams(
@@ -541,9 +560,15 @@ async fn matching_streams_resolves_ids_from_stream_dir() {
                 "service.name",
                 AttrValue::Str("api".into()),
             )],
+            &accounting,
         )
         .expect("resolve");
     assert_eq!(matched, vec![api_id], "only the api stream matches");
+    assert_eq!(
+        accounting.snapshot().decompressed_bytes,
+        stream_desc.uncomp_len,
+        "matching_streams's STREAM_DIR decode charges exactly its zstd uncomp_len"
+    );
 
     // A value present in no stream resolves to the empty set.
     let none = fetcher
@@ -553,6 +578,7 @@ async fn matching_streams_resolves_ids_from_stream_dir() {
                 "service.name",
                 AttrValue::Str("absent".into()),
             )],
+            &accounting,
         )
         .expect("resolve");
     assert!(none.is_empty(), "no stream carries service.name=absent");

--- a/crates/ravel-query/tests/log_page_dir_fetch.rs
+++ b/crates/ravel-query/tests/log_page_dir_fetch.rs
@@ -850,6 +850,53 @@ async fn plan_segment_on_a_version_4_object_fetches_no_page_bytes() {
     );
 }
 
+/// The skip-decidable plan path's own directory decompression lands in the
+/// PLAN phase, not phase-less or pooled away: `plan_segment` decodes SKIP_IDX
+/// and FIELD_DIR through `plan_section_raw`, and both are always zstd (the
+/// writer stores every whole-read directory section COMP_ZSTD unconditionally,
+/// docs/log-segment-format.md), so a caller threading a [`PhaseAccounting`]'s
+/// `plan()` handle through must see the exact sum of their `uncomp_len` show up
+/// under `snapshot().plan.decompressed_bytes` (issue #1401 finding 2).
+#[tokio::test]
+async fn plan_segment_charges_directory_decompression_to_the_plan_phase() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let store: Arc<dyn ObjectStoreBackend> = store_with(&bytes).await;
+
+    let f = footer_of(&bytes);
+    let mut expected = 0u64;
+    for k in [kind::SKIP_IDX, kind::FIELD_DIR] {
+        let desc = *f.section(k).expect("section present");
+        assert_eq!(
+            desc.comp,
+            footer::COMP_ZSTD,
+            "fixture section {k} must be zstd for this test"
+        );
+        expected += desc.uncomp_len;
+    }
+
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&store))
+        .with_block_range_threshold(0)
+        .with_block_range(ranged(store, &bytes));
+    let seg = seg_ref(bytes.len() as u64, &recs);
+    let query = LogQuery::new(i64::MIN, i64::MAX).with_prune(code_between(0, 0));
+    let phase = ravel_query::PhaseAccounting::new();
+
+    let (survivors, _stats, _footer, _whole_object) = fetcher
+        .plan_segment(&seg, TENANT, &query, phase.plan())
+        .await
+        .expect("plan_segment")
+        .expect("relevant segment");
+    assert_eq!(survivors, 1, "the numeric arm keeps one block");
+
+    let snap = phase.snapshot();
+    assert_eq!(
+        snap.plan.decompressed_bytes, expected,
+        "plan_segment's skip-decidable path charges exactly SKIP_IDX + \
+         FIELD_DIR's zstd uncomp_len to the plan phase"
+    );
+}
+
 // ---- 6. two partitions, one chunk, one GET --------------------------------
 
 /// Two partitions resolving the same chunk range collapse onto one store GET.

--- a/crates/ravel-query/tests/log_page_dir_fetch.rs
+++ b/crates/ravel-query/tests/log_page_dir_fetch.rs
@@ -897,6 +897,74 @@ async fn plan_segment_charges_directory_decompression_to_the_plan_phase() {
     );
 }
 
+/// The plan FALLBACK (a predicate SKIP_IDX cannot decide: here a `has_word`
+/// content arm) opens the reader over the fetched object to count survivors.
+/// That open decodes STREAM_DIR, FIELD_DIR, SKIP_IDX and PAGE_DIR, and those
+/// bytes ride in the reader's own `ScanStats`, not on any handle, so
+/// `plan_segment` must charge them to the plan phase itself: the exact sum of
+/// the four sections' `uncomp_len` (each zstd on this fixture), and nothing on
+/// the scan phase, since counting survivors decodes no block.
+///
+/// Read whole on purpose: with the block-range threshold at `u64::MAX` the
+/// fallback's `tenant_bytes` is one whole-object GET with no fetcher-side
+/// directory decode, so the reader's open is the only decompression there is
+/// and the oracle is exactly those four sections.
+#[tokio::test]
+async fn plan_segment_fallback_charges_the_reader_open_to_the_plan_phase() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let store: Arc<dyn ObjectStoreBackend> = store_with(&bytes).await;
+
+    let f = footer_of(&bytes);
+    let mut expected = 0u64;
+    for k in [
+        kind::STREAM_DIR,
+        kind::FIELD_DIR,
+        kind::SKIP_IDX,
+        kind::PAGE_DIR,
+    ] {
+        let desc = *f.section(k).expect("section present");
+        assert_eq!(
+            desc.comp,
+            footer::COMP_ZSTD,
+            "fixture section {k} must be zstd for this test"
+        );
+        expected += desc.uncomp_len;
+    }
+
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&store)).with_block_range_threshold(u64::MAX);
+    let seg = seg_ref(bytes.len() as u64, &recs);
+    // A body word the filler alphabet cannot spell as a token: a bloom-only
+    // arm SKIP_IDX cannot decide, which is what sends `plan_segment` down the
+    // fallback.
+    let query = LogQuery::new(i64::MIN, i64::MAX).with_content(Predicate::HasWord {
+        field: FieldSel::Body,
+        word: "no.such.word".into(),
+    });
+    let phase = ravel_query::PhaseAccounting::new();
+
+    let (_survivors, _stats, carried_footer, _whole_object) = fetcher
+        .plan_segment(&seg, TENANT, &query, phase.plan())
+        .await
+        .expect("plan_segment")
+        .expect("relevant segment");
+    assert!(
+        carried_footer.is_none(),
+        "the fallback carries no footer forward"
+    );
+
+    let snap = phase.snapshot();
+    assert_eq!(
+        snap.plan.decompressed_bytes, expected,
+        "the fallback plan read charges exactly the reader's four directory \
+         decodes to the plan phase"
+    );
+    assert_eq!(
+        snap.scan.decompressed_bytes, 0,
+        "counting survivors decodes no block, so the scan phase stays at zero"
+    );
+}
+
 // ---- 6. two partitions, one chunk, one GET --------------------------------
 
 /// Two partitions resolving the same chunk range collapse onto one store GET.

--- a/crates/ravel-sql/src/cost.rs
+++ b/crates/ravel-sql/src/cost.rs
@@ -94,19 +94,24 @@ pub fn estimate_metrics_cost(snapshot: &Snapshot, catalog_requests: u64) -> Cost
 /// Cost estimate for a logs-target SQL query, given the pinned snapshot and
 /// the catalog term computed before `resolve` ran.
 ///
-/// The log fetch funnel (`LogSegmentFetcher::fetch_accounted`) issues
-/// exactly one GET per relevant segment and never decompresses on a
-/// separately-accounted path (it never calls `add_decompressed_bytes`), so
-/// both the request count and the byte sums here are exact bounds rather
-/// than padded guesses: no chase/retry safety factor applies because there
-/// is no chase/retry path to guard against.
+/// The log fetch funnel (`LogSegmentFetcher::fetch_accounted`) issues exactly
+/// one GET per relevant segment, so the request count and the store-byte sum
+/// here are exact bounds rather than padded guesses: no chase/retry safety
+/// factor applies because there is no chase/retry path to guard against. The
+/// funnel does now decompress on a separately-accounted path -- the scan reader
+/// calls `add_decompressed_bytes` for the directory sections it opens and the
+/// block pages it decodes (issue #1401) -- but that is an OBSERVED figure the
+/// scan reports after the fact, not part of this pre-execution bound: the
+/// estimate here carries no decompressed-byte term for logs (it passes `0`),
+/// because a logs scan's decompressed output depends on which blocks survive
+/// pruning, which this snapshot-only estimate does not compute.
 ///
 /// This serves the `alerts` and `audit` tables too (ADR-1101 decision 1), not
 /// only `logs`. An alert record and an audit record ride RLOG v1 verbatim, so
 /// their scans fetch through the same funnel with the same shape: one
-/// `fetch_accounted_with_tenant` per relevant segment, one GET each, no
-/// separately-accounted decompression. The estimate is therefore identical,
-/// and a renamed copy per table would only invite drift.
+/// `fetch_accounted_with_tenant` per relevant segment, one GET each, the same
+/// after-the-fact decompressed-byte accounting. The estimate is therefore
+/// identical, and a renamed copy per table would only invite drift.
 pub fn estimate_logs_cost(snapshot: &Snapshot, catalog_requests: u64) -> CostEstimate {
     let segments = snapshot.segments.len() as u64;
     let series: u64 = snapshot.segments.iter().map(|s| s.series_count).sum();
@@ -131,11 +136,14 @@ pub fn estimate_logs_cost(snapshot: &Snapshot, catalog_requests: u64) -> CostEst
 /// the catalog term computed before `resolve` ran.
 ///
 /// The span fetch funnel (`SpanSegmentFetcher::fetch_accounted`) issues
-/// exactly one GET per relevant segment and never decompresses on a
-/// separately-accounted path (it never calls `add_decompressed_bytes`), so
-/// both the request count and the byte sums here are exact bounds rather than
-/// padded guesses, exactly like [`estimate_logs_cost`]: no chase/retry safety
-/// factor applies because there is no chase/retry path to guard against.
+/// exactly one GET per relevant segment, so the request count and the
+/// store-byte sum here are exact bounds rather than padded guesses, exactly
+/// like [`estimate_logs_cost`]: no chase/retry safety factor applies because
+/// there is no chase/retry path to guard against. Like the logs estimate this
+/// carries no decompressed-byte term (it passes `0`); unlike the logs scan
+/// reader, the span (RSPAN) read path does not yet report decompressed bytes at
+/// all, so for spans the figure is simply absent rather than observed after the
+/// fact (issue #1401 instrumented the RLOG scan reader only).
 ///
 /// Reached from `executor::SqlExecutor::resolve` for a `TargetSignal::Spans`
 /// query (ADR-0045 decision 5), beside its `estimate_metrics_cost` and

--- a/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
+++ b/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
@@ -75,13 +75,18 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use ravel_cache::{Cache, CacheLimits};
 use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
 use ravel_logseg::writer::ObjectIdentity;
-use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_logseg::{
+    AttrValue, ColumnSelection, LogRecord, Predicate, RlogConfig, RlogReader, RlogWriter,
+    stream_attrs_bytes,
+};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{
     Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
     PageToken, PutOptions, PutOutcome, StoreError,
 };
-use ravel_query::{BlockRangeFetcher, CacheFetchError, LogSegmentFetcher, QueryPhase};
+use ravel_query::{
+    BlockRangeFetcher, CacheFetchError, LogQuery, LogSegmentFetcher, PhaseAccounting, QueryPhase,
+};
 use ravel_sql::{
     DeclaredColumn, DeclaredType, FIRST_DECLARED_COL, LOG_COL_TS, LogsTableProvider, has_word_udf,
 };
@@ -1693,4 +1698,199 @@ async fn carried_object_reopen_does_not_double_charge_reused_bytes() {
          pay for its own re-fetch instead of double-charging the same \
          buffer as reused a second time"
     );
+}
+
+// ---- issue #1401: decompressed-byte accounting follows the decode path -----
+//
+// The fixtures above use incompressible filler so every body page stays raw:
+// perfect for wire-byte proportionality, useless for decompressed bytes, which
+// only a zstd page produces. These tests use their own compressible-body
+// segment so each block's `body` page is stored COMP_ZSTD and decoding it
+// charges a nonzero, exactly-known decompressed length.
+
+/// A body zstd shrinks hard (one 12-byte phrase repeated), so its `body` page
+/// is stored COMP_ZSTD and decompresses to a nonzero, countable length.
+fn compressible_body(blk: usize) -> String {
+    format!("blk{blk} {}", "log message ".repeat(400))
+}
+
+fn compressible_record(blk: usize) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("svc".to_string()),
+    )];
+    let ts = blk as i64;
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: compressible_body(blk),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    }
+}
+
+/// Blocks in the decompressed-accounting fixture: one record per block, distinct
+/// `ts_ns` per block, so a ts range prunes an exact block subset at the skip
+/// index (the ranged path then fetches only that subset).
+const DECOMP_BLOCKS: usize = 3;
+
+/// Build a single 3-block segment with compressible bodies and return its
+/// `SegmentRef` alongside the raw object, so a whole-object [`RlogReader`] can
+/// compute the exact decompressed reference each scan path must match.
+async fn write_compressible_segment(store: &dyn ObjectStoreBackend) -> (SegmentRef, Vec<u8>) {
+    let recs: Vec<LogRecord> = (0..DECOMP_BLOCKS).map(compressible_record).collect();
+    let mut w = RlogWriter::new(one_record_blocks(), identity(1));
+    for r in &recs {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    let key = "logs/decompressed_seg.rlog".to_string();
+    let content_hash = *blake3::hash(&bytes).as_bytes();
+    store
+        .put(&key, bytes::Bytes::from(bytes.clone()), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = SegmentRef {
+        data_object_key: key,
+        object_size: size,
+        min_event_ts_ns: 0,
+        max_event_ts_ns: (DECOMP_BLOCKS - 1) as i64,
+        ingest_hour_bucket: 0,
+        sample_count: recs.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
+    };
+    (seg, bytes)
+}
+
+/// `ScanStats.decompressed_bytes` a whole-object [`RlogReader`] reports for a
+/// scan over the inclusive ts range `[lo, hi]`: the reference each fetcher scan
+/// path must match to the byte.
+fn reader_decompressed(obj: &[u8], lo: i64, hi: i64) -> u64 {
+    let cfg = RlogConfig::default();
+    let reader = RlogReader::new(obj, &cfg).expect("open");
+    let mut scan = reader
+        .scan_blocks(
+            &Predicate::TsRange {
+                min_ns: lo,
+                max_ns: hi,
+            },
+            &[],
+            &ColumnSelection::all(),
+        )
+        .expect("scan");
+    while scan.next_block(obj).expect("next").is_some() {}
+    scan.stats().decompressed_bytes
+}
+
+/// A logs scan's `decompressed_bytes` counts exactly what the scan decoded, on
+/// both the ranged and the whole-object fetch paths, and lands in the scan
+/// phase. The whole-object statement decodes every block; the ranged statement
+/// is ts-pruned to block 0; the difference is exactly the pages of the blocks
+/// the ranged path skipped, which is the number that shows the counter follows
+/// the decode path and not the fetch (issue #1401).
+#[tokio::test]
+async fn decompressed_bytes_follows_decode_path_in_scan_phase() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let (seg, obj) = write_compressible_segment(store.as_ref()).await;
+
+    // Reader references. A ts range matching no block decodes nothing, so it
+    // reports only the object's directory decompression (the open-time seed);
+    // each single-block scan is that seed plus that block's zstd page bytes.
+    let dirs = reader_decompressed(&obj, 1_000, 1_000);
+    let b0 = reader_decompressed(&obj, 0, 0) - dirs;
+    let b1 = reader_decompressed(&obj, 1, 1) - dirs;
+    let b2 = reader_decompressed(&obj, 2, 2) - dirs;
+    let all = reader_decompressed(&obj, i64::MIN, i64::MAX);
+    assert!(b0 > 0 && b1 > 0 && b2 > 0, "each block carries a zstd body page");
+    assert_eq!(
+        all,
+        dirs + b0 + b1 + b2,
+        "an all-blocks scan is the directories plus every block's pages"
+    );
+
+    // Ranged path: a ts-pruned statement decoding only block 0.
+    let ranged = fetcher(Arc::clone(&store), 1 << 20);
+    let phase_r = PhaseAccounting::new();
+    let mut rscan = ranged
+        .scan_accounted_with_tenant(
+            &seg,
+            TenantHash(TENANT),
+            &LogQuery::new(0, 0),
+            &ColumnSelection::all(),
+            phase_r.scan(),
+        )
+        .await
+        .expect("ranged scan")
+        .expect("segment is ts-relevant");
+    while rscan.next_block().expect("next").is_some() {}
+    drop(rscan);
+    let r = phase_r.snapshot();
+
+    // Whole-object path: a full-window statement reading the whole object in one
+    // GET and decoding every block.
+    let whole = fetcher(Arc::clone(&store), 1 << 20);
+    let phase_w = PhaseAccounting::new();
+    let mut wscan = whole
+        .scan_whole_accounted_with_tenant(
+            &seg,
+            TenantHash(TENANT),
+            &LogQuery::new(i64::MIN, i64::MAX),
+            &ColumnSelection::all(),
+            phase_w.scan(),
+        )
+        .await
+        .expect("whole scan")
+        .expect("segment is ts-relevant");
+    while wscan.next_block().expect("next").is_some() {}
+    drop(wscan);
+    let w = phase_w.snapshot();
+
+    // Each path charges exactly the reader reference for the sections it
+    // decompressed: directories plus the block pages it decoded.
+    assert_eq!(
+        r.scan.decompressed_bytes,
+        dirs + b0,
+        "the ranged path decoded only block 0"
+    );
+    assert_eq!(
+        w.scan.decompressed_bytes,
+        all,
+        "the whole-object path decoded every block"
+    );
+
+    // The whole-object figure exceeds the ranged figure by exactly the pages of
+    // the two blocks the ranged path pruned.
+    assert_eq!(
+        w.scan.decompressed_bytes - r.scan.decompressed_bytes,
+        b1 + b2,
+        "the difference is exactly the skipped blocks' decompressed pages"
+    );
+
+    // The figure lands in the scan phase and nowhere else: these funnels open
+    // the scan reader directly and never run a plan-phase survivor count.
+    for (name, snap) in [("ranged", &r), ("whole", &w)] {
+        assert_eq!(snap.resolve.decompressed_bytes, 0, "{name} resolve phase");
+        assert_eq!(snap.plan.decompressed_bytes, 0, "{name} plan phase");
+        assert_eq!(snap.probe.decompressed_bytes, 0, "{name} probe phase");
+        assert!(
+            snap.scan.decompressed_bytes > 0,
+            "{name} scan phase carries the decompressed bytes"
+        );
+    }
 }

--- a/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
+++ b/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
@@ -1754,7 +1754,11 @@ async fn write_compressible_segment(store: &dyn ObjectStoreBackend) -> (SegmentR
     let key = "logs/decompressed_seg.rlog".to_string();
     let content_hash = *blake3::hash(&bytes).as_bytes();
     store
-        .put(&key, bytes::Bytes::from(bytes.clone()), PutOptions::default())
+        .put(
+            &key,
+            bytes::Bytes::from(bytes.clone()),
+            PutOptions::default(),
+        )
         .await
         .expect("put");
     let seg = SegmentRef {
@@ -1817,7 +1821,10 @@ async fn decompressed_bytes_follows_decode_path_in_scan_phase() {
     let b1 = reader_decompressed(&obj, 1, 1) - dirs;
     let b2 = reader_decompressed(&obj, 2, 2) - dirs;
     let all = reader_decompressed(&obj, i64::MIN, i64::MAX);
-    assert!(b0 > 0 && b1 > 0 && b2 > 0, "each block carries a zstd body page");
+    assert!(
+        b0 > 0 && b1 > 0 && b2 > 0,
+        "each block carries a zstd body page"
+    );
     assert_eq!(
         all,
         dirs + b0 + b1 + b2,
@@ -1861,25 +1868,54 @@ async fn decompressed_bytes_follows_decode_path_in_scan_phase() {
     drop(wscan);
     let w = phase_w.snapshot();
 
+    // The ranged (version-4) fetch path decodes SKIP_IDX and PAGE_DIR itself,
+    // to resolve candidate blocks and their pages (`fetch_object_v4`), and now
+    // charges that decode to the scan phase (issue #1401 finding 3). `open_scan`
+    // then builds its own `RlogReader` over the fetched buffer, which decodes
+    // every directory section again to open the object -- `dirs`, `b0`, `b1`,
+    // and `b2` above already include that reader-side cost. So the ranged path
+    // legitimately double-charges SKIP_IDX and PAGE_DIR: once for locating the
+    // candidate blocks before the buffer exists, once for opening the reader
+    // over the buffer it fetched. FIELD_DIR is not part of this fixture's
+    // ranged fetch (`LogQuery::new(0, 0)` carries no NumRange arm and the scan
+    // selects every column, so `fetch_object_v4` skips it, per its own doc
+    // comment), so only these two sections double-count.
+    let footer = ravel_logseg::footer::open(&obj).expect("open");
+    let mut fetch_side_dirs = 0u64;
+    for k in [
+        ravel_logseg::footer::kind::SKIP_IDX,
+        ravel_logseg::footer::kind::PAGE_DIR,
+    ] {
+        let desc = *footer.section(k).expect("section");
+        assert_eq!(
+            desc.comp,
+            ravel_logseg::footer::COMP_ZSTD,
+            "fixture section {k} must be zstd for this test"
+        );
+        fetch_side_dirs += desc.uncomp_len;
+    }
+
     // Each path charges exactly the reader reference for the sections it
-    // decompressed: directories plus the block pages it decoded.
+    // decompressed, plus the ranged path's own fetch-side directory decode.
     assert_eq!(
         r.scan.decompressed_bytes,
-        dirs + b0,
-        "the ranged path decoded only block 0"
+        dirs + b0 + fetch_side_dirs,
+        "the ranged path decoded only block 0, plus its own SKIP_IDX/PAGE_DIR fetch-side decode"
     );
     assert_eq!(
-        w.scan.decompressed_bytes,
-        all,
-        "the whole-object path decoded every block"
+        w.scan.decompressed_bytes, all,
+        "the whole-object path never fetch-side decodes a directory section, so it \
+         matches the reader reference exactly"
     );
 
-    // The whole-object figure exceeds the ranged figure by exactly the pages of
-    // the two blocks the ranged path pruned.
+    // The whole-object figure now trails the ranged figure's directory work by
+    // fetch_side_dirs: the difference is the skipped blocks' pages minus the
+    // ranged path's extra double-charged directory bytes.
     assert_eq!(
         w.scan.decompressed_bytes - r.scan.decompressed_bytes,
-        b1 + b2,
-        "the difference is exactly the skipped blocks' decompressed pages"
+        b1 + b2 - fetch_side_dirs,
+        "the difference is the skipped blocks' pages minus the ranged path's \
+         double-charged SKIP_IDX/PAGE_DIR"
     );
 
     // The figure lands in the scan phase and nowhere else: these funnels open

--- a/docs/guides/tracing.md
+++ b/docs/guides/tracing.md
@@ -98,7 +98,7 @@ name alone and you will see two shapes:
 | `page_fetch` | metric | `page_kind`, `series_count`, `s3_requests`, `s3_bytes` |
 | `page_fetch` | logs | `signal = "logs"`, `s3_requests`, `s3_bytes` |
 | `decode` | metric | `page_kind`, `series_count`, `decompressed_bytes` |
-| `decode` | logs | `signal = "logs"`, `blocks_scanned`, `blocks_total` |
+| `decode` | logs | `signal = "logs"`, `blocks_scanned`, `blocks_total`, `decompressed_bytes` |
 
 - The logs `page_fetch` records `s3_requests`/`s3_bytes` with the same meaning
   as the metric one (this call's own store-GET cost: one GET on the uncached or
@@ -106,15 +106,14 @@ name alone and you will see two shapes:
   `series_count`: RLOG has no scalar/histogram page kinds, and its unit of
   identity is the log stream, not the metric series, so neither field maps onto
   this path.
-- The logs `decode` records `blocks_scanned` and `blocks_total` rather than
-  `decompressed_bytes`. No decompressed-byte count is available here without a
-  structural change to the log segment reader, which counts blocks rather than
-  bytes and never sums its per-block decompression.
-  `blocks_scanned`/`blocks_total` are instead a real
-  pruning-effectiveness signal (how much of the object's block index the scan
-  had to touch after skip-index, POSTINGS, and bloom pruning), analogous to
-  `catalog_resolve`'s `segments_pruned` on the metric path, which is likewise a
-  pruning count and not a byte count.
+- The logs `decode` records `decompressed_bytes` with the same meaning as the
+  metric one: the uncompressed size zstd produced for this object, covering
+  its directory sections, any POSTINGS probe, and every decoded block page. It
+  also records `blocks_scanned`/`blocks_total`, a pruning-effectiveness signal
+  (how much of the object's block index the scan had to touch after
+  skip-index, POSTINGS, and bloom pruning), analogous to `catalog_resolve`'s
+  `segments_pruned` on the metric path, which is likewise a pruning count and
+  not a byte count.
 
 ## Turning them on
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1702,6 +1702,21 @@ sequence issued (probe, directory sections, coalesced candidate-block
 ranges) and the bytes they moved, again zero when every extent was a cache
 hit.
 
+On the log-signal path `decompressed_bytes` is the bytes zstd produced on
+the RLOG scan and plan paths, both whole-object and ranged: the directory
+sections the scan reader opens (`RlogReader::new` over STREAM_DIR, FIELD_DIR,
+SKIP_IDX, PAGE_DIR) plus every block page the scan decodes, and, on the plan
+path, the SKIP_IDX/FIELD_DIR a selective query decompresses to count
+survivors. A section stored raw contributes nothing; a zstd one contributes
+its decompressed output's actual length. It is zero on a query that opens no
+RLOG section, and, unlike the wire-byte counters, it does not fall to zero on
+a warm cache: a scan served entirely from the fetcher cache still decompresses
+what it decodes, which is what makes this the figure that attributes a warm
+run's engine time. The scan reader's own decompression lands on the `scan`
+phase handle (folded once at scan exhaustion by `LogSegmentScan::finish`); a
+plan-phase survivor-count decode lands on the `plan` handle. Spans (RSPAN) do
+not yet report decompressed bytes.
+
 Span fields otherwise carry only bounded values: `tenant_hash` as a hex
 string, `object_size`, matcher/series counts, and fixed-set kind strings
 (`page_kind`, `eval_kind`), never query text, label values, object keys,

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1705,17 +1705,34 @@ hit.
 On the log-signal path `decompressed_bytes` is the bytes zstd produced on
 the RLOG scan and plan paths, both whole-object and ranged: the directory
 sections the scan reader opens (`RlogReader::new` over STREAM_DIR, FIELD_DIR,
-SKIP_IDX, PAGE_DIR) plus every block page the scan decodes, and, on the plan
-path, the SKIP_IDX/FIELD_DIR a selective query decompresses to count
+SKIP_IDX, PAGE_DIR) plus every block page the scan decodes plus, for a
+postings-eligible arm, the one POSTINGS term block
+`PostingsSection::probe_accounted` decompresses to resolve it, and, on the
+plan path, the SKIP_IDX/FIELD_DIR a selective query decompresses to count
 survivors. A section stored raw contributes nothing; a zstd one contributes
 its decompressed output's actual length. It is zero on a query that opens no
 RLOG section, and, unlike the wire-byte counters, it does not fall to zero on
 a warm cache: a scan served entirely from the fetcher cache still decompresses
 what it decodes, which is what makes this the figure that attributes a warm
-run's engine time. The scan reader's own decompression lands on the `scan`
-phase handle (folded once at scan exhaustion by `LogSegmentScan::finish`); a
-plan-phase survivor-count decode lands on the `plan` handle. Spans (RSPAN) do
-not yet report decompressed bytes.
+run's engine time.
+
+A decode charges no phase tag of its own: it adds to whichever
+`QueryAccounting` handle its caller passed in, the same handle that read's
+wire bytes are already charged against. The scan reader's own directory
+decode lands on the `scan` phase handle (folded once at scan exhaustion by
+`LogSegmentScan::finish`); a plan-phase survivor-count decode lands on the
+`plan` handle. An above-threshold ranged fetch decodes SKIP_IDX itself (and,
+on a version-4 object, PAGE_DIR) to resolve candidate blocks and their pages
+before the scan reader opens the fetched buffer and decodes every directory
+section again to build its own indices, so the ranged path's figure counts
+SKIP_IDX and PAGE_DIR twice: once for locating the blocks before the buffer
+exists, once for opening the reader over what was fetched. Both decodes are
+real zstd work the query paid for. The whole-object path never separately
+decodes a directory section before the scan reader opens it, so it carries no
+such double count. A stream-attribute-equality query's STREAM_DIR resolution
+(`LogSegmentFetcher::matching_streams`/`fetch_stream_dir`) decompresses the
+same way, on whichever handle its own caller passed in. Spans (RSPAN) do not
+yet report decompressed bytes.
 
 Span fields otherwise carry only bounded values: `tenant_hash` as a hex
 string, `object_size`, matcher/series counts, and fixed-set kind strings


### PR DESCRIPTION
The cost report's `decompressedBytes` was always zero for RLOG queries.
No decompress site charged what it inflated, so a warm run's engine
time had no figure to attribute it to, and a whole-object read and a
ranged read reported the same zero for very different amounts of zstd
work.

Every zstd decompress on the read paths now charges the returned
buffer's actual length, not the header's declared length and not the
compressed length, to the accounting handle its caller passed: the four
directory sections opened in `RlogReader::new`, pages in
`decode_v4_block`, the POSTINGS term block in `PostingsSection::probe`,
and in ravel-query the plan-phase directory reads in `plan_section_raw`
and the ranged-path decodes of SKIP_IDX, PAGE_DIR, FIELD_DIR and
STREAM_DIR that previously went through the plain decoder. The ranged
v4 path decodes SKIP_IDX and PAGE_DIR twice at runtime, once fetcher-side
to choose candidate blocks and once when the scan reader opens the
fetched buffer; both are charged because both are work done, and
docs/query-engine.md now says so alongside the section list. Dropping
the second decode by handing the fetcher's decoded directories to the
reader is tracked in #1426.

Tests pin exact figures derived from each fixture's footer descriptors,
never `> 0`: the per-section and summed directory charges, the exact page
total across every block, the postings block, the plan-phase sum, the
ranged run's own per-phase figure, and the exact whole-object minus
ranged difference. Each assertion was shown failing with its charge
removed. The stale comments in `cost.rs` that described the field as
never populated are corrected; `CostEstimate::new` passes `0` because the
estimate precedes the decode.

Provenance: the fleet task for this ticket reached the 4-hour runtime
ceiling after committing its work but before running its own gates. The
recovered branch was rebased onto main, reviewed, and fixed locally in a
second round that added the POSTINGS and ranged-path charges, the
plan-phase test, the exact page-total assertion, and the doc text. fmt,
scoped clippy, the ravel-logseg, ravel-query and ravel-sql test suites,
and the docs gates ran locally on this exact tree. The `sql` and
`flight-sql` feature lanes run in PR CI: the flight-sql lane needs about
31 GB of build output that this machine does not have.

Fixes: #1401
Refs: #1185
