### PR TITLE
feat(alerting): bound alert eval ticks with a derived state memo

### DIFF
--- a/docs/adrs/1294-alert-state-memo.md
+++ b/docs/adrs/1294-alert-state-memo.md
@@ -48,7 +48,12 @@ transitions written since the memo rather than the whole history.
    one), a `watermark_hour` (the ingest hour the memo was stamped in), and the
    folded records: one `AlertRecord` per `alert_id`. The reader accepts exactly
    `format_version == 1` and refuses 0 and any future version, treating a
-   refused or undecodable body the same as an absent one.
+   refused or undecodable body the same as an absent one. A body that repeats an
+   `alert_id` is a decode error, not a last-wins insert: the fold's output is
+   keyed by `alert_id`, so a duplicate is ambiguous, and silently keeping one
+   copy could seed stale state for an hour below the watermark that the tail never
+   re-reads. Refusing it routes the tick through the same full-fold-and-rewrite
+   recovery an absent or corrupt memo takes.
 
 3. **Read path (every tick, before the lease).** GET the memo. Then, whatever
    the memo says, issue one `start-after` LIST over the commit prefix that skips
@@ -70,12 +75,32 @@ transitions written since the memo rather than the whole history.
    the hour a memo was stamped in is never skipped.
 
 5. **Write path (lease holder only, end of tick).** After rule evaluation, the
-   lease holder rewrites the memo with the just-folded latest state, stamping
-   the current ingest hour as the new `watermark_hour`, using `PutMode::
-   Overwrite`. Only the lease holder writes, so there is a single writer per
-   key and no CAS is needed. The write is debounced: a tick that changed neither
-   the watermark hour nor any record writes nothing. A failed write is logged
-   and ignored; it costs the next tick a full fold, never correctness.
+   lease holder rewrites the memo with the just-folded latest state, stamping the
+   **seal-bound hour** as the new `watermark_hour`, using `PutMode::Overwrite`.
+   Only the lease holder writes, so there is a single writer per key and no CAS
+   is needed. The write is debounced: a tick that changed neither the watermark
+   hour nor any record writes nothing. A failed write is logged and ignored; it
+   costs the next tick a full fold, never correctness.
+
+   The seal-bound hour, not `hour_bucket(now_ns)`, is what the watermark may
+   advance to. The alert lease permits a two-holder overlap (`acquire_lease`):
+   a prior holder whose lease has expired can still finish one in-flight tick and
+   publish a transition after this holder's tail LIST, stamped at the prior
+   holder's own clock. If that stamp lands in an hour below the watermark, the
+   tail excludes it from every future tick and the memo omits it permanently,
+   breaking the staleness invariant below by a legal interleaving. The seal bound
+   is the newest ingest hour no overlapping holder can still write into: the
+   ingest hour of `now_ns - (lease_ttl + query_deadline)`. `lease_ttl` is
+   `LEASE_TTL_TICKS` (3) times the evaluation interval; a prior holder held the
+   lease at its own tick start, so its lease had to expire before this holder
+   took over, which puts its transition stamp at least `lease_ttl` behind this
+   holder's reading. `query_deadline` (`DEFAULT_QUERY_DEADLINE`, 30s) is added as
+   the only wall-clock tolerance the alerting path defines, covering the in-flight
+   tick's own duration and modest inter-node clock skew; the alerting path
+   defines no dedicated cross-node skew constant, and a deployment whose skew
+   exceeds the query deadline would need to widen this margin. Holding the
+   watermark back never loses correctness, only re-reads a bounded tail; the tail
+   is still a single LIST over a `start-after` marker range.
 
 6. **The memo is a derived cache, never a source of truth.** ADR-0040
    decision 3 stands unchanged: current state is still defined as the fold over
@@ -131,19 +156,43 @@ from its own `ts_ns` (`publish` stamps `ingest_hour_bucket = hour_bucket(record.
 ts_ns)`), and a record's fold order is keyed on the same `ts_ns`, so a record's
 hour and its order are consistent. Partition the records by hour. Every record
 at an hour strictly below the watermark contributed to the memo when it was
-stamped and is present in the seed; no such record is written after the memo,
-because the memo writer is always the lease holder that wrote this tick's
-transitions, in the same tick. Every record at an hour at or above the
+stamped and is present in the seed. Every record at an hour at or above the
 watermark is re-read by the tail LIST, which covers exactly those hours
 inclusive. So every record reaches the fold through one path or the other, and
 the seed-plus-tail fold sees the same record set as a full fold. The tie-break
 (memoized copy at `seq == 0` versus re-read copy at `seq > 0`) never changes the
 folded value because a re-read record is byte-identical to its memoized copy.
 
-The watermark may move backward across ticks (a backward clock step widens the
-tail to cover more hours), which only ever re-reads more, never fewer, so the
+The invariant's precondition (`watermark_hour` at or below every hour the tail
+covers) is not automatic: a `watermark_hour` at `hour_bucket(now_ns)` is broken
+by the alert lease's documented two-holder overlap. A prior holder whose lease
+has expired can still finish an in-flight tick and publish a transition after
+this holder's tail LIST, stamped at the prior holder's own clock. That stamp can
+fall in an hour strictly below `hour_bucket(now_ns)` (the prior holder's clock
+reads behind, and its transition is stamped at a tick-start reading at least one
+`lease_ttl` behind this holder's), so a watermark at `hour_bucket(now_ns)` would
+exclude that hour from every future tail and drop the record permanently: a
+below-watermark record written *after* the memo, which the "no such record is
+written after the memo" step above assumed away. The seal-bound watermark
+(decision 5) restores the precondition: it is the ingest hour of
+`now_ns - (lease_ttl + query_deadline)`, older than any hour an overlapping
+holder can still stamp into, so every late transition lands at an hour at or
+above the watermark and is re-read by the tail.
+
+The watermark may also move backward across ticks (a backward clock step widens
+the tail to cover more hours), which only ever re-reads more, never fewer, so the
 invariant is preserved; the resulting duplicate reads stay within ADR-0043
 decision 6's documented at-least-once tolerance.
+
+An alternative to the seal bound is a **lease-generation fence** (design (b)):
+carry the lease generation on every transition and in the memo, refuse a memo
+write (by CAS) when the generation has moved, and fold any tail transition from
+an older generation regardless of hour. It removes the hour-skew reasoning
+entirely but costs a new field on the frozen `AlertRecord` write path (a format
+change under ravel-alerting, out of this change's scope), a durable generation
+counter, and a CAS on the memo write that the single-writer-per-key model
+otherwise does not need. The seal bound needs no new durable field and stays
+within `alerting.rs`, so it is preferred here.
 
 ## Rejected alternatives
 
@@ -180,10 +229,18 @@ decision 6's documented at-least-once tolerance.
 
 ## Consequences
 
-- A steady-state tick costs a memo GET, a lease GET, one tail LIST, and `2T`
-  GETs where `T` is the number of transitions written since the memo
-  (`T <= R` in steady state, and `T` is often 0), down from `ceil(N / page)`
-  LISTs and `2N` GETs. The cost stops growing with history.
+- A steady-state tick costs a memo GET, a lease GET, one tail LIST (a single
+  `start-after` call over a marker range), and `2T` GETs where `T` is the number
+  of transitions in the hours the tail covers, down from `ceil(N / page)` LISTs
+  and `2N` GETs. The cost stops growing with history. Because the seal-bound
+  watermark holds back by `lease_ttl + query_deadline` (a few minutes at the
+  defaults), the tail covers not just the current hour but every hour within that
+  seal margin, so `T` counts transitions in that trailing window rather than only
+  the current hour. For a quiet tenant whose last transition is older than the
+  seal margin, `T` is 0 and the tick is exactly 2 GETs and 1 LIST; a transition
+  is re-read for the few ticks until it falls below the widened watermark. This is
+  the honest bound after the seal-bound watermark; the earlier "current hour only"
+  figure did not account for the lease overlap and could lose a late transition.
 - A cold, absent, corrupt, or unsupported-version memo pays a one-time full fold
   and then rewrites a valid memo, so the expensive path is self-healing and
   bounded to the tick that hit it.

--- a/docs/adrs/1294-alert-state-memo.md
+++ b/docs/adrs/1294-alert-state-memo.md
@@ -1,0 +1,197 @@
+# ADR-1294: A derived alert-state memo bounding evaluation tick cost
+
+Status: Proposed
+
+## Context
+
+The alert evaluator (`services/ravel-server/src/alerting.rs`) runs one tick
+per tenant on an interval. Each tick must know the current state of every
+alert, which ADR-0040 decision 3 defines as a fold: the record with the
+greatest order among all records sharing an `alert_id`. State is derived, never
+mutated in place; every transition (fires, resolves, suppresses) is a new
+immutable RLOG record under the tenant's `Signal::Alerts` commit prefix.
+
+Before this ADR the fold ran cold every tick: a `list_all` over the whole
+alerts commit prefix, then a commit GET plus a data GET per commit record, then
+an RLOG scan of each object. `Signal::Alerts` is absent from
+`maintain::MAINTAINED_SIGNALS`, so nothing folds or compacts that history in the
+background and it only grows. The cost per tick is therefore
+`ceil(N / page)` LISTs plus `2N` GETs, where `N` is the cumulative count of
+transitions ever written, and it is independent of the rule count `R`.
+
+The waste is structural. `alert_id = compute_alert_id(rule_id, rule.labels)` is
+computed from a rule's static labels, so a rule maps to exactly one `alert_id`
+for its lifetime. The fold's output therefore holds at most `R` entries, one
+per rule, yet reading it costs `2N` GETs over a history that never stops
+growing. A tenant with 10 rules and a year of flap history pays for the year on
+every tick to learn 10 current states.
+
+The object key layout (docs/catalog-and-mvcc.md) and the RLOG record format
+(ADR-0040, docs/log-segment-format.md) are frozen contracts. The alert history
+is also read by the `alerts` SQL table (ADR-1101), so it cannot be trimmed or
+rewritten to make the fold cheaper. The fix has to leave every existing record
+and every existing key untouched and add only a derived cache.
+
+## Decision
+
+Fold the latest-state-per-`alert_id` into one durable, tenant-wide memo object
+and read it at the start of each tick, so a steady-state tick folds only the
+transitions written since the memo rather than the whole history.
+
+1. **Key.** The memo lives at `t/<tenant_hash>/a/state/latest`, one object per
+   tenant. It sits deliberately outside the `t/<tenant_hash>/a/c/` commit prefix
+   so that neither the evaluator's own fold nor the `alerts` SQL table's listing
+   of commit records ever sees it. It is a new key prefix under an existing
+   signal, additive: no existing key changes shape or meaning.
+
+2. **Body.** A small JSON object carrying its own `format_version` (1 on day
+   one), a `watermark_hour` (the ingest hour the memo was stamped in), and the
+   folded records: one `AlertRecord` per `alert_id`. The reader accepts exactly
+   `format_version == 1` and refuses 0 and any future version, treating a
+   refused or undecodable body the same as an absent one.
+
+3. **Read path (every tick, before the lease).** GET the memo. Then, whatever
+   the memo says, issue one `start-after` LIST over the commit prefix that skips
+   every ingest hour strictly below `watermark_hour` server-side, and fold the
+   commit records it returns (a commit GET plus a data GET per transition in
+   that window) on top of the memoized state. Each memoized record is seeded
+   into the fold at order `(ts_ns, 0, 0)`, below any real commit the tail
+   re-reads (order `(ts_ns, epoch, seq)` with a nonzero `seq`), so a re-read
+   transition always wins the tie against its own memoized copy; the two are
+   byte-identical, so the tie only decides which clone survives, never the
+   folded state. A missing, corrupt, or unsupported-version memo falls back to a
+   full fold over the whole history.
+
+4. **The tail LIST is not optional.** It is what makes a stale memo detectable:
+   a transition written after the memo was stamped lands at an hour at or above
+   the watermark and is folded in by the tail. Skipping the tail when the memo
+   is present would return stale state. The watermark hour itself is always
+   re-folded (its keys sort after the bare `prefix + hour_string` cursor), so
+   the hour a memo was stamped in is never skipped.
+
+5. **Write path (lease holder only, end of tick).** After rule evaluation, the
+   lease holder rewrites the memo with the just-folded latest state, stamping
+   the current ingest hour as the new `watermark_hour`, using `PutMode::
+   Overwrite`. Only the lease holder writes, so there is a single writer per
+   key and no CAS is needed. The write is debounced: a tick that changed neither
+   the watermark hour nor any record writes nothing. A failed write is logged
+   and ignored; it costs the next tick a full fold, never correctness.
+
+6. **The memo is a derived cache, never a source of truth.** ADR-0040
+   decision 3 stands unchanged: current state is still defined as the fold over
+   immutable records. The memo only pre-computes that fold up to a watermark.
+   Losing, staling, or corrupting it costs a rescan, never a wrong answer. No
+   record format changes and the `alerts` SQL table is untouched.
+
+### Migration class
+
+Under ADR-0066 this is a **Class B** object: derived, reconstructible, rebuilt
+continuously from the immutable commit records it folds. It introduces a new
+derived-object key prefix, not a new version of any frozen format, so it needs
+no version bump to any existing format and no dual-reader window on the record
+side. Its own `format_version` field carries the memo's version independently;
+a future memo-body change bumps that field, and because the object is
+single-key `Overwrite` and advisory, an old-version body is simply ignored and
+overwritten rather than migrated. Adding a new self-owned key prefix without a
+version bump follows the `sys/maintain/memo/<process_id>` precedent (ADR-0065
+decision 3): a self-owned, `Overwrite`, versioned-tag, advisory,
+reconstructible snapshot beside the data it summarises, where losing or staling
+the snapshot costs at most a rescan. This memo is the same pattern, scoped
+per tenant rather than per maintenance worker.
+
+### Data flow
+
+```mermaid
+flowchart TD
+    tick[Evaluation tick] --> getmemo[GET t/tenant/a/state/latest]
+    getmemo -->|present, version 1| seed[Seed fold from memo at order ts,0,0]
+    getmemo -->|absent, corrupt, or bad version| full[Full fold over whole history]
+    seed --> tail[start-after LIST over hours at or above watermark]
+    tail --> foldtail[Commit GET + data GET per transition in the tail]
+    foldtail --> latest[Folded latest state per alert_id]
+    full --> latest
+    latest --> lease{Hold tenant lease?}
+    lease -->|no| done[Deliver queued notifications only]
+    lease -->|yes| eval[Evaluate rules, write transitions]
+    eval --> write[Overwrite memo: watermark = current hour, records = latest]
+    write --> done
+```
+
+### Formal model note
+
+ADR-1113's verification suite covers the maintenance and catalog fold
+protocols; this memo introduces one invariant in the same style, stated here so
+that suite can adopt it. Let the **memo staleness invariant** be: if
+`memo.watermark_hour` is at or below every ingest hour that the tail LIST
+covers, then the state produced by seeding from the memo and folding the tail
+equals the state produced by a full fold over the whole history.
+
+The argument rests on one consistency fact: a record's ingest hour is derived
+from its own `ts_ns` (`publish` stamps `ingest_hour_bucket = hour_bucket(record.
+ts_ns)`), and a record's fold order is keyed on the same `ts_ns`, so a record's
+hour and its order are consistent. Partition the records by hour. Every record
+at an hour strictly below the watermark contributed to the memo when it was
+stamped and is present in the seed; no such record is written after the memo,
+because the memo writer is always the lease holder that wrote this tick's
+transitions, in the same tick. Every record at an hour at or above the
+watermark is re-read by the tail LIST, which covers exactly those hours
+inclusive. So every record reaches the fold through one path or the other, and
+the seed-plus-tail fold sees the same record set as a full fold. The tie-break
+(memoized copy at `seq == 0` versus re-read copy at `seq > 0`) never changes the
+folded value because a re-read record is byte-identical to its memoized copy.
+
+The watermark may move backward across ticks (a backward clock step widens the
+tail to cover more hours), which only ever re-reads more, never fewer, so the
+invariant is preserved; the resulting duplicate reads stay within ADR-0043
+decision 6's documented at-least-once tolerance.
+
+## Rejected alternatives
+
+- **(a) Trim or compact the alert history behind a retention path so the full
+  fold stays cheap.** Rejected on cost and on correctness. Trimming to keep only
+  the latest record per `alert_id` is a rewrite whose cost is `R x W` (it must
+  read and re-emit state on every write), not the `R` this ADR targets, and it
+  deletes exactly the transition history the `alerts` SQL table (ADR-1101) reads.
+  A derived cache beside the immutable history gets the read speedup without
+  touching the history at all.
+
+- **(b) Add `Signal::Alerts` to the fold's maintained signal set so background
+  maintenance compacts it.** Rejected: compaction reduces the number of objects
+  but the tick still folds the whole compacted history, so per-tick GETs stay
+  `O(N)` rather than dropping to the transitions since a watermark. Worse, no
+  producer reads L1 alert parts today, so turning maintenance on for this signal
+  activates the unfinished-compaction defects tracked in issue #1137. This ADR
+  needs neither: the memo bounds the tick without compacting anything.
+
+- **(c) One memo object per `alert_id` instead of one per tenant.** Rejected:
+  the tick would then GET `R` memo objects and perform `R` per-alert staleness
+  comparisons every tick, trading one tenant-wide GET for `R` GETs and turning a
+  single tail LIST into a per-alert reconciliation. The fold's output is already
+  tenant-wide and at most `R` entries, so one object holds it with one GET.
+
+- **(d) A bounded newest-first walk over recent hours with an early stop, and no
+  memo.** Rejected on correctness. An alert that entered `Firing` at the start of
+  a multi-day incident has its latest transition sitting many hours in the past;
+  a bounded lookback that stops after the most recent `k` hours would miss that
+  record entirely and read the alert as not firing. Current state has no bounded
+  time horizon, so no bounded hour walk can derive it. The memo carries the
+  below-watermark state forward explicitly instead of hoping it falls inside a
+  window.
+
+## Consequences
+
+- A steady-state tick costs a memo GET, a lease GET, one tail LIST, and `2T`
+  GETs where `T` is the number of transitions written since the memo
+  (`T <= R` in steady state, and `T` is often 0), down from `ceil(N / page)`
+  LISTs and `2N` GETs. The cost stops growing with history.
+- A cold, absent, corrupt, or unsupported-version memo pays a one-time full fold
+  and then rewrites a valid memo, so the expensive path is self-healing and
+  bounded to the tick that hit it.
+- Every replica reads the memo; only the lease holder writes it, so the memo has
+  a single writer per key and needs no CAS.
+- The `alerts` SQL table, the RLOG record format, and every existing key are
+  unchanged. The alert history is neither trimmed nor compacted.
+- docs/catalog-and-mvcc.md gains one key-layout row for the memo prefix.
+- A new derived-object key prefix now exists under the alerts signal; a future
+  memo-body change bumps the memo's own `format_version` and relies on the
+  ignore-and-overwrite path rather than a record migration.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -147,4 +147,5 @@ the reservation commit that used to work around it.
 | [1195](1195-unbundle-fetch-concurrency.md) | Unbundle `--fetch-concurrency`, and make GET concurrency a process-wide limit | Proposed |
 | [1196](1196-fetch-objective-cost-first-default-latency-first-policy.md) | Keep the cost-first fetch default, add a latency-first policy | Proposed |
 | [1199](1199-bounded-query-io-and-tail-checkpoints.md) | Bounded query I/O accounting, and a pre-registered measured gate deciding whether an L0.5 tail checkpoint gets built at all | Proposed |
+| [1294](1294-alert-state-memo.md) | A durable, derived alert-state memo per tenant that bounds each alert evaluation tick to a memo GET, a lease GET, one tail LIST, and the transitions since the memo, instead of re-folding the whole `Signal::Alerts` history every tick | Proposed |
 | [1374](1374-agent-mcp-server.md) | A first-party MCP server behind a shared query service layer, with a bounded, evidence-bearing agent result contract | Proposed |

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -13,6 +13,7 @@ t/<tenant_hash>/m/c/<shard>/<ingest_hour>/l1.<input_set_hash16>.cmt       compac
 t/<tenant_hash>/m/c/<shard>/<ingest_hour>/rw.<input_set_hash16>.cmt       rewrite record (selective erasure; ADR-0064)
 t/<tenant_hash>/m/c/<shard>/<ingest_hour>/retire.tmb                      retention tombstone
 t/<tenant_hash>/m/maint/<shard>/cursor                                    advisory scan cursor
+t/<tenant_hash>/a/state/latest                                            derived alert-state memo (per-tenant, Overwrite, versioned body, advisory; ADR-1294)
 t/<tenant_hash>/<signal>/del/<request_id>.dreq                          erasure request (CreateIfAbsent, immutable; ADR-0064)
 t/<tenant_hash>/<signal>/del/<request_id>.done                          erasure completion (CreateIfAbsent, immutable, PII-free; ADR-0064)
 t/<tenant_hash>/<signal>/prov                                           shard_count provisioning record (write-once, additive; ADR-0050 §5)
@@ -160,6 +161,27 @@ existed, which is what keeps "no correctness-critical distributed locks" true.
 This is a claim, deliberately **not** a lease (`LeaseCheck` is the unrelated GC
 reader-protection gate) and **not** membership (that is the
 `sys/maintain/workers/` prefix above).
+
+`t/<tenant_hash>/a/state/latest` (ADR-1294, Proposed) is the alert evaluator's
+derived state memo, one object per tenant holding the folded latest record per
+`alert_id` plus the ingest hour it was stamped in. It is a derived cache of the
+`Signal::Alerts` fold (ADR-0040 decision 3), placed deliberately outside the
+`t/<tenant_hash>/a/c/` commit prefix so neither the evaluator's own fold nor the
+`alerts` SQL table's listing of commit records ever sees it. On each tick every
+replica GETs the memo and folds only the commit records at or after its stamped
+hour (one server-side `start-after` LIST plus a commit/data GET pair per
+transition in that window), instead of re-folding the whole ever-growing alert
+history; the lease holder then rewrites the memo with a plain `Overwrite`
+(single writer per key, debounced so an unchanged tick writes nothing). The body
+carries its own `format_version`, and a reader that finds the memo absent,
+undecodable, or of an unsupported version falls back to a full fold and rewrites
+a valid memo, so the memo is **advisory and reconstructible**: losing, staling,
+or corrupting it costs at most one tick's full fold, never a wrong alert state.
+The non-optional tail LIST is what keeps a stale memo from being trusted: a
+transition written after the memo lands at an hour at or above the watermark and
+is folded in. The `Signal::Alerts` records, the RLOG format, and every other key
+are untouched; this is a new derived-object prefix, no version bump, following
+the `sys/maintain/memo/` precedent above (ADR-0065 §3).
 
 `sys/qualification` and the `sys/qualify/` prefix (ADR-0050 §6) are
 additive root-level keys, outside any tenant's `t/<tenant_hash>/` space.

--- a/services/ravel-server/src/alert_state_memo.rs
+++ b/services/ravel-server/src/alert_state_memo.rs
@@ -182,7 +182,19 @@ pub fn decode(bytes: &[u8]) -> Result<AlertStateMemo, MemoError> {
     let mut records = HashMap::with_capacity(wire.records.len());
     for wire_record in wire.records {
         let (alert_id, record) = wire_record.into_record()?;
-        records.insert(alert_id, record);
+        // A well-formed memo holds one record per alert_id (the fold's output is
+        // keyed by alert_id). A body that repeats an alert_id is ambiguous: a
+        // silent last-wins insert would let a stale duplicate seed the state for
+        // an hour below the watermark, which the tail never re-reads, so the
+        // evaluator would serve wrong state instead of falling back to a full
+        // fold. Refuse it as a decode error, the same non-fatal path a truncated
+        // or bad-version memo takes: the caller rescans and rewrites a clean memo.
+        if records.insert(alert_id, record).is_some() {
+            return Err(MemoError::Decode(format!(
+                "duplicate alert_id {} in memo",
+                alert_id.to_hex()
+            )));
+        }
     }
     Ok(AlertStateMemo {
         watermark_hour: wire.watermark_hour,
@@ -299,6 +311,21 @@ mod tests {
             matches!(err, MemoError::UnsupportedVersion { found: 2 }),
             "got {err:?}"
         );
+    }
+
+    #[test]
+    fn a_duplicate_alert_id_is_a_decode_error() {
+        // A body that is otherwise well-formed but carries the same alert_id
+        // twice. A last-wins insert would silently drop one record and could
+        // seed stale below-watermark state; the reader must refuse it so the
+        // caller falls back to a full fold instead.
+        let bytes = br#"{"format_version":1,"watermark_hour":1,"records":[
+            {"alert_id":"11111111111111111111111111111111","rule_id":"r","state":"firing",
+             "generation":0,"ts_ns":1,"labels":[],"annotations":[],"body":"b"},
+            {"alert_id":"11111111111111111111111111111111","rule_id":"r","state":"resolved",
+             "generation":1,"ts_ns":2,"labels":[],"annotations":[],"body":"b"}]}"#;
+        let err = decode(bytes).expect_err("duplicate alert_id rejected");
+        assert!(matches!(err, MemoError::Decode(_)), "got {err:?}");
     }
 
     #[test]

--- a/services/ravel-server/src/alert_state_memo.rs
+++ b/services/ravel-server/src/alert_state_memo.rs
@@ -1,0 +1,312 @@
+//! Tenant-wide latest-alert-state memo (issue #1294).
+//!
+//! [`crate::alerting::AlertEvaluator`] derives each alert's current state by
+//! folding the tenant's whole `Signal::Alerts` transition history to the most
+//! recent record per `alert_id` (ADR-0040 decision 3). Nothing maintains that
+//! signal (`Signal::Alerts` is absent from `maintain::MAINTAINED_SIGNALS`), so
+//! the history only grows, and a fold that re-reads all of it every tick costs
+//! `ceil(N/page)` LISTs plus `2N` GETs where `N` is the cumulative transition
+//! count, independent of the rule count the evaluator actually needs.
+//!
+//! This memo is a derived cache of that fold at one durable, tenant-wide key
+//! (`t/<tenant_hash>/a/state/latest`), deliberately outside the
+//! `t/<tenant>/a/c/` commit prefix so neither the fold nor ravel-sql's `alerts`
+//! table ever lists it. It is never source of truth: the transition records
+//! remain the only durable state (ADR-0040 decision 3 is untouched, no record
+//! format changes). Following the `sys/maintain/memo` precedent (ADR-0065),
+//! everything here is advisory and reconstructible; a lost, stale, or corrupt
+//! memo costs a rescan, never correctness, because the reader always re-lists
+//! the hours at or after the memo's watermark and re-folds them over the memo.
+//!
+//! # Wire format and versioning
+//!
+//! The memo carries an explicit `format_version` from day one. The reader is a
+//! supported-set gate accepting exactly `{1}` and refusing `0` and any future
+//! version it does not understand, so a forward-incompatible writer can never
+//! be mistaken for a valid memo: an unsupported version falls back to a full
+//! fold exactly as an absent or corrupt memo does. The writer is the alert
+//! lease holder only, a single writer per key, using [`PutMode::Overwrite`].
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use ravel_alerting::{AlertId, AlertRecord, AlertState};
+use ravel_object_store::{GetRange, ObjectStoreBackend, PutMode, PutOptions, StoreError};
+use ravel_types::TenantHash;
+use serde::{Deserialize, Serialize};
+
+/// The only `format_version` this build writes and the sole member of the set
+/// its reader accepts. Bumping it is an ADR-gated change; a reader that meets a
+/// version outside its supported set falls back to a full fold.
+pub const ALERT_STATE_MEMO_FORMAT_VERSION: u32 = 1;
+
+/// The memo object key for a tenant's alert state.
+///
+/// Under the tenant's alert keyspace (`Signal::Alerts` prefix `a`) but outside
+/// the `c/<shard>/` commit prefix that
+/// [`crate::alerting::AlertEvaluator::load_latest_records`] folds and that
+/// ravel-sql's `alerts` table reads, so neither ever lists this key or mistakes
+/// it for a commit record. It is mutable, derived coordination state, not an
+/// immutable data/commit object, so the object-key immutability rule does not
+/// apply to it.
+pub fn alert_state_memo_key(tenant: &TenantHash) -> String {
+    format!("t/{}/a/state/latest", tenant.to_hex())
+}
+
+/// Decoding a memo failed. Both variants are non-fatal at the call site: the
+/// evaluator logs and falls back to a full fold, then rewrites the memo.
+#[derive(Debug, thiserror::Error)]
+pub enum MemoError {
+    /// The bytes are not a well-formed memo (truncated, not JSON, a field of
+    /// the wrong type, or an `alert_id`/`state` that does not decode).
+    #[error("alert state memo decode: {0}")]
+    Decode(String),
+    /// The memo is well-formed but carries a `format_version` this reader does
+    /// not support.
+    #[error(
+        "unsupported alert state memo format_version {found}; this reader supports \
+         {{{ALERT_STATE_MEMO_FORMAT_VERSION}}}"
+    )]
+    UnsupportedVersion { found: u32 },
+}
+
+/// The folded latest-state-per-`alert_id` snapshot, plus the watermark hour the
+/// reader must re-list at or after to catch any transition written since the
+/// memo was stamped.
+#[derive(Debug, Clone)]
+pub struct AlertStateMemo {
+    /// `hour_bucket(now_ns)` at the moment this memo was written. Every alert
+    /// record whose ingest hour is strictly below this is fully represented in
+    /// `records`; the reader re-lists hours at or after it to fold in anything
+    /// newer. Never above the writer's own tick hour, so no writer ever stamps
+    /// a watermark past a record it has not folded.
+    pub watermark_hour: u32,
+    /// Latest record per `alert_id` as of `watermark_hour`.
+    pub records: HashMap<AlertId, AlertRecord>,
+}
+
+/// The version header parsed before the full body, so an unsupported version is
+/// reported as [`MemoError::UnsupportedVersion`] rather than a decode failure of
+/// a body whose shape it does not share. Extra fields are ignored (no
+/// `deny_unknown_fields`).
+#[derive(Deserialize)]
+struct WireHeader {
+    format_version: u32,
+}
+
+/// The on-object memo shape. `AlertRecord` and `AlertId` carry no serde derives,
+/// so records are mirrored field-for-field with `alert_id` and `state` in their
+/// canonical string forms (the same forms the RLOG `attrs` use).
+#[derive(Serialize, Deserialize)]
+struct WireMemo {
+    format_version: u32,
+    watermark_hour: u32,
+    records: Vec<WireRecord>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct WireRecord {
+    /// Lowercase hex, as [`AlertId::to_hex`].
+    alert_id: String,
+    rule_id: String,
+    /// `firing`/`resolved`/`pending`/`suppressed`, as [`AlertState::as_str`].
+    state: String,
+    generation: u32,
+    ts_ns: i64,
+    labels: Vec<(String, String)>,
+    annotations: Vec<(String, String)>,
+    body: String,
+}
+
+impl WireRecord {
+    fn from_record(record: &AlertRecord) -> Self {
+        WireRecord {
+            alert_id: record.alert_id.to_hex(),
+            rule_id: record.rule_id.clone(),
+            state: record.state.as_str().to_string(),
+            generation: record.generation,
+            ts_ns: record.ts_ns,
+            labels: record.labels.clone(),
+            annotations: record.annotations.clone(),
+            body: record.body.clone(),
+        }
+    }
+
+    fn into_record(self) -> Result<(AlertId, AlertRecord), MemoError> {
+        let alert_id =
+            AlertId::from_hex(&self.alert_id).map_err(|err| MemoError::Decode(err.to_string()))?;
+        let state = AlertState::parse(&self.state)
+            .ok_or_else(|| MemoError::Decode(format!("unknown alert state {:?}", self.state)))?;
+        let record = AlertRecord {
+            alert_id,
+            rule_id: self.rule_id,
+            state,
+            generation: self.generation,
+            ts_ns: self.ts_ns,
+            labels: self.labels,
+            annotations: self.annotations,
+            body: self.body,
+        };
+        Ok((alert_id, record))
+    }
+}
+
+/// Serialize a memo to its on-object bytes, stamping the current
+/// [`ALERT_STATE_MEMO_FORMAT_VERSION`].
+pub fn encode(memo: &AlertStateMemo) -> Vec<u8> {
+    let wire = WireMemo {
+        format_version: ALERT_STATE_MEMO_FORMAT_VERSION,
+        watermark_hour: memo.watermark_hour,
+        records: memo.records.values().map(WireRecord::from_record).collect(),
+    };
+    // A `WireMemo` of owned Rust scalars and strings cannot fail to serialize;
+    // treat any error as a decode-class failure rather than panicking.
+    serde_json::to_vec(&wire).unwrap_or_default()
+}
+
+/// Parse memo bytes, gating on the supported version set before the body.
+///
+/// Never panics: a truncated or malformed object, an `alert_id`/`state` that
+/// does not decode, or a version outside the supported set is a typed error the
+/// caller turns into a full fold, not a crash.
+pub fn decode(bytes: &[u8]) -> Result<AlertStateMemo, MemoError> {
+    let header: WireHeader =
+        serde_json::from_slice(bytes).map_err(|err| MemoError::Decode(err.to_string()))?;
+    if header.format_version != ALERT_STATE_MEMO_FORMAT_VERSION {
+        return Err(MemoError::UnsupportedVersion {
+            found: header.format_version,
+        });
+    }
+    let wire: WireMemo =
+        serde_json::from_slice(bytes).map_err(|err| MemoError::Decode(err.to_string()))?;
+    let mut records = HashMap::with_capacity(wire.records.len());
+    for wire_record in wire.records {
+        let (alert_id, record) = wire_record.into_record()?;
+        records.insert(alert_id, record);
+    }
+    Ok(AlertStateMemo {
+        watermark_hour: wire.watermark_hour,
+        records,
+    })
+}
+
+/// Read and decode the tenant's memo.
+///
+/// `Ok(None)` when no memo exists yet (the cold-start case). `Err` on any store
+/// failure other than not-found, and on a corrupt or unsupported-version memo,
+/// so the caller can log the distinction; in every non-`Some` case the caller
+/// falls back to a full fold.
+pub async fn read_alert_state_memo(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+) -> anyhow::Result<Option<AlertStateMemo>> {
+    let key = alert_state_memo_key(tenant);
+    let outcome = match store.get(&key, GetRange::Full).await {
+        Ok(outcome) => outcome,
+        Err(StoreError::NotFound) => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    Ok(Some(decode(&outcome.data)?))
+}
+
+/// Overwrite the tenant's memo. Called only by the alert lease holder, so this
+/// is a single writer per key; `PutMode::Overwrite` because a stale memo is
+/// harmless (the reader re-folds the tail) and last-write-wins during a brief
+/// two-holder lease handover leaves correct derived state either way.
+pub async fn write_alert_state_memo(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    memo: &AlertStateMemo,
+) -> anyhow::Result<()> {
+    let key = alert_state_memo_key(tenant);
+    let body = Bytes::from(encode(memo));
+    store
+        .put(
+            &key,
+            body,
+            PutOptions {
+                mode: PutMode::Overwrite,
+                checksum: None,
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn record(id: u8, state: AlertState, ts_ns: i64) -> AlertRecord {
+        AlertRecord {
+            alert_id: AlertId([id; 16]),
+            rule_id: format!("rule-{id}"),
+            state,
+            generation: 0,
+            ts_ns,
+            labels: vec![("severity".to_string(), "page".to_string())],
+            annotations: vec![("summary".to_string(), "high".to_string())],
+            body: format!("alert {id}"),
+        }
+    }
+
+    #[test]
+    fn round_trip_preserves_every_field() {
+        let mut records = HashMap::new();
+        let a = record(1, AlertState::Firing, 100);
+        let b = record(2, AlertState::Resolved, 200);
+        records.insert(a.alert_id, a.clone());
+        records.insert(b.alert_id, b.clone());
+        let memo = AlertStateMemo {
+            watermark_hour: 42,
+            records,
+        };
+
+        let decoded = decode(&encode(&memo)).expect("round trips");
+        assert_eq!(decoded.watermark_hour, 42);
+        assert_eq!(decoded.records.len(), 2);
+        assert_eq!(decoded.records.get(&a.alert_id), Some(&a));
+        assert_eq!(decoded.records.get(&b.alert_id), Some(&b));
+    }
+
+    #[test]
+    fn truncated_bytes_are_a_decode_error_not_a_panic() {
+        let memo = AlertStateMemo {
+            watermark_hour: 1,
+            records: HashMap::new(),
+        };
+        let bytes = encode(&memo);
+        let err = decode(&bytes[..bytes.len() / 2]).expect_err("truncation rejected");
+        assert!(matches!(err, MemoError::Decode(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn version_zero_is_unsupported_not_decode() {
+        let bytes = br#"{"format_version":0,"watermark_hour":1,"records":[]}"#;
+        let err = decode(bytes).expect_err("version 0 rejected");
+        assert!(
+            matches!(err, MemoError::UnsupportedVersion { found: 0 }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn future_version_is_unsupported_not_decode() {
+        let bytes = br#"{"format_version":2,"watermark_hour":1,"records":[]}"#;
+        let err = decode(bytes).expect_err("version 2 rejected");
+        assert!(
+            matches!(err, MemoError::UnsupportedVersion { found: 2 }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_state_string_is_a_decode_error() {
+        let bytes = br#"{"format_version":1,"watermark_hour":1,"records":[
+            {"alert_id":"00000000000000000000000000000000","rule_id":"r","state":"exploded",
+             "generation":0,"ts_ns":1,"labels":[],"annotations":[],"body":"b"}]}"#;
+        let err = decode(bytes).expect_err("unknown state rejected");
+        assert!(matches!(err, MemoError::Decode(_)), "got {err:?}");
+    }
+}

--- a/services/ravel-server/src/alerting.rs
+++ b/services/ravel-server/src/alerting.rs
@@ -48,6 +48,20 @@
 //! per alert_id for one tenant", and the cost is bounded by the number of
 //! transitions, not by ingest volume, because a record is written only on a
 //! transition (ADR-0043 decision 4).
+//!
+//! # The state memo
+//!
+//! `Signal::Alerts` is never maintained (it is absent from
+//! `maintain::MAINTAINED_SIGNALS`), so that transition history only grows and a
+//! full fold every tick costs `2N` GETs for a cumulative transition count `N`,
+//! independent of the rule count actually needed. [`AlertEvaluator::fold_latest`]
+//! avoids that with a tenant-wide derived cache, the alert state memo
+//! ([`crate::alert_state_memo`], issue #1294): each tick seeds from the memo and
+//! folds only the ingest hours at or after its watermark. The memo is never
+//! source of truth (the transition records remain the only durable state,
+//! ADR-0040 decision 3); a lost, stale, or corrupt memo costs a full fold, never
+//! correctness, because the tail listing re-folds every hour that could hold a
+//! record written since the memo. Only the lease holder writes it.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -66,7 +80,9 @@ use ravel_commit::rng::{RngSource, SystemRng};
 use ravel_commit::{keys, publish, record};
 use ravel_ingest::{Clock, LOG_SEGMENT_FORMAT_VERSION};
 use ravel_logseg::{ObjectIdentity, Predicate, RlogConfig, RlogReader};
-use ravel_object_store::{GetRange, ObjectStoreBackend, PutMode, PutOptions, StoreError, list_all};
+use ravel_object_store::{
+    GetRange, ObjectMeta, ObjectStoreBackend, PutMode, PutOptions, StoreError, list_all,
+};
 use ravel_promql::Value as PromqlValue;
 use ravel_query::{Coverage, QueryEngine};
 use ravel_types::{Signal, TenantHash, TenantId};
@@ -76,6 +92,7 @@ use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::alert_sink::{AlertNotification, AlertSink, DEFAULT_SINK_TIMEOUT, deliver};
+use crate::alert_state_memo::{AlertStateMemo, read_alert_state_memo, write_alert_state_memo};
 
 /// Default `--alert-eval-interval-secs`: 60 seconds, Prometheus' own default
 /// rule-evaluation interval.
@@ -464,7 +481,25 @@ impl AlertEvaluator {
         let mut report = AlertEvalReport::default();
         let now_ns = self.clock.now_ns();
 
-        let mut latest = match self.load_latest_records().await {
+        // Read the derived state memo first, before the lease and unguarded: it
+        // is an advisory cache every replica reads, so each folds only the ingest
+        // hours since the memo instead of the whole history (issue #1294). A
+        // missing memo (cold start), a corrupt one, or an unsupported-version one
+        // is not an error here; it falls back to a full fold below, and the lease
+        // holder rewrites a valid memo at the end of the tick.
+        let memo = match read_alert_state_memo(self.store.as_ref(), &self.tenant).await {
+            Ok(memo) => memo,
+            Err(err) => {
+                tracing::warn!(
+                    tenant = %self.tenant.to_hex(),
+                    error = %err,
+                    "alert evaluation: alert state memo unreadable; folding full history this tick"
+                );
+                None
+            }
+        };
+
+        let mut latest = match self.fold_latest(memo.as_ref()).await {
             Ok(latest) => latest,
             Err(err) => {
                 tracing::warn!(
@@ -543,6 +578,33 @@ impl AlertEvaluator {
                 self.queue_repeat_if_due(rule, &latest, now_ns, &mut report);
             }
             self.rules = rules;
+
+            // Refresh the derived state memo from the just-folded latest state
+            // (issue #1294). Lease holder only, so there is a single writer per
+            // key; debounced so a tick that changed neither the watermark hour
+            // nor any record skips the write. The memo is advisory and
+            // reconstructible (ADR-0065 precedent): a failed write costs the next
+            // tick a full fold, never correctness.
+            let watermark_hour = hour_bucket(now_ns);
+            let unchanged = memo
+                .as_ref()
+                .is_some_and(|m| m.watermark_hour == watermark_hour && m.records == latest);
+            if !unchanged {
+                let refreshed = AlertStateMemo {
+                    watermark_hour,
+                    records: latest.clone(),
+                };
+                if let Err(err) =
+                    write_alert_state_memo(self.store.as_ref(), &self.tenant, &refreshed).await
+                {
+                    tracing::warn!(
+                        tenant = %self.tenant.to_hex(),
+                        error = %err,
+                        "alert evaluation: could not refresh the alert state memo; a full fold \
+                         recovers it next tick"
+                    );
+                }
+            }
         } else if !report.lease_unavailable {
             report.lease_not_held = true;
             tracing::debug!(
@@ -957,11 +1019,87 @@ impl AlertEvaluator {
     /// partial history would look like "this alert is not firing" and re-fire
     /// an alert that already is.
     async fn load_latest_records(&self) -> anyhow::Result<HashMap<AlertId, AlertRecord>> {
+        Ok(flatten_fold(self.full_fold().await?))
+    }
+
+    /// Fold the tenant's alert history to latest-per-`alert_id`, using `memo` as
+    /// a derived cache when one is present (issue #1294).
+    ///
+    /// With a memo, this seeds from its folded snapshot and then folds only the
+    /// commit records at or after `memo.watermark_hour`, so the per-tick cost is
+    /// bounded by the transitions written since the memo rather than by the
+    /// whole history. The tail listing is non-optional: it is what makes a stale
+    /// memo detectable rather than silently wrong, since any record written
+    /// since the memo is stamped at an ingest hour at or above its watermark and
+    /// is therefore re-listed here. Records below the watermark come only from
+    /// the memo, which is why an arbitrarily old still-`Firing` record survives a
+    /// tail that a bounded lookback would step past.
+    ///
+    /// With no memo (cold, absent, corrupt, or unsupported version) this is a
+    /// full fold, identical to [`Self::load_latest_records`].
+    async fn fold_latest(
+        &self,
+        memo: Option<&AlertStateMemo>,
+    ) -> anyhow::Result<HashMap<AlertId, AlertRecord>> {
+        let best = match memo {
+            Some(memo) => {
+                // Seed each memoized record at fold order `(ts_ns, 0, 0)` so any
+                // real commit the tail re-reads (order `(ts_ns, epoch, seq)` with
+                // a nonzero seq) wins the tie against its own memoized copy. The
+                // two are byte-identical, so the tie-break only decides which
+                // clone survives, never the folded state.
+                let mut best: HashMap<AlertId, ((i64, u64, u64), AlertRecord)> = memo
+                    .records
+                    .iter()
+                    .map(|(id, record)| (*id, ((record.ts_ns, 0, 0), record.clone())))
+                    .collect();
+                self.fold_tail(&mut best, memo.watermark_hour).await?;
+                best
+            }
+            // No memo: the cold path is a full fold, the same read
+            // `load_latest_records` performs.
+            None => return self.load_latest_records().await,
+        };
+        Ok(flatten_fold(best))
+    }
+
+    /// Full fold over the whole alert commit history, keyed by fold order.
+    async fn full_fold(&self) -> anyhow::Result<FoldedByOrder> {
         let prefix = keys::commit_shard_prefix(&self.tenant, Signal::Alerts, ALERT_SHARD)?;
         let entries = list_all(self.store.as_ref(), &prefix).await?;
+        let mut best = HashMap::new();
+        self.fold_commit_entries(entries, &mut best).await?;
+        Ok(best)
+    }
 
+    /// Fold the commit records at or after `watermark_hour` into `best`.
+    ///
+    /// One `start-after` LIST over the commit prefix, skipping every ingest hour
+    /// strictly below the watermark server-side, then a commit+data GET pair per
+    /// transition in that window. The watermark hour itself is included (its keys
+    /// sort after the bare `prefix + hour_string` cursor), so the hour a memo was
+    /// stamped in is always re-folded.
+    async fn fold_tail(&self, best: &mut FoldedByOrder, watermark_hour: u32) -> anyhow::Result<()> {
+        let prefix = keys::commit_shard_prefix(&self.tenant, Signal::Alerts, ALERT_SHARD)?;
+        let start_after = format!("{prefix}{}", keys::ingest_hour_string(watermark_hour));
+        let entries = list_all_after(self.store.as_ref(), &prefix, &start_after).await?;
+        self.fold_commit_entries(entries, best).await
+    }
+
+    /// Read each commit record in `entries` and the RLOG object it names, folding
+    /// every alert record into `best` by `(ts_ns, epoch, seq)`.
+    ///
+    /// Records are reached through commit records, never by listing data objects:
+    /// an object whose commit never landed is an abandoned write and must not
+    /// influence state. Any malformed entry aborts the whole read rather than
+    /// being skipped: a partial history would look like "this alert is not
+    /// firing" and re-fire an alert that already is.
+    async fn fold_commit_entries(
+        &self,
+        entries: Vec<ObjectMeta>,
+        best: &mut FoldedByOrder,
+    ) -> anyhow::Result<()> {
         let cfg = RlogConfig::default();
-        let mut best: HashMap<AlertId, ((i64, u64, u64), AlertRecord)> = HashMap::new();
         for meta in entries {
             let parsed = match keys::partition_bucket_entry(&meta.key)? {
                 keys::BucketEntry::CommitRecord(parsed) => parsed,
@@ -1005,10 +1143,7 @@ impl AlertEvaluator {
                 }
             }
         }
-        Ok(best
-            .into_iter()
-            .map(|(id, (_order, record))| (id, record))
-            .collect())
+        Ok(())
     }
 
     /// Attempt delivery of every undelivered notification to every sink,
@@ -1052,6 +1187,45 @@ impl AlertEvaluator {
             }
         }
     }
+}
+
+/// A fold in progress: the winning `(ts_ns, epoch, seq)` order and record for
+/// each `alert_id` seen so far.
+type FoldedByOrder = HashMap<AlertId, ((i64, u64, u64), AlertRecord)>;
+
+/// Drop the fold-order key, leaving the latest record per `alert_id`.
+fn flatten_fold(best: FoldedByOrder) -> HashMap<AlertId, AlertRecord> {
+    best.into_iter()
+        .map(|(id, (_order, record))| (id, record))
+        .collect()
+}
+
+/// Drain every page of a `start-after` listing, the [`list_all`] analogue for
+/// [`ObjectStoreBackend::list_after`]. Every returned key sorts strictly after
+/// `start_after`.
+async fn list_all_after(
+    store: &dyn ObjectStoreBackend,
+    prefix: &str,
+    start_after: &str,
+) -> anyhow::Result<Vec<ObjectMeta>> {
+    let mut out: Vec<ObjectMeta> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut page_token = None;
+    loop {
+        let page = store
+            .list_after(prefix, Some(start_after), page_token)
+            .await?;
+        for meta in page.objects {
+            if seen.insert(meta.key.clone()) {
+                out.push(meta);
+            }
+        }
+        match page.next {
+            Some(next) => page_token = Some(next),
+            None => break,
+        }
+    }
+    Ok(out)
 }
 
 /// The hour bucket a commit record stamped at `now_ns` belongs to. A pre-epoch
@@ -1606,7 +1780,9 @@ mod tick_tests {
 
     use std::sync::atomic::{AtomicI64, Ordering};
 
+    use ravel_alerting::build_transition_record;
     use ravel_catalog::{Catalog, CatalogConfig};
+    use ravel_object_store::InstrumentedStore;
     use ravel_object_store::memory::MemoryStore;
     use ravel_query::{EngineConfig, QueryEngine};
     use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
@@ -2136,6 +2312,229 @@ mod tick_tests {
         assert_eq!(
             report.repeats_queued, 1,
             "at the 60s default cadence a repeat is due"
+        );
+    }
+
+    // --- Alert state memo (issue #1294) --------------------------------------
+    //
+    // These pin the fold's per-tick object-store cost. A counting store
+    // (`InstrumentedStore`) makes the request count an assertion, not a comment:
+    // the whole point of the memo is that a steady-state tick reads only the
+    // tail, not the whole history, so the number of GETs it issues is the claim.
+
+    /// Publish `records` as real alert transition objects, one commit + one data
+    /// object each, at the ingest hour of each record's own `ts_ns`. Distinct
+    /// writer seqs keep the commit keys from colliding, so `n` records yield `n`
+    /// commit records under the alerts prefix.
+    async fn seed_alert_history(evaluator: &AlertEvaluator, records: &[AlertRecord]) {
+        for (i, record) in records.iter().enumerate() {
+            let seq = 10_000 + i as u64;
+            let identity = ObjectIdentity {
+                tenant_hash: evaluator.tenant.0,
+                shard: ALERT_SHARD,
+                writer_id: evaluator.writer_id.into_bytes(),
+                writer_epoch: ALERT_WRITER_EPOCH,
+                writer_seq: seq,
+            };
+            let bytes =
+                ravel_alerting::encode_record_object(record, RlogConfig::default(), identity)
+                    .expect("encode alert record");
+            evaluator
+                .publish(bytes, seq, record.ts_ns)
+                .await
+                .expect("publish alert record");
+        }
+    }
+
+    /// A full fold reads exactly one commit GET and one data GET per transition
+    /// record, so its cost grows with the cumulative history `N`. This is the
+    /// baseline the memo removes.
+    #[tokio::test]
+    async fn a_full_fold_reads_two_gets_per_transition() {
+        let inner = Arc::new(InstrumentedStore::new(MemoryStore::new()));
+        let metrics = inner.metrics();
+        let store: Arc<dyn ObjectStoreBackend> = inner;
+        let ev = evaluator(Arc::clone(&store), TestClock::at(NOW_NS));
+        let rule = threshold_rule();
+
+        let n: u64 = 4;
+        let records: Vec<AlertRecord> = (0..n)
+            .map(|i| build_transition_record(&rule, AlertState::Firing, 0, NOW_NS + i as i64))
+            .collect();
+        seed_alert_history(&ev, &records).await;
+
+        let before = metrics.snapshot();
+        let latest = ev.load_latest_records().await.expect("full fold");
+        let after = metrics.snapshot();
+
+        assert_eq!(latest.len(), 1, "all transitions share one alert_id");
+        assert_eq!(
+            after.get.calls - before.get.calls,
+            2 * n,
+            "a full fold reads one commit GET and one data GET per transition record"
+        );
+    }
+
+    /// The memo path folds only the ingest hours at or after the watermark. With
+    /// every seeded record below the watermark, a steady-state fold reads zero
+    /// commit/data GETs and issues exactly one tail LIST, yet still returns the
+    /// full folded state, including a `Firing` record that lives only in the memo
+    /// (the case a bounded newest-first lookback would lose).
+    #[tokio::test]
+    async fn the_memo_path_reads_only_hours_at_or_after_the_watermark() {
+        let inner = Arc::new(InstrumentedStore::new(MemoryStore::new()));
+        let metrics = inner.metrics();
+        let store: Arc<dyn ObjectStoreBackend> = inner;
+        let ev = evaluator(Arc::clone(&store), TestClock::at(NOW_NS));
+        let rule = threshold_rule();
+        let alert_id = compute_alert_id(&rule.rule_id, &rule.labels);
+
+        // Three transitions for one alert, all in ingest hour 0, last is Firing.
+        let n = 3;
+        let records: Vec<AlertRecord> = (0..n)
+            .map(|i| {
+                let state = if i + 1 == n {
+                    AlertState::Firing
+                } else {
+                    AlertState::Pending
+                };
+                build_transition_record(&rule, state, 0, NOW_NS)
+            })
+            .collect();
+        seed_alert_history(&ev, &records).await;
+
+        let full = ev.load_latest_records().await.expect("full fold");
+
+        // A memo whose watermark is hour 1, above every seeded record's hour 0.
+        let memo = AlertStateMemo {
+            watermark_hour: 1,
+            records: full.clone(),
+        };
+
+        let before = metrics.snapshot();
+        let via_memo = ev.fold_latest(Some(&memo)).await.expect("memo fold");
+        let after = metrics.snapshot();
+
+        assert_eq!(
+            via_memo, full,
+            "the memo path folds to the same latest state as a full fold"
+        );
+        assert_eq!(
+            via_memo.get(&alert_id).map(|r| r.state),
+            Some(AlertState::Firing),
+            "an hour-0 Firing below the watermark survives via the memo, not the tail"
+        );
+        assert_eq!(
+            after.get.calls - before.get.calls,
+            0,
+            "the memo path issues no commit or data GETs for hours below the watermark"
+        );
+        assert_eq!(
+            after.list_calls() - before.list_calls(),
+            1,
+            "the memo path issues exactly one tail LIST"
+        );
+    }
+
+    /// A transition written after the memo, at an hour at or above its
+    /// watermark, is folded in by the non-optional tail LIST: the memo path
+    /// matches a full fold rather than returning the stale memoized state.
+    #[tokio::test]
+    async fn a_transition_after_the_memo_is_caught_by_the_tail_list() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let ev = evaluator(Arc::clone(&store), TestClock::at(NOW_NS));
+        let rule = threshold_rule();
+        let alert_id = compute_alert_id(&rule.rule_id, &rule.labels);
+
+        // Memo snapshot: Firing as of hour 0, watermark hour 1. This record is
+        // never written to the store; it exists only in the memo.
+        let firing = build_transition_record(&rule, AlertState::Firing, 0, NOW_NS);
+        let mut memo_records = HashMap::new();
+        memo_records.insert(alert_id, firing);
+        let memo = AlertStateMemo {
+            watermark_hour: 1,
+            records: memo_records,
+        };
+
+        // A newer Resolved transition lands in hour 1, at the watermark.
+        let hour1_ts = NS_PER_HOUR + NOW_NS;
+        let resolved = build_transition_record(&rule, AlertState::Resolved, 0, hour1_ts);
+        seed_alert_history(&ev, &[resolved]).await;
+
+        let via_memo = ev.fold_latest(Some(&memo)).await.expect("memo fold");
+        let full = ev.load_latest_records().await.expect("full fold");
+
+        assert_eq!(
+            via_memo, full,
+            "the tail list folds in the transition written after the memo"
+        );
+        assert_eq!(
+            via_memo.get(&alert_id).map(|r| r.state),
+            Some(AlertState::Resolved),
+            "the memo path reflects the Resolved written after the memo, not the stale Firing"
+        );
+    }
+
+    /// The lease holder writes the state memo after a tick, stamping the current
+    /// hour as the watermark and recording every folded alert.
+    #[tokio::test]
+    async fn the_lease_holder_writes_the_state_memo() {
+        let store = seeded_store().await;
+        let tenant = TenantId::new(TENANT).hash();
+        let mut ev = evaluator(Arc::clone(&store), TestClock::at(NOW_NS));
+
+        assert_eq!(ev.run_tick().await.records_written, 1, "onset fires");
+
+        let memo = read_alert_state_memo(store.as_ref(), &tenant)
+            .await
+            .expect("memo readable")
+            .expect("the lease holder wrote a memo");
+        assert_eq!(
+            memo.watermark_hour,
+            hour_bucket(NOW_NS),
+            "the watermark is the tick's ingest hour"
+        );
+        let rule = threshold_rule();
+        let alert_id = compute_alert_id(&rule.rule_id, &rule.labels);
+        assert_eq!(
+            memo.records.get(&alert_id).map(|r| r.state),
+            Some(AlertState::Firing),
+            "the memo records the firing alert the tick just wrote"
+        );
+    }
+
+    /// A corrupt memo is not fatal: the tick falls back to a full fold, still
+    /// fires, and the lease holder overwrites the garbage with a valid memo.
+    #[tokio::test]
+    async fn a_corrupt_memo_is_ignored_and_rewritten() {
+        let store = seeded_store().await;
+        let tenant = TenantId::new(TENANT).hash();
+        store
+            .put(
+                &crate::alert_state_memo::alert_state_memo_key(&tenant),
+                Bytes::from_static(b"not a memo"),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put garbage memo");
+
+        let mut ev = evaluator(Arc::clone(&store), TestClock::at(NOW_NS));
+        assert_eq!(
+            ev.run_tick().await.records_written,
+            1,
+            "a corrupt memo falls back to a full fold, not a skipped tick"
+        );
+
+        let memo = read_alert_state_memo(store.as_ref(), &tenant)
+            .await
+            .expect("memo now decodes")
+            .expect("memo present after rewrite");
+        let rule = threshold_rule();
+        let alert_id = compute_alert_id(&rule.rule_id, &rule.labels);
+        assert_eq!(
+            memo.records.get(&alert_id).map(|r| r.state),
+            Some(AlertState::Firing),
+            "the holder rewrote a valid memo over the garbage"
         );
     }
 }

--- a/services/ravel-server/src/alerting.rs
+++ b/services/ravel-server/src/alerting.rs
@@ -585,7 +585,17 @@ impl AlertEvaluator {
             // nor any record skips the write. The memo is advisory and
             // reconstructible (ADR-0065 precedent): a failed write costs the next
             // tick a full fold, never correctness.
-            let watermark_hour = hour_bucket(now_ns);
+            //
+            // The watermark is the seal bound, not `hour_bucket(now_ns)`. The
+            // alert lease permits a two-holder overlap (see `acquire_lease`): a
+            // prior holder can still publish one in-flight transition after this
+            // holder's tail LIST, stamped at the prior holder's own clock. If
+            // that stamp lands in an hour below the watermark, the tail would
+            // exclude it from every future tick and the memo would omit it
+            // permanently. `seal_bound_hour` holds the watermark back to the
+            // newest hour no overlapping holder can still write into, so the tail
+            // always re-reads such a late transition (ADR-1294 decision 5).
+            let watermark_hour = self.seal_bound_hour(now_ns);
             let unchanged = memo
                 .as_ref()
                 .is_some_and(|m| m.watermark_hour == watermark_hour && m.records == latest);
@@ -616,6 +626,36 @@ impl AlertEvaluator {
 
         self.flush_sinks(&mut report).await;
         report
+    }
+
+    /// The newest ingest hour that is sealed for alert writes as of `now_ns`:
+    /// the memo watermark. No overlapping lease holder can still stamp a
+    /// transition into this hour or any older one, so a tail LIST that starts at
+    /// this hour re-reads every transition an in-flight prior holder might
+    /// publish after this tick's own tail LIST.
+    ///
+    /// The alert lease documents a two-holder overlap (see [`Self::acquire_lease`]):
+    /// a prior holder whose lease has expired can still finish an in-flight tick
+    /// and publish one transition. That transition is stamped at the prior
+    /// holder's own tick-start clock reading. The prior holder held the lease at
+    /// its tick start, so its lease had to expire before this holder could take
+    /// over, which puts its stamp at least one lease lifetime ([`Self::lease_ttl`],
+    /// `LEASE_TTL_TICKS` times the eval interval) behind the reading this holder
+    /// took over with. It can lag further by the in-flight tick's own duration
+    /// and by clock skew between the two holders; [`DEFAULT_QUERY_DEADLINE`] (this
+    /// evaluator's `query_deadline`) is the only wall-clock tolerance the
+    /// alerting path defines, so it stands in for that second term. The seal
+    /// margin is therefore `lease_ttl + query_deadline`, and the watermark is the
+    /// ingest hour of `now_ns - seal_margin`. A deployment whose inter-node clock
+    /// skew exceeds the query deadline would need to widen this margin.
+    fn seal_bound_hour(&self, now_ns: i64) -> u32 {
+        let seal_margin_ns = i64::try_from(
+            self.lease_ttl
+                .saturating_add(self.query_deadline)
+                .as_nanos(),
+        )
+        .unwrap_or(i64::MAX);
+        hour_bucket(now_ns.saturating_sub(seal_margin_ns))
     }
 
     /// Try to own this tenant's alert lease for this tick.
@@ -1877,8 +1917,15 @@ mod tick_tests {
             min_ingest_ts_ns: written.summary.min_event_ts_ns,
             max_ingest_ts_ns: written.summary.max_event_ts_ns,
             segment_format_version: 1,
-            created_unix_ns: 10,
-            ingest_hour_bucket: 0,
+            // Created in the same hour the object's events fall in, so the
+            // commit-record cross-check (`ingest_hour_bucket` at or before the
+            // created hour) holds when the seed is in a later hour than epoch.
+            created_unix_ns: written.summary.max_event_ts_ns,
+            // Key the commit under the ingest hour of its own event time so a
+            // query whose window falls in a later hour still resolves it. At the
+            // hour-0 timestamps most tests use this is 0, unchanged; the memo
+            // seal-bound tests seed a metric in hour 1 and need it keyed there.
+            ingest_hour_bucket: hour_bucket(written.summary.max_event_ts_ns),
         })
         .expect("valid commit record");
 
@@ -2327,8 +2374,20 @@ mod tick_tests {
     /// writer seqs keep the commit keys from colliding, so `n` records yield `n`
     /// commit records under the alerts prefix.
     async fn seed_alert_history(evaluator: &AlertEvaluator, records: &[AlertRecord]) {
+        seed_alert_history_from(evaluator, records, 10_000).await;
+    }
+
+    /// [`seed_alert_history`] with an explicit base writer seq, so two seeding
+    /// calls against one evaluator (a prior-holder write published after the
+    /// first batch) do not collide on `(writer_id, epoch, seq)` and its commit
+    /// key.
+    async fn seed_alert_history_from(
+        evaluator: &AlertEvaluator,
+        records: &[AlertRecord],
+        base_seq: u64,
+    ) {
         for (i, record) in records.iter().enumerate() {
-            let seq = 10_000 + i as u64;
+            let seq = base_seq + i as u64;
             let identity = ObjectIdentity {
                 tenant_hash: evaluator.tenant.0,
                 shard: ALERT_SHARD,
@@ -2491,8 +2550,8 @@ mod tick_tests {
             .expect("the lease holder wrote a memo");
         assert_eq!(
             memo.watermark_hour,
-            hour_bucket(NOW_NS),
-            "the watermark is the tick's ingest hour"
+            ev.seal_bound_hour(NOW_NS),
+            "the watermark is the seal-bound hour, not the tick's own hour"
         );
         let rule = threshold_rule();
         let alert_id = compute_alert_id(&rule.rule_id, &rule.labels);
@@ -2535,6 +2594,179 @@ mod tick_tests {
             memo.records.get(&alert_id).map(|r| r.state),
             Some(AlertState::Firing),
             "the holder rewrote a valid memo over the garbage"
+        );
+    }
+
+    /// A memo body that repeats an alert_id is refused as a corrupt memo, so the
+    /// tick falls back to a full fold exactly as `a_corrupt_memo_is_ignored_and_
+    /// rewritten` does, and the fallback fold reads the same `2N` GETs as any
+    /// full fold (finding 1, issue #1294).
+    #[tokio::test]
+    async fn a_duplicate_alert_id_memo_falls_back_to_a_full_fold() {
+        let inner = Arc::new(InstrumentedStore::new(MemoryStore::new()));
+        let metrics = inner.metrics();
+        let store: Arc<dyn ObjectStoreBackend> = inner;
+        let tenant = TenantId::new(TENANT).hash();
+        publish_metric(
+            store.as_ref(),
+            &TenantId::new(TENANT),
+            &[(NOW_NS - 30 * NS_PER_SEC, 1.0)],
+        )
+        .await;
+        let ev = evaluator(Arc::clone(&store), TestClock::at(NOW_NS));
+        let rule = threshold_rule();
+
+        // A single transition in the durable history: a full fold of it is 2 GETs.
+        let n: u64 = 1;
+        let records: Vec<AlertRecord> = (0..n)
+            .map(|i| build_transition_record(&rule, AlertState::Firing, 0, NOW_NS + i as i64))
+            .collect();
+        seed_alert_history(&ev, &records).await;
+
+        // A well-formed memo body that lists the one alert_id twice.
+        let alert_id = compute_alert_id(&rule.rule_id, &rule.labels);
+        let hex = alert_id.to_hex();
+        let body = format!(
+            r#"{{"format_version":1,"watermark_hour":1,"records":[
+                {{"alert_id":"{hex}","rule_id":"high-cpu","state":"firing",
+                 "generation":0,"ts_ns":1,"labels":[],"annotations":[],"body":"b"}},
+                {{"alert_id":"{hex}","rule_id":"high-cpu","state":"resolved",
+                 "generation":1,"ts_ns":2,"labels":[],"annotations":[],"body":"b"}}]}}"#
+        );
+        store
+            .put(
+                &crate::alert_state_memo::alert_state_memo_key(&tenant),
+                Bytes::from(body),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put duplicate-alert_id memo");
+
+        // The reader refuses the duplicate memo outright.
+        assert!(
+            read_alert_state_memo(store.as_ref(), &tenant)
+                .await
+                .is_err(),
+            "a memo repeating an alert_id is refused, not silently deduped"
+        );
+
+        // So the tick folds `None`: a full fold, exactly 2 GETs per transition.
+        let before = metrics.snapshot();
+        let latest = ev.fold_latest(None).await.expect("full fold fallback");
+        let after = metrics.snapshot();
+        assert_eq!(latest.len(), 1, "all transitions share one alert_id");
+        assert_eq!(
+            after.get.calls - before.get.calls,
+            2 * n,
+            "the duplicate-memo fallback is a full fold: one commit GET and one \
+             data GET per transition"
+        );
+    }
+
+    /// The memo watermark is the seal-bound hour, strictly older than the tick's
+    /// own hour when the tick runs within the seal margin of an hour boundary.
+    /// Pinning it to `hour_bucket(now_ns)` (the flip) would let it advance past an
+    /// hour an overlapping prior holder can still write into (finding 2,
+    /// issue #1294).
+    #[tokio::test]
+    async fn the_watermark_never_exceeds_the_seal_bound() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new(TENANT).hash();
+        // A `now` just inside hour 1, within the seal margin of the hour-0
+        // boundary, so the seal bound is hour 0 while the tick's own hour is 1.
+        let now = NS_PER_HOUR + 60 * NS_PER_SEC;
+        publish_metric(
+            store.as_ref(),
+            &TenantId::new(TENANT),
+            &[(now - 30 * NS_PER_SEC, 1.0)],
+        )
+        .await;
+        let mut ev = evaluator(Arc::clone(&store), TestClock::at(now));
+
+        assert_eq!(ev.run_tick().await.records_written, 1, "onset fires");
+
+        let seal = ev.seal_bound_hour(now);
+        assert!(
+            seal < hour_bucket(now),
+            "test is only meaningful when the seal bound (hour {seal}) is strictly \
+             older than the tick's own hour (hour {})",
+            hour_bucket(now)
+        );
+        let memo = read_alert_state_memo(store.as_ref(), &tenant)
+            .await
+            .expect("memo readable")
+            .expect("the lease holder wrote a memo");
+        assert_eq!(
+            memo.watermark_hour, seal,
+            "the watermark is pinned to the seal-bound hour, not the tick's own hour"
+        );
+    }
+
+    /// A transition an overlapping prior holder publishes into an hour below the
+    /// tick's own hour, after this holder's tail LIST, is still folded in on the
+    /// next tick: the seal-bound watermark keeps that hour inside the tail. With
+    /// the watermark reverted to the tick's own hour (the flip) the tail skips
+    /// the hour and the transition is lost forever from the memo (finding 2,
+    /// issue #1294).
+    #[tokio::test]
+    async fn a_transition_published_by_an_overlapping_prior_holder_is_not_lost() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new(TENANT).hash();
+        let rule = threshold_rule();
+        let alert_id = compute_alert_id(&rule.rule_id, &rule.labels);
+
+        // A `now` just inside hour 1, within the seal margin of the hour-0
+        // boundary: the seal-bound watermark is hour 0, the tick's own hour is 1.
+        let now = NS_PER_HOUR + 60 * NS_PER_SEC;
+        // Metric above the threshold so holder A stays Firing and writes no new
+        // transition this tick.
+        publish_metric(
+            store.as_ref(),
+            &TenantId::new(TENANT),
+            &[(now - 30 * NS_PER_SEC, 1.0)],
+        )
+        .await;
+        let mut a = evaluator(Arc::clone(&store), TestClock::at(now));
+
+        // Pre-seed a Firing transition in hour 0, so A folds to Firing.
+        let firing_ts = NS_PER_HOUR - 200 * NS_PER_SEC;
+        assert_eq!(hour_bucket(firing_ts), 0, "the firing record is in hour 0");
+        let firing = build_transition_record(&rule, AlertState::Firing, 0, firing_ts);
+        seed_alert_history_from(&a, &[firing], 10_000).await;
+
+        // A's tick: folds Firing, writes no transition, writes the memo.
+        assert_eq!(
+            a.run_tick().await.records_written,
+            0,
+            "already firing: no new transition written this tick"
+        );
+
+        // The prior holder B, still in flight after A's tail LIST, publishes a
+        // Resolved transition. Its skewed clock stamps it in hour 0 (below A's own
+        // hour 1) but later in ts than A's firing record, so it is the new latest.
+        let resolved_ts = NS_PER_HOUR - 100 * NS_PER_SEC;
+        assert_eq!(hour_bucket(resolved_ts), 0, "the late resolve is in hour 0");
+        assert!(resolved_ts > firing_ts, "the resolve supersedes the firing");
+        let resolved = build_transition_record(&rule, AlertState::Resolved, 0, resolved_ts);
+        seed_alert_history_from(&a, &[resolved], 20_000).await;
+
+        // The next tick reads the memo A wrote and folds its tail on top.
+        let memo = read_alert_state_memo(store.as_ref(), &tenant)
+            .await
+            .expect("memo readable")
+            .expect("A wrote a memo");
+        let via_memo = a.fold_latest(Some(&memo)).await.expect("memo fold");
+        let full = a.load_latest_records().await.expect("full fold");
+
+        assert_eq!(
+            via_memo, full,
+            "the seal-bound watermark keeps the prior holder's hour in the tail, so \
+             the memo fold matches the full fold exactly"
+        );
+        assert_eq!(
+            via_memo.get(&alert_id).map(|r| r.state),
+            Some(AlertState::Resolved),
+            "the late Resolved from the overlapping prior holder is not lost"
         );
     }
 }

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod admission_reconcile;
 pub mod alert_sink;
+pub mod alert_state_memo;
 pub mod alerting;
 pub mod analytics;
 pub mod bucket_protection;


### PR DESCRIPTION
The alert evaluator re-read the entire alert transition history on every
tick: a listing of the whole alerts prefix and then, per entry, a GET of
the commit record and a GET of the data object. Nothing ever compacted or
folded that history, so the per-tick cost grew with the cumulative
transition count rather than the rule count, and no test bounded it.

There is exactly one alert_id per configured rule, so the evaluator
needs one latest record per rule and was reading all of them. This folds
latest-state-per-alert_id into one tenant-wide memo at
t/<tenant>/a/state/latest, written by the lease holder only, that the
evaluator reads on every tick, followed by one listing of the hours at or
after the memo's watermark so a transition written since the memo is
always found and a stale memo is detectable rather than silently wrong.
An absent or corrupt memo falls back to one full fold and is rewritten;
the memo is a derived cache, never a source of truth, so ADR-0040's
fold-derived state stands and no record format changes. The memo carries
its own format_version with a supported-set reader that accepts exactly
{1}.

The last commit closes two review findings. A memo that repeats an
alert_id is refused as a decode error and triggers the full fold instead
of silently keeping the later duplicate. And the watermark is now
seal-bound: it never advances past now minus the lease TTL plus the query
deadline, so a transition that a prior lease holder publishes after this
holder's tail listing, stamped into an older hour by its own clock, is
still inside every future tail listing rather than lost for good. The
steady-state cost stays exactly two GETs and one LIST per replica once
the last transition is older than that margin, and 2 + 2T GETs with T
transitions inside it; tests pin those counts with a counting store and
pin the overlap case as an exact record map against the full fold.

ADR-1294 records the decision, the ADR-0066 migration class (new key
prefix, no version bump, on the sys/maintain/memo precedent), the seal
margin and its constants, and the rejected alternatives. The key layout
in docs/catalog-and-mvcc.md gains the row.

Supersedes #1416.

Fixes: #1294
