### PR TITLE
feat(operator): qualify object store before serving

### DIFF
--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -605,6 +605,11 @@
                     "format": "int32",
                     "nullable": true,
                     "type": "integer"
+                  },
+                  "storeQualifiedHash": {
+                    "description": "The qualify-Job input hash (bucket, region, endpoint, image, credentials\nSecret name) that store qualification last succeeded against (issue #36).\nThe operator gates serving on `ravel store qualify` before it creates any\nDeployment; recording the qualified inputs here makes that gate durable:\na later pass whose inputs still hash to this value proceeds without\nre-running qualification even after the one-shot Job has been\nTTL-garbage-collected, and a pass whose inputs no longer match re-runs it\n(the `StoreQualified` condition flips back to `Pending`) without tearing\ndown the running Deployments. Absent until the first qualification\nsucceeds. Qualification is never re-run on a schedule; only an input\nchange re-triggers it.",
+                    "nullable": true,
+                    "type": "string"
                   }
                 },
                 "type": "object"

--- a/deploy/k8s/operator/rbac.yaml
+++ b/deploy/k8s/operator/rbac.yaml
@@ -13,6 +13,11 @@
 #   - PodDisruptionBudgets (policy): full lifecycle, for the per-tier PDBs the
 #     operator renders (issue #126, ADR-0034 hardening amendment). Delete is what
 #     converges maintain's PDB away when maintain.enabled goes back to false.
+#   - Jobs (batch): full lifecycle, for the one-shot store-qualification Job the
+#     operator runs before it creates any serving Deployment (issue #36). Create
+#     to start it, get/list/watch to observe its terminal state, delete to
+#     recreate it when the qualified inputs change (its pod template is
+#     immutable) and to let its TTL-driven cleanup be operator-owned.
 #   - RavelCluster (and its status subresource): watch the spec, write status.
 #   - Secrets: get only, and NEVER granted by this cluster-wide ClusterRole
 #     (issue #126). The operator reads the credentials, tenant-token, and
@@ -87,6 +92,9 @@ rules:
     verbs: ["get", "update", "patch"]
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
+    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
     verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/k8s/operator/rbac.yaml
+++ b/deploy/k8s/operator/rbac.yaml
@@ -1,24 +1,38 @@
-# RBAC for the Ravel operator (ADR-0034). Grants exactly what the reconcile
-# loop needs and nothing broader:
-#   - Deployments and Services: full lifecycle for the objects it manages
-#     (create/update/patch for apply, get/list/watch for the informer cache,
-#     delete to remove the maintain Deployment when maintain.enabled is false).
-#   - Ingresses: the same lifecycle, for the ingest-affinity Ingress objects
-#     (ADR-0076 decision 1). Delete is what lets gateway.ingestAffinity.enabled
-#     go back to false without leaving an orphan routing live ingest traffic.
-#   - HTTPRoutes/GRPCRoutes (gateway.networking.k8s.io): the same lifecycle, for
-#     the Gateway API exposure routes (ADR-0080 decision 2). Delete is what lets
-#     gateway.exposure be removed without leaving an orphan route attached to
-#     the Gateway.
-#   - PodDisruptionBudgets (policy): full lifecycle, for the per-tier PDBs the
-#     operator renders (issue #126, ADR-0034 hardening amendment). Delete is what
-#     converges maintain's PDB away when maintain.enabled goes back to false.
-#   - Jobs (batch): full lifecycle, for the one-shot store-qualification Job the
-#     operator runs before it creates any serving Deployment (issue #36). Create
-#     to start it, get/list/watch to observe its terminal state, delete to
-#     recreate it when the qualified inputs change (its pod template is
-#     immutable) and to let its TTL-driven cleanup be operator-owned.
-#   - RavelCluster (and its status subresource): watch the spec, write status.
+# RBAC for the Ravel operator (ADR-0034). Grants exactly the verbs the
+# reconcile loop actually calls and nothing broader. Every write goes through
+# server-side apply, which is a PATCH (creating an object that does not yet
+# exist needs `create` as well), so `update` (the PUT verb) is never issued and
+# is granted nowhere. Reads come from three mechanisms: an explicit `.get()`,
+# an informer (`Controller`/`.owns()`, which LIST+WATCH only), and RBAC
+# escalation prevention (creating a Role that grants a verb requires the
+# operator to already hold that verb). A resource the operator only writes and
+# deletes gets `create`/`patch`/`delete` and no read verbs.
+#   - Deployments: create/patch (apply), get (live replica reads,
+#     controller::live_replica_counts / live_deployment_exists), list/watch
+#     (the `.owns()` informer), delete (remove the maintain Deployment when
+#     maintain.enabled is false, and the router sweep).
+#   - Services: create/patch (apply), list/watch (the `.owns()` informer),
+#     get/list/watch (escalation: the router Role,
+#     reconcile::desired_router_role, grants `services get/list/watch`), delete
+#     (the router sweep). No `.get()` call, but get is required for escalation.
+#   - Ingresses: create/patch (apply), list/watch (the `.owns()` informer),
+#     delete (ADR-0076 decision 1: lets gateway.ingestAffinity.enabled go back
+#     to false without orphaning a route). No `.get()` and no informer beyond
+#     list/watch, so no bare `get`.
+#   - HTTPRoutes/GRPCRoutes (gateway.networking.k8s.io): create/patch (apply)
+#     and delete only, for the Gateway API exposure routes (ADR-0080 decision
+#     2). They are applied and swept, never read (no informer, no `.get()`).
+#   - PodDisruptionBudgets (policy): create/patch (apply) and delete only, for
+#     the per-tier PDBs (issue #126, ADR-0034 hardening amendment). Applied and
+#     swept, never read.
+#   - Jobs (batch): create/patch (apply), get (observe the qualify Job's
+#     terminal state, controller::observe_qualify_job), delete (recreate it with
+#     foreground propagation when the qualified inputs change; its pod template
+#     is immutable). Not watched by an informer, so no list/watch.
+#   - RavelCluster: list/watch only (the primary `Controller` informer; the
+#     reconcile object comes from the informer cache, never a `.get()`, and the
+#     spec is never patched). Its status subresource: patch only (patch_status
+#     is a merge PATCH; the status is never read back or replaced).
 #   - Secrets: get only, and NEVER granted by this cluster-wide ClusterRole
 #     (issue #126). The operator reads the credentials, tenant-token, and
 #     deployment-key Secrets to resolve tenant names; it never lists, writes, or
@@ -31,12 +45,13 @@
 #     namespace with no such RoleBinding 403s on Secret resolution and the
 #     operator reports a SecretsUnreadable condition on it (see
 #     crate::controller::secret_error).
-#   - ServiceAccounts, Roles, and RoleBindings: the same lifecycle, for the
-#     ravel-native ingest router's own ServiceAccount and its namespaced,
-#     least-privilege Role/RoleBinding (ADR-0080 decision 3). The operator's own
-#     identity needs these verbs to create those objects for the router; delete
-#     is what lets backend: ravelNative be switched away without leaving the
-#     router's RBAC orphaned.
+#   - ServiceAccounts, Roles, and RoleBindings: create/patch (apply) and delete
+#     only, for the ravel-native ingest router's own ServiceAccount and its
+#     namespaced, least-privilege Role/RoleBinding (ADR-0080 decision 3). The
+#     operator applies and sweeps these, never reads them, so no read verbs;
+#     delete is what lets backend: ravelNative be switched away without leaving
+#     the router's RBAC orphaned. (Creating the router Role is what forces the
+#     services and endpointslices read grants below, via escalation prevention.)
 #   - EndpointSlices (discovery.k8s.io): get/list/watch only. The operator never
 #     reads EndpointSlices itself; it needs this grant because Kubernetes RBAC
 #     escalation prevention forbids creating a Role that grants a permission the
@@ -63,39 +78,53 @@ metadata:
     app.kubernetes.io/name: ravel-operator
     app.kubernetes.io/managed-by: ravel-operator
 rules:
+  # apply (create+patch), explicit .get() reads, .owns() informer (list+watch),
+  # and delete (maintain teardown + router sweep).
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "get", "list", "watch", "delete"]
+  # apply, .owns() informer (list+watch), get/list/watch required by escalation
+  # prevention (the router Role grants services get/list/watch), and delete.
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "get", "list", "watch", "delete"]
+  # apply, .owns() informer (list+watch), delete. No explicit get, no escalation.
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "list", "watch", "delete"]
+  # applied and swept only, never read.
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes", "grpcroutes"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "delete"]
+  # applied and swept only, never read.
   - apiGroups: [""]
     resources: ["serviceaccounts"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "delete"]
+  # applied and swept only, never read.
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "delete"]
+  # escalation-prevention grant for the router Role only; never read directly.
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
+  # primary informer only; the spec is never patched (only the status is).
   - apiGroups: ["ravel.nofire.ai"]
     resources: ["ravelclusters"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    verbs: ["list", "watch"]
+  # patch_status is a merge PATCH; status is never read back or replaced.
   - apiGroups: ["ravel.nofire.ai"]
     resources: ["ravelclusters/status"]
-    verbs: ["get", "update", "patch"]
+    verbs: ["patch"]
+  # applied and swept only, never read.
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "delete"]
+  # apply, explicit .get() (observe the qualify Job), delete (foreground
+  # recreate). Not watched by an informer, so no list/watch.
   - apiGroups: ["batch"]
     resources: ["jobs"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "get", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -307,14 +307,37 @@ loop as everything else:
   namespace, with the server image, credentials Secret, bucket, region, and
   endpoint of the tiers it gates, running `ravel store qualify`. The
   gateway, query, and maintain Deployments are created only once that Job
-  reports `Complete`. `restartPolicy: Never`, a small `backoffLimit`, and a
-  `ttlSecondsAfterFinished` keep a finished Job from accumulating.
+  reports `Complete`. `restartPolicy: Never`, a small `backoffLimit`, an
+  `activeDeadlineSeconds`, and a `ttlSecondsAfterFinished` keep a finished
+  Job from accumulating.
+- The Job sets `activeDeadlineSeconds` because `backoffLimit` bounds only how
+  many *failed* attempts run, not one attempt that never terminates: a
+  qualify pod against an S3 endpoint that accepts the connection and then
+  never answers would otherwise run indefinitely, leaving `StoreQualified`
+  stuck at `Pending` with no Deployment ever created. The deadline is 900 s,
+  derived from what `ravel store qualify` does: it runs 28 sequential object
+  operations (create-if-absent probe 3, CAS-version probe 4, read-after-write
+  probe 10 = 5 cycles of put+get, list-after-write probe 10 = 5 cycles of
+  put+list, and the final `sys/qualification` write 1; the two informational
+  probes issue no request through the object-store contract). Each operation's
+  per-request ceiling is the S3 client's 20 s `request_timeout`, so a
+  slow-but-healthy run whose every operation nears that ceiling without
+  retrying is bounded by 28 * 20 s = 560 s. 900 s adds a ~1.6x margin (340 s)
+  for pod scheduling, image pull, and the odd single retry, while staying far
+  below a hung endpoint's ~200 s-per-operation worst case (`retry_timeout`
+  180 s + `request_timeout` 20 s), so a hang trips the deadline after roughly
+  four stalled operations. The deadline is a tuning knob, deliberately not
+  part of the qualified-input hash: changing it must not re-run a
+  qualification that already passed.
 - A new `StoreQualified` status condition carries the gate's state with the
   same shape as the other conditions (reasons `Pending` while the Job is
-  created or running, `Succeeded` once it completes, `Failed` when it
-  exhausts its `backoffLimit`, the last carrying the Job's terminal
-  message). On `Failed` no Deployment is created and the pass requeues on
-  the existing failure backoff rather than spinning.
+  created or running, `Succeeded` once it completes, `Failed` when it fails,
+  the last carrying the Job's terminal reason and message). A Job that fails
+  by exhausting its `backoffLimit` and one the Job controller fails for
+  exceeding `activeDeadlineSeconds` (reason `DeadlineExceeded`) both read as
+  `Failed`, with the reason named in the message so an operator sees why. On
+  `Failed` no Deployment is created and the pass requeues on the existing
+  failure backoff rather than spinning.
 - The inputs qualification proves against (bucket, region, endpoint, image,
   credentials Secret name) are hashed into a Job annotation and, on success,
   into a durable `status.storeQualifiedHash`. A later pass whose inputs

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -314,21 +314,27 @@ loop as everything else:
   many *failed* attempts run, not one attempt that never terminates: a
   qualify pod against an S3 endpoint that accepts the connection and then
   never answers would otherwise run indefinitely, leaving `StoreQualified`
-  stuck at `Pending` with no Deployment ever created. The deadline is 900 s,
-  derived from what `ravel store qualify` does: it runs 28 sequential object
+  stuck at `Pending` with no Deployment ever created. This deadline is
+  JOB-WIDE, not per-attempt: Kubernetes counts it against the Job's total
+  active time summed across every retry, and it takes precedence over
+  `backoffLimit`. So the two knobs are sized together, or a slow-but-healthy
+  first attempt plus a retry would trip `DeadlineExceeded` before the retry
+  budget was ever spent. `ravel store qualify` runs 28 sequential object
   operations (create-if-absent probe 3, CAS-version probe 4, read-after-write
   probe 10 = 5 cycles of put+get, list-after-write probe 10 = 5 cycles of
   put+list, and the final `sys/qualification` write 1; the two informational
   probes issue no request through the object-store contract). Each operation's
-  per-request ceiling is the S3 client's 20 s `request_timeout`, so a
-  slow-but-healthy run whose every operation nears that ceiling without
-  retrying is bounded by 28 * 20 s = 560 s. 900 s adds a ~1.6x margin (340 s)
-  for pod scheduling, image pull, and the odd single retry, while staying far
-  below a hung endpoint's ~200 s-per-operation worst case (`retry_timeout`
-  180 s + `request_timeout` 20 s), so a hang trips the deadline after roughly
-  four stalled operations. The deadline is a tuning knob, deliberately not
-  part of the qualified-input hash: changing it must not re-run a
-  qualification that already passed.
+  per-request ceiling is the S3 client's 20 s `request_timeout`, so one
+  slow-but-healthy attempt whose every operation nears that ceiling without
+  retrying is bounded by 28 * 20 s = 560 s; adding ~140 s per attempt for pod
+  scheduling and image pull gives a 700 s per-attempt budget. `backoffLimit`
+  is 1 (two attempts: the initial run plus one retry), so the Job-wide deadline
+  is 2 * 700 s = 1400 s -- a slow-but-healthy initial attempt AND a full retry
+  both complete before it fires. A single hung attempt still terminates, at the
+  1400 s Job-wide bound rather than running forever (a hung endpoint stalls each
+  operation at ~200 s = `retry_timeout` 180 s + `request_timeout` 20 s). Both
+  knobs are tuning parameters, deliberately not part of the qualified-input
+  hash: changing either must not re-run a qualification that already passed.
 - A new `StoreQualified` status condition carries the gate's state with the
   same shape as the other conditions (reasons `Pending` while the Job is
   created or running, `Succeeded` once it completes, `Failed` when it fails,
@@ -339,14 +345,29 @@ loop as everything else:
   `Failed` no Deployment is created and the pass requeues on the existing
   failure backoff rather than spinning.
 - The inputs qualification proves against (bucket, region, endpoint, image,
-  credentials Secret name) are hashed into a Job annotation and, on success,
-  into a durable `status.storeQualifiedHash`. A later pass whose inputs
-  still hash to the recorded value proceeds without re-running qualification
-  even after the Job's TTL garbage-collected it. When the inputs change, the
-  operator deletes the stale Job (its pod template is immutable), recreates
-  it, and flips `StoreQualified` back to `Pending`; a cluster that was
-  already serving keeps its existing Deployments up while the new inputs
+  credentials Secret name, and that credentials Secret's `resourceVersion`)
+  are hashed into a Job annotation and, on success, into a durable
+  `status.storeQualifiedHash`. A later pass whose inputs still hash to the
+  recorded value proceeds without re-running qualification even after the
+  Job's TTL garbage-collected it. When the inputs change, the operator
+  deletes the stale Job with foreground propagation (its pod template is
+  immutable, and foreground propagation tears down the old Pod before the Job
+  object disappears so the replacement never races a live stale Pod),
+  recreates it, and flips `StoreQualified` back to `Pending`; a cluster that
+  was already serving keeps its existing Deployments up while the new inputs
   qualify, rather than being torn down for a pending config edit.
+  - The credentials `resourceVersion` is what makes a fixed-name credential
+    ROTATION re-qualify: rotating the Secret in place keeps its name but bumps
+    its `resourceVersion`, so without it a rotation to credentials that no
+    longer pass the contract would skip qualification once the prior Job had
+    been TTL-collected. Only the `resourceVersion` (opaque API metadata) enters
+    the hash, never any Secret data, and it reaches neither the status nor a
+    log line. The operator does not watch Secrets (the per-namespace
+    `ravel-operator-secrets` RoleBinding grants `get` only, not `watch`), so a
+    rotation is noticed on the next periodic requeue (the controller's 300 s
+    resync): that pass reads the new `resourceVersion`, the hash changes, and
+    the gate recreates the Job. The bound on noticing an in-place rotation is
+    therefore one resync interval.
 - Non-goal: qualification is not re-run on a schedule. It runs once per
   distinct set of inputs and only re-runs when those inputs change. A
   periodic re-qualification would add object-store traffic and a recurring
@@ -357,7 +378,14 @@ Because the operator now qualifies, the kind lane's hand-run qualification
 Job is removed from scripts/kind-up.sh: it deploys through the operator, so
 the operator's Job is the single qualification and a second one would only
 duplicate it. The RBAC in deploy/k8s/operator/rbac.yaml gains a `batch`
-`jobs` rule (full lifecycle) for the Job the operator now owns. The gate
+`jobs` rule for the Job the operator now owns, scoped to the verbs the
+reconcile loop calls: `create`/`patch` (server-side apply), `get` (observe the
+Job's terminal state), and `delete` (foreground recreate on an input change).
+It is not watched by an informer, so it takes no `list`/`watch`, and every
+write is a PATCH, so it takes no `update`. That same audit -- server-side apply
+is a PATCH, not a PUT, and a resource the operator only applies and sweeps is
+never read -- removed the unused `update` verb from every rule and the unused
+read verbs from the write-only resources. The gate
 decision and the Job renderer are pure functions in `reconcile.rs` with
 unit tests; the runtime behavior (the Job actually completing and the
 Deployments appearing only after) is left to the k8s CI lane (decision 8),

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -289,6 +289,57 @@ runtime; nothing rejects the pod for the dropped capability. What the kind
 lane actually proves is that the hardened pods reach readiness and complete
 an OTLP round trip, not that a missing capability is rejected.
 
+**Amendment (2026-09-07): the operator qualifies the object store before it
+serves (issue #36).** Every `ravel-server` mode refuses to start on a
+non-Memory store whose `sys/qualification` marker is absent (ADR-0050
+section 6, EC7), and that marker is only ever written by an explicit
+`ravel store qualify` run. The operator described in decision 3 never made
+that run, so a RavelCluster pointed at a backend that fails the object-store
+contract (docs/object-store-contract.md) came up as three tiers of pods all
+crash-looping on the same startup refusal, with the reason buried in pod
+logs rather than on `.status`. The kind lane papered over this with a
+hand-run qualification Job (scripts/kind-up.sh) that a real install had no
+equivalent of. Qualification is now the operator's job, in the same reconcile
+loop as everything else:
+
+- Before it creates any serving Deployment, the reconcile loop renders and
+  applies a one-shot Job named `<cluster>-qualify` in the cluster's
+  namespace, with the server image, credentials Secret, bucket, region, and
+  endpoint of the tiers it gates, running `ravel store qualify`. The
+  gateway, query, and maintain Deployments are created only once that Job
+  reports `Complete`. `restartPolicy: Never`, a small `backoffLimit`, and a
+  `ttlSecondsAfterFinished` keep a finished Job from accumulating.
+- A new `StoreQualified` status condition carries the gate's state with the
+  same shape as the other conditions (reasons `Pending` while the Job is
+  created or running, `Succeeded` once it completes, `Failed` when it
+  exhausts its `backoffLimit`, the last carrying the Job's terminal
+  message). On `Failed` no Deployment is created and the pass requeues on
+  the existing failure backoff rather than spinning.
+- The inputs qualification proves against (bucket, region, endpoint, image,
+  credentials Secret name) are hashed into a Job annotation and, on success,
+  into a durable `status.storeQualifiedHash`. A later pass whose inputs
+  still hash to the recorded value proceeds without re-running qualification
+  even after the Job's TTL garbage-collected it. When the inputs change, the
+  operator deletes the stale Job (its pod template is immutable), recreates
+  it, and flips `StoreQualified` back to `Pending`; a cluster that was
+  already serving keeps its existing Deployments up while the new inputs
+  qualify, rather than being torn down for a pending config edit.
+- Non-goal: qualification is not re-run on a schedule. It runs once per
+  distinct set of inputs and only re-runs when those inputs change. A
+  periodic re-qualification would add object-store traffic and a recurring
+  failure mode for no gain, since the contract a backend satisfies does not
+  lapse between config edits.
+
+Because the operator now qualifies, the kind lane's hand-run qualification
+Job is removed from scripts/kind-up.sh: it deploys through the operator, so
+the operator's Job is the single qualification and a second one would only
+duplicate it. The RBAC in deploy/k8s/operator/rbac.yaml gains a `batch`
+`jobs` rule (full lifecycle) for the Job the operator now owns. The gate
+decision and the Job renderer are pure functions in `reconcile.rs` with
+unit tests; the runtime behavior (the Job actually completing and the
+Deployments appearing only after) is left to the k8s CI lane (decision 8),
+unproven until that lane runs.
+
 ## Rejected alternatives
 
 1. **Go operator (kubebuilder/controller-runtime).** The larger example

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,7 +195,17 @@ encryption headers.
 Startup on any non-memory store is also gated on a durable qualification
 record: a deployment runs `ravel-cli store qualify` once before its first
 server starts, which proves the backend honours the semantics the commit
-protocol depends on before any data rides on them. The capability table, the
+protocol depends on before any data rides on them. On Kubernetes the
+operator makes that run itself: before it creates any serving Deployment for
+a `RavelCluster`, it applies a one-shot `<cluster>-qualify` Job running
+`ravel store qualify` against that cluster's bucket and gates the gateway,
+query, and maintain Deployments on the Job completing, so a cluster never
+comes up as three tiers crash-looping on a backend that fails the contract.
+It records the qualified inputs (bucket, region, endpoint, image,
+credentials Secret) in a `StoreQualified` status condition and a durable
+`status.storeQualifiedHash`, re-runs qualification only when those inputs
+change (never on a schedule), and leaves a running cluster's Deployments up
+while re-qualifying (ADR-0034). The capability table, the
 qualification suite, and the retry and timeout contract are in
 [docs/object-store-contract.md](object-store-contract.md).
 

--- a/scripts/kind-up.sh
+++ b/scripts/kind-up.sh
@@ -194,62 +194,11 @@ if ! kubectl wait --namespace "$NAMESPACE" --for=condition=Complete --timeout=30
 fi
 log "bucket ${BUCKET} ready on ${S3_ENDPOINT}"
 
-# ---- 4b. store qualification --------------------------------------------
-# ADR-0050 section 6 (EC7): server startup on a non-Memory store
-# refuses unless `sys/qualification` is already present. Unlike the tenancy
-# marker and gc-config objects, there is deliberately no bootstrap-and-continue
-# path for this one -- it is only ever written by an explicit `ravel-cli store
-# qualify` run, so this script has to be that run, or every gateway/query/
-# maintain pod the RavelCluster below creates crash-loops on a fresh bucket
-# (the exact EC3/#566 startup-refusal shape, this time for qualification).
-# Runs as a one-shot Job using the server image already loaded into the
-# cluster (it ships ravel-cli alongside ravel-server, see the Dockerfile),
-# against the same bucket/credentials the RavelCluster will use.
-log "running store qualification (ravel-cli store qualify) against ${S3_ENDPOINT}"
-kubectl delete job ravel-store-qualify --namespace "$NAMESPACE" \
-  --ignore-not-found --wait=true >/dev/null
-kubectl apply -f - <<YAML
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ravel-store-qualify
-  namespace: ${NAMESPACE}
-spec:
-  backoffLimit: 2
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: qualify
-          image: ${SERVER_IMAGE}
-          imagePullPolicy: IfNotPresent
-          command: ["/usr/local/bin/ravel-cli"]
-          args: ["--store", "s3", "store", "qualify"]
-          env:
-            - name: RAVEL_S3_ENDPOINT
-              value: "${S3_ENDPOINT}"
-            - name: RAVEL_S3_BUCKET
-              value: "${BUCKET}"
-            - name: RAVEL_S3_REGION
-              value: "us-east-1"
-            - name: RAVEL_S3_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ${S3_CREDENTIALS_SECRET}
-                  key: accessKeyId
-            - name: RAVEL_S3_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ${S3_CREDENTIALS_SECRET}
-                  key: secretAccessKey
-YAML
-if ! kubectl wait --namespace "$NAMESPACE" --for=condition=Complete --timeout=120s \
-  job/ravel-store-qualify; then
-  kubectl logs --namespace "$NAMESPACE" job/ravel-store-qualify 2>&1 |
-    sed 's/^/[qualify-job] /' >&2 || true
-  die "store qualification job did not complete"
-fi
-log "store qualified"
+# Store qualification is no longer a step here: the operator runs its own
+# one-shot `<cluster>-qualify` Job before it creates any serving Deployment and
+# gates them on its success (issue #36, ADR-0034), so this script installing the
+# operator (step 5) and applying the RavelCluster (step 6) is enough to qualify
+# the bucket exactly once. A hand-run Job here would only duplicate it.
 
 # ---- 5. operator -------------------------------------------------------------
 # CRD before the operator Deployment: the operator's watch fails until the

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -307,6 +307,21 @@ async fn resolve_credential_resource_versions(
     Ok(versions)
 }
 
+/// The shared `storage.s3.credentialsSecretRef` Secret's resolved
+/// `resourceVersion` (findings 3 and 6): the credential the qualify Job
+/// authenticates with, and the one folded into [`qualify_job_input_hash`].
+/// Looked up by the SHARED credential's name so a per-tier override's
+/// `resourceVersion` never stands in for it. `None` when that Secret's version
+/// could not be resolved (absent from the map).
+fn shared_credentials_rv<'a>(
+    spec: &RavelClusterSpec,
+    versions: &'a std::collections::BTreeMap<String, String>,
+) -> Option<&'a str> {
+    versions
+        .get(&spec.storage.s3.credentials_secret_ref.name)
+        .map(String::as_str)
+}
+
 /// Map a Secret `get` error: a 404 becomes [`Error::SecretNotFound`] naming the
 /// Secret and the spec field that referenced it; a 403 becomes
 /// [`Error::SecretsUnreadable`] naming the namespace, Secret, and the
@@ -916,6 +931,33 @@ where
     Ok(())
 }
 
+/// [`DeleteParams`] for the stale qualify Job (finding 2): foreground
+/// propagation, so Kubernetes keeps the Job object (blocked by the
+/// `foregroundDeletion` finalizer) until its owned Pod has been deleted, rather
+/// than removing the Job while that Pod still runs. The controller only creates
+/// the replacement Job once it observes the old one fully absent
+/// ([`QualificationDecision::Qualify`] with `recreate: false`), so foreground
+/// propagation is what guarantees the old inputs' Pod is gone before the fresh
+/// Job's Pod starts. Factored out so the propagation choice is pinned by a unit
+/// test.
+fn stale_qualify_job_delete_params() -> DeleteParams {
+    DeleteParams::foreground()
+}
+
+/// Delete the stale qualify Job with foreground propagation
+/// ([`stale_qualify_job_delete_params`]), treating a 404 as success (it may have
+/// already been collected). Re-issuing this on a Job already terminating is
+/// idempotent: the controller keeps deciding `recreate` (the terminating Job
+/// still reports the old input hash) and requeues until the Job is fully absent.
+async fn delete_stale_qualify_job(api: &Api<Job>, name: &str) -> Result<(), Error> {
+    if let Err(err) = api.delete(name, &stale_qualify_job_delete_params()).await
+        && !is_not_found(&err)
+    {
+        return Err(err.into());
+    }
+    Ok(())
+}
+
 /// Reconcile one `RavelCluster` to its desired Deployments and Services.
 ///
 /// Wraps [`reconcile_inner`] so that any failure before the success-path status
@@ -971,8 +1013,10 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 obj.metadata.generation,
                 &reason,
                 &message,
-                waiting_since,
-                store_qualified_hash,
+                PersistedStatus {
+                    gc_bootstrap_waiting_since: waiting_since,
+                    store_qualified_hash,
+                },
                 extra_conditions,
             )
             .await
@@ -994,6 +1038,27 @@ async fn reconcile_inner(
     instance: &str,
     mut extra_conditions: Vec<Condition>,
 ) -> Result<Action, Error> {
+    // Read the resourceVersion of every credential Secret the spec references
+    // BEFORE the qualification gate (finding 3): the shared storage.s3 credential
+    // plus any per-tier override (ADR-0055 section 5). Resolving credentials
+    // first means a missing or unreadable Secret surfaces as SecretNotFound /
+    // SecretsUnreadable straight away, rather than leaving the qualify Job's
+    // required secretKeyRef pods Pending until the deadline fires and
+    // StoreQualified reporting DeadlineExceeded (and a Failed Job with the current
+    // hash sitting Failed until its TTL collects it) instead of the real cause.
+    // The resolved versions are reused for the qualified-input hash below and for
+    // rendering further down, so this is one read, not an extra one: each
+    // Deployment's pod-template checksum is later computed from the one Secret its
+    // tier resolves to, so a per-role credential rotation rolls only the
+    // Deployment(s) that consume it.
+    let credential_resource_versions =
+        resolve_credential_resource_versions(client, namespace, &obj.spec).await?;
+    // The shared credentials Secret's resourceVersion feeds the qualified-input
+    // hash (finding 6): the qualify Job authenticates with this same shared
+    // Secret, so a fixed-name rotation of it is a different qualified input and
+    // must re-run qualification.
+    let shared_rv = shared_credentials_rv(&obj.spec, &credential_resource_versions);
+
     // Store qualification gate (issue #36). Before anything that would read or
     // write the object store is created -- the sys/auth token map, the ingest
     // router, and above all the serving Deployments -- prove the store passes
@@ -1007,7 +1072,7 @@ async fn reconcile_inner(
     // re-trigger it (ADR-0034).
     let jobs: Api<Job> = Api::namespaced(client.clone(), namespace);
     let qualify_name = child(instance, QUALIFY_COMPONENT);
-    let desired_hash = qualify_job_input_hash(&obj.spec);
+    let desired_hash = qualify_job_input_hash(&obj.spec, shared_rv);
     let qualified_hash = obj
         .status
         .as_ref()
@@ -1037,16 +1102,33 @@ async fn reconcile_inner(
             // re-qualifying after a config edit keeps the ones it has (this pass
             // never reaches the Deployment apply/sweep below), so a pending
             // config change does not tear a serving cluster down.
+            //
+            // `unavailable_reason` carries the qualification state onto the
+            // `Available=False` condition (finding 4), so a fresh cluster held for
+            // qualification says why -- Pending with the qualifying message, or
+            // Failed with the Job's failure message -- instead of the generic
+            // MinimumReplicasUnavailable. `build_status` ignores it when prior
+            // ready replicas keep the cluster Available, so a serving cluster under
+            // re-qualification stays Available=True.
             let owner = obj.controller_owner_ref(&()).map(|owner| vec![owner]);
-            let (store_qualified_condition, action) = match &decision {
+            let (store_qualified_condition, unavailable_reason, action): (
+                Condition,
+                (&str, String),
+                Action,
+            ) = match &decision {
                 QualificationDecision::Qualify { recreate } => {
                     if *recreate {
                         // The Job's inputs changed; its pod template is immutable,
-                        // so delete the stale Job (its pods with it) and let the
-                        // next pass observe it absent and create a fresh one.
-                        delete_if_present(&jobs, &qualify_name).await?;
+                        // so delete the stale Job with FOREGROUND propagation
+                        // (finding 2) -- its owned Pod is torn down before the Job
+                        // object disappears -- and let a later pass observe it fully
+                        // absent and create a fresh one. Without foreground
+                        // propagation Kubernetes can remove the Job while its Pod
+                        // still runs the old inputs, and the next reconcile would
+                        // create the replacement alongside that live stale Pod.
+                        delete_stale_qualify_job(&jobs, &qualify_name).await?;
                     } else {
-                        let mut job = desired_qualify_job(&obj.spec, instance);
+                        let mut job = desired_qualify_job(&obj.spec, instance, shared_rv);
                         job.metadata.namespace = Some(namespace.to_string());
                         job.metadata.owner_references = owner;
                         apply(&jobs, &qualify_name, &job).await?;
@@ -1059,6 +1141,10 @@ async fn reconcile_inner(
                             STORE_QUALIFIED_PENDING_REASON,
                             STORE_QUALIFYING_MESSAGE,
                         ),
+                        (
+                            STORE_QUALIFIED_PENDING_REASON,
+                            STORE_QUALIFYING_MESSAGE.to_string(),
+                        ),
                         Action::requeue(BOOTSTRAP_POLL),
                     )
                 }
@@ -1070,6 +1156,10 @@ async fn reconcile_inner(
                         STORE_QUALIFIED_PENDING_REASON,
                         STORE_QUALIFYING_MESSAGE,
                     ),
+                    (
+                        STORE_QUALIFIED_PENDING_REASON,
+                        STORE_QUALIFYING_MESSAGE.to_string(),
+                    ),
                     Action::requeue(BOOTSTRAP_POLL),
                 ),
                 QualificationDecision::Failed(message) => (
@@ -1080,6 +1170,7 @@ async fn reconcile_inner(
                         STORE_QUALIFIED_FAILED_REASON,
                         message,
                     ),
+                    (STORE_QUALIFIED_FAILED_REASON, message.clone()),
                     Action::requeue(RETRY),
                 ),
                 QualificationDecision::Proceed => unreachable!("Proceed handled above"),
@@ -1089,7 +1180,8 @@ async fn reconcile_inner(
             // Report the readiness a prior pass recorded, so a cluster already
             // serving through a re-qualification keeps `Available=True` instead of
             // flipping to "waiting for tiers" on every poll while the new inputs
-            // qualify. A fresh cluster has none of these and reports Available=False.
+            // qualify. A fresh cluster has none of these and reports Available=False
+            // with the qualification reason.
             let prior = obj.status.as_ref();
             write_status(
                 client,
@@ -1099,9 +1191,12 @@ async fn reconcile_inner(
                 prior.and_then(|s| s.gateway_ready_replicas),
                 prior.and_then(|s| s.query_ready_replicas),
                 prior.and_then(|s| s.maintain_ready_replicas),
-                None,
-                prior.and_then(|s| s.gc_bootstrap_waiting_since.clone()),
-                qualified_hash,
+                Some((unavailable_reason.0, unavailable_reason.1.as_str())),
+                PersistedStatus {
+                    gc_bootstrap_waiting_since: prior
+                        .and_then(|s| s.gc_bootstrap_waiting_since.clone()),
+                    store_qualified_hash: qualified_hash,
+                },
                 extra_conditions,
             )
             .await?;
@@ -1160,16 +1255,11 @@ async fn reconcile_inner(
         .await;
     }
 
-    // Read the resourceVersion of every credential Secret the spec references:
-    // the shared storage.s3 credential plus any per-tier override (ADR-0055
-    // section 5). Each Deployment's pod-template checksum is later computed (in
-    // reconcile) from the one Secret its tier resolves to, so a per-role
-    // credential rotation rolls only the Deployment(s) that consume it. The
-    // shared credential is always referenced (some tier falls back to it unless
-    // all three override); reading it always keeps the no-override path
-    // identical to before.
-    let credential_resource_versions =
-        resolve_credential_resource_versions(client, namespace, &obj.spec).await?;
+    // Reuse the credential resourceVersions resolved before the gate (finding 3):
+    // each Deployment's pod-template checksum is computed (in reconcile) from the
+    // one Secret its tier resolves to, so a per-role credential rotation rolls
+    // only the Deployment(s) that consume it. The shared credential is always
+    // referenced (some tier falls back to it unless all three override).
     let render_ctx = RenderCtx {
         tenant_names: token_secret.tenant_names,
         token_resource_version: token_secret.resource_version,
@@ -1512,8 +1602,10 @@ async fn reconcile_inner(
         query_ready,
         maintain_ready,
         available_hold.as_ref().map(|(r, m)| (*r, m.as_str())),
-        gc_bootstrap_waiting_since,
-        store_qualified_hash,
+        PersistedStatus {
+            gc_bootstrap_waiting_since,
+            store_qualified_hash,
+        },
         extra_conditions,
     )
     .await?;
@@ -1715,6 +1807,22 @@ fn spec_conditions(spec: &RavelClusterSpec, observed_generation: Option<i64>) ->
     )]
 }
 
+/// The two durable status fields that outlive a single reconcile pass and ride
+/// through every status writer: the `sys/gc` bootstrap-wait start timestamp and
+/// the qualified-inputs hash. Grouped in one named struct (finding 5) so the two
+/// adjacent `Option<String>` values cannot be swapped at a call site: a swap
+/// would persist the timestamp as the hash (and vice versa), silently
+/// re-triggering qualification or breaking stall tracking.
+#[derive(Debug, Clone, Default)]
+struct PersistedStatus {
+    /// `status.gcBootstrapWaitingSince`: the RFC3339 instant the current
+    /// bootstrap hold began, or `None` when not holding.
+    gc_bootstrap_waiting_since: Option<String>,
+    /// `status.storeQualifiedHash`: the inputs the store last qualified
+    /// against (issue #36), or `None` before the first qualification.
+    store_qualified_hash: Option<String>,
+}
+
 /// Build the success-path status: observed generation, per-mode ready replicas,
 /// an `Available` condition derived from whether the gateway and query tiers
 /// report ready replicas, and whatever spec-derived conditions this pass
@@ -1722,17 +1830,15 @@ fn spec_conditions(spec: &RavelClusterSpec, observed_generation: Option<i64>) ->
 ///
 /// `unavailable_reason` names a specific reason for `Available=False` when this
 /// pass knows one better than "not ready yet": today the `sys/gc` bootstrap
-/// hold and its unavailable case. It cannot make a ready cluster unavailable,
-/// only explain an unready one.
-#[allow(clippy::too_many_arguments)]
+/// hold and its unavailable case, and the store-qualification hold (finding 4).
+/// It cannot make a ready cluster unavailable, only explain an unready one.
 fn build_status(
     observed_generation: Option<i64>,
     gateway_ready: Option<i32>,
     query_ready: Option<i32>,
     maintain_ready: Option<i32>,
     unavailable_reason: Option<(&str, &str)>,
-    gc_bootstrap_waiting_since: Option<String>,
-    store_qualified_hash: Option<String>,
+    persisted: PersistedStatus,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let available = gateway_ready.unwrap_or(0) > 0 && query_ready.unwrap_or(0) > 0;
@@ -1762,8 +1868,8 @@ fn build_status(
         gateway_ready_replicas: gateway_ready,
         query_ready_replicas: query_ready,
         maintain_ready_replicas: maintain_ready,
-        gc_bootstrap_waiting_since,
-        store_qualified_hash,
+        gc_bootstrap_waiting_since: persisted.gc_bootstrap_waiting_since,
+        store_qualified_hash: persisted.store_qualified_hash,
         conditions,
     }
 }
@@ -1778,8 +1884,7 @@ fn build_degraded_status(
     observed_generation: Option<i64>,
     reason: &str,
     message: &str,
-    gc_bootstrap_waiting_since: Option<String>,
-    store_qualified_hash: Option<String>,
+    persisted: PersistedStatus,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let mut conditions = vec![
@@ -1792,8 +1897,8 @@ fn build_degraded_status(
         gateway_ready_replicas: None,
         query_ready_replicas: None,
         maintain_ready_replicas: None,
-        gc_bootstrap_waiting_since,
-        store_qualified_hash,
+        gc_bootstrap_waiting_since: persisted.gc_bootstrap_waiting_since,
+        store_qualified_hash: persisted.store_qualified_hash,
         conditions,
     }
 }
@@ -1813,8 +1918,7 @@ async fn write_status(
     query_ready: Option<i32>,
     maintain_ready: Option<i32>,
     unavailable_reason: Option<(&str, &str)>,
-    gc_bootstrap_waiting_since: Option<String>,
-    store_qualified_hash: Option<String>,
+    persisted: PersistedStatus,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_status(
@@ -1823,8 +1927,7 @@ async fn write_status(
         query_ready,
         maintain_ready,
         unavailable_reason,
-        gc_bootstrap_waiting_since,
-        store_qualified_hash,
+        persisted,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -1845,16 +1948,14 @@ async fn write_degraded_status(
     observed_generation: Option<i64>,
     reason: &str,
     message: &str,
-    gc_bootstrap_waiting_since: Option<String>,
-    store_qualified_hash: Option<String>,
+    persisted: PersistedStatus,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_degraded_status(
         observed_generation,
         reason,
         message,
-        gc_bootstrap_waiting_since,
-        store_qualified_hash,
+        persisted,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -2293,8 +2394,7 @@ mod tests {
             Some(2),
             Some(1),
             None,
-            None,
-            None,
+            PersistedStatus::default(),
             extra.clone(),
         );
         assert_eq!(
@@ -2317,8 +2417,7 @@ mod tests {
             Some(7),
             "SecretNotFound",
             "no such Secret",
-            None,
-            None,
+            PersistedStatus::default(),
             extra,
         );
         assert_eq!(
@@ -2382,13 +2481,17 @@ mod tests {
                 Some(1),
                 None,
                 None,
-                None,
-                None,
+                PersistedStatus::default(),
                 extra.clone(),
             );
             assert_eq!(condition_types(&ok.conditions), vec!["Available"]);
-            let degraded =
-                build_degraded_status(Some(2), "ReconcileError", "boom", None, None, extra);
+            let degraded = build_degraded_status(
+                Some(2),
+                "ReconcileError",
+                "boom",
+                PersistedStatus::default(),
+                extra,
+            );
             assert_eq!(
                 condition_types(&degraded.conditions),
                 vec!["Degraded", "Available"]
@@ -2398,6 +2501,13 @@ mod tests {
 
     /// A reconcile error during a bootstrap hold must not restart the stall
     /// clock: the persisted timestamp survives the Degraded write unchanged.
+    ///
+    /// Also the finding-5 guard: the timestamp and the qualified-inputs hash are
+    /// carried in one named [`PersistedStatus`], so a value handed in as the
+    /// timestamp lands in `gcBootstrapWaitingSince` and one handed in as the hash
+    /// lands in `storeQualifiedHash`. The two are deliberately distinct, non-swap
+    /// values here: if the struct fields were transposed this assertion would
+    /// catch it (a positional pair would not).
     #[test]
     fn degraded_status_carries_the_bootstrap_wait_timestamp() {
         let since = "2026-09-02T18:00:00Z".to_string();
@@ -2405,8 +2515,10 @@ mod tests {
             Some(3),
             "SecretNotFound",
             "no such Secret",
-            Some(since.clone()),
-            None,
+            PersistedStatus {
+                gc_bootstrap_waiting_since: Some(since.clone()),
+                store_qualified_hash: Some("qhash-9".to_string()),
+            },
             Vec::new(),
         );
         assert_eq!(
@@ -2414,8 +2526,18 @@ mod tests {
             Some(since.as_str()),
             "a transient error must leave the stall clock where it was"
         );
-        let cleared =
-            build_degraded_status(Some(3), "ReconcileError", "boom", None, None, Vec::new());
+        assert_eq!(
+            degraded.store_qualified_hash.as_deref(),
+            Some("qhash-9"),
+            "the qualified-inputs hash lands in its own field, never swapped with the timestamp"
+        );
+        let cleared = build_degraded_status(
+            Some(3),
+            "ReconcileError",
+            "boom",
+            PersistedStatus::default(),
+            Vec::new(),
+        );
         assert_eq!(cleared.gc_bootstrap_waiting_since, None);
     }
 
@@ -2437,8 +2559,7 @@ mod tests {
                 WAITING_FOR_GC_BOOTSTRAP_REASON,
                 WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
             )),
-            None,
-            None,
+            PersistedStatus::default(),
             vec![condition(
                 "Degraded",
                 false,
@@ -2471,8 +2592,7 @@ mod tests {
                 GC_BOOTSTRAP_UNAVAILABLE_REASON,
                 GC_BOOTSTRAP_UNAVAILABLE_MESSAGE,
             )),
-            None,
-            None,
+            PersistedStatus::default(),
             vec![condition(
                 "Degraded",
                 true,
@@ -2498,8 +2618,7 @@ mod tests {
                 WAITING_FOR_GC_BOOTSTRAP_REASON,
                 WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
             )),
-            None,
-            None,
+            PersistedStatus::default(),
             Vec::new(),
         );
         let available = find(&ready.conditions, "Available");
@@ -2522,8 +2641,7 @@ mod tests {
             Some(1),
             None,
             None,
-            None,
-            None,
+            PersistedStatus::default(),
             Vec::new(),
         );
         assert_eq!(condition_types(&running.conditions), vec!["Available"]);
@@ -2544,8 +2662,10 @@ mod tests {
             Some(1),
             None,
             None,
-            None,
-            Some("qhash".to_string()),
+            PersistedStatus {
+                store_qualified_hash: Some("qhash".to_string()),
+                ..PersistedStatus::default()
+            },
             Vec::new(),
         );
         assert_eq!(ok.store_qualified_hash.as_deref(), Some("qhash"));
@@ -2554,11 +2674,132 @@ mod tests {
             Some(1),
             "ReconcileError",
             "boom",
-            None,
-            Some("qhash".to_string()),
+            PersistedStatus {
+                store_qualified_hash: Some("qhash".to_string()),
+                ..PersistedStatus::default()
+            },
             Vec::new(),
         );
         assert_eq!(degraded.store_qualified_hash.as_deref(), Some("qhash"));
+    }
+
+    /// The stale qualify Job is deleted with FOREGROUND propagation (finding 2),
+    /// so Kubernetes keeps the Job object until its owned Pod is gone rather than
+    /// removing the Job while the Pod still runs the old inputs. The controller
+    /// only creates the replacement once it observes the Job fully absent, so
+    /// foreground propagation is what prevents a fresh Job's Pod starting
+    /// alongside a live stale one.
+    #[test]
+    fn stale_qualify_job_deletes_with_foreground_propagation() {
+        use kube::api::PropagationPolicy;
+        assert_eq!(
+            stale_qualify_job_delete_params().propagation_policy,
+            Some(PropagationPolicy::Foreground),
+            "the stale qualify Job must be deleted with foreground propagation"
+        );
+    }
+
+    /// During the qualification hold on a FRESH cluster (no prior ready
+    /// replicas), `Available=False` carries the qualification reason and message
+    /// (finding 4), not the generic MinimumReplicasUnavailable: `Pending` with
+    /// the qualifying message while the Job is created or running.
+    #[test]
+    fn qualification_hold_names_pending_on_available_for_a_fresh_cluster() {
+        let held = build_status(
+            Some(1),
+            None,
+            None,
+            None,
+            Some((STORE_QUALIFIED_PENDING_REASON, STORE_QUALIFYING_MESSAGE)),
+            PersistedStatus::default(),
+            vec![condition(
+                "StoreQualified",
+                false,
+                Some(1),
+                STORE_QUALIFIED_PENDING_REASON,
+                STORE_QUALIFYING_MESSAGE,
+            )],
+        );
+        let available = find(&held.conditions, "Available");
+        assert_eq!(available.status, "False");
+        assert_eq!(
+            available.reason, STORE_QUALIFIED_PENDING_REASON,
+            "Available names the qualification reason, not MinimumReplicasUnavailable"
+        );
+        assert_ne!(available.reason, "MinimumReplicasUnavailable");
+        assert!(
+            available.message.contains("ravel store qualify"),
+            "Available carries the qualifying message: {}",
+            available.message
+        );
+    }
+
+    /// A qualify Job that Failed (its `backoffLimit` exhausted, or the Job
+    /// controller's `DeadlineExceeded`) surfaces its own terminal message on
+    /// `Available=False` with reason `Failed` (finding 4), so an operator sees
+    /// why qualification did not finish, verbatim.
+    #[test]
+    fn qualification_failed_names_the_job_message_on_available() {
+        let message = "DeadlineExceeded: Job was active longer than specified deadline";
+        let held = build_status(
+            Some(2),
+            None,
+            None,
+            None,
+            Some((STORE_QUALIFIED_FAILED_REASON, message)),
+            PersistedStatus::default(),
+            Vec::new(),
+        );
+        let available = find(&held.conditions, "Available");
+        assert_eq!(available.status, "False");
+        assert_eq!(available.reason, STORE_QUALIFIED_FAILED_REASON);
+        assert_eq!(
+            available.message, message,
+            "the Job's failure message reaches Available verbatim"
+        );
+    }
+
+    /// A serving cluster under re-qualification stays `Available=True` (finding
+    /// 4): prior ready gateway and query replicas keep it available even though
+    /// the qualification hold passes an unavailable reason. A named reason can
+    /// only explain an unready cluster, never make a ready one unavailable.
+    #[test]
+    fn serving_cluster_stays_available_during_requalification() {
+        let serving = build_status(
+            Some(3),
+            Some(2),
+            Some(2),
+            Some(1),
+            Some((STORE_QUALIFIED_PENDING_REASON, STORE_QUALIFYING_MESSAGE)),
+            PersistedStatus::default(),
+            Vec::new(),
+        );
+        let available = find(&serving.conditions, "Available");
+        assert_eq!(available.status, "True");
+        assert_eq!(available.reason, "MinimumReplicasAvailable");
+    }
+
+    /// Finding 3: credential resourceVersions are resolved before the gate and
+    /// reused for the qualified-input hash. The value selected is the SHARED
+    /// storage.s3 credential's (the one the qualify Job authenticates with),
+    /// looked up by that Secret's name, never a per-tier override's. Absent from
+    /// the resolved map (unresolved) is None, not some other Secret's version.
+    #[test]
+    fn shared_credentials_rv_selects_the_shared_secret_not_a_tier_override() {
+        let spec = spec_with_affinity(None); // shared credential name is "ravel-s3"
+        let mut versions = BTreeMap::new();
+        versions.insert("ravel-s3".to_string(), "rv-shared".to_string());
+        versions.insert("query-creds".to_string(), "rv-override".to_string());
+        assert_eq!(
+            shared_credentials_rv(&spec, &versions),
+            Some("rv-shared"),
+            "the shared storage.s3 credential's resourceVersion is selected"
+        );
+        assert_eq!(
+            shared_credentials_rv(&spec, &BTreeMap::new()),
+            None,
+            "an unresolved shared credential is None, never a stand-in version"
+        );
     }
 
     /// The stall threshold as a signed second count, the unit
@@ -2710,8 +2951,7 @@ mod tests {
             Some(1),
             Some(1),
             None,
-            None,
-            None,
+            PersistedStatus::default(),
             Vec::new(),
         );
         assert_eq!(

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use k8s_openapi::api::apps::v1::Deployment;
+use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::{Secret, Service, ServiceAccount};
 use k8s_openapi::api::networking::v1::Ingress;
 use k8s_openapi::api::policy::v1::PodDisruptionBudget;
@@ -37,11 +38,14 @@ use crate::crd::{
 use crate::reconcile::{
     DEPLOYMENT_KEY_SECRET_KEY, DeploymentTier, GC_BOOTSTRAP_STALL_AFTER,
     GC_BOOTSTRAP_STALLED_REASON, GC_BOOTSTRAP_UNAVAILABLE_MESSAGE, GC_BOOTSTRAP_UNAVAILABLE_REASON,
-    GcBootstrapGate, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
-    WAITING_FOR_GC_BOOTSTRAP_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_REASON, desired_objects,
-    grpcroute_api_resource, httproute_api_resource, possible_gateway_route_names,
-    possible_ingest_ingress_names, possible_pod_disruption_budget_names,
-    possible_router_object_names,
+    GcBootstrapGate, QUALIFY_COMPONENT, QUALIFY_SPEC_HASH_ANNOTATION, QualificationDecision,
+    QualifyJobObservation, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
+    STORE_QUALIFIED_FAILED_REASON, STORE_QUALIFIED_MESSAGE, STORE_QUALIFIED_PENDING_REASON,
+    STORE_QUALIFIED_SUCCEEDED_REASON, STORE_QUALIFYING_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
+    WAITING_FOR_GC_BOOTSTRAP_REASON, desired_objects, desired_qualify_job, grpcroute_api_resource,
+    httproute_api_resource, possible_gateway_route_names, possible_ingest_ingress_names,
+    possible_pod_disruption_budget_names, possible_router_object_names, qualification_decision,
+    qualify_job_input_hash, qualify_job_phase,
 };
 
 /// Server-side-apply field manager name.
@@ -952,6 +956,14 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 .status
                 .as_ref()
                 .and_then(|status| status.gc_bootstrap_waiting_since.clone());
+            // The qualified-inputs hash is owned by the qualification gate, not
+            // this error path: carry the persisted value through unchanged so a
+            // transient error after a cluster is already qualified does not drop
+            // the record and re-trigger qualification on the next pass.
+            let store_qualified_hash = obj
+                .status
+                .as_ref()
+                .and_then(|status| status.store_qualified_hash.clone());
             if let Err(status_err) = write_degraded_status(
                 client,
                 &namespace,
@@ -960,6 +972,7 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 &reason,
                 &message,
                 waiting_since,
+                store_qualified_hash,
                 extra_conditions,
             )
             .await
@@ -981,6 +994,121 @@ async fn reconcile_inner(
     instance: &str,
     mut extra_conditions: Vec<Condition>,
 ) -> Result<Action, Error> {
+    // Store qualification gate (issue #36). Before anything that would read or
+    // write the object store is created -- the sys/auth token map, the ingest
+    // router, and above all the serving Deployments -- prove the store passes
+    // `ravel store qualify`. A cluster brought up on a backend that fails the
+    // object-store contract (docs/object-store-contract.md) would otherwise
+    // crash-loop every server pod with an opaque runtime error; here it fails
+    // once, visibly, on a one-shot Job, and the `StoreQualified` condition says
+    // why. Qualification is proven for the current inputs and never re-run on a
+    // schedule: a durable `status.storeQualifiedHash` records the inputs it last
+    // passed against, so a finished Job garbage-collected by its TTL does not
+    // re-trigger it (ADR-0034).
+    let jobs: Api<Job> = Api::namespaced(client.clone(), namespace);
+    let qualify_name = child(instance, QUALIFY_COMPONENT);
+    let desired_hash = qualify_job_input_hash(&obj.spec);
+    let qualified_hash = obj
+        .status
+        .as_ref()
+        .and_then(|status| status.store_qualified_hash.clone());
+    let observation = observe_qualify_job(&jobs, &qualify_name).await?;
+    let decision = qualification_decision(&desired_hash, qualified_hash.as_deref(), &observation);
+
+    // The hash to persist on THIS pass's status: the current inputs once
+    // qualification proceeds, otherwise the last-qualified value unchanged (kept
+    // so an in-flight re-qualification does not drop the record and, with it, the
+    // gate that keeps existing Deployments up while the new inputs qualify).
+    let store_qualified_hash = match &decision {
+        QualificationDecision::Proceed => {
+            extra_conditions.push(condition(
+                "StoreQualified",
+                true,
+                obj.metadata.generation,
+                STORE_QUALIFIED_SUCCEEDED_REASON,
+                STORE_QUALIFIED_MESSAGE,
+            ));
+            Some(desired_hash.clone())
+        }
+        _ => {
+            // Not qualified for the current inputs: create or recreate the Job,
+            // record a `StoreQualified` condition, and return WITHOUT touching
+            // any Deployment. A fresh cluster gets none; a running cluster
+            // re-qualifying after a config edit keeps the ones it has (this pass
+            // never reaches the Deployment apply/sweep below), so a pending
+            // config change does not tear a serving cluster down.
+            let owner = obj.controller_owner_ref(&()).map(|owner| vec![owner]);
+            let (store_qualified_condition, action) = match &decision {
+                QualificationDecision::Qualify { recreate } => {
+                    if *recreate {
+                        // The Job's inputs changed; its pod template is immutable,
+                        // so delete the stale Job (its pods with it) and let the
+                        // next pass observe it absent and create a fresh one.
+                        delete_if_present(&jobs, &qualify_name).await?;
+                    } else {
+                        let mut job = desired_qualify_job(&obj.spec, instance);
+                        job.metadata.namespace = Some(namespace.to_string());
+                        job.metadata.owner_references = owner;
+                        apply(&jobs, &qualify_name, &job).await?;
+                    }
+                    (
+                        condition(
+                            "StoreQualified",
+                            false,
+                            obj.metadata.generation,
+                            STORE_QUALIFIED_PENDING_REASON,
+                            STORE_QUALIFYING_MESSAGE,
+                        ),
+                        Action::requeue(BOOTSTRAP_POLL),
+                    )
+                }
+                QualificationDecision::Waiting => (
+                    condition(
+                        "StoreQualified",
+                        false,
+                        obj.metadata.generation,
+                        STORE_QUALIFIED_PENDING_REASON,
+                        STORE_QUALIFYING_MESSAGE,
+                    ),
+                    Action::requeue(BOOTSTRAP_POLL),
+                ),
+                QualificationDecision::Failed(message) => (
+                    condition(
+                        "StoreQualified",
+                        false,
+                        obj.metadata.generation,
+                        STORE_QUALIFIED_FAILED_REASON,
+                        message,
+                    ),
+                    Action::requeue(RETRY),
+                ),
+                QualificationDecision::Proceed => unreachable!("Proceed handled above"),
+            };
+            extra_conditions.push(store_qualified_condition);
+
+            // Report the readiness a prior pass recorded, so a cluster already
+            // serving through a re-qualification keeps `Available=True` instead of
+            // flipping to "waiting for tiers" on every poll while the new inputs
+            // qualify. A fresh cluster has none of these and reports Available=False.
+            let prior = obj.status.as_ref();
+            write_status(
+                client,
+                namespace,
+                instance,
+                obj.metadata.generation,
+                prior.and_then(|s| s.gateway_ready_replicas),
+                prior.and_then(|s| s.query_ready_replicas),
+                prior.and_then(|s| s.maintain_ready_replicas),
+                None,
+                prior.and_then(|s| s.gc_bootstrap_waiting_since.clone()),
+                qualified_hash,
+                extra_conditions,
+            )
+            .await?;
+            return Ok(action);
+        }
+    };
+
     let token_secret = resolve_token_secret(
         client,
         namespace,
@@ -1385,6 +1513,7 @@ async fn reconcile_inner(
         maintain_ready,
         available_hold.as_ref().map(|(r, m)| (*r, m.as_str())),
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         extra_conditions,
     )
     .await?;
@@ -1469,6 +1598,29 @@ async fn live_deployment_exists(api: &Api<Deployment>, name: &str) -> Result<boo
     match api.get(name).await {
         Ok(_) => Ok(true),
         Err(err) if is_not_found(&err) => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Observe the live qualify Job for a cluster (issue #36): its recorded input
+/// hash (the [`QUALIFY_SPEC_HASH_ANNOTATION`] value, `None` when the annotation
+/// is missing) and its terminal phase, or [`QualifyJobObservation::Absent`] when
+/// no Job exists (a fresh cluster, or one whose finished Job has been
+/// TTL-garbage-collected). A not-found is `Absent`; any other error propagates.
+async fn observe_qualify_job(jobs: &Api<Job>, name: &str) -> Result<QualifyJobObservation, Error> {
+    match jobs.get(name).await {
+        Ok(job) => {
+            let spec_hash = job
+                .metadata
+                .annotations
+                .as_ref()
+                .and_then(|annotations| annotations.get(QUALIFY_SPEC_HASH_ANNOTATION).cloned());
+            Ok(QualifyJobObservation::Present {
+                spec_hash,
+                phase: qualify_job_phase(&job),
+            })
+        }
+        Err(err) if is_not_found(&err) => Ok(QualifyJobObservation::Absent),
         Err(err) => Err(err.into()),
     }
 }
@@ -1580,6 +1732,7 @@ fn build_status(
     maintain_ready: Option<i32>,
     unavailable_reason: Option<(&str, &str)>,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let available = gateway_ready.unwrap_or(0) > 0 && query_ready.unwrap_or(0) > 0;
@@ -1610,6 +1763,7 @@ fn build_status(
         query_ready_replicas: query_ready,
         maintain_ready_replicas: maintain_ready,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         conditions,
     }
 }
@@ -1625,6 +1779,7 @@ fn build_degraded_status(
     reason: &str,
     message: &str,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let mut conditions = vec![
@@ -1638,6 +1793,7 @@ fn build_degraded_status(
         query_ready_replicas: None,
         maintain_ready_replicas: None,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         conditions,
     }
 }
@@ -1658,6 +1814,7 @@ async fn write_status(
     maintain_ready: Option<i32>,
     unavailable_reason: Option<(&str, &str)>,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_status(
@@ -1667,6 +1824,7 @@ async fn write_status(
         maintain_ready,
         unavailable_reason,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -1688,6 +1846,7 @@ async fn write_degraded_status(
     reason: &str,
     message: &str,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_degraded_status(
@@ -1695,6 +1854,7 @@ async fn write_degraded_status(
         reason,
         message,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -2134,6 +2294,7 @@ mod tests {
             Some(1),
             None,
             None,
+            None,
             extra.clone(),
         );
         assert_eq!(
@@ -2152,8 +2313,14 @@ mod tests {
             deprecated.message
         );
 
-        let degraded =
-            build_degraded_status(Some(7), "SecretNotFound", "no such Secret", None, extra);
+        let degraded = build_degraded_status(
+            Some(7),
+            "SecretNotFound",
+            "no such Secret",
+            None,
+            None,
+            extra,
+        );
         assert_eq!(
             condition_types(&degraded.conditions),
             vec!["Degraded", "Available", "IngestAffinityBackendDeprecated"]
@@ -2209,9 +2376,19 @@ mod tests {
                 "no spec-derived condition, got {:?}",
                 condition_types(&extra)
             );
-            let ok = build_status(Some(2), Some(1), Some(1), None, None, None, extra.clone());
+            let ok = build_status(
+                Some(2),
+                Some(1),
+                Some(1),
+                None,
+                None,
+                None,
+                None,
+                extra.clone(),
+            );
             assert_eq!(condition_types(&ok.conditions), vec!["Available"]);
-            let degraded = build_degraded_status(Some(2), "ReconcileError", "boom", None, extra);
+            let degraded =
+                build_degraded_status(Some(2), "ReconcileError", "boom", None, None, extra);
             assert_eq!(
                 condition_types(&degraded.conditions),
                 vec!["Degraded", "Available"]
@@ -2229,6 +2406,7 @@ mod tests {
             "SecretNotFound",
             "no such Secret",
             Some(since.clone()),
+            None,
             Vec::new(),
         );
         assert_eq!(
@@ -2236,7 +2414,8 @@ mod tests {
             Some(since.as_str()),
             "a transient error must leave the stall clock where it was"
         );
-        let cleared = build_degraded_status(Some(3), "ReconcileError", "boom", None, Vec::new());
+        let cleared =
+            build_degraded_status(Some(3), "ReconcileError", "boom", None, None, Vec::new());
         assert_eq!(cleared.gc_bootstrap_waiting_since, None);
     }
 
@@ -2258,6 +2437,7 @@ mod tests {
                 WAITING_FOR_GC_BOOTSTRAP_REASON,
                 WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
             )),
+            None,
             None,
             vec![condition(
                 "Degraded",
@@ -2292,6 +2472,7 @@ mod tests {
                 GC_BOOTSTRAP_UNAVAILABLE_MESSAGE,
             )),
             None,
+            None,
             vec![condition(
                 "Degraded",
                 true,
@@ -2318,6 +2499,7 @@ mod tests {
                 WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
             )),
             None,
+            None,
             Vec::new(),
         );
         let available = find(&ready.conditions, "Available");
@@ -2334,11 +2516,49 @@ mod tests {
     /// effect, where the old plan withheld the tiers and nothing ever unblocked.
     #[test]
     fn gc_bootstrap_unavailable_clears_once_the_request_serving_tiers_report_ready() {
-        let running = build_status(Some(9), Some(1), Some(1), None, None, None, Vec::new());
+        let running = build_status(
+            Some(9),
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+        );
         assert_eq!(condition_types(&running.conditions), vec!["Available"]);
         let available = find(&running.conditions, "Available");
         assert_eq!(available.status, "True");
         assert_eq!(available.reason, "MinimumReplicasAvailable");
+    }
+
+    /// The durable qualified-inputs hash (issue #36) is written into the status
+    /// by both builders, so the qualification gate survives the Job's TTL-GC and
+    /// an operator restart. A dropped field here would silently re-run
+    /// qualification on the next pass.
+    #[test]
+    fn status_builders_carry_the_store_qualified_hash() {
+        let ok = build_status(
+            Some(1),
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+            Some("qhash".to_string()),
+            Vec::new(),
+        );
+        assert_eq!(ok.store_qualified_hash.as_deref(), Some("qhash"));
+
+        let degraded = build_degraded_status(
+            Some(1),
+            "ReconcileError",
+            "boom",
+            None,
+            Some("qhash".to_string()),
+            Vec::new(),
+        );
+        assert_eq!(degraded.store_qualified_hash.as_deref(), Some("qhash"));
     }
 
     /// The stall threshold as a signed second count, the unit
@@ -2484,7 +2704,16 @@ mod tests {
         );
         // reconcile therefore builds the status with no wait timestamp and no
         // stall condition.
-        let status = build_status(Some(2), Some(1), Some(1), Some(1), None, None, Vec::new());
+        let status = build_status(
+            Some(2),
+            Some(1),
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+            Vec::new(),
+        );
         assert_eq!(
             status.gc_bootstrap_waiting_since, None,
             "the timestamp is cleared once not waiting"

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -738,6 +738,20 @@ pub struct RavelClusterStatus {
     #[serde(default)]
     pub gc_bootstrap_waiting_since: Option<String>,
 
+    /// The qualify-Job input hash (bucket, region, endpoint, image, credentials
+    /// Secret name) that store qualification last succeeded against (issue #36).
+    /// The operator gates serving on `ravel store qualify` before it creates any
+    /// Deployment; recording the qualified inputs here makes that gate durable:
+    /// a later pass whose inputs still hash to this value proceeds without
+    /// re-running qualification even after the one-shot Job has been
+    /// TTL-garbage-collected, and a pass whose inputs no longer match re-runs it
+    /// (the `StoreQualified` condition flips back to `Pending`) without tearing
+    /// down the running Deployments. Absent until the first qualification
+    /// succeeds. Qualification is never re-run on a schedule; only an input
+    /// change re-triggers it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store_qualified_hash: Option<String>,
+
     /// Standard Kubernetes conditions: `Available`, `Progressing`, `Degraded`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1929,6 +1929,33 @@ pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 4;
 /// garbage-collected after success does not re-trigger qualification.
 pub const QUALIFY_JOB_TTL_SECONDS: i32 = 3600;
 
+/// `activeDeadlineSeconds` for the qualify Job: a wall-clock bound on a single
+/// attempt, so a qualify pod that hangs (an S3 endpoint that accepts the TCP
+/// connection and then never answers) becomes a `Failed` Job with reason
+/// `DeadlineExceeded` instead of running indefinitely. `backoffLimit` bounds
+/// only how many *failed* attempts run; it does nothing for one attempt that
+/// never terminates, which leaves `StoreQualified` stuck at `Pending` forever.
+///
+/// The value must clear a slow-but-healthy run with margin. `ravel store
+/// qualify` runs 28 sequential object operations against the bucket: probe
+/// create-if-absent (put, put, get = 3), probe CAS version (put, put, put,
+/// get = 4), probe read-after-write ([`super`]'s `CONSISTENCY_CYCLES` = 5
+/// put+get = 10), probe list-after-write (5 put+list = 10), and the final
+/// `sys/qualification` create-if-absent write (1); the two informational
+/// probes issue no request through the `ObjectStoreBackend` contract. Each
+/// operation's per-request ceiling is the S3 client's 20 s `request_timeout`
+/// (ravel-object-store `S3HttpConfig::default`), so a slow-but-healthy run
+/// whose every operation approaches that ceiling without retrying is bounded
+/// by 28 * 20 s = 560 s. 900 s adds a ~1.6x margin (340 s of slack) for pod
+/// scheduling, image pull, and the occasional single retry, while staying far
+/// below a hung endpoint's ~200 s-per-operation worst case (`retry_timeout`
+/// 180 s + `request_timeout` 20 s): a hang trips the deadline after roughly
+/// four stalled operations rather than exhausting all 28.
+///
+/// Not part of [`qualify_job_input_hash`]: tuning this deadline must not
+/// re-run a qualification that already passed.
+pub const QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS: i64 = 900;
+
 /// `StoreQualified` reason while the qualify Job is being created or is still
 /// running: serving is held until it reports success.
 pub const STORE_QUALIFIED_PENDING_REASON: &str = "Pending";
@@ -1993,8 +2020,10 @@ pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
 ///
 /// The Job carries [`QUALIFY_SPEC_HASH_ANNOTATION`] so the controller re-runs it
 /// when its inputs change and skips it when they do not, and sets
-/// `restartPolicy: Never`, a small [`QUALIFY_JOB_BACKOFF_LIMIT`], and
-/// [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not accumulate.
+/// `restartPolicy: Never`, a small [`QUALIFY_JOB_BACKOFF_LIMIT`],
+/// [`QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS`] so a hung attempt fails rather than
+/// runs forever, and [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not
+/// accumulate.
 pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
     let labels = labels(instance, QUALIFY_COMPONENT);
     let mut env = vec![
@@ -2048,6 +2077,7 @@ pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
         },
         spec: Some(JobSpec {
             backoff_limit: Some(QUALIFY_JOB_BACKOFF_LIMIT),
+            active_deadline_seconds: Some(QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS),
             ttl_seconds_after_finished: Some(QUALIFY_JOB_TTL_SECONDS),
             template: PodTemplateSpec {
                 metadata: Some(ObjectMeta {
@@ -2158,8 +2188,16 @@ pub fn qualification_decision(
 }
 
 /// The [`QualifyJobPhase`] a live Job reports, read from its status conditions:
-/// `Complete=True` is success, `Failed=True` is failure (its message carried
-/// through), anything else is still running.
+/// `Complete=True` is success, `Failed=True` is failure, anything else is still
+/// running.
+///
+/// A `Failed` condition's `reason` is prepended to its `message` (`"<reason>:
+/// <message>"`) so the `StoreQualified` condition names why the Job failed, not
+/// only the human message. This matters for a deadline-exceeded Job: the Job
+/// controller sets reason `DeadlineExceeded` with a generic message ("Job was
+/// active longer than specified deadline"), and the reason is the part an
+/// operator needs to see. When only one of reason/message is present that one
+/// is used verbatim; when neither is, a fixed fallback is.
 pub fn qualify_job_phase(job: &Job) -> QualifyJobPhase {
     let Some(conditions) = job.status.as_ref().and_then(|s| s.conditions.as_ref()) else {
         return QualifyJobPhase::Running;
@@ -2171,13 +2209,15 @@ pub fn qualify_job_phase(job: &Job) -> QualifyJobPhase {
         match c.type_.as_str() {
             "Complete" => return QualifyJobPhase::Succeeded,
             "Failed" => {
-                let message = c
-                    .message
-                    .clone()
-                    .filter(|m| !m.is_empty())
-                    .or_else(|| c.reason.clone())
-                    .unwrap_or_else(|| "the store qualification Job failed".to_string());
-                return QualifyJobPhase::Failed(message);
+                let reason = c.reason.clone().filter(|r| !r.is_empty());
+                let message = c.message.clone().filter(|m| !m.is_empty());
+                let text = match (reason, message) {
+                    (Some(reason), Some(message)) => format!("{reason}: {message}"),
+                    (Some(reason), None) => reason,
+                    (None, Some(message)) => message,
+                    (None, None) => "the store qualification Job failed".to_string(),
+                };
+                return QualifyJobPhase::Failed(text);
             }
             _ => {}
         }
@@ -5444,6 +5484,26 @@ mod tests {
         }
     }
 
+    /// A Job reporting `Failed=True` with the given `reason` and `message`, the
+    /// shape the Kubernetes Job controller sets when it fails a Job (a
+    /// deadline-exceeded Job carries reason `DeadlineExceeded`).
+    fn job_with_failed_reason(reason: &str, message: Option<&str>) -> Job {
+        use k8s_openapi::api::batch::v1::{JobCondition, JobStatus};
+        Job {
+            status: Some(JobStatus {
+                conditions: Some(vec![JobCondition {
+                    type_: "Failed".to_string(),
+                    status: "True".to_string(),
+                    reason: Some(reason.to_string()),
+                    message: message.map(str::to_string),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
     /// The input hash is stable for one spec and changes for each of the five
     /// inputs it covers, and only those. Pins the exact set of fields that
     /// re-trigger qualification (issue #36): a change to any of them is a
@@ -5602,6 +5662,99 @@ mod tests {
         assert_eq!(
             qualify_job_phase(&job_with_condition("Failed", "False", None)),
             QualifyJobPhase::Running
+        );
+    }
+
+    /// The rendered qualify Job sets `activeDeadlineSeconds` to the chosen value,
+    /// so a hung attempt (an endpoint that accepts the connection and never
+    /// answers) becomes a `Failed` Job rather than running forever. `backoffLimit`
+    /// bounds only failed attempts, not one attempt that never terminates.
+    #[test]
+    fn qualify_job_bounds_a_hung_attempt() {
+        let spec = base_spec();
+        let job = desired_qualify_job(&spec, "prod");
+        let job_spec = job.spec.as_ref().expect("qualify Job has a spec");
+        assert_eq!(
+            job_spec.active_deadline_seconds,
+            Some(QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS),
+            "the qualify Job bounds a single attempt with activeDeadlineSeconds"
+        );
+        assert_eq!(
+            QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS, 900,
+            "the chosen deadline is 900 s (28 sequential ops * 20 s request_timeout \
+             = 560 s slow-but-healthy, plus a ~1.6x margin)"
+        );
+    }
+
+    /// A Job the Kubernetes Job controller failed for exceeding its
+    /// `activeDeadlineSeconds` reports `Failed=True` with reason
+    /// `DeadlineExceeded`. That reads as [`QualificationDecision::Failed`] (which
+    /// the controller renders as `StoreQualified=False`), and its message names
+    /// the reason exactly so an operator sees why qualification did not finish.
+    #[test]
+    fn a_deadline_exceeded_job_reads_as_failed_with_its_reason() {
+        let job = job_with_failed_reason(
+            "DeadlineExceeded",
+            Some("Job was active longer than specified deadline"),
+        );
+        let phase = qualify_job_phase(&job);
+        let message = match &phase {
+            QualifyJobPhase::Failed(message) => message.clone(),
+            other => panic!("a Failed=True Job reads as Failed, got {other:?}"),
+        };
+        assert!(
+            message.contains("DeadlineExceeded"),
+            "the failure message names the DeadlineExceeded reason exactly: {message:?}"
+        );
+
+        // The gate reports a Present Job for the current inputs in the Failed
+        // phase as Failed, carrying that message; the controller turns Failed
+        // into StoreQualified=False with STORE_QUALIFIED_FAILED_REASON.
+        let decision = qualification_decision(
+            "h",
+            None,
+            &QualifyJobObservation::Present {
+                spec_hash: Some("h".to_string()),
+                phase,
+            },
+        );
+        assert_eq!(decision, QualificationDecision::Failed(message));
+    }
+
+    /// The `activeDeadlineSeconds` is a tuning knob, not a store-identity input:
+    /// [`qualify_job_input_hash`] covers exactly the five inputs qualification
+    /// proves against and never the deadline, so changing the deadline leaves the
+    /// hash equal and does not re-run a qualification that already passed.
+    #[test]
+    fn the_deadline_is_not_part_of_the_qualified_input_hash() {
+        use std::hash::{Hash, Hasher};
+        let spec = base_spec();
+
+        // Recompute the hash over exactly the five qualified inputs, deliberately
+        // excluding the deadline. If the production hasher folded the deadline in,
+        // this reference would diverge and the assertion would fail.
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        spec.storage.s3.bucket.hash(&mut hasher);
+        spec.storage.s3.region.hash(&mut hasher);
+        spec.storage
+            .s3
+            .endpoint
+            .as_deref()
+            .unwrap_or("")
+            .hash(&mut hasher);
+        spec.image.hash(&mut hasher);
+        spec.storage
+            .s3
+            .credentials_secret_ref
+            .name
+            .hash(&mut hasher);
+        let expected = format!("{:016x}", hasher.finish());
+
+        assert_eq!(
+            qualify_job_input_hash(&spec),
+            expected,
+            "the qualified-input hash covers exactly the five store-identity inputs, never the \
+             deadline"
         );
     }
 

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy};
+use k8s_openapi::api::batch::v1::{Job, JobSpec};
 use k8s_openapi::api::core::v1::{
     Affinity, Capabilities, Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction,
     KeyToPath, PodAffinityTerm, PodAntiAffinity, PodSecurityContext, PodSpec, PodTemplateSpec,
@@ -1904,6 +1905,284 @@ pub fn gc_bootstrap_plan(spec: &RavelClusterSpec) -> GcBootstrapPlan {
         gate,
         maintain_enabled: spec.maintain.enabled,
     }
+}
+
+/// Component suffix of the one-shot store-qualification Job (issue #36): its
+/// child name is `<cluster>-qualify`.
+pub const QUALIFY_COMPONENT: &str = "qualify";
+
+/// Annotation on the qualify Job carrying [`qualify_job_input_hash`], so a
+/// change to the inputs qualification proves against (bucket, region, endpoint,
+/// image, credentials Secret name) re-runs it and a no-op reconcile does not.
+pub const QUALIFY_SPEC_HASH_ANNOTATION: &str = "ravel.nofire.ai/qualify-spec-hash";
+
+/// `backoffLimit` for the qualify Job: a few retries absorb a transient S3
+/// error (a backend still coming up) without spinning forever on a genuine
+/// qualification failure (a backend that fails conditional-create atomicity or
+/// list consistency). Four attempts, then the Job reports `Failed` and the
+/// controller surfaces it on the `StoreQualified` condition.
+pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 4;
+
+/// `ttlSecondsAfterFinished` for the qualify Job: one hour, so a finished Job
+/// does not accumulate across reconciles or re-qualifications. The qualified
+/// state itself is durable in `status.storeQualifiedHash`, so a Job
+/// garbage-collected after success does not re-trigger qualification.
+pub const QUALIFY_JOB_TTL_SECONDS: i32 = 3600;
+
+/// `StoreQualified` reason while the qualify Job is being created or is still
+/// running: serving is held until it reports success.
+pub const STORE_QUALIFIED_PENDING_REASON: &str = "Pending";
+
+/// `StoreQualified` reason once the store has been qualified for the current
+/// inputs; serving proceeds.
+pub const STORE_QUALIFIED_SUCCEEDED_REASON: &str = "Succeeded";
+
+/// `StoreQualified` reason when the qualify Job exhausted its `backoffLimit`
+/// without succeeding; serving stays held and the pass requeues on backoff.
+pub const STORE_QUALIFIED_FAILED_REASON: &str = "Failed";
+
+/// Message paired with [`STORE_QUALIFIED_PENDING_REASON`].
+pub const STORE_QUALIFYING_MESSAGE: &str = "running store qualification (ravel store qualify) against the cluster's bucket; the \
+     gateway, query, and maintain Deployments are held until it succeeds so the cluster never \
+     serves on a backend that fails the object-store contract (docs/object-store-contract.md)";
+
+/// Message paired with [`STORE_QUALIFIED_SUCCEEDED_REASON`].
+pub const STORE_QUALIFIED_MESSAGE: &str =
+    "the object store passed ravel store qualify; serving Deployments may be created";
+
+/// A deterministic change-detection hash over the inputs store qualification
+/// proves against (issue #36): the bucket, region, endpoint, server image, and
+/// the credentials Secret name. When any of these changes the store the cluster
+/// would serve on is a different one, so qualification is re-run; an unrelated
+/// spec edit (a replica count, a fold interval) leaves this stable and does not
+/// re-qualify.
+///
+/// `DefaultHasher` (SipHash with fixed keys) is deterministic across processes,
+/// so an operator restart does not spuriously re-qualify. It is a change signal,
+/// not a security boundary, exactly like [`secrets_checksum`].
+pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    spec.storage.s3.bucket.hash(&mut hasher);
+    spec.storage.s3.region.hash(&mut hasher);
+    spec.storage
+        .s3
+        .endpoint
+        .as_deref()
+        .unwrap_or("")
+        .hash(&mut hasher);
+    spec.image.hash(&mut hasher);
+    spec.storage
+        .s3
+        .credentials_secret_ref
+        .name
+        .hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// The one-shot store-qualification Job for a cluster (issue #36).
+///
+/// Runs `ravel store qualify` (the same `ravel-cli` binary the server image
+/// ships) against the cluster's bucket before any serving Deployment is created,
+/// so a backend that fails the object-store contract is caught at deploy time
+/// rather than crash-looping every server pod on a fresh bucket. Image and
+/// credentials mirror the server Deployment's shared
+/// `storage.s3.credentialsSecretRef`; the bucket, region, and endpoint reach
+/// `ravel-cli` through the same `RAVEL_S3_*` env vars it reads (clap `env`), the
+/// exact shape the kind lane's hand-run Job used.
+///
+/// The Job carries [`QUALIFY_SPEC_HASH_ANNOTATION`] so the controller re-runs it
+/// when its inputs change and skips it when they do not, and sets
+/// `restartPolicy: Never`, a small [`QUALIFY_JOB_BACKOFF_LIMIT`], and
+/// [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not accumulate.
+pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
+    let labels = labels(instance, QUALIFY_COMPONENT);
+    let mut env = vec![
+        EnvVar {
+            name: "RAVEL_S3_BUCKET".to_string(),
+            value: Some(spec.storage.s3.bucket.clone()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "RAVEL_S3_REGION".to_string(),
+            value: Some(spec.storage.s3.region.clone()),
+            ..Default::default()
+        },
+    ];
+    if let Some(endpoint) = &spec.storage.s3.endpoint {
+        env.push(EnvVar {
+            name: "RAVEL_S3_ENDPOINT".to_string(),
+            value: Some(endpoint.clone()),
+            ..Default::default()
+        });
+    }
+    // Credentials mirror the server Deployment exactly: sourced from the shared
+    // credentials Secret via secretKeyRef, never literal values.
+    env.extend(s3_credential_env(spec, None));
+
+    let container = Container {
+        name: "qualify".to_string(),
+        image: Some(spec.image.clone()),
+        image_pull_policy: spec.image_pull_policy.clone(),
+        command: Some(vec!["/usr/local/bin/ravel-cli".to_string()]),
+        args: Some(vec![
+            "--store".to_string(),
+            "s3".to_string(),
+            "store".to_string(),
+            "qualify".to_string(),
+        ]),
+        env: Some(env),
+        security_context: Some(container_security_context()),
+        ..Default::default()
+    };
+
+    Job {
+        metadata: ObjectMeta {
+            name: Some(child_name(instance, QUALIFY_COMPONENT)),
+            labels: Some(labels.clone()),
+            annotations: Some(BTreeMap::from([(
+                QUALIFY_SPEC_HASH_ANNOTATION.to_string(),
+                qualify_job_input_hash(spec),
+            )])),
+            ..Default::default()
+        },
+        spec: Some(JobSpec {
+            backoff_limit: Some(QUALIFY_JOB_BACKOFF_LIMIT),
+            ttl_seconds_after_finished: Some(QUALIFY_JOB_TTL_SECONDS),
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    restart_policy: Some("Never".to_string()),
+                    containers: vec![container],
+                    security_context: Some(pod_security_context()),
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        status: None,
+    }
+}
+
+/// The terminal state of the live qualify Job this reconcile pass observed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QualifyJobPhase {
+    /// Neither `Complete` nor `Failed` reported yet.
+    Running,
+    /// The Job reported `Complete=True`.
+    Succeeded,
+    /// The Job reported `Failed=True` (its `backoffLimit` was exhausted). Carries
+    /// the Job's terminal condition message for the `StoreQualified` condition.
+    Failed(String),
+}
+
+/// What the controller observed about the live qualify Job for a cluster.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QualifyJobObservation {
+    /// No qualify Job exists (a fresh cluster, or one whose finished Job has been
+    /// TTL-garbage-collected).
+    Absent,
+    /// A qualify Job exists. `spec_hash` is its [`QUALIFY_SPEC_HASH_ANNOTATION`]
+    /// value (`None` if the annotation is missing), `phase` its terminal state.
+    Present {
+        /// The Job's recorded input hash, or `None` when the annotation is
+        /// absent.
+        spec_hash: Option<String>,
+        /// The Job's terminal state this pass.
+        phase: QualifyJobPhase,
+    },
+}
+
+/// The gate decision one reconcile pass takes on store qualification (issue #36).
+///
+/// [`crate::controller`] acts on exactly this, so a test asserting on a decision
+/// here is asserting on the operator's real gating behavior.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QualificationDecision {
+    /// The store is qualified for the current inputs: create the serving
+    /// Deployments. No qualify-Job write this pass.
+    Proceed,
+    /// (Re)run qualification and hold the serving Deployments. `recreate` is
+    /// true when a Job for stale inputs must be deleted first (a config edit
+    /// landed); the controller deletes it and lets the next pass create a fresh
+    /// one. False when no Job exists and one must be created now.
+    Qualify {
+        /// Whether a stale Job must be deleted before a fresh one is created.
+        recreate: bool,
+    },
+    /// The qualify Job is still running: hold the serving Deployments, no write.
+    Waiting,
+    /// The qualify Job failed: hold the serving Deployments and requeue on
+    /// backoff. Carries the Job's terminal message.
+    Failed(String),
+}
+
+/// Decide the qualification gate for a pass, purely from the desired input hash,
+/// the durably-recorded qualified hash (`status.storeQualifiedHash`), and the
+/// live Job observation.
+///
+/// A recorded qualified hash equal to the desired one short-circuits to
+/// [`QualificationDecision::Proceed`]: qualification already passed for these
+/// inputs and is never re-run on a schedule, so the Job's absence (after TTL GC)
+/// is not a reason to re-qualify. Otherwise the decision follows the live Job:
+/// absent means create one; a Job for a different (or missing) hash means a
+/// config edit landed and the stale Job is recreated; a Job for the current hash
+/// reports the qualification's progress.
+pub fn qualification_decision(
+    desired_hash: &str,
+    qualified_hash: Option<&str>,
+    observation: &QualifyJobObservation,
+) -> QualificationDecision {
+    if qualified_hash == Some(desired_hash) {
+        return QualificationDecision::Proceed;
+    }
+    match observation {
+        QualifyJobObservation::Absent => QualificationDecision::Qualify { recreate: false },
+        QualifyJobObservation::Present { spec_hash, phase } => {
+            if spec_hash.as_deref() != Some(desired_hash) {
+                QualificationDecision::Qualify { recreate: true }
+            } else {
+                match phase {
+                    QualifyJobPhase::Running => QualificationDecision::Waiting,
+                    QualifyJobPhase::Succeeded => QualificationDecision::Proceed,
+                    QualifyJobPhase::Failed(message) => {
+                        QualificationDecision::Failed(message.clone())
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The [`QualifyJobPhase`] a live Job reports, read from its status conditions:
+/// `Complete=True` is success, `Failed=True` is failure (its message carried
+/// through), anything else is still running.
+pub fn qualify_job_phase(job: &Job) -> QualifyJobPhase {
+    let Some(conditions) = job.status.as_ref().and_then(|s| s.conditions.as_ref()) else {
+        return QualifyJobPhase::Running;
+    };
+    for c in conditions {
+        if c.status != "True" {
+            continue;
+        }
+        match c.type_.as_str() {
+            "Complete" => return QualifyJobPhase::Succeeded,
+            "Failed" => {
+                let message = c
+                    .message
+                    .clone()
+                    .filter(|m| !m.is_empty())
+                    .or_else(|| c.reason.clone())
+                    .unwrap_or_else(|| "the store qualification Job failed".to_string());
+                return QualifyJobPhase::Failed(message);
+            }
+            _ => {}
+        }
+    }
+    QualifyJobPhase::Running
 }
 
 /// A tier's PodDisruptionBudget (issue #126, deliverable 4), capping how many of
@@ -5144,6 +5423,268 @@ mod tests {
         assert!(
             secrets_binding.contains("namespace: ravel-system"),
             "the shipped secrets RoleBinding binds ravel-system, the operator's own namespace"
+        );
+    }
+
+    /// A job condition of the given type/status, the shape
+    /// [`qualify_job_phase`] reads.
+    fn job_with_condition(type_: &str, status: &str, message: Option<&str>) -> Job {
+        use k8s_openapi::api::batch::v1::{JobCondition, JobStatus};
+        Job {
+            status: Some(JobStatus {
+                conditions: Some(vec![JobCondition {
+                    type_: type_.to_string(),
+                    status: status.to_string(),
+                    message: message.map(str::to_string),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// The input hash is stable for one spec and changes for each of the five
+    /// inputs it covers, and only those. Pins the exact set of fields that
+    /// re-trigger qualification (issue #36): a change to any of them is a
+    /// different store to prove, an unrelated change is not.
+    #[test]
+    fn qualify_input_hash_tracks_exactly_the_qualified_inputs() {
+        let spec = base_spec();
+        let base = qualify_job_input_hash(&spec);
+        assert_eq!(
+            base,
+            qualify_job_input_hash(&spec),
+            "the hash is deterministic for one spec"
+        );
+
+        let mut bucket = spec.clone();
+        bucket.storage.s3.bucket = "other-bucket".to_string();
+        let mut region = spec.clone();
+        region.storage.s3.region = "us-east-1".to_string();
+        let mut endpoint = spec.clone();
+        endpoint.storage.s3.endpoint = Some("http://other:9000".to_string());
+        let mut image = spec.clone();
+        image.image = "registry.example/ravel:v2".to_string();
+        let mut creds = spec.clone();
+        creds.storage.s3.credentials_secret_ref.name = "other-s3".to_string();
+        for (label, changed) in [
+            ("bucket", &bucket),
+            ("region", &region),
+            ("endpoint", &endpoint),
+            ("image", &image),
+            ("credentials secret", &creds),
+        ] {
+            assert_ne!(
+                base,
+                qualify_job_input_hash(changed),
+                "a change to {label} re-triggers qualification"
+            );
+        }
+
+        // A field qualification does not depend on leaves the hash unchanged, so
+        // an unrelated spec edit does not re-run qualification.
+        let mut replicas = spec.clone();
+        replicas.gateway.replicas = spec.gateway.replicas + 5;
+        assert_eq!(
+            base,
+            qualify_job_input_hash(&replicas),
+            "an unrelated spec edit (replica count) does not re-qualify"
+        );
+    }
+
+    /// The rendered qualify Job: name, image, command/args, credentials, the
+    /// spec-hash annotation, and the one-shot execution shape. Exact values, so
+    /// the Job the operator applies is pinned (issue #36).
+    #[test]
+    fn qualify_job_renders_a_one_shot_store_qualify() {
+        let spec = base_spec();
+        let job = desired_qualify_job(&spec, "prod");
+
+        assert_eq!(job.metadata.name.as_deref(), Some("prod-qualify"));
+        assert_eq!(
+            job.metadata
+                .annotations
+                .as_ref()
+                .and_then(|a| a.get(QUALIFY_SPEC_HASH_ANNOTATION))
+                .map(String::as_str),
+            Some(qualify_job_input_hash(&spec).as_str()),
+            "the annotation records the input hash so a change re-runs the Job"
+        );
+
+        let job_spec = job.spec.as_ref().expect("qualify Job has a spec");
+        assert_eq!(job_spec.backoff_limit, Some(QUALIFY_JOB_BACKOFF_LIMIT));
+        assert_eq!(
+            job_spec.ttl_seconds_after_finished,
+            Some(QUALIFY_JOB_TTL_SECONDS)
+        );
+        let pod = job_spec
+            .template
+            .spec
+            .as_ref()
+            .expect("qualify Job has a pod spec");
+        assert_eq!(pod.restart_policy.as_deref(), Some("Never"));
+        assert_eq!(pod.containers.len(), 1, "one qualify container");
+        let container = &pod.containers[0];
+        assert_eq!(
+            container.image.as_deref(),
+            Some("registry.example/ravel:v1")
+        );
+        assert_eq!(
+            container.command.as_deref(),
+            Some(["/usr/local/bin/ravel-cli".to_string()].as_slice())
+        );
+        assert_eq!(
+            container.args.as_deref(),
+            Some(
+                [
+                    "--store".to_string(),
+                    "s3".to_string(),
+                    "store".to_string(),
+                    "qualify".to_string(),
+                ]
+                .as_slice()
+            )
+        );
+        let env = container.env.as_ref().expect("qualify container has env");
+        let env_value = |name: &str| {
+            env.iter()
+                .find(|e| e.name == name)
+                .and_then(|e| e.value.clone())
+        };
+        assert_eq!(env_value("RAVEL_S3_BUCKET").as_deref(), Some("ravel-data"));
+        assert_eq!(env_value("RAVEL_S3_REGION").as_deref(), Some("eu-west-1"));
+        assert_eq!(
+            env_value("RAVEL_S3_ENDPOINT").as_deref(),
+            Some("http://minio:9000")
+        );
+        // Credentials come from the shared Secret via secretKeyRef, never a
+        // literal value in the pod spec.
+        let access = env
+            .iter()
+            .find(|e| e.name == "RAVEL_S3_ACCESS_KEY")
+            .expect("access key env present");
+        assert!(access.value.is_none(), "the access key is never a literal");
+        assert_eq!(
+            access
+                .value_from
+                .as_ref()
+                .and_then(|s| s.secret_key_ref.as_ref())
+                .map(|r| (r.name.as_str(), r.key.as_str())),
+            Some(("ravel-s3", S3_ACCESS_KEY_ID_KEY)),
+        );
+    }
+
+    /// `qualify_job_phase` reads the Job's terminal condition: `Complete=True`
+    /// is success, `Failed=True` carries its message, nothing terminal is still
+    /// running.
+    #[test]
+    fn qualify_job_phase_reads_the_terminal_condition() {
+        assert_eq!(
+            qualify_job_phase(&Job::default()),
+            QualifyJobPhase::Running,
+            "a Job with no status is still running"
+        );
+        assert_eq!(
+            qualify_job_phase(&job_with_condition("Complete", "True", None)),
+            QualifyJobPhase::Succeeded
+        );
+        assert_eq!(
+            qualify_job_phase(&job_with_condition(
+                "Failed",
+                "True",
+                Some("backend rejected CAS")
+            )),
+            QualifyJobPhase::Failed("backend rejected CAS".to_string()),
+            "the failure carries the Job's own terminal message"
+        );
+        // A condition that is not True does not count as terminal.
+        assert_eq!(
+            qualify_job_phase(&job_with_condition("Failed", "False", None)),
+            QualifyJobPhase::Running
+        );
+    }
+
+    /// A cluster already qualified for the current inputs proceeds without
+    /// re-running qualification, whatever the live Job says -- even absent
+    /// (TTL-garbage-collected). This is what keeps qualification from re-running
+    /// on a schedule.
+    #[test]
+    fn qualified_inputs_proceed_without_rerunning() {
+        let hash = "abc123".to_string();
+        for observation in [
+            QualifyJobObservation::Absent,
+            QualifyJobObservation::Present {
+                spec_hash: Some(hash.clone()),
+                phase: QualifyJobPhase::Succeeded,
+            },
+        ] {
+            assert_eq!(
+                qualification_decision(&hash, Some(&hash), &observation),
+                QualificationDecision::Proceed,
+                "recorded qualified inputs short-circuit to Proceed"
+            );
+        }
+    }
+
+    /// A fresh cluster (nothing qualified, no Job) creates the qualify Job
+    /// without recreating anything, and holds serving until it completes.
+    #[test]
+    fn fresh_cluster_creates_the_qualify_job() {
+        assert_eq!(
+            qualification_decision("h", None, &QualifyJobObservation::Absent),
+            QualificationDecision::Qualify { recreate: false },
+        );
+    }
+
+    /// A running Job for the current inputs holds serving; a completed one lets
+    /// it proceed; a failed one surfaces the Job's message and stays held.
+    #[test]
+    fn matching_job_reports_its_progress() {
+        let present = |phase| QualifyJobObservation::Present {
+            spec_hash: Some("h".to_string()),
+            phase,
+        };
+        assert_eq!(
+            qualification_decision("h", None, &present(QualifyJobPhase::Running)),
+            QualificationDecision::Waiting,
+        );
+        assert_eq!(
+            qualification_decision("h", None, &present(QualifyJobPhase::Succeeded)),
+            QualificationDecision::Proceed,
+        );
+        assert_eq!(
+            qualification_decision(
+                "h",
+                None,
+                &present(QualifyJobPhase::Failed("boom".to_string()))
+            ),
+            QualificationDecision::Failed("boom".to_string()),
+        );
+    }
+
+    /// When the inputs change on an already-qualified cluster, a Job for the old
+    /// inputs (or one missing the annotation) is recreated, not read as the
+    /// current one. The old qualified hash does not short-circuit because it no
+    /// longer equals the desired hash.
+    #[test]
+    fn changed_inputs_recreate_a_stale_job() {
+        let stale = QualifyJobObservation::Present {
+            spec_hash: Some("old".to_string()),
+            phase: QualifyJobPhase::Succeeded,
+        };
+        assert_eq!(
+            qualification_decision("new", Some("old"), &stale),
+            QualificationDecision::Qualify { recreate: true },
+        );
+        // A Job with no recorded hash is also stale against any desired hash.
+        let unannotated = QualifyJobObservation::Present {
+            spec_hash: None,
+            phase: QualifyJobPhase::Succeeded,
+        };
+        assert_eq!(
+            qualification_decision("new", Some("old"), &unannotated),
+            QualificationDecision::Qualify { recreate: true },
         );
     }
 }

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1913,15 +1913,27 @@ pub const QUALIFY_COMPONENT: &str = "qualify";
 
 /// Annotation on the qualify Job carrying [`qualify_job_input_hash`], so a
 /// change to the inputs qualification proves against (bucket, region, endpoint,
-/// image, credentials Secret name) re-runs it and a no-op reconcile does not.
+/// image, credentials Secret name and its resourceVersion) re-runs it and a
+/// no-op reconcile does not.
 pub const QUALIFY_SPEC_HASH_ANNOTATION: &str = "ravel.nofire.ai/qualify-spec-hash";
 
-/// `backoffLimit` for the qualify Job: a few retries absorb a transient S3
-/// error (a backend still coming up) without spinning forever on a genuine
-/// qualification failure (a backend that fails conditional-create atomicity or
-/// list consistency). Four attempts, then the Job reports `Failed` and the
-/// controller surfaces it on the `StoreQualified` condition.
-pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 4;
+/// `backoffLimit` for the qualify Job: one retry absorbs a transient S3 error
+/// (a backend still coming up) without spinning on a genuine qualification
+/// failure (a backend that fails conditional-create atomicity or list
+/// consistency). Two attempts total (the initial run plus one retry), then the
+/// Job reports `Failed` and the controller surfaces it on the `StoreQualified`
+/// condition.
+///
+/// Kept small deliberately: `activeDeadlineSeconds` is a Job-WIDE bound on the
+/// total active time across every retry (it takes precedence over
+/// `backoffLimit`), so the two knobs must be sized together. A larger retry
+/// count would either not fit under the deadline (a slow-but-healthy attempt
+/// plus a retry would trip `DeadlineExceeded` before the retry budget was
+/// spent) or force the deadline so high that a hung Job ran for many minutes
+/// before it was cut off. Two attempts is the value that lets one retry
+/// complete a full slow-but-healthy run within
+/// [`QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS`].
+pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 1;
 
 /// `ttlSecondsAfterFinished` for the qualify Job: one hour, so a finished Job
 /// does not accumulate across reconciles or re-qualifications. The qualified
@@ -1929,32 +1941,42 @@ pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 4;
 /// garbage-collected after success does not re-trigger qualification.
 pub const QUALIFY_JOB_TTL_SECONDS: i32 = 3600;
 
-/// `activeDeadlineSeconds` for the qualify Job: a wall-clock bound on a single
-/// attempt, so a qualify pod that hangs (an S3 endpoint that accepts the TCP
-/// connection and then never answers) becomes a `Failed` Job with reason
-/// `DeadlineExceeded` instead of running indefinitely. `backoffLimit` bounds
-/// only how many *failed* attempts run; it does nothing for one attempt that
-/// never terminates, which leaves `StoreQualified` stuck at `Pending` forever.
+/// `activeDeadlineSeconds` for the qualify Job: a wall-clock bound so a qualify
+/// pod that hangs (an S3 endpoint that accepts the TCP connection and then
+/// never answers) becomes a `Failed` Job with reason `DeadlineExceeded`
+/// instead of running indefinitely. `backoffLimit` bounds only how many
+/// *failed* attempts run; it does nothing for one attempt that never
+/// terminates, which leaves `StoreQualified` stuck at `Pending` forever.
 ///
-/// The value must clear a slow-but-healthy run with margin. `ravel store
-/// qualify` runs 28 sequential object operations against the bucket: probe
-/// create-if-absent (put, put, get = 3), probe CAS version (put, put, put,
-/// get = 4), probe read-after-write ([`super`]'s `CONSISTENCY_CYCLES` = 5
-/// put+get = 10), probe list-after-write (5 put+list = 10), and the final
-/// `sys/qualification` create-if-absent write (1); the two informational
-/// probes issue no request through the `ObjectStoreBackend` contract. Each
-/// operation's per-request ceiling is the S3 client's 20 s `request_timeout`
-/// (ravel-object-store `S3HttpConfig::default`), so a slow-but-healthy run
-/// whose every operation approaches that ceiling without retrying is bounded
-/// by 28 * 20 s = 560 s. 900 s adds a ~1.6x margin (340 s of slack) for pod
-/// scheduling, image pull, and the occasional single retry, while staying far
-/// below a hung endpoint's ~200 s-per-operation worst case (`retry_timeout`
-/// 180 s + `request_timeout` 20 s): a hang trips the deadline after roughly
-/// four stalled operations rather than exhausting all 28.
+/// This deadline is JOB-WIDE, not per-attempt: Kubernetes counts it against
+/// the Job's total active time summed across every retry, and it takes
+/// precedence over `backoffLimit` (whichever limit is hit first fails the
+/// Job). So the value must fit the intended retries end to end, not just one
+/// attempt, or a slow-but-healthy first attempt plus a retry would trip
+/// `DeadlineExceeded` before the retry budget ([`QUALIFY_JOB_BACKOFF_LIMIT`])
+/// was ever spent.
 ///
-/// Not part of [`qualify_job_input_hash`]: tuning this deadline must not
-/// re-run a qualification that already passed.
-pub const QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS: i64 = 900;
+/// Arithmetic. `ravel store qualify` runs 28 sequential object operations
+/// against the bucket: probe create-if-absent (put, put, get = 3), probe CAS
+/// version (put, put, put, get = 4), probe read-after-write ([`super`]'s
+/// `CONSISTENCY_CYCLES` = 5 put+get = 10), probe list-after-write (5 put+list
+/// = 10), and the final `sys/qualification` create-if-absent write (1); the two
+/// informational probes issue no request through the `ObjectStoreBackend`
+/// contract. Each operation's per-request ceiling is the S3 client's 20 s
+/// `request_timeout` (ravel-object-store `S3HttpConfig::default`), so one
+/// slow-but-healthy attempt whose every operation approaches that ceiling
+/// without retrying is bounded by 28 * 20 s = 560 s. Adding ~140 s per attempt
+/// for pod scheduling and image pull gives a 700 s per-attempt budget. With
+/// `QUALIFY_JOB_BACKOFF_LIMIT` = 1 the Job runs at most two attempts, so the
+/// Job-wide deadline is 2 * 700 s = 1400 s: a slow-but-healthy initial attempt
+/// AND a full retry both complete before it fires. A single hung attempt still
+/// terminates, at the 1400 s Job-wide bound rather than running forever
+/// (a hung endpoint stalls each operation at ~200 s = `retry_timeout` 180 s +
+/// `request_timeout` 20 s).
+///
+/// Not part of [`qualify_job_input_hash`]: tuning this deadline (or the backoff
+/// limit) must not re-run a qualification that already passed.
+pub const QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS: i64 = 1400;
 
 /// `StoreQualified` reason while the qualify Job is being created or is still
 /// running: serving is held until it reports success.
@@ -1978,16 +2000,35 @@ pub const STORE_QUALIFIED_MESSAGE: &str =
     "the object store passed ravel store qualify; serving Deployments may be created";
 
 /// A deterministic change-detection hash over the inputs store qualification
-/// proves against (issue #36): the bucket, region, endpoint, server image, and
-/// the credentials Secret name. When any of these changes the store the cluster
-/// would serve on is a different one, so qualification is re-run; an unrelated
-/// spec edit (a replica count, a fold interval) leaves this stable and does not
-/// re-qualify.
+/// proves against (issue #36): the bucket, region, endpoint, server image, the
+/// credentials Secret NAME, and that credentials Secret's `resourceVersion`.
+/// When any of these changes the store the cluster would serve on, or the
+/// credentials it would serve with, is different, so qualification is re-run; an
+/// unrelated spec edit (a replica count, a fold interval) leaves this stable and
+/// does not re-qualify.
+///
+/// The `resourceVersion` is what makes a fixed-name credential ROTATION
+/// re-qualify (finding, issue #36): rotating the Secret in place keeps its name
+/// but bumps its `resourceVersion`, so without it a rotation to credentials that
+/// no longer pass the object-store contract would skip qualification entirely
+/// once the prior Job had been TTL-garbage-collected. Only the `resourceVersion`
+/// (opaque API metadata) enters the hash, never any Secret DATA: the operator
+/// never reads the credential values here (it resolves only the
+/// `resourceVersion`, see `controller::resolve_credential_resource_versions`),
+/// and this value reaches neither the status nor a log line. The operator does
+/// not watch Secrets (the per-namespace `ravel-operator-secrets` RoleBinding
+/// grants `get` only, not `watch`), so a rotation is noticed on the next
+/// periodic requeue (`controller::RESYNC`, 300 s): that pass reads the new
+/// `resourceVersion`, this hash changes, and the gate recreates the Job. The
+/// bound on noticing a rotation is therefore one `RESYNC` interval.
 ///
 /// `DefaultHasher` (SipHash with fixed keys) is deterministic across processes,
 /// so an operator restart does not spuriously re-qualify. It is a change signal,
 /// not a security boundary, exactly like [`secrets_checksum`].
-pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
+pub fn qualify_job_input_hash(
+    spec: &RavelClusterSpec,
+    credentials_resource_version: Option<&str>,
+) -> String {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     spec.storage.s3.bucket.hash(&mut hasher);
@@ -2004,6 +2045,7 @@ pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
         .credentials_secret_ref
         .name
         .hash(&mut hasher);
+    credentials_resource_version.unwrap_or("").hash(&mut hasher);
     format!("{:016x}", hasher.finish())
 }
 
@@ -2024,7 +2066,16 @@ pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
 /// [`QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS`] so a hung attempt fails rather than
 /// runs forever, and [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not
 /// accumulate.
-pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
+///
+/// `credentials_resource_version` is the shared credentials Secret's resolved
+/// `resourceVersion` (the controller reads it before the gate); it flows into
+/// [`qualify_job_input_hash`] so the recorded annotation matches the gate's
+/// desired hash and a fixed-name credential rotation re-qualifies.
+pub fn desired_qualify_job(
+    spec: &RavelClusterSpec,
+    instance: &str,
+    credentials_resource_version: Option<&str>,
+) -> Job {
     let labels = labels(instance, QUALIFY_COMPONENT);
     let mut env = vec![
         EnvVar {
@@ -2071,7 +2122,7 @@ pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
             labels: Some(labels.clone()),
             annotations: Some(BTreeMap::from([(
                 QUALIFY_SPEC_HASH_ANNOTATION.to_string(),
-                qualify_job_input_hash(spec),
+                qualify_job_input_hash(spec, credentials_resource_version),
             )])),
             ..Default::default()
         },
@@ -5466,6 +5517,40 @@ mod tests {
         );
     }
 
+    /// Finding 1 verb sweep. Every operator write is server-side apply (a PATCH,
+    /// with `create` for objects that do not yet exist) or a delete, never a
+    /// PUT, so no rule grants the `update` verb. The `batch`/`jobs` rule is
+    /// exactly the verbs the reconcile loop calls: `create`/`patch` (apply),
+    /// `get` (observe the qualify Job), and `delete` (foreground recreate); it is
+    /// not watched by an informer, so no `list`/`watch`. A text scan so a rule
+    /// that reintroduces a dead verb fails the gate.
+    #[test]
+    fn rbac_grants_only_the_verbs_the_reconcile_loop_calls() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../deploy/k8s/operator/rbac.yaml");
+        let manifest = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+        // No rule anywhere grants `update` (matched with its YAML quotes so the
+        // word "update" in a comment does not count).
+        assert!(
+            !manifest.contains("\"update\""),
+            "server-side apply is a PATCH, not a PUT: no rule may grant the update verb"
+        );
+
+        // The jobs rule grants exactly create/patch/get/delete.
+        let jobs_verbs = manifest
+            .lines()
+            .skip_while(|l| l.trim() != "resources: [\"jobs\"]")
+            .nth(1)
+            .map(str::trim)
+            .expect("rbac.yaml defines a batch/jobs rule with a verbs line");
+        assert_eq!(
+            jobs_verbs, "verbs: [\"create\", \"patch\", \"get\", \"delete\"]",
+            "the jobs rule grants only create/patch (apply), get (observe), and delete"
+        );
+    }
+
     /// A job condition of the given type/status, the shape
     /// [`qualify_job_phase`] reads.
     fn job_with_condition(type_: &str, status: &str, message: Option<&str>) -> Job {
@@ -5511,11 +5596,11 @@ mod tests {
     #[test]
     fn qualify_input_hash_tracks_exactly_the_qualified_inputs() {
         let spec = base_spec();
-        let base = qualify_job_input_hash(&spec);
+        let base = qualify_job_input_hash(&spec, Some("rv-1"));
         assert_eq!(
             base,
-            qualify_job_input_hash(&spec),
-            "the hash is deterministic for one spec"
+            qualify_job_input_hash(&spec, Some("rv-1")),
+            "the hash is deterministic for one spec and resourceVersion"
         );
 
         let mut bucket = spec.clone();
@@ -5537,10 +5622,19 @@ mod tests {
         ] {
             assert_ne!(
                 base,
-                qualify_job_input_hash(changed),
+                qualify_job_input_hash(changed, Some("rv-1")),
                 "a change to {label} re-triggers qualification"
             );
         }
+
+        // A fixed-name credential rotation (same Secret name, new
+        // resourceVersion) is a different credential and must re-trigger
+        // qualification, even though every spec field is unchanged.
+        assert_ne!(
+            base,
+            qualify_job_input_hash(&spec, Some("rv-2")),
+            "a new credentials resourceVersion (rotation in place) re-qualifies"
+        );
 
         // A field qualification does not depend on leaves the hash unchanged, so
         // an unrelated spec edit does not re-run qualification.
@@ -5548,7 +5642,7 @@ mod tests {
         replicas.gateway.replicas = spec.gateway.replicas + 5;
         assert_eq!(
             base,
-            qualify_job_input_hash(&replicas),
+            qualify_job_input_hash(&replicas, Some("rv-1")),
             "an unrelated spec edit (replica count) does not re-qualify"
         );
     }
@@ -5559,7 +5653,7 @@ mod tests {
     #[test]
     fn qualify_job_renders_a_one_shot_store_qualify() {
         let spec = base_spec();
-        let job = desired_qualify_job(&spec, "prod");
+        let job = desired_qualify_job(&spec, "prod", Some("rv-1"));
 
         assert_eq!(job.metadata.name.as_deref(), Some("prod-qualify"));
         assert_eq!(
@@ -5568,7 +5662,7 @@ mod tests {
                 .as_ref()
                 .and_then(|a| a.get(QUALIFY_SPEC_HASH_ANNOTATION))
                 .map(String::as_str),
-            Some(qualify_job_input_hash(&spec).as_str()),
+            Some(qualify_job_input_hash(&spec, Some("rv-1")).as_str()),
             "the annotation records the input hash so a change re-runs the Job"
         );
 
@@ -5672,17 +5766,35 @@ mod tests {
     #[test]
     fn qualify_job_bounds_a_hung_attempt() {
         let spec = base_spec();
-        let job = desired_qualify_job(&spec, "prod");
+        let job = desired_qualify_job(&spec, "prod", None);
         let job_spec = job.spec.as_ref().expect("qualify Job has a spec");
         assert_eq!(
             job_spec.active_deadline_seconds,
             Some(QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS),
-            "the qualify Job bounds a single attempt with activeDeadlineSeconds"
+            "the qualify Job bounds its total active time with activeDeadlineSeconds"
         );
         assert_eq!(
-            QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS, 900,
-            "the chosen deadline is 900 s (28 sequential ops * 20 s request_timeout \
-             = 560 s slow-but-healthy, plus a ~1.6x margin)"
+            job_spec.backoff_limit,
+            Some(QUALIFY_JOB_BACKOFF_LIMIT),
+            "the qualify Job caps its retries with backoffLimit"
+        );
+        // activeDeadlineSeconds is Job-wide (summed across every retry) and takes
+        // precedence over backoffLimit, so the deadline must fit the intended
+        // attempts end to end: 700 s per attempt (560 s of ops + ~140 s pod
+        // scheduling/pull) * (backoffLimit + 1) attempts.
+        assert_eq!(
+            QUALIFY_JOB_BACKOFF_LIMIT, 1,
+            "one retry (two attempts total)"
+        );
+        assert_eq!(
+            QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS, 1400,
+            "the Job-wide deadline is 1400 s = 700 s per attempt * 2 attempts, so a \
+             slow-but-healthy first attempt plus one full retry both fit before it fires"
+        );
+        assert_eq!(
+            QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS,
+            700 * i64::from(QUALIFY_JOB_BACKOFF_LIMIT + 1),
+            "the deadline and the backoff limit are sized together"
         );
     }
 
@@ -5721,18 +5833,19 @@ mod tests {
         assert_eq!(decision, QualificationDecision::Failed(message));
     }
 
-    /// The `activeDeadlineSeconds` is a tuning knob, not a store-identity input:
-    /// [`qualify_job_input_hash`] covers exactly the five inputs qualification
-    /// proves against and never the deadline, so changing the deadline leaves the
-    /// hash equal and does not re-run a qualification that already passed.
+    /// The `activeDeadlineSeconds` and `backoffLimit` are tuning knobs, not
+    /// store-identity inputs: [`qualify_job_input_hash`] covers exactly the
+    /// bucket, region, endpoint, image, credentials Secret name, and credentials
+    /// `resourceVersion`, and never either knob, so tuning them leaves the hash
+    /// equal and does not re-run a qualification that already passed.
     #[test]
     fn the_deadline_is_not_part_of_the_qualified_input_hash() {
         use std::hash::{Hash, Hasher};
         let spec = base_spec();
 
-        // Recompute the hash over exactly the five qualified inputs, deliberately
-        // excluding the deadline. If the production hasher folded the deadline in,
-        // this reference would diverge and the assertion would fail.
+        // Recompute the hash over exactly the six qualified inputs, deliberately
+        // excluding both knobs. If the production hasher folded either in, this
+        // reference would diverge and the assertion would fail.
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         spec.storage.s3.bucket.hash(&mut hasher);
         spec.storage.s3.region.hash(&mut hasher);
@@ -5748,13 +5861,14 @@ mod tests {
             .credentials_secret_ref
             .name
             .hash(&mut hasher);
+        "rv-1".hash(&mut hasher);
         let expected = format!("{:016x}", hasher.finish());
 
         assert_eq!(
-            qualify_job_input_hash(&spec),
+            qualify_job_input_hash(&spec, Some("rv-1")),
             expected,
-            "the qualified-input hash covers exactly the five store-identity inputs, never the \
-             deadline"
+            "the qualified-input hash covers exactly the six store-identity inputs, never the \
+             deadline or the backoff limit"
         );
     }
 
@@ -5838,6 +5952,61 @@ mod tests {
         assert_eq!(
             qualification_decision("new", Some("old"), &unannotated),
             QualificationDecision::Qualify { recreate: true },
+        );
+    }
+
+    /// Fixed-name credential rotation (issue #36): the credentials Secret keeps
+    /// its name but its content is rotated in place, so its `resourceVersion`
+    /// bumps. The qualified-input hash changes, so an already-qualified cluster
+    /// whose last Job succeeded is driven back to `Qualify { recreate: true }`
+    /// (the controller renders `StoreQualified=Pending` and recreates the Job).
+    /// The converse: an unchanged `resourceVersion` yields the same hash and
+    /// `Proceed`, so a steady-state reconcile never re-runs qualification.
+    #[test]
+    fn fixed_name_credential_rotation_re_qualifies() {
+        let spec = base_spec();
+        let before = qualify_job_input_hash(&spec, Some("rv-1"));
+        let after = qualify_job_input_hash(&spec, Some("rv-2"));
+        assert_ne!(
+            before, after,
+            "a rotated credentials Secret (new resourceVersion) is a new qualified input"
+        );
+
+        // Rotation: the durable qualified hash is the pre-rotation one, the
+        // desired hash is the post-rotation one, and the live Job (if not yet
+        // GC'd) still carries the pre-rotation hash and succeeded.
+        let rotated = qualification_decision(
+            &after,
+            Some(&before),
+            &QualifyJobObservation::Present {
+                spec_hash: Some(before.clone()),
+                phase: QualifyJobPhase::Succeeded,
+            },
+        );
+        assert_eq!(
+            rotated,
+            QualificationDecision::Qualify { recreate: true },
+            "a fixed-name rotation must recreate the Job and flip StoreQualified to Pending"
+        );
+        // Even after the prior Job's TTL GC (Absent) a rotation re-runs.
+        assert_eq!(
+            qualification_decision(&after, Some(&before), &QualifyJobObservation::Absent),
+            QualificationDecision::Qualify { recreate: false },
+            "a rotation after TTL GC creates a fresh Job"
+        );
+
+        // Converse: same resourceVersion, same hash, no re-run.
+        assert_eq!(
+            qualification_decision(
+                &before,
+                Some(&before),
+                &QualifyJobObservation::Present {
+                    spec_hash: Some(before.clone()),
+                    phase: QualifyJobPhase::Succeeded,
+                },
+            ),
+            QualificationDecision::Proceed,
+            "an unchanged resourceVersion must not re-run qualification"
         );
     }
 }


### PR DESCRIPTION
The operator created a RavelCluster's Deployments as soon as the resource
existed; nothing ran `ravel store qualify` against the cluster's bucket
first, so the kind lane was qualified by a hand-run Job and production
was not. A backend that fails conditional-create atomicity or listing
order is exactly what qualification catches.

The reconcile loop now creates a one-shot <cluster>-qualify Job with the
server Deployment's image, env and credential Secret, and creates the
Deployments only after it succeeds. A StoreQualified status condition
carries Pending, Succeeded or Failed with the Job's terminal message; a
failed qualification creates no Deployment and requeues on the existing
backoff. The qualified inputs (bucket, region, endpoint, image, Secret
name and the Secret's resourceVersion) are hashed into
status.storeQualifiedHash, so a later pass with the same inputs proceeds
without re-running after the Job's TTL has collected it, and a change to
any of them, including a fixed-name credential rotation, recreates the
Job and flips the condition back to Pending without tearing down running
Deployments. The operator's secrets grant is get only, so a rotation is
noticed on the next periodic resync, within 300 seconds. Qualification
is never re-run on a schedule.

A hung attempt is bounded by activeDeadlineSeconds, which applies to the
whole Job across retries: 700 seconds per attempt (28 sequential object
operations at the client's 20 second request timeout plus scheduling and
image pull) times two attempts with backoffLimit 1, so 1400 seconds; a
deadline-exceeded Job reads as Failed with that reason in the condition,
and neither knob is part of the qualified input hash. The credential
Secret is resolved before the qualification gate, so a missing or
unreadable Secret reports SecretNotFound or SecretsUnreadable instead of
a deadline. A stale Job is deleted with foreground propagation and its
replacement created only once it is observed gone. While qualification
holds a fresh cluster, Available carries the qualification reason and
message rather than the generic replica message; a serving cluster under
re-qualification stays Available. The persisted status fields travel in
a named struct. The ClusterRole grants only the verbs the reconcile loop
calls, which drops update everywhere since server-side apply is patch,
and a test pins that set.

The CRD's status schema gains the hash field so the subresource does not
prune it; kind-up.sh drops its hand-run Job because the lane deploys
through the operator. ADR-0034 records the gate, the identity, and the
deadline as an amendment.

The operator has no fake-client harness, so the scenarios are pinned at
the qualification_decision layer the controller acts on. kind run
34166711817 passed on the previous round's head; the lane is re-run on
this branch before merge.

Supersedes #1430.

Refs: #36
