### PR TITLE
feat(sql): bound top-k grouped aggregate state for min/max ordering

### DIFF
--- a/crates/ravel-sql/src/bounded_topk.rs
+++ b/crates/ravel-sql/src/bounded_topk.rs
@@ -1,0 +1,289 @@
+//! Bounded top-k grouped aggregation (issue #1402).
+//!
+//! # The problem
+//!
+//! `GROUP BY <high-cardinality key> ... ORDER BY <aggregate> DESC LIMIT k`
+//! materialises one accumulator per distinct key even though the client asked
+//! for `k` rows. The measured instance is ClickBench q33 (`GROUP BY
+//! "WatchID","ClientIP"`, roughly 10^8 nearly-unique groups), whose
+//! intermediate state reaches 10.09 GB to return 10 rows. ADR-0013 forbids the
+//! obvious escape: budget exhaustion is an error, never a partial result, and
+//! spilling stays disabled. The only admissible route is to stop building the
+//! state in the first place.
+//!
+//! # What can and cannot be bounded exactly
+//!
+//! The pinned DataFusion (54.1) already ships the operator: an `AggregateExec`
+//! carrying `LimitOptions` executes as `GroupedTopKAggregateStream`, a bounded
+//! priority map of `k` groups instead of an unbounded group table. This rule
+//! decides *when* ravel lets that happen; it does not reimplement it.
+//!
+//! The gate is narrower than issue #1402 proposed, because the property the
+//! issue named ("the ordering aggregate is monotone non-decreasing in its
+//! inputs, so a group evicted below the k-th cannot re-enter") is false. Take
+//! `ORDER BY count(*) DESC LIMIT 1` over the row sequence `A, B, B, B`. After
+//! row 1 the map holds `{A: 1}`. Row 2 opens group `B` with a running count of
+//! `1`, which does not beat the retained `1`, so `B` is evicted; rows 3 and 4
+//! evict it again. The bounded answer is `A` with 1, the true answer is `B`
+//! with 3. Monotonicity says a group's running value is a LOWER bound on its
+//! final value, and a lower bound is the wrong direction for pruning: nothing
+//! in the stream bounds a group's future contribution from ABOVE, so an
+//! accumulating aggregate (`count`, `sum`) cannot be pruned without either
+//! approximation (forbidden: exact semantics by default) or a second pass.
+//! `count`/`sum` are therefore NOT admitted here, and
+//! `count_ordering_is_refused_and_still_returns_the_true_top_k` in
+//! `tests/bounded_topk_aggregate.rs` is the pin that reddens if the gate is
+//! ever widened to them.
+//!
+//! What *is* exact is a value-selective ordering aggregate: `max` under a
+//! descending sort and `min` under an ascending one. Their per-group result is
+//! the extreme of independently contributed row values rather than a running
+//! accumulation, which is what makes eviction safe. See
+//! [`BoundedTopKAggregate`]'s doc comment for the argument.
+//!
+//! # Why the gate is ravel's and not DataFusion's default
+//!
+//! `datafusion.optimizer.enable_topk_aggregation` defaults to `true`, so
+//! DataFusion's own `TopKAggregation` rule was live in every ravel session,
+//! ungated. Two of the shapes it admits are ones ravel must not take:
+//!
+//! - **Float `min`/`max`.** ADR-0023 gives ravel its own total-order min/max
+//!   UDAF whose float comparison is `f64::total_cmp`, so `-0.0` and NaN
+//!   payloads order deterministically. The priority map does its own
+//!   comparisons and never constructs that accumulator, so a float `min`/`max`
+//!   routed through it answers under DataFusion's ordering, not ravel's.
+//!   [`crate::minmax::is_float`] inputs are refused here.
+//! - **An unbounded `LIMIT`.** The bound this rule buys is proportional to the
+//!   limit; at a large enough `k` the priority map is the group table with
+//!   extra steps. [`crate::SqlConfig::bounded_topk_max_limit`] is the ceiling.
+//!
+//! So [`crate::session_config`] turns `enable_topk_aggregation` off for every
+//! query and this rule re-admits exactly the vetted shape. `None` for the
+//! config threshold does not install the rule at all, which is the operator
+//! opt-out and the rule-off side of every test in
+//! `tests/bounded_topk_aggregate.rs`.
+
+use std::sync::Arc;
+
+use datafusion::common::Result as DFResult;
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::aggregates::{AggregateExec, LimitOptions, topk_types_supported};
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::coop::CooperativeExec;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::sorts::sort::SortExec;
+
+use crate::minmax::is_float;
+
+/// The rule's name, as it appears in DataFusion's optimizer diagnostics.
+pub const BOUNDED_TOPK_AGGREGATE_RULE: &str = "bounded_topk_aggregate";
+
+/// Bounds the intermediate state of a grouped aggregate whose only consumer is
+/// a top-k sort, by handing DataFusion's `GroupedTopKAggregateStream` a limit
+/// (issue #1402). See the module docs for the gate and for the aggregates it
+/// refuses.
+///
+/// **Exactness.** The rule fires only for `max` under a descending sort and
+/// `min` under an ascending one, where a group's result is the extreme of its
+/// rows' independently contributed values: the priority map drops a group only
+/// when its best value so far loses to the current k-th best, and that k-th
+/// best only ever tightens as more rows arrive. A group whose true extreme
+/// beats the FINAL k-th therefore also beat every earlier, weaker threshold, so
+/// it was admitted at the moment that value arrived and carries exactly that
+/// value, which is why no correct answer can be evicted and no evicted group
+/// can have belonged in the answer.
+#[derive(Debug)]
+pub struct BoundedTopKAggregate {
+    /// The largest `LIMIT` this rule will bound an aggregate for. See
+    /// [`crate::SqlConfig::bounded_topk_max_limit`].
+    max_limit: usize,
+}
+
+impl BoundedTopKAggregate {
+    /// The rule with `max_limit` as its `LIMIT` ceiling.
+    pub fn new(max_limit: usize) -> Self {
+        BoundedTopKAggregate { max_limit }
+    }
+}
+
+impl PhysicalOptimizerRule for BoundedTopKAggregate {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        plan.transform_down(|node| self.rewrite(node)).data()
+    }
+
+    fn name(&self) -> &str {
+        BOUNDED_TOPK_AGGREGATE_RULE
+    }
+
+    fn schema_check(&self) -> bool {
+        // The rewrite sets an execution hint and rebuilds no schema, so let
+        // DataFusion assert that: a rule that changed a column type here would
+        // be changing a client-visible result.
+        true
+    }
+}
+
+impl BoundedTopKAggregate {
+    /// Try to rewrite one node. Returns it unchanged unless it is a qualifying
+    /// top-k sort over a qualifying grouped aggregate.
+    fn rewrite(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+    ) -> DFResult<Transformed<Arc<dyn ExecutionPlan>>> {
+        let Some(sort) = node.downcast_ref::<SortExec>() else {
+            return Ok(Transformed::no(node));
+        };
+        // No `fetch` is no top-k: the sort materialises every group whatever
+        // this rule does, and there is no `k` to bound the aggregate by.
+        let Some(limit) = sort.fetch() else {
+            return Ok(Transformed::no(node));
+        };
+        if limit > self.max_limit {
+            return Ok(Transformed::no(node));
+        }
+        // A per-partition sort keeps `fetch` rows PER partition; the bound the
+        // doc comment argues is written for one stream of at most `k` rows.
+        if sort.preserve_partitioning() {
+            return Ok(Transformed::no(node));
+        }
+        // Exactly one ordering expression, and it must name a column: the gate
+        // compares it against one aggregate's output field by name, and a
+        // second ordering key would decide ties the priority map does not know
+        // about.
+        let ordering: &[_] = sort.expr();
+        let [order] = ordering else {
+            return Ok(Transformed::no(node));
+        };
+        let Some(order_column) = order.expr.downcast_ref::<Column>() else {
+            return Ok(Transformed::no(node));
+        };
+        let descending = order.options.descending;
+
+        // Walk down to every aggregate stage feeding this sort, tracking the
+        // ordering column through renaming projections the way DataFusion's own
+        // rule does. `refused` latches: once an unrecognised node is seen,
+        // nothing below it is touched.
+        let mut order_name = order_column.name().to_string();
+        let mut refused = false;
+        let mut bounded = false;
+        let input = Arc::clone(sort.input())
+            .transform_down(|inner| {
+                if refused {
+                    return Ok(Transformed::no(inner));
+                }
+                if let Some(aggregate) = inner.downcast_ref::<AggregateExec>() {
+                    match bound_aggregate(aggregate, &order_name, descending, limit) {
+                        Some(rewritten) => {
+                            bounded = true;
+                            return Ok(Transformed::yes(Arc::new(rewritten) as _));
+                        }
+                        None => refused = true,
+                    }
+                } else if let Some(projection) = inner.downcast_ref::<ProjectionExec>() {
+                    for expr in projection.expr() {
+                        if expr.alias == order_name
+                            && let Some(source) = expr.expr.downcast_ref::<Column>()
+                        {
+                            order_name = source.name().to_string();
+                        }
+                    }
+                } else if !is_pass_through(&inner) {
+                    refused = true;
+                }
+                Ok(Transformed::no(inner))
+            })
+            .data()?;
+
+        if !bounded {
+            return Ok(Transformed::no(node));
+        }
+        let rewritten = SortExec::new(sort.expr().clone(), input)
+            .with_fetch(sort.fetch())
+            .with_preserve_partitioning(sort.preserve_partitioning());
+        Ok(Transformed::yes(Arc::new(rewritten)))
+    }
+}
+
+/// A node between the top-k sort and the aggregate that neither drops rows nor
+/// renames the ordering column.
+///
+/// The allowlist is the mechanism, not a fallback: anything outside it refuses
+/// the rewrite. A `FilterExec` is deliberately absent, and that is the `HAVING`
+/// case -- a post-aggregation filter decides which groups reach the sort, so
+/// keeping only `k` groups underneath it would discard groups the filter would
+/// have let through. A node carrying its own `fetch` is refused for the same
+/// reason.
+fn is_pass_through(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    if plan.fetch().is_some() {
+        return false;
+    }
+    // `CoalescePartitionsExec` collapses the partial stages under the final
+    // one; `CooperativeExec` is DataFusion 54's yield wrapper. A
+    // `RepartitionExec` of any partitioning preserves every row: it moves rows
+    // between partitions, and the sort above it still takes the global top `k`
+    // from whatever each partition kept.
+    plan.is::<CoalescePartitionsExec>()
+        || plan.is::<CooperativeExec>()
+        || plan.is::<RepartitionExec>()
+}
+
+/// The gate, one conjunct per `return None`. `Some` is the aggregate rebuilt to
+/// execute as a bounded priority map of `limit` groups.
+fn bound_aggregate(
+    aggregate: &AggregateExec,
+    order_name: &str,
+    descending: bool,
+    limit: usize,
+) -> Option<AggregateExec> {
+    // Already carrying a limit: leave whoever set it alone.
+    if aggregate.limit_options().is_some() {
+        return None;
+    }
+    // The priority map is keyed by a single group value. A grouping set or a
+    // null expression is a different group-key shape entirely.
+    let group_by = aggregate.group_expr();
+    if group_by.has_grouping_set() || !group_by.null_expr().is_empty() {
+        return None;
+    }
+    let [(group_key, _)] = group_by.expr() else {
+        return None;
+    };
+    // A `FILTER` clause makes the aggregate's value a function of rows the
+    // priority map never sees it reject.
+    if aggregate.filter_expr().iter().any(Option::is_some) {
+        return None;
+    }
+    // The ordering aggregate must be the only aggregate, must be
+    // value-selective (`min`/`max`, which is what `get_minmax_desc` reports),
+    // must be sorted in the direction its own extreme runs, and must be the
+    // column the sort actually orders by. An accumulating aggregate (`count`,
+    // `sum`) reports nothing here and is refused; the module docs give the
+    // counterexample that makes that a correctness gate rather than a
+    // conservative default.
+    let (field, aggregate_descending) = aggregate.get_minmax_desc()?;
+    if aggregate_descending != descending || field.name() != order_name {
+        return None;
+    }
+    // ADR-0023: ravel's float min/max is a total order the priority map does
+    // not implement. Refusing float input keeps the answer ravel's.
+    if is_float(field.data_type()) {
+        return None;
+    }
+    let key_type = group_key.data_type(&aggregate.input().schema()).ok()?;
+    if !topk_types_supported(&key_type, field.data_type()) {
+        return None;
+    }
+    Some(AggregateExec::with_new_limit_options(
+        aggregate,
+        Some(LimitOptions::new_with_order(limit, descending)),
+    ))
+}

--- a/crates/ravel-sql/src/bounded_topk.rs
+++ b/crates/ravel-sql/src/bounded_topk.rs
@@ -222,11 +222,18 @@ impl BoundedTopKAggregate {
                         None => refused = true,
                     }
                 } else if let Some(projection) = inner.downcast_ref::<ProjectionExec>() {
+                    // One remap per projection: the alias lives in the
+                    // projection's output namespace and the source in its
+                    // input's, so once the name has crossed to the input side
+                    // it must not be matched against this projection's other
+                    // aliases, or `b AS a` and `a AS m` would chain and name a
+                    // different aggregate than the sort orders by.
                     for expr in projection.expr() {
                         if expr.alias == order_name
                             && let Some(source) = expr.expr.downcast_ref::<Column>()
                         {
                             order_name = source.name().to_string();
+                            break;
                         }
                     }
                 } else if !is_pass_through(&inner) {

--- a/crates/ravel-sql/src/bounded_topk.rs
+++ b/crates/ravel-sql/src/bounded_topk.rs
@@ -41,6 +41,25 @@
 //! accumulation, which is what makes eviction safe. See
 //! [`BoundedTopKAggregate`]'s doc comment for the argument.
 //!
+//! A NULL ordering value breaks that argument at the input, not the
+//! aggregate: DataFusion's priority map never admits a group whose ordering
+//! value is NULL, so under the default `NULLS FIRST` that group belongs first
+//! in the unbounded answer, and under `NULLS LAST` it still belongs whenever
+//! fewer than `k` non-null groups exist. A plain column the input schema
+//! marks non-nullable is the only input the map's NULL-blind admission is
+//! provably exact for, so `bound_aggregate` refuses any other ordering input.
+//! Every declared attribute column is nullable by construction
+//! (`crate::logs_schema`, "Every declared column is nullable"), so today this
+//! only fires over a fixed non-nullable column such as `ts`, `severity_num`,
+//! or `flags`; widening it to a declared column needs a statistics-derived
+//! proof that the column holds no NULLs, which is a separate change.
+//!
+//! At a tie on the k-th value the bounded map keeps the later-arriving group,
+//! and the unbounded sort's own choice between tied groups is arrival-order
+//! dependent too; SQL leaves that order unspecified, so
+//! `tests/bounded_topk_aggregate.rs` builds its fixture to have no ties rather
+//! than assert one order over the other.
+//!
 //! # Why the gate is ravel's and not DataFusion's default
 //!
 //! `datafusion.optimizer.enable_topk_aggregation` defaults to `true`, so
@@ -48,11 +67,14 @@
 //! ungated. Two of the shapes it admits are ones ravel must not take:
 //!
 //! - **Float `min`/`max`.** ADR-0023 gives ravel its own total-order min/max
-//!   UDAF whose float comparison is `f64::total_cmp`, so `-0.0` and NaN
-//!   payloads order deterministically. The priority map does its own
-//!   comparisons and never constructs that accumulator, so a float `min`/`max`
-//!   routed through it answers under DataFusion's ordering, not ravel's.
-//!   [`crate::minmax::is_float`] inputs are refused here.
+//!   UDAF whose comparison is `f64::total_cmp`, so `-0.0` and NaN payloads
+//!   order deterministically. The priority map's heap also orders with
+//!   `total_cmp`, but its worse-than pre-check -- the fast path that decides
+//!   whether an incoming row can possibly replace the current k-th -- compares
+//!   with `PartialOrd` instead, so whether `-0.0` against `0.0` and NaN
+//!   payloads end up ordered the way ADR-0023 mandates is not something this
+//!   rule can prove. [`crate::minmax::is_float`] inputs are refused here
+//!   rather than assumed correct.
 //! - **An unbounded `LIMIT`.** The bound this rule buys is proportional to the
 //!   limit; at a large enough `k` the priority map is the group table with
 //!   extra steps. [`crate::SqlConfig::bounded_topk_max_limit`] is the ceiling.
@@ -71,7 +93,9 @@ use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion::physical_plan::aggregates::{AggregateExec, LimitOptions, topk_types_supported};
+use datafusion::physical_plan::aggregates::{
+    AggregateExec, AggregateInputMode, LimitOptions, topk_types_supported,
+};
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::coop::CooperativeExec;
 use datafusion::physical_plan::projection::ProjectionExec;
@@ -175,6 +199,14 @@ impl BoundedTopKAggregate {
         let mut order_name = order_column.name().to_string();
         let mut refused = false;
         let mut bounded = false;
+        // A two-stage plan calls `bound_aggregate` twice for the same logical
+        // aggregate: once on the `Final`/`FinalPartitioned` node, whose own
+        // "input" is the OTHER stage's merged accumulator state, and once on
+        // the `Partial` node below it, whose input is the real scan schema.
+        // Only the latter can verify the ordering-input nullability conjunct
+        // against a real column; the rewrite is trusted only once at least
+        // one stage has done that verification.
+        let mut nullability_verified = false;
         let input = Arc::clone(sort.input())
             .transform_down(|inner| {
                 if refused {
@@ -182,8 +214,9 @@ impl BoundedTopKAggregate {
                 }
                 if let Some(aggregate) = inner.downcast_ref::<AggregateExec>() {
                     match bound_aggregate(aggregate, &order_name, descending, limit) {
-                        Some(rewritten) => {
+                        Some((rewritten, verified_here)) => {
                             bounded = true;
+                            nullability_verified |= verified_here;
                             return Ok(Transformed::yes(Arc::new(rewritten) as _));
                         }
                         None => refused = true,
@@ -203,7 +236,7 @@ impl BoundedTopKAggregate {
             })
             .data()?;
 
-        if !bounded {
+        if !bounded || !nullability_verified {
             return Ok(Transformed::no(node));
         }
         let rewritten = SortExec::new(sort.expr().clone(), input)
@@ -236,14 +269,18 @@ fn is_pass_through(plan: &Arc<dyn ExecutionPlan>) -> bool {
         || plan.is::<RepartitionExec>()
 }
 
-/// The gate, one conjunct per `return None`. `Some` is the aggregate rebuilt to
-/// execute as a bounded priority map of `limit` groups.
+/// The gate, one conjunct per `return None`. `Some` carries the aggregate
+/// rebuilt to execute as a bounded priority map of `limit` groups, and
+/// whether THIS call independently verified the ordering-input nullability
+/// conjunct against a real (non-synthetic) schema field -- see the note at
+/// this function's call site on why that can only happen for some stages of
+/// a multi-stage aggregation.
 fn bound_aggregate(
     aggregate: &AggregateExec,
     order_name: &str,
     descending: bool,
     limit: usize,
-) -> Option<AggregateExec> {
+) -> Option<(AggregateExec, bool)> {
     // Already carrying a limit: leave whoever set it alone.
     if aggregate.limit_options().is_some() {
         return None;
@@ -273,8 +310,48 @@ fn bound_aggregate(
     if aggregate_descending != descending || field.name() != order_name {
         return None;
     }
-    // ADR-0023: ravel's float min/max is a total order the priority map does
-    // not implement. Refusing float input keeps the answer ravel's.
+    // The ordering aggregate's own input must be incapable of NULL: the
+    // priority map never admits a NULL-valued group, and a nullable input can
+    // hold one. The module docs give the NULLS FIRST/LAST argument that makes
+    // this a correctness gate.
+    //
+    // This stage's `aggregate.input()` is only the real (scan-derived) schema
+    // when the stage consumes raw rows (`AggregateInputMode::Raw`: `Partial`,
+    // `Single`, `SinglePartitioned`). A `Final`/`FinalPartitioned` stage's
+    // input is the OTHER stage's merged accumulator state, whose field for
+    // this same aggregate is a synthetic one DataFusion marks nullable by
+    // default regardless of the real column (`AggregateUDFImpl::is_nullable`
+    // defaults to `true`, and ravel's `max`/`min` do not override it) -- an
+    // artifact of the two-stage plan, not a signal about the real data. So
+    // the check below runs only at a raw-input stage, and callers trust the
+    // rewrite only once some stage in the chain has actually run it (see the
+    // `nullability_verified` note at the call site).
+    let nullability_verified = if aggregate.mode().input_mode() == AggregateInputMode::Raw {
+        // A plain column is the only input shape this rule can check
+        // nullability against; anything else (an expression, a literal) is
+        // refused with it.
+        let order_arg = aggregate.aggr_expr().first()?;
+        let order_args = order_arg.expressions();
+        let [order_input] = order_args.as_slice() else {
+            return None;
+        };
+        let order_input_column = order_input.downcast_ref::<Column>()?;
+        // Resolve by the column's position, not its name: a physical column
+        // is bound to an index, and two fields can share a name.
+        let input_schema = aggregate.input().schema();
+        let input_field = input_schema.fields().get(order_input_column.index())?;
+        if input_field.is_nullable() {
+            return None;
+        }
+        true
+    } else {
+        false
+    };
+    // The priority map orders floats with `total_cmp` like ADR-0023's total
+    // order, but its worse-than pre-check compares with `PartialOrd`, so
+    // whether it treats `-0.0`/`0.0` and NaN payloads the way ADR-0023
+    // mandates is not proven here. Refusing float input keeps the answer
+    // provably ravel's rather than assumed so.
     if is_float(field.data_type()) {
         return None;
     }
@@ -282,8 +359,9 @@ fn bound_aggregate(
     if !topk_types_supported(&key_type, field.data_type()) {
         return None;
     }
-    Some(AggregateExec::with_new_limit_options(
+    let rewritten = AggregateExec::with_new_limit_options(
         aggregate,
         Some(LimitOptions::new_with_order(limit, descending)),
-    ))
+    );
+    Some((rewritten, nullability_verified))
 }

--- a/crates/ravel-sql/src/config.rs
+++ b/crates/ravel-sql/src/config.rs
@@ -42,6 +42,23 @@ pub const DEFAULT_MAX_QUERY_BYTES: usize = 256 * 1024 * 1024;
 /// 105 columns and sorts and filters on two, i.e. 103 surplus columns.
 pub const DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS: usize = 8;
 
+/// Default `LIMIT` ceiling for bounded top-k grouped aggregation (issue
+/// #1402): a `GROUP BY ... ORDER BY max(col) DESC LIMIT k` keeps its aggregate
+/// state bounded by `k` only while `k` is at or below this.
+///
+/// The rewrite replaces one accumulator per distinct group with a priority map
+/// of `k` groups per aggregate stage, so the state it retains is `k` times the
+/// per-group state times the number of stages (a partial per scan partition
+/// plus one final). At 1,024 that is a few tens of thousands of retained
+/// groups against a group table that the statements this exists for grow to
+/// 10^8, which is the ratio the bound is worth having. Above it the priority
+/// map stops being a bound and becomes the group table with a heap bolted on,
+/// and its per-row comparison against the k-th best is pure overhead. The
+/// number is a ceiling on where the trade stays clearly positive, not a tuned
+/// optimum: the measured statement asks for `LIMIT 10`, three orders of
+/// magnitude below it.
+pub const DEFAULT_BOUNDED_TOPK_MAX_LIMIT: usize = 1024;
+
 /// Under-count of DataFusion 54's `GroupValues::size()` against the real
 /// hashbrown allocation of the group-key table (issue #740, finding 2).
 /// `size()` charges `capacity() * entry_size`, where `capacity()` is the
@@ -250,6 +267,22 @@ pub struct SqlConfig {
     /// surviving rows instead of for every row. So this is a cost knob, never
     /// a correctness one.
     pub late_materialization_extra_columns: Option<usize>,
+    /// `LIMIT` ceiling for bounded top-k grouped aggregation (issue #1402).
+    /// `Some(k)` installs [`crate::BoundedTopKAggregate`] and lets it bound a
+    /// grouped aggregate whose only consumer is a top-k sort of at most `k`
+    /// rows; `None` does not install the rule at all, which is the operator
+    /// opt-out and the "before" side of `tests/bounded_topk_aggregate.rs`.
+    ///
+    /// Default [`DEFAULT_BOUNDED_TOPK_MAX_LIMIT`]. Set once at server startup,
+    /// like every other field here.
+    ///
+    /// The rewrite is invisible to results, and narrowly so: it fires only for
+    /// a value-selective ordering aggregate (`max` descending, `min`
+    /// ascending) over a non-float input, where a group the bounded map evicts
+    /// provably could not have been in the answer. It does NOT fire for
+    /// `count` or `sum`, which cannot be pruned exactly at all; see the
+    /// `crate::bounded_topk` module docs for the counterexample.
+    pub bounded_topk_max_limit: Option<usize>,
     /// Bounded ephemeral spill scratch (ADR-0954). `None`, the default, means
     /// the disk manager stays
     /// [`Disabled`](datafusion::execution::disk_manager::DiskManagerMode::Disabled)
@@ -286,6 +319,7 @@ impl Default for SqlConfig {
             parallel_final_aggregation: true,
             skip_partial_aggregation: true,
             late_materialization_extra_columns: Some(DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS),
+            bounded_topk_max_limit: Some(DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
             // Spill off. See the field doc: this is requirement 9 of #954 (a
             // no-spill deployment profile) and it is what makes enabling spill
             // an operator decision rather than a version upgrade.
@@ -434,5 +468,14 @@ mod tests {
             Some(8)
         );
         assert_eq!(DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS, 8);
+    }
+
+    /// Issue #1402: the rule ships installed, with a `LIMIT` ceiling. Both
+    /// halves are pinned, so neither the default nor the constant can drift
+    /// without this failing.
+    #[test]
+    fn bounded_topk_defaults_to_a_limit_of_1024() {
+        assert_eq!(SqlConfig::default().bounded_topk_max_limit, Some(1024));
+        assert_eq!(DEFAULT_BOUNDED_TOPK_MAX_LIMIT, 1024);
     }
 }

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -45,6 +45,7 @@ mod audit_pushdown;
 mod audit_scan;
 mod audit_schema;
 mod avg;
+mod bounded_topk;
 mod config;
 pub mod conformance;
 mod cost;
@@ -101,11 +102,12 @@ pub use audit_pushdown::{AuditPushdown, extract_audit};
 pub use audit_schema::{
     AUDIT_COL_ATTRS, AUDIT_COL_BODY, AUDIT_COL_SEVERITY_TEXT, AUDIT_COL_TS, audit_schema,
 };
+pub use bounded_topk::{BOUNDED_TOPK_AGGREGATE_RULE, BoundedTopKAggregate};
 pub use config::{
-    DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS, DEFAULT_MAX_QUERY_BYTES, ENV_SPILL_DIR,
-    ENV_SPILL_MAX_BYTES, GROUP_VALUES_CEILING_COMPENSATION, GROUP_VALUES_RESIZE_TRANSIENT_FACTOR,
-    GROUP_VALUES_UNDERCOUNT_FACTOR, SpillConfig, SpillConfigError, SqlConfig,
-    compensated_group_values_ceiling,
+    DEFAULT_BOUNDED_TOPK_MAX_LIMIT, DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS,
+    DEFAULT_MAX_QUERY_BYTES, ENV_SPILL_DIR, ENV_SPILL_MAX_BYTES, GROUP_VALUES_CEILING_COMPENSATION,
+    GROUP_VALUES_RESIZE_TRANSIENT_FACTOR, GROUP_VALUES_UNDERCOUNT_FACTOR, SpillConfig,
+    SpillConfigError, SqlConfig, compensated_group_values_ceiling,
 };
 pub use declared::{DeclaredColumn, DeclaredColumnSource, DeclaredType, StaticDeclaredColumns};
 #[cfg(feature = "flight-sql")]

--- a/crates/ravel-sql/src/session.rs
+++ b/crates/ravel-sql/src/session.rs
@@ -122,6 +122,7 @@ use url::Url;
 use crate::alerts_provider::AlertsTableProvider;
 use crate::audit_provider::AuditTableProvider;
 use crate::avg::sequential_avg_udaf;
+use crate::bounded_topk::BoundedTopKAggregate;
 use crate::config::SqlConfig;
 use crate::group_keys::DictionaryGroupKeysAsViews;
 use crate::late_materialization::TopKLateMaterialization;
@@ -561,6 +562,17 @@ pub fn session_config(
             .skip_partial_aggregation_probe_ratio_threshold = SKIP_PARTIAL_AGGREGATION_PROBE_RATIO;
     }
 
+    // Issue #1402. DataFusion's own `TopKAggregation` rule defaults ON
+    // (`enable_topk_aggregation`), and it admits two shapes ravel must not
+    // take: a float `min`/`max`, whose answer would come from the priority
+    // map's ordering instead of ADR-0023's total order, and an arbitrarily
+    // large `LIMIT`, where the bound is no longer worth its per-row
+    // comparison. It is turned off here for every query and
+    // `crate::BoundedTopKAggregate`, installed by `build_session`, re-admits
+    // exactly the vetted shape. Written as a typed field for the same reason
+    // the knobs above are.
+    session.options_mut().optimizer.enable_topk_aggregation = false;
+
     if repartition_free {
         // The `repartition_*` knobs above do not cover DataFusion's round-robin
         // fan-out, which `EnforceDistribution` inserts on its own whenever an
@@ -669,6 +681,16 @@ pub fn build_session(
     if let Some(extra_columns) = config.late_materialization_extra_columns {
         builder = builder
             .with_physical_optimizer_rule(Arc::new(TopKLateMaterialization::new(extra_columns)));
+    }
+    // Issue #1402: bound a grouped aggregate whose only consumer is a top-k
+    // sort. Appended after the default rules for the same reason the rules
+    // above are: the shape it matches is the partial/final aggregation split
+    // `EnforceDistribution` chose, under the `SortExec` fetch DataFusion's
+    // limit pushdown produced. `None` does not install it at all, which is the
+    // operator opt-out and the "before" side of the regression fixture.
+    if let Some(max_limit) = config.bounded_topk_max_limit {
+        builder =
+            builder.with_physical_optimizer_rule(Arc::new(BoundedTopKAggregate::new(max_limit)));
     }
     let state = builder.build();
     let mut ctx = SessionContext::new_with_state(state);
@@ -936,6 +958,24 @@ mod tests {
         assert!(!options.optimizer.repartition_sorts);
         assert!(!options.optimizer.repartition_windows);
         assert!(!options.optimizer.repartition_file_scans);
+    }
+
+    /// Issue #1402: DataFusion's own ungated top-k aggregation rule is off in
+    /// every session, whatever the other per-query inputs say. It defaults ON
+    /// upstream, so this is the assertion that a DataFusion upgrade cannot
+    /// quietly restore it: `crate::BoundedTopKAggregate` is the only path to a
+    /// bounded grouped aggregate here, and it is the only one whose gate has
+    /// been argued.
+    #[test]
+    fn datafusion_topk_aggregation_is_off_in_every_session() {
+        for exact_typed in [false, true] {
+            let config =
+                session_config(&SqlConfig::default(), exact_typed, SpillDecision::Disabled);
+            assert!(
+                !config.options().optimizer.enable_topk_aggregation,
+                "exact_typed_aggregates={exact_typed}"
+            );
+        }
     }
 
     /// ADR-0094 decision 2: `exact_typed_aggregates = true` flips ONLY

--- a/crates/ravel-sql/tests/bounded_topk_aggregate.rs
+++ b/crates/ravel-sql/tests/bounded_topk_aggregate.rs
@@ -17,7 +17,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use datafusion::arrow::array::{Array, Int64Array, TimestampNanosecondArray};
-use datafusion::physical_plan::displayable;
+use datafusion::physical_plan::aggregates::AggregateExec;
+use datafusion::physical_plan::{ExecutionPlan, displayable};
 use ravel_catalog::{Catalog, CatalogConfig};
 use ravel_commit::publish::RetryPolicy;
 use ravel_commit::record::NewCommitRecord;
@@ -238,6 +239,13 @@ fn request(sql: &str) -> SqlRequest {
 /// `EXPLAIN` renders it. Plan equality in the gate's negative tests is equality
 /// of this string.
 async fn physical_plan(executor: &SqlExecutor, sql: &str) -> String {
+    let plan = physical_plan_tree(executor, sql).await;
+    format!("{}", displayable(plan.as_ref()).indent(false))
+}
+
+/// The physical plan itself, for assertions that inspect operators rather
+/// than the rendered text.
+async fn physical_plan_tree(executor: &SqlExecutor, sql: &str) -> Arc<dyn ExecutionPlan> {
     let accounting = QueryAccounting::new();
     let declared = executor
         .resolve_declared_columns(tenant().hash(), request(sql).now_ns)
@@ -250,11 +258,25 @@ async fn physical_plan(executor: &SqlExecutor, sql: &str) -> String {
         .plan_pinned(tenant().hash(), snapshot, sql, &accounting, &declared)
         .await
         .expect("query plans");
-    let plan = planned
+    planned
         .create_physical_plan()
         .await
-        .expect("physical plan builds");
-    format!("{}", displayable(plan.as_ref()).indent(false))
+        .expect("physical plan builds")
+}
+
+/// Every `AggregateExec` limit in `plan`, in pre-order: the structural form
+/// of the `lim=[k]` marker, independent of how DataFusion renders it.
+fn aggregate_limits(plan: &Arc<dyn ExecutionPlan>) -> Vec<usize> {
+    let mut out = Vec::new();
+    if let Some(aggregate) = plan.downcast_ref::<AggregateExec>()
+        && let Some(options) = aggregate.limit_options()
+    {
+        out.push(options.limit);
+    }
+    for child in plan.children() {
+        out.extend(aggregate_limits(child));
+    }
+    out
 }
 
 /// `column`'s value at `row` as `i64`, whichever of the two integer-shaped
@@ -633,16 +655,24 @@ async fn a_nullable_ordering_input_does_not_fire() {
 /// tests (an unbounded plan answers the same query correctly too). Only this
 /// test and the bytes test below would catch that stub, and this one names
 /// the mechanism directly: the rule-on plan differs from the rule-off plan,
-/// and it carries the aggregate's limit marker.
+/// and an `AggregateExec` in it carries exactly `TOP_K` as its limit,
+/// inspected on the operator rather than in the rendered text so a display
+/// change cannot fail it while the limit is still there.
 #[tokio::test]
 async fn the_rule_rewrites_the_gated_shape() {
     let sql = topk_sql(TOP_K);
-    let on = physical_plan(&executor(SMALL_KEYS, Some(TOP_K)).await, &sql).await;
-    let off = physical_plan(&executor(SMALL_KEYS, None).await, &sql).await;
+    let on_tree = physical_plan_tree(&executor(SMALL_KEYS, Some(TOP_K)).await, &sql).await;
+    let off_tree = physical_plan_tree(&executor(SMALL_KEYS, None).await, &sql).await;
+    let on = format!("{}", displayable(on_tree.as_ref()).indent(false));
+    let off = format!("{}", displayable(off_tree.as_ref()).indent(false));
     assert_ne!(on, off, "the rule did not change the plan:\n{on}");
     assert!(
-        on.contains(&format!("lim=[{TOP_K}]")),
-        "the rule-on plan carries no limit marker:\n{on}"
+        aggregate_limits(&on_tree).contains(&TOP_K),
+        "no AggregateExec in the rule-on plan carries limit {TOP_K}:\n{on}"
+    );
+    assert!(
+        aggregate_limits(&off_tree).is_empty(),
+        "the rule-off plan carries an aggregate limit:\n{off}"
     );
 }
 

--- a/crates/ravel-sql/tests/bounded_topk_aggregate.rs
+++ b/crates/ravel-sql/tests/bounded_topk_aggregate.rs
@@ -1,0 +1,551 @@
+//! Issue #1402: bounded top-k grouped aggregation.
+//!
+//! Every test drives a real `SqlExecutor` over a real RLOG object in a
+//! `MemoryStore`, so what is asserted is the shipped plan and the shipped
+//! answer, not a rule invoked in isolation.
+//!
+//! The "rule off" side of every comparison is
+//! `SqlConfig::bounded_topk_max_limit = None`, which does not install
+//! `BoundedTopKAggregate` at all. DataFusion's own `TopKAggregation` is off in
+//! both configurations (`crate::session_config`), so "off" is a plan with no
+//! bounded aggregate anywhere, which is what the gate's negative cases must
+//! reproduce byte for byte.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use datafusion::arrow::array::Int64Array;
+use datafusion::physical_plan::displayable;
+use ravel_catalog::{Catalog, CatalogConfig};
+use ravel_commit::publish::RetryPolicy;
+use ravel_commit::record::NewCommitRecord;
+use ravel_commit::{keys, publish, record};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::{LogSegmentFetcher, SegmentFetcher};
+use ravel_sql::{
+    DeclaredColumn, DeclaredType, SpanSegmentFetcher, SqlConfig, SqlExecutor, SqlRequest,
+    StaticDeclaredColumns,
+};
+use ravel_types::accounting::QueryAccounting;
+use ravel_types::logstream::AttrValue;
+use ravel_types::{Signal, TenantId, TimeRange};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// The fixture
+// ---------------------------------------------------------------------------
+
+/// The declared group-key column: an `I64` attribute, so the group key resolves
+/// to Arrow `Int64` and the priority map's supported-key-type check is not the
+/// thing under test.
+const KEY_COL: &str = "gid";
+
+/// The declared value column the ordering aggregate reads.
+const VAL_COL: &str = "val";
+
+/// Distinct group keys in the main fixture. Above the 1,000 the answer-identity
+/// case calls for, and far enough above `TOP_K` that a bounded aggregate and an
+/// unbounded one hold visibly different amounts of state.
+const KEYS: i64 = 200_000;
+
+/// The small fixture's distinct group-key count, one tenth of [`KEYS`]. The
+/// bound test is the pair: rule-off peak intermediate bytes must grow with this
+/// number, rule-on peak must not.
+const SMALL_KEYS: i64 = 20_000;
+
+/// The `LIMIT` every top-k statement here asks for.
+const TOP_K: usize = 10;
+
+/// The group whose running maximum sits at the very bottom of the stream for
+/// almost its whole length and is then overtaken by one late row. It is the
+/// eviction-soundness case: a bounded map that compared it at the wrong time,
+/// or that kept partial state per group instead of the group's extreme, loses
+/// it.
+const LATE_KEY: i64 = 7;
+
+/// The value that late row carries: above every `val` any other group holds, so
+/// [`LATE_KEY`] must come first in the top-k.
+const LATE_VALUE: i64 = 10_000_000;
+
+fn tenant() -> TenantId {
+    TenantId::new("bounded-topk-1402".to_string())
+}
+
+fn log_record(ts: i64, gid: i64, val: i64) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: "req".into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![
+            (KEY_COL.to_string(), AttrValue::I64(gid)),
+            (VAL_COL.to_string(), AttrValue::I64(val)),
+        ],
+    }
+}
+
+/// `keys` groups of one row each, group `i` carrying `val = i`, in ascending
+/// `gid` order, followed by one extra row for [`LATE_KEY`] carrying
+/// [`LATE_VALUE`].
+///
+/// Two properties the assertions rest on, both hand-computable:
+///
+/// - `max(val)` per group is `gid`, except [`LATE_KEY`], whose maximum is
+///   [`LATE_VALUE`]. Every group's maximum is therefore distinct, so the top-k
+///   by `max(val) DESC` has no ties to break and a byte-identical row
+///   comparison is meaningful.
+/// - `count(*)` per group is 1, except [`LATE_KEY`], whose count is 2. So the
+///   true top-1 by count is [`LATE_KEY`], and it is the LAST group any
+///   count-ordered stream could learn about.
+fn records(keys: i64) -> Vec<LogRecord> {
+    let mut out: Vec<LogRecord> = (0..keys).map(|i| log_record(i + 1, i, i)).collect();
+    out.push(log_record(keys + 1, LATE_KEY, LATE_VALUE));
+    out
+}
+
+/// Write one RLOG object holding `records` and publish its commit record, so a
+/// real `Catalog::resolve` finds it.
+async fn publish_logs(store: &dyn ObjectStoreBackend, tenant: &TenantId, records: &[LogRecord]) {
+    let identity = ObjectIdentity {
+        tenant_hash: tenant.hash().0,
+        shard: 0,
+        writer_id: [4u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    };
+    let mut writer = RlogWriter::new(RlogConfig::default(), identity);
+    for r in records {
+        writer.push(r.clone()).expect("push record");
+    }
+    let bytes = writer.finish().expect("finish rlog");
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    let rec = record::build(NewCommitRecord {
+        tenant_hash: tenant.hash(),
+        signal: Signal::Logs,
+        shard: 0,
+        writer_id: Uuid::from_u128(9_1402),
+        writer_epoch: 1,
+        writer_seq: 1,
+        object_size: bytes.len() as u64,
+        content_hash: [8u8; 32],
+        sample_count: records.len() as u64,
+        series_count: 1,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        min_ingest_ts_ns: min,
+        max_ingest_ts_ns: max,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        created_unix_ns: 10,
+        ingest_hour_bucket: 0,
+    })
+    .expect("valid logs commit record");
+    let data_key = keys::reconstruct_data_key(&rec).expect("logs data key");
+    store
+        .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put rlog object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish logs commit record");
+}
+
+fn declared() -> Vec<DeclaredColumn> {
+    vec![
+        DeclaredColumn::new(KEY_COL, DeclaredType::I64),
+        DeclaredColumn::new(VAL_COL, DeclaredType::I64),
+    ]
+}
+
+/// An executor over a fresh tenant holding [`records`]`(keys)`.
+/// `max_limit` is [`SqlConfig::bounded_topk_max_limit`]: `None` is the rule-off
+/// side of every comparison here.
+async fn executor(keys: i64, max_limit: Option<usize>) -> SqlExecutor {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    publish_logs(store.as_ref(), &tenant(), &records(keys)).await;
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
+    let config = SqlConfig {
+        bounded_topk_max_limit: max_limit,
+        ..SqlConfig::default()
+    };
+    SqlExecutor::new(
+        catalog,
+        SegmentFetcher::new(Arc::clone(&store)),
+        LogSegmentFetcher::new(Arc::clone(&store)),
+        SpanSegmentFetcher::new(Arc::clone(&store)),
+        config,
+        1 << 30,
+    )
+    .with_declared_column_source(Arc::new(StaticDeclaredColumns::new(declared())))
+}
+
+fn request(sql: &str) -> SqlRequest {
+    SqlRequest {
+        sql: sql.to_string(),
+        window: TimeRange {
+            start_ns: 0,
+            end_ns: i64::MAX,
+        },
+        min_tokens: Vec::new(),
+        now_ns: 1_000_000,
+        deadline: Duration::from_secs(120),
+    }
+}
+
+/// The physical plan `sql` produces under `executor`, rendered exactly as
+/// `EXPLAIN` renders it. Plan equality in the gate's negative tests is equality
+/// of this string.
+async fn physical_plan(executor: &SqlExecutor, sql: &str) -> String {
+    let accounting = QueryAccounting::new();
+    let declared = executor
+        .resolve_declared_columns(tenant().hash(), request(sql).now_ns)
+        .await;
+    let (snapshot, _) = executor
+        .resolve_snapshot(tenant().hash(), &request(sql), &accounting)
+        .await
+        .expect("snapshot resolves");
+    let planned = executor
+        .plan_pinned(tenant().hash(), snapshot, sql, &accounting, &declared)
+        .await
+        .expect("query plans");
+    let plan = planned
+        .create_physical_plan()
+        .await
+        .expect("physical plan builds");
+    format!("{}", displayable(plan.as_ref()).indent(false))
+}
+
+/// Every `(Int64, Int64)` row `sql` returns, in the order it returns them.
+async fn rows(executor: &SqlExecutor, sql: &str) -> Vec<(i64, i64)> {
+    let outcome = executor
+        .execute(tenant().hash(), &request(sql))
+        .await
+        .expect("query runs");
+    let mut out = Vec::new();
+    for batch in outcome.output.batches() {
+        let keys = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("group key is Int64");
+        let values = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("aggregate is Int64");
+        for row in 0..batch.num_rows() {
+            out.push((keys.value(row), values.value(row)));
+        }
+    }
+    out
+}
+
+/// `sql`'s peak intermediate bytes under `executor`, as the wire reports them.
+async fn peak_intermediate_bytes(executor: &SqlExecutor, sql: &str) -> u64 {
+    let outcome = executor
+        .execute(tenant().hash(), &request(sql))
+        .await
+        .expect("query runs");
+    outcome.accounting.peak_intermediate_bytes
+}
+
+/// The statement the gate admits: a high-cardinality group key, a
+/// value-selective ordering aggregate, a matching sort direction, a small
+/// `LIMIT`.
+fn topk_sql(limit: usize) -> String {
+    format!(
+        "SELECT {KEY_COL}, max({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} \
+         ORDER BY m DESC LIMIT {limit}"
+    )
+}
+
+/// The hand-computed top-`TOP_K` of [`records`]: the late group first with its
+/// late value, then the highest `gid`s, each with `max(val) = gid`.
+fn expected_top_k() -> Vec<(i64, i64)> {
+    let mut expected = vec![(LATE_KEY, LATE_VALUE)];
+    expected.extend((0..TOP_K as i64 - 1).map(|i| {
+        let gid = KEYS - 1 - i;
+        (gid, gid)
+    }));
+    expected
+}
+
+// ---------------------------------------------------------------------------
+// Deliverable 1: the shape the rule must target
+// ---------------------------------------------------------------------------
+
+/// The operator chain q33 plans to, captured with no rule installed.
+///
+/// q33 is `GROUP BY "WatchID","ClientIP" ... ORDER BY count(*) DESC LIMIT 10`;
+/// the two group keys and the accumulating ordering aggregate are both visible
+/// in the chain below, and both are conjuncts the gate refuses. This test is
+/// the record of the shape, so a DataFusion upgrade that reshapes it fails here
+/// rather than silently moving the rule's target.
+#[tokio::test]
+async fn q33_shape_plans_to_a_sort_over_a_two_stage_aggregate() {
+    let executor = executor(SMALL_KEYS, None).await;
+    let sql = format!(
+        "SELECT {KEY_COL}, {VAL_COL}, count(*) AS c, sum({VAL_COL}) AS s \
+         FROM logs GROUP BY {KEY_COL}, {VAL_COL} ORDER BY c DESC LIMIT 10"
+    );
+    let plan = physical_plan(&executor, &sql).await;
+    let chain: Vec<&str> = plan
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            trimmed
+                .split_once(':')
+                .map_or(trimmed, |(node, _)| node)
+                .trim()
+        })
+        .collect();
+    assert_eq!(
+        chain,
+        vec![
+            "SortExec",
+            "CoalescePartitionsExec",
+            "ProjectionExec",
+            "AggregateExec",
+            "RepartitionExec",
+            "AggregateExec",
+            "RepartitionExec",
+            "LogsScanExec",
+        ],
+        "q33's operator chain changed:\n{plan}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Answer identity
+// ---------------------------------------------------------------------------
+
+/// The rule changes no answer: the same rows, in the same order, with it on and
+/// off, over 20,000 distinct keys whose top-10 is hand-computable and has no
+/// ties.
+#[tokio::test]
+async fn bounded_top_k_returns_the_same_rows_as_the_unbounded_plan() {
+    let sql = topk_sql(TOP_K);
+    let on = rows(&executor(KEYS, Some(TOP_K)).await, &sql).await;
+    let off = rows(&executor(KEYS, None).await, &sql).await;
+    assert_eq!(on, expected_top_k(), "the bounded plan's rows");
+    assert_eq!(off, expected_top_k(), "the unbounded plan's rows");
+    assert_eq!(on, off);
+}
+
+/// The eviction-soundness case the exactness argument rests on.
+///
+/// [`LATE_KEY`]'s running maximum is 7 while 19,993 groups with larger maxima
+/// stream past it, so it is below the k-th best for all but the last row of the
+/// scan; that last row makes it the largest group of all. A bounded aggregate
+/// that compared groups on partial state, or that could not readmit a group
+/// after dropping it, returns a top-k without it. Asserted at rank 1
+/// specifically, not merely present.
+#[tokio::test]
+async fn a_group_overtaken_at_the_last_row_is_still_first_in_the_top_k() {
+    let sql = topk_sql(TOP_K);
+    let out = rows(&executor(KEYS, Some(TOP_K)).await, &sql).await;
+    assert_eq!(out[0], (LATE_KEY, LATE_VALUE), "full top-k: {out:?}");
+}
+
+// ---------------------------------------------------------------------------
+// The gate, one negative test per conjunct
+// ---------------------------------------------------------------------------
+
+/// Every statement the gate must refuse plans byte-identically to the same
+/// statement with the rule uninstalled.
+///
+/// Plan equality, not answer equality: a rule that fired on the wrong shape and
+/// happened to answer correctly would still be unproven, and would still be
+/// bounding state it has no argument for.
+async fn assert_plan_unchanged(sql: &str, why: &str) {
+    let on = physical_plan(&executor(SMALL_KEYS, Some(TOP_K)).await, sql).await;
+    let off = physical_plan(&executor(SMALL_KEYS, None).await, sql).await;
+    assert_eq!(on, off, "the rule fired on {why}");
+}
+
+/// Conjunct: the ordering aggregate must be value-selective. `avg` accumulates,
+/// so a group's future rows can move its value in either direction and no
+/// pruning argument exists at all.
+#[tokio::test]
+async fn avg_ordering_does_not_fire() {
+    let sql = format!(
+        "SELECT {KEY_COL}, avg({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} \
+         ORDER BY m DESC LIMIT {TOP_K}"
+    );
+    assert_plan_unchanged(&sql, "an avg-ordered top-k").await;
+}
+
+/// Conjunct: the sort direction must be the one the aggregate's extreme runs
+/// in. `min` finds the smallest value, so a DESCENDING sort on it asks for the
+/// groups whose minimum is largest, which the priority map's ordering does not
+/// produce.
+#[tokio::test]
+async fn min_ordered_descending_does_not_fire() {
+    let sql = format!(
+        "SELECT {KEY_COL}, min({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} \
+         ORDER BY m DESC LIMIT {TOP_K}"
+    );
+    assert_plan_unchanged(&sql, "a min-ordered descending top-k").await;
+}
+
+/// Conjunct: the ordering aggregate must be an aggregate. Ordering by the group
+/// key is a different rewrite with a different argument (DataFusion's own rule
+/// admits it; this one does not).
+#[tokio::test]
+async fn ordering_by_the_group_key_does_not_fire() {
+    let sql = format!(
+        "SELECT {KEY_COL}, max({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} \
+         ORDER BY {KEY_COL} DESC LIMIT {TOP_K}"
+    );
+    assert_plan_unchanged(&sql, "a group-key-ordered top-k").await;
+}
+
+/// Conjunct: the `LIMIT` must be at or below
+/// [`SqlConfig::bounded_topk_max_limit`]. Asserted at the boundary: `TOP_K + 1`
+/// against a ceiling of `TOP_K`, so an off-by-one in the comparison fails here.
+#[tokio::test]
+async fn a_limit_above_the_threshold_does_not_fire() {
+    let sql = topk_sql(TOP_K + 1);
+    assert_plan_unchanged(&sql, "a top-k above the configured limit").await;
+}
+
+/// Conjunct: there must be a `LIMIT`. Without one the sort materialises every
+/// group whatever any aggregate below it does, so there is no `k` to bound by.
+#[tokio::test]
+async fn no_limit_does_not_fire() {
+    let sql = format!(
+        "SELECT {KEY_COL}, max({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} ORDER BY m DESC"
+    );
+    assert_plan_unchanged(&sql, "an unlimited sort").await;
+}
+
+/// Conjunct: a post-aggregation filter decides which groups reach the sort, so
+/// keeping only `k` groups underneath it would discard groups `HAVING` would
+/// have let through.
+#[tokio::test]
+async fn a_having_clause_does_not_fire() {
+    let sql = format!(
+        "SELECT {KEY_COL}, max({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} \
+         HAVING max({VAL_COL}) > 5 ORDER BY m DESC LIMIT {TOP_K}"
+    );
+    assert_plan_unchanged(&sql, "a HAVING-filtered top-k").await;
+}
+
+/// The conjunct issue #1402 asked for and this rule refuses.
+///
+/// `count` is monotone non-decreasing, which is exactly the property the issue
+/// named as sufficient, and it is not: a running count is a LOWER bound on a
+/// group's final count, so a group below the k-th can still overtake it.
+/// [`LATE_KEY`] is that group here -- it has 2 rows to everyone else's 1, and
+/// its second row is the last row of the scan, so a bounded count-eviction with
+/// `LIMIT 1` would answer `(0, 1)` instead of `(7, 2)`.
+///
+/// Both halves are asserted: the true answer, and that the plan is the
+/// unbounded one. Widening the gate to `count` reddens the second immediately
+/// and the first as soon as the priority map is what executes.
+#[tokio::test]
+async fn count_ordering_is_refused_and_still_returns_the_true_top_k() {
+    let sql = format!(
+        "SELECT {KEY_COL}, count(*) AS c FROM logs GROUP BY {KEY_COL} ORDER BY c DESC LIMIT 1"
+    );
+    assert_plan_unchanged(&sql, "a count-ordered top-k").await;
+    let out = rows(&executor(KEYS, Some(TOP_K)).await, &sql).await;
+    assert_eq!(out, vec![(LATE_KEY, 2)]);
+}
+
+/// The same refusal for `sum`, whose running value is a lower bound on its
+/// final value for exactly as long as the summed column is non-negative, and
+/// which is therefore prunable for exactly as long as nothing bounds a group's
+/// remaining rows from above: never.
+#[tokio::test]
+async fn sum_ordering_does_not_fire() {
+    let sql = format!(
+        "SELECT {KEY_COL}, sum({VAL_COL}) AS s FROM logs GROUP BY {KEY_COL} \
+         ORDER BY s DESC LIMIT {TOP_K}"
+    );
+    assert_plan_unchanged(&sql, "a sum-ordered top-k").await;
+}
+
+// ---------------------------------------------------------------------------
+// The bound
+// ---------------------------------------------------------------------------
+
+/// Measured `peak_intermediate_bytes` for [`topk_sql`]`(TOP_K)` over the
+/// 20,000-key fixture with the rule installed. Every figure in this group is
+/// reproducible to the byte on this fixture (three consecutive runs, identical
+/// values), which is what makes pinning them rather than banding them the
+/// stronger check.
+const PEAK_ON_SMALL: u64 = 1_050_112;
+
+/// The same statement over the 200,000-key fixture with the rule installed.
+/// Ten times the groups for 1.75 times the bytes, and the growth that is left
+/// is the scan's own batches, not aggregate state.
+const PEAK_ON_LARGE: u64 = 1_837_456;
+
+/// The 20,000-key fixture with the rule uninstalled.
+const PEAK_OFF_SMALL: u64 = 1_143_552;
+
+/// The 200,000-key fixture with the rule uninstalled: ten times the groups for
+/// 9.4 times the bytes. This is the figure issue #1402 exists to remove, at
+/// fixture scale.
+const PEAK_OFF_LARGE: u64 = 10_748_928;
+
+/// The claim, as a ratio between two measured pairs.
+///
+/// With the rule off, `peak_intermediate_bytes` for the admitted statement
+/// grows with the distinct-key count (9.4x for 10x the keys): the aggregate
+/// holds one accumulator per group. With the rule on it does not (1.75x, and
+/// that residue is scan batches), because the aggregate holds `k` groups
+/// whatever the key count is. At the large fixture the ratio between the two
+/// is 5.85x.
+///
+/// All four figures are pinned, and the three ratios are asserted separately so
+/// a change that moved every figure by the same factor still has to explain
+/// itself. Changing `Some(TOP_K)` to `None` on the `on_large` line below is the
+/// demonstration that the bound assertion is load-bearing: `on_large` becomes
+/// `PEAK_OFF_LARGE` and the first assertion, `assert_eq!(on_large,
+/// PEAK_ON_LARGE, ...)`, fails with `10748928` against `1837456`.
+#[tokio::test]
+async fn peak_intermediate_bytes_stops_scaling_with_the_key_count() {
+    let sql = topk_sql(TOP_K);
+    let on_small = peak_intermediate_bytes(&executor(SMALL_KEYS, Some(TOP_K)).await, &sql).await;
+    let on_large = peak_intermediate_bytes(&executor(KEYS, Some(TOP_K)).await, &sql).await;
+    let off_small = peak_intermediate_bytes(&executor(SMALL_KEYS, None).await, &sql).await;
+    let off_large = peak_intermediate_bytes(&executor(KEYS, None).await, &sql).await;
+
+    assert_eq!(on_large, PEAK_ON_LARGE, "rule on, {KEYS} keys");
+    assert_eq!(on_small, PEAK_ON_SMALL, "rule on, {SMALL_KEYS} keys");
+    assert_eq!(off_large, PEAK_OFF_LARGE, "rule off, {KEYS} keys");
+    assert_eq!(off_small, PEAK_OFF_SMALL, "rule off, {SMALL_KEYS} keys");
+
+    assert!(
+        on_large < 2 * on_small,
+        "the bounded plan's peak must not scale with the key count: \
+         {on_large} against {on_small} for ten times the groups"
+    );
+    assert!(
+        off_large > 8 * off_small,
+        "the unbounded plan's peak must scale with the key count: \
+         {off_large} against {off_small} for ten times the groups"
+    );
+    assert!(
+        off_large > 5 * on_large,
+        "the bound must be worth having at {KEYS} keys: {off_large} against {on_large}"
+    );
+}

--- a/crates/ravel-sql/tests/bounded_topk_aggregate.rs
+++ b/crates/ravel-sql/tests/bounded_topk_aggregate.rs
@@ -16,7 +16,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use datafusion::arrow::array::Int64Array;
+use datafusion::arrow::array::{Array, Int64Array, TimestampNanosecondArray};
 use datafusion::physical_plan::displayable;
 use ravel_catalog::{Catalog, CatalogConfig};
 use ravel_commit::publish::RetryPolicy;
@@ -77,10 +77,25 @@ fn tenant() -> TenantId {
 }
 
 fn log_record(ts: i64, gid: i64, val: i64) -> LogRecord {
+    log_record_with_attrs(ts, gid, Some(val))
+}
+
+/// A record whose declared `val` attribute is entirely absent, so the `val`
+/// column reads NULL for it: the fixture for
+/// [`a_nullable_ordering_input_does_not_fire`].
+fn log_record_no_val(ts: i64, gid: i64) -> LogRecord {
+    log_record_with_attrs(ts, gid, None)
+}
+
+fn log_record_with_attrs(ts: i64, gid: i64, val: Option<i64>) -> LogRecord {
     let resource = vec![(
         "service.name".to_string(),
         AttrValue::Str("api".to_string()),
     )];
+    let mut attrs = vec![(KEY_COL.to_string(), AttrValue::I64(gid))];
+    if let Some(val) = val {
+        attrs.push((VAL_COL.to_string(), AttrValue::I64(val)));
+    }
     LogRecord {
         stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
         stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
@@ -92,23 +107,26 @@ fn log_record(ts: i64, gid: i64, val: i64) -> LogRecord {
         trace_id: None,
         span_id: None,
         flags: 0,
-        attrs: vec![
-            (KEY_COL.to_string(), AttrValue::I64(gid)),
-            (VAL_COL.to_string(), AttrValue::I64(val)),
-        ],
+        attrs,
     }
 }
 
-/// `keys` groups of one row each, group `i` carrying `val = i`, in ascending
-/// `gid` order, followed by one extra row for [`LATE_KEY`] carrying
-/// [`LATE_VALUE`].
+/// `keys` groups of one row each, group `i` carrying `val = i` and `ts = i +
+/// 1`, in ascending `gid` order, followed by one extra row for [`LATE_KEY`]
+/// carrying `ts = keys + 1` and [`LATE_VALUE`].
 ///
-/// Two properties the assertions rest on, both hand-computable:
+/// Three properties the assertions rest on, all hand-computable:
 ///
 /// - `max(val)` per group is `gid`, except [`LATE_KEY`], whose maximum is
 ///   [`LATE_VALUE`]. Every group's maximum is therefore distinct, so the top-k
 ///   by `max(val) DESC` has no ties to break and a byte-identical row
-///   comparison is meaningful.
+///   comparison is meaningful. `val` is a declared column, so it is nullable
+///   (`ravel_sql::logs_schema`); the ordering-input nullability gate refuses
+///   it, which is what the negative test dedicated to that gate exercises.
+/// - `max(ts)` per group is `gid + 1`, except [`LATE_KEY`], whose maximum is
+///   `keys + 1`, the largest `ts` any group holds. Every group's maximum is
+///   therefore distinct here too. `ts` is a fixed, non-nullable column, so
+///   this is the ordering input the admitted (positive) tests use.
 /// - `count(*)` per group is 1, except [`LATE_KEY`], whose count is 2. So the
 ///   true top-1 by count is [`LATE_KEY`], and it is the LAST group any
 ///   count-ordered stream could learn about.
@@ -172,12 +190,12 @@ fn declared() -> Vec<DeclaredColumn> {
     ]
 }
 
-/// An executor over a fresh tenant holding [`records`]`(keys)`.
+/// An executor over a fresh tenant holding `records`.
 /// `max_limit` is [`SqlConfig::bounded_topk_max_limit`]: `None` is the rule-off
 /// side of every comparison here.
-async fn executor(keys: i64, max_limit: Option<usize>) -> SqlExecutor {
+async fn executor_with_records(records: Vec<LogRecord>, max_limit: Option<usize>) -> SqlExecutor {
     let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
-    publish_logs(store.as_ref(), &tenant(), &records(keys)).await;
+    publish_logs(store.as_ref(), &tenant(), &records).await;
     let catalog =
         Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
     let config = SqlConfig {
@@ -195,6 +213,11 @@ async fn executor(keys: i64, max_limit: Option<usize>) -> SqlExecutor {
     .with_declared_column_source(Arc::new(StaticDeclaredColumns::new(declared())))
 }
 
+/// An executor over a fresh tenant holding [`records`]`(keys)`.
+async fn executor(keys: i64, max_limit: Option<usize>) -> SqlExecutor {
+    executor_with_records(records(keys), max_limit).await
+}
+
 fn request(sql: &str) -> SqlRequest {
     SqlRequest {
         sql: sql.to_string(),
@@ -205,6 +228,9 @@ fn request(sql: &str) -> SqlRequest {
         min_tokens: Vec::new(),
         now_ns: 1_000_000,
         deadline: Duration::from_secs(120),
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     }
 }
 
@@ -231,7 +257,24 @@ async fn physical_plan(executor: &SqlExecutor, sql: &str) -> String {
     format!("{}", displayable(plan.as_ref()).indent(false))
 }
 
-/// Every `(Int64, Int64)` row `sql` returns, in the order it returns them.
+/// `column`'s value at `row` as `i64`, whichever of the two integer-shaped
+/// arrow types this file's aggregates return: `Int64` for `count(*)` and the
+/// group key, `Timestamp(Nanosecond)` for `max(ts)`. Both are `i64` under the
+/// hood, so one comparison type serves every test in this file.
+fn value_as_i64(column: &dyn Array, row: usize) -> i64 {
+    if let Some(a) = column.as_any().downcast_ref::<Int64Array>() {
+        return a.value(row);
+    }
+    if let Some(a) = column.as_any().downcast_ref::<TimestampNanosecondArray>() {
+        return a.value(row);
+    }
+    panic!(
+        "unsupported column type for row extraction: {:?}",
+        column.data_type()
+    );
+}
+
+/// Every `(gid, value)` row `sql` returns, in the order it returns them.
 async fn rows(executor: &SqlExecutor, sql: &str) -> Vec<(i64, i64)> {
     let outcome = executor
         .execute(tenant().hash(), &request(sql))
@@ -244,13 +287,9 @@ async fn rows(executor: &SqlExecutor, sql: &str) -> Vec<(i64, i64)> {
             .as_any()
             .downcast_ref::<Int64Array>()
             .expect("group key is Int64");
-        let values = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .expect("aggregate is Int64");
+        let values = batch.column(1).as_ref();
         for row in 0..batch.num_rows() {
-            out.push((keys.value(row), values.value(row)));
+            out.push((keys.value(row), value_as_i64(values, row)));
         }
     }
     out
@@ -266,22 +305,25 @@ async fn peak_intermediate_bytes(executor: &SqlExecutor, sql: &str) -> u64 {
 }
 
 /// The statement the gate admits: a high-cardinality group key, a
-/// value-selective ordering aggregate, a matching sort direction, a small
-/// `LIMIT`.
+/// value-selective ordering aggregate over a fixed non-nullable column, a
+/// matching sort direction, a small `LIMIT`. Orders by `ts`, not `val`: `val`
+/// is a declared column and every declared column is nullable
+/// (`ravel_sql::logs_schema`), which the ordering-input nullability gate now
+/// refuses regardless of whether any row's `val` is actually NULL.
 fn topk_sql(limit: usize) -> String {
     format!(
-        "SELECT {KEY_COL}, max({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} \
+        "SELECT {KEY_COL}, max(ts) AS m FROM logs GROUP BY {KEY_COL} \
          ORDER BY m DESC LIMIT {limit}"
     )
 }
 
 /// The hand-computed top-`TOP_K` of [`records`]: the late group first with its
-/// late value, then the highest `gid`s, each with `max(val) = gid`.
+/// late `ts`, then the highest `gid`s, each with `max(ts) = gid + 1`.
 fn expected_top_k() -> Vec<(i64, i64)> {
-    let mut expected = vec![(LATE_KEY, LATE_VALUE)];
+    let mut expected = vec![(LATE_KEY, KEYS + 1)];
     expected.extend((0..TOP_K as i64 - 1).map(|i| {
         let gid = KEYS - 1 - i;
-        (gid, gid)
+        (gid, gid + 1)
     }));
     expected
 }
@@ -336,8 +378,8 @@ async fn q33_shape_plans_to_a_sort_over_a_two_stage_aggregate() {
 // ---------------------------------------------------------------------------
 
 /// The rule changes no answer: the same rows, in the same order, with it on and
-/// off, over 20,000 distinct keys whose top-10 is hand-computable and has no
-/// ties.
+/// off, over 200,000 (`KEYS`) distinct keys whose top-10 is hand-computable
+/// and has no ties.
 #[tokio::test]
 async fn bounded_top_k_returns_the_same_rows_as_the_unbounded_plan() {
     let sql = topk_sql(TOP_K);
@@ -350,9 +392,10 @@ async fn bounded_top_k_returns_the_same_rows_as_the_unbounded_plan() {
 
 /// The eviction-soundness case the exactness argument rests on.
 ///
-/// [`LATE_KEY`]'s running maximum is 7 while 19,993 groups with larger maxima
-/// stream past it, so it is below the k-th best for all but the last row of the
-/// scan; that last row makes it the largest group of all. A bounded aggregate
+/// [`LATE_KEY`]'s running maximum is 8 (`ts` of its one row in the main loop)
+/// while 199,992 groups with larger maxima stream past it, so it is below the
+/// k-th best for all but the last row of the scan; that last row, carrying
+/// `ts = KEYS + 1`, makes it the largest group of all. A bounded aggregate
 /// that compared groups on partial state, or that could not readmit a group
 /// after dropping it, returns a top-k without it. Asserted at rank 1
 /// specifically, not merely present.
@@ -360,7 +403,7 @@ async fn bounded_top_k_returns_the_same_rows_as_the_unbounded_plan() {
 async fn a_group_overtaken_at_the_last_row_is_still_first_in_the_top_k() {
     let sql = topk_sql(TOP_K);
     let out = rows(&executor(KEYS, Some(TOP_K)).await, &sql).await;
-    assert_eq!(out[0], (LATE_KEY, LATE_VALUE), "full top-k: {out:?}");
+    assert_eq!(out[0], (LATE_KEY, KEYS + 1), "full top-k: {out:?}");
 }
 
 // ---------------------------------------------------------------------------
@@ -398,7 +441,7 @@ async fn avg_ordering_does_not_fire() {
 #[tokio::test]
 async fn min_ordered_descending_does_not_fire() {
     let sql = format!(
-        "SELECT {KEY_COL}, min({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} \
+        "SELECT {KEY_COL}, min(ts) AS m FROM logs GROUP BY {KEY_COL} \
          ORDER BY m DESC LIMIT {TOP_K}"
     );
     assert_plan_unchanged(&sql, "a min-ordered descending top-k").await;
@@ -410,7 +453,7 @@ async fn min_ordered_descending_does_not_fire() {
 #[tokio::test]
 async fn ordering_by_the_group_key_does_not_fire() {
     let sql = format!(
-        "SELECT {KEY_COL}, max({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} \
+        "SELECT {KEY_COL}, max(ts) AS m FROM logs GROUP BY {KEY_COL} \
          ORDER BY {KEY_COL} DESC LIMIT {TOP_K}"
     );
     assert_plan_unchanged(&sql, "a group-key-ordered top-k").await;
@@ -429,9 +472,8 @@ async fn a_limit_above_the_threshold_does_not_fire() {
 /// group whatever any aggregate below it does, so there is no `k` to bound by.
 #[tokio::test]
 async fn no_limit_does_not_fire() {
-    let sql = format!(
-        "SELECT {KEY_COL}, max({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} ORDER BY m DESC"
-    );
+    let sql =
+        format!("SELECT {KEY_COL}, max(ts) AS m FROM logs GROUP BY {KEY_COL} ORDER BY m DESC");
     assert_plan_unchanged(&sql, "an unlimited sort").await;
 }
 
@@ -441,8 +483,8 @@ async fn no_limit_does_not_fire() {
 #[tokio::test]
 async fn a_having_clause_does_not_fire() {
     let sql = format!(
-        "SELECT {KEY_COL}, max({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} \
-         HAVING max({VAL_COL}) > 5 ORDER BY m DESC LIMIT {TOP_K}"
+        "SELECT {KEY_COL}, max(ts) AS m FROM logs GROUP BY {KEY_COL} \
+         HAVING max(ts) > to_timestamp_nanos(5) ORDER BY m DESC LIMIT {TOP_K}"
     );
     assert_plan_unchanged(&sql, "a HAVING-filtered top-k").await;
 }
@@ -482,6 +524,128 @@ async fn sum_ordering_does_not_fire() {
     assert_plan_unchanged(&sql, "a sum-ordered top-k").await;
 }
 
+/// Distinct group-key count for [`a_nullable_ordering_input_does_not_fire`]'s
+/// fixture. Small and separate from [`KEYS`]/[`SMALL_KEYS`]: this test is
+/// about one property, a NULL ordering input, not about scale.
+const NULL_FIXTURE_KEYS: i64 = 100;
+
+/// The group whose one row omits `val` entirely: the reviewer's probe. Under
+/// `ORDER BY max(val) DESC` (the default `NULLS FIRST`) it must rank first in
+/// both the unbounded answer and, because the gate refuses this ordering
+/// input, the "bounded" one too.
+const NULL_GROUP: i64 = 999_999;
+
+/// `keys` groups of one row each carrying `val = gid`, plus one more group,
+/// [`NULL_GROUP`], whose row has no `val` attribute at all.
+fn records_with_a_null_group(keys: i64) -> Vec<LogRecord> {
+    let mut out: Vec<LogRecord> = (0..keys).map(|i| log_record(i + 1, i, i)).collect();
+    out.push(log_record_no_val(keys + 1, NULL_GROUP));
+    out
+}
+
+/// Every `(gid, Option<value>)` row `sql` returns, in the order it returns
+/// them. Unlike [`rows`], this keeps NULL visible, because the property under
+/// test is which group ranks first and an all-NULL group has no `i64` to
+/// report.
+async fn rows_nullable(executor: &SqlExecutor, sql: &str) -> Vec<(i64, Option<i64>)> {
+    let outcome = executor
+        .execute(tenant().hash(), &request(sql))
+        .await
+        .expect("query runs");
+    let mut out = Vec::new();
+    for batch in outcome.output.batches() {
+        let keys = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("group key is Int64");
+        let values = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("aggregate is Int64");
+        for row in 0..batch.num_rows() {
+            let value = if values.is_null(row) {
+                None
+            } else {
+                Some(values.value(row))
+            };
+            out.push((keys.value(row), value));
+        }
+    }
+    out
+}
+
+/// Conjunct: the ordering aggregate's own input must be a plain column the
+/// input schema marks non-nullable.
+///
+/// DataFusion's priority map never admits a group whose ordering value is
+/// NULL. [`NULL_GROUP`]'s only row omits `val`, so under the default `NULLS
+/// FIRST` it ranks first in the unbounded answer; a rule that let this
+/// ordering input through would silently drop it instead. That is the
+/// reviewer's probe: unbounded `[(999999, None), (99, Some(99)), (98,
+/// Some(98))]` against a would-be bounded `[(99, Some(99)), (98, Some(98)),
+/// (97, Some(97))]`.
+///
+/// Both halves are asserted here: the plan is the unbounded one, and the
+/// returned rows put the all-NULL group first regardless of which plan ran.
+#[tokio::test]
+async fn a_nullable_ordering_input_does_not_fire() {
+    let sql = format!(
+        "SELECT {KEY_COL}, max({VAL_COL}) AS m FROM logs GROUP BY {KEY_COL} \
+         ORDER BY m DESC LIMIT 3"
+    );
+    let on = physical_plan(
+        &executor_with_records(records_with_a_null_group(NULL_FIXTURE_KEYS), Some(3)).await,
+        &sql,
+    )
+    .await;
+    let off = physical_plan(
+        &executor_with_records(records_with_a_null_group(NULL_FIXTURE_KEYS), None).await,
+        &sql,
+    )
+    .await;
+    assert_eq!(on, off, "the rule fired on a nullable ordering input");
+
+    let out = rows_nullable(
+        &executor_with_records(records_with_a_null_group(NULL_FIXTURE_KEYS), Some(3)).await,
+        &sql,
+    )
+    .await;
+    assert_eq!(
+        out,
+        vec![
+            (NULL_GROUP, None),
+            (NULL_FIXTURE_KEYS - 1, Some(NULL_FIXTURE_KEYS - 1)),
+            (NULL_FIXTURE_KEYS - 2, Some(NULL_FIXTURE_KEYS - 2)),
+        ],
+        "full top-3: {out:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The rule actually fires
+// ---------------------------------------------------------------------------
+
+/// No test above this one asserts that the rule CHANGES the plan when it
+/// fires: a rule stubbed to `Transformed::no` on every node would still pass
+/// every negative test (plan unchanged is the point) and the answer-identity
+/// tests (an unbounded plan answers the same query correctly too). Only this
+/// test and the bytes test below would catch that stub, and this one names
+/// the mechanism directly: the rule-on plan differs from the rule-off plan,
+/// and it carries the aggregate's limit marker.
+#[tokio::test]
+async fn the_rule_rewrites_the_gated_shape() {
+    let sql = topk_sql(TOP_K);
+    let on = physical_plan(&executor(SMALL_KEYS, Some(TOP_K)).await, &sql).await;
+    let off = physical_plan(&executor(SMALL_KEYS, None).await, &sql).await;
+    assert_ne!(on, off, "the rule did not change the plan:\n{on}");
+    assert!(
+        on.contains(&format!("lim=[{TOP_K}]")),
+        "the rule-on plan carries no limit marker:\n{on}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // The bound
 // ---------------------------------------------------------------------------
@@ -494,9 +658,9 @@ async fn sum_ordering_does_not_fire() {
 const PEAK_ON_SMALL: u64 = 1_050_112;
 
 /// The same statement over the 200,000-key fixture with the rule installed.
-/// Ten times the groups for 1.75 times the bytes, and the growth that is left
+/// Ten times the groups for 1.62 times the bytes, and the growth that is left
 /// is the scan's own batches, not aggregate state.
-const PEAK_ON_LARGE: u64 = 1_837_456;
+const PEAK_ON_LARGE: u64 = 1_706_120;
 
 /// The 20,000-key fixture with the rule uninstalled.
 const PEAK_OFF_SMALL: u64 = 1_143_552;
@@ -510,17 +674,17 @@ const PEAK_OFF_LARGE: u64 = 10_748_928;
 ///
 /// With the rule off, `peak_intermediate_bytes` for the admitted statement
 /// grows with the distinct-key count (9.4x for 10x the keys): the aggregate
-/// holds one accumulator per group. With the rule on it does not (1.75x, and
+/// holds one accumulator per group. With the rule on it does not (1.62x, and
 /// that residue is scan batches), because the aggregate holds `k` groups
 /// whatever the key count is. At the large fixture the ratio between the two
-/// is 5.85x.
+/// is 6.30x.
 ///
 /// All four figures are pinned, and the three ratios are asserted separately so
 /// a change that moved every figure by the same factor still has to explain
 /// itself. Changing `Some(TOP_K)` to `None` on the `on_large` line below is the
 /// demonstration that the bound assertion is load-bearing: `on_large` becomes
 /// `PEAK_OFF_LARGE` and the first assertion, `assert_eq!(on_large,
-/// PEAK_ON_LARGE, ...)`, fails with `10748928` against `1837456`.
+/// PEAK_ON_LARGE, ...)`, fails with `10748928` against `1706120`.
 #[tokio::test]
 async fn peak_intermediate_bytes_stops_scaling_with_the_key_count() {
     let sql = topk_sql(TOP_K);

--- a/crates/ravel-sql/tests/ceiling_breach.rs
+++ b/crates/ravel-sql/tests/ceiling_breach.rs
@@ -66,6 +66,10 @@ async fn a_join_that_overruns_the_query_ceiling_aborts_and_frees_the_tenant_budg
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; this fixture's
+        // statement is a join, not a grouped top-k, so the rule could not fire
+        // either way. Left on the shipped default.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };

--- a/crates/ravel-sql/tests/memory_accounting.rs
+++ b/crates/ravel-sql/tests/memory_accounting.rs
@@ -271,6 +271,9 @@ async fn a_query_that_outgrows_its_pool_still_releases_tenant_bytes() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };

--- a/crates/ravel-sql/tests/memory_ceiling_and_budget_errors.rs
+++ b/crates/ravel-sql/tests/memory_ceiling_and_budget_errors.rs
@@ -195,6 +195,9 @@ async fn a_sort_or_aggregate_budget_error_keeps_its_type() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };
@@ -277,6 +280,9 @@ async fn a_high_cardinality_aggregation_over_budget_is_resources_exhausted() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };
@@ -367,6 +373,9 @@ async fn a_high_cardinality_aggregation_is_refused_by_the_aggregate_not_the_scan
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };
@@ -474,6 +483,9 @@ async fn a_large_order_by_over_budget_is_resources_exhausted() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };

--- a/crates/ravel-sql/tests/pushdown_memory.rs
+++ b/crates/ravel-sql/tests/pushdown_memory.rs
@@ -821,6 +821,9 @@ async fn byte_budget_exceeded_returns_typed_error() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };
@@ -913,6 +916,9 @@ async fn high_cardinality_trips_query_pool_before_tenant() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };
@@ -973,6 +979,9 @@ async fn tenant_budget_trips_and_rolls_back_the_query_reservation() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };
@@ -1035,6 +1044,9 @@ async fn query_budget_reported_first_when_both_ceilings_are_equally_reachable() 
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };

--- a/crates/ravel-sql/tests/scan_budgets.rs
+++ b/crates/ravel-sql/tests/scan_budgets.rs
@@ -489,6 +489,9 @@ fn task_ctx_with_query_bytes(max_query_bytes: usize) -> Arc<TaskContext> {
         // Named explicitly rather than spread from the default so a new field
         // keeps failing this initializer closed.
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         // ADR-0954: spill off, as on the shipped default.
         spill: None,
     };

--- a/crates/ravel-sql/tests/spill.rs
+++ b/crates/ravel-sql/tests/spill.rs
@@ -181,6 +181,9 @@ fn spill_config(spill_dir: PathBuf, scratch_bytes: u64, query_bytes: usize) -> S
         parallel_final_aggregation: false,
         skip_partial_aggregation: true,
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         spill: Some(SpillConfig {
             dir: spill_dir,
             max_bytes: scratch_bytes,
@@ -779,6 +782,9 @@ fn parallel_config(spill: Option<SpillConfig>) -> SqlConfig {
         parallel_final_aggregation: true,
         skip_partial_aggregation: true,
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         spill,
     }
 }
@@ -930,6 +936,9 @@ async fn spill_off_reproduces_todays_refusal() {
         parallel_final_aggregation: false,
         skip_partial_aggregation: true,
         late_materialization_extra_columns: None,
+        // Issue #1402's rewrite is a `SqlConfig` field too; left on the shipped
+        // default, since none of these fixtures plans a grouped top-k.
+        bounded_topk_max_limit: Some(ravel_sql::DEFAULT_BOUNDED_TOPK_MAX_LIMIT),
         spill: None,
     };
     assert_eq!(config.spill, None, "this case is the spill-off default");

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -2752,6 +2752,48 @@ its 16-block, 41-column fixture phase 1 decodes 3 pages per block against the
 single-phase plan's 39 over the same 16 blocks, and un-cached, a `k = 10`
 statement moves 103,606 bytes in 14 GETs against a single pass's 29,645 in 4.
 
+#### Bounded top-k grouped aggregation (issue #1402)
+
+`BoundedTopKAggregate` is a physical optimizer rule (installed by
+`build_session` when `SqlConfig::bounded_topk_max_limit` is `Some`) that stops
+a `GROUP BY <high-cardinality key> ... ORDER BY <aggregate> LIMIT k` from
+materialising one accumulator per distinct group to return `k` rows. It fires
+only when every one of these holds: the plan is a single-stream `SortExec` with
+a `fetch` at or below the configured limit, ordering by exactly one column;
+every node between that sort and the aggregate is a coalesce, a repartition, a
+cooperative wrapper, or a renaming projection (a `HAVING` filter refuses, since
+it decides which groups reach the sort); the aggregate has exactly one group
+key, no `FILTER` clause, and exactly one aggregate expression; that aggregate is
+`max` under a descending sort or `min` under an ascending one; and its input
+type is not floating point. Under those conditions the aggregate is rebuilt with
+DataFusion's `LimitOptions`, which executes it as a bounded priority map of `k`
+groups. Outside them the plan is byte-identical to the one the uninstalled rule
+produces, which `crates/ravel-sql/tests/bounded_topk_aggregate.rs` asserts for
+every conjunct by comparing the rendered physical plans rather than the answers.
+
+The rule is exact, and the gate is what makes it exact. A `max`/`min` group's
+result is the extreme of independently contributed row values, so the priority
+map drops a group only when its best value so far loses to the current k-th
+best, and that k-th best only tightens; a group whose true extreme beats the
+final k-th therefore beat every earlier threshold too, was admitted the moment
+that value arrived, and carries exactly that value. `count` and `sum` do NOT get
+this treatment even though they are monotone non-decreasing, because
+monotonicity makes a running value a *lower* bound on the final one and pruning
+needs an upper bound: `ORDER BY count(*) DESC LIMIT 1` over the row sequence
+`A, B, B, B` would evict `B` three times at a running count of 1 and answer `A`
+with 1 instead of `B` with 3. The float exclusion is the ADR-0023 total order:
+the priority map compares values itself and never constructs ravel's
+total-order min/max accumulator, so a float input routed through it would answer
+under DataFusion's ordering of `-0.0` and NaN payloads rather than ravel's.
+DataFusion's own `TopKAggregation` rule, which admits both of those shapes and
+defaults on, is turned off in `session_config` for exactly this reason.
+
+On the test fixture (200,000 distinct keys, `ORDER BY max(val) DESC LIMIT 10`)
+`peakIntermediateBytes` is 1,837,456 with the rule installed against 10,748,928
+without it. Across a tenfold increase in distinct keys the rule-off figure grows
+9.4x and the rule-on figure 1.75x, and the residual growth on the rule-on side
+is the scan's own batches rather than aggregate state.
+
 Both gaps ADR-0033 recorded are now closed. Both were deliberate, not
 oversights.
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -2752,7 +2752,7 @@ its 16-block, 41-column fixture phase 1 decodes 3 pages per block against the
 single-phase plan's 39 over the same 16 blocks, and un-cached, a `k = 10`
 statement moves 103,606 bytes in 14 GETs against a single pass's 29,645 in 4.
 
-#### Bounded top-k grouped aggregation (issue #1402)
+#### Bounded top-k grouped aggregation
 
 `BoundedTopKAggregate` is a physical optimizer rule (installed by
 `build_session` when `SqlConfig::bounded_topk_max_limit` is `Some`) that stops
@@ -2764,8 +2764,9 @@ every node between that sort and the aggregate is a coalesce, a repartition, a
 cooperative wrapper, or a renaming projection (a `HAVING` filter refuses, since
 it decides which groups reach the sort); the aggregate has exactly one group
 key, no `FILTER` clause, and exactly one aggregate expression; that aggregate is
-`max` under a descending sort or `min` under an ascending one; and its input
-type is not floating point. Under those conditions the aggregate is rebuilt with
+`max` under a descending sort or `min` under an ascending one; its input type
+is not floating point; and its input is a plain column that the input schema
+marks non-nullable. Under those conditions the aggregate is rebuilt with
 DataFusion's `LimitOptions`, which executes it as a bounded priority map of `k`
 groups. Outside them the plan is byte-identical to the one the uninstalled rule
 produces, which `crates/ravel-sql/tests/bounded_topk_aggregate.rs` asserts for
@@ -2781,18 +2782,37 @@ this treatment even though they are monotone non-decreasing, because
 monotonicity makes a running value a *lower* bound on the final one and pruning
 needs an upper bound: `ORDER BY count(*) DESC LIMIT 1` over the row sequence
 `A, B, B, B` would evict `B` three times at a running count of 1 and answer `A`
-with 1 instead of `B` with 3. The float exclusion is the ADR-0023 total order:
-the priority map compares values itself and never constructs ravel's
-total-order min/max accumulator, so a float input routed through it would answer
-under DataFusion's ordering of `-0.0` and NaN payloads rather than ravel's.
-DataFusion's own `TopKAggregation` rule, which admits both of those shapes and
-defaults on, is turned off in `session_config` for exactly this reason.
+with 1 instead of `B` with 3. The float exclusion keeps the answer provably
+ravel's: the priority map's heap orders floats with `total_cmp`, the same
+comparison ADR-0023 mandates, but its worse-than pre-check compares with
+`PartialOrd` instead, so whether `-0.0` against `0.0` and NaN payloads end up
+ordered the way ADR-0023 requires is not something this rule can prove.
+DataFusion's own `TopKAggregation` rule, which admits float input (and an
+unbounded `LIMIT`), defaults on and is turned off in `session_config` for
+exactly this reason.
 
-On the test fixture (200,000 distinct keys, `ORDER BY max(val) DESC LIMIT 10`)
-`peakIntermediateBytes` is 1,837,456 with the rule installed against 10,748,928
+The ordering-input nullability conjunct closes a separate hole: DataFusion's
+priority map never admits a group whose ordering value is NULL, so under the
+default `NULLS FIRST` such a group belongs first in the unbounded answer, and
+under `NULLS LAST` it still belongs whenever fewer than `k` non-null groups
+exist. A plain column the input schema marks non-nullable is the only input
+this rule can prove the map's NULL-blind admission exact for. Every typed
+attribute column is nullable by construction
+(`crates/ravel-sql/src/logs_schema.rs`), so today the conjunct only admits a
+fixed column such as `ts`, `severity_num`, or `flags`; widening it to a typed
+attribute column needs a statistics-derived proof that the column holds no
+NULLs, which is a separate change. At a tie on the k-th value the bounded map
+keeps the later-arriving group, and the unbounded sort's own tie-break is
+arrival-order dependent too; SQL leaves that order unspecified.
+
+On the test fixture (200,000 distinct keys, `ORDER BY max(ts) DESC LIMIT 10`)
+`peakIntermediateBytes` is 1,706,120 with the rule installed against 10,748,928
 without it. Across a tenfold increase in distinct keys the rule-off figure grows
-9.4x and the rule-on figure 1.75x, and the residual growth on the rule-on side
-is the scan's own batches rather than aggregate state.
+9.4x and the rule-on figure 1.62x, and the residual growth on the rule-on side
+is the scan's own batches rather than aggregate state. The statement orders by
+`ts`, a fixed non-nullable column, rather than a typed attribute column: a
+typed attribute column is always nullable and the ordering-input conjunct
+above refuses it regardless of whether any row's value is actually NULL.
 
 Both gaps ADR-0033 recorded are now closed. Both were deliberate, not
 oversights.

--- a/services/ravel-server/src/query.rs
+++ b/services/ravel-server/src/query.rs
@@ -306,6 +306,12 @@ pub fn build_sql_state(
         // is an in-process escape hatch and the regression fixture's red side,
         // not a server-level knob.
         late_materialization_extra_columns: SqlConfig::default().late_materialization_extra_columns,
+        // The bounded top-k grouped aggregate's limit ceiling: the shipped
+        // default, with no flag, for the same reason as the two lines above.
+        // The rewrite is exact for the shape it admits, so the `SqlConfig`
+        // field is an in-process escape hatch and the tests' rule-off side,
+        // not a server-level knob.
+        bounded_topk_max_limit: SqlConfig::default().bounded_topk_max_limit,
         // ADR-0954: bounded ephemeral spill is off by default (requirement 9's
         // no-spill deployment profile). `with_spill_from_env` below fills this
         // from `RAVEL_SQL_SPILL_DIR`/`RAVEL_SQL_SPILL_MAX_BYTES` when both are


### PR DESCRIPTION
A GROUP BY over a high-cardinality key whose only consumer is an ORDER BY
... LIMIT k materialised one accumulator per distinct group to return k
rows. ClickBench q33 reaches 10.09 GB of intermediate state for 10 rows,
and ADR-0013 leaves no escape at execution time: budget exhaustion is an
error, never a partial result, and spilling stays disabled.

`BoundedTopKAggregate` is a physical optimizer rule that hands
DataFusion's own bounded grouped aggregate a limit, so the aggregate keeps
k groups in a priority map instead of a group table. The operator is
DataFusion's; what is new is the gate. It fires only for a single-stream
sort with a fetch at or below `SqlConfig::bounded_topk_max_limit`,
ordering by one column, over pass-through nodes only, above an aggregate
with one group key, no FILTER clause, and one aggregate expression that is
`max` under a descending sort or `min` under an ascending one over a
non-float input.

The gate is narrower than issue #1402 asked for, and deliberately so. The
issue proposed admitting any aggregate that is monotone non-decreasing in
its inputs, naming COUNT and SUM, on the argument that a group evicted
below the k-th cannot re-enter. That argument does not hold: monotonicity
makes a group's running value a lower bound on its final value, and
pruning needs an upper bound. `ORDER BY count(*) DESC LIMIT 1` over the
row sequence A, B, B, B evicts B three times at a running count of 1 and
answers A with 1 instead of B with 3. COUNT and SUM are refused, and a
test pins both the refusal and the true answer, so widening the gate to
them fails immediately. q33 itself orders by COUNT and is therefore not
bounded by this change; the issue stays open for the COUNT case.

A value-selective aggregate is different, and that is the exactness
argument the rule rests on: a max or min group's result is the extreme of
independently contributed row values, the map drops a group only when its
best value so far loses to the current k-th best, and the k-th best only
tightens, so a group whose true extreme beats the final k-th beat every
earlier threshold and was admitted carrying exactly that value.

The bound is exact only when the ordering aggregate's input column cannot
be NULL. DataFusion's priority map never admits a group whose ordering
value is NULL, and under the default NULLS FIRST such a group ranks first
in the unbounded answer (under NULLS LAST it still belongs in the answer
whenever fewer than k non-null groups exist), so the gate also requires
the input field to be non-nullable in the scan schema. Every declared
column is nullable by construction, so the rule fires today only when the
ordering aggregate reads a fixed column such as `ts`, `severity_num` or
`flags`; a statistics-derived proof of no NULLs that would widen it to
declared columns is #1433. At a tie on the k-th value the bounded map
keeps the later-arriving group while the unbounded sort's choice is
arrival-dependent too; SQL leaves that order unspecified.

Two behaviour changes beyond the new rule. DataFusion's ungated
`TopKAggregation` rule was live in every session by default. It admitted
an all-NULL ordering group into exactly the silent wrong answer above
(reproduced on main before this change), float min/max, whose heap orders
by `total_cmp` but pre-checks with `PartialOrd`, so its treatment of
`-0.0` and NaN payloads is not provably the total order ADR-0023 gives
ravel's accumulators, and an unbounded LIMIT. Session config now turns it
off for every query and this rule re-admits only the vetted shape, pinned
by a session test so a DataFusion upgrade cannot restore it silently. A
float or nullable min/max top-k, and any min/max top-k with a LIMIT above
the threshold, now run the unbounded aggregate under the same memory
ceiling as before.

Measured on the new fixture (200,000 distinct keys, `ORDER BY max(ts)
DESC LIMIT 10`): peak intermediate bytes 1,706,120 with the rule against
10,748,928 without it. Across a tenfold rise in distinct keys the rule-off
figure grows 9.4x and the rule-on figure 1.62x, the residue being scan
batches rather than aggregate state. All four figures are pinned as exact
constants and reproduce to the byte. Every gate conjunct has a negative
test asserting equality of the rendered physical plan against the
rule-uninstalled plan, a positive test asserts the plan does change for
the gated shape, a nullable-input test asserts the all-NULL group stays
first, and an eviction test overtakes the k-th group on the last row of
the scan.

The server's `SqlConfig` literal in `services/ravel-server/src/query.rs`
names every field, so it gains `bounded_topk_max_limit` at the shipped
default, as an in-process escape hatch rather than a flag, the same way
its neighbours are set.

Provenance: fleet task, executor gates scoped to ravel-sql (fmt, clippy,
the crate's own tests, doc-drift); three adversarial review rounds and
the crate gates at merge time; the workspace clippy, the `sql` and the
`flight-sql` feature lanes run in PR CI.

Refs: #1402
Refs: #1185
