### PR TITLE
feat(operator): qualify object store before serving

### DIFF
--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -605,6 +605,11 @@
                     "format": "int32",
                     "nullable": true,
                     "type": "integer"
+                  },
+                  "storeQualifiedHash": {
+                    "description": "The qualify-Job input hash (bucket, region, endpoint, image, credentials\nSecret name) that store qualification last succeeded against (issue #36).\nThe operator gates serving on `ravel store qualify` before it creates any\nDeployment; recording the qualified inputs here makes that gate durable:\na later pass whose inputs still hash to this value proceeds without\nre-running qualification even after the one-shot Job has been\nTTL-garbage-collected, and a pass whose inputs no longer match re-runs it\n(the `StoreQualified` condition flips back to `Pending`) without tearing\ndown the running Deployments. Absent until the first qualification\nsucceeds. Qualification is never re-run on a schedule; only an input\nchange re-triggers it.",
+                    "nullable": true,
+                    "type": "string"
                   }
                 },
                 "type": "object"

--- a/deploy/k8s/operator/rbac.yaml
+++ b/deploy/k8s/operator/rbac.yaml
@@ -13,6 +13,11 @@
 #   - PodDisruptionBudgets (policy): full lifecycle, for the per-tier PDBs the
 #     operator renders (issue #126, ADR-0034 hardening amendment). Delete is what
 #     converges maintain's PDB away when maintain.enabled goes back to false.
+#   - Jobs (batch): full lifecycle, for the one-shot store-qualification Job the
+#     operator runs before it creates any serving Deployment (issue #36). Create
+#     to start it, get/list/watch to observe its terminal state, delete to
+#     recreate it when the qualified inputs change (its pod template is
+#     immutable) and to let its TTL-driven cleanup be operator-owned.
 #   - RavelCluster (and its status subresource): watch the spec, write status.
 #   - Secrets: get only, and NEVER granted by this cluster-wide ClusterRole
 #     (issue #126). The operator reads the credentials, tenant-token, and
@@ -87,6 +92,9 @@ rules:
     verbs: ["get", "update", "patch"]
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
+    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
     verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -307,14 +307,37 @@ loop as everything else:
   namespace, with the server image, credentials Secret, bucket, region, and
   endpoint of the tiers it gates, running `ravel store qualify`. The
   gateway, query, and maintain Deployments are created only once that Job
-  reports `Complete`. `restartPolicy: Never`, a small `backoffLimit`, and a
-  `ttlSecondsAfterFinished` keep a finished Job from accumulating.
+  reports `Complete`. `restartPolicy: Never`, a small `backoffLimit`, an
+  `activeDeadlineSeconds`, and a `ttlSecondsAfterFinished` keep a finished
+  Job from accumulating.
+- The Job sets `activeDeadlineSeconds` because `backoffLimit` bounds only how
+  many *failed* attempts run, not one attempt that never terminates: a
+  qualify pod against an S3 endpoint that accepts the connection and then
+  never answers would otherwise run indefinitely, leaving `StoreQualified`
+  stuck at `Pending` with no Deployment ever created. The deadline is 900 s,
+  derived from what `ravel store qualify` does: it runs 28 sequential object
+  operations (create-if-absent probe 3, CAS-version probe 4, read-after-write
+  probe 10 = 5 cycles of put+get, list-after-write probe 10 = 5 cycles of
+  put+list, and the final `sys/qualification` write 1; the two informational
+  probes issue no request through the object-store contract). Each operation's
+  per-request ceiling is the S3 client's 20 s `request_timeout`, so a
+  slow-but-healthy run whose every operation nears that ceiling without
+  retrying is bounded by 28 * 20 s = 560 s. 900 s adds a ~1.6x margin (340 s)
+  for pod scheduling, image pull, and the odd single retry, while staying far
+  below a hung endpoint's ~200 s-per-operation worst case (`retry_timeout`
+  180 s + `request_timeout` 20 s), so a hang trips the deadline after roughly
+  four stalled operations. The deadline is a tuning knob, deliberately not
+  part of the qualified-input hash: changing it must not re-run a
+  qualification that already passed.
 - A new `StoreQualified` status condition carries the gate's state with the
   same shape as the other conditions (reasons `Pending` while the Job is
-  created or running, `Succeeded` once it completes, `Failed` when it
-  exhausts its `backoffLimit`, the last carrying the Job's terminal
-  message). On `Failed` no Deployment is created and the pass requeues on
-  the existing failure backoff rather than spinning.
+  created or running, `Succeeded` once it completes, `Failed` when it fails,
+  the last carrying the Job's terminal reason and message). A Job that fails
+  by exhausting its `backoffLimit` and one the Job controller fails for
+  exceeding `activeDeadlineSeconds` (reason `DeadlineExceeded`) both read as
+  `Failed`, with the reason named in the message so an operator sees why. On
+  `Failed` no Deployment is created and the pass requeues on the existing
+  failure backoff rather than spinning.
 - The inputs qualification proves against (bucket, region, endpoint, image,
   credentials Secret name) are hashed into a Job annotation and, on success,
   into a durable `status.storeQualifiedHash`. A later pass whose inputs

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -289,6 +289,57 @@ runtime; nothing rejects the pod for the dropped capability. What the kind
 lane actually proves is that the hardened pods reach readiness and complete
 an OTLP round trip, not that a missing capability is rejected.
 
+**Amendment (2026-09-07): the operator qualifies the object store before it
+serves (issue #36).** Every `ravel-server` mode refuses to start on a
+non-Memory store whose `sys/qualification` marker is absent (ADR-0050
+section 6, EC7), and that marker is only ever written by an explicit
+`ravel store qualify` run. The operator described in decision 3 never made
+that run, so a RavelCluster pointed at a backend that fails the object-store
+contract (docs/object-store-contract.md) came up as three tiers of pods all
+crash-looping on the same startup refusal, with the reason buried in pod
+logs rather than on `.status`. The kind lane papered over this with a
+hand-run qualification Job (scripts/kind-up.sh) that a real install had no
+equivalent of. Qualification is now the operator's job, in the same reconcile
+loop as everything else:
+
+- Before it creates any serving Deployment, the reconcile loop renders and
+  applies a one-shot Job named `<cluster>-qualify` in the cluster's
+  namespace, with the server image, credentials Secret, bucket, region, and
+  endpoint of the tiers it gates, running `ravel store qualify`. The
+  gateway, query, and maintain Deployments are created only once that Job
+  reports `Complete`. `restartPolicy: Never`, a small `backoffLimit`, and a
+  `ttlSecondsAfterFinished` keep a finished Job from accumulating.
+- A new `StoreQualified` status condition carries the gate's state with the
+  same shape as the other conditions (reasons `Pending` while the Job is
+  created or running, `Succeeded` once it completes, `Failed` when it
+  exhausts its `backoffLimit`, the last carrying the Job's terminal
+  message). On `Failed` no Deployment is created and the pass requeues on
+  the existing failure backoff rather than spinning.
+- The inputs qualification proves against (bucket, region, endpoint, image,
+  credentials Secret name) are hashed into a Job annotation and, on success,
+  into a durable `status.storeQualifiedHash`. A later pass whose inputs
+  still hash to the recorded value proceeds without re-running qualification
+  even after the Job's TTL garbage-collected it. When the inputs change, the
+  operator deletes the stale Job (its pod template is immutable), recreates
+  it, and flips `StoreQualified` back to `Pending`; a cluster that was
+  already serving keeps its existing Deployments up while the new inputs
+  qualify, rather than being torn down for a pending config edit.
+- Non-goal: qualification is not re-run on a schedule. It runs once per
+  distinct set of inputs and only re-runs when those inputs change. A
+  periodic re-qualification would add object-store traffic and a recurring
+  failure mode for no gain, since the contract a backend satisfies does not
+  lapse between config edits.
+
+Because the operator now qualifies, the kind lane's hand-run qualification
+Job is removed from scripts/kind-up.sh: it deploys through the operator, so
+the operator's Job is the single qualification and a second one would only
+duplicate it. The RBAC in deploy/k8s/operator/rbac.yaml gains a `batch`
+`jobs` rule (full lifecycle) for the Job the operator now owns. The gate
+decision and the Job renderer are pure functions in `reconcile.rs` with
+unit tests; the runtime behavior (the Job actually completing and the
+Deployments appearing only after) is left to the k8s CI lane (decision 8),
+unproven until that lane runs.
+
 ## Rejected alternatives
 
 1. **Go operator (kubebuilder/controller-runtime).** The larger example

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,7 +195,17 @@ encryption headers.
 Startup on any non-memory store is also gated on a durable qualification
 record: a deployment runs `ravel-cli store qualify` once before its first
 server starts, which proves the backend honours the semantics the commit
-protocol depends on before any data rides on them. The capability table, the
+protocol depends on before any data rides on them. On Kubernetes the
+operator makes that run itself: before it creates any serving Deployment for
+a `RavelCluster`, it applies a one-shot `<cluster>-qualify` Job running
+`ravel store qualify` against that cluster's bucket and gates the gateway,
+query, and maintain Deployments on the Job completing, so a cluster never
+comes up as three tiers crash-looping on a backend that fails the contract.
+It records the qualified inputs (bucket, region, endpoint, image,
+credentials Secret) in a `StoreQualified` status condition and a durable
+`status.storeQualifiedHash`, re-runs qualification only when those inputs
+change (never on a schedule), and leaves a running cluster's Deployments up
+while re-qualifying (ADR-0034). The capability table, the
 qualification suite, and the retry and timeout contract are in
 [docs/object-store-contract.md](object-store-contract.md).
 

--- a/scripts/kind-up.sh
+++ b/scripts/kind-up.sh
@@ -194,62 +194,11 @@ if ! kubectl wait --namespace "$NAMESPACE" --for=condition=Complete --timeout=30
 fi
 log "bucket ${BUCKET} ready on ${S3_ENDPOINT}"
 
-# ---- 4b. store qualification --------------------------------------------
-# ADR-0050 section 6 (EC7): server startup on a non-Memory store
-# refuses unless `sys/qualification` is already present. Unlike the tenancy
-# marker and gc-config objects, there is deliberately no bootstrap-and-continue
-# path for this one -- it is only ever written by an explicit `ravel-cli store
-# qualify` run, so this script has to be that run, or every gateway/query/
-# maintain pod the RavelCluster below creates crash-loops on a fresh bucket
-# (the exact EC3/#566 startup-refusal shape, this time for qualification).
-# Runs as a one-shot Job using the server image already loaded into the
-# cluster (it ships ravel-cli alongside ravel-server, see the Dockerfile),
-# against the same bucket/credentials the RavelCluster will use.
-log "running store qualification (ravel-cli store qualify) against ${S3_ENDPOINT}"
-kubectl delete job ravel-store-qualify --namespace "$NAMESPACE" \
-  --ignore-not-found --wait=true >/dev/null
-kubectl apply -f - <<YAML
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ravel-store-qualify
-  namespace: ${NAMESPACE}
-spec:
-  backoffLimit: 2
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: qualify
-          image: ${SERVER_IMAGE}
-          imagePullPolicy: IfNotPresent
-          command: ["/usr/local/bin/ravel-cli"]
-          args: ["--store", "s3", "store", "qualify"]
-          env:
-            - name: RAVEL_S3_ENDPOINT
-              value: "${S3_ENDPOINT}"
-            - name: RAVEL_S3_BUCKET
-              value: "${BUCKET}"
-            - name: RAVEL_S3_REGION
-              value: "us-east-1"
-            - name: RAVEL_S3_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ${S3_CREDENTIALS_SECRET}
-                  key: accessKeyId
-            - name: RAVEL_S3_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ${S3_CREDENTIALS_SECRET}
-                  key: secretAccessKey
-YAML
-if ! kubectl wait --namespace "$NAMESPACE" --for=condition=Complete --timeout=120s \
-  job/ravel-store-qualify; then
-  kubectl logs --namespace "$NAMESPACE" job/ravel-store-qualify 2>&1 |
-    sed 's/^/[qualify-job] /' >&2 || true
-  die "store qualification job did not complete"
-fi
-log "store qualified"
+# Store qualification is no longer a step here: the operator runs its own
+# one-shot `<cluster>-qualify` Job before it creates any serving Deployment and
+# gates them on its success (issue #36, ADR-0034), so this script installing the
+# operator (step 5) and applying the RavelCluster (step 6) is enough to qualify
+# the bucket exactly once. A hand-run Job here would only duplicate it.
 
 # ---- 5. operator -------------------------------------------------------------
 # CRD before the operator Deployment: the operator's watch fails until the

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use k8s_openapi::api::apps::v1::Deployment;
+use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::{Secret, Service, ServiceAccount};
 use k8s_openapi::api::networking::v1::Ingress;
 use k8s_openapi::api::policy::v1::PodDisruptionBudget;
@@ -37,11 +38,14 @@ use crate::crd::{
 use crate::reconcile::{
     DEPLOYMENT_KEY_SECRET_KEY, DeploymentTier, GC_BOOTSTRAP_STALL_AFTER,
     GC_BOOTSTRAP_STALLED_REASON, GC_BOOTSTRAP_UNAVAILABLE_MESSAGE, GC_BOOTSTRAP_UNAVAILABLE_REASON,
-    GcBootstrapGate, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
-    WAITING_FOR_GC_BOOTSTRAP_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_REASON, desired_objects,
-    grpcroute_api_resource, httproute_api_resource, possible_gateway_route_names,
-    possible_ingest_ingress_names, possible_pod_disruption_budget_names,
-    possible_router_object_names,
+    GcBootstrapGate, QUALIFY_COMPONENT, QUALIFY_SPEC_HASH_ANNOTATION, QualificationDecision,
+    QualifyJobObservation, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
+    STORE_QUALIFIED_FAILED_REASON, STORE_QUALIFIED_MESSAGE, STORE_QUALIFIED_PENDING_REASON,
+    STORE_QUALIFIED_SUCCEEDED_REASON, STORE_QUALIFYING_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
+    WAITING_FOR_GC_BOOTSTRAP_REASON, desired_objects, desired_qualify_job, grpcroute_api_resource,
+    httproute_api_resource, possible_gateway_route_names, possible_ingest_ingress_names,
+    possible_pod_disruption_budget_names, possible_router_object_names, qualification_decision,
+    qualify_job_input_hash, qualify_job_phase,
 };
 
 /// Server-side-apply field manager name.
@@ -952,6 +956,14 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 .status
                 .as_ref()
                 .and_then(|status| status.gc_bootstrap_waiting_since.clone());
+            // The qualified-inputs hash is owned by the qualification gate, not
+            // this error path: carry the persisted value through unchanged so a
+            // transient error after a cluster is already qualified does not drop
+            // the record and re-trigger qualification on the next pass.
+            let store_qualified_hash = obj
+                .status
+                .as_ref()
+                .and_then(|status| status.store_qualified_hash.clone());
             if let Err(status_err) = write_degraded_status(
                 client,
                 &namespace,
@@ -960,6 +972,7 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 &reason,
                 &message,
                 waiting_since,
+                store_qualified_hash,
                 extra_conditions,
             )
             .await
@@ -981,6 +994,121 @@ async fn reconcile_inner(
     instance: &str,
     mut extra_conditions: Vec<Condition>,
 ) -> Result<Action, Error> {
+    // Store qualification gate (issue #36). Before anything that would read or
+    // write the object store is created -- the sys/auth token map, the ingest
+    // router, and above all the serving Deployments -- prove the store passes
+    // `ravel store qualify`. A cluster brought up on a backend that fails the
+    // object-store contract (docs/object-store-contract.md) would otherwise
+    // crash-loop every server pod with an opaque runtime error; here it fails
+    // once, visibly, on a one-shot Job, and the `StoreQualified` condition says
+    // why. Qualification is proven for the current inputs and never re-run on a
+    // schedule: a durable `status.storeQualifiedHash` records the inputs it last
+    // passed against, so a finished Job garbage-collected by its TTL does not
+    // re-trigger it (ADR-0034).
+    let jobs: Api<Job> = Api::namespaced(client.clone(), namespace);
+    let qualify_name = child(instance, QUALIFY_COMPONENT);
+    let desired_hash = qualify_job_input_hash(&obj.spec);
+    let qualified_hash = obj
+        .status
+        .as_ref()
+        .and_then(|status| status.store_qualified_hash.clone());
+    let observation = observe_qualify_job(&jobs, &qualify_name).await?;
+    let decision = qualification_decision(&desired_hash, qualified_hash.as_deref(), &observation);
+
+    // The hash to persist on THIS pass's status: the current inputs once
+    // qualification proceeds, otherwise the last-qualified value unchanged (kept
+    // so an in-flight re-qualification does not drop the record and, with it, the
+    // gate that keeps existing Deployments up while the new inputs qualify).
+    let store_qualified_hash = match &decision {
+        QualificationDecision::Proceed => {
+            extra_conditions.push(condition(
+                "StoreQualified",
+                true,
+                obj.metadata.generation,
+                STORE_QUALIFIED_SUCCEEDED_REASON,
+                STORE_QUALIFIED_MESSAGE,
+            ));
+            Some(desired_hash.clone())
+        }
+        _ => {
+            // Not qualified for the current inputs: create or recreate the Job,
+            // record a `StoreQualified` condition, and return WITHOUT touching
+            // any Deployment. A fresh cluster gets none; a running cluster
+            // re-qualifying after a config edit keeps the ones it has (this pass
+            // never reaches the Deployment apply/sweep below), so a pending
+            // config change does not tear a serving cluster down.
+            let owner = obj.controller_owner_ref(&()).map(|owner| vec![owner]);
+            let (store_qualified_condition, action) = match &decision {
+                QualificationDecision::Qualify { recreate } => {
+                    if *recreate {
+                        // The Job's inputs changed; its pod template is immutable,
+                        // so delete the stale Job (its pods with it) and let the
+                        // next pass observe it absent and create a fresh one.
+                        delete_if_present(&jobs, &qualify_name).await?;
+                    } else {
+                        let mut job = desired_qualify_job(&obj.spec, instance);
+                        job.metadata.namespace = Some(namespace.to_string());
+                        job.metadata.owner_references = owner;
+                        apply(&jobs, &qualify_name, &job).await?;
+                    }
+                    (
+                        condition(
+                            "StoreQualified",
+                            false,
+                            obj.metadata.generation,
+                            STORE_QUALIFIED_PENDING_REASON,
+                            STORE_QUALIFYING_MESSAGE,
+                        ),
+                        Action::requeue(BOOTSTRAP_POLL),
+                    )
+                }
+                QualificationDecision::Waiting => (
+                    condition(
+                        "StoreQualified",
+                        false,
+                        obj.metadata.generation,
+                        STORE_QUALIFIED_PENDING_REASON,
+                        STORE_QUALIFYING_MESSAGE,
+                    ),
+                    Action::requeue(BOOTSTRAP_POLL),
+                ),
+                QualificationDecision::Failed(message) => (
+                    condition(
+                        "StoreQualified",
+                        false,
+                        obj.metadata.generation,
+                        STORE_QUALIFIED_FAILED_REASON,
+                        message,
+                    ),
+                    Action::requeue(RETRY),
+                ),
+                QualificationDecision::Proceed => unreachable!("Proceed handled above"),
+            };
+            extra_conditions.push(store_qualified_condition);
+
+            // Report the readiness a prior pass recorded, so a cluster already
+            // serving through a re-qualification keeps `Available=True` instead of
+            // flipping to "waiting for tiers" on every poll while the new inputs
+            // qualify. A fresh cluster has none of these and reports Available=False.
+            let prior = obj.status.as_ref();
+            write_status(
+                client,
+                namespace,
+                instance,
+                obj.metadata.generation,
+                prior.and_then(|s| s.gateway_ready_replicas),
+                prior.and_then(|s| s.query_ready_replicas),
+                prior.and_then(|s| s.maintain_ready_replicas),
+                None,
+                prior.and_then(|s| s.gc_bootstrap_waiting_since.clone()),
+                qualified_hash,
+                extra_conditions,
+            )
+            .await?;
+            return Ok(action);
+        }
+    };
+
     let token_secret = resolve_token_secret(
         client,
         namespace,
@@ -1385,6 +1513,7 @@ async fn reconcile_inner(
         maintain_ready,
         available_hold.as_ref().map(|(r, m)| (*r, m.as_str())),
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         extra_conditions,
     )
     .await?;
@@ -1469,6 +1598,29 @@ async fn live_deployment_exists(api: &Api<Deployment>, name: &str) -> Result<boo
     match api.get(name).await {
         Ok(_) => Ok(true),
         Err(err) if is_not_found(&err) => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Observe the live qualify Job for a cluster (issue #36): its recorded input
+/// hash (the [`QUALIFY_SPEC_HASH_ANNOTATION`] value, `None` when the annotation
+/// is missing) and its terminal phase, or [`QualifyJobObservation::Absent`] when
+/// no Job exists (a fresh cluster, or one whose finished Job has been
+/// TTL-garbage-collected). A not-found is `Absent`; any other error propagates.
+async fn observe_qualify_job(jobs: &Api<Job>, name: &str) -> Result<QualifyJobObservation, Error> {
+    match jobs.get(name).await {
+        Ok(job) => {
+            let spec_hash = job
+                .metadata
+                .annotations
+                .as_ref()
+                .and_then(|annotations| annotations.get(QUALIFY_SPEC_HASH_ANNOTATION).cloned());
+            Ok(QualifyJobObservation::Present {
+                spec_hash,
+                phase: qualify_job_phase(&job),
+            })
+        }
+        Err(err) if is_not_found(&err) => Ok(QualifyJobObservation::Absent),
         Err(err) => Err(err.into()),
     }
 }
@@ -1580,6 +1732,7 @@ fn build_status(
     maintain_ready: Option<i32>,
     unavailable_reason: Option<(&str, &str)>,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let available = gateway_ready.unwrap_or(0) > 0 && query_ready.unwrap_or(0) > 0;
@@ -1610,6 +1763,7 @@ fn build_status(
         query_ready_replicas: query_ready,
         maintain_ready_replicas: maintain_ready,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         conditions,
     }
 }
@@ -1625,6 +1779,7 @@ fn build_degraded_status(
     reason: &str,
     message: &str,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let mut conditions = vec![
@@ -1638,6 +1793,7 @@ fn build_degraded_status(
         query_ready_replicas: None,
         maintain_ready_replicas: None,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         conditions,
     }
 }
@@ -1658,6 +1814,7 @@ async fn write_status(
     maintain_ready: Option<i32>,
     unavailable_reason: Option<(&str, &str)>,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_status(
@@ -1667,6 +1824,7 @@ async fn write_status(
         maintain_ready,
         unavailable_reason,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -1688,6 +1846,7 @@ async fn write_degraded_status(
     reason: &str,
     message: &str,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_degraded_status(
@@ -1695,6 +1854,7 @@ async fn write_degraded_status(
         reason,
         message,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -2134,6 +2294,7 @@ mod tests {
             Some(1),
             None,
             None,
+            None,
             extra.clone(),
         );
         assert_eq!(
@@ -2152,8 +2313,14 @@ mod tests {
             deprecated.message
         );
 
-        let degraded =
-            build_degraded_status(Some(7), "SecretNotFound", "no such Secret", None, extra);
+        let degraded = build_degraded_status(
+            Some(7),
+            "SecretNotFound",
+            "no such Secret",
+            None,
+            None,
+            extra,
+        );
         assert_eq!(
             condition_types(&degraded.conditions),
             vec!["Degraded", "Available", "IngestAffinityBackendDeprecated"]
@@ -2209,9 +2376,19 @@ mod tests {
                 "no spec-derived condition, got {:?}",
                 condition_types(&extra)
             );
-            let ok = build_status(Some(2), Some(1), Some(1), None, None, None, extra.clone());
+            let ok = build_status(
+                Some(2),
+                Some(1),
+                Some(1),
+                None,
+                None,
+                None,
+                None,
+                extra.clone(),
+            );
             assert_eq!(condition_types(&ok.conditions), vec!["Available"]);
-            let degraded = build_degraded_status(Some(2), "ReconcileError", "boom", None, extra);
+            let degraded =
+                build_degraded_status(Some(2), "ReconcileError", "boom", None, None, extra);
             assert_eq!(
                 condition_types(&degraded.conditions),
                 vec!["Degraded", "Available"]
@@ -2229,6 +2406,7 @@ mod tests {
             "SecretNotFound",
             "no such Secret",
             Some(since.clone()),
+            None,
             Vec::new(),
         );
         assert_eq!(
@@ -2236,7 +2414,8 @@ mod tests {
             Some(since.as_str()),
             "a transient error must leave the stall clock where it was"
         );
-        let cleared = build_degraded_status(Some(3), "ReconcileError", "boom", None, Vec::new());
+        let cleared =
+            build_degraded_status(Some(3), "ReconcileError", "boom", None, None, Vec::new());
         assert_eq!(cleared.gc_bootstrap_waiting_since, None);
     }
 
@@ -2258,6 +2437,7 @@ mod tests {
                 WAITING_FOR_GC_BOOTSTRAP_REASON,
                 WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
             )),
+            None,
             None,
             vec![condition(
                 "Degraded",
@@ -2292,6 +2472,7 @@ mod tests {
                 GC_BOOTSTRAP_UNAVAILABLE_MESSAGE,
             )),
             None,
+            None,
             vec![condition(
                 "Degraded",
                 true,
@@ -2318,6 +2499,7 @@ mod tests {
                 WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
             )),
             None,
+            None,
             Vec::new(),
         );
         let available = find(&ready.conditions, "Available");
@@ -2334,11 +2516,49 @@ mod tests {
     /// effect, where the old plan withheld the tiers and nothing ever unblocked.
     #[test]
     fn gc_bootstrap_unavailable_clears_once_the_request_serving_tiers_report_ready() {
-        let running = build_status(Some(9), Some(1), Some(1), None, None, None, Vec::new());
+        let running = build_status(
+            Some(9),
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+        );
         assert_eq!(condition_types(&running.conditions), vec!["Available"]);
         let available = find(&running.conditions, "Available");
         assert_eq!(available.status, "True");
         assert_eq!(available.reason, "MinimumReplicasAvailable");
+    }
+
+    /// The durable qualified-inputs hash (issue #36) is written into the status
+    /// by both builders, so the qualification gate survives the Job's TTL-GC and
+    /// an operator restart. A dropped field here would silently re-run
+    /// qualification on the next pass.
+    #[test]
+    fn status_builders_carry_the_store_qualified_hash() {
+        let ok = build_status(
+            Some(1),
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+            Some("qhash".to_string()),
+            Vec::new(),
+        );
+        assert_eq!(ok.store_qualified_hash.as_deref(), Some("qhash"));
+
+        let degraded = build_degraded_status(
+            Some(1),
+            "ReconcileError",
+            "boom",
+            None,
+            Some("qhash".to_string()),
+            Vec::new(),
+        );
+        assert_eq!(degraded.store_qualified_hash.as_deref(), Some("qhash"));
     }
 
     /// The stall threshold as a signed second count, the unit
@@ -2484,7 +2704,16 @@ mod tests {
         );
         // reconcile therefore builds the status with no wait timestamp and no
         // stall condition.
-        let status = build_status(Some(2), Some(1), Some(1), Some(1), None, None, Vec::new());
+        let status = build_status(
+            Some(2),
+            Some(1),
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+            Vec::new(),
+        );
         assert_eq!(
             status.gc_bootstrap_waiting_since, None,
             "the timestamp is cleared once not waiting"

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -738,6 +738,20 @@ pub struct RavelClusterStatus {
     #[serde(default)]
     pub gc_bootstrap_waiting_since: Option<String>,
 
+    /// The qualify-Job input hash (bucket, region, endpoint, image, credentials
+    /// Secret name) that store qualification last succeeded against (issue #36).
+    /// The operator gates serving on `ravel store qualify` before it creates any
+    /// Deployment; recording the qualified inputs here makes that gate durable:
+    /// a later pass whose inputs still hash to this value proceeds without
+    /// re-running qualification even after the one-shot Job has been
+    /// TTL-garbage-collected, and a pass whose inputs no longer match re-runs it
+    /// (the `StoreQualified` condition flips back to `Pending`) without tearing
+    /// down the running Deployments. Absent until the first qualification
+    /// succeeds. Qualification is never re-run on a schedule; only an input
+    /// change re-triggers it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store_qualified_hash: Option<String>,
+
     /// Standard Kubernetes conditions: `Available`, `Progressing`, `Degraded`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1929,6 +1929,33 @@ pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 4;
 /// garbage-collected after success does not re-trigger qualification.
 pub const QUALIFY_JOB_TTL_SECONDS: i32 = 3600;
 
+/// `activeDeadlineSeconds` for the qualify Job: a wall-clock bound on a single
+/// attempt, so a qualify pod that hangs (an S3 endpoint that accepts the TCP
+/// connection and then never answers) becomes a `Failed` Job with reason
+/// `DeadlineExceeded` instead of running indefinitely. `backoffLimit` bounds
+/// only how many *failed* attempts run; it does nothing for one attempt that
+/// never terminates, which leaves `StoreQualified` stuck at `Pending` forever.
+///
+/// The value must clear a slow-but-healthy run with margin. `ravel store
+/// qualify` runs 28 sequential object operations against the bucket: probe
+/// create-if-absent (put, put, get = 3), probe CAS version (put, put, put,
+/// get = 4), probe read-after-write ([`super`]'s `CONSISTENCY_CYCLES` = 5
+/// put+get = 10), probe list-after-write (5 put+list = 10), and the final
+/// `sys/qualification` create-if-absent write (1); the two informational
+/// probes issue no request through the `ObjectStoreBackend` contract. Each
+/// operation's per-request ceiling is the S3 client's 20 s `request_timeout`
+/// (ravel-object-store `S3HttpConfig::default`), so a slow-but-healthy run
+/// whose every operation approaches that ceiling without retrying is bounded
+/// by 28 * 20 s = 560 s. 900 s adds a ~1.6x margin (340 s of slack) for pod
+/// scheduling, image pull, and the occasional single retry, while staying far
+/// below a hung endpoint's ~200 s-per-operation worst case (`retry_timeout`
+/// 180 s + `request_timeout` 20 s): a hang trips the deadline after roughly
+/// four stalled operations rather than exhausting all 28.
+///
+/// Not part of [`qualify_job_input_hash`]: tuning this deadline must not
+/// re-run a qualification that already passed.
+pub const QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS: i64 = 900;
+
 /// `StoreQualified` reason while the qualify Job is being created or is still
 /// running: serving is held until it reports success.
 pub const STORE_QUALIFIED_PENDING_REASON: &str = "Pending";
@@ -1993,8 +2020,10 @@ pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
 ///
 /// The Job carries [`QUALIFY_SPEC_HASH_ANNOTATION`] so the controller re-runs it
 /// when its inputs change and skips it when they do not, and sets
-/// `restartPolicy: Never`, a small [`QUALIFY_JOB_BACKOFF_LIMIT`], and
-/// [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not accumulate.
+/// `restartPolicy: Never`, a small [`QUALIFY_JOB_BACKOFF_LIMIT`],
+/// [`QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS`] so a hung attempt fails rather than
+/// runs forever, and [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not
+/// accumulate.
 pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
     let labels = labels(instance, QUALIFY_COMPONENT);
     let mut env = vec![
@@ -2048,6 +2077,7 @@ pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
         },
         spec: Some(JobSpec {
             backoff_limit: Some(QUALIFY_JOB_BACKOFF_LIMIT),
+            active_deadline_seconds: Some(QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS),
             ttl_seconds_after_finished: Some(QUALIFY_JOB_TTL_SECONDS),
             template: PodTemplateSpec {
                 metadata: Some(ObjectMeta {
@@ -2158,8 +2188,16 @@ pub fn qualification_decision(
 }
 
 /// The [`QualifyJobPhase`] a live Job reports, read from its status conditions:
-/// `Complete=True` is success, `Failed=True` is failure (its message carried
-/// through), anything else is still running.
+/// `Complete=True` is success, `Failed=True` is failure, anything else is still
+/// running.
+///
+/// A `Failed` condition's `reason` is prepended to its `message` (`"<reason>:
+/// <message>"`) so the `StoreQualified` condition names why the Job failed, not
+/// only the human message. This matters for a deadline-exceeded Job: the Job
+/// controller sets reason `DeadlineExceeded` with a generic message ("Job was
+/// active longer than specified deadline"), and the reason is the part an
+/// operator needs to see. When only one of reason/message is present that one
+/// is used verbatim; when neither is, a fixed fallback is.
 pub fn qualify_job_phase(job: &Job) -> QualifyJobPhase {
     let Some(conditions) = job.status.as_ref().and_then(|s| s.conditions.as_ref()) else {
         return QualifyJobPhase::Running;
@@ -2171,13 +2209,15 @@ pub fn qualify_job_phase(job: &Job) -> QualifyJobPhase {
         match c.type_.as_str() {
             "Complete" => return QualifyJobPhase::Succeeded,
             "Failed" => {
-                let message = c
-                    .message
-                    .clone()
-                    .filter(|m| !m.is_empty())
-                    .or_else(|| c.reason.clone())
-                    .unwrap_or_else(|| "the store qualification Job failed".to_string());
-                return QualifyJobPhase::Failed(message);
+                let reason = c.reason.clone().filter(|r| !r.is_empty());
+                let message = c.message.clone().filter(|m| !m.is_empty());
+                let text = match (reason, message) {
+                    (Some(reason), Some(message)) => format!("{reason}: {message}"),
+                    (Some(reason), None) => reason,
+                    (None, Some(message)) => message,
+                    (None, None) => "the store qualification Job failed".to_string(),
+                };
+                return QualifyJobPhase::Failed(text);
             }
             _ => {}
         }
@@ -5444,6 +5484,26 @@ mod tests {
         }
     }
 
+    /// A Job reporting `Failed=True` with the given `reason` and `message`, the
+    /// shape the Kubernetes Job controller sets when it fails a Job (a
+    /// deadline-exceeded Job carries reason `DeadlineExceeded`).
+    fn job_with_failed_reason(reason: &str, message: Option<&str>) -> Job {
+        use k8s_openapi::api::batch::v1::{JobCondition, JobStatus};
+        Job {
+            status: Some(JobStatus {
+                conditions: Some(vec![JobCondition {
+                    type_: "Failed".to_string(),
+                    status: "True".to_string(),
+                    reason: Some(reason.to_string()),
+                    message: message.map(str::to_string),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
     /// The input hash is stable for one spec and changes for each of the five
     /// inputs it covers, and only those. Pins the exact set of fields that
     /// re-trigger qualification (issue #36): a change to any of them is a
@@ -5602,6 +5662,99 @@ mod tests {
         assert_eq!(
             qualify_job_phase(&job_with_condition("Failed", "False", None)),
             QualifyJobPhase::Running
+        );
+    }
+
+    /// The rendered qualify Job sets `activeDeadlineSeconds` to the chosen value,
+    /// so a hung attempt (an endpoint that accepts the connection and never
+    /// answers) becomes a `Failed` Job rather than running forever. `backoffLimit`
+    /// bounds only failed attempts, not one attempt that never terminates.
+    #[test]
+    fn qualify_job_bounds_a_hung_attempt() {
+        let spec = base_spec();
+        let job = desired_qualify_job(&spec, "prod");
+        let job_spec = job.spec.as_ref().expect("qualify Job has a spec");
+        assert_eq!(
+            job_spec.active_deadline_seconds,
+            Some(QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS),
+            "the qualify Job bounds a single attempt with activeDeadlineSeconds"
+        );
+        assert_eq!(
+            QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS, 900,
+            "the chosen deadline is 900 s (28 sequential ops * 20 s request_timeout \
+             = 560 s slow-but-healthy, plus a ~1.6x margin)"
+        );
+    }
+
+    /// A Job the Kubernetes Job controller failed for exceeding its
+    /// `activeDeadlineSeconds` reports `Failed=True` with reason
+    /// `DeadlineExceeded`. That reads as [`QualificationDecision::Failed`] (which
+    /// the controller renders as `StoreQualified=False`), and its message names
+    /// the reason exactly so an operator sees why qualification did not finish.
+    #[test]
+    fn a_deadline_exceeded_job_reads_as_failed_with_its_reason() {
+        let job = job_with_failed_reason(
+            "DeadlineExceeded",
+            Some("Job was active longer than specified deadline"),
+        );
+        let phase = qualify_job_phase(&job);
+        let message = match &phase {
+            QualifyJobPhase::Failed(message) => message.clone(),
+            other => panic!("a Failed=True Job reads as Failed, got {other:?}"),
+        };
+        assert!(
+            message.contains("DeadlineExceeded"),
+            "the failure message names the DeadlineExceeded reason exactly: {message:?}"
+        );
+
+        // The gate reports a Present Job for the current inputs in the Failed
+        // phase as Failed, carrying that message; the controller turns Failed
+        // into StoreQualified=False with STORE_QUALIFIED_FAILED_REASON.
+        let decision = qualification_decision(
+            "h",
+            None,
+            &QualifyJobObservation::Present {
+                spec_hash: Some("h".to_string()),
+                phase,
+            },
+        );
+        assert_eq!(decision, QualificationDecision::Failed(message));
+    }
+
+    /// The `activeDeadlineSeconds` is a tuning knob, not a store-identity input:
+    /// [`qualify_job_input_hash`] covers exactly the five inputs qualification
+    /// proves against and never the deadline, so changing the deadline leaves the
+    /// hash equal and does not re-run a qualification that already passed.
+    #[test]
+    fn the_deadline_is_not_part_of_the_qualified_input_hash() {
+        use std::hash::{Hash, Hasher};
+        let spec = base_spec();
+
+        // Recompute the hash over exactly the five qualified inputs, deliberately
+        // excluding the deadline. If the production hasher folded the deadline in,
+        // this reference would diverge and the assertion would fail.
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        spec.storage.s3.bucket.hash(&mut hasher);
+        spec.storage.s3.region.hash(&mut hasher);
+        spec.storage
+            .s3
+            .endpoint
+            .as_deref()
+            .unwrap_or("")
+            .hash(&mut hasher);
+        spec.image.hash(&mut hasher);
+        spec.storage
+            .s3
+            .credentials_secret_ref
+            .name
+            .hash(&mut hasher);
+        let expected = format!("{:016x}", hasher.finish());
+
+        assert_eq!(
+            qualify_job_input_hash(&spec),
+            expected,
+            "the qualified-input hash covers exactly the five store-identity inputs, never the \
+             deadline"
         );
     }
 

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy};
+use k8s_openapi::api::batch::v1::{Job, JobSpec};
 use k8s_openapi::api::core::v1::{
     Affinity, Capabilities, Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction,
     KeyToPath, PodAffinityTerm, PodAntiAffinity, PodSecurityContext, PodSpec, PodTemplateSpec,
@@ -1904,6 +1905,284 @@ pub fn gc_bootstrap_plan(spec: &RavelClusterSpec) -> GcBootstrapPlan {
         gate,
         maintain_enabled: spec.maintain.enabled,
     }
+}
+
+/// Component suffix of the one-shot store-qualification Job (issue #36): its
+/// child name is `<cluster>-qualify`.
+pub const QUALIFY_COMPONENT: &str = "qualify";
+
+/// Annotation on the qualify Job carrying [`qualify_job_input_hash`], so a
+/// change to the inputs qualification proves against (bucket, region, endpoint,
+/// image, credentials Secret name) re-runs it and a no-op reconcile does not.
+pub const QUALIFY_SPEC_HASH_ANNOTATION: &str = "ravel.nofire.ai/qualify-spec-hash";
+
+/// `backoffLimit` for the qualify Job: a few retries absorb a transient S3
+/// error (a backend still coming up) without spinning forever on a genuine
+/// qualification failure (a backend that fails conditional-create atomicity or
+/// list consistency). Four attempts, then the Job reports `Failed` and the
+/// controller surfaces it on the `StoreQualified` condition.
+pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 4;
+
+/// `ttlSecondsAfterFinished` for the qualify Job: one hour, so a finished Job
+/// does not accumulate across reconciles or re-qualifications. The qualified
+/// state itself is durable in `status.storeQualifiedHash`, so a Job
+/// garbage-collected after success does not re-trigger qualification.
+pub const QUALIFY_JOB_TTL_SECONDS: i32 = 3600;
+
+/// `StoreQualified` reason while the qualify Job is being created or is still
+/// running: serving is held until it reports success.
+pub const STORE_QUALIFIED_PENDING_REASON: &str = "Pending";
+
+/// `StoreQualified` reason once the store has been qualified for the current
+/// inputs; serving proceeds.
+pub const STORE_QUALIFIED_SUCCEEDED_REASON: &str = "Succeeded";
+
+/// `StoreQualified` reason when the qualify Job exhausted its `backoffLimit`
+/// without succeeding; serving stays held and the pass requeues on backoff.
+pub const STORE_QUALIFIED_FAILED_REASON: &str = "Failed";
+
+/// Message paired with [`STORE_QUALIFIED_PENDING_REASON`].
+pub const STORE_QUALIFYING_MESSAGE: &str = "running store qualification (ravel store qualify) against the cluster's bucket; the \
+     gateway, query, and maintain Deployments are held until it succeeds so the cluster never \
+     serves on a backend that fails the object-store contract (docs/object-store-contract.md)";
+
+/// Message paired with [`STORE_QUALIFIED_SUCCEEDED_REASON`].
+pub const STORE_QUALIFIED_MESSAGE: &str =
+    "the object store passed ravel store qualify; serving Deployments may be created";
+
+/// A deterministic change-detection hash over the inputs store qualification
+/// proves against (issue #36): the bucket, region, endpoint, server image, and
+/// the credentials Secret name. When any of these changes the store the cluster
+/// would serve on is a different one, so qualification is re-run; an unrelated
+/// spec edit (a replica count, a fold interval) leaves this stable and does not
+/// re-qualify.
+///
+/// `DefaultHasher` (SipHash with fixed keys) is deterministic across processes,
+/// so an operator restart does not spuriously re-qualify. It is a change signal,
+/// not a security boundary, exactly like [`secrets_checksum`].
+pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    spec.storage.s3.bucket.hash(&mut hasher);
+    spec.storage.s3.region.hash(&mut hasher);
+    spec.storage
+        .s3
+        .endpoint
+        .as_deref()
+        .unwrap_or("")
+        .hash(&mut hasher);
+    spec.image.hash(&mut hasher);
+    spec.storage
+        .s3
+        .credentials_secret_ref
+        .name
+        .hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// The one-shot store-qualification Job for a cluster (issue #36).
+///
+/// Runs `ravel store qualify` (the same `ravel-cli` binary the server image
+/// ships) against the cluster's bucket before any serving Deployment is created,
+/// so a backend that fails the object-store contract is caught at deploy time
+/// rather than crash-looping every server pod on a fresh bucket. Image and
+/// credentials mirror the server Deployment's shared
+/// `storage.s3.credentialsSecretRef`; the bucket, region, and endpoint reach
+/// `ravel-cli` through the same `RAVEL_S3_*` env vars it reads (clap `env`), the
+/// exact shape the kind lane's hand-run Job used.
+///
+/// The Job carries [`QUALIFY_SPEC_HASH_ANNOTATION`] so the controller re-runs it
+/// when its inputs change and skips it when they do not, and sets
+/// `restartPolicy: Never`, a small [`QUALIFY_JOB_BACKOFF_LIMIT`], and
+/// [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not accumulate.
+pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
+    let labels = labels(instance, QUALIFY_COMPONENT);
+    let mut env = vec![
+        EnvVar {
+            name: "RAVEL_S3_BUCKET".to_string(),
+            value: Some(spec.storage.s3.bucket.clone()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "RAVEL_S3_REGION".to_string(),
+            value: Some(spec.storage.s3.region.clone()),
+            ..Default::default()
+        },
+    ];
+    if let Some(endpoint) = &spec.storage.s3.endpoint {
+        env.push(EnvVar {
+            name: "RAVEL_S3_ENDPOINT".to_string(),
+            value: Some(endpoint.clone()),
+            ..Default::default()
+        });
+    }
+    // Credentials mirror the server Deployment exactly: sourced from the shared
+    // credentials Secret via secretKeyRef, never literal values.
+    env.extend(s3_credential_env(spec, None));
+
+    let container = Container {
+        name: "qualify".to_string(),
+        image: Some(spec.image.clone()),
+        image_pull_policy: spec.image_pull_policy.clone(),
+        command: Some(vec!["/usr/local/bin/ravel-cli".to_string()]),
+        args: Some(vec![
+            "--store".to_string(),
+            "s3".to_string(),
+            "store".to_string(),
+            "qualify".to_string(),
+        ]),
+        env: Some(env),
+        security_context: Some(container_security_context()),
+        ..Default::default()
+    };
+
+    Job {
+        metadata: ObjectMeta {
+            name: Some(child_name(instance, QUALIFY_COMPONENT)),
+            labels: Some(labels.clone()),
+            annotations: Some(BTreeMap::from([(
+                QUALIFY_SPEC_HASH_ANNOTATION.to_string(),
+                qualify_job_input_hash(spec),
+            )])),
+            ..Default::default()
+        },
+        spec: Some(JobSpec {
+            backoff_limit: Some(QUALIFY_JOB_BACKOFF_LIMIT),
+            ttl_seconds_after_finished: Some(QUALIFY_JOB_TTL_SECONDS),
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    restart_policy: Some("Never".to_string()),
+                    containers: vec![container],
+                    security_context: Some(pod_security_context()),
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        status: None,
+    }
+}
+
+/// The terminal state of the live qualify Job this reconcile pass observed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QualifyJobPhase {
+    /// Neither `Complete` nor `Failed` reported yet.
+    Running,
+    /// The Job reported `Complete=True`.
+    Succeeded,
+    /// The Job reported `Failed=True` (its `backoffLimit` was exhausted). Carries
+    /// the Job's terminal condition message for the `StoreQualified` condition.
+    Failed(String),
+}
+
+/// What the controller observed about the live qualify Job for a cluster.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QualifyJobObservation {
+    /// No qualify Job exists (a fresh cluster, or one whose finished Job has been
+    /// TTL-garbage-collected).
+    Absent,
+    /// A qualify Job exists. `spec_hash` is its [`QUALIFY_SPEC_HASH_ANNOTATION`]
+    /// value (`None` if the annotation is missing), `phase` its terminal state.
+    Present {
+        /// The Job's recorded input hash, or `None` when the annotation is
+        /// absent.
+        spec_hash: Option<String>,
+        /// The Job's terminal state this pass.
+        phase: QualifyJobPhase,
+    },
+}
+
+/// The gate decision one reconcile pass takes on store qualification (issue #36).
+///
+/// [`crate::controller`] acts on exactly this, so a test asserting on a decision
+/// here is asserting on the operator's real gating behavior.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QualificationDecision {
+    /// The store is qualified for the current inputs: create the serving
+    /// Deployments. No qualify-Job write this pass.
+    Proceed,
+    /// (Re)run qualification and hold the serving Deployments. `recreate` is
+    /// true when a Job for stale inputs must be deleted first (a config edit
+    /// landed); the controller deletes it and lets the next pass create a fresh
+    /// one. False when no Job exists and one must be created now.
+    Qualify {
+        /// Whether a stale Job must be deleted before a fresh one is created.
+        recreate: bool,
+    },
+    /// The qualify Job is still running: hold the serving Deployments, no write.
+    Waiting,
+    /// The qualify Job failed: hold the serving Deployments and requeue on
+    /// backoff. Carries the Job's terminal message.
+    Failed(String),
+}
+
+/// Decide the qualification gate for a pass, purely from the desired input hash,
+/// the durably-recorded qualified hash (`status.storeQualifiedHash`), and the
+/// live Job observation.
+///
+/// A recorded qualified hash equal to the desired one short-circuits to
+/// [`QualificationDecision::Proceed`]: qualification already passed for these
+/// inputs and is never re-run on a schedule, so the Job's absence (after TTL GC)
+/// is not a reason to re-qualify. Otherwise the decision follows the live Job:
+/// absent means create one; a Job for a different (or missing) hash means a
+/// config edit landed and the stale Job is recreated; a Job for the current hash
+/// reports the qualification's progress.
+pub fn qualification_decision(
+    desired_hash: &str,
+    qualified_hash: Option<&str>,
+    observation: &QualifyJobObservation,
+) -> QualificationDecision {
+    if qualified_hash == Some(desired_hash) {
+        return QualificationDecision::Proceed;
+    }
+    match observation {
+        QualifyJobObservation::Absent => QualificationDecision::Qualify { recreate: false },
+        QualifyJobObservation::Present { spec_hash, phase } => {
+            if spec_hash.as_deref() != Some(desired_hash) {
+                QualificationDecision::Qualify { recreate: true }
+            } else {
+                match phase {
+                    QualifyJobPhase::Running => QualificationDecision::Waiting,
+                    QualifyJobPhase::Succeeded => QualificationDecision::Proceed,
+                    QualifyJobPhase::Failed(message) => {
+                        QualificationDecision::Failed(message.clone())
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The [`QualifyJobPhase`] a live Job reports, read from its status conditions:
+/// `Complete=True` is success, `Failed=True` is failure (its message carried
+/// through), anything else is still running.
+pub fn qualify_job_phase(job: &Job) -> QualifyJobPhase {
+    let Some(conditions) = job.status.as_ref().and_then(|s| s.conditions.as_ref()) else {
+        return QualifyJobPhase::Running;
+    };
+    for c in conditions {
+        if c.status != "True" {
+            continue;
+        }
+        match c.type_.as_str() {
+            "Complete" => return QualifyJobPhase::Succeeded,
+            "Failed" => {
+                let message = c
+                    .message
+                    .clone()
+                    .filter(|m| !m.is_empty())
+                    .or_else(|| c.reason.clone())
+                    .unwrap_or_else(|| "the store qualification Job failed".to_string());
+                return QualifyJobPhase::Failed(message);
+            }
+            _ => {}
+        }
+    }
+    QualifyJobPhase::Running
 }
 
 /// A tier's PodDisruptionBudget (issue #126, deliverable 4), capping how many of
@@ -5144,6 +5423,268 @@ mod tests {
         assert!(
             secrets_binding.contains("namespace: ravel-system"),
             "the shipped secrets RoleBinding binds ravel-system, the operator's own namespace"
+        );
+    }
+
+    /// A job condition of the given type/status, the shape
+    /// [`qualify_job_phase`] reads.
+    fn job_with_condition(type_: &str, status: &str, message: Option<&str>) -> Job {
+        use k8s_openapi::api::batch::v1::{JobCondition, JobStatus};
+        Job {
+            status: Some(JobStatus {
+                conditions: Some(vec![JobCondition {
+                    type_: type_.to_string(),
+                    status: status.to_string(),
+                    message: message.map(str::to_string),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// The input hash is stable for one spec and changes for each of the five
+    /// inputs it covers, and only those. Pins the exact set of fields that
+    /// re-trigger qualification (issue #36): a change to any of them is a
+    /// different store to prove, an unrelated change is not.
+    #[test]
+    fn qualify_input_hash_tracks_exactly_the_qualified_inputs() {
+        let spec = base_spec();
+        let base = qualify_job_input_hash(&spec);
+        assert_eq!(
+            base,
+            qualify_job_input_hash(&spec),
+            "the hash is deterministic for one spec"
+        );
+
+        let mut bucket = spec.clone();
+        bucket.storage.s3.bucket = "other-bucket".to_string();
+        let mut region = spec.clone();
+        region.storage.s3.region = "us-east-1".to_string();
+        let mut endpoint = spec.clone();
+        endpoint.storage.s3.endpoint = Some("http://other:9000".to_string());
+        let mut image = spec.clone();
+        image.image = "registry.example/ravel:v2".to_string();
+        let mut creds = spec.clone();
+        creds.storage.s3.credentials_secret_ref.name = "other-s3".to_string();
+        for (label, changed) in [
+            ("bucket", &bucket),
+            ("region", &region),
+            ("endpoint", &endpoint),
+            ("image", &image),
+            ("credentials secret", &creds),
+        ] {
+            assert_ne!(
+                base,
+                qualify_job_input_hash(changed),
+                "a change to {label} re-triggers qualification"
+            );
+        }
+
+        // A field qualification does not depend on leaves the hash unchanged, so
+        // an unrelated spec edit does not re-run qualification.
+        let mut replicas = spec.clone();
+        replicas.gateway.replicas = spec.gateway.replicas + 5;
+        assert_eq!(
+            base,
+            qualify_job_input_hash(&replicas),
+            "an unrelated spec edit (replica count) does not re-qualify"
+        );
+    }
+
+    /// The rendered qualify Job: name, image, command/args, credentials, the
+    /// spec-hash annotation, and the one-shot execution shape. Exact values, so
+    /// the Job the operator applies is pinned (issue #36).
+    #[test]
+    fn qualify_job_renders_a_one_shot_store_qualify() {
+        let spec = base_spec();
+        let job = desired_qualify_job(&spec, "prod");
+
+        assert_eq!(job.metadata.name.as_deref(), Some("prod-qualify"));
+        assert_eq!(
+            job.metadata
+                .annotations
+                .as_ref()
+                .and_then(|a| a.get(QUALIFY_SPEC_HASH_ANNOTATION))
+                .map(String::as_str),
+            Some(qualify_job_input_hash(&spec).as_str()),
+            "the annotation records the input hash so a change re-runs the Job"
+        );
+
+        let job_spec = job.spec.as_ref().expect("qualify Job has a spec");
+        assert_eq!(job_spec.backoff_limit, Some(QUALIFY_JOB_BACKOFF_LIMIT));
+        assert_eq!(
+            job_spec.ttl_seconds_after_finished,
+            Some(QUALIFY_JOB_TTL_SECONDS)
+        );
+        let pod = job_spec
+            .template
+            .spec
+            .as_ref()
+            .expect("qualify Job has a pod spec");
+        assert_eq!(pod.restart_policy.as_deref(), Some("Never"));
+        assert_eq!(pod.containers.len(), 1, "one qualify container");
+        let container = &pod.containers[0];
+        assert_eq!(
+            container.image.as_deref(),
+            Some("registry.example/ravel:v1")
+        );
+        assert_eq!(
+            container.command.as_deref(),
+            Some(["/usr/local/bin/ravel-cli".to_string()].as_slice())
+        );
+        assert_eq!(
+            container.args.as_deref(),
+            Some(
+                [
+                    "--store".to_string(),
+                    "s3".to_string(),
+                    "store".to_string(),
+                    "qualify".to_string(),
+                ]
+                .as_slice()
+            )
+        );
+        let env = container.env.as_ref().expect("qualify container has env");
+        let env_value = |name: &str| {
+            env.iter()
+                .find(|e| e.name == name)
+                .and_then(|e| e.value.clone())
+        };
+        assert_eq!(env_value("RAVEL_S3_BUCKET").as_deref(), Some("ravel-data"));
+        assert_eq!(env_value("RAVEL_S3_REGION").as_deref(), Some("eu-west-1"));
+        assert_eq!(
+            env_value("RAVEL_S3_ENDPOINT").as_deref(),
+            Some("http://minio:9000")
+        );
+        // Credentials come from the shared Secret via secretKeyRef, never a
+        // literal value in the pod spec.
+        let access = env
+            .iter()
+            .find(|e| e.name == "RAVEL_S3_ACCESS_KEY")
+            .expect("access key env present");
+        assert!(access.value.is_none(), "the access key is never a literal");
+        assert_eq!(
+            access
+                .value_from
+                .as_ref()
+                .and_then(|s| s.secret_key_ref.as_ref())
+                .map(|r| (r.name.as_str(), r.key.as_str())),
+            Some(("ravel-s3", S3_ACCESS_KEY_ID_KEY)),
+        );
+    }
+
+    /// `qualify_job_phase` reads the Job's terminal condition: `Complete=True`
+    /// is success, `Failed=True` carries its message, nothing terminal is still
+    /// running.
+    #[test]
+    fn qualify_job_phase_reads_the_terminal_condition() {
+        assert_eq!(
+            qualify_job_phase(&Job::default()),
+            QualifyJobPhase::Running,
+            "a Job with no status is still running"
+        );
+        assert_eq!(
+            qualify_job_phase(&job_with_condition("Complete", "True", None)),
+            QualifyJobPhase::Succeeded
+        );
+        assert_eq!(
+            qualify_job_phase(&job_with_condition(
+                "Failed",
+                "True",
+                Some("backend rejected CAS")
+            )),
+            QualifyJobPhase::Failed("backend rejected CAS".to_string()),
+            "the failure carries the Job's own terminal message"
+        );
+        // A condition that is not True does not count as terminal.
+        assert_eq!(
+            qualify_job_phase(&job_with_condition("Failed", "False", None)),
+            QualifyJobPhase::Running
+        );
+    }
+
+    /// A cluster already qualified for the current inputs proceeds without
+    /// re-running qualification, whatever the live Job says -- even absent
+    /// (TTL-garbage-collected). This is what keeps qualification from re-running
+    /// on a schedule.
+    #[test]
+    fn qualified_inputs_proceed_without_rerunning() {
+        let hash = "abc123".to_string();
+        for observation in [
+            QualifyJobObservation::Absent,
+            QualifyJobObservation::Present {
+                spec_hash: Some(hash.clone()),
+                phase: QualifyJobPhase::Succeeded,
+            },
+        ] {
+            assert_eq!(
+                qualification_decision(&hash, Some(&hash), &observation),
+                QualificationDecision::Proceed,
+                "recorded qualified inputs short-circuit to Proceed"
+            );
+        }
+    }
+
+    /// A fresh cluster (nothing qualified, no Job) creates the qualify Job
+    /// without recreating anything, and holds serving until it completes.
+    #[test]
+    fn fresh_cluster_creates_the_qualify_job() {
+        assert_eq!(
+            qualification_decision("h", None, &QualifyJobObservation::Absent),
+            QualificationDecision::Qualify { recreate: false },
+        );
+    }
+
+    /// A running Job for the current inputs holds serving; a completed one lets
+    /// it proceed; a failed one surfaces the Job's message and stays held.
+    #[test]
+    fn matching_job_reports_its_progress() {
+        let present = |phase| QualifyJobObservation::Present {
+            spec_hash: Some("h".to_string()),
+            phase,
+        };
+        assert_eq!(
+            qualification_decision("h", None, &present(QualifyJobPhase::Running)),
+            QualificationDecision::Waiting,
+        );
+        assert_eq!(
+            qualification_decision("h", None, &present(QualifyJobPhase::Succeeded)),
+            QualificationDecision::Proceed,
+        );
+        assert_eq!(
+            qualification_decision(
+                "h",
+                None,
+                &present(QualifyJobPhase::Failed("boom".to_string()))
+            ),
+            QualificationDecision::Failed("boom".to_string()),
+        );
+    }
+
+    /// When the inputs change on an already-qualified cluster, a Job for the old
+    /// inputs (or one missing the annotation) is recreated, not read as the
+    /// current one. The old qualified hash does not short-circuit because it no
+    /// longer equals the desired hash.
+    #[test]
+    fn changed_inputs_recreate_a_stale_job() {
+        let stale = QualifyJobObservation::Present {
+            spec_hash: Some("old".to_string()),
+            phase: QualifyJobPhase::Succeeded,
+        };
+        assert_eq!(
+            qualification_decision("new", Some("old"), &stale),
+            QualificationDecision::Qualify { recreate: true },
+        );
+        // A Job with no recorded hash is also stale against any desired hash.
+        let unannotated = QualifyJobObservation::Present {
+            spec_hash: None,
+            phase: QualifyJobPhase::Succeeded,
+        };
+        assert_eq!(
+            qualification_decision("new", Some("old"), &unannotated),
+            QualificationDecision::Qualify { recreate: true },
         );
     }
 }


### PR DESCRIPTION
The operator created a RavelCluster's Deployments as soon as the resource
existed; nothing ran `ravel store qualify` against the cluster's bucket
first, so the kind lane was qualified by a hand-run Job and production
was not. A backend that fails conditional-create atomicity or listing
order is exactly what qualification catches.

The reconcile loop now creates a one-shot <cluster>-qualify Job with the
server Deployment's image, env and credential Secret, and creates the
Deployments only after it succeeds. A StoreQualified status condition
carries Pending, Succeeded or Failed with the Job's terminal message; a
failed qualification creates no Deployment and requeues on the existing
backoff. The qualified inputs (bucket, region, endpoint, image, Secret
name) are hashed into status.storeQualifiedHash, so a later pass with
the same inputs proceeds without re-running after the Job's TTL has
collected it, and a change to any of them recreates the Job and flips
the condition back to Pending without tearing down running Deployments.
Qualification is never re-run on a schedule.

The last commit bounds a hung attempt: backoffLimit bounds failures
only, so a pod whose endpoint accepts the connection and never answers
would leave StoreQualified pending forever. The Job now carries
activeDeadlineSeconds 900, from 28 sequential object operations at the
S3 client's 20 second request timeout (560 seconds for a slow but
healthy run) plus slack for scheduling and image pull; a deadline
exceeded Job reads as Failed with the DeadlineExceeded reason in the
condition message, and the deadline is not part of the qualified input
hash so tuning it never re-runs qualification. Serving Deployments stay
bounded by their liveness probes.

The ClusterRole gains batch/v1 jobs; the CRD's status schema gains the
hash field so the subresource does not prune it; kind-up.sh drops its
hand-run Job because the lane deploys through the operator. ADR-0034
records the gate and the deadline as an amendment.

The operator has no fake-client harness, so the scenarios are pinned at
the qualification_decision layer the controller acts on. kind run
34153768540 passed on the first round's head; the lane is re-run on this
branch before merge.

Supersedes #1415.

Refs: #36
