### PR TITLE
feat(catalog): stamp sys record version 2 and floor the read gates

### DIFF
--- a/crates/ravel-catalog/src/auth_token_map.rs
+++ b/crates/ravel-catalog/src/auth_token_map.rs
@@ -41,18 +41,37 @@ use ravel_proto::sys::v1::TokenHashEntry as ProtoTokenHashEntry;
 /// never under a tenant prefix.
 pub const AUTH_KEY: &str = "sys/auth";
 
-/// Format version written into every `sys/auth` object this module emits, and
-/// the highest version it reads. A future version is refused rather than misread
-/// under the v1 layout, matching the `prov` / `enc` / `t/<hash>/config` records'
-/// fail-closed-on-newer guard (each uses its own comparison operator; see each
-/// module for its exact check).
+/// Format version written into every `sys/auth` object this module emits. The
+/// versions it READS are the closed set
+/// [`AUTH_TOKEN_MAP_MIN_READ_VERSION`]`..=`[`AUTH_TOKEN_MAP_MAX_READ_VERSION`],
+/// which today equals `{1, 2}`; anything outside it is refused rather than
+/// misread, matching the `prov` / `enc` / `t/<hash>/config` records' gates.
 ///
 /// Bumped 1 -> 2 for the `managed_by` ownership marker (ADR-0072 decision 4
 /// amendment): `TokenHashEntry.managed_by` is `optional` and additive,
 /// so the bump is a floor signal, not a wire necessity. This build accepts a
-/// stored 1 or 2 unconditionally -- an absent `managed_by` decodes the same
-/// way under either version, as unmanaged -- and always writes 2.
+/// stored 1 or 2 -- an absent `managed_by` decodes the same way under either
+/// version, as unmanaged -- and always writes 2.
 pub const AUTH_TOKEN_MAP_FORMAT_VERSION: u32 = 2;
+
+/// Lowest `format_version` this build reads for `sys/auth`.
+///
+/// A supported set has a floor as well as a ceiling (ADR-0066 decision 4). Before
+/// this constant the gate was ceiling-only, so version 0 -- an unstamped record,
+/// which is also what an empty or truncated-to-defaults decode produces -- was
+/// admitted, decoded, and then rewritten under CAS by [`upsert_token`] and its
+/// siblings as a version-2 record. A record no supported writer ever produced now
+/// fails closed with [`AuthTokenMapError::VersionBelowFloor`], whose remediation
+/// is the opposite of the above-ceiling one: investigate the record's origin
+/// rather than upgrade this binary.
+pub const AUTH_TOKEN_MAP_MIN_READ_VERSION: u32 = 1;
+
+/// Highest `format_version` this build reads for `sys/auth`. Equal to
+/// [`AUTH_TOKEN_MAP_FORMAT_VERSION`]: this record is not mid-rollout, so the
+/// reader's ceiling and the writer's stamp are the same number. They part only
+/// while a readers-before-writers sequence is in flight, as ADR-0066 R1 did for
+/// the three records this crate rolls forward.
+pub const AUTH_TOKEN_MAP_MAX_READ_VERSION: u32 = AUTH_TOKEN_MAP_FORMAT_VERSION;
 
 /// [`TokenEntry::managed_by`] value the operator's reconcile loop stamps on
 /// every entry it writes from a `tenantTokensSecretRef` Secret (ADR-0072
@@ -218,11 +237,27 @@ pub enum AuthTokenMapError {
         #[source]
         source: prost::DecodeError,
     },
+    /// The stored map declares a version above this build's read ceiling: a newer
+    /// writer produced it. Distinct from [`Self::VersionBelowFloor`] because the
+    /// remediations are opposite; see that variant.
     #[error(
-        "auth map {AUTH_KEY:?} declares format_version {got}, but this build only understands \
-         version {AUTH_TOKEN_MAP_FORMAT_VERSION}: refusing rather than misread a future format"
+        "auth map {AUTH_KEY:?} declares format_version {got}, above the highest version this build \
+         reads ({ceiling}): a newer writer produced it, so refusing rather than misread it. \
+         Upgrade this binary to one whose reader accepts version {got}"
     )]
-    UnsupportedVersion { got: u32 },
+    UnsupportedVersion { got: u32, ceiling: u32 },
+    /// The stored map declares a version below this build's read floor: an
+    /// unstamped record, or one predating the supported floor. Reported
+    /// separately from [`Self::UnsupportedVersion`] because an operator told "a
+    /// future format" for a version-0 record goes looking for a newer writer that
+    /// does not exist, when the actual question is where a record no supported
+    /// writer produced came from.
+    #[error(
+        "auth map {AUTH_KEY:?} declares format_version {got}, below the lowest version this build \
+         reads ({floor}): the record is unstamped or predates the supported floor, not a future \
+         format. Refusing rather than admit a record no supported writer produced"
+    )]
+    VersionBelowFloor { got: u32, floor: u32 },
     #[error("auth map {AUTH_KEY:?} is corrupt: {defect} (ADR-0066 decision 6)")]
     Corrupt { defect: AuthMapDefect },
     /// The stored map's `key_fingerprint` disagrees with the configured
@@ -272,19 +307,44 @@ pub enum AuthTokenMapError {
     },
 }
 
+/// The auth map's read gate: accept exactly the closed set
+/// `min_read_version..=max_read_version`, and report which side of it a refused
+/// record fell on. The bounds are parameters rather than the constants read
+/// directly so a test can instantiate the gate another release of this code
+/// carries.
+fn check_read_version(
+    format_version: u32,
+    min_read_version: u32,
+    max_read_version: u32,
+) -> Result<(), AuthTokenMapError> {
+    if format_version < min_read_version {
+        return Err(AuthTokenMapError::VersionBelowFloor {
+            got: format_version,
+            floor: min_read_version,
+        });
+    }
+    if format_version > max_read_version {
+        return Err(AuthTokenMapError::UnsupportedVersion {
+            got: format_version,
+            ceiling: max_read_version,
+        });
+    }
+    Ok(())
+}
+
 /// Decode and validate a proto auth map, checking the version, the deployment-key
-/// fingerprint, and the structural invariants fail-closed. A future format, a map
-/// under the wrong deployment key, a bad hash length, an empty tenant id, or a
-/// duplicate hash is refused rather than read.
+/// fingerprint, and the structural invariants fail-closed. A version outside the
+/// supported read set, a map under the wrong deployment key, a bad hash length, an
+/// empty tenant id, or a duplicate hash is refused rather than read.
 fn decode_map(
     proto: &ProtoAuthTokenMap,
     deployment_key: &[u8; 32],
 ) -> Result<AuthTokenMap, AuthTokenMapError> {
-    if proto.format_version > AUTH_TOKEN_MAP_FORMAT_VERSION {
-        return Err(AuthTokenMapError::UnsupportedVersion {
-            got: proto.format_version,
-        });
-    }
+    check_read_version(
+        proto.format_version,
+        AUTH_TOKEN_MAP_MIN_READ_VERSION,
+        AUTH_TOKEN_MAP_MAX_READ_VERSION,
+    )?;
     if proto.key_fingerprint.len() != KEY_FINGERPRINT_LEN {
         return Err(AuthTokenMapError::Corrupt {
             defect: AuthMapDefect::BadFingerprintLength,
@@ -1138,12 +1198,12 @@ mod tests {
         );
     }
 
-    /// A future format_version is refused rather than misread.
-    #[tokio::test]
-    async fn read_rejects_future_format_version() {
-        let store = mem();
+    /// Seed `sys/auth` at an explicit `format_version`, bypassing the writer's
+    /// stamp, so a test can place exactly the object an older or newer writer
+    /// would have left.
+    async fn seed_at_version(store: &dyn ObjectStoreBackend, version: u32) {
         let proto = ProtoAuthTokenMap {
-            format_version: AUTH_TOKEN_MAP_FORMAT_VERSION + 1,
+            format_version: version,
             key_fingerprint: key_fingerprint(KEY).to_vec(),
             entries: vec![],
             updated_unix_ns: 1,
@@ -1155,13 +1215,81 @@ mod tests {
                 PutOptions::default(),
             )
             .await
-            .expect("seed future");
+            .expect("seed at an explicit version");
+    }
+
+    /// The read gate is the closed set {1, 2}, a floor AND a ceiling (ADR-0066
+    /// decision 4). Both versions in the set decode; version 0 (an unstamped
+    /// record) and version 3 (above the ceiling) are both refused, and with
+    /// DIFFERENT typed errors, because the two demand opposite remediation.
+    /// Before this the gate was ceiling-only and version 0 was admitted, then
+    /// rewritten as version 2 by the next CAS write.
+    #[tokio::test]
+    async fn read_accepts_the_supported_set_and_refuses_either_side_of_it() {
+        assert_eq!(AUTH_TOKEN_MAP_MIN_READ_VERSION, 1);
+        assert_eq!(AUTH_TOKEN_MAP_MAX_READ_VERSION, 2);
+        assert_eq!(AUTH_TOKEN_MAP_FORMAT_VERSION, 2);
+
+        for version in [1u32, 2u32] {
+            let store = mem();
+            seed_at_version(store.as_ref(), version).await;
+            let (map, _v) = read_auth_map(store.as_ref(), KEY)
+                .await
+                .unwrap_or_else(|e| panic!("version {version} must decode: {e}"))
+                .expect("a present object is Some");
+            assert!(
+                map.entries.is_empty(),
+                "version {version} decodes to the seeded (empty) entry set"
+            );
+        }
+
+        let store = mem();
+        seed_at_version(store.as_ref(), 3).await;
         let err = read_auth_map(store.as_ref(), KEY)
             .await
-            .expect_err("a future format_version must be refused");
+            .expect_err("a version above the ceiling must be refused");
         assert!(
-            matches!(err, AuthTokenMapError::UnsupportedVersion { .. }),
+            matches!(
+                err,
+                AuthTokenMapError::UnsupportedVersion { got: 3, ceiling: 2 }
+            ),
             "got: {err}"
+        );
+
+        let store = mem();
+        seed_at_version(store.as_ref(), 0).await;
+        let err = read_auth_map(store.as_ref(), KEY)
+            .await
+            .expect_err("a version below the floor must be refused");
+        assert!(
+            matches!(
+                err,
+                AuthTokenMapError::VersionBelowFloor { got: 0, floor: 1 }
+            ),
+            "got: {err}"
+        );
+    }
+
+    /// The two version diagnostics say different things. An operator reading the
+    /// below-floor message must not be sent looking for a newer writer, and the
+    /// above-ceiling message must name the upgrade. Asserted on the rendered
+    /// strings because the message is the whole remediation signal.
+    #[test]
+    fn the_two_version_diagnostics_are_distinguishable() {
+        let above = check_read_version(3, 1, 2).expect_err("3 is above the ceiling");
+        let below = check_read_version(0, 1, 2).expect_err("0 is below the floor");
+        let above = above.to_string();
+        let below = below.to_string();
+        assert!(above.contains("above the highest version"), "got: {above}");
+        assert!(above.contains("Upgrade this binary"), "got: {above}");
+        assert!(below.contains("below the lowest version"), "got: {below}");
+        assert!(
+            below.contains("not a future format"),
+            "the below-floor message must not read as a future format: {below}"
+        );
+        assert!(
+            !below.contains("Upgrade this binary"),
+            "an unstamped record is not fixed by upgrading: {below}"
         );
     }
 

--- a/crates/ravel-catalog/src/key_epoch.rs
+++ b/crates/ravel-catalog/src/key_epoch.rs
@@ -38,11 +38,31 @@ use ravel_object_store::{GetRange, ObjectStoreBackend, PutMode, PutOptions, Stor
 use ravel_proto::sys::v1 as sysproto;
 use ravel_types::TenantHash;
 
-/// Format floor written into every key-epoch record this build emits, and the
-/// highest record version it understands. A record declaring a higher version
-/// is refused rather than misread under this layout (ADR-0062 decision 1b),
-/// matching the `prov`/`sys/gc` records' version guards.
+/// Format floor written into every key-epoch record this build emits. The
+/// versions it READS are the closed set
+/// [`KEY_EPOCH_MIN_READ_VERSION`]`..=`[`KEY_EPOCH_MAX_READ_VERSION`], which today
+/// is the single version `{1}`; anything outside it is refused rather than
+/// misread under this layout (ADR-0062 decision 1b), matching the `prov` records'
+/// gate.
 pub const KEY_EPOCH_FORMAT_VERSION: u32 = 1;
+
+/// Lowest `format_version` this build reads for a key-epoch record.
+///
+/// A supported set has a floor as well as a ceiling (ADR-0066 decision 4). Before
+/// this constant the gate was ceiling-only, so version 0 -- an unstamped record --
+/// was admitted, decoded, and then rewritten under CAS by [`record_key_epoch`],
+/// which re-encodes the whole record. A record no supported writer produced now
+/// fails closed with [`KeyEpochError::VersionBelowFloor`], whose remediation is
+/// the opposite of the above-ceiling one: investigate the record's origin rather
+/// than upgrade this binary.
+pub const KEY_EPOCH_MIN_READ_VERSION: u32 = 1;
+
+/// Highest `format_version` this build reads for a key-epoch record. Equal to
+/// [`KEY_EPOCH_FORMAT_VERSION`]: this record has had no additive change, so its
+/// reader ceiling and writer stamp are the same number. They part only while a
+/// readers-before-writers sequence is in flight, as ADR-0066 R1 did for the three
+/// records this crate rolls forward.
+pub const KEY_EPOCH_MAX_READ_VERSION: u32 = KEY_EPOCH_FORMAT_VERSION;
 
 /// Object key for a tenant's key-epoch record: `t/<hex>/enc`. Tenant-scoped,
 /// not per-signal, since a tenant's KMS key applies across every signal
@@ -69,11 +89,27 @@ pub enum KeyEpochError {
         #[source]
         source: prost::DecodeError,
     },
+    /// The record declares a version above this build's read ceiling: a newer
+    /// writer produced it. Distinct from [`Self::VersionBelowFloor`] because the
+    /// remediations are opposite; see that variant.
     #[error(
-        "key-epoch record {key:?} declares format_version {got}, but this build only understands \
-         version {KEY_EPOCH_FORMAT_VERSION}: refusing rather than misread a future record format"
+        "key-epoch record {key:?} declares format_version {got}, above the highest version this \
+         build reads ({ceiling}): a newer writer produced it, so refusing rather than misread it. \
+         Upgrade this binary to one whose reader accepts version {got}"
     )]
-    UnsupportedVersion { key: String, got: u32 },
+    UnsupportedVersion { key: String, got: u32, ceiling: u32 },
+    /// The record declares a version below this build's read floor: an unstamped
+    /// record, or one predating the supported floor. Reported separately from
+    /// [`Self::UnsupportedVersion`] because an operator told "a future record
+    /// format" for a version-0 record goes looking for a newer writer that does
+    /// not exist, when the actual question is where a record no supported writer
+    /// produced came from.
+    #[error(
+        "key-epoch record {key:?} declares format_version {got}, below the lowest version this \
+         build reads ({floor}): the record is unstamped or predates the supported floor, not a \
+         future format. Refusing rather than admit a record no supported writer produced"
+    )]
+    VersionBelowFloor { key: String, got: u32, floor: u32 },
     #[error(
         "key-epoch record {key:?} is misfiled: it records {field} {actual}, but the key it was \
          read under expects {expected}"
@@ -217,22 +253,50 @@ pub fn read_epochs(
     Ok(out)
 }
 
+/// The key-epoch read gate: accept exactly the closed set
+/// `min_read_version..=max_read_version`, and report which side of it a refused
+/// record fell on. The bounds are parameters rather than the constants read
+/// directly so a test can instantiate the gate another release of this code
+/// carries.
+fn check_read_version(
+    format_version: u32,
+    min_read_version: u32,
+    max_read_version: u32,
+    key: &str,
+) -> Result<(), KeyEpochError> {
+    if format_version < min_read_version {
+        return Err(KeyEpochError::VersionBelowFloor {
+            key: key.to_string(),
+            got: format_version,
+            floor: min_read_version,
+        });
+    }
+    if format_version > max_read_version {
+        return Err(KeyEpochError::UnsupportedVersion {
+            key: key.to_string(),
+            got: format_version,
+            ceiling: max_read_version,
+        });
+    }
+    Ok(())
+}
+
 /// [`read_epochs`], plus the format-version and tenant-misfile guard a caller
 /// that decodes a record it read directly must apply before trusting it: a
-/// record from a future format, or one misfiled/corrupted under the wrong
-/// tenant's `t/<hash>/enc` key, must be refused rather than read as this
+/// record outside the supported read set, or one misfiled/corrupted under the
+/// wrong tenant's `t/<hash>/enc` key, must be refused rather than read as this
 /// tenant's key history.
 pub fn read_epochs_checked(
     record: &sysproto::KeyEpochRecord,
     key: &str,
     tenant_hash: &TenantHash,
 ) -> Result<Vec<KeyEpoch>, KeyEpochError> {
-    if record.format_version > KEY_EPOCH_FORMAT_VERSION {
-        return Err(KeyEpochError::UnsupportedVersion {
-            key: key.to_string(),
-            got: record.format_version,
-        });
-    }
+    check_read_version(
+        record.format_version,
+        KEY_EPOCH_MIN_READ_VERSION,
+        KEY_EPOCH_MAX_READ_VERSION,
+        key,
+    )?;
     if record.tenant_hash.as_slice() != tenant_hash.0.as_slice() {
         return Err(KeyEpochError::CorruptRecord {
             key: key.to_string(),
@@ -788,13 +852,12 @@ mod tests {
         ));
     }
 
-    /// A future format_version is refused rather than misread under this
-    /// layout.
-    #[tokio::test]
-    async fn read_rejects_future_format_version() {
-        let store = mem();
+    /// Seed a key-epoch record at an explicit `format_version`, bypassing the
+    /// writer's stamp, so a test can place exactly the record an older or newer
+    /// writer would have left.
+    async fn seed_at_version(store: &dyn ObjectStoreBackend, version: u32) {
         let record = sysproto::KeyEpochRecord {
-            format_version: KEY_EPOCH_FORMAT_VERSION + 1,
+            format_version: version,
             tenant_hash: tenant().0.to_vec(),
             created_unix_ns: 0,
             epochs: vec![sysproto::KeyEpoch {
@@ -810,10 +873,85 @@ mod tests {
                 PutOptions::default(),
             )
             .await
-            .expect("put future record");
+            .expect("seed at an explicit version");
+    }
+
+    /// The read gate is the closed set {1}, a floor AND a ceiling (ADR-0066
+    /// decision 4). Version 1 decodes; version 0 (an unstamped record) and
+    /// version 2 (above the ceiling) are both refused, and with DIFFERENT typed
+    /// errors, because the two demand opposite remediation. Before this the gate
+    /// was ceiling-only and version 0 was admitted, then re-encoded whole by the
+    /// next `record_key_epoch` CAS append.
+    #[tokio::test]
+    async fn read_accepts_the_supported_set_and_refuses_either_side_of_it() {
+        assert_eq!(KEY_EPOCH_MIN_READ_VERSION, 1);
+        assert_eq!(KEY_EPOCH_MAX_READ_VERSION, 1);
+        assert_eq!(KEY_EPOCH_FORMAT_VERSION, 1);
+
+        let store = mem();
+        seed_at_version(store.as_ref(), 1).await;
+        let epochs = read_epochs_from_store(store.as_ref(), &tenant())
+            .await
+            .expect("version 1 must decode")
+            .expect("a present record is Some");
+        assert_eq!(epochs.len(), 1, "the seeded epoch history decodes");
+
+        let store = mem();
+        seed_at_version(store.as_ref(), 2).await;
         let err = read_epochs_from_store(store.as_ref(), &tenant())
             .await
-            .expect_err("a future format_version must be refused");
-        assert!(matches!(err, KeyEpochError::UnsupportedVersion { .. }));
+            .expect_err("a version above the ceiling must be refused");
+        assert!(
+            matches!(
+                err,
+                KeyEpochError::UnsupportedVersion {
+                    got: 2,
+                    ceiling: 1,
+                    ..
+                }
+            ),
+            "got: {err}"
+        );
+
+        let store = mem();
+        seed_at_version(store.as_ref(), 0).await;
+        let err = read_epochs_from_store(store.as_ref(), &tenant())
+            .await
+            .expect_err("a version below the floor must be refused");
+        assert!(
+            matches!(
+                err,
+                KeyEpochError::VersionBelowFloor {
+                    got: 0,
+                    floor: 1,
+                    ..
+                }
+            ),
+            "got: {err}"
+        );
+    }
+
+    /// The two version diagnostics say different things. An operator reading the
+    /// below-floor message must not be sent looking for a newer writer, and the
+    /// above-ceiling message must name the upgrade. Asserted on the rendered
+    /// strings because the message is the whole remediation signal.
+    #[test]
+    fn the_two_version_diagnostics_are_distinguishable() {
+        let key = enc_key(&tenant());
+        let above = check_read_version(2, 1, 1, &key).expect_err("2 is above the ceiling");
+        let below = check_read_version(0, 1, 1, &key).expect_err("0 is below the floor");
+        let above = above.to_string();
+        let below = below.to_string();
+        assert!(above.contains("above the highest version"), "got: {above}");
+        assert!(above.contains("Upgrade this binary"), "got: {above}");
+        assert!(below.contains("below the lowest version"), "got: {below}");
+        assert!(
+            below.contains("not a future format"),
+            "the below-floor message must not read as a future format: {below}"
+        );
+        assert!(
+            !below.contains("Upgrade this binary"),
+            "an unstamped record is not fixed by upgrading: {below}"
+        );
     }
 }

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -23,8 +23,15 @@ mod snapshot_format;
 mod snapshot_resolve;
 mod tenant_config;
 
+// The five versioned sys/* records this crate owns each export their writer
+// stamp AND the closed read set (MIN..=MAX) their reader accepts. The pair is
+// public because it is the contract, not an implementation detail: the ADR-0066
+// enumeration guard in tests/ asserts the checked-in classification table's
+// read-version slices against these constants, so widening a gate without
+// updating the table fails rather than passing silently.
 pub use auth_token_map::{
-    AUTH_KEY, AUTH_TOKEN_MAP_FORMAT_VERSION, AuthMapDefect, AuthTokenMap, AuthTokenMapError,
+    AUTH_KEY, AUTH_TOKEN_MAP_FORMAT_VERSION, AUTH_TOKEN_MAP_MAX_READ_VERSION,
+    AUTH_TOKEN_MAP_MIN_READ_VERSION, AuthMapDefect, AuthTokenMap, AuthTokenMapError,
     KEY_FINGERPRINT_LEN, MANAGED_BY_CLI, MANAGED_BY_OPERATOR, SetOutcome as AuthSetOutcome,
     TOKEN_HASH_LEN, TokenEntry, key_fingerprint, read_auth_map, remove_token,
     remove_tokens_by_tenant, remove_tokens_by_tenant_owned_by, replace_tenant_tokens,
@@ -50,24 +57,27 @@ pub use declared_stats::{DeclaredColumnStats, read_snapshot_entry};
 pub use error::CatalogError;
 pub use fold::{FoldReport, PostingsBuildError, Transaction, fetch_segment_names};
 pub use key_epoch::{
-    EpochDefect, KEY_EPOCH_FORMAT_VERSION, KeyEpoch, KeyEpochError, KeyEpochOutcome, enc_key,
-    epoch_for_write, read_epochs, read_epochs_checked, read_epochs_from_store, record_key_epoch,
+    EpochDefect, KEY_EPOCH_FORMAT_VERSION, KEY_EPOCH_MAX_READ_VERSION, KEY_EPOCH_MIN_READ_VERSION,
+    KeyEpoch, KeyEpochError, KeyEpochOutcome, enc_key, epoch_for_write, read_epochs,
+    read_epochs_checked, read_epochs_from_store, record_key_epoch,
 };
 pub use metrics_meta::{
     DEFAULT_METRICS_META_ENTRY_CAP, MAX_METRICS_META_DECOMPRESSED_BYTES,
-    METRICS_META_FORMAT_VERSION, MergeOutcome, MetricKind, MetricMetadataEntry, MetricsMetaDefect,
-    MetricsMetaError, merge_entries, metrics_meta_key, read_metrics_meta,
-    read_metrics_meta_for_serve, write_metrics_meta,
+    METRICS_META_FORMAT_VERSION, METRICS_META_MAX_READ_VERSION, METRICS_META_MIN_READ_VERSION,
+    MergeOutcome, MetricKind, MetricMetadataEntry, MetricsMetaDefect, MetricsMetaError,
+    merge_entries, metrics_meta_key, read_metrics_meta, read_metrics_meta_for_serve,
+    write_metrics_meta,
 };
 pub use provisioning::{
     AbsentPolicy, DEFAULT_SCAN_SLACK_HOURS, FLUSH_BOUND_SLACK_HOURS, FloorDefect,
     FloorRaiseOutcome, FormatFloor, GenerationDefect, MAX_SHARD_COUNT, PROVISIONING_FORMAT_VERSION,
-    ProvisioningCheck, ProvisioningError, ReshardOutcome, ShardGeneration, active_shard_count,
-    append_generation, current_floor, current_floor_from_store, max_scan_count_over_range,
-    provisioning_key, raise_format_floor, read_floors, read_floors_checked, read_floors_from_store,
-    read_generations, read_generations_checked, read_generations_from_store, scan_count,
-    scan_shards_for_hour, scan_shards_over_range, shard_ceiling, shard_count_drift_count,
-    stable_generation_for_hour, validate_or_adopt,
+    PROVISIONING_MAX_READ_VERSION, PROVISIONING_MIN_READ_VERSION, ProvisioningCheck,
+    ProvisioningError, ReshardOutcome, ShardGeneration, active_shard_count, append_generation,
+    current_floor, current_floor_from_store, max_scan_count_over_range, provisioning_key,
+    raise_format_floor, read_floors, read_floors_checked, read_floors_from_store, read_generations,
+    read_generations_checked, read_generations_from_store, scan_count, scan_shards_for_hour,
+    scan_shards_over_range, shard_ceiling, shard_count_drift_count, stable_generation_for_hour,
+    validate_or_adopt,
 };
 pub use seal_divergence::{
     EntryIdentity, SealDivergenceError, SealDivergenceReport, verify_seal_divergence,
@@ -82,7 +92,8 @@ pub use snapshot_format::{
 };
 pub use tenant_config::{
     DeclaredColumnType, DeclaredTypedColumn, FIXED_LOGS_SQL_COLUMNS,
-    SetOutcome as TenantConfigSetOutcome, TENANT_CONFIG_FORMAT_VERSION, TenantConfig,
+    SetOutcome as TenantConfigSetOutcome, TENANT_CONFIG_FORMAT_VERSION,
+    TENANT_CONFIG_MAX_READ_VERSION, TENANT_CONFIG_MIN_READ_VERSION, TenantConfig,
     TenantConfigError, TenantLifecycleState, TypedAttrColumnError, config_key, read_config,
     read_config_values, resolve_retention_window, set_tenant_config, validate_typed_attr_columns,
 };

--- a/crates/ravel-catalog/src/metrics_meta.rs
+++ b/crates/ravel-catalog/src/metrics_meta.rs
@@ -47,37 +47,49 @@ use ravel_proto::sys::v1 as sysproto;
 use ravel_types::TenantHash;
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Format floor written into every metadata record this build emits: the writer,
-/// including the CAS-loser re-merge rewrite, stamps exactly this. It is also the
-/// highest version the read-merge-write rewrite can reproduce byte-for-byte, so
-/// [`read_metrics_meta`] (the read that feeds that rewrite) refuses any record
-/// declaring a version above it rather than let a whole-record re-encode strip a
-/// field it does not model (ADR-0066 decision 5).
-pub const METRICS_META_FORMAT_VERSION: u32 = 1;
+/// Format version written into every metadata record this build emits: the
+/// writer, including the CAS-loser re-merge rewrite, stamps exactly this. It is
+/// also the highest version the read-merge-write rewrite can reproduce
+/// byte-for-byte, so [`read_metrics_meta`] (the read that feeds that rewrite)
+/// refuses any record declaring a version above it rather than let a whole-record
+/// re-encode strip a field it does not model (ADR-0066 decision 5).
+///
+/// ADR-0066 R2 raised this from 1 to 2, the writer half of the
+/// readers-before-writers sequence R1 opened. Version 2 carries the same field
+/// set as version 1; the bump is a floor signal, so a binary predating R1 --
+/// whose gate ceiling is 1 -- refuses these records instead of rewriting them
+/// whole and stripping the additive fields it does not model. That fail-closed
+/// refusal is the point (issue #1300), and it is safe only because R1's decode
+/// gate accepts 2 fleet-wide already.
+pub const METRICS_META_FORMAT_VERSION: u32 = 2;
 
 /// Highest record version the decode gate accepts: the supported read set is
-/// `1..=METRICS_META_MAX_READ_VERSION` (ADR-0066 decision 4). A record declaring
-/// a higher version is refused rather than misread under this layout, matching
-/// the `config` / `prov` / `enc` records' version guards.
+/// `METRICS_META_MIN_READ_VERSION..=METRICS_META_MAX_READ_VERSION` (ADR-0066
+/// decision 4). A record declaring a higher version is refused rather than
+/// misread under this layout, matching the `config` / `prov` / `enc` records'
+/// version guards.
 ///
-/// This exceeds [`METRICS_META_FORMAT_VERSION`] on purpose: the decode gate
-/// accepts the next version before any writer emits it (readers-before-writers),
-/// so a future serve-only reader that models only the v1 fields reads a v2
-/// record's v1 fields rather than failing closed. Note that [`read_metrics_meta`]
-/// itself is stricter: because it returns the CAS version a caller writes back
-/// with, it doubles as the read for the CAS-loser re-merge rewrite and refuses a
-/// version above [`METRICS_META_FORMAT_VERSION`] (decision 5). The writer bump to
-/// 2 (R2) is a separate later change, sequenced after this decode gate accepts 2
-/// fleet-wide.
+/// R1 raised this to 2 one release ahead of the writer (readers-before-writers),
+/// so a serve-only reader that models only the v1 fields read a v2 record's v1
+/// fields rather than failing closed. R2 flipped the writer into that
+/// already-accepted ceiling, so the read set is unchanged here and now ends
+/// exactly at what the writer stamps. A future additive field repeats the
+/// sequence: raise this ceiling first, ship it, then raise the writer. While the
+/// two differ, [`read_metrics_meta`] is the stricter of the pair: because it
+/// returns the CAS version a caller writes back with, it doubles as the read for
+/// the CAS-loser re-merge rewrite and refuses anything above
+/// [`METRICS_META_FORMAT_VERSION`] (decision 5), which
+/// [`read_metrics_meta_for_serve`] accepts.
 pub const METRICS_META_MAX_READ_VERSION: u32 = 2;
 
 /// Lowest record version the decode gate accepts: the supported read set is a
 /// closed interval `METRICS_META_MIN_READ_VERSION..=METRICS_META_MAX_READ_VERSION`,
 /// a set with a floor and not a ceiling. Version 0 is an unstamped record from a
 /// writer that never set `format_version`; admitting it would let a valid-shaped
-/// but unstamped record be served as this tenant's metadata and rewritten as
-/// version 1 by the CAS-loser re-merge, so it is refused with the same
-/// `UnsupportedVersion` error the ceiling uses (ADR-0066 decision 4).
+/// but unstamped record be served as this tenant's metadata and rewritten by the
+/// CAS-loser re-merge, so it is refused with
+/// [`MetricsMetaError::VersionBelowFloor`] -- a distinct error from the ceiling's,
+/// because the remediation is distinct (ADR-0066 decision 4).
 pub const METRICS_META_MIN_READ_VERSION: u32 = 1;
 
 /// zstd level for the record body. 3 is the level
@@ -245,19 +257,37 @@ pub enum MetricsMetaError {
         #[source]
         source: prost::DecodeError,
     },
+    /// The record declares a version ABOVE the decode gate's ceiling: a newer
+    /// writer produced it, and this build cannot know which fields it carries.
+    /// Refused rather than misread. The remediation is to upgrade this binary,
+    /// which is why this is a separate variant from
+    /// [`MetricsMetaError::VersionBelowFloor`] (a below-floor record is not a
+    /// future format and upgrading fixes nothing).
     #[error(
-        "metadata record {key:?} declares format_version {got}, but this build only understands \
-         versions 1..={METRICS_META_MAX_READ_VERSION}: refusing rather than misread a future record \
-         format"
+        "metadata record {key:?} declares format_version {got}, above the highest version this \
+         build reads ({ceiling}): a newer writer produced it, so refusing rather than misread it. \
+         Upgrade this binary to one whose reader accepts version {got}"
     )]
-    UnsupportedVersion { key: String, got: u32 },
+    UnsupportedVersion { key: String, got: u32, ceiling: u32 },
+    /// The record declares a version BELOW the decode gate's floor. Version 0 is
+    /// the case that occurs in practice: an unstamped record from a writer that
+    /// never set `format_version`. This is not a future format, so upgrading
+    /// changes nothing; the record itself has to be migrated or rewritten by a
+    /// writer of a supported version.
+    #[error(
+        "metadata record {key:?} declares format_version {got}, below the lowest version this \
+         build reads ({floor}): the record is unstamped or predates the supported floor, not a \
+         future format. Refusing rather than admit a record no supported writer produced"
+    )]
+    VersionBelowFloor { key: String, got: u32, floor: u32 },
     /// [`read_metrics_meta`] read a record declaring a version this build's writer
     /// cannot reproduce (> [`METRICS_META_FORMAT_VERSION`]). That read feeds the
     /// CAS-loser re-merge, which re-encodes the whole record through this build's
     /// field set, so a field a newer writer added would be silently dropped on the
     /// write-back; the read is refused so the merge never runs and nothing is
-    /// stripped (ADR-0066 decision 5). The decode gate itself still accepts the
-    /// record up to [`METRICS_META_MAX_READ_VERSION`] for a read-only serve path.
+    /// stripped (ADR-0066 decision 5). This is what separates the strict reader
+    /// from [`read_metrics_meta_for_serve`], which never writes and so accepts
+    /// every version the decode gate does.
     #[error(
         "metadata record {key:?} declares format_version {got}, newer than this build's writer \
          version {METRICS_META_FORMAT_VERSION}: refusing to read it for a whole-record rewrite that \
@@ -450,6 +480,43 @@ fn build_record(
     }
 }
 
+/// Classify a record's declared `format_version` against a closed supported read
+/// interval `min_read_version..=max_read_version` (ADR-0066 decision 4). The one
+/// gate every reader of this record goes through.
+///
+/// Below the floor and above the ceiling are separate errors because the
+/// remediation is opposite: an above-ceiling record needs a newer binary, a
+/// below-floor record needs the record migrated and would not be helped by any
+/// upgrade.
+///
+/// The bounds are parameters rather than direct reads of the two constants so a
+/// test can instantiate the gate another release of this code carries. Under
+/// readers-before-writers sequencing two adjacent releases hold different bounds
+/// over this same gate, and reproducing an older binary's refusal is exactly what
+/// proves the version bump fails closed instead of stripping fields.
+fn check_read_version(
+    format_version: u32,
+    min_read_version: u32,
+    max_read_version: u32,
+    key: &str,
+) -> Result<(), MetricsMetaError> {
+    if format_version < min_read_version {
+        return Err(MetricsMetaError::VersionBelowFloor {
+            key: key.to_string(),
+            got: format_version,
+            floor: min_read_version,
+        });
+    }
+    if format_version > max_read_version {
+        return Err(MetricsMetaError::UnsupportedVersion {
+            key: key.to_string(),
+            got: format_version,
+            ceiling: max_read_version,
+        });
+    }
+    Ok(())
+}
+
 /// Decode a proto record into domain entries, validating the version, the
 /// misfile guard, and every entry's structure fail-closed. A record from a
 /// future format, one misfiled under the wrong tenant's key, one with an empty
@@ -460,14 +527,12 @@ fn decode_record(
     key: &str,
     tenant_hash: &TenantHash,
 ) -> Result<Vec<MetricMetadataEntry>, MetricsMetaError> {
-    if record.format_version < METRICS_META_MIN_READ_VERSION
-        || record.format_version > METRICS_META_MAX_READ_VERSION
-    {
-        return Err(MetricsMetaError::UnsupportedVersion {
-            key: key.to_string(),
-            got: record.format_version,
-        });
-    }
+    check_read_version(
+        record.format_version,
+        METRICS_META_MIN_READ_VERSION,
+        METRICS_META_MAX_READ_VERSION,
+        key,
+    )?;
     if record.tenant_hash.as_slice() != tenant_hash.0.as_slice() {
         return Err(MetricsMetaError::MisfiledTenant {
             key: key.to_string(),
@@ -565,23 +630,36 @@ fn decompress_body(key: &str, body: &[u8]) -> Result<Vec<u8>, MetricsMetaError> 
     Ok(out)
 }
 
+/// Decompress and prost-decode a stored body into the proto record, with no
+/// validation beyond "these bytes are a record". Split out of [`decode_body`] so
+/// a rewrite caller can read the declared `format_version` and refuse a record
+/// newer than it can reproduce BEFORE the read gate speaks (ADR-0066 decision 5):
+/// on a write path the operator needs to hear that nothing was persisted, not
+/// that the record could not be read.
+fn decode_proto(
+    body: &[u8],
+    key: &str,
+) -> Result<sysproto::MetricMetadataRecord, MetricsMetaError> {
+    let raw = decompress_body(key, body)?;
+    sysproto::MetricMetadataRecord::decode(raw.as_slice()).map_err(|source| {
+        MetricsMetaError::Decode {
+            key: key.to_string(),
+            source,
+        }
+    })
+}
+
 /// Decode a stored body into domain entries plus the record's declared
 /// `format_version`: decompress, prost-decode, validate. The version is returned
-/// alongside the entries so a rewrite caller can refuse a record newer than it
-/// can reproduce (ADR-0066 decision 5); the entry validation here accepts the
-/// full supported read set (up to [`METRICS_META_MAX_READ_VERSION`]).
+/// alongside the entries so a caller can reason about it; the entry validation
+/// here accepts the full supported read set
+/// (`METRICS_META_MIN_READ_VERSION..=METRICS_META_MAX_READ_VERSION`).
 fn decode_body(
     body: &[u8],
     key: &str,
     tenant_hash: &TenantHash,
 ) -> Result<(Vec<MetricMetadataEntry>, u32), MetricsMetaError> {
-    let raw = decompress_body(key, body)?;
-    let record = sysproto::MetricMetadataRecord::decode(raw.as_slice()).map_err(|source| {
-        MetricsMetaError::Decode {
-            key: key.to_string(),
-            source,
-        }
-    })?;
+    let record = decode_proto(body, key)?;
     let format_version = record.format_version;
     let entries = decode_record(&record, key, tenant_hash)?;
     Ok((entries, format_version))
@@ -625,7 +703,7 @@ pub async fn read_metrics_meta(
     let key = metrics_meta_key(tenant_hash);
     match store.get(&key, GetRange::Full).await {
         Ok(outcome) => {
-            let (entries, format_version) = decode_body(outcome.data.as_ref(), &key, tenant_hash)?;
+            let record = decode_proto(outcome.data.as_ref(), &key)?;
             // Rewrite refusal (ADR-0066 decision 5): the returned version is what a
             // caller CAS-writes back against after a re-merge, so this read feeds a
             // whole-record rewrite. A record a newer writer wrote may carry a field
@@ -633,12 +711,20 @@ pub async fn read_metrics_meta(
             // here so the merge never runs. A read failure makes the sink drop the
             // window (no write, no strip) and the serve path fall back to an empty
             // record for one horizon, both fail-safe.
-            if format_version > METRICS_META_FORMAT_VERSION {
+            //
+            // Checked BEFORE the decode gate, whose ceiling is the read ceiling:
+            // this caller is about to write, so it must hear that nothing was
+            // persisted and why. The two ceilings are equal today and the read gate
+            // would refuse the same records with the wrong diagnostic; they part
+            // again the moment a future additive field raises the read ceiling
+            // ahead of the writer.
+            if record.format_version > METRICS_META_FORMAT_VERSION {
                 return Err(MetricsMetaError::RefusingToRewriteNewerRecord {
                     key,
-                    got: format_version,
+                    got: record.format_version,
                 });
             }
+            let entries = decode_record(&record, &key, tenant_hash)?;
             Ok(Some((entries, outcome.version)))
         }
         Err(StoreError::NotFound) => Ok(None),
@@ -651,14 +737,16 @@ pub async fn read_metrics_meta(
 ///
 /// Unlike [`read_metrics_meta`], this does NOT apply the rewrite refusal
 /// (ADR-0066 decision 5): a serve caller never writes the record back, so a
-/// version-2 record it cannot reproduce byte-for-byte is still safe to read for
-/// the v1 fields this build models. The decode gate is the shared `decode_body`,
-/// so the accepted read set is the full
+/// record it cannot reproduce byte-for-byte is still safe to read for the fields
+/// this build does model. The decode gate is the shared `decode_body`, so the
+/// accepted read set is the full
 /// `METRICS_META_MIN_READ_VERSION..=METRICS_META_MAX_READ_VERSION`.
 /// [`read_metrics_meta`] stays strict for the CAS-loser re-merge rewrite, which
 /// does feed a whole-record re-encode and must refuse a version it would strip.
-/// Without this split the shared reader would turn every version-2 record into an
-/// empty metadata snapshot for one horizon during the writer rollout (R2).
+/// Without this split the shared reader would turn every record from a newer
+/// writer into an empty metadata snapshot for one horizon during that writer's
+/// rollout, which is exactly what the R2 rollout of the version-2 writer would
+/// have done to every serve path.
 pub async fn read_metrics_meta_for_serve(
     store: &dyn ObjectStoreBackend,
     tenant_hash: &TenantHash,
@@ -1266,13 +1354,15 @@ mod tests {
         assert_eq!(out.merged, out2.merged, "order-independent, byte-stable");
     }
 
-    /// ADR-0066 R1: the writer still stamps 1 while the decode gate accepts
-    /// {1, 2}. A premature writer bump (R2) would flip these pins.
+    /// ADR-0066 R2: the writer now stamps 2, inside the {1, 2} set R1 shipped to
+    /// every reader one release earlier. The exact values are pinned, not a
+    /// relation: a silent third bump has to edit this test.
     #[test]
-    fn writer_stamps_one_while_reader_accepts_two() {
+    fn metrics_meta_version_constants() {
         let built = build_record(&tenant(), &[entry("a", MetricKind::Counter, "h", "", 1)]);
-        assert_eq!(built.format_version, 1, "writer stamps version 1 (R1)");
-        assert_eq!(METRICS_META_FORMAT_VERSION, 1);
+        assert_eq!(built.format_version, 2, "writer stamps version 2 (R2)");
+        assert_eq!(METRICS_META_FORMAT_VERSION, 2);
+        assert_eq!(METRICS_META_MIN_READ_VERSION, 1);
         assert_eq!(METRICS_META_MAX_READ_VERSION, 2);
     }
 
@@ -1310,54 +1400,89 @@ mod tests {
         let body = body_at_version(3, &entries);
         let err = decode_body(&body, &key, &tenant()).expect_err("version 3 must be refused");
         assert!(
-            matches!(err, MetricsMetaError::UnsupportedVersion { got: 3, .. }),
+            matches!(
+                err,
+                MetricsMetaError::UnsupportedVersion {
+                    got: 3,
+                    ceiling: 2,
+                    ..
+                }
+            ),
             "got: {err}"
         );
 
-        // Version 0 (below the floor: an unstamped record) is refused too. A
-        // supported set has a floor as well as a ceiling.
+        // Version 0 (below the floor: an unstamped record) is refused too, and
+        // with the OTHER diagnostic: an operator reading "above the ceiling" for
+        // an unstamped record would go looking for a newer writer that does not
+        // exist. A supported set has a floor as well as a ceiling.
         let body = body_at_version(0, &entries);
         let err = decode_body(&body, &key, &tenant()).expect_err("version 0 must be refused");
         assert!(
-            matches!(err, MetricsMetaError::UnsupportedVersion { got: 0, .. }),
+            matches!(
+                err,
+                MetricsMetaError::VersionBelowFloor {
+                    got: 0,
+                    floor: 1,
+                    ..
+                }
+            ),
             "got: {err}"
         );
     }
 
     /// ADR-0066 item 2: the read-only serve reader and the strict rewrite reader
-    /// split on a version-2 record. `read_metrics_meta_for_serve` (the query
-    /// metadata cache's read) decodes a version-2 record's v1 fields and returns
-    /// them; `read_metrics_meta` (the read that feeds the CAS-loser re-merge
-    /// rewrite) refuses the same record with `RefusingToRewriteNewerRecord`. This
-    /// is what keeps the cache from serving an empty snapshot for one horizon once
-    /// a writer emits version 2 (R2), while the rewrite path stays fail-closed.
+    /// take different paths on a record newer than this build's writer. Both
+    /// refuse a version-3 record, but with different typed errors, and that
+    /// difference is the point: the serve path reports a read it cannot satisfy
+    /// (`UnsupportedVersion`), while the rewrite path reports that it declined to
+    /// write (`RefusingToRewriteNewerRecord`) so the operator knows nothing was
+    /// persisted. Version 2 (what this build's writer stamps, R2) is served
+    /// normally.
     #[tokio::test]
-    async fn serve_reader_accepts_version_two_while_strict_reader_refuses_it() {
+    async fn serve_and_strict_readers_report_a_newer_record_differently() {
         let store = mem();
         let key = metrics_meta_key(&tenant());
         let entries = vec![entry("a", MetricKind::Counter, "h", "u", 1)];
-        let seeded = body_at_version(2, &entries);
+
+        let current = body_at_version(2, &entries);
+        store
+            .put(&key, current.into(), PutOptions::default())
+            .await
+            .expect("seed a version-2 record");
+        let (served, _version) = read_metrics_meta_for_serve(store.as_ref(), &tenant())
+            .await
+            .expect("serve reader must not error on the version this build writes")
+            .expect("a present record is Some");
+        assert_eq!(served, entries, "the serve reader returns the v2 entries");
+
+        let seeded = body_at_version(3, &entries);
         store
             .put(&key, seeded.clone().into(), PutOptions::default())
             .await
-            .expect("seed a version-2 record");
+            .expect("seed a version-3 record");
 
-        let (served, _version) = read_metrics_meta_for_serve(store.as_ref(), &tenant())
+        let err = read_metrics_meta_for_serve(store.as_ref(), &tenant())
             .await
-            .expect("serve reader must not error on a version-2 record")
-            .expect("a present record is Some");
-        assert_eq!(
-            served, entries,
-            "the serve reader returns the version-2 record's v1 entries"
+            .expect_err("the serve reader refuses a record above its ceiling");
+        assert!(
+            matches!(
+                err,
+                MetricsMetaError::UnsupportedVersion {
+                    got: 3,
+                    ceiling: 2,
+                    ..
+                }
+            ),
+            "got: {err}"
         );
 
         let err = read_metrics_meta(store.as_ref(), &tenant())
             .await
-            .expect_err("the strict rewrite reader must refuse a version-2 record");
+            .expect_err("the strict rewrite reader must refuse a version-3 record");
         assert!(
             matches!(
                 err,
-                MetricsMetaError::RefusingToRewriteNewerRecord { got: 2, .. }
+                MetricsMetaError::RefusingToRewriteNewerRecord { got: 3, .. }
             ),
             "got: {err}"
         );
@@ -1371,21 +1496,21 @@ mod tests {
     }
 
     /// The merge-and-rewrite equivalent of the tenant-config test: reading a
-    /// version-2 record for the CAS-loser re-merge is REFUSED, not decoded into
-    /// entries a version-1 writer would re-encode and strip. `read_metrics_meta`
-    /// returns the CAS version a caller writes back with, so it is the read that
-    /// feeds the rewrite; it refuses the newer record. The stored bytes must be
-    /// exactly unchanged (the read errored before any merge or write). Named per
-    /// ADR-0066 R1 (decision 5).
+    /// record from a newer writer for the CAS-loser re-merge is REFUSED, not
+    /// decoded into entries this writer would re-encode and strip.
+    /// `read_metrics_meta` returns the CAS version a caller writes back with, so
+    /// it is the read that feeds the rewrite; it refuses the newer record. The
+    /// stored bytes must be exactly unchanged (the read errored before any merge
+    /// or write). ADR-0066 decision 5.
     #[tokio::test]
-    async fn rewrite_refuses_a_version_two_record_from_a_version_one_writer() {
+    async fn rewrite_refuses_a_record_from_a_newer_writer() {
         let store = mem();
         let key = metrics_meta_key(&tenant());
-        let seeded = body_at_version(2, &[entry("a", MetricKind::Counter, "h", "u", 1)]);
+        let seeded = body_at_version(3, &[entry("a", MetricKind::Counter, "h", "u", 1)]);
         store
             .put(&key, seeded.clone().into(), PutOptions::default())
             .await
-            .expect("seed a version-2 record");
+            .expect("seed a version-3 record");
 
         let err = read_metrics_meta(store.as_ref(), &tenant())
             .await
@@ -1393,7 +1518,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                MetricsMetaError::RefusingToRewriteNewerRecord { got: 2, .. }
+                MetricsMetaError::RefusingToRewriteNewerRecord { got: 3, .. }
             ),
             "got: {err}"
         );
@@ -1402,7 +1527,7 @@ mod tests {
         assert_eq!(
             after.as_ref(),
             seeded.as_slice(),
-            "the stored version-2 record must be byte-for-byte unchanged"
+            "the stored version-3 record must be byte-for-byte unchanged"
         );
     }
 
@@ -1703,5 +1828,148 @@ mod tests {
             sorted.dedup();
             prop_assert_eq!(&names, &sorted);
         }
+    }
+
+    // ---- ADR-0066 R2: the writer flip, and what it does to a lagging binary ----
+
+    /// A field a newer writer added and this build does not model, on the wire:
+    /// protobuf field 15, varint. prost keeps no unknown fields, so any whole
+    /// record round-trip through the generated type drops it. This is the exact
+    /// mechanism issue #1300 names, and it works for `MetricMetadataRecord`, which
+    /// has no additive field past version 1 to borrow for the test.
+    const UNMODELED_FIELD_TAG: u8 = 15 << 3;
+    const UNMODELED_FIELD_VALUE: u8 = 0x2A;
+
+    /// Append the unmodeled field to an encoded (pre-compression) record.
+    fn with_unmodeled_field(mut encoded: Vec<u8>) -> Vec<u8> {
+        encoded.push(UNMODELED_FIELD_TAG);
+        encoded.push(UNMODELED_FIELD_VALUE);
+        encoded
+    }
+
+    /// Compress an already-encoded record body the way the writer does.
+    fn compress(raw: &[u8]) -> Vec<u8> {
+        zstd::bulk::compress(raw, ZSTD_LEVEL).expect("compress")
+    }
+
+    /// The read-modify-write a binary that predates ADR-0066 R1 performs: decode
+    /// the stored record, gate it against the pre-R1 supported set (exactly {1}),
+    /// and re-encode it whole. Built from the shared [`check_read_version`] gate
+    /// with the pre-R1 bounds rather than by running a second binary, so the
+    /// refusal this test asserts is the same code path a real old build runs.
+    fn pre_r1_rewrite(stored: &[u8], key: &str) -> Result<Vec<u8>, MetricsMetaError> {
+        let raw = decompress_body(key, stored)?;
+        let record = sysproto::MetricMetadataRecord::decode(raw.as_slice()).map_err(|source| {
+            MetricsMetaError::Decode {
+                key: key.to_string(),
+                source,
+            }
+        })?;
+        check_read_version(record.format_version, 1, 1, key)?;
+        Ok(record.encode_to_vec())
+    }
+
+    /// Issue #1300's own test for the metric-metadata family. A record written by
+    /// the current writer (version 2, carrying a field an older binary does not
+    /// model) is handed to a binary whose accepted set is exactly {1}. That binary
+    /// must REFUSE it with the above-ceiling error rather than decode-and-re-encode
+    /// it, and the stored object must be byte-for-byte untouched. The second half
+    /// proves the strip is real: the same decode-and-re-encode, when it is allowed
+    /// to run, comes back missing the field.
+    #[tokio::test]
+    async fn a_pre_r1_binary_refuses_a_current_record_instead_of_stripping_it() {
+        let store = mem();
+        let key = metrics_meta_key(&tenant());
+        let entries = vec![entry("a", MetricKind::Counter, "h", "u", 1)];
+
+        let raw = with_unmodeled_field(build_record(&tenant(), &entries).encode_to_vec());
+        let seeded = compress(&raw);
+        store
+            .put(&key, seeded.clone().into(), PutOptions::default())
+            .await
+            .expect("seed a current-writer record carrying an unmodeled field");
+
+        let stored = store.get(&key, GetRange::Full).await.expect("read").data;
+        let decoded = decode_proto(stored.as_ref(), &key).expect("decode");
+        assert_eq!(
+            decoded.format_version, 2,
+            "the current writer stamps version 2"
+        );
+
+        let err = pre_r1_rewrite(stored.as_ref(), &key)
+            .expect_err("a binary that reads only {1} must refuse a version-2 record");
+        assert!(
+            matches!(
+                err,
+                MetricsMetaError::UnsupportedVersion {
+                    got: 2,
+                    ceiling: 1,
+                    ..
+                }
+            ),
+            "got: {err}"
+        );
+
+        let after = store.get(&key, GetRange::Full).await.expect("re-read").data;
+        assert_eq!(
+            after.as_ref(),
+            seeded.as_slice(),
+            "the refused rewrite left the stored record byte-for-byte unchanged"
+        );
+
+        // The flip, in one assertion: had the old binary been allowed to proceed
+        // (a version-1 stamp, which is what this writer emitted before R2), its
+        // re-encode drops the trailing unmodeled field.
+        let mut older = build_record(&tenant(), &entries);
+        older.format_version = 1;
+        let older_raw = with_unmodeled_field(older.encode_to_vec());
+        let re_encoded =
+            pre_r1_rewrite(&compress(&older_raw), &key).expect("a version-1 record is accepted");
+        assert_eq!(
+            re_encoded.as_slice(),
+            &older_raw[..older_raw.len() - 2],
+            "the accepted rewrite stripped exactly the two unmodeled-field bytes"
+        );
+    }
+
+    /// The writer stamps 2 on the wire, on every path that produces a stored
+    /// record: the create and the CAS-replace. Asserted on the bytes read back
+    /// from the store, not on the in-memory record, so a version lost between
+    /// encode and PUT would fail here.
+    #[tokio::test]
+    async fn every_writer_stamps_version_two_on_the_wire() {
+        let store = mem();
+        let key = metrics_meta_key(&tenant());
+        let entries = vec![entry("a", MetricKind::Counter, "h", "u", 1)];
+
+        async fn stamped(store: &dyn ObjectStoreBackend, key: &str) -> u32 {
+            let body = store.get(key, GetRange::Full).await.expect("read").data;
+            decode_proto(body.as_ref(), key)
+                .expect("decode")
+                .format_version
+        }
+
+        write_metrics_meta(store.as_ref(), &tenant(), &entries, None)
+            .await
+            .expect("create");
+        assert_eq!(stamped(store.as_ref(), &key).await, 2, "create stamps 2");
+
+        // A CAS-replace over a record a version-1 writer left behind comes back as
+        // version 2: this is the upgrade path, not just the fresh-write path.
+        let seeded = body_at_version(1, &entries);
+        let seeded_version = store
+            .put(&key, seeded.into(), PutOptions::default())
+            .await
+            .expect("seed a version-1 record")
+            .version;
+        assert_eq!(stamped(store.as_ref(), &key).await, 1, "seeded at 1");
+        write_metrics_meta(store.as_ref(), &tenant(), &entries, Some(seeded_version))
+            .await
+            .expect("CAS-replace");
+        assert_eq!(
+            stamped(store.as_ref(), &key).await,
+            2,
+            "a CAS-replace over a version-1 record rewrites it as version 2"
+        );
     }
 }

--- a/crates/ravel-catalog/src/provisioning.rs
+++ b/crates/ravel-catalog/src/provisioning.rs
@@ -38,37 +38,46 @@ use ravel_object_store::{
 use ravel_proto::sys::v1 as sysproto;
 use ravel_types::{Signal, TenantHash};
 
-/// Format floor written into every provisioning record this build emits: every
-/// writer, including the CAS rewrite paths ([`append_generation`],
+/// Format version written into every provisioning record this build emits:
+/// every writer, including the CAS rewrite paths ([`append_generation`],
 /// [`raise_format_floor`]), stamps exactly this. It is also the highest version
 /// a rewrite path can reproduce byte-for-byte, so a rewrite refuses any record
 /// declaring a version above it rather than strip a field it does not model
 /// (ADR-0066 decision 5).
-pub const PROVISIONING_FORMAT_VERSION: u32 = 1;
+///
+/// ADR-0066 R2 raised this from 1 to 2, the writer half of the
+/// readers-before-writers sequence R1 opened. Version 2 carries the same field
+/// set as version 1; the bump is a floor signal, so a binary predating R1 --
+/// whose gate ceiling is 1 -- refuses these records instead of rewriting them
+/// whole and stripping the additive fields it does not model. That fail-closed
+/// refusal is the point (issue #1300), and it is safe only because R1's reader
+/// accepts 2 fleet-wide already.
+pub const PROVISIONING_FORMAT_VERSION: u32 = 2;
 
 /// Highest record version a reader accepts: the supported read set is
-/// `1..=PROVISIONING_MAX_READ_VERSION` (ADR-0066 decision 4). A record declaring
-/// a higher version is refused rather than misread under this layout, matching
-/// the `sys/tenancy` marker's version guard.
+/// `PROVISIONING_MIN_READ_VERSION..=PROVISIONING_MAX_READ_VERSION` (ADR-0066
+/// decision 4). A record declaring a higher version is refused rather than
+/// misread under this layout, matching the `sys/tenancy` marker's version guard.
 ///
-/// This exceeds [`PROVISIONING_FORMAT_VERSION`] on purpose: readers accept the
-/// next version before any writer emits it (readers-before-writers), so a
-/// lagging binary meeting a record a newer peer wrote halts nowhere on the read
-/// path. This record is read on the ingest hot path by `GenerationSwitch`, which
-/// fails a flush closed on a read failure, so a single-release bump that refused
-/// the newer version would be a fleet-wide ingest outage during any rolling
-/// upgrade; the two-release readers-then-writers split avoids it. The writer
-/// bump to 2 (R2) is a separate later change, sequenced after this reader accepts
-/// 2 fleet-wide.
+/// R1 raised this to 2 one release ahead of the writer (readers-before-writers),
+/// so a lagging binary meeting a record a newer peer wrote halted nowhere on the
+/// read path. This record is read on the ingest hot path by `GenerationSwitch`,
+/// which fails a flush closed on a read failure, so a single-release bump that
+/// refused the newer version would have been a fleet-wide ingest outage during
+/// any rolling upgrade. R2 flipped the writer into that already-accepted
+/// ceiling, so the read set is unchanged here and now ends exactly at what the
+/// writer stamps. A future additive field repeats the sequence: raise this
+/// ceiling first, ship it, then raise the writer.
 pub const PROVISIONING_MAX_READ_VERSION: u32 = 2;
 
 /// Lowest record version a reader accepts: the supported read set is a closed
 /// interval `PROVISIONING_MIN_READ_VERSION..=PROVISIONING_MAX_READ_VERSION`, a
 /// set with a floor and not a ceiling. Version 0 is an unstamped record from a
 /// writer that never set `format_version`; admitting it would let a valid-shaped
-/// but unstamped record enter shard routing and be rewritten as version 1 by a
-/// CAS path, so it is refused with the same `UnsupportedVersion` error the
-/// ceiling uses (ADR-0066 decision 4).
+/// but unstamped record enter shard routing and be rewritten by a CAS path, so
+/// it is refused with [`ProvisioningError::VersionBelowFloor`] -- a distinct
+/// error from the ceiling's, because the remediation is distinct (ADR-0066
+/// decision 4).
 pub const PROVISIONING_MIN_READ_VERSION: u32 = 1;
 
 /// Object key for a (tenant, signal) provisioning record: `t/<hex>/<sig>/prov`.
@@ -122,19 +131,39 @@ pub enum ProvisioningError {
         #[source]
         source: prost::DecodeError,
     },
+    /// The record declares a version ABOVE the reader's ceiling: a newer writer
+    /// produced it, and this build cannot know which fields it carries. Refused
+    /// rather than misread. The remediation is to upgrade this binary, which is
+    /// why this is a separate variant from
+    /// [`ProvisioningError::VersionBelowFloor`] (a below-floor record is not a
+    /// future format and upgrading fixes nothing).
     #[error(
-        "provisioning record {key:?} declares format_version {got}, but this build only \
-         understands versions 1..={PROVISIONING_MAX_READ_VERSION}: refusing rather than misread a \
-         future record format"
+        "provisioning record {key:?} declares format_version {got}, above the highest version this \
+         build reads ({ceiling}): a newer writer produced it, so refusing rather than misread it. \
+         Upgrade this binary to one whose reader accepts version {got}"
     )]
-    UnsupportedVersion { key: String, got: u32 },
+    UnsupportedVersion { key: String, got: u32, ceiling: u32 },
+    /// The record declares a version BELOW the reader's floor. Version 0 is the
+    /// case that occurs in practice: an unstamped record from a writer that
+    /// never set `format_version`. This is not a future format, so upgrading
+    /// changes nothing; the record itself has to be migrated or rewritten by a
+    /// writer of a supported version.
+    #[error(
+        "provisioning record {key:?} declares format_version {got}, below the lowest version this \
+         build reads ({floor}): the record is unstamped or predates the supported floor, not a \
+         future format. Refusing rather than admit a record no supported writer produced"
+    )]
+    VersionBelowFloor { key: String, got: u32, floor: u32 },
     /// A CAS rewrite path ([`append_generation`], [`raise_format_floor`]) read a
     /// record declaring a version this build's writer cannot reproduce
     /// (> [`PROVISIONING_FORMAT_VERSION`]). Rewriting it whole would re-encode
     /// through this build's field set and silently drop any field a newer writer
     /// added, so the rewrite is refused and nothing is written (ADR-0066 decision
-    /// 5). A read-only path still accepts the record (up to
-    /// [`PROVISIONING_MAX_READ_VERSION`]); only a rewrite is refused.
+    /// 5). Distinct from [`ProvisioningError::UnsupportedVersion`] because it
+    /// says nothing was written rather than nothing was read: while
+    /// [`PROVISIONING_MAX_READ_VERSION`] exceeds the writer's version (the state
+    /// R1 shipped, and the state any future additive field re-enters) a read-only
+    /// path accepts exactly the versions a rewrite refuses here.
     #[error(
         "provisioning record {key:?} declares format_version {got}, newer than this build's writer \
          version {PROVISIONING_FORMAT_VERSION}: refusing to rewrite it whole and strip fields this \
@@ -843,6 +872,54 @@ pub fn read_generations(
     Ok(out)
 }
 
+/// Classify a record's declared `format_version` against a closed supported
+/// read interval `min_read_version..=max_read_version` (ADR-0066 decision 4).
+/// The one gate every reader of this record goes through.
+///
+/// Below the floor and above the ceiling are separate errors because the
+/// remediation is opposite: an above-ceiling record needs a newer binary, a
+/// below-floor record needs the record migrated and would not be helped by any
+/// upgrade.
+///
+/// The bounds are parameters rather than direct reads of the two constants so a
+/// test can instantiate the gate another release of this code carries. Under
+/// readers-before-writers sequencing two adjacent releases hold different bounds
+/// over this same gate, and reproducing an older binary's refusal is exactly
+/// what proves the version bump fails closed instead of stripping fields.
+fn check_read_version(
+    format_version: u32,
+    min_read_version: u32,
+    max_read_version: u32,
+    key: &str,
+) -> Result<(), ProvisioningError> {
+    if format_version < min_read_version {
+        return Err(ProvisioningError::VersionBelowFloor {
+            key: key.to_string(),
+            got: format_version,
+            floor: min_read_version,
+        });
+    }
+    if format_version > max_read_version {
+        return Err(ProvisioningError::UnsupportedVersion {
+            key: key.to_string(),
+            got: format_version,
+            ceiling: max_read_version,
+        });
+    }
+    Ok(())
+}
+
+/// [`check_read_version`] at this build's own bounds, the form every production
+/// reader calls.
+fn check_supported_version(format_version: u32, key: &str) -> Result<(), ProvisioningError> {
+    check_read_version(
+        format_version,
+        PROVISIONING_MIN_READ_VERSION,
+        PROVISIONING_MAX_READ_VERSION,
+        key,
+    )
+}
+
 /// [`read_generations`], plus the same format-version and (tenant, signal)
 /// misfile guard [`validate_record`] applies before it ever calls
 /// `read_generations`. `read_generations` alone trusts that the record was
@@ -858,14 +935,7 @@ pub fn read_generations_checked(
     tenant_hash: &TenantHash,
     signal: Signal,
 ) -> Result<Vec<ShardGeneration>, ProvisioningError> {
-    if record.format_version < PROVISIONING_MIN_READ_VERSION
-        || record.format_version > PROVISIONING_MAX_READ_VERSION
-    {
-        return Err(ProvisioningError::UnsupportedVersion {
-            key: key.to_string(),
-            got: record.format_version,
-        });
-    }
+    check_supported_version(record.format_version, key)?;
     if record.tenant_hash.as_slice() != tenant_hash.0.as_slice() {
         return Err(ProvisioningError::CorruptRecord {
             key: key.to_string(),
@@ -1132,14 +1202,7 @@ fn validate_record(
     signal: Signal,
     shard_count: u32,
 ) -> Result<(), ProvisioningError> {
-    if record.format_version < PROVISIONING_MIN_READ_VERSION
-        || record.format_version > PROVISIONING_MAX_READ_VERSION
-    {
-        return Err(ProvisioningError::UnsupportedVersion {
-            key: key.to_string(),
-            got: record.format_version,
-        });
-    }
+    check_supported_version(record.format_version, key)?;
     if record.tenant_hash.as_slice() != tenant_hash.0.as_slice() {
         return Err(ProvisioningError::CorruptRecord {
             key: key.to_string(),
@@ -1501,8 +1564,12 @@ pub async fn append_generation(
     });
 
     // Persist the full, now-explicit history. The scalar shard_count stays
-    // generation 0's count; every prior generation is carried verbatim.
+    // generation 0's count; every prior generation is carried verbatim. The
+    // stamp is this build's writer version, not the version read: these bytes
+    // are what this build's field set produces, so they must declare it (a
+    // version-1 record rewritten here comes back as version 2).
     let mut new_record = record;
+    new_record.format_version = PROVISIONING_FORMAT_VERSION;
     new_record.generations = history
         .iter()
         .map(|g| sysproto::ShardGeneration {
@@ -1644,14 +1711,7 @@ pub fn read_floors_checked(
     tenant_hash: &TenantHash,
     signal: Signal,
 ) -> Result<Vec<FormatFloor>, ProvisioningError> {
-    if record.format_version < PROVISIONING_MIN_READ_VERSION
-        || record.format_version > PROVISIONING_MAX_READ_VERSION
-    {
-        return Err(ProvisioningError::UnsupportedVersion {
-            key: key.to_string(),
-            got: record.format_version,
-        });
-    }
+    check_supported_version(record.format_version, key)?;
     if record.tenant_hash.as_slice() != tenant_hash.0.as_slice() {
         return Err(ProvisioningError::CorruptRecord {
             key: key.to_string(),
@@ -1815,8 +1875,11 @@ pub async fn raise_format_floor(
         raised_by: raised_by.to_string(),
     });
 
-    // Persist the full history. shard_count and generations are carried verbatim.
+    // Persist the full history. shard_count and generations are carried
+    // verbatim; the stamp becomes this build's writer version, same reason as
+    // in `append_generation`.
     let mut new_record = record;
+    new_record.format_version = PROVISIONING_FORMAT_VERSION;
     new_record.format_floors = floors
         .iter()
         .map(|f| sysproto::FormatFloor {
@@ -4040,9 +4103,10 @@ pub(crate) mod tests {
         );
     }
 
-    /// A record built at first write carries no floors, and its bytes are
-    /// unchanged by this field (additive: the empty list is omitted on encode),
-    /// so a pre-EM reader is unaffected.
+    /// A record built at first write carries no floors, and the floor field adds
+    /// no bytes to it (additive: the empty list is omitted on encode). What a
+    /// pre-EM reader now refuses on is the version stamp alone, deliberately
+    /// (ADR-0066 R2), not the presence of field 7.
     #[test]
     fn built_record_has_no_floors_and_is_byte_compatible() {
         let built = build_record(&tenant(), Signal::Metrics, 4, 1_234);
@@ -4050,10 +4114,11 @@ pub(crate) mod tests {
             built.format_floors.is_empty(),
             "a freshly built record carries no floors"
         );
-        // ADR-0066 R1: the writer still stamps 1 while readers accept {1, 2}. A
-        // premature writer bump (R2) would flip these pins.
-        assert_eq!(built.format_version, 1, "writer stamps version 1 (R1)");
-        assert_eq!(PROVISIONING_FORMAT_VERSION, 1);
+        // ADR-0066 R2: the writer stamps 2, the ceiling R1 shipped a release
+        // earlier. The read set is unchanged at {1, 2}.
+        assert_eq!(built.format_version, 2, "writer stamps version 2 (R2)");
+        assert_eq!(PROVISIONING_FORMAT_VERSION, 2);
+        assert_eq!(PROVISIONING_MIN_READ_VERSION, 1);
         assert_eq!(PROVISIONING_MAX_READ_VERSION, 2);
         let key = provisioning_key(&tenant(), Signal::Metrics);
         let floors = read_floors(&built, &key).expect("empty floor history is valid");
@@ -4061,15 +4126,15 @@ pub(crate) mod tests {
         assert_eq!(current_floor(&floors, RSEG), None);
     }
 
-    // ---- ADR-0066 R1: reader supported set {1, 2}, rewrite refuses newer ----
+    // ---- ADR-0066: reader supported set {1, 2}, rewrite refuses newer ----
 
-    /// A version-2 record shaped exactly like one a newer writer would persist:
-    /// generation 0's implicit count plus a raised format floor in field 7,
-    /// stamped `format_version = 2`. `raise_unix`/`raised_by` are pinned so the
-    /// encoded bytes are deterministic for the exact-bytes preservation check.
-    fn version_two_record_with_floor() -> sysproto::ProvisioningRecord {
+    /// A record shaped exactly like one a newer writer would persist: generation
+    /// 0's implicit count plus a raised format floor in field 7, stamped at
+    /// `version`. `raised_unix_ns`/`raised_by` are pinned so the encoded bytes
+    /// are deterministic for the exact-bytes preservation checks.
+    fn record_with_floor_at_version(version: u32) -> sysproto::ProvisioningRecord {
         sysproto::ProvisioningRecord {
-            format_version: 2,
+            format_version: version,
             tenant_hash: tenant().0.to_vec(),
             signal: sysproto::Signal::Metrics as i32,
             shard_count: 4,
@@ -4090,8 +4155,10 @@ pub(crate) mod tests {
     /// read_generations_checked, read_floors_checked), while both a version-0
     /// record (below the floor: an unstamped record from a writer that never set
     /// format_version) and a version-3 record (above the ceiling) are refused at
-    /// each with a typed UnsupportedVersion. Pins ADR-0066 decision 4's supported
-    /// set for the three provisioning reader sites.
+    /// each, with the two refusals carrying DIFFERENT typed errors:
+    /// VersionBelowFloor and UnsupportedVersion. Pins ADR-0066 decision 4's
+    /// supported set for the three provisioning reader sites, and the split
+    /// diagnostic an operator reads off them.
     #[tokio::test]
     async fn reader_accepts_version_one_and_two_and_refuses_zero_and_three() {
         let key = provisioning_key(&tenant(), Signal::Metrics);
@@ -4131,14 +4198,22 @@ pub(crate) mod tests {
         assert!(
             matches!(
                 read_generations_checked(&v3, &key, &tenant(), Signal::Metrics),
-                Err(ProvisioningError::UnsupportedVersion { got: 3, .. })
+                Err(ProvisioningError::UnsupportedVersion {
+                    got: 3,
+                    ceiling: 2,
+                    ..
+                })
             ),
             "read_generations_checked must refuse version 3"
         );
         assert!(
             matches!(
                 read_floors_checked(&v3, &key, &tenant(), Signal::Metrics),
-                Err(ProvisioningError::UnsupportedVersion { got: 3, .. })
+                Err(ProvisioningError::UnsupportedVersion {
+                    got: 3,
+                    ceiling: 2,
+                    ..
+                })
             ),
             "read_floors_checked must refuse version 3"
         );
@@ -4158,31 +4233,45 @@ pub(crate) mod tests {
                     AbsentPolicy::CheckOnly,
                 )
                 .await,
-                Err(ProvisioningError::UnsupportedVersion { got: 3, .. })
+                Err(ProvisioningError::UnsupportedVersion {
+                    got: 3,
+                    ceiling: 2,
+                    ..
+                })
             ),
             "validate_record must refuse version 3"
         );
 
         // Version 0 (below the floor: an unstamped record from a writer that
-        // never set format_version) is refused at each gate. A supported set has
-        // a floor as well as a ceiling: admitting version 0 would let a
-        // valid-shaped but unstamped record enter shard routing and later be
-        // rewritten as version 1 by a CAS path.
+        // never set format_version) is refused at each gate, and with the
+        // below-floor error rather than the ceiling's: an operator who upgrades
+        // on reading "a newer writer produced it" learns nothing here, the
+        // record itself is the problem. A supported set has a floor as well as a
+        // ceiling: admitting version 0 would let a valid-shaped but unstamped
+        // record enter shard routing and later be rewritten by a CAS path.
         let mut v0 = build_record(&tenant(), Signal::Metrics, 4, 1_000);
         v0.format_version = 0;
         assert!(
             matches!(
                 read_generations_checked(&v0, &key, &tenant(), Signal::Metrics),
-                Err(ProvisioningError::UnsupportedVersion { got: 0, .. })
+                Err(ProvisioningError::VersionBelowFloor {
+                    got: 0,
+                    floor: 1,
+                    ..
+                })
             ),
-            "read_generations_checked must refuse version 0"
+            "read_generations_checked must refuse version 0 as below the floor"
         );
         assert!(
             matches!(
                 read_floors_checked(&v0, &key, &tenant(), Signal::Metrics),
-                Err(ProvisioningError::UnsupportedVersion { got: 0, .. })
+                Err(ProvisioningError::VersionBelowFloor {
+                    got: 0,
+                    floor: 1,
+                    ..
+                })
             ),
-            "read_floors_checked must refuse version 0"
+            "read_floors_checked must refuse version 0 as below the floor"
         );
         let store = mem();
         store
@@ -4200,38 +4289,42 @@ pub(crate) mod tests {
                     AbsentPolicy::CheckOnly,
                 )
                 .await,
-                Err(ProvisioningError::UnsupportedVersion { got: 0, .. })
+                Err(ProvisioningError::VersionBelowFloor {
+                    got: 0,
+                    floor: 1,
+                    ..
+                })
             ),
-            "validate_record must refuse version 0"
+            "validate_record must refuse version 0 as below the floor"
         );
     }
 
-    /// A version-2 record carrying a format floor (field 7) put through the
-    /// old-shaped `append_generation` rewrite is REFUSED, not stripped: the
-    /// rewrite re-encodes the whole record through this build's field set, which
-    /// would drop a field a newer writer added. The stored bytes must be exactly
-    /// unchanged after the refusal (no CAS write happened at all). Named per the
-    /// ADR-0066 R1 spec; field 7 is one this build does model, so the refusal is
-    /// version-driven (a v2 record may carry a field this build does NOT model),
-    /// not field-driven.
+    /// A record from a writer newer than this build (version 3, above what this
+    /// build stamps) put through the `append_generation` rewrite is REFUSED, not
+    /// stripped: the rewrite re-encodes the whole record through this build's
+    /// field set, which would drop a field that newer writer added. The stored
+    /// bytes must be exactly unchanged after the refusal (no CAS write happened
+    /// at all). The refusal is version-driven, not field-driven: field 7 is one
+    /// this build models, and the record is refused anyway because a version
+    /// above the writer's may carry a field it does not.
     #[tokio::test]
     async fn append_generation_preserves_format_floors_written_by_a_newer_writer() {
         let store = mem();
         let key = provisioning_key(&tenant(), Signal::Metrics);
-        let seeded = version_two_record_with_floor().encode_to_vec();
+        let seeded = record_with_floor_at_version(3).encode_to_vec();
         store
             .put(&key, seeded.clone().into(), PutOptions::default())
             .await
-            .expect("seed a version-2 record with a format floor");
+            .expect("seed a version-3 record with a format floor");
 
-        // Reshard append onto a version-2 record: refused, not stripped.
+        // Reshard append onto a newer record: refused, not stripped.
         let err = append_generation(store.as_ref(), &tenant(), Signal::Metrics, 8, 1_000_000, 0)
             .await
             .expect_err("appending onto a newer record must be refused");
         assert!(
             matches!(
                 err,
-                ProvisioningError::RefusingToRewriteNewerRecord { got: 2, .. }
+                ProvisioningError::RefusingToRewriteNewerRecord { got: 3, .. }
             ),
             "got: {err}"
         );
@@ -4241,22 +4334,23 @@ pub(crate) mod tests {
         assert_eq!(
             after.as_ref(),
             seeded.as_slice(),
-            "the stored version-2 record must be byte-for-byte unchanged"
+            "the stored version-3 record must be byte-for-byte unchanged"
         );
     }
 
-    /// The sibling rewrite path: `raise_format_floor` refuses a version-2 record
-    /// too, leaving its bytes exactly unchanged. Sweeps the rule across both CAS
-    /// rewrite paths of this record, not only the one the spec named.
+    /// The sibling rewrite path: `raise_format_floor` refuses a record from a
+    /// newer writer too, leaving its bytes exactly unchanged. Sweeps the rule
+    /// across both CAS rewrite paths of this record, not only the one the spec
+    /// named.
     #[tokio::test]
-    async fn raise_format_floor_refuses_a_version_two_record_from_a_version_one_writer() {
+    async fn raise_format_floor_refuses_a_record_from_a_newer_writer() {
         let store = mem();
         let key = provisioning_key(&tenant(), Signal::Metrics);
-        let seeded = version_two_record_with_floor().encode_to_vec();
+        let seeded = record_with_floor_at_version(3).encode_to_vec();
         store
             .put(&key, seeded.clone().into(), PutOptions::default())
             .await
-            .expect("seed a version-2 record");
+            .expect("seed a version-3 record");
 
         let err = raise_format_floor(
             store.as_ref(),
@@ -4272,7 +4366,7 @@ pub(crate) mod tests {
         assert!(
             matches!(
                 err,
-                ProvisioningError::RefusingToRewriteNewerRecord { got: 2, .. }
+                ProvisioningError::RefusingToRewriteNewerRecord { got: 3, .. }
             ),
             "got: {err}"
         );
@@ -4281,7 +4375,7 @@ pub(crate) mod tests {
         assert_eq!(
             after.as_ref(),
             seeded.as_slice(),
-            "the stored version-2 record must be byte-for-byte unchanged"
+            "the stored version-3 record must be byte-for-byte unchanged"
         );
     }
 
@@ -4343,6 +4437,176 @@ pub(crate) mod tests {
         assert!(
             matches!(err, ProvisioningError::Decode { .. }),
             "got: {err}"
+        );
+    }
+
+    // ---- ADR-0066 R2: the writer stamps 2 and a pre-R1 binary fails closed ----
+
+    /// Tag byte for field 15, varint wire type: a field number no
+    /// `ProvisioningRecord` this build models uses (1..=7 are taken). Appended to
+    /// an encoded record it is, on the wire, exactly an additive field a newer
+    /// writer added, and prost keeps no unknown fields, so any whole-record
+    /// re-encode through this build's field set drops it. That is the strip
+    /// issue #1300 is about, reproduced without needing a second binary.
+    const UNMODELED_FIELD_TAG: u8 = 15 << 3;
+    const UNMODELED_FIELD_VALUE: u8 = 0x2A;
+
+    fn with_unmodeled_field(mut encoded: Vec<u8>) -> Vec<u8> {
+        encoded.push(UNMODELED_FIELD_TAG);
+        encoded.push(UNMODELED_FIELD_VALUE);
+        encoded
+    }
+
+    /// The read-modify-write a binary predating the first round performs: its
+    /// reader gate is this same shared gate at the pre-R1 bounds (a supported set
+    /// of exactly {1}), and its write re-encodes the decoded view, so any field
+    /// it does not model is gone from the bytes it puts back. Built from the
+    /// shared gate rather than by running a second binary.
+    fn pre_r1_rewrite(stored: &[u8], key: &str) -> Result<Vec<u8>, ProvisioningError> {
+        let record = sysproto::ProvisioningRecord::decode(stored).map_err(|source| {
+            ProvisioningError::Decode {
+                key: key.to_string(),
+                source,
+            }
+        })?;
+        check_read_version(record.format_version, 1, 1, key)?;
+        Ok(record.encode_to_vec())
+    }
+
+    /// The test issue #1300 asks for, for the ProvisioningRecord family. A record
+    /// the current writer produced, carrying a field a version-1 writer never
+    /// emits, is REFUSED by a binary that predates the first round, with the
+    /// above-ceiling error, and the stored bytes are unchanged. The last
+    /// assertion shows the alternative is a real strip: a re-encode that the gate
+    /// had admitted comes back short by exactly that field.
+    ///
+    /// Flip the writer back to stamping 1 and this fails twice over: the stamp
+    /// assertion, and then the refusal, because the old gate accepts a version-1
+    /// record and strips the field.
+    #[tokio::test]
+    async fn a_pre_r1_binary_refuses_a_current_record_instead_of_stripping_it() {
+        let store = mem();
+        let key = provisioning_key(&tenant(), Signal::Metrics);
+        let seeded = with_unmodeled_field(
+            build_record(&tenant(), Signal::Metrics, 4, 1_000).encode_to_vec(),
+        );
+        store
+            .put(&key, seeded.clone().into(), PutOptions::default())
+            .await
+            .expect("seed a current-writer record carrying an unmodeled field");
+
+        let stored = sysproto::ProvisioningRecord::decode(seeded.as_slice()).expect("decode");
+        assert_eq!(
+            stored.format_version, 2,
+            "the current writer stamps exactly version 2"
+        );
+
+        let err = pre_r1_rewrite(&seeded, &key)
+            .expect_err("a binary predating R1 must refuse this record, not rewrite it");
+        assert!(
+            matches!(
+                err,
+                ProvisioningError::UnsupportedVersion {
+                    got: 2,
+                    ceiling: 1,
+                    ..
+                }
+            ),
+            "got: {err}"
+        );
+
+        // Nothing was written back: the record, unmodeled field included, is
+        // byte-for-byte what the current writer put there.
+        let after = store.get(&key, GetRange::Full).await.expect("re-read").data;
+        assert_eq!(
+            after.as_ref(),
+            seeded.as_slice(),
+            "the refused record must be byte-for-byte unchanged"
+        );
+
+        // And the strip the refusal prevents is real, not hypothetical: the
+        // bytes a whole-record re-encode produces are the seeded bytes minus
+        // exactly the two bytes of the unmodeled field.
+        let re_encoded = sysproto::ProvisioningRecord::decode(seeded.as_slice())
+            .expect("decode")
+            .encode_to_vec();
+        assert_eq!(
+            re_encoded.as_slice(),
+            &seeded[..seeded.len() - 2],
+            "a whole-record re-encode drops the unmodeled field"
+        );
+    }
+
+    /// Every writer of this record stamps 2 on the wire: first write, reshard
+    /// append, floor raise. Asserted on the bytes read back from the store and
+    /// decoded, at the exact value, not on the in-memory struct and not with an
+    /// inequality. The append case starts from a stored version-1 record, so it
+    /// also pins that a rewrite re-stamps rather than carrying the read version
+    /// through.
+    #[tokio::test]
+    async fn every_writer_stamps_version_two_on_the_wire() {
+        /// The `format_version` on the wire at `key`, decoded from the stored
+        /// bytes rather than read off any in-memory struct.
+        async fn stamped(store: &dyn ObjectStoreBackend, key: &str) -> u32 {
+            let bytes = store.get(key, GetRange::Full).await.expect("re-read").data;
+            sysproto::ProvisioningRecord::decode(bytes.as_ref())
+                .expect("decode")
+                .format_version
+        }
+
+        let store = mem();
+        let key = provisioning_key(&tenant(), Signal::Metrics);
+
+        // 1. First write, through validate_or_adopt's create path.
+        validate_or_adopt(
+            store.as_ref(),
+            &tenant(),
+            Signal::Metrics,
+            4,
+            1_000,
+            AbsentPolicy::CreateFromConfig,
+        )
+        .await
+        .expect("first write");
+        assert_eq!(
+            stamped(store.as_ref(), &key).await,
+            2,
+            "the first-write path stamps 2"
+        );
+
+        // 2. Reshard append, starting from a stored version-1 record: the
+        //    rewrite re-stamps to this build's writer version.
+        let mut v1 = build_record(&tenant(), Signal::Metrics, 4, 1_000);
+        v1.format_version = 1;
+        store
+            .put(&key, v1.encode_to_vec().into(), PutOptions::default())
+            .await
+            .expect("seed a version-1 record");
+        append_generation(store.as_ref(), &tenant(), Signal::Metrics, 8, 1_000_000, 0)
+            .await
+            .expect("append onto a version-1 record");
+        assert_eq!(
+            stamped(store.as_ref(), &key).await,
+            2,
+            "the reshard rewrite re-stamps a version-1 record as 2"
+        );
+
+        // 3. Floor raise.
+        raise_format_floor(
+            store.as_ref(),
+            &tenant(),
+            Signal::Metrics,
+            "rseg",
+            6,
+            "job",
+            3_000,
+        )
+        .await
+        .expect("raise a floor");
+        assert_eq!(
+            stamped(store.as_ref(), &key).await,
+            2,
+            "the floor-raise rewrite stamps 2"
         );
     }
 }

--- a/crates/ravel-catalog/src/tenant_config.rs
+++ b/crates/ravel-catalog/src/tenant_config.rs
@@ -38,34 +38,45 @@ use ravel_object_store::{GetRange, ObjectStoreBackend, PutMode, PutOptions, Stor
 use ravel_proto::sys::v1 as sysproto;
 use ravel_types::TenantHash;
 
-/// Format floor written into every config record this build emits: the writer,
+/// Format version written into every config record this build emits: the writer,
 /// including the CAS-replace rewrite in [`set_tenant_config`], stamps exactly
 /// this. It is also the highest version a rewrite can reproduce byte-for-byte, so
 /// a rewrite refuses any record declaring a version above it rather than strip a
 /// field it does not model (ADR-0066 decision 5).
-pub const TENANT_CONFIG_FORMAT_VERSION: u32 = 1;
+///
+/// ADR-0066 R2 raised this from 1 to 2, the writer half of the
+/// readers-before-writers sequence R1 opened. Version 2 carries the same field
+/// set as version 1; the bump is a floor signal, so a binary predating R1 --
+/// whose gate ceiling is 1 -- refuses these records instead of rewriting them
+/// whole and stripping `typed_attr_columns` (field 12) and anything else it does
+/// not model. That fail-closed refusal is the point (issue #1300), and it is
+/// safe only because R1's reader accepts 2 fleet-wide already.
+pub const TENANT_CONFIG_FORMAT_VERSION: u32 = 2;
 
 /// Highest record version a reader accepts: the supported read set is
-/// `1..=TENANT_CONFIG_MAX_READ_VERSION` (ADR-0066 decision 4). A record declaring
-/// a higher version is refused rather than misread under this layout, matching
-/// the `prov` / `enc` records' version guards.
+/// `TENANT_CONFIG_MIN_READ_VERSION..=TENANT_CONFIG_MAX_READ_VERSION` (ADR-0066
+/// decision 4). A record declaring a higher version is refused rather than
+/// misread under this layout, matching the `prov` / `enc` records' version
+/// guards.
 ///
-/// This exceeds [`TENANT_CONFIG_FORMAT_VERSION`] on purpose: readers accept the
-/// next version before any writer emits it (readers-before-writers), so a lagging
-/// binary reading a record a newer peer wrote does not fail closed. The lifecycle
-/// refresh loop reads this record on a bounded-staleness horizon; a single-release
-/// bump that refused the newer version would break that refresh across a rolling
-/// upgrade. The writer bump to 2 (R2) is a separate later change, sequenced after
-/// this reader accepts 2 fleet-wide.
+/// R1 raised this to 2 one release ahead of the writer (readers-before-writers),
+/// so a lagging binary reading a record a newer peer wrote did not fail closed.
+/// The lifecycle refresh loop reads this record on a bounded-staleness horizon; a
+/// single-release bump that refused the newer version would have broken that
+/// refresh across a rolling upgrade. R2 flipped the writer into that
+/// already-accepted ceiling, so the read set is unchanged here and now ends
+/// exactly at what the writer stamps. A future additive field repeats the
+/// sequence: raise this ceiling first, ship it, then raise the writer.
 pub const TENANT_CONFIG_MAX_READ_VERSION: u32 = 2;
 
 /// Lowest record version a reader accepts: the supported read set is a closed
 /// interval `TENANT_CONFIG_MIN_READ_VERSION..=TENANT_CONFIG_MAX_READ_VERSION`, a
 /// set with a floor and not a ceiling. Version 0 is an unstamped record from a
 /// writer that never set `format_version`; admitting it would let a valid-shaped
-/// but unstamped record be applied by `read_config` and rewritten as version 1
-/// by the CAS `set_tenant_config` path, so it is refused with the same
-/// `UnsupportedVersion` error the ceiling uses (ADR-0066 decision 4).
+/// but unstamped record be applied by `read_config` and rewritten by the CAS
+/// `set_tenant_config` path, so it is refused with
+/// [`TenantConfigError::VersionBelowFloor`] -- a distinct error from the
+/// ceiling's, because the remediation is distinct (ADR-0066 decision 4).
 pub const TENANT_CONFIG_MIN_READ_VERSION: u32 = 1;
 
 /// Object key for a tenant's config record: `t/<hex>/config`. Tenant-scoped, not
@@ -340,18 +351,36 @@ pub enum TenantConfigError {
         #[source]
         source: prost::DecodeError,
     },
+    /// The record declares a version ABOVE the reader's ceiling: a newer writer
+    /// produced it, and this build cannot know which fields it carries. Refused
+    /// rather than misread. The remediation is to upgrade this binary, which is
+    /// why this is a separate variant from
+    /// [`TenantConfigError::VersionBelowFloor`] (a below-floor record is not a
+    /// future format and upgrading fixes nothing).
     #[error(
-        "config record {key:?} declares format_version {got}, but this build only understands \
-         versions 1..={TENANT_CONFIG_MAX_READ_VERSION}: refusing rather than misread a future \
-         record format"
+        "config record {key:?} declares format_version {got}, above the highest version this build \
+         reads ({ceiling}): a newer writer produced it, so refusing rather than misread it. \
+         Upgrade this binary to one whose reader accepts version {got}"
     )]
-    UnsupportedVersion { key: String, got: u32 },
+    UnsupportedVersion { key: String, got: u32, ceiling: u32 },
+    /// The record declares a version BELOW the reader's floor. Version 0 is the
+    /// case that occurs in practice: an unstamped record from a writer that never
+    /// set `format_version`. This is not a future format, so upgrading changes
+    /// nothing; the record itself has to be migrated or rewritten by a writer of
+    /// a supported version.
+    #[error(
+        "config record {key:?} declares format_version {got}, below the lowest version this build \
+         reads ({floor}): the record is unstamped or predates the supported floor, not a future \
+         format. Refusing rather than admit a record no supported writer produced"
+    )]
+    VersionBelowFloor { key: String, got: u32, floor: u32 },
     /// [`set_tenant_config`] read a record declaring a version this build's writer
     /// cannot reproduce (> [`TENANT_CONFIG_FORMAT_VERSION`]). The whole-record
     /// CAS-replace rebuilds the body from this build's field set, so a field a
     /// newer writer added would be silently dropped; the write is refused and
-    /// nothing is persisted (ADR-0066 decision 5). A read-only path still accepts
-    /// the record (up to [`TENANT_CONFIG_MAX_READ_VERSION`]).
+    /// nothing is persisted (ADR-0066 decision 5). Checked before the decode
+    /// gate, so the diagnostic on the write path names the rewrite hazard rather
+    /// than the read ceiling.
     #[error(
         "config record {key:?} declares format_version {got}, newer than this build's writer \
          version {TENANT_CONFIG_FORMAT_VERSION}: refusing to rewrite it whole and strip fields this \
@@ -415,6 +444,43 @@ impl TenantConfigError {
     }
 }
 
+/// Classify a record's declared `format_version` against a closed supported read
+/// interval `min_read_version..=max_read_version` (ADR-0066 decision 4). The one
+/// gate every reader of this record goes through.
+///
+/// Below the floor and above the ceiling are separate errors because the
+/// remediation is opposite: an above-ceiling record needs a newer binary, a
+/// below-floor record needs the record migrated and would not be helped by any
+/// upgrade.
+///
+/// The bounds are parameters rather than direct reads of the two constants so a
+/// test can instantiate the gate another release of this code carries. Under
+/// readers-before-writers sequencing two adjacent releases hold different bounds
+/// over this same gate, and reproducing an older binary's refusal is exactly what
+/// proves the version bump fails closed instead of stripping fields.
+fn check_read_version(
+    format_version: u32,
+    min_read_version: u32,
+    max_read_version: u32,
+    key: &str,
+) -> Result<(), TenantConfigError> {
+    if format_version < min_read_version {
+        return Err(TenantConfigError::VersionBelowFloor {
+            key: key.to_string(),
+            got: format_version,
+            floor: min_read_version,
+        });
+    }
+    if format_version > max_read_version {
+        return Err(TenantConfigError::UnsupportedVersion {
+            key: key.to_string(),
+            got: format_version,
+            ceiling: max_read_version,
+        });
+    }
+    Ok(())
+}
+
 /// Decode a proto record into the domain [`TenantConfig`], validating the
 /// version, the (tenant) misfile guard, and the lifecycle state fail-closed. A
 /// record from a future format, one misfiled under the wrong tenant's `config`
@@ -425,14 +491,12 @@ fn decode_record(
     key: &str,
     tenant_hash: &TenantHash,
 ) -> Result<TenantConfig, TenantConfigError> {
-    if record.format_version < TENANT_CONFIG_MIN_READ_VERSION
-        || record.format_version > TENANT_CONFIG_MAX_READ_VERSION
-    {
-        return Err(TenantConfigError::UnsupportedVersion {
-            key: key.to_string(),
-            got: record.format_version,
-        });
-    }
+    check_read_version(
+        record.format_version,
+        TENANT_CONFIG_MIN_READ_VERSION,
+        TENANT_CONFIG_MAX_READ_VERSION,
+        key,
+    )?;
     if record.tenant_hash.as_slice() != tenant_hash.0.as_slice() {
         return Err(TenantConfigError::CorruptRecord {
             key: key.to_string(),
@@ -610,22 +674,27 @@ pub async fn set_tenant_config(
                         source,
                     }
                 })?;
-            // Guard version and misfile before writing back: set_tenant_config
-            // persists the record, so trusting a misfiled or future-format read
-            // would durably corrupt it.
-            decode_record(&existing, &key, tenant_hash)?;
             // Rewrite refusal (ADR-0066 decision 5): the CAS-replace below rebuilds
             // the body from this build's field set. A record a newer writer wrote
             // (version above what this build stamps) may carry a field this build
-            // does not model, which the rebuild would strip. decode_record above
-            // accepts the wider read set, so this narrower check refuses the
-            // rewrite explicitly. Nothing is written.
+            // does not model, which the rebuild would strip. Nothing is written.
+            //
+            // Checked BEFORE decode_record, whose ceiling is the read ceiling: on
+            // a write path the operator needs to hear that nothing was persisted
+            // and why, not that the record could not be read. The two ceilings are
+            // equal today and the read gate would refuse the same records with the
+            // wrong diagnostic; they part again the moment a future additive field
+            // raises the read ceiling ahead of the writer.
             if existing.format_version > TENANT_CONFIG_FORMAT_VERSION {
                 return Err(TenantConfigError::RefusingToRewriteNewerRecord {
                     key,
                     got: existing.format_version,
                 });
             }
+            // Guard version and misfile before writing back: set_tenant_config
+            // persists the record, so trusting a misfiled or below-floor read
+            // would durably corrupt it.
+            decode_record(&existing, &key, tenant_hash)?;
             let created_unix_ns = existing.created_unix_ns;
             let record = build_record(tenant_hash, config, created_unix_ns, now_ns);
             match store
@@ -967,8 +1036,10 @@ mod tests {
     /// ceiling: a version-1 and a version-2 record both read back through
     /// `read_config`; both a version-0 record (below the floor: an unstamped
     /// record from a writer that never set format_version) and a version-3 record
-    /// (above the ceiling) are refused with a typed UnsupportedVersion. Pins
-    /// ADR-0066 decision 4 for the tenant-config reader gate (decode_record).
+    /// (above the ceiling) are refused, with the two refusals carrying DIFFERENT
+    /// typed errors: VersionBelowFloor and UnsupportedVersion. Pins ADR-0066
+    /// decision 4 for the tenant-config reader gate (decode_record), and the
+    /// split diagnostic an operator reads off it.
     #[tokio::test]
     async fn reader_accepts_version_one_and_two_and_refuses_zero_and_three() {
         for version in [1u32, 2u32] {
@@ -1014,12 +1085,22 @@ mod tests {
             .await
             .expect_err("version 3 must be refused");
         assert!(
-            matches!(err, TenantConfigError::UnsupportedVersion { got: 3, .. }),
+            matches!(
+                err,
+                TenantConfigError::UnsupportedVersion {
+                    got: 3,
+                    ceiling: 2,
+                    ..
+                }
+            ),
             "got: {err}"
         );
 
-        // Version 0 (below the floor: an unstamped record) is refused too. A
-        // supported set has a floor as well as a ceiling.
+        // Version 0 (below the floor: an unstamped record) is refused too, and
+        // with the below-floor error rather than the ceiling's: an operator who
+        // upgrades on reading "a newer writer produced it" learns nothing here,
+        // the record itself is the problem. A supported set has a floor as well
+        // as a ceiling.
         let store = mem();
         let mut v0 = build_record(
             &tenant(),
@@ -1040,34 +1121,43 @@ mod tests {
             .await
             .expect_err("version 0 must be refused");
         assert!(
-            matches!(err, TenantConfigError::UnsupportedVersion { got: 0, .. }),
+            matches!(
+                err,
+                TenantConfigError::VersionBelowFloor {
+                    got: 0,
+                    floor: 1,
+                    ..
+                }
+            ),
             "got: {err}"
         );
     }
 
-    /// A version-2 config record put through `set_tenant_config`'s whole-record
-    /// CAS-replace is REFUSED, not rebuilt at version 1: the rebuild names every
-    /// field explicitly and would drop any field a newer writer added. The stored
-    /// bytes must be exactly unchanged. Named per ADR-0066 R1 (decision 5).
+    /// A record from a writer newer than this build (version 3, above what this
+    /// build stamps) put through `set_tenant_config`'s whole-record CAS-replace is
+    /// REFUSED, not rebuilt: the rebuild names every field explicitly and would
+    /// drop any field that newer writer added. The stored bytes must be exactly
+    /// unchanged, and the error must be the write-path one (nothing was
+    /// persisted), not the read gate's ceiling error.
     #[tokio::test]
-    async fn set_tenant_config_refuses_a_version_two_record_from_a_version_one_writer() {
+    async fn set_tenant_config_refuses_a_record_from_a_newer_writer() {
         let store = mem();
         let key = config_key(&tenant());
-        // A version-2 record on disk (as a newer writer would leave it).
+        // A version-3 record on disk (as a newer writer would leave it).
         let mut seeded_record = build_record(
             &tenant(),
             &TenantConfig::new(TenantLifecycleState::Suspended),
             1_000,
             1_000,
         );
-        seeded_record.format_version = 2;
+        seeded_record.format_version = 3;
         let seeded = seeded_record.encode_to_vec();
         store
             .put(&key, seeded.clone().into(), PutOptions::default())
             .await
-            .expect("seed a version-2 config record");
+            .expect("seed a version-3 config record");
 
-        // A version-1 writer tries to overwrite it: refused, nothing written.
+        // This build's writer tries to overwrite it: refused, nothing written.
         let err = set_tenant_config(
             store.as_ref(),
             &tenant(),
@@ -1079,7 +1169,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                TenantConfigError::RefusingToRewriteNewerRecord { got: 2, .. }
+                TenantConfigError::RefusingToRewriteNewerRecord { got: 3, .. }
             ),
             "got: {err}"
         );
@@ -1088,7 +1178,7 @@ mod tests {
         assert_eq!(
             after.as_ref(),
             seeded.as_slice(),
-            "the stored version-2 record must be byte-for-byte unchanged"
+            "the stored version-3 record must be byte-for-byte unchanged"
         );
     }
 
@@ -1143,20 +1233,182 @@ mod tests {
         );
     }
 
-    /// `TENANT_CONFIG_FORMAT_VERSION` is unchanged by the additive
-    /// `typed_attr_columns` field (ADR-0090: no bump for an additive field).
-    /// Pinned so a future accidental bump on this field's account fails loudly.
+    /// The version constants this record is governed by, pinned at their exact
+    /// values so any move is a deliberate edit here.
+    ///
+    /// ADR-0090 said `typed_attr_columns` being additive did not by itself
+    /// justify a bump, and it did not get one. ADR-0066 R2 bumps the writer for a
+    /// different reason: not to describe a field, but to make a binary predating
+    /// the first round refuse these records rather than rewrite them whole and
+    /// strip fields it does not model.
     #[test]
-    fn tenant_config_format_version_is_unchanged() {
+    fn tenant_config_version_constants() {
         assert_eq!(
-            TENANT_CONFIG_FORMAT_VERSION, 1,
-            "typed_attr_columns is additive; ADR-0090 forbids a format-version bump"
+            TENANT_CONFIG_FORMAT_VERSION, 2,
+            "the writer stamps 2 (ADR-0066 R2)"
         );
-        // ADR-0066 R1: the writer still stamps 1 while readers accept {1, 2}. A
-        // premature writer bump (R2) here would flip this pin.
+        assert_eq!(
+            TENANT_CONFIG_MIN_READ_VERSION, 1,
+            "version 1 records stay readable"
+        );
         assert_eq!(
             TENANT_CONFIG_MAX_READ_VERSION, 2,
-            "readers accept versions 1 and 2 (ADR-0066 decision 4); writer stays at 1 until R2"
+            "readers accept versions 1 and 2 (ADR-0066 decision 4)"
+        );
+    }
+
+    // ---- ADR-0066 R2: the writer stamps 2 and a pre-R1 binary fails closed ----
+
+    /// Tag byte for field 15, varint wire type: a field number no
+    /// `TenantConfigRecord` this build models uses (1..=12 are taken). Appended to
+    /// an encoded record it is, on the wire, exactly an additive field a newer
+    /// writer added, and prost keeps no unknown fields, so any whole-record
+    /// re-encode through this build's field set drops it. That is the strip issue
+    /// #1300 is about, reproduced without needing a second binary.
+    const UNMODELED_FIELD_TAG: u8 = 15 << 3;
+    const UNMODELED_FIELD_VALUE: u8 = 0x2A;
+
+    fn with_unmodeled_field(mut encoded: Vec<u8>) -> Vec<u8> {
+        encoded.push(UNMODELED_FIELD_TAG);
+        encoded.push(UNMODELED_FIELD_VALUE);
+        encoded
+    }
+
+    /// The read-modify-write a binary predating the first round performs: its
+    /// reader gate is this same shared gate at the pre-R1 bounds (a supported set
+    /// of exactly {1}), and its write rebuilds the body from its own field set, so
+    /// any field it does not model is gone from the bytes it puts back. Built from
+    /// the shared gate rather than by running a second binary.
+    fn pre_r1_rewrite(stored: &[u8], key: &str) -> Result<Vec<u8>, TenantConfigError> {
+        let record = sysproto::TenantConfigRecord::decode(stored).map_err(|source| {
+            TenantConfigError::Decode {
+                key: key.to_string(),
+                source,
+            }
+        })?;
+        check_read_version(record.format_version, 1, 1, key)?;
+        Ok(record.encode_to_vec())
+    }
+
+    /// The test issue #1300 asks for, for the TenantConfigRecord family. A record
+    /// the current writer produced, carrying a field a version-1 writer never
+    /// emits, is REFUSED by a binary that predates the first round, with the
+    /// above-ceiling error, and the stored bytes are unchanged. The last assertion
+    /// shows the alternative is a real strip.
+    ///
+    /// Flip the writer back to stamping 1 and this fails twice over: the stamp
+    /// assertion, and then the refusal, because the old gate accepts a version-1
+    /// record and strips the field.
+    #[tokio::test]
+    async fn a_pre_r1_binary_refuses_a_current_record_instead_of_stripping_it() {
+        let store = mem();
+        let key = config_key(&tenant());
+        let seeded = with_unmodeled_field(
+            build_record(&tenant(), &full_config(), 1_000, 1_000).encode_to_vec(),
+        );
+        store
+            .put(&key, seeded.clone().into(), PutOptions::default())
+            .await
+            .expect("seed a current-writer record carrying an unmodeled field");
+
+        let stored = sysproto::TenantConfigRecord::decode(seeded.as_slice()).expect("decode");
+        assert_eq!(
+            stored.format_version, 2,
+            "the current writer stamps exactly version 2"
+        );
+
+        let err = pre_r1_rewrite(&seeded, &key)
+            .expect_err("a binary predating R1 must refuse this record, not rewrite it");
+        assert!(
+            matches!(
+                err,
+                TenantConfigError::UnsupportedVersion {
+                    got: 2,
+                    ceiling: 1,
+                    ..
+                }
+            ),
+            "got: {err}"
+        );
+
+        let after = store.get(&key, GetRange::Full).await.expect("re-read").data;
+        assert_eq!(
+            after.as_ref(),
+            seeded.as_slice(),
+            "the refused record must be byte-for-byte unchanged"
+        );
+
+        // And the strip the refusal prevents is real: the bytes a whole-record
+        // re-encode produces are the seeded bytes minus exactly the unmodeled
+        // field's two.
+        let re_encoded = sysproto::TenantConfigRecord::decode(seeded.as_slice())
+            .expect("decode")
+            .encode_to_vec();
+        assert_eq!(
+            re_encoded.as_slice(),
+            &seeded[..seeded.len() - 2],
+            "a whole-record re-encode drops the unmodeled field"
+        );
+    }
+
+    /// Both writers of this record stamp 2 on the wire: the CreateIfAbsent create
+    /// and the CAS-replace update. Asserted on the bytes read back from the store
+    /// and decoded, at the exact value. The update case starts from a stored
+    /// version-1 record, so it also pins that the rewrite re-stamps rather than
+    /// carrying the read version through.
+    #[tokio::test]
+    async fn every_writer_stamps_version_two_on_the_wire() {
+        /// The `format_version` on the wire at `key`, decoded from the stored
+        /// bytes rather than read off any in-memory struct.
+        async fn stamped(store: &dyn ObjectStoreBackend, key: &str) -> u32 {
+            let bytes = store.get(key, GetRange::Full).await.expect("re-read").data;
+            sysproto::TenantConfigRecord::decode(bytes.as_ref())
+                .expect("decode")
+                .format_version
+        }
+
+        let store = mem();
+        let key = config_key(&tenant());
+
+        // 1. Create.
+        set_tenant_config(
+            store.as_ref(),
+            &tenant(),
+            &TenantConfig::new(TenantLifecycleState::Active),
+            1_000,
+        )
+        .await
+        .expect("create");
+        assert_eq!(
+            stamped(store.as_ref(), &key).await,
+            2,
+            "the create path stamps 2"
+        );
+
+        // 2. CAS-replace over a stored version-1 record.
+        let mut v1 = build_record(
+            &tenant(),
+            &TenantConfig::new(TenantLifecycleState::Active),
+            1_000,
+            1_000,
+        );
+        v1.format_version = 1;
+        store
+            .put(&key, v1.encode_to_vec().into(), PutOptions::default())
+            .await
+            .expect("seed a version-1 record");
+        set_tenant_config(
+            store.as_ref(),
+            &tenant(),
+            &TenantConfig::new(TenantLifecycleState::Suspended),
+            2_000,
+        )
+        .await
+        .expect("update");
+        assert_eq!(
+            stamped(store.as_ref(), &key).await,
+            2,
+            "the CAS-replace re-stamps a version-1 record as 2"
         );
     }
 

--- a/crates/ravel-catalog/tests/sys_proto_format_version_classification.rs
+++ b/crates/ravel-catalog/tests/sys_proto_format_version_classification.rs
@@ -57,10 +57,14 @@ fn classification_table() -> BTreeMap<&'static str, Class> {
         ("AdmissionUsageSnapshot", Immutable(&[1])),
         ("WorkerHeartbeat", Immutable(&[1])),
         // Read-modify-write under CAS. ProvisioningRecord / TenantConfigRecord /
-        // MetricMetadataRecord accept {1, 2} after ADR-0066 R1 (this change);
-        // AuthTokenMap already accepts {1, 2} (managed_by, ADR-0072 #897). The
-        // rest still accept {1}: their reader gates are unchanged here because
-        // their crates are in flight under other work (reported, not fixed).
+        // MetricMetadataRecord accept {1, 2} after ADR-0066 R1; AuthTokenMap
+        // accepts {1, 2} (managed_by, ADR-0072 #897) and KeyEpochRecord {1}, both
+        // as a floor-and-ceiling set since ADR-0066 R2. GcConfig and
+        // CompactionClaim still carry ceiling-only gates in their own crates
+        // (ravel-maintain, ravel-fleet), outside this change's scope: reported,
+        // not fixed. Every slice belonging to a ravel-catalog reader is checked
+        // against that reader's own constants by
+        // `catalog_read_sets_match_their_readers_constants`.
         ("ProvisioningRecord", CasMutable(&[1, 2])),
         ("TenantConfigRecord", CasMutable(&[1, 2])),
         ("MetricMetadataRecord", CasMutable(&[1, 2])),
@@ -157,14 +161,81 @@ fn classification_is_complete() {
         "classification_table() names messages not in sys.proto (renamed or removed?): {stale:?}"
     );
 
-    // Sanity: the eleven versioned messages ADR-0066 enumerates are all present,
-    // so a parser regression that silently found none is itself caught.
+    // Sanity: the proto and the table enumerate the same number of messages, so a
+    // parser regression that silently found none (or found a subset) is itself
+    // caught. The count comes from the table rather than a literal so that adding
+    // a message and classifying it in the same commit does not have to edit a
+    // number in a third place -- but the floor below still catches a parser that
+    // returns nothing, which the equality alone would not if the table were also
+    // empty.
+    assert!(
+        !in_proto.is_empty(),
+        "the parser enumerated no versioned messages at all: a parser regression, not an empty schema"
+    );
+    assert!(
+        !classified.is_empty(),
+        "the classification table is empty: it must enumerate every versioned sys.proto message"
+    );
     assert_eq!(
         in_proto.len(),
-        11,
-        "expected 11 versioned sys.proto messages (ADR-0066 decision 4); found {}: {in_proto:?}",
+        classification_table().len(),
+        "the proto and the classification table must enumerate the same messages; found {}: {in_proto:?}",
         in_proto.len()
     );
+}
+
+/// Every read-version slice in the table that belongs to a reader THIS crate owns
+/// is the closed set that reader's own `MIN_READ_VERSION..=MAX_READ_VERSION`
+/// constants define. Widening a gate without updating the table therefore fails
+/// here, which is the point: a table that merely restated the constants would
+/// track any change silently and guard nothing.
+///
+/// The six messages absent from this list are read outside ravel-catalog
+/// (ravel-fleet, ravel-maintain, ravel-server, ravel-ingest). Asserting their
+/// slices against their constants would need a dev-dependency on each of those
+/// crates, so their entries stay literal and are maintained by hand.
+#[test]
+fn catalog_read_sets_match_their_readers_constants() {
+    use ravel_catalog as cat;
+
+    let expected: BTreeMap<&'static str, Vec<u32>> = BTreeMap::from([
+        (
+            "ProvisioningRecord",
+            (cat::PROVISIONING_MIN_READ_VERSION..=cat::PROVISIONING_MAX_READ_VERSION).collect(),
+        ),
+        (
+            "TenantConfigRecord",
+            (cat::TENANT_CONFIG_MIN_READ_VERSION..=cat::TENANT_CONFIG_MAX_READ_VERSION).collect(),
+        ),
+        (
+            "MetricMetadataRecord",
+            (cat::METRICS_META_MIN_READ_VERSION..=cat::METRICS_META_MAX_READ_VERSION).collect(),
+        ),
+        (
+            "AuthTokenMap",
+            (cat::AUTH_TOKEN_MAP_MIN_READ_VERSION..=cat::AUTH_TOKEN_MAP_MAX_READ_VERSION).collect(),
+        ),
+        (
+            "KeyEpochRecord",
+            (cat::KEY_EPOCH_MIN_READ_VERSION..=cat::KEY_EPOCH_MAX_READ_VERSION).collect(),
+        ),
+    ]);
+
+    let table = classification_table();
+    for (name, versions) in expected {
+        let class = table
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} must be classified"));
+        let listed = match class {
+            Class::CasMutable(v) | Class::Immutable(v) => *v,
+        };
+        assert_eq!(
+            listed,
+            versions.as_slice(),
+            "{name}: the table's read set disagrees with its reader's MIN/MAX constants. \
+             A widened gate must be recorded here too (ADR-0066 decision 4)."
+        );
+    }
 }
 
 /// Every CasMutable supported set is non-empty and includes version 1 (the

--- a/docs/adrs/0066-format-migration-machinery.md
+++ b/docs/adrs/0066-format-migration-machinery.md
@@ -212,10 +212,16 @@ which fails if a new versioned message lands unclassified):
 | `ProvisioningRecord` | **CAS-mutable** | `provisioning::append_generation`, `raise_format_floor` | **{1, 2}** |
 | `TenantConfigRecord` | **CAS-mutable** | `tenant_config::set_tenant_config` | **{1, 2}** |
 | `MetricMetadataRecord` | **CAS-mutable** | ingest metadata sink read→`merge_entries`→write | **{1, 2}** |
-| `AuthTokenMap` | **CAS-mutable** | `sys/auth` CAS-replace | {1, 2} (already, managed_by) |
-| `GcConfig` | **CAS-mutable** | `ravel-maintain::gc_config::set_gc_config` | {1} |
-| `CompactionClaim` | **CAS-mutable** | ADR-1029 claim renew/steal/complete | {1} |
-| `KeyEpochRecord` | **CAS-mutable** | `ravel-catalog::key_epoch` append-epoch CAS | {1} |
+| `AuthTokenMap` | **CAS-mutable** | `sys/auth` CAS-replace | {1, 2} (managed_by; floor added in R2) |
+| `GcConfig` | **CAS-mutable** | `ravel-maintain::gc_config::set_gc_config` | {1}, ceiling-only gate |
+| `CompactionClaim` | **CAS-mutable** | ADR-1029 claim renew/steal/complete | {1}, ceiling-only gate |
+| `KeyEpochRecord` | **CAS-mutable** | `ravel-catalog::key_epoch` append-epoch CAS | {1} (floor added in R2) |
+
+Every read set in this table that belongs to a reader in `ravel-catalog` is
+asserted against that reader's own `MIN_READ_VERSION..=MAX_READ_VERSION`
+constants by the enumeration test, so a widened gate that does not update this
+table fails. The four rows whose readers live in other crates are maintained by
+hand.
 
 "Never rewritten" covers the write-once markers AND the sole-writer
 `PutMode::Overwrite` snapshots (`AdmissionUsageSnapshot`, `WorkerHeartbeat`): each
@@ -240,10 +246,12 @@ record without the field.
 **R1 (this change, #1300).** The reader half, for the three records whose gates
 were permissive: `ProvisioningRecord`, `TenantConfigRecord`, `MetricMetadataRecord`
 now accept the read set exactly {1, 2} and their CAS rewrite paths refuse a
-record whose version exceeds what this build's writer stamps (still 1),
+record whose version exceeds what this build's writer stamps (1 as of R1; see
+the R2 amendment below, which raised it to 2),
 preventing the strip before any version-2 writer exists. The accepted set is a
-set with a floor, not a ceiling: each reader gate rejects a version below 1 with
-the same typed `UnsupportedVersion` error it uses for a version above 2. A
+set with a floor, not a ceiling: each reader gate rejects a version below 1 as
+well as one above 2. (R1 reported both sides with one typed
+`UnsupportedVersion` error; R2 split them, see below.) A
 version-0 record — a valid-shaped record from a writer that never stamped
 `format_version` — is therefore refused rather than admitted and later rewritten
 as version 1 by a CAS path; whether any pre-release binary ever wrote such a
@@ -256,11 +264,11 @@ any rolling upgrade. R1 is the readers; **R2** (a later task, after this reader
 is fleet-wide) is the writer flip that stamps 2 with a new additive field and
 models it.
 
-**R2's obligation.** When R2 adds the version-2 field, it models that field in
-these readers and re-encoders, so a version-2 record is then read AND rewritten
-without loss — the read set stays {1, 2} but the rewrite paths stop refusing 2.
-Until R2, a version-2 record cannot exist (every writer stamps 1), so R1's
-refusals only ever fire during a mixed-version window a future R2 rollout opens.
+**R2's obligation.** R2 flips the writer to stamp 2. The read set stays {1, 2}
+and the rewrite paths stop refusing 2, because 2 becomes what this build's writer
+itself produces. Until R2, a version-2 record cannot exist (every writer stamps
+1), so R1's refusals only ever fire during a mixed-version window the R2 rollout
+opens. See the R2 amendment below for what actually shipped.
 
 **A note on `MetricMetadataRecord`'s serve path.** Its record is read by two
 callers with opposite obligations: the ingest sink merges and CAS-writes it back
@@ -271,25 +279,26 @@ splits the read accordingly rather than forcing both through one function.
 with, so it refuses a version-2 record and keeps the sink from stripping.
 `read_metrics_meta_for_serve` is the read-only decoder for the cache; it applies
 the shared `decode_body` gate ({1, 2}) and does NOT apply the rewrite refusal, so
-a version-2 record's v1 fields are served rather than turned into an empty
-snapshot. The query metadata cache's fetch calls the serve reader. An earlier
+a record above what this build rewrites has its readable fields served rather
+than turned into an empty snapshot. BOTH of the query metadata cache's reads —
+the inline fill and the background refresh — call the serve reader; the strict
+`read_metrics_meta` survives only on the paths that write the record back (the
+ingest metadata sink and the server's metadata sink task). An earlier
 draft of this amendment accepted "serve an empty record for one horizon" on a
 version-2 record during an R2 rollout as a bounded cost; the split removes that
-degradation, so it is no longer a trade-off this ADR accepts. (The single
-background-refresh caller in that cache still uses the strict reader; widening it
-is follow-up work outside #1300's permitted scope and does not reintroduce the
-serve-empty horizon on the inline fetch path.)
+degradation, so it is no longer a trade-off this ADR accepts.
 
-**The four never-audited records, reported not fixed here (their crates are in
-flight under other work):** `TenantRecoveryManifest` and `AdmissionUsageSnapshot`
-are never-rewritten (write-once and sole-writer-overwrite respectively), so they
-carry no strip risk. `GcConfig` (ravel-maintain) and `KeyEpochRecord`
-(ravel-catalog `key_epoch`) ARE CAS-mutable and still carry the permissive reader
-gate; neither has an additive field shipped past version 1 today, so neither is a
-*live* strip instance, but both would be if an additive field lands before their
-gate is widened. `CompactionClaim` (ADR-1029) is likewise CAS-mutable with a
-permissive gate and no post-v1 additive field. These are flagged for their owning
-tasks; this change does not touch their gates.
+**The four never-audited records.** `TenantRecoveryManifest` and
+`AdmissionUsageSnapshot` are never-rewritten (write-once and
+sole-writer-overwrite respectively), so they carry no strip risk. `GcConfig`
+(ravel-maintain) and `KeyEpochRecord` (ravel-catalog `key_epoch`) ARE CAS-mutable
+and, at R1, still carried the permissive reader gate; neither has an additive
+field shipped past version 1 today, so neither is a *live* strip instance, but
+both would be if an additive field lands before their gate is widened.
+`CompactionClaim` (ADR-1029) is likewise CAS-mutable with a permissive gate and
+no post-v1 additive field. R1 did not touch any of their gates. R2 fixed
+`KeyEpochRecord`'s (it lives in this crate); `GcConfig` and `CompactionClaim`
+remain flagged for their owning tasks in ravel-maintain and ravel-fleet.
 
 **Rejected R1 alternatives** (and why the reader-set-plus-rewrite-refusal shape
 won): an unknown-tail bytes field to carry unmodeled fields across a rewrite (its
@@ -299,3 +308,72 @@ gate (a durable read on every CAS path, and it cannot protect the first write
 after a bump); and prospective-only (bump only future writers), which leaves f6,
 f7, and f12 strippable by every already-deployed binary — the live half of the
 bug.
+
+## Amendment (R2, 2026-09-07, #1300): the writer flip, and floors on the last two gates
+
+**The writer flip.** From this change the three CAS-mutable records this crate
+owns are stamped version 2 by every writer that emits them:
+`ProvisioningRecord` (`validate_or_adopt`, `append_generation`,
+`raise_format_floor`), `TenantConfigRecord` (`set_tenant_config`), and
+`MetricMetadataRecord` (`write_metrics_meta`). The readers' accepted set is
+unchanged at {1, 2}, so every version-1 record any earlier build wrote stays
+readable and nothing is migrated. The two CAS rewrite paths on
+`ProvisioningRecord` also re-stamp: a version-1 record they append to comes back
+as version 2.
+
+**What the flip buys, which is the whole point of the issue.** A binary that
+predates R1 accepts only version 1. Against a record this build wrote, it now
+REFUSES rather than decoding it, dropping the fields it does not model, and
+CAS-writing the stripped record back. That is the fail-closed behaviour #1300
+asks for, and it is now the observable behaviour of a real code path rather than
+a claim: each of the three record families has a test that seeds a current-writer
+record carrying a field this build does not model, hands it to the shared decode
+gate instantiated at the pre-R1 bounds (exactly {1}), asserts the typed
+above-ceiling refusal, and asserts the stored bytes are byte-identical afterwards
+— then flips the stamp to 1 and asserts the same rewrite strips the field, so the
+hazard is demonstrated and not merely asserted.
+
+**Rollout precondition, unchanged from R1 and now load-bearing.** This flip is
+safe only because R1's readers are already fleet-wide. A deployment that has NOT
+rolled out an R1 build must not run an R2 build: `ProvisioningRecord` is read on
+the ingest hot path by `GenerationSwitch`, which fails a flush CLOSED, so a
+pre-R1 binary meeting a version-2 record refuses the flush. That is the intended
+fail-closed direction, but during a rolling upgrade it is an outage, which is
+precisely why the bump was split across two releases.
+
+**Deleting version-1 read support is a later, separate change.** It is legal only
+when every bucket's recorded `format_floors` for the affected family exceeds
+version 1, per decision 3: the floor is raised by the migration job's
+verification step after an `audit-versions` enumeration comes back clean, and the
+change that drops the read support must cite those recorded floors. Nothing in
+R2 authorizes it. Until then the read set stays {1, 2} and a version-1 record is
+a first-class readable record.
+
+**The last two ceiling-only gates.** `AuthTokenMap` (`decode_map`) and
+`KeyEpochRecord` (`read_epochs_checked`) carried the same defect R1 fixed on the
+other three: a `format_version > CONSTANT` test with no floor, so version 0 — an
+unstamped record no supported writer produced — was admitted, decoded, and then
+re-encoded whole by the next CAS write, stamped at this build's version with any
+unmodeled field dropped. Both now gate on a closed set:
+`AUTH_TOKEN_MAP_MIN_READ_VERSION..=AUTH_TOKEN_MAP_MAX_READ_VERSION` = {1, 2} and
+`KEY_EPOCH_MIN_READ_VERSION..=KEY_EPOCH_MAX_READ_VERSION` = {1}. Neither ceiling
+is widened: widening one would start an unrequested readers-before-writers
+sequence for a record with no additive field to ship.
+
+**Split diagnostics.** All five gates now report the two ways a version can fall
+outside the set with two different typed errors. `UnsupportedVersion` names the
+ceiling and tells the operator to upgrade the binary; `VersionBelowFloor` names
+the floor and says explicitly that the record is unstamped or predates the floor
+and is *not* a future format. R1 used one variant whose message called a
+below-floor version "a future record format", which points at the opposite
+remediation from the one that would work.
+
+**Formal method: RUST_ONLY.** No TLA+ or Alloy model. The version stamp is a
+field on a record, not a protocol step: there is no new interleaving to check,
+because the ordering constraint (readers everywhere before any writer emits the
+new version) is the same readers-before-writers sequencing R1 already stated as
+the class rule, and this change is one release of that sequence. The properties
+that could go wrong here are single-record decode properties — which versions a
+gate admits, and whether a refused rewrite leaves the object untouched — and
+those are pinned by tests over the real code, including a `MemoryStore`
+byte-identity assertion after each refusal.

--- a/proto/ravel/sys.proto
+++ b/proto/ravel/sys.proto
@@ -92,15 +92,25 @@ message ProvisioningRecord {
   // reader that only knows a lower version refuses rather than misreading a
   // future layout as v1 (matching TenancyMarker's format_version guard).
   //
-  // Writers stamp 1. Readers accept the SET {1, 2}: this record is CAS-mutable
-  // (append_generation, raise_format_floor rewrite it whole), so per the
-  // ADR-0066 R1 amendment its readers accept the next version before any writer
-  // emits it (readers-before-writers), and its rewrite paths REFUSE a record
-  // whose version exceeds what this build's writer stamps rather than re-encode
-  // it through an older field set and strip a field a newer writer added. This
-  // is why the ADR-0052 note below, which reasons only about an old READER, is
-  // not sufficient on its own for a CAS-mutable record: an old WRITER rewriting
-  // a newer record is the hazard the SET and the rewrite refusal close.
+  // Version 2 is current: writers stamp 2 and readers accept the SET {1, 2}.
+  // Version 1 remains fully readable, so a record any earlier build wrote is
+  // still read, and nothing has to be migrated.
+  //
+  // This record is CAS-mutable (append_generation, raise_format_floor rewrite it
+  // whole), so per the ADR-0066 R1 amendment its readers accepted version 2
+  // fleet-wide one release BEFORE any writer emitted it
+  // (readers-before-writers); the R2 amendment then flipped the writer into that
+  // already-accepted ceiling. Its rewrite paths REFUSE a record whose version
+  // exceeds what this build's writer stamps rather than re-encode it through an
+  // older field set and strip a field a newer writer added. This is why the
+  // ADR-0052 note below, which reasons only about an old READER, is not
+  // sufficient on its own for a CAS-mutable record: an old WRITER rewriting a
+  // newer record is the hazard the SET and the rewrite refusal close.
+  //
+  // A version-1 writer never emits `generations` (field 6) or `format_floors`
+  // (field 7): both were added after that writer, which is exactly why a binary
+  // predating the R1 readers now refuses a version-2 record rather than
+  // rewriting it without them.
   //
   // Adding `generations` (field 6) is additive and does NOT bump the version a
   // WRITER stamps: a pre-ADR-0052 reader that skips the unknown field 6 still
@@ -147,11 +157,13 @@ message ProvisioningRecord {
   // That old-READER reasoning is necessary but not sufficient for this
   // CAS-mutable record: an old WRITER that rewrites a record a newer writer
   // stamped (append_generation, raise_format_floor) would re-encode it without a
-  // field it does not model and strip it. The R1 amendment (ADR-0066, #1300)
-  // closes that: readers accept the version SET {1, 2}, and the rewrite paths
-  // refuse a record newer than the writer stamps. Any additive field added after
-  // this one still follows the CAS-mutable rule: bump the version, ship the
-  // reader that accepts it fleet-wide, THEN flip the writer.
+  // field it does not model and strip it. The R1 and R2 amendments (ADR-0066,
+  // #1300) close that: readers accept the version SET {1, 2}, the writer now
+  // stamps 2 so a binary predating those readers fails closed on every current
+  // record instead of stripping it, and the rewrite paths refuse a record newer
+  // than the writer stamps. Any additive field added after this one still
+  // follows the CAS-mutable rule: bump the version, ship the reader that accepts
+  // it fleet-wide, THEN flip the writer.
   //
   // Decode enforces, per family, that floor_version is strictly increasing in
   // append order (floors raised only); a later entry for a family at or below an
@@ -412,7 +424,15 @@ message KeyEpochRecord {
   // Format floor: the minimum reader version that understands this record. A
   // reader that only knows a lower version refuses rather than misreading a
   // future layout as v1 (matching TenancyMarker/ProvisioningRecord/GcConfig).
-  // = 1.
+  //
+  // Writers stamp 1, and readers accept the SET {1}: a floor as well as a
+  // ceiling, since ADR-0066 R2. This record is CAS-mutable (record_key_epoch
+  // re-encodes it whole to append an epoch), so an unstamped version-0 record
+  // admitted by the old ceiling-only gate would have come back stamped 1 with
+  // any field this build does not model dropped. Version 0 is now refused with a
+  // below-floor error, distinct from the above-ceiling one. An additive field
+  // here follows the CAS-mutable rule: bump to 2, ship the reader that accepts
+  // {1, 2} fleet-wide, THEN flip the writer.
   uint32 format_version = 1;
   bytes tenant_hash = 2;         // 16 bytes; the `t/<tenant_hash>/` prefix owner
   sfixed64 created_unix_ns = 3;  // informational; when the record was first written
@@ -533,13 +553,21 @@ message TenantConfigRecord {
   // reader that only knows a lower version refuses rather than misreading a
   // future layout, matching every other durable record's version guard.
   //
-  // Writers stamp 1. Readers accept the SET {1, 2}: this record is CAS-mutable
-  // (set_tenant_config rebuilds it whole under CasVersion, naming every field it
-  // knows), so per the ADR-0066 R1 amendment its reader accepts the next version
-  // before any writer emits it, and set_tenant_config REFUSES to rewrite a record
-  // newer than this build's writer stamps rather than rebuild it at the older
-  // field set and strip a field a newer writer added (e.g. a field past
-  // `typed_attr_columns`).
+  // Version 2 is current: writers stamp 2 and readers accept the SET {1, 2}.
+  // Version 1 remains fully readable, so a record any earlier build wrote is
+  // still read, and nothing has to be migrated.
+  //
+  // This record is CAS-mutable (set_tenant_config rebuilds it whole under
+  // CasVersion, naming every field it knows), so per the ADR-0066 R1 amendment
+  // its reader accepted version 2 fleet-wide one release BEFORE any writer
+  // emitted it; the R2 amendment then flipped the writer into that
+  // already-accepted ceiling. set_tenant_config REFUSES to rewrite a record newer
+  // than this build's writer stamps rather than rebuild it at the older field set
+  // and strip a field a newer writer added.
+  //
+  // A version-1 writer never emits `typed_attr_columns` (field 12): it was added
+  // after that writer, which is exactly why a binary predating the R1 readers now
+  // refuses a version-2 record rather than rebuilding it without that field.
   uint32 format_version = 1;
   bytes tenant_hash = 2;              // 16 bytes; the `t/<tenant_hash>/` prefix owner
   TenantLifecycleState lifecycle_state = 3;
@@ -563,12 +591,14 @@ message TenantConfigRecord {
   // present-but-empty vs absent distinction). Additive field: a reader that
   // skips this unknown field reads every earlier field exactly as before, and a
   // reader that understands it sees an absent sub-message on every pre-ADR-0090
-  // record, identical to "no override". No writer version bump for THIS field
-  // (ADR-0090 Consequences). But note this record is CAS-mutable: any field
-  // added AFTER this one must follow the CAS-mutable rule (ADR-0066 R1
-  // amendment) -- bump the version, ship the reader that accepts it fleet-wide,
-  // then flip the writer -- because set_tenant_config rewrites the record whole
-  // and a lagging writer would otherwise strip the new field.
+  // record, identical to "no override". No writer version bump was taken for
+  // THIS field (ADR-0090 Consequences); the writer's later move to 2 is the
+  // ADR-0066 R2 floor signal for the record as a whole, not a bump on this
+  // field's account. Any field added AFTER this one must follow the CAS-mutable
+  // rule (ADR-0066 R1 amendment) -- bump the version, ship the reader that
+  // accepts it fleet-wide, then flip the writer -- because set_tenant_config
+  // rewrites the record whole and a lagging writer would otherwise strip the new
+  // field.
   TypedAttrColumnConfig typed_attr_columns = 12;
 }
 
@@ -642,6 +672,13 @@ message AuthTokenMap {
   // upgraded too. A v2+ reader accepts both a stored 1 and a stored 2
   // (every entry decodes the same either way; an absent `managed_by` just
   // means unmanaged).
+  //
+  // The accepted set is exactly {1, 2}: a floor as well as a ceiling, since
+  // ADR-0066 R2. This object is CAS-mutable (upsert_token and its siblings
+  // rebuild it whole under CasVersion), so an unstamped version-0 object admitted
+  // by the old ceiling-only gate would have come back stamped 2 with any field
+  // this build does not model dropped. Version 0 is now refused with a
+  // below-floor error, distinct from the above-ceiling one.
   uint32 format_version = 1;
   // A 16-byte fingerprint of the deployment key the token hashes are keyed
   // under: blake3::derive_key("ravel-auth-v1-fingerprint", deployment_key)
@@ -728,15 +765,24 @@ message MetricMetadataRecord {
   // reader that only knows a lower version refuses rather than misreading a
   // future layout, matching every other durable record's version guard.
   //
-  // Writers stamp 1. The decode gate accepts the SET {1, 2}: this record is
-  // CAS-mutable (the ingest sink reads it, field-wise re-merges via
-  // merge_entries, and CAS-writes it back), so per the ADR-0066 R1 amendment the
-  // decode gate accepts the next version before any writer emits it. The read
-  // that FEEDS that rewrite (read_metrics_meta, which returns the CAS version a
-  // caller writes back with) is stricter: it REFUSES a record newer than this
-  // build's writer stamps, so a lagging binary drops the merge window rather than
-  // re-encoding the record through an older field set and stripping a field a
-  // newer writer added.
+  // Version 2 is current: writers stamp 2 and the decode gate accepts the SET
+  // {1, 2}. Version 1 remains fully readable, so a record any earlier build wrote
+  // is still read, and nothing has to be migrated.
+  //
+  // This record is CAS-mutable (the ingest sink reads it, field-wise re-merges
+  // via merge_entries, and CAS-writes it back), so per the ADR-0066 R1 amendment
+  // the decode gate accepted version 2 fleet-wide one release BEFORE any writer
+  // emitted it; the R2 amendment then flipped the writer into that
+  // already-accepted ceiling. The read that FEEDS that rewrite
+  // (read_metrics_meta, which returns the CAS version a caller writes back with)
+  // is stricter: it REFUSES a record newer than this build's writer stamps, so a
+  // lagging binary drops the merge window rather than re-encoding the record
+  // through an older field set and stripping a field a newer writer added.
+  //
+  // Unlike the other two records the R2 flip covers, version 2 here adds NO
+  // field: every field a version-2 writer emits, a version-1 writer emitted too.
+  // The bump is purely the floor signal, so a binary predating the R1 decode gate
+  // fails closed on a current record instead of rewriting it.
   uint32 format_version = 1;
   // One entry per metric family name. Decode enforces: every family_name is
   // non-empty, no family_name repeats (a duplicate would make a


### PR DESCRIPTION
Mutable sys records grow new fields without a version bump, and a lagging
binary that rewrites the record whole under compare-and-swap strips those
fields: prost keeps no unknown fields, and the provisioning, tenant config
and metric metadata writers all round-trip or rebuild the record. The
first round made every reader a supported-set gate accepting {1, 2} with a
floor, so the N-1 reader was in place before an N writer could ship.

This round flips the three writers to stamp format_version 2, so a binary
that predates the first round refuses these records instead of stripping
them, which is the fail-closed behaviour the issue asks for. Deleting
version-1 read support stays a later change that must cite the recorded
floors. The two remaining ceiling-only gates, auth_token_map's decode_map
and key_epoch's read_epochs_checked, which accepted version 0, get the
same floor-and-ceiling treatment through a shared check_read_version with
distinct below-floor and above-ceiling errors. The proto comments say
version 2 is current and version 1 stays readable; ADR-0066 carries a
dated R2 amendment and its refresh-path sentence now matches the code.

The issue's own test runs once per record family: a version-2 record is
rewritten through a reader whose accepted set is exactly {1}, the rewrite
is refused with the above-ceiling error, and the stored bytes are
unchanged. The classification table asserts each record's version slice
against its reader's re-exported constants and derives its expected count
from the table, so a widened gate fails the table.

Out of scope and reported: CompactionClaim in ravel-fleet has the same
ceiling-only gate, GcConfig gates with equality and cannot widen, and
ADR-0072 quotes the old auth_token_map expression.

Fixes: #1300
