### PR TITLE
feat(operator): qualify object store before serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **The operator's Secret change-detection checksum is now a `blake3` digest, 64
+  hex characters** (issue #36). It replaces a 16-character standard-hasher value
+  that was not stable across Rust toolchain versions. Because the annotation
+  value changes, the first reconcile after upgrading the operator rolls every
+  rendered gateway, query, and enabled maintain Deployment once, even when their
+  referenced Secrets are unchanged; subsequent reconciles are stable. Schedule
+  the operator upgrade in a maintenance window that tolerates one rolling restart
+  of each serving tier.
+- **The operator now bounds qualify-Job recreations for a store that keeps
+  failing qualification** (issue #36). A failing `ravel-cli store qualify` Job is
+  recreated on a capped exponential backoff (30 s doubling to a 480 s ceiling)
+  and, after 6 consecutive failures, held in a one-hour terminal cooldown that
+  only an input change or the cooldown's expiry clears, rather than looping
+  delete/recreate every retry interval. The failure count and next-retry instant
+  are persisted in `RavelCluster` status, and the `StoreQualified=False`
+  condition names the attempt count and the next retry time.
 - **`latency-first`'s published trade is re-measured and now names the commit it
   was taken on** (issue #1316). Over 3 reps on the reference corpus,
   42-statement basis, true cold in the warm-up-empty state, at concurrency 256:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4836,6 +4836,7 @@ dependencies = [
 name = "ravel-operator"
 version = "0.14.0"
 dependencies = [
+ "blake3",
  "clap",
  "futures",
  "hex",

--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -600,6 +600,17 @@
                     "nullable": true,
                     "type": "integer"
                   },
+                  "qualifyFailureCount": {
+                    "description": "Consecutive qualify-Job failures for the current inputs (issue #36, finding\n3). Drives the capped exponential recreation backoff and the terminal\ncooldown: the operator does not recreate a failing qualify Job unboundedly,\nit spaces the recreations out and, past a threshold, holds. Reset to absent\non a successful qualification and on any input change (a moving\n`storeQualifiedHash` input); never part of the qualified-input hash, so\ncounting failures never re-runs a qualification that would otherwise pass.\n\nSerialized even when absent (as explicit `null`) so the status merge patch\nclears it on success; a skipped field would leave a stale count behind.",
+                    "format": "int32",
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "qualifyNextRetryTime": {
+                    "description": "RFC3339 instant before which the operator creates no new qualify Job after\na failure (issue #36, finding 3): the next point on the capped exponential\nbackoff, or the terminal cooldown's expiry. Absent when not holding.\n\nSerialized even when absent (as explicit `null`) so the status merge patch\nclears it; a skipped field would leave a stale deadline behind.",
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "queryReadyReplicas": {
                     "description": "Ready replicas reported by the query Deployment.",
                     "format": "int32",
@@ -607,7 +618,7 @@
                     "type": "integer"
                   },
                   "storeQualifiedHash": {
-                    "description": "The qualify-Job input hash (bucket, region, endpoint, image, credentials\nSecret name) that store qualification last succeeded against (issue #36).\nThe operator gates serving on `ravel store qualify` before it creates any\nDeployment; recording the qualified inputs here makes that gate durable:\na later pass whose inputs still hash to this value proceeds without\nre-running qualification even after the one-shot Job has been\nTTL-garbage-collected, and a pass whose inputs no longer match re-runs it\n(the `StoreQualified` condition flips back to `Pending`) without tearing\ndown the running Deployments. Absent until the first qualification\nsucceeds. Qualification is never re-run on a schedule; only an input\nchange re-triggers it.",
+                    "description": "The qualify-Job input hash (bucket, region, endpoint, image, credentials\nSecret name) that store qualification last succeeded against (issue #36).\nThe operator gates serving on `ravel-cli store qualify` before it creates any\nDeployment; recording the qualified inputs here makes that gate durable:\na later pass whose inputs still hash to this value proceeds without\nre-running qualification even after the one-shot Job has been\nTTL-garbage-collected, and a pass whose inputs no longer match re-runs it\n(the `StoreQualified` condition flips back to `Pending`) without tearing\ndown the running Deployments. Absent until the first qualification\nsucceeds. Qualification is never re-run on a schedule; only an input\nchange re-triggers it.",
                     "nullable": true,
                     "type": "string"
                   }

--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -605,6 +605,11 @@
                     "format": "int32",
                     "nullable": true,
                     "type": "integer"
+                  },
+                  "storeQualifiedHash": {
+                    "description": "The qualify-Job input hash (bucket, region, endpoint, image, credentials\nSecret name) that store qualification last succeeded against (issue #36).\nThe operator gates serving on `ravel store qualify` before it creates any\nDeployment; recording the qualified inputs here makes that gate durable:\na later pass whose inputs still hash to this value proceeds without\nre-running qualification even after the one-shot Job has been\nTTL-garbage-collected, and a pass whose inputs no longer match re-runs it\n(the `StoreQualified` condition flips back to `Pending`) without tearing\ndown the running Deployments. Absent until the first qualification\nsucceeds. Qualification is never re-run on a schedule; only an input\nchange re-triggers it.",
+                    "nullable": true,
+                    "type": "string"
                   }
                 },
                 "type": "object"

--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -611,6 +611,11 @@
                     "nullable": true,
                     "type": "string"
                   },
+                  "qualifyRetryHash": {
+                    "description": "The qualify-Job input hash the persisted `qualifyFailureCount` and\n`qualifyNextRetryTime` were recorded against (issue #36, finding 3). The\nretry state is meaningful only for the inputs that produced the failures:\nwhen the desired inputs no longer hash to this value the operator resets\nthe count and next-retry and qualifies the new inputs at once, whether or\nnot the failing Job still exists. Without this key the operator cannot tell\na changed-input pass from an unchanged one once the Failed Job is\nTTL-garbage-collected (both observe the Job absent), so a config edit made\nafter the Job's TTL collected it would wait out the old inputs' cooldown and\ninherit their failure count. This is never part of the qualified-input hash\nitself, so recording it never re-runs a qualification that would pass.\n\nSerialized even when absent (as explicit `null`) so the status merge patch\nclears it on reset or success; a skipped field would leave a stale key\nbehind.",
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "queryReadyReplicas": {
                     "description": "Ready replicas reported by the query Deployment.",
                     "format": "int32",

--- a/deploy/k8s/operator/rbac.yaml
+++ b/deploy/k8s/operator/rbac.yaml
@@ -13,6 +13,11 @@
 #   - PodDisruptionBudgets (policy): full lifecycle, for the per-tier PDBs the
 #     operator renders (issue #126, ADR-0034 hardening amendment). Delete is what
 #     converges maintain's PDB away when maintain.enabled goes back to false.
+#   - Jobs (batch): full lifecycle, for the one-shot store-qualification Job the
+#     operator runs before it creates any serving Deployment (issue #36). Create
+#     to start it, get/list/watch to observe its terminal state, delete to
+#     recreate it when the qualified inputs change (its pod template is
+#     immutable) and to let its TTL-driven cleanup be operator-owned.
 #   - RavelCluster (and its status subresource): watch the spec, write status.
 #   - Secrets: get only, and NEVER granted by this cluster-wide ClusterRole
 #     (issue #126). The operator reads the credentials, tenant-token, and
@@ -87,6 +92,9 @@ rules:
     verbs: ["get", "update", "patch"]
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
+    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
     verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/k8s/operator/rbac.yaml
+++ b/deploy/k8s/operator/rbac.yaml
@@ -1,24 +1,38 @@
-# RBAC for the Ravel operator (ADR-0034). Grants exactly what the reconcile
-# loop needs and nothing broader:
-#   - Deployments and Services: full lifecycle for the objects it manages
-#     (create/update/patch for apply, get/list/watch for the informer cache,
-#     delete to remove the maintain Deployment when maintain.enabled is false).
-#   - Ingresses: the same lifecycle, for the ingest-affinity Ingress objects
-#     (ADR-0076 decision 1). Delete is what lets gateway.ingestAffinity.enabled
-#     go back to false without leaving an orphan routing live ingest traffic.
-#   - HTTPRoutes/GRPCRoutes (gateway.networking.k8s.io): the same lifecycle, for
-#     the Gateway API exposure routes (ADR-0080 decision 2). Delete is what lets
-#     gateway.exposure be removed without leaving an orphan route attached to
-#     the Gateway.
-#   - PodDisruptionBudgets (policy): full lifecycle, for the per-tier PDBs the
-#     operator renders (issue #126, ADR-0034 hardening amendment). Delete is what
-#     converges maintain's PDB away when maintain.enabled goes back to false.
-#   - Jobs (batch): full lifecycle, for the one-shot store-qualification Job the
-#     operator runs before it creates any serving Deployment (issue #36). Create
-#     to start it, get/list/watch to observe its terminal state, delete to
-#     recreate it when the qualified inputs change (its pod template is
-#     immutable) and to let its TTL-driven cleanup be operator-owned.
-#   - RavelCluster (and its status subresource): watch the spec, write status.
+# RBAC for the Ravel operator (ADR-0034). Grants exactly the verbs the
+# reconcile loop actually calls and nothing broader. Every write goes through
+# server-side apply, which is a PATCH (creating an object that does not yet
+# exist needs `create` as well), so `update` (the PUT verb) is never issued and
+# is granted nowhere. Reads come from three mechanisms: an explicit `.get()`,
+# an informer (`Controller`/`.owns()`, which LIST+WATCH only), and RBAC
+# escalation prevention (creating a Role that grants a verb requires the
+# operator to already hold that verb). A resource the operator only writes and
+# deletes gets `create`/`patch`/`delete` and no read verbs.
+#   - Deployments: create/patch (apply), get (live replica reads,
+#     controller::live_replica_counts / live_deployment_exists), list/watch
+#     (the `.owns()` informer), delete (remove the maintain Deployment when
+#     maintain.enabled is false, and the router sweep).
+#   - Services: create/patch (apply), list/watch (the `.owns()` informer),
+#     get/list/watch (escalation: the router Role,
+#     reconcile::desired_router_role, grants `services get/list/watch`), delete
+#     (the router sweep). No `.get()` call, but get is required for escalation.
+#   - Ingresses: create/patch (apply), list/watch (the `.owns()` informer),
+#     delete (ADR-0076 decision 1: lets gateway.ingestAffinity.enabled go back
+#     to false without orphaning a route). No `.get()` and no informer beyond
+#     list/watch, so no bare `get`.
+#   - HTTPRoutes/GRPCRoutes (gateway.networking.k8s.io): create/patch (apply)
+#     and delete only, for the Gateway API exposure routes (ADR-0080 decision
+#     2). They are applied and swept, never read (no informer, no `.get()`).
+#   - PodDisruptionBudgets (policy): create/patch (apply) and delete only, for
+#     the per-tier PDBs (issue #126, ADR-0034 hardening amendment). Applied and
+#     swept, never read.
+#   - Jobs (batch): create/patch (apply), get (observe the qualify Job's
+#     terminal state, controller::observe_qualify_job), delete (recreate it with
+#     foreground propagation when the qualified inputs change; its pod template
+#     is immutable). Not watched by an informer, so no list/watch.
+#   - RavelCluster: list/watch only (the primary `Controller` informer; the
+#     reconcile object comes from the informer cache, never a `.get()`, and the
+#     spec is never patched). Its status subresource: patch only (patch_status
+#     is a merge PATCH; the status is never read back or replaced).
 #   - Secrets: get only, and NEVER granted by this cluster-wide ClusterRole
 #     (issue #126). The operator reads the credentials, tenant-token, and
 #     deployment-key Secrets to resolve tenant names; it never lists, writes, or
@@ -31,12 +45,13 @@
 #     namespace with no such RoleBinding 403s on Secret resolution and the
 #     operator reports a SecretsUnreadable condition on it (see
 #     crate::controller::secret_error).
-#   - ServiceAccounts, Roles, and RoleBindings: the same lifecycle, for the
-#     ravel-native ingest router's own ServiceAccount and its namespaced,
-#     least-privilege Role/RoleBinding (ADR-0080 decision 3). The operator's own
-#     identity needs these verbs to create those objects for the router; delete
-#     is what lets backend: ravelNative be switched away without leaving the
-#     router's RBAC orphaned.
+#   - ServiceAccounts, Roles, and RoleBindings: create/patch (apply) and delete
+#     only, for the ravel-native ingest router's own ServiceAccount and its
+#     namespaced, least-privilege Role/RoleBinding (ADR-0080 decision 3). The
+#     operator applies and sweeps these, never reads them, so no read verbs;
+#     delete is what lets backend: ravelNative be switched away without leaving
+#     the router's RBAC orphaned. (Creating the router Role is what forces the
+#     services and endpointslices read grants below, via escalation prevention.)
 #   - EndpointSlices (discovery.k8s.io): get/list/watch only. The operator never
 #     reads EndpointSlices itself; it needs this grant because Kubernetes RBAC
 #     escalation prevention forbids creating a Role that grants a permission the
@@ -63,39 +78,53 @@ metadata:
     app.kubernetes.io/name: ravel-operator
     app.kubernetes.io/managed-by: ravel-operator
 rules:
+  # apply (create+patch), explicit .get() reads, .owns() informer (list+watch),
+  # and delete (maintain teardown + router sweep).
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "get", "list", "watch", "delete"]
+  # apply, .owns() informer (list+watch), get/list/watch required by escalation
+  # prevention (the router Role grants services get/list/watch), and delete.
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "get", "list", "watch", "delete"]
+  # apply, .owns() informer (list+watch), delete. No explicit get, no escalation.
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "list", "watch", "delete"]
+  # applied and swept only, never read.
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes", "grpcroutes"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "delete"]
+  # applied and swept only, never read.
   - apiGroups: [""]
     resources: ["serviceaccounts"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "delete"]
+  # applied and swept only, never read.
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "delete"]
+  # escalation-prevention grant for the router Role only; never read directly.
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
+  # primary informer only; the spec is never patched (only the status is).
   - apiGroups: ["ravel.nofire.ai"]
     resources: ["ravelclusters"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    verbs: ["list", "watch"]
+  # patch_status is a merge PATCH; status is never read back or replaced.
   - apiGroups: ["ravel.nofire.ai"]
     resources: ["ravelclusters/status"]
-    verbs: ["get", "update", "patch"]
+    verbs: ["patch"]
+  # applied and swept only, never read.
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "delete"]
+  # apply, explicit .get() (observe the qualify Job), delete (foreground
+  # recreate). Not watched by an informer, so no list/watch.
   - apiGroups: ["batch"]
     resources: ["jobs"]
-    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    verbs: ["create", "patch", "get", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -307,14 +307,37 @@ loop as everything else:
   namespace, with the server image, credentials Secret, bucket, region, and
   endpoint of the tiers it gates, running `ravel store qualify`. The
   gateway, query, and maintain Deployments are created only once that Job
-  reports `Complete`. `restartPolicy: Never`, a small `backoffLimit`, and a
-  `ttlSecondsAfterFinished` keep a finished Job from accumulating.
+  reports `Complete`. `restartPolicy: Never`, a small `backoffLimit`, an
+  `activeDeadlineSeconds`, and a `ttlSecondsAfterFinished` keep a finished
+  Job from accumulating.
+- The Job sets `activeDeadlineSeconds` because `backoffLimit` bounds only how
+  many *failed* attempts run, not one attempt that never terminates: a
+  qualify pod against an S3 endpoint that accepts the connection and then
+  never answers would otherwise run indefinitely, leaving `StoreQualified`
+  stuck at `Pending` with no Deployment ever created. The deadline is 900 s,
+  derived from what `ravel store qualify` does: it runs 28 sequential object
+  operations (create-if-absent probe 3, CAS-version probe 4, read-after-write
+  probe 10 = 5 cycles of put+get, list-after-write probe 10 = 5 cycles of
+  put+list, and the final `sys/qualification` write 1; the two informational
+  probes issue no request through the object-store contract). Each operation's
+  per-request ceiling is the S3 client's 20 s `request_timeout`, so a
+  slow-but-healthy run whose every operation nears that ceiling without
+  retrying is bounded by 28 * 20 s = 560 s. 900 s adds a ~1.6x margin (340 s)
+  for pod scheduling, image pull, and the odd single retry, while staying far
+  below a hung endpoint's ~200 s-per-operation worst case (`retry_timeout`
+  180 s + `request_timeout` 20 s), so a hang trips the deadline after roughly
+  four stalled operations. The deadline is a tuning knob, deliberately not
+  part of the qualified-input hash: changing it must not re-run a
+  qualification that already passed.
 - A new `StoreQualified` status condition carries the gate's state with the
   same shape as the other conditions (reasons `Pending` while the Job is
-  created or running, `Succeeded` once it completes, `Failed` when it
-  exhausts its `backoffLimit`, the last carrying the Job's terminal
-  message). On `Failed` no Deployment is created and the pass requeues on
-  the existing failure backoff rather than spinning.
+  created or running, `Succeeded` once it completes, `Failed` when it fails,
+  the last carrying the Job's terminal reason and message). A Job that fails
+  by exhausting its `backoffLimit` and one the Job controller fails for
+  exceeding `activeDeadlineSeconds` (reason `DeadlineExceeded`) both read as
+  `Failed`, with the reason named in the message so an operator sees why. On
+  `Failed` no Deployment is created and the pass requeues on the existing
+  failure backoff rather than spinning.
 - The inputs qualification proves against (bucket, region, endpoint, image,
   credentials Secret name) are hashed into a Job annotation and, on success,
   into a durable `status.storeQualifiedHash`. A later pass whose inputs

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -391,6 +391,26 @@ unit tests; the runtime behavior (the Job actually completing and the
 Deployments appearing only after) is left to the k8s CI lane (decision 8),
 unproven until that lane runs.
 
+**Amendment (2026-09-08): the gate no longer re-triggers itself.** Two
+refinements stop the qualification hold from spinning. First, the primary
+`RavelCluster` watch drops status-only updates: its trigger stream runs through
+a generation predicate (`predicates::generation`), so an event passes only when
+`.metadata.generation` changed. Every reconcile rewrites `.status`, and without
+the filter each write re-enqueued the object before its requeue delay elapsed,
+so a terminally `Failed` qualify Job (which the controller does not watch) was
+deleted and recreated in a tight loop. A spec edit bumps the generation and
+still reconciles; a deletion arrives as its own watch event, not a status-only
+apply. Second, status conditions preserve their `lastTransitionTime` across a
+pass that does not change the condition's status value, per the Kubernetes
+convention that the field records the last transition, not the last write, so
+an unchanged condition no longer reads as a change on every pass. The `Failed`
+qualification hold requeues on the failure backoff, not the shorter bootstrap
+poll. The kind lane (scripts/kind-up.sh) reuses clusters and re-applies the dev
+RavelCluster, so it now waits for `StoreQualified=True` at
+`observedGeneration == .metadata.generation` before `Available=True`: a
+re-qualification in flight cannot let the wait return on the previous
+generation's readiness.
+
 ## Rejected alternatives
 
 1. **Go operator (kubebuilder/controller-runtime).** The larger example

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -314,21 +314,27 @@ loop as everything else:
   many *failed* attempts run, not one attempt that never terminates: a
   qualify pod against an S3 endpoint that accepts the connection and then
   never answers would otherwise run indefinitely, leaving `StoreQualified`
-  stuck at `Pending` with no Deployment ever created. The deadline is 900 s,
-  derived from what `ravel store qualify` does: it runs 28 sequential object
+  stuck at `Pending` with no Deployment ever created. This deadline is
+  JOB-WIDE, not per-attempt: Kubernetes counts it against the Job's total
+  active time summed across every retry, and it takes precedence over
+  `backoffLimit`. So the two knobs are sized together, or a slow-but-healthy
+  first attempt plus a retry would trip `DeadlineExceeded` before the retry
+  budget was ever spent. `ravel store qualify` runs 28 sequential object
   operations (create-if-absent probe 3, CAS-version probe 4, read-after-write
   probe 10 = 5 cycles of put+get, list-after-write probe 10 = 5 cycles of
   put+list, and the final `sys/qualification` write 1; the two informational
   probes issue no request through the object-store contract). Each operation's
-  per-request ceiling is the S3 client's 20 s `request_timeout`, so a
-  slow-but-healthy run whose every operation nears that ceiling without
-  retrying is bounded by 28 * 20 s = 560 s. 900 s adds a ~1.6x margin (340 s)
-  for pod scheduling, image pull, and the odd single retry, while staying far
-  below a hung endpoint's ~200 s-per-operation worst case (`retry_timeout`
-  180 s + `request_timeout` 20 s), so a hang trips the deadline after roughly
-  four stalled operations. The deadline is a tuning knob, deliberately not
-  part of the qualified-input hash: changing it must not re-run a
-  qualification that already passed.
+  per-request ceiling is the S3 client's 20 s `request_timeout`, so one
+  slow-but-healthy attempt whose every operation nears that ceiling without
+  retrying is bounded by 28 * 20 s = 560 s; adding ~140 s per attempt for pod
+  scheduling and image pull gives a 700 s per-attempt budget. `backoffLimit`
+  is 1 (two attempts: the initial run plus one retry), so the Job-wide deadline
+  is 2 * 700 s = 1400 s -- a slow-but-healthy initial attempt AND a full retry
+  both complete before it fires. A single hung attempt still terminates, at the
+  1400 s Job-wide bound rather than running forever (a hung endpoint stalls each
+  operation at ~200 s = `retry_timeout` 180 s + `request_timeout` 20 s). Both
+  knobs are tuning parameters, deliberately not part of the qualified-input
+  hash: changing either must not re-run a qualification that already passed.
 - A new `StoreQualified` status condition carries the gate's state with the
   same shape as the other conditions (reasons `Pending` while the Job is
   created or running, `Succeeded` once it completes, `Failed` when it fails,
@@ -339,14 +345,29 @@ loop as everything else:
   `Failed` no Deployment is created and the pass requeues on the existing
   failure backoff rather than spinning.
 - The inputs qualification proves against (bucket, region, endpoint, image,
-  credentials Secret name) are hashed into a Job annotation and, on success,
-  into a durable `status.storeQualifiedHash`. A later pass whose inputs
-  still hash to the recorded value proceeds without re-running qualification
-  even after the Job's TTL garbage-collected it. When the inputs change, the
-  operator deletes the stale Job (its pod template is immutable), recreates
-  it, and flips `StoreQualified` back to `Pending`; a cluster that was
-  already serving keeps its existing Deployments up while the new inputs
+  credentials Secret name, and that credentials Secret's `resourceVersion`)
+  are hashed into a Job annotation and, on success, into a durable
+  `status.storeQualifiedHash`. A later pass whose inputs still hash to the
+  recorded value proceeds without re-running qualification even after the
+  Job's TTL garbage-collected it. When the inputs change, the operator
+  deletes the stale Job with foreground propagation (its pod template is
+  immutable, and foreground propagation tears down the old Pod before the Job
+  object disappears so the replacement never races a live stale Pod),
+  recreates it, and flips `StoreQualified` back to `Pending`; a cluster that
+  was already serving keeps its existing Deployments up while the new inputs
   qualify, rather than being torn down for a pending config edit.
+  - The credentials `resourceVersion` is what makes a fixed-name credential
+    ROTATION re-qualify: rotating the Secret in place keeps its name but bumps
+    its `resourceVersion`, so without it a rotation to credentials that no
+    longer pass the contract would skip qualification once the prior Job had
+    been TTL-collected. Only the `resourceVersion` (opaque API metadata) enters
+    the hash, never any Secret data, and it reaches neither the status nor a
+    log line. The operator does not watch Secrets (the per-namespace
+    `ravel-operator-secrets` RoleBinding grants `get` only, not `watch`), so a
+    rotation is noticed on the next periodic requeue (the controller's 300 s
+    resync): that pass reads the new `resourceVersion`, the hash changes, and
+    the gate recreates the Job. The bound on noticing an in-place rotation is
+    therefore one resync interval.
 - Non-goal: qualification is not re-run on a schedule. It runs once per
   distinct set of inputs and only re-runs when those inputs change. A
   periodic re-qualification would add object-store traffic and a recurring
@@ -357,7 +378,14 @@ Because the operator now qualifies, the kind lane's hand-run qualification
 Job is removed from scripts/kind-up.sh: it deploys through the operator, so
 the operator's Job is the single qualification and a second one would only
 duplicate it. The RBAC in deploy/k8s/operator/rbac.yaml gains a `batch`
-`jobs` rule (full lifecycle) for the Job the operator now owns. The gate
+`jobs` rule for the Job the operator now owns, scoped to the verbs the
+reconcile loop calls: `create`/`patch` (server-side apply), `get` (observe the
+Job's terminal state), and `delete` (foreground recreate on an input change).
+It is not watched by an informer, so it takes no `list`/`watch`, and every
+write is a PATCH, so it takes no `update`. That same audit -- server-side apply
+is a PATCH, not a PUT, and a resource the operator only applies and sweeps is
+never read -- removed the unused `update` verb from every rule and the unused
+read verbs from the write-only resources. The gate
 decision and the Job renderer are pure functions in `reconcile.rs` with
 unit tests; the runtime behavior (the Job actually completing and the
 Deployments appearing only after) is left to the k8s CI lane (decision 8),

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -421,15 +421,21 @@ failure backoff, saw it Absent, and recreated it, forever: the Job's own
 `backoffLimit` and `activeDeadlineSeconds` bound attempts within one Job, never
 the number of Jobs. The gate now recreates on a capped exponential backoff (base
 30 s doubling to a 480 s ceiling over the first five failures) and, after 6
-consecutive failures, holds in a one-hour terminal cooldown. The failure count
-and the next-retry instant are persisted in status (`status.qualifyFailureCount`,
-`status.qualifyNextRetryTime`); both are serialized even when absent so a status
-merge patch clears them, and neither enters the qualified-input hash, so counting
-failures never re-runs a qualification that would otherwise pass. The `Failed`
-Job is kept in place during the backoff as the record of which inputs are
-failing, so an input change during a long cooldown reads as a stale Job
-(`recreate`), resets the count, and recreates at once rather than waiting the
-cooldown out. The count resets on a successful qualification. The
+consecutive failures, holds in a one-hour terminal cooldown. The failure count,
+the next-retry instant, and the qualified-input hash the failures were recorded
+against are persisted in status (`status.qualifyFailureCount`,
+`status.qualifyNextRetryTime`, `status.qualifyRetryHash`); all three are
+serialized even when absent so a status merge patch clears them, and none enters
+the qualified-input hash, so counting failures never re-runs a qualification that
+would otherwise pass. The retry state is keyed by that recorded hash: whenever the
+desired inputs no longer hash to it the operator drops the count and the
+next-retry and qualifies the new inputs at once, whether or not the `Failed` Job
+still exists. This is what makes an input change during a long cooldown reset and
+recreate at once rather than waiting the cooldown out, even after the `Failed`
+Job's TTL garbage-collected it (once the Job is gone, both a changed and an
+unchanged pass observe it absent, so only the recorded hash distinguishes them);
+the terminal cooldown is kept only while the hashes match. The count resets on a
+successful qualification. The
 `StoreQualified=False` condition names the consecutive-failure count and the next
 retry time. This supersedes the earlier "requeues on the existing failure backoff
 rather than spinning" note: the requeue is now the computed backoff, and past the

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -293,7 +293,7 @@ an OTLP round trip, not that a missing capability is rejected.
 serves (issue #36).** Every `ravel-server` mode refuses to start on a
 non-Memory store whose `sys/qualification` marker is absent (ADR-0050
 section 6, EC7), and that marker is only ever written by an explicit
-`ravel store qualify` run. The operator described in decision 3 never made
+`ravel-cli store qualify` run. The operator described in decision 3 never made
 that run, so a RavelCluster pointed at a backend that fails the object-store
 contract (docs/object-store-contract.md) came up as three tiers of pods all
 crash-looping on the same startup refusal, with the reason buried in pod
@@ -305,7 +305,7 @@ loop as everything else:
 - Before it creates any serving Deployment, the reconcile loop renders and
   applies a one-shot Job named `<cluster>-qualify` in the cluster's
   namespace, with the server image, credentials Secret, bucket, region, and
-  endpoint of the tiers it gates, running `ravel store qualify`. The
+  endpoint of the tiers it gates, running `ravel-cli store qualify`. The
   gateway, query, and maintain Deployments are created only once that Job
   reports `Complete`. `restartPolicy: Never`, a small `backoffLimit`, an
   `activeDeadlineSeconds`, and a `ttlSecondsAfterFinished` keep a finished
@@ -319,7 +319,7 @@ loop as everything else:
   active time summed across every retry, and it takes precedence over
   `backoffLimit`. So the two knobs are sized together, or a slow-but-healthy
   first attempt plus a retry would trip `DeadlineExceeded` before the retry
-  budget was ever spent. `ravel store qualify` runs 28 sequential object
+  budget was ever spent. `ravel-cli store qualify` runs 28 sequential object
   operations (create-if-absent probe 3, CAS-version probe 4, read-after-write
   probe 10 = 5 cycles of put+get, list-after-write probe 10 = 5 cycles of
   put+list, and the final `sys/qualification` write 1; the two informational
@@ -410,6 +410,41 @@ RavelCluster, so it now waits for `StoreQualified=True` at
 `observedGeneration == .metadata.generation` before `Available=True`: a
 re-qualification in flight cannot let the wait return on the previous
 generation's readiness.
+
+**Amendment (2026-09-08): qualify-Job recreations are bounded, and the Secret
+change-detection checksum moved to blake3.** Two follow-ups from review of the
+qualification gate.
+
+First, a store that keeps failing qualification no longer recreates its Job
+without bound. The prior behavior deleted a `Failed` Job, requeued on the
+failure backoff, saw it Absent, and recreated it, forever: the Job's own
+`backoffLimit` and `activeDeadlineSeconds` bound attempts within one Job, never
+the number of Jobs. The gate now recreates on a capped exponential backoff (base
+30 s doubling to a 480 s ceiling over the first five failures) and, after 6
+consecutive failures, holds in a one-hour terminal cooldown. The failure count
+and the next-retry instant are persisted in status (`status.qualifyFailureCount`,
+`status.qualifyNextRetryTime`); both are serialized even when absent so a status
+merge patch clears them, and neither enters the qualified-input hash, so counting
+failures never re-runs a qualification that would otherwise pass. The `Failed`
+Job is kept in place during the backoff as the record of which inputs are
+failing, so an input change during a long cooldown reads as a stale Job
+(`recreate`), resets the count, and recreates at once rather than waiting the
+cooldown out. The count resets on a successful qualification. The
+`StoreQualified=False` condition names the consecutive-failure count and the next
+retry time. This supersedes the earlier "requeues on the existing failure backoff
+rather than spinning" note: the requeue is now the computed backoff, and past the
+threshold the gate holds instead of recreating.
+
+Second, the operator's Secret change-detection checksum
+(`SECRETS_CHECKSUM_ANNOTATION`, and the qualified-input hash) is now a `blake3`
+digest rendered as 64 hex characters, replacing a 16-character standard-hasher
+value that was not stable across Rust toolchain versions. An unstable hash could
+silently miss a Secret change (or spuriously roll on a toolchain bump). Because
+the annotation value itself changes, the first reconcile after upgrading the
+operator rolls every rendered gateway, query, and enabled maintain Deployment
+once even when the referenced Secrets are unchanged; subsequent reconciles are
+stable. Operators should schedule the operator upgrade in a maintenance window
+that tolerates one rolling restart of each serving tier.
 
 ## Rejected alternatives
 

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -289,6 +289,57 @@ runtime; nothing rejects the pod for the dropped capability. What the kind
 lane actually proves is that the hardened pods reach readiness and complete
 an OTLP round trip, not that a missing capability is rejected.
 
+**Amendment (2026-09-07): the operator qualifies the object store before it
+serves (issue #36).** Every `ravel-server` mode refuses to start on a
+non-Memory store whose `sys/qualification` marker is absent (ADR-0050
+section 6, EC7), and that marker is only ever written by an explicit
+`ravel store qualify` run. The operator described in decision 3 never made
+that run, so a RavelCluster pointed at a backend that fails the object-store
+contract (docs/object-store-contract.md) came up as three tiers of pods all
+crash-looping on the same startup refusal, with the reason buried in pod
+logs rather than on `.status`. The kind lane papered over this with a
+hand-run qualification Job (scripts/kind-up.sh) that a real install had no
+equivalent of. Qualification is now the operator's job, in the same reconcile
+loop as everything else:
+
+- Before it creates any serving Deployment, the reconcile loop renders and
+  applies a one-shot Job named `<cluster>-qualify` in the cluster's
+  namespace, with the server image, credentials Secret, bucket, region, and
+  endpoint of the tiers it gates, running `ravel store qualify`. The
+  gateway, query, and maintain Deployments are created only once that Job
+  reports `Complete`. `restartPolicy: Never`, a small `backoffLimit`, and a
+  `ttlSecondsAfterFinished` keep a finished Job from accumulating.
+- A new `StoreQualified` status condition carries the gate's state with the
+  same shape as the other conditions (reasons `Pending` while the Job is
+  created or running, `Succeeded` once it completes, `Failed` when it
+  exhausts its `backoffLimit`, the last carrying the Job's terminal
+  message). On `Failed` no Deployment is created and the pass requeues on
+  the existing failure backoff rather than spinning.
+- The inputs qualification proves against (bucket, region, endpoint, image,
+  credentials Secret name) are hashed into a Job annotation and, on success,
+  into a durable `status.storeQualifiedHash`. A later pass whose inputs
+  still hash to the recorded value proceeds without re-running qualification
+  even after the Job's TTL garbage-collected it. When the inputs change, the
+  operator deletes the stale Job (its pod template is immutable), recreates
+  it, and flips `StoreQualified` back to `Pending`; a cluster that was
+  already serving keeps its existing Deployments up while the new inputs
+  qualify, rather than being torn down for a pending config edit.
+- Non-goal: qualification is not re-run on a schedule. It runs once per
+  distinct set of inputs and only re-runs when those inputs change. A
+  periodic re-qualification would add object-store traffic and a recurring
+  failure mode for no gain, since the contract a backend satisfies does not
+  lapse between config edits.
+
+Because the operator now qualifies, the kind lane's hand-run qualification
+Job is removed from scripts/kind-up.sh: it deploys through the operator, so
+the operator's Job is the single qualification and a second one would only
+duplicate it. The RBAC in deploy/k8s/operator/rbac.yaml gains a `batch`
+`jobs` rule (full lifecycle) for the Job the operator now owns. The gate
+decision and the Job renderer are pure functions in `reconcile.rs` with
+unit tests; the runtime behavior (the Job actually completing and the
+Deployments appearing only after) is left to the k8s CI lane (decision 8),
+unproven until that lane runs.
+
 ## Rejected alternatives
 
 1. **Go operator (kubebuilder/controller-runtime).** The larger example

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,7 +198,7 @@ server starts, which proves the backend honours the semantics the commit
 protocol depends on before any data rides on them. On Kubernetes the
 operator makes that run itself: before it creates any serving Deployment for
 a `RavelCluster`, it applies a one-shot `<cluster>-qualify` Job running
-`ravel store qualify` against that cluster's bucket and gates the gateway,
+`ravel-cli store qualify` against that cluster's bucket and gates the gateway,
 query, and maintain Deployments on the Job completing, so a cluster never
 comes up as three tiers crash-looping on a backend that fails the contract.
 It records the qualified inputs (bucket, region, endpoint, image, the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,11 +201,14 @@ a `RavelCluster`, it applies a one-shot `<cluster>-qualify` Job running
 `ravel store qualify` against that cluster's bucket and gates the gateway,
 query, and maintain Deployments on the Job completing, so a cluster never
 comes up as three tiers crash-looping on a backend that fails the contract.
-It records the qualified inputs (bucket, region, endpoint, image,
-credentials Secret) in a `StoreQualified` status condition and a durable
-`status.storeQualifiedHash`, re-runs qualification only when those inputs
-change (never on a schedule), and leaves a running cluster's Deployments up
-while re-qualifying (ADR-0034). The capability table, the
+It records the qualified inputs (bucket, region, endpoint, image, the
+credentials Secret name, and that Secret's `resourceVersion`) in a
+`StoreQualified` status condition and a durable `status.storeQualifiedHash`,
+re-runs qualification only when those inputs change (never on a schedule), and
+leaves a running cluster's Deployments up while re-qualifying (ADR-0034).
+Because the credentials Secret's `resourceVersion` is one of those inputs,
+rotating that Secret in place (same name, new content, bumped
+`resourceVersion`) is a changed input and re-runs qualification. The capability table, the
 qualification suite, and the retry and timeout contract are in
 [docs/object-store-contract.md](object-store-contract.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,7 +195,17 @@ encryption headers.
 Startup on any non-memory store is also gated on a durable qualification
 record: a deployment runs `ravel-cli store qualify` once before its first
 server starts, which proves the backend honours the semantics the commit
-protocol depends on before any data rides on them. The capability table, the
+protocol depends on before any data rides on them. On Kubernetes the
+operator makes that run itself: before it creates any serving Deployment for
+a `RavelCluster`, it applies a one-shot `<cluster>-qualify` Job running
+`ravel store qualify` against that cluster's bucket and gates the gateway,
+query, and maintain Deployments on the Job completing, so a cluster never
+comes up as three tiers crash-looping on a backend that fails the contract.
+It records the qualified inputs (bucket, region, endpoint, image,
+credentials Secret) in a `StoreQualified` status condition and a durable
+`status.storeQualifiedHash`, re-runs qualification only when those inputs
+change (never on a schedule), and leaves a running cluster's Deployments up
+while re-qualifying (ADR-0034). The capability table, the
 qualification suite, and the retry and timeout contract are in
 [docs/object-store-contract.md](object-store-contract.md).
 

--- a/scripts/kind-up.sh
+++ b/scripts/kind-up.sh
@@ -194,62 +194,11 @@ if ! kubectl wait --namespace "$NAMESPACE" --for=condition=Complete --timeout=30
 fi
 log "bucket ${BUCKET} ready on ${S3_ENDPOINT}"
 
-# ---- 4b. store qualification --------------------------------------------
-# ADR-0050 section 6 (EC7): server startup on a non-Memory store
-# refuses unless `sys/qualification` is already present. Unlike the tenancy
-# marker and gc-config objects, there is deliberately no bootstrap-and-continue
-# path for this one -- it is only ever written by an explicit `ravel-cli store
-# qualify` run, so this script has to be that run, or every gateway/query/
-# maintain pod the RavelCluster below creates crash-loops on a fresh bucket
-# (the exact EC3/#566 startup-refusal shape, this time for qualification).
-# Runs as a one-shot Job using the server image already loaded into the
-# cluster (it ships ravel-cli alongside ravel-server, see the Dockerfile),
-# against the same bucket/credentials the RavelCluster will use.
-log "running store qualification (ravel-cli store qualify) against ${S3_ENDPOINT}"
-kubectl delete job ravel-store-qualify --namespace "$NAMESPACE" \
-  --ignore-not-found --wait=true >/dev/null
-kubectl apply -f - <<YAML
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ravel-store-qualify
-  namespace: ${NAMESPACE}
-spec:
-  backoffLimit: 2
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: qualify
-          image: ${SERVER_IMAGE}
-          imagePullPolicy: IfNotPresent
-          command: ["/usr/local/bin/ravel-cli"]
-          args: ["--store", "s3", "store", "qualify"]
-          env:
-            - name: RAVEL_S3_ENDPOINT
-              value: "${S3_ENDPOINT}"
-            - name: RAVEL_S3_BUCKET
-              value: "${BUCKET}"
-            - name: RAVEL_S3_REGION
-              value: "us-east-1"
-            - name: RAVEL_S3_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ${S3_CREDENTIALS_SECRET}
-                  key: accessKeyId
-            - name: RAVEL_S3_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ${S3_CREDENTIALS_SECRET}
-                  key: secretAccessKey
-YAML
-if ! kubectl wait --namespace "$NAMESPACE" --for=condition=Complete --timeout=120s \
-  job/ravel-store-qualify; then
-  kubectl logs --namespace "$NAMESPACE" job/ravel-store-qualify 2>&1 |
-    sed 's/^/[qualify-job] /' >&2 || true
-  die "store qualification job did not complete"
-fi
-log "store qualified"
+# Store qualification is no longer a step here: the operator runs its own
+# one-shot `<cluster>-qualify` Job before it creates any serving Deployment and
+# gates them on its success (issue #36, ADR-0034), so this script installing the
+# operator (step 5) and applying the RavelCluster (step 6) is enough to qualify
+# the bucket exactly once. A hand-run Job here would only duplicate it.
 
 # ---- 5. operator -------------------------------------------------------------
 # CRD before the operator Deployment: the operator's watch fails until the

--- a/scripts/kind-up.sh
+++ b/scripts/kind-up.sh
@@ -82,14 +82,22 @@ die() {
 wait_cluster_condition() {
   local ctype="$1" want="$2" timeout="$3" desc="$4"
   local deadline=$(( SECONDS + timeout ))
-  local gen obsgen cstatus
+  local snap rest gen obsgen cstatus
   while (( SECONDS < deadline )); do
-    gen="$(kubectl get --namespace "$NAMESPACE" "ravelcluster/${CLUSTER_CR}" \
-      -o jsonpath='{.metadata.generation}' 2>/dev/null || true)"
-    cstatus="$(kubectl get --namespace "$NAMESPACE" "ravelcluster/${CLUSTER_CR}" \
-      -o jsonpath="{.status.conditions[?(@.type==\"${ctype}\")].status}" 2>/dev/null || true)"
-    obsgen="$(kubectl get --namespace "$NAMESPACE" "ravelcluster/${CLUSTER_CR}" \
-      -o jsonpath="{.status.conditions[?(@.type==\"${ctype}\")].observedGeneration}" 2>/dev/null || true)"
+    # One GET per iteration: read .metadata.generation, the condition status, and
+    # its observedGeneration from a SINGLE object snapshot. Reading them in three
+    # separate kubectl calls let a spec change land between reads, matching an old
+    # condition against an old generation and returning success early. A single
+    # jsonpath template applied to one fetched object is an atomic read of all
+    # three, joined by a literal '|' none of the values can contain (an integer,
+    # a True/False/Unknown status, an integer).
+    snap="$(kubectl get --namespace "$NAMESPACE" "ravelcluster/${CLUSTER_CR}" \
+      -o jsonpath="{.metadata.generation}|{.status.conditions[?(@.type==\"${ctype}\")].status}|{.status.conditions[?(@.type==\"${ctype}\")].observedGeneration}" \
+      2>/dev/null || true)"
+    gen="${snap%%|*}"
+    rest="${snap#*|}"
+    cstatus="${rest%%|*}"
+    obsgen="${rest##*|}"
     if [[ -n "$gen" && "$cstatus" == "$want" && "$obsgen" == "$gen" ]]; then
       return 0
     fi

--- a/scripts/kind-up.sh
+++ b/scripts/kind-up.sh
@@ -70,6 +70,34 @@ die() {
   exit 1
 }
 
+# Wait until a RavelCluster status condition reaches a target status AND its
+# observedGeneration has caught up to .metadata.generation, i.e. the condition
+# reflects the currently applied spec rather than a prior one. The lane reuses
+# clusters and re-applies the dev RavelCluster (step 6), so a re-qualification
+# can be in flight while the operator still reports the previous generation's
+# Available=True; a bare `kubectl wait --for=condition=Available` would then
+# return before the new qualification and Deployment rollout finish. Bounded by
+# an explicit timeout so a stuck condition fails with a clear message instead of
+# hanging. Args: condition type, target status, timeout seconds, description.
+wait_cluster_condition() {
+  local ctype="$1" want="$2" timeout="$3" desc="$4"
+  local deadline=$(( SECONDS + timeout ))
+  local gen obsgen cstatus
+  while (( SECONDS < deadline )); do
+    gen="$(kubectl get --namespace "$NAMESPACE" "ravelcluster/${CLUSTER_CR}" \
+      -o jsonpath='{.metadata.generation}' 2>/dev/null || true)"
+    cstatus="$(kubectl get --namespace "$NAMESPACE" "ravelcluster/${CLUSTER_CR}" \
+      -o jsonpath="{.status.conditions[?(@.type==\"${ctype}\")].status}" 2>/dev/null || true)"
+    obsgen="$(kubectl get --namespace "$NAMESPACE" "ravelcluster/${CLUSTER_CR}" \
+      -o jsonpath="{.status.conditions[?(@.type==\"${ctype}\")].observedGeneration}" 2>/dev/null || true)"
+    if [[ -n "$gen" && "$cstatus" == "$want" && "$obsgen" == "$gen" ]]; then
+      return 0
+    fi
+    sleep 3
+  done
+  die "timed out after ${timeout}s waiting for ${desc}: ${ctype}=${want} at generation ${gen:-?} (observed ${ctype}=${cstatus:-<none>} at generation ${obsgen:-<none>})"
+}
+
 # On any failure after the cluster exists, dump what a human would ask for
 # first. Without this the script's last line is a bare `kubectl wait` timeout,
 # which says nothing about why a pod never went ready.
@@ -254,12 +282,19 @@ spec:
 YAML
 
 # ---- 7. readiness ------------------------------------------------------------
-# The operator sets Available=True only when both the gateway and the query
-# Deployment report ready replicas, so this waits on real pods passing /readyz
-# against the real backend, not on objects existing.
-log "waiting for RavelCluster ${CLUSTER_CR} to report Available"
-kubectl wait --namespace "$NAMESPACE" --for=condition=Available --timeout=300s \
-  "ravelcluster/${CLUSTER_CR}"
+# Two bounded stages, in order, because the lane reuses clusters and re-applies
+# the dev RavelCluster. First StoreQualified=True at the current generation: on
+# a reused cluster the operator re-runs qualification for the new inputs while it
+# keeps the previous generation's Available=True, so gating on Available alone
+# could return before the new qualification (and the Deployment rollout it gates)
+# even starts. Then Available=True at the current generation, which the operator
+# sets only when both the gateway and query Deployments report ready replicas for
+# the applied spec: real pods passing /readyz against the real backend, not
+# objects existing.
+log "waiting for RavelCluster ${CLUSTER_CR} to report StoreQualified for the applied spec"
+wait_cluster_condition StoreQualified True 300 "store qualification to pass"
+log "waiting for RavelCluster ${CLUSTER_CR} to report Available for the applied spec"
+wait_cluster_condition Available True 300 "the gateway and query tiers to become ready"
 
 log "cluster up. Deployments:"
 kubectl get --namespace "$NAMESPACE" deployments

--- a/services/ravel-operator/Cargo.toml
+++ b/services/ravel-operator/Cargo.toml
@@ -45,6 +45,13 @@ ravel-types = { workspace = true }
 # pin; adds no new external crate.
 ravel-object-store = { workspace = true }
 hex = { workspace = true }
+# Stable change-detection hashing for the qualified-input hash and the
+# per-tier secrets checksum (#36 finding 3). std's DefaultHasher is not stable
+# across Rust releases, so a toolchain upgrade would re-run qualification and
+# roll every tier Deployment for unchanged inputs. blake3 is a fixed algorithm,
+# so the hash depends only on the inputs. Already a workspace pin; adds no new
+# external crate.
+blake3 = { workspace = true }
 # rustls 0.23 crypto-provider selection (main.rs). kube's rustls-tls feature
 # below pins `ring`; ravel-object-store pulls `aws-lc-rs` transitively via the
 # workspace's own jsonwebtoken pin (root Cargo.toml: aws_lc_rs, chosen there to

--- a/services/ravel-operator/Cargo.toml
+++ b/services/ravel-operator/Cargo.toml
@@ -11,7 +11,12 @@ path = "src/main.rs"
 
 [dependencies]
 kube = { workspace = true }
-kube-runtime = { workspace = true }
+# unstable-runtime-stream-control gates Controller::for_stream, used in
+# controller::run to feed the primary RavelCluster watch through a
+# predicate_filter that drops status-only updates (generation unchanged). It is
+# a cargo feature only, adds no new external crate, and does not require a
+# RUSTFLAGS cfg.
+kube-runtime = { workspace = true, features = ["unstable-runtime-stream-control"] }
 k8s-openapi = { workspace = true }
 schemars = { workspace = true }
 tokio = { workspace = true }

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -999,6 +999,33 @@ fn degraded_store_qualified_hash(
     proceed_hash.or(persisted)
 }
 
+/// The `extra_conditions` to PATCH onto the degraded status (finding 1).
+/// [`reconcile_inner`] takes `extra_conditions` by clone and pushes
+/// `StoreQualified=True` onto that local copy in the `Proceed` arm, so the
+/// mutation never reaches the outer error path here, and
+/// [`write_degraded_status`] replaces the whole `conditions` array. When a pass
+/// qualified before a later step failed (`qualification_passed`), re-add the
+/// condition so the degraded object still carries `StoreQualified=True` for as
+/// long as that step keeps failing; otherwise a stage-one wait keyed on the
+/// condition burns its full bound instead of failing on the `Degraded` reason.
+/// Reconstructed from the same `proceed_hash` signal the persisted hash reads.
+fn degraded_extra_conditions(
+    mut base: Vec<Condition>,
+    qualification_passed: bool,
+    generation: Option<i64>,
+) -> Vec<Condition> {
+    if qualification_passed {
+        base.push(condition(
+            "StoreQualified",
+            true,
+            generation,
+            STORE_QUALIFIED_SUCCEEDED_REASON,
+            STORE_QUALIFIED_MESSAGE,
+        ));
+    }
+    base
+}
+
 /// Reconcile one `RavelCluster` to its desired Deployments and Services.
 ///
 /// Wraps [`reconcile_inner`] so that any failure before the success-path status
@@ -1051,6 +1078,11 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
             // pass's proof and re-run qualification once the Job's TTL collected
             // it; using it when the pass never qualified is correct.
             let qualification_passed = proceed_hash.is_some();
+            let degraded_conditions = degraded_extra_conditions(
+                extra_conditions,
+                qualification_passed,
+                obj.metadata.generation,
+            );
             let store_qualified_hash = degraded_store_qualified_hash(
                 proceed_hash,
                 obj.status
@@ -1092,7 +1124,7 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                     qualify_next_retry_time,
                     qualify_retry_hash,
                 },
-                extra_conditions,
+                degraded_conditions,
                 obj.status
                     .as_ref()
                     .map(|s| s.conditions.as_slice())
@@ -2979,6 +3011,44 @@ mod tests {
         );
         // Never qualified and nothing persisted: None.
         assert_eq!(degraded_store_qualified_hash(None, None), None);
+    }
+
+    /// The degraded error path re-adds StoreQualified=True when the pass reached
+    /// Proceed before a later step failed (finding 1), exact condition. The
+    /// Proceed arm pushes it onto reconcile_inner's cloned copy, which never
+    /// reaches this writer, and the writer PATCHes the whole conditions array; so
+    /// without the re-add the degraded object drops StoreQualified entirely and a
+    /// stage-one wait keyed on it burns its full bound. When the pass failed
+    /// before the gate (`qualification_passed` false), the base conditions pass
+    /// through untouched and StoreQualified stays absent.
+    #[test]
+    fn degraded_status_keeps_store_qualified_after_a_post_proceed_failure() {
+        let base = vec![condition(
+            "SpecValid",
+            true,
+            Some(7),
+            "Accepted",
+            "spec accepted",
+        )];
+
+        // Reached Proceed, then a later apply failed: StoreQualified=True is
+        // re-added with the exact success reason and message, generation carried.
+        let after = degraded_extra_conditions(base.clone(), true, Some(7));
+        let store_qualified = after
+            .iter()
+            .find(|c| c.r#type == "StoreQualified")
+            .expect("StoreQualified re-added on the degraded write after Proceed");
+        assert_eq!(store_qualified.status, "True");
+        assert_eq!(store_qualified.reason, STORE_QUALIFIED_SUCCEEDED_REASON);
+        assert_eq!(store_qualified.message, STORE_QUALIFIED_MESSAGE);
+        assert_eq!(store_qualified.observed_generation, Some(7));
+        // The base conditions are preserved, not replaced.
+        assert!(after.iter().any(|c| c.r#type == "SpecValid"));
+
+        // Failed before the gate: base passes through, StoreQualified absent.
+        let untouched = degraded_extra_conditions(base.clone(), false, Some(7));
+        assert!(!untouched.iter().any(|c| c.r#type == "StoreQualified"));
+        assert_eq!(untouched.len(), base.len());
     }
 
     /// Finding 3: credential resourceVersions are resolved before the gate and

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -23,7 +23,7 @@ use kube::api::{DeleteParams, Patch, PatchParams};
 use kube::core::DynamicObject;
 use kube::{Api, Client, Resource, ResourceExt};
 use kube_runtime::controller::{Action, Controller};
-use kube_runtime::watcher;
+use kube_runtime::{WatchStreamExt, predicates, reflector, watcher};
 use ravel_object_store::ObjectStoreBackend;
 use ravel_object_store::s3::{S3Config, S3Store};
 use ravel_types::{Signal, TenantHash, TenantHashScheme, TenantId};
@@ -988,12 +988,16 @@ struct QualifyGatePlan {
 
 /// Map a non-Proceed [`QualificationDecision`] to its [`QualifyGatePlan`].
 ///
-/// A Failed Job is deleted and requeued at [`BOOTSTRAP_POLL`], not left to sit
-/// until its TTL (finding 4): the controller does not watch Jobs, so nothing
-/// else recreates it, and a fresh cluster would otherwise have no Deployments
-/// for about an hour after two failed attempts. The `StoreQualified=False`
-/// condition still carries the Job's failure reason and message across that
-/// gap, so the operator's user still sees why qualification did not finish.
+/// A Failed Job is deleted, not left to sit until its TTL: the controller does
+/// not watch Jobs, so nothing else recreates it, and a fresh cluster would
+/// otherwise have no Deployments for about an hour after two failed attempts.
+/// The Failed hold requeues at [`RETRY`], the failure backoff, not
+/// [`BOOTSTRAP_POLL`]. Deleting the Job rewrites `.status`, and the primary
+/// watch drops that status-only write ([`predicates::generation`]), so nothing
+/// re-enqueues the object before the requeue delay; a shorter poll here would
+/// only rebuild-and-refail the Job faster. The `StoreQualified=False` condition
+/// still carries the Job's failure reason and message across the gap, so the
+/// operator's user still sees why qualification did not finish.
 fn qualify_gate_plan(decision: &QualificationDecision, generation: Option<i64>) -> QualifyGatePlan {
     match decision {
         QualificationDecision::Qualify { recreate } => QualifyGatePlan {
@@ -1040,7 +1044,7 @@ fn qualify_gate_plan(decision: &QualificationDecision, generation: Option<i64>) 
                 message,
             ),
             unavailable_reason: (STORE_QUALIFIED_FAILED_REASON, message.clone()),
-            requeue: BOOTSTRAP_POLL,
+            requeue: RETRY,
         },
         QualificationDecision::Proceed => {
             unreachable!("Proceed is handled on the success path, never planned as a hold")
@@ -1131,6 +1135,10 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                     store_qualified_hash,
                 },
                 extra_conditions,
+                obj.status
+                    .as_ref()
+                    .map(|s| s.conditions.as_slice())
+                    .unwrap_or_default(),
             )
             .await
             {
@@ -1278,6 +1286,7 @@ async fn reconcile_inner(
                     store_qualified_hash: qualified_hash,
                 },
                 extra_conditions,
+                prior.map(|s| s.conditions.as_slice()).unwrap_or_default(),
             )
             .await?;
             return Ok(Action::requeue(plan.requeue));
@@ -1687,6 +1696,10 @@ async fn reconcile_inner(
             store_qualified_hash,
         },
         extra_conditions,
+        obj.status
+            .as_ref()
+            .map(|s| s.conditions.as_slice())
+            .unwrap_or_default(),
     )
     .await?;
 
@@ -1855,6 +1868,30 @@ fn condition(
     }
 }
 
+/// Carry each condition's `lastTransitionTime` forward from the previous status
+/// whenever its `status` value is unchanged, per the Kubernetes convention that
+/// the field records the last time the condition transitioned, not the last
+/// time it was written. [`condition`] stamps a fresh timestamp on every pass, so
+/// without this an otherwise-unchanged condition would get a new
+/// `lastTransitionTime` each reconcile; the primary `RavelCluster` watch would
+/// then see every status write as a change and re-enqueue the object before its
+/// requeue delay elapsed, which is what let a terminally Failed qualify Job be
+/// deleted and recreated in a tight loop. A condition whose type is absent from
+/// `previous`, or whose status differs, keeps its freshly stamped time.
+fn preserve_transition_times(
+    mut conditions: Vec<Condition>,
+    previous: &[Condition],
+) -> Vec<Condition> {
+    for c in &mut conditions {
+        if let Some(prev) = previous.iter().find(|p| p.r#type == c.r#type)
+            && prev.status == c.status
+        {
+            c.last_transition_time = prev.last_transition_time.clone();
+        }
+    }
+    conditions
+}
+
 /// Conditions derived from the spec alone, independent of whether this pass
 /// succeeds or fails (ADR-0080 decision 1).
 ///
@@ -2000,8 +2037,9 @@ async fn write_status(
     unavailable_reason: Option<(&str, &str)>,
     persisted: PersistedStatus,
     extra_conditions: Vec<Condition>,
+    previous_conditions: &[Condition],
 ) -> Result<(), Error> {
-    let status = build_status(
+    let mut status = build_status(
         observed_generation,
         gateway_ready,
         query_ready,
@@ -2010,6 +2048,7 @@ async fn write_status(
         persisted,
         extra_conditions,
     );
+    status.conditions = preserve_transition_times(status.conditions, previous_conditions);
     patch_status(client, namespace, instance, &status).await
 }
 
@@ -2030,14 +2069,16 @@ async fn write_degraded_status(
     message: &str,
     persisted: PersistedStatus,
     extra_conditions: Vec<Condition>,
+    previous_conditions: &[Condition],
 ) -> Result<(), Error> {
-    let status = build_degraded_status(
+    let mut status = build_degraded_status(
         observed_generation,
         reason,
         message,
         persisted,
         extra_conditions,
     );
+    status.conditions = preserve_transition_times(status.conditions, previous_conditions);
     patch_status(client, namespace, instance, &status).await
 }
 
@@ -2308,8 +2349,25 @@ pub async fn run() -> Result<(), Error> {
     // this operator manages.
     let managed = watcher::Config::default().labels("app.kubernetes.io/managed-by=ravel-operator");
 
+    // Drop status-only updates on the primary `RavelCluster` watch. Every
+    // reconcile pass rewrites `.status`; without this filter each write
+    // re-enqueues the object immediately, before the pass's requeue delay, so a
+    // terminally Failed qualify Job (which the controller does not watch) would
+    // be deleted and recreated in a tight loop. `predicates::generation` passes
+    // an event only when `metadata.generation` changed: a spec edit bumps it, a
+    // status-only write does not. Deletions arrive as separate watch events, not
+    // status-only applies, so they flow through unaffected (as they do with
+    // `Controller::new`, which also drives the primary off `applied_objects`).
+    // The reflector store feeds the same owner lookups `.owns()` needs.
+    let (reader, writer) = reflector::store();
+    let cluster_events = watcher(clusters, watcher::Config::default())
+        .default_backoff()
+        .reflect(writer)
+        .applied_objects()
+        .predicate_filter(predicates::generation, Default::default());
+
     info!("starting ravel-operator controller");
-    Controller::new(clusters, watcher::Config::default())
+    Controller::for_stream(cluster_events, reader)
         .owns(deployments, managed.clone())
         .owns(services, managed.clone())
         .owns(ingresses, managed)
@@ -2859,20 +2917,21 @@ mod tests {
         assert_eq!(available.reason, "MinimumReplicasAvailable");
     }
 
-    /// A Failed qualify Job is not left to sit until its TTL (finding 4): the
-    /// gate plan deletes it (foreground, via [`QualifyJobAction::DeleteStale`])
-    /// and requeues at [`BOOTSTRAP_POLL`], so the next pass observes it Absent
-    /// and creates a fresh Job, rather than the earlier RETRY-only requeue that
-    /// left a fresh cluster without Deployments until the TTL fired. The
-    /// `StoreQualified=False` condition still carries the Job's failure reason
-    /// and message across that gap.
+    /// A Failed qualify Job is deleted (foreground, via
+    /// [`QualifyJobAction::DeleteStale`]) so the next pass observes it Absent and
+    /// creates a fresh Job, and the hold requeues at [`RETRY`], the failure
+    /// backoff, not [`BOOTSTRAP_POLL`]: the primary watch drops the status-only
+    /// write that the delete produces, so nothing re-enqueues the object before
+    /// the delay, and a shorter poll would only rebuild-and-refail the Job
+    /// faster. The `StoreQualified=False` condition still carries the Job's
+    /// failure reason and message across that gap.
     #[test]
-    fn failed_qualification_deletes_the_job_and_requeues_soon() {
+    fn failed_qualification_deletes_the_job_and_requeues_on_retry() {
         let message = "backend rejected CAS".to_string();
         let plan = qualify_gate_plan(&QualificationDecision::Failed(message.clone()), Some(7));
         assert_eq!(plan.job_action, QualifyJobAction::DeleteStale);
-        assert_eq!(plan.requeue, BOOTSTRAP_POLL);
-        assert_ne!(plan.requeue, RETRY);
+        assert_eq!(plan.requeue, RETRY);
+        assert_ne!(plan.requeue, BOOTSTRAP_POLL);
         assert_eq!(plan.store_qualified_condition.status, "False");
         assert_eq!(
             plan.store_qualified_condition.reason,
@@ -2885,9 +2944,11 @@ mod tests {
         );
     }
 
-    /// The gate plan maps each non-Proceed decision to its Job action, and every
-    /// hold requeues at [`BOOTSTRAP_POLL`] (finding 4): an absent Job is created,
-    /// a stale or Failed Job is deleted, a running Job is left untouched.
+    /// The gate plan maps each non-Proceed decision to its Job action: an absent
+    /// Job is created, a stale or Failed Job is deleted, a running Job is left
+    /// untouched. A precondition hold (Create/Recreate/Waiting) requeues at
+    /// [`BOOTSTRAP_POLL`]; a Failed hold requeues at [`RETRY`], the failure
+    /// backoff.
     #[test]
     fn gate_plan_maps_each_hold_to_its_job_action() {
         assert_eq!(
@@ -2906,7 +2967,6 @@ mod tests {
             QualificationDecision::Qualify { recreate: false },
             QualificationDecision::Qualify { recreate: true },
             QualificationDecision::Waiting,
-            QualificationDecision::Failed("m".to_string()),
         ] {
             assert_eq!(
                 qualify_gate_plan(&decision, None).requeue,
@@ -2914,6 +2974,11 @@ mod tests {
                 "{decision:?} requeues at BOOTSTRAP_POLL"
             );
         }
+        assert_eq!(
+            qualify_gate_plan(&QualificationDecision::Failed("m".to_string()), None).requeue,
+            RETRY,
+            "Failed requeues at RETRY"
+        );
     }
 
     /// The degraded error path persists the FRESH qualified-input hash when the
@@ -3603,6 +3668,151 @@ mod tests {
 
         assert_eq!(secret_value(&secret, "key"), Some(b"from-data".to_vec()));
         assert_eq!(secret_value(&secret, "missing"), None);
+    }
+
+    /// A `RavelCluster` with a fixed identity (name/namespace/uid) and a chosen
+    /// generation, for the primary-watch predicate test. The status carries a
+    /// distinctive `lastTransitionTime` so two events at the same generation but
+    /// different status can be built.
+    fn cluster_event(generation: i64, transition_time: &str) -> RavelCluster {
+        let mut rc = RavelCluster::new("primary", spec_with_affinity(None));
+        rc.metadata.namespace = Some("ns".to_string());
+        rc.metadata.uid = Some("uid-1".to_string());
+        rc.metadata.generation = Some(generation);
+        rc.status = Some(RavelClusterStatus {
+            observed_generation: Some(generation),
+            conditions: vec![Condition {
+                r#type: "Available".to_string(),
+                status: "False".to_string(),
+                observed_generation: Some(generation),
+                last_transition_time: Some(transition_time.to_string()),
+                reason: "Pending".to_string(),
+                message: "waiting".to_string(),
+            }],
+            ..RavelClusterStatus::default()
+        });
+        rc
+    }
+
+    /// The primary-watch predicate ([`predicates::generation`], as wired in
+    /// [`run`]) drops a status-only event -- same `metadata.generation`, same
+    /// spec, only `.status` changed -- and keeps an event whose generation moved
+    /// (which a spec edit bumps). Without this filter each status write the
+    /// operator makes re-enqueues the object immediately, before the requeue
+    /// delay, so a Failed qualify Job cycles delete/recreate in a tight loop.
+    #[tokio::test]
+    async fn generation_predicate_drops_status_only_events() {
+        use futures::stream;
+
+        let events: Vec<Result<RavelCluster, watcher::Error>> = vec![
+            // First apply at generation 1: passes (never seen before).
+            Ok(cluster_event(1, "2000-01-01T00:00:00Z")),
+            // Status-only rewrite at the same generation: dropped.
+            Ok(cluster_event(1, "2001-01-01T00:00:00Z")),
+            // Spec edit bumps the generation to 2: passes.
+            Ok(cluster_event(2, "2002-01-01T00:00:00Z")),
+        ];
+
+        let passed: Vec<i64> = stream::iter(events)
+            .predicate_filter(predicates::generation, Default::default())
+            .filter_map(|r| async move { r.ok() })
+            .map(|rc| rc.metadata.generation.expect("generation set"))
+            .collect()
+            .await;
+
+        assert_eq!(
+            passed,
+            vec![1, 2],
+            "the status-only event at generation 1 must be dropped and the \
+             generation-2 event kept"
+        );
+    }
+
+    /// A repeated pass with identical inputs leaves each condition's
+    /// `lastTransitionTime` untouched: [`preserve_transition_times`] carries it
+    /// forward from the previous status whenever the `status` value is unchanged,
+    /// so a Failed hold rewritten pass after pass does not stamp a new timestamp
+    /// (which is what the primary watch would otherwise see as a change).
+    #[test]
+    fn repeated_failed_pass_keeps_last_transition_time() {
+        let message = "backend rejected CAS".to_string();
+        let plan = qualify_gate_plan(&QualificationDecision::Failed(message.clone()), Some(7));
+        // The Failed hold's status: Available=False plus StoreQualified=False,
+        // exactly as `reconcile_inner` assembles it.
+        let built = build_status(
+            None,
+            None,
+            None,
+            None,
+            Some((
+                plan.unavailable_reason.0,
+                plan.unavailable_reason.1.as_str(),
+            )),
+            PersistedStatus::default(),
+            vec![plan.store_qualified_condition.clone()],
+        );
+
+        // The previous status: the same conditions with a fixed, distinctive
+        // transition time. A fresh build stamps "now"; preservation must replace
+        // it with this value because the status did not transition.
+        let sentinel = "2000-01-01T00:00:00Z";
+        let previous: Vec<Condition> = built
+            .conditions
+            .iter()
+            .map(|c| Condition {
+                last_transition_time: Some(sentinel.to_string()),
+                ..c.clone()
+            })
+            .collect();
+
+        let preserved = preserve_transition_times(built.conditions.clone(), &previous);
+        assert!(
+            !preserved.is_empty(),
+            "the Failed hold records at least Available and StoreQualified"
+        );
+        for c in &preserved {
+            assert_eq!(
+                c.last_transition_time.as_deref(),
+                Some(sentinel),
+                "{} did not transition, so its lastTransitionTime must be carried \
+                 forward unchanged",
+                c.r#type
+            );
+        }
+    }
+
+    /// When a condition actually transitions (its `status` value flips),
+    /// [`preserve_transition_times`] keeps the freshly stamped time rather than
+    /// the previous one: the timestamp records the last real transition.
+    #[test]
+    fn transition_restamps_last_transition_time() {
+        let fresh = vec![condition(
+            "Available",
+            true,
+            Some(3),
+            "MinimumReplicasAvailable",
+            "ready",
+        )];
+        let fresh_time = fresh[0].last_transition_time.clone();
+        let previous = vec![Condition {
+            r#type: "Available".to_string(),
+            status: "False".to_string(),
+            observed_generation: Some(2),
+            last_transition_time: Some("2000-01-01T00:00:00Z".to_string()),
+            reason: "MinimumReplicasUnavailable".to_string(),
+            message: "waiting".to_string(),
+        }];
+
+        let preserved = preserve_transition_times(fresh, &previous);
+        assert_eq!(
+            preserved[0].last_transition_time, fresh_time,
+            "a False -> True transition must keep the new timestamp, not the \
+             previous one"
+        );
+        assert_ne!(
+            preserved[0].last_transition_time.as_deref(),
+            Some("2000-01-01T00:00:00Z"),
+        );
     }
 
     /// #147 (ADR-0076 decision 2 / ADR-0052): `reconcile_shard_overrides` is

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -39,11 +39,12 @@ use crate::reconcile::{
     DEPLOYMENT_KEY_SECRET_KEY, DeploymentTier, GC_BOOTSTRAP_STALL_AFTER,
     GC_BOOTSTRAP_STALLED_REASON, GC_BOOTSTRAP_UNAVAILABLE_MESSAGE, GC_BOOTSTRAP_UNAVAILABLE_REASON,
     GcBootstrapGate, QUALIFY_COMPONENT, QUALIFY_SPEC_HASH_ANNOTATION, QualificationDecision,
-    QualifyJobObservation, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
-    STORE_QUALIFIED_FAILED_REASON, STORE_QUALIFIED_MESSAGE, STORE_QUALIFIED_PENDING_REASON,
-    STORE_QUALIFIED_SUCCEEDED_REASON, STORE_QUALIFYING_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
-    WAITING_FOR_GC_BOOTSTRAP_REASON, desired_objects, desired_qualify_job, grpcroute_api_resource,
-    httproute_api_resource, possible_gateway_route_names, possible_ingest_ingress_names,
+    QualifyJobAction, QualifyJobObservation, QualifyStoreReason, RenderCtx, RenderError,
+    S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY, STORE_QUALIFIED_FAILED_REASON,
+    STORE_QUALIFIED_MESSAGE, STORE_QUALIFIED_PENDING_REASON, STORE_QUALIFIED_SUCCEEDED_REASON,
+    STORE_QUALIFYING_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_REASON,
+    desired_objects, desired_qualify_job, grpcroute_api_resource, httproute_api_resource,
+    plan_qualify_gate, possible_gateway_route_names, possible_ingest_ingress_names,
     possible_pod_disruption_budget_names, possible_router_object_names, qualification_decision,
     qualify_job_input_hash, qualify_job_phase,
 };
@@ -958,96 +959,28 @@ async fn delete_stale_qualify_job(api: &Api<Job>, name: &str) -> Result<(), Erro
     Ok(())
 }
 
-/// What a non-Proceed qualification pass must do to the qualify Job.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum QualifyJobAction {
-    /// Create the qualify Job for the current inputs: none exists yet.
-    Create,
-    /// Delete the existing Job with foreground propagation, so a later pass
-    /// observes it absent and creates a fresh one. Used both when a config edit
-    /// made the Job's inputs stale and when the current-hash Job Failed (finding
-    /// 4): the controller does not watch Jobs, so a Failed Job left in place
-    /// would block Deployments until its TTL collected it about an hour later.
-    DeleteStale,
-    /// Leave the Job untouched: it is running the current inputs.
-    None,
-}
-
-/// The plan for a reconcile pass that did NOT reach
-/// [`QualificationDecision::Proceed`]: the Job mutation to perform, the
-/// `StoreQualified` condition to record, the reason/message to carry onto
-/// `Available`, and how soon to requeue. Pure, so every arm's action and timing
-/// is pinned by a unit test; the caller performs the Job create/delete named by
-/// `job_action` and requeues after `requeue`.
-struct QualifyGatePlan {
-    job_action: QualifyJobAction,
-    store_qualified_condition: Condition,
-    unavailable_reason: (&'static str, String),
-    requeue: Duration,
-}
-
-/// Map a non-Proceed [`QualificationDecision`] to its [`QualifyGatePlan`].
-///
-/// A Failed Job is deleted, not left to sit until its TTL: the controller does
-/// not watch Jobs, so nothing else recreates it, and a fresh cluster would
-/// otherwise have no Deployments for about an hour after two failed attempts.
-/// The Failed hold requeues at [`RETRY`], the failure backoff, not
-/// [`BOOTSTRAP_POLL`]. Deleting the Job rewrites `.status`, and the primary
-/// watch drops that status-only write ([`predicates::generation`]), so nothing
-/// re-enqueues the object before the requeue delay; a shorter poll here would
-/// only rebuild-and-refail the Job faster. The `StoreQualified=False` condition
-/// still carries the Job's failure reason and message across the gap, so the
-/// operator's user still sees why qualification did not finish.
-fn qualify_gate_plan(decision: &QualificationDecision, generation: Option<i64>) -> QualifyGatePlan {
-    match decision {
-        QualificationDecision::Qualify { recreate } => QualifyGatePlan {
-            job_action: if *recreate {
-                QualifyJobAction::DeleteStale
-            } else {
-                QualifyJobAction::Create
-            },
-            store_qualified_condition: condition(
-                "StoreQualified",
-                false,
-                generation,
-                STORE_QUALIFIED_PENDING_REASON,
-                STORE_QUALIFYING_MESSAGE,
-            ),
-            unavailable_reason: (
-                STORE_QUALIFIED_PENDING_REASON,
-                STORE_QUALIFYING_MESSAGE.to_string(),
-            ),
-            requeue: BOOTSTRAP_POLL,
-        },
-        QualificationDecision::Waiting => QualifyGatePlan {
-            job_action: QualifyJobAction::None,
-            store_qualified_condition: condition(
-                "StoreQualified",
-                false,
-                generation,
-                STORE_QUALIFIED_PENDING_REASON,
-                STORE_QUALIFYING_MESSAGE,
-            ),
-            unavailable_reason: (
-                STORE_QUALIFIED_PENDING_REASON,
-                STORE_QUALIFYING_MESSAGE.to_string(),
-            ),
-            requeue: BOOTSTRAP_POLL,
-        },
-        QualificationDecision::Failed(message) => QualifyGatePlan {
-            job_action: QualifyJobAction::DeleteStale,
-            store_qualified_condition: condition(
-                "StoreQualified",
-                false,
-                generation,
-                STORE_QUALIFIED_FAILED_REASON,
-                message,
-            ),
-            unavailable_reason: (STORE_QUALIFIED_FAILED_REASON, message.clone()),
-            requeue: RETRY,
-        },
-        QualificationDecision::Proceed => {
-            unreachable!("Proceed is handled on the success path, never planned as a hold")
+/// The `StoreQualified=False` message for a Failed qualification hold (finding
+/// 3), naming the consecutive-failure count and, when the plan set one, the next
+/// retry instant, plus the Job's own failure message when it carried one. Kept
+/// terse so `kubectl describe` shows the attempt count and when the next attempt
+/// is due without scrolling.
+fn qualify_failed_message(
+    count: i32,
+    next_retry_unix: Option<i64>,
+    job_message: Option<&str>,
+) -> String {
+    let cause = job_message
+        .map(|m| format!(": {m}"))
+        .unwrap_or_else(|| ".".to_string());
+    match next_retry_unix {
+        Some(due) => format!(
+            "store qualification failed after {count} consecutive attempt(s){cause} next retry at {}",
+            format_rfc3339_utc(due)
+        ),
+        None => {
+            format!(
+                "store qualification failed after {count} consecutive attempt(s){cause} retrying now"
+            )
         }
     }
 }
@@ -1117,12 +1050,30 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
             // the old hash after a successful qualification would discard the
             // pass's proof and re-run qualification once the Job's TTL collected
             // it; using it when the pass never qualified is correct.
+            let qualification_passed = proceed_hash.is_some();
             let store_qualified_hash = degraded_store_qualified_hash(
                 proceed_hash,
                 obj.status
                     .as_ref()
                     .and_then(|status| status.store_qualified_hash.clone()),
             );
+            // Qualify retry state on the degraded write (issue #36, finding 3): if
+            // this pass qualified before the later step failed, reset it (the
+            // qualification succeeded); otherwise the failure is before the gate,
+            // so carry the persisted retry state through unchanged rather than
+            // resetting a real backoff on an unrelated error.
+            let (qualify_failure_count, qualify_next_retry_time) = if qualification_passed {
+                (None, None)
+            } else {
+                (
+                    obj.status
+                        .as_ref()
+                        .and_then(|status| status.qualify_failure_count),
+                    obj.status
+                        .as_ref()
+                        .and_then(|status| status.qualify_next_retry_time.clone()),
+                )
+            };
             if let Err(status_err) = write_degraded_status(
                 client,
                 &namespace,
@@ -1133,6 +1084,8 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 PersistedStatus {
                     gc_bootstrap_waiting_since: waiting_since,
                     store_qualified_hash,
+                    qualify_failure_count,
+                    qualify_next_retry_time,
                 },
                 extra_conditions,
                 obj.status
@@ -1184,7 +1137,7 @@ async fn reconcile_inner(
     // Store qualification gate (issue #36). Before anything that would read or
     // write the object store is created -- the sys/auth token map, the ingest
     // router, and above all the serving Deployments -- prove the store passes
-    // `ravel store qualify`. A cluster brought up on a backend that fails the
+    // `ravel-cli store qualify`. A cluster brought up on a backend that fails the
     // object-store contract (docs/object-store-contract.md) would otherwise
     // crash-loop every server pod with an opaque runtime error; here it fails
     // once, visibly, on a one-shot Job, and the `StoreQualified` condition says
@@ -1225,22 +1178,37 @@ async fn reconcile_inner(
             Some(desired_hash.clone())
         }
         _ => {
-            // Not qualified for the current inputs: create, recreate, or delete
-            // the Job per the plan, record a `StoreQualified` condition, and
+            // Not qualified for the current inputs: create, recreate, delete, or
+            // hold the Job per the plan, record a `StoreQualified` condition, and
             // return WITHOUT touching any Deployment. A fresh cluster gets none;
             // a running cluster re-qualifying after a config edit keeps the ones
             // it has (this pass never reaches the Deployment apply/sweep below),
             // so a pending config change does not tear a serving cluster down.
             //
-            // `plan.unavailable_reason` carries the qualification state onto the
-            // `Available=False` condition (finding 4), so a fresh cluster held for
-            // qualification says why -- Pending with the qualifying message, or
-            // Failed with the Job's failure message -- instead of the generic
-            // MinimumReplicasUnavailable. `build_status` ignores it when prior
-            // ready replicas keep the cluster Available, so a serving cluster under
+            // The plan bounds cross-Job churn (finding 3): a store that keeps
+            // failing qualification is recreated on a capped exponential backoff
+            // and, past a threshold, held in a terminal cooldown, with the failure
+            // count and next-retry instant persisted in status. The chosen reason
+            // and message carry the qualification state onto the `Available=False`
+            // condition, so a fresh cluster held for qualification says why --
+            // Pending with the qualifying message, or Failed naming the attempt
+            // count and the next retry time -- instead of the generic
+            // MinimumReplicasUnavailable. `build_status` ignores it when prior ready
+            // replicas keep the cluster Available, so a serving cluster under
             // re-qualification stays Available=True.
-            let plan = qualify_gate_plan(&decision, obj.metadata.generation);
-            match plan.job_action {
+            let prior = obj.status.as_ref();
+            let failure_count = prior.and_then(|s| s.qualify_failure_count).unwrap_or(0);
+            let next_retry_unix = prior
+                .and_then(|s| s.qualify_next_retry_time.as_deref())
+                .and_then(parse_rfc3339_utc);
+            let plan = plan_qualify_gate(
+                &decision,
+                failure_count,
+                next_retry_unix,
+                now_unix_secs(),
+                i64::try_from(BOOTSTRAP_POLL.as_secs()).unwrap_or(10),
+            );
+            match plan.action {
                 QualifyJobAction::Create => {
                     let owner = obj.controller_owner_ref(&()).map(|owner| vec![owner]);
                     let mut job = desired_qualify_job(&obj.spec, instance, shared_rv);
@@ -1260,14 +1228,33 @@ async fn reconcile_inner(
                 }
                 QualifyJobAction::None => {}
             }
-            extra_conditions.push(plan.store_qualified_condition);
+            let (reason, message) = match plan.reason {
+                QualifyStoreReason::Pending => (
+                    STORE_QUALIFIED_PENDING_REASON,
+                    STORE_QUALIFYING_MESSAGE.to_string(),
+                ),
+                QualifyStoreReason::Failed => (
+                    STORE_QUALIFIED_FAILED_REASON,
+                    qualify_failed_message(
+                        plan.failure_count.unwrap_or(failure_count),
+                        plan.next_retry_unix,
+                        plan.job_message.as_deref(),
+                    ),
+                ),
+            };
+            extra_conditions.push(condition(
+                "StoreQualified",
+                false,
+                obj.metadata.generation,
+                reason,
+                &message,
+            ));
 
             // Report the readiness a prior pass recorded, so a cluster already
             // serving through a re-qualification keeps `Available=True` instead of
             // flipping to "waiting for tiers" on every poll while the new inputs
             // qualify. A fresh cluster has none of these and reports Available=False
             // with the qualification reason.
-            let prior = obj.status.as_ref();
             write_status(
                 client,
                 namespace,
@@ -1276,20 +1263,21 @@ async fn reconcile_inner(
                 prior.and_then(|s| s.gateway_ready_replicas),
                 prior.and_then(|s| s.query_ready_replicas),
                 prior.and_then(|s| s.maintain_ready_replicas),
-                Some((
-                    plan.unavailable_reason.0,
-                    plan.unavailable_reason.1.as_str(),
-                )),
+                Some((reason, message.as_str())),
                 PersistedStatus {
                     gc_bootstrap_waiting_since: prior
                         .and_then(|s| s.gc_bootstrap_waiting_since.clone()),
                     store_qualified_hash: qualified_hash,
+                    qualify_failure_count: plan.failure_count,
+                    qualify_next_retry_time: plan.next_retry_unix.map(format_rfc3339_utc),
                 },
                 extra_conditions,
                 prior.map(|s| s.conditions.as_slice()).unwrap_or_default(),
             )
             .await?;
-            return Ok(Action::requeue(plan.requeue));
+            return Ok(Action::requeue(Duration::from_secs(
+                u64::try_from(plan.requeue_seconds).unwrap_or(30),
+            )));
         }
     };
 
@@ -1694,6 +1682,11 @@ async fn reconcile_inner(
         PersistedStatus {
             gc_bootstrap_waiting_since,
             store_qualified_hash,
+            // Qualification passed for these inputs this pass, so clear the retry
+            // budget (issue #36, finding 3): the next failure, if any, starts a
+            // fresh backoff from one rather than resuming a stale count.
+            qualify_failure_count: None,
+            qualify_next_retry_time: None,
         },
         extra_conditions,
         obj.status
@@ -1938,6 +1931,12 @@ struct PersistedStatus {
     /// `status.storeQualifiedHash`: the inputs the store last qualified
     /// against (issue #36), or `None` before the first qualification.
     store_qualified_hash: Option<String>,
+    /// `status.qualifyFailureCount`: consecutive qualify-Job failures for the
+    /// current inputs (issue #36, finding 3), or `None` when not in a retry hold.
+    qualify_failure_count: Option<i32>,
+    /// `status.qualifyNextRetryTime`: the RFC3339 instant before which no new
+    /// qualify Job is created after a failure, or `None` when not holding.
+    qualify_next_retry_time: Option<String>,
 }
 
 /// Build the success-path status: observed generation, per-mode ready replicas,
@@ -1987,6 +1986,8 @@ fn build_status(
         maintain_ready_replicas: maintain_ready,
         gc_bootstrap_waiting_since: persisted.gc_bootstrap_waiting_since,
         store_qualified_hash: persisted.store_qualified_hash,
+        qualify_failure_count: persisted.qualify_failure_count,
+        qualify_next_retry_time: persisted.qualify_next_retry_time,
         conditions,
     }
 }
@@ -2016,6 +2017,8 @@ fn build_degraded_status(
         maintain_ready_replicas: None,
         gc_bootstrap_waiting_since: persisted.gc_bootstrap_waiting_since,
         store_qualified_hash: persisted.store_qualified_hash,
+        qualify_failure_count: persisted.qualify_failure_count,
+        qualify_next_retry_time: persisted.qualify_next_retry_time,
         conditions,
     }
 }
@@ -2656,6 +2659,7 @@ mod tests {
             PersistedStatus {
                 gc_bootstrap_waiting_since: Some(since.clone()),
                 store_qualified_hash: Some("qhash-9".to_string()),
+                ..PersistedStatus::default()
             },
             Vec::new(),
         );
@@ -2866,7 +2870,7 @@ mod tests {
         );
         assert_ne!(available.reason, "MinimumReplicasUnavailable");
         assert!(
-            available.message.contains("ravel store qualify"),
+            available.message.contains("ravel-cli store qualify"),
             "Available carries the qualifying message: {}",
             available.message
         );
@@ -2917,67 +2921,25 @@ mod tests {
         assert_eq!(available.reason, "MinimumReplicasAvailable");
     }
 
-    /// A Failed qualify Job is deleted (foreground, via
-    /// [`QualifyJobAction::DeleteStale`]) so the next pass observes it Absent and
-    /// creates a fresh Job, and the hold requeues at [`RETRY`], the failure
-    /// backoff, not [`BOOTSTRAP_POLL`]: the primary watch drops the status-only
-    /// write that the delete produces, so nothing re-enqueues the object before
-    /// the delay, and a shorter poll would only rebuild-and-refail the Job
-    /// faster. The `StoreQualified=False` condition still carries the Job's
-    /// failure reason and message across that gap.
+    /// The Failed hold message names the consecutive-failure count and the next
+    /// retry instant, and carries the Job's own failure message when it had one.
     #[test]
-    fn failed_qualification_deletes_the_job_and_requeues_on_retry() {
-        let message = "backend rejected CAS".to_string();
-        let plan = qualify_gate_plan(&QualificationDecision::Failed(message.clone()), Some(7));
-        assert_eq!(plan.job_action, QualifyJobAction::DeleteStale);
-        assert_eq!(plan.requeue, RETRY);
-        assert_ne!(plan.requeue, BOOTSTRAP_POLL);
-        assert_eq!(plan.store_qualified_condition.status, "False");
+    fn qualify_failed_message_names_count_and_next_retry() {
+        let with_retry =
+            qualify_failed_message(3, Some(1_700_000_000), Some("backend rejected CAS"));
         assert_eq!(
-            plan.store_qualified_condition.reason,
-            STORE_QUALIFIED_FAILED_REASON
+            with_retry,
+            "store qualification failed after 3 consecutive attempt(s): backend rejected CAS next retry at 2023-11-14T22:13:20Z"
         );
-        assert_eq!(plan.store_qualified_condition.message, message);
+        let no_cause = qualify_failed_message(1, Some(1_700_000_000), None);
         assert_eq!(
-            plan.unavailable_reason,
-            (STORE_QUALIFIED_FAILED_REASON, message)
+            no_cause,
+            "store qualification failed after 1 consecutive attempt(s). next retry at 2023-11-14T22:13:20Z"
         );
-    }
-
-    /// The gate plan maps each non-Proceed decision to its Job action: an absent
-    /// Job is created, a stale or Failed Job is deleted, a running Job is left
-    /// untouched. A precondition hold (Create/Recreate/Waiting) requeues at
-    /// [`BOOTSTRAP_POLL`]; a Failed hold requeues at [`RETRY`], the failure
-    /// backoff.
-    #[test]
-    fn gate_plan_maps_each_hold_to_its_job_action() {
+        let retrying_now = qualify_failed_message(2, None, Some("still failing"));
         assert_eq!(
-            qualify_gate_plan(&QualificationDecision::Qualify { recreate: false }, None).job_action,
-            QualifyJobAction::Create
-        );
-        assert_eq!(
-            qualify_gate_plan(&QualificationDecision::Qualify { recreate: true }, None).job_action,
-            QualifyJobAction::DeleteStale
-        );
-        assert_eq!(
-            qualify_gate_plan(&QualificationDecision::Waiting, None).job_action,
-            QualifyJobAction::None
-        );
-        for decision in [
-            QualificationDecision::Qualify { recreate: false },
-            QualificationDecision::Qualify { recreate: true },
-            QualificationDecision::Waiting,
-        ] {
-            assert_eq!(
-                qualify_gate_plan(&decision, None).requeue,
-                BOOTSTRAP_POLL,
-                "{decision:?} requeues at BOOTSTRAP_POLL"
-            );
-        }
-        assert_eq!(
-            qualify_gate_plan(&QualificationDecision::Failed("m".to_string()), None).requeue,
-            RETRY,
-            "Failed requeues at RETRY"
+            retrying_now,
+            "store qualification failed after 2 consecutive attempt(s): still failing retrying now"
         );
     }
 
@@ -3735,8 +3697,16 @@ mod tests {
     /// (which is what the primary watch would otherwise see as a change).
     #[test]
     fn repeated_failed_pass_keeps_last_transition_time() {
-        let message = "backend rejected CAS".to_string();
-        let plan = qualify_gate_plan(&QualificationDecision::Failed(message.clone()), Some(7));
+        let message = "store qualification failed after 3 consecutive attempt(s): \
+                       backend rejected CAS retrying now"
+            .to_string();
+        let store_qualified = condition(
+            "StoreQualified",
+            false,
+            Some(7),
+            STORE_QUALIFIED_FAILED_REASON,
+            &message,
+        );
         // The Failed hold's status: Available=False plus StoreQualified=False,
         // exactly as `reconcile_inner` assembles it.
         let built = build_status(
@@ -3744,12 +3714,9 @@ mod tests {
             None,
             None,
             None,
-            Some((
-                plan.unavailable_reason.0,
-                plan.unavailable_reason.1.as_str(),
-            )),
+            Some((STORE_QUALIFIED_FAILED_REASON, message.as_str())),
             PersistedStatus::default(),
-            vec![plan.store_qualified_condition.clone()],
+            vec![store_qualified.clone()],
         );
 
         // The previous status: the same conditions with a fixed, distinctive

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -958,6 +958,110 @@ async fn delete_stale_qualify_job(api: &Api<Job>, name: &str) -> Result<(), Erro
     Ok(())
 }
 
+/// What a non-Proceed qualification pass must do to the qualify Job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum QualifyJobAction {
+    /// Create the qualify Job for the current inputs: none exists yet.
+    Create,
+    /// Delete the existing Job with foreground propagation, so a later pass
+    /// observes it absent and creates a fresh one. Used both when a config edit
+    /// made the Job's inputs stale and when the current-hash Job Failed (finding
+    /// 4): the controller does not watch Jobs, so a Failed Job left in place
+    /// would block Deployments until its TTL collected it about an hour later.
+    DeleteStale,
+    /// Leave the Job untouched: it is running the current inputs.
+    None,
+}
+
+/// The plan for a reconcile pass that did NOT reach
+/// [`QualificationDecision::Proceed`]: the Job mutation to perform, the
+/// `StoreQualified` condition to record, the reason/message to carry onto
+/// `Available`, and how soon to requeue. Pure, so every arm's action and timing
+/// is pinned by a unit test; the caller performs the Job create/delete named by
+/// `job_action` and requeues after `requeue`.
+struct QualifyGatePlan {
+    job_action: QualifyJobAction,
+    store_qualified_condition: Condition,
+    unavailable_reason: (&'static str, String),
+    requeue: Duration,
+}
+
+/// Map a non-Proceed [`QualificationDecision`] to its [`QualifyGatePlan`].
+///
+/// A Failed Job is deleted and requeued at [`BOOTSTRAP_POLL`], not left to sit
+/// until its TTL (finding 4): the controller does not watch Jobs, so nothing
+/// else recreates it, and a fresh cluster would otherwise have no Deployments
+/// for about an hour after two failed attempts. The `StoreQualified=False`
+/// condition still carries the Job's failure reason and message across that
+/// gap, so the operator's user still sees why qualification did not finish.
+fn qualify_gate_plan(decision: &QualificationDecision, generation: Option<i64>) -> QualifyGatePlan {
+    match decision {
+        QualificationDecision::Qualify { recreate } => QualifyGatePlan {
+            job_action: if *recreate {
+                QualifyJobAction::DeleteStale
+            } else {
+                QualifyJobAction::Create
+            },
+            store_qualified_condition: condition(
+                "StoreQualified",
+                false,
+                generation,
+                STORE_QUALIFIED_PENDING_REASON,
+                STORE_QUALIFYING_MESSAGE,
+            ),
+            unavailable_reason: (
+                STORE_QUALIFIED_PENDING_REASON,
+                STORE_QUALIFYING_MESSAGE.to_string(),
+            ),
+            requeue: BOOTSTRAP_POLL,
+        },
+        QualificationDecision::Waiting => QualifyGatePlan {
+            job_action: QualifyJobAction::None,
+            store_qualified_condition: condition(
+                "StoreQualified",
+                false,
+                generation,
+                STORE_QUALIFIED_PENDING_REASON,
+                STORE_QUALIFYING_MESSAGE,
+            ),
+            unavailable_reason: (
+                STORE_QUALIFIED_PENDING_REASON,
+                STORE_QUALIFYING_MESSAGE.to_string(),
+            ),
+            requeue: BOOTSTRAP_POLL,
+        },
+        QualificationDecision::Failed(message) => QualifyGatePlan {
+            job_action: QualifyJobAction::DeleteStale,
+            store_qualified_condition: condition(
+                "StoreQualified",
+                false,
+                generation,
+                STORE_QUALIFIED_FAILED_REASON,
+                message,
+            ),
+            unavailable_reason: (STORE_QUALIFIED_FAILED_REASON, message.clone()),
+            requeue: BOOTSTRAP_POLL,
+        },
+        QualificationDecision::Proceed => {
+            unreachable!("Proceed is handled on the success path, never planned as a hold")
+        }
+    }
+}
+
+/// The `store_qualified_hash` to persist on the degraded error path (finding
+/// 2). `proceed_hash` is `Some` when the pass reached
+/// [`QualificationDecision::Proceed`] (qualification passed before a later step
+/// failed); in that case its fresh value wins, so a successful qualification is
+/// not discarded and re-run once the Job's TTL collects it. When the pass
+/// failed before the gate, `proceed_hash` is `None` and the last-persisted
+/// value is carried through unchanged.
+fn degraded_store_qualified_hash(
+    proceed_hash: Option<String>,
+    persisted: Option<String>,
+) -> Option<String> {
+    proceed_hash.or(persisted)
+}
+
 /// Reconcile one `RavelCluster` to its desired Deployments and Services.
 ///
 /// Wraps [`reconcile_inner`] so that any failure before the success-path status
@@ -978,12 +1082,17 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
     // writer silently drops them.
     let extra_conditions = spec_conditions(&obj.spec, obj.metadata.generation);
 
+    // Set by `reconcile_inner` to the fresh qualified-input hash once a pass
+    // reaches `QualificationDecision::Proceed`, so the degraded error path below
+    // persists it rather than the stale `obj.status` value (finding 2).
+    let mut proceed_hash: Option<String> = None;
     match reconcile_inner(
         &obj,
         client,
         &namespace,
         &instance,
         extra_conditions.clone(),
+        &mut proceed_hash,
     )
     .await
     {
@@ -998,14 +1107,18 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 .status
                 .as_ref()
                 .and_then(|status| status.gc_bootstrap_waiting_since.clone());
-            // The qualified-inputs hash is owned by the qualification gate, not
-            // this error path: carry the persisted value through unchanged so a
-            // transient error after a cluster is already qualified does not drop
-            // the record and re-trigger qualification on the next pass.
-            let store_qualified_hash = obj
-                .status
-                .as_ref()
-                .and_then(|status| status.store_qualified_hash.clone());
+            // The qualified-inputs hash to persist on the degraded write
+            // (finding 2): the fresh hash if this pass already qualified before
+            // the failing step, otherwise the persisted value unchanged. Using
+            // the old hash after a successful qualification would discard the
+            // pass's proof and re-run qualification once the Job's TTL collected
+            // it; using it when the pass never qualified is correct.
+            let store_qualified_hash = degraded_store_qualified_hash(
+                proceed_hash,
+                obj.status
+                    .as_ref()
+                    .and_then(|status| status.store_qualified_hash.clone()),
+            );
             if let Err(status_err) = write_degraded_status(
                 client,
                 &namespace,
@@ -1037,6 +1150,7 @@ async fn reconcile_inner(
     namespace: &str,
     instance: &str,
     mut extra_conditions: Vec<Condition>,
+    proceed_hash: &mut Option<String>,
 ) -> Result<Action, Error> {
     // Read the resourceVersion of every credential Secret the spec references
     // BEFORE the qualification gate (finding 3): the shared storage.s3 credential
@@ -1093,89 +1207,52 @@ async fn reconcile_inner(
                 STORE_QUALIFIED_SUCCEEDED_REASON,
                 STORE_QUALIFIED_MESSAGE,
             ));
+            // Qualification passed this pass. Carry the fresh hash into the
+            // outer error path (finding 2): a later fallible step
+            // (resolve_deployment_key, an apply) can still return Err, and
+            // without this the degraded status writer would rebuild the hash
+            // from the OLD obj.status and discard a successful qualification,
+            // re-running it once the Job's TTL collected the passing Job.
+            *proceed_hash = Some(desired_hash.clone());
             Some(desired_hash.clone())
         }
         _ => {
-            // Not qualified for the current inputs: create or recreate the Job,
-            // record a `StoreQualified` condition, and return WITHOUT touching
-            // any Deployment. A fresh cluster gets none; a running cluster
-            // re-qualifying after a config edit keeps the ones it has (this pass
-            // never reaches the Deployment apply/sweep below), so a pending
-            // config change does not tear a serving cluster down.
+            // Not qualified for the current inputs: create, recreate, or delete
+            // the Job per the plan, record a `StoreQualified` condition, and
+            // return WITHOUT touching any Deployment. A fresh cluster gets none;
+            // a running cluster re-qualifying after a config edit keeps the ones
+            // it has (this pass never reaches the Deployment apply/sweep below),
+            // so a pending config change does not tear a serving cluster down.
             //
-            // `unavailable_reason` carries the qualification state onto the
+            // `plan.unavailable_reason` carries the qualification state onto the
             // `Available=False` condition (finding 4), so a fresh cluster held for
             // qualification says why -- Pending with the qualifying message, or
             // Failed with the Job's failure message -- instead of the generic
             // MinimumReplicasUnavailable. `build_status` ignores it when prior
             // ready replicas keep the cluster Available, so a serving cluster under
             // re-qualification stays Available=True.
-            let owner = obj.controller_owner_ref(&()).map(|owner| vec![owner]);
-            let (store_qualified_condition, unavailable_reason, action): (
-                Condition,
-                (&str, String),
-                Action,
-            ) = match &decision {
-                QualificationDecision::Qualify { recreate } => {
-                    if *recreate {
-                        // The Job's inputs changed; its pod template is immutable,
-                        // so delete the stale Job with FOREGROUND propagation
-                        // (finding 2) -- its owned Pod is torn down before the Job
-                        // object disappears -- and let a later pass observe it fully
-                        // absent and create a fresh one. Without foreground
-                        // propagation Kubernetes can remove the Job while its Pod
-                        // still runs the old inputs, and the next reconcile would
-                        // create the replacement alongside that live stale Pod.
-                        delete_stale_qualify_job(&jobs, &qualify_name).await?;
-                    } else {
-                        let mut job = desired_qualify_job(&obj.spec, instance, shared_rv);
-                        job.metadata.namespace = Some(namespace.to_string());
-                        job.metadata.owner_references = owner;
-                        apply(&jobs, &qualify_name, &job).await?;
-                    }
-                    (
-                        condition(
-                            "StoreQualified",
-                            false,
-                            obj.metadata.generation,
-                            STORE_QUALIFIED_PENDING_REASON,
-                            STORE_QUALIFYING_MESSAGE,
-                        ),
-                        (
-                            STORE_QUALIFIED_PENDING_REASON,
-                            STORE_QUALIFYING_MESSAGE.to_string(),
-                        ),
-                        Action::requeue(BOOTSTRAP_POLL),
-                    )
+            let plan = qualify_gate_plan(&decision, obj.metadata.generation);
+            match plan.job_action {
+                QualifyJobAction::Create => {
+                    let owner = obj.controller_owner_ref(&()).map(|owner| vec![owner]);
+                    let mut job = desired_qualify_job(&obj.spec, instance, shared_rv);
+                    job.metadata.namespace = Some(namespace.to_string());
+                    job.metadata.owner_references = owner;
+                    apply(&jobs, &qualify_name, &job).await?;
                 }
-                QualificationDecision::Waiting => (
-                    condition(
-                        "StoreQualified",
-                        false,
-                        obj.metadata.generation,
-                        STORE_QUALIFIED_PENDING_REASON,
-                        STORE_QUALIFYING_MESSAGE,
-                    ),
-                    (
-                        STORE_QUALIFIED_PENDING_REASON,
-                        STORE_QUALIFYING_MESSAGE.to_string(),
-                    ),
-                    Action::requeue(BOOTSTRAP_POLL),
-                ),
-                QualificationDecision::Failed(message) => (
-                    condition(
-                        "StoreQualified",
-                        false,
-                        obj.metadata.generation,
-                        STORE_QUALIFIED_FAILED_REASON,
-                        message,
-                    ),
-                    (STORE_QUALIFIED_FAILED_REASON, message.clone()),
-                    Action::requeue(RETRY),
-                ),
-                QualificationDecision::Proceed => unreachable!("Proceed handled above"),
-            };
-            extra_conditions.push(store_qualified_condition);
+                QualifyJobAction::DeleteStale => {
+                    // Delete the stale or Failed Job with FOREGROUND propagation:
+                    // its owned Pod is torn down before the Job object disappears,
+                    // and a later pass observes it fully absent and creates a
+                    // fresh one. Without foreground propagation Kubernetes can
+                    // remove the Job while its Pod still runs the old inputs, and
+                    // the next reconcile would create the replacement alongside
+                    // that live stale Pod.
+                    delete_stale_qualify_job(&jobs, &qualify_name).await?;
+                }
+                QualifyJobAction::None => {}
+            }
+            extra_conditions.push(plan.store_qualified_condition);
 
             // Report the readiness a prior pass recorded, so a cluster already
             // serving through a re-qualification keeps `Available=True` instead of
@@ -1191,7 +1268,10 @@ async fn reconcile_inner(
                 prior.and_then(|s| s.gateway_ready_replicas),
                 prior.and_then(|s| s.query_ready_replicas),
                 prior.and_then(|s| s.maintain_ready_replicas),
-                Some((unavailable_reason.0, unavailable_reason.1.as_str())),
+                Some((
+                    plan.unavailable_reason.0,
+                    plan.unavailable_reason.1.as_str(),
+                )),
                 PersistedStatus {
                     gc_bootstrap_waiting_since: prior
                         .and_then(|s| s.gc_bootstrap_waiting_since.clone()),
@@ -1200,7 +1280,7 @@ async fn reconcile_inner(
                 extra_conditions,
             )
             .await?;
-            return Ok(action);
+            return Ok(Action::requeue(plan.requeue));
         }
     };
 
@@ -2777,6 +2857,84 @@ mod tests {
         let available = find(&serving.conditions, "Available");
         assert_eq!(available.status, "True");
         assert_eq!(available.reason, "MinimumReplicasAvailable");
+    }
+
+    /// A Failed qualify Job is not left to sit until its TTL (finding 4): the
+    /// gate plan deletes it (foreground, via [`QualifyJobAction::DeleteStale`])
+    /// and requeues at [`BOOTSTRAP_POLL`], so the next pass observes it Absent
+    /// and creates a fresh Job, rather than the earlier RETRY-only requeue that
+    /// left a fresh cluster without Deployments until the TTL fired. The
+    /// `StoreQualified=False` condition still carries the Job's failure reason
+    /// and message across that gap.
+    #[test]
+    fn failed_qualification_deletes_the_job_and_requeues_soon() {
+        let message = "backend rejected CAS".to_string();
+        let plan = qualify_gate_plan(&QualificationDecision::Failed(message.clone()), Some(7));
+        assert_eq!(plan.job_action, QualifyJobAction::DeleteStale);
+        assert_eq!(plan.requeue, BOOTSTRAP_POLL);
+        assert_ne!(plan.requeue, RETRY);
+        assert_eq!(plan.store_qualified_condition.status, "False");
+        assert_eq!(
+            plan.store_qualified_condition.reason,
+            STORE_QUALIFIED_FAILED_REASON
+        );
+        assert_eq!(plan.store_qualified_condition.message, message);
+        assert_eq!(
+            plan.unavailable_reason,
+            (STORE_QUALIFIED_FAILED_REASON, message)
+        );
+    }
+
+    /// The gate plan maps each non-Proceed decision to its Job action, and every
+    /// hold requeues at [`BOOTSTRAP_POLL`] (finding 4): an absent Job is created,
+    /// a stale or Failed Job is deleted, a running Job is left untouched.
+    #[test]
+    fn gate_plan_maps_each_hold_to_its_job_action() {
+        assert_eq!(
+            qualify_gate_plan(&QualificationDecision::Qualify { recreate: false }, None).job_action,
+            QualifyJobAction::Create
+        );
+        assert_eq!(
+            qualify_gate_plan(&QualificationDecision::Qualify { recreate: true }, None).job_action,
+            QualifyJobAction::DeleteStale
+        );
+        assert_eq!(
+            qualify_gate_plan(&QualificationDecision::Waiting, None).job_action,
+            QualifyJobAction::None
+        );
+        for decision in [
+            QualificationDecision::Qualify { recreate: false },
+            QualificationDecision::Qualify { recreate: true },
+            QualificationDecision::Waiting,
+            QualificationDecision::Failed("m".to_string()),
+        ] {
+            assert_eq!(
+                qualify_gate_plan(&decision, None).requeue,
+                BOOTSTRAP_POLL,
+                "{decision:?} requeues at BOOTSTRAP_POLL"
+            );
+        }
+    }
+
+    /// The degraded error path persists the FRESH qualified-input hash when the
+    /// pass reached Proceed before a later step failed (finding 2), exact value,
+    /// so a successful qualification is not discarded and re-run once the Job's
+    /// TTL collects it. When the pass failed before the gate (`proceed_hash`
+    /// None), the last-persisted value is carried through unchanged.
+    #[test]
+    fn degraded_status_keeps_the_fresh_hash_after_a_post_proceed_failure() {
+        // Reached Proceed, then a later apply failed: the fresh hash wins.
+        assert_eq!(
+            degraded_store_qualified_hash(Some("fresh".to_string()), Some("old".to_string())),
+            Some("fresh".to_string())
+        );
+        // Failed before the gate: the old persisted hash is kept unchanged.
+        assert_eq!(
+            degraded_store_qualified_hash(None, Some("old".to_string())),
+            Some("old".to_string())
+        );
+        // Never qualified and nothing persisted: None.
+        assert_eq!(degraded_store_qualified_hash(None, None), None);
     }
 
     /// Finding 3: credential resourceVersions are resolved before the gate and

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -307,6 +307,21 @@ async fn resolve_credential_resource_versions(
     Ok(versions)
 }
 
+/// The shared `storage.s3.credentialsSecretRef` Secret's resolved
+/// `resourceVersion` (findings 3 and 6): the credential the qualify Job
+/// authenticates with, and the one folded into [`qualify_job_input_hash`].
+/// Looked up by the SHARED credential's name so a per-tier override's
+/// `resourceVersion` never stands in for it. `None` when that Secret's version
+/// could not be resolved (absent from the map).
+fn shared_credentials_rv<'a>(
+    spec: &RavelClusterSpec,
+    versions: &'a std::collections::BTreeMap<String, String>,
+) -> Option<&'a str> {
+    versions
+        .get(&spec.storage.s3.credentials_secret_ref.name)
+        .map(String::as_str)
+}
+
 /// Map a Secret `get` error: a 404 becomes [`Error::SecretNotFound`] naming the
 /// Secret and the spec field that referenced it; a 403 becomes
 /// [`Error::SecretsUnreadable`] naming the namespace, Secret, and the
@@ -916,6 +931,33 @@ where
     Ok(())
 }
 
+/// [`DeleteParams`] for the stale qualify Job (finding 2): foreground
+/// propagation, so Kubernetes keeps the Job object (blocked by the
+/// `foregroundDeletion` finalizer) until its owned Pod has been deleted, rather
+/// than removing the Job while that Pod still runs. The controller only creates
+/// the replacement Job once it observes the old one fully absent
+/// ([`QualificationDecision::Qualify`] with `recreate: false`), so foreground
+/// propagation is what guarantees the old inputs' Pod is gone before the fresh
+/// Job's Pod starts. Factored out so the propagation choice is pinned by a unit
+/// test.
+fn stale_qualify_job_delete_params() -> DeleteParams {
+    DeleteParams::foreground()
+}
+
+/// Delete the stale qualify Job with foreground propagation
+/// ([`stale_qualify_job_delete_params`]), treating a 404 as success (it may have
+/// already been collected). Re-issuing this on a Job already terminating is
+/// idempotent: the controller keeps deciding `recreate` (the terminating Job
+/// still reports the old input hash) and requeues until the Job is fully absent.
+async fn delete_stale_qualify_job(api: &Api<Job>, name: &str) -> Result<(), Error> {
+    if let Err(err) = api.delete(name, &stale_qualify_job_delete_params()).await
+        && !is_not_found(&err)
+    {
+        return Err(err.into());
+    }
+    Ok(())
+}
+
 /// Reconcile one `RavelCluster` to its desired Deployments and Services.
 ///
 /// Wraps [`reconcile_inner`] so that any failure before the success-path status
@@ -971,8 +1013,10 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 obj.metadata.generation,
                 &reason,
                 &message,
-                waiting_since,
-                store_qualified_hash,
+                PersistedStatus {
+                    gc_bootstrap_waiting_since: waiting_since,
+                    store_qualified_hash,
+                },
                 extra_conditions,
             )
             .await
@@ -994,6 +1038,27 @@ async fn reconcile_inner(
     instance: &str,
     mut extra_conditions: Vec<Condition>,
 ) -> Result<Action, Error> {
+    // Read the resourceVersion of every credential Secret the spec references
+    // BEFORE the qualification gate (finding 3): the shared storage.s3 credential
+    // plus any per-tier override (ADR-0055 section 5). Resolving credentials
+    // first means a missing or unreadable Secret surfaces as SecretNotFound /
+    // SecretsUnreadable straight away, rather than leaving the qualify Job's
+    // required secretKeyRef pods Pending until the deadline fires and
+    // StoreQualified reporting DeadlineExceeded (and a Failed Job with the current
+    // hash sitting Failed until its TTL collects it) instead of the real cause.
+    // The resolved versions are reused for the qualified-input hash below and for
+    // rendering further down, so this is one read, not an extra one: each
+    // Deployment's pod-template checksum is later computed from the one Secret its
+    // tier resolves to, so a per-role credential rotation rolls only the
+    // Deployment(s) that consume it.
+    let credential_resource_versions =
+        resolve_credential_resource_versions(client, namespace, &obj.spec).await?;
+    // The shared credentials Secret's resourceVersion feeds the qualified-input
+    // hash (finding 6): the qualify Job authenticates with this same shared
+    // Secret, so a fixed-name rotation of it is a different qualified input and
+    // must re-run qualification.
+    let shared_rv = shared_credentials_rv(&obj.spec, &credential_resource_versions);
+
     // Store qualification gate (issue #36). Before anything that would read or
     // write the object store is created -- the sys/auth token map, the ingest
     // router, and above all the serving Deployments -- prove the store passes
@@ -1007,7 +1072,7 @@ async fn reconcile_inner(
     // re-trigger it (ADR-0034).
     let jobs: Api<Job> = Api::namespaced(client.clone(), namespace);
     let qualify_name = child(instance, QUALIFY_COMPONENT);
-    let desired_hash = qualify_job_input_hash(&obj.spec);
+    let desired_hash = qualify_job_input_hash(&obj.spec, shared_rv);
     let qualified_hash = obj
         .status
         .as_ref()
@@ -1037,16 +1102,33 @@ async fn reconcile_inner(
             // re-qualifying after a config edit keeps the ones it has (this pass
             // never reaches the Deployment apply/sweep below), so a pending
             // config change does not tear a serving cluster down.
+            //
+            // `unavailable_reason` carries the qualification state onto the
+            // `Available=False` condition (finding 4), so a fresh cluster held for
+            // qualification says why -- Pending with the qualifying message, or
+            // Failed with the Job's failure message -- instead of the generic
+            // MinimumReplicasUnavailable. `build_status` ignores it when prior
+            // ready replicas keep the cluster Available, so a serving cluster under
+            // re-qualification stays Available=True.
             let owner = obj.controller_owner_ref(&()).map(|owner| vec![owner]);
-            let (store_qualified_condition, action) = match &decision {
+            let (store_qualified_condition, unavailable_reason, action): (
+                Condition,
+                (&str, String),
+                Action,
+            ) = match &decision {
                 QualificationDecision::Qualify { recreate } => {
                     if *recreate {
                         // The Job's inputs changed; its pod template is immutable,
-                        // so delete the stale Job (its pods with it) and let the
-                        // next pass observe it absent and create a fresh one.
-                        delete_if_present(&jobs, &qualify_name).await?;
+                        // so delete the stale Job with FOREGROUND propagation
+                        // (finding 2) -- its owned Pod is torn down before the Job
+                        // object disappears -- and let a later pass observe it fully
+                        // absent and create a fresh one. Without foreground
+                        // propagation Kubernetes can remove the Job while its Pod
+                        // still runs the old inputs, and the next reconcile would
+                        // create the replacement alongside that live stale Pod.
+                        delete_stale_qualify_job(&jobs, &qualify_name).await?;
                     } else {
-                        let mut job = desired_qualify_job(&obj.spec, instance);
+                        let mut job = desired_qualify_job(&obj.spec, instance, shared_rv);
                         job.metadata.namespace = Some(namespace.to_string());
                         job.metadata.owner_references = owner;
                         apply(&jobs, &qualify_name, &job).await?;
@@ -1059,6 +1141,10 @@ async fn reconcile_inner(
                             STORE_QUALIFIED_PENDING_REASON,
                             STORE_QUALIFYING_MESSAGE,
                         ),
+                        (
+                            STORE_QUALIFIED_PENDING_REASON,
+                            STORE_QUALIFYING_MESSAGE.to_string(),
+                        ),
                         Action::requeue(BOOTSTRAP_POLL),
                     )
                 }
@@ -1070,6 +1156,10 @@ async fn reconcile_inner(
                         STORE_QUALIFIED_PENDING_REASON,
                         STORE_QUALIFYING_MESSAGE,
                     ),
+                    (
+                        STORE_QUALIFIED_PENDING_REASON,
+                        STORE_QUALIFYING_MESSAGE.to_string(),
+                    ),
                     Action::requeue(BOOTSTRAP_POLL),
                 ),
                 QualificationDecision::Failed(message) => (
@@ -1080,6 +1170,7 @@ async fn reconcile_inner(
                         STORE_QUALIFIED_FAILED_REASON,
                         message,
                     ),
+                    (STORE_QUALIFIED_FAILED_REASON, message.clone()),
                     Action::requeue(RETRY),
                 ),
                 QualificationDecision::Proceed => unreachable!("Proceed handled above"),
@@ -1089,7 +1180,8 @@ async fn reconcile_inner(
             // Report the readiness a prior pass recorded, so a cluster already
             // serving through a re-qualification keeps `Available=True` instead of
             // flipping to "waiting for tiers" on every poll while the new inputs
-            // qualify. A fresh cluster has none of these and reports Available=False.
+            // qualify. A fresh cluster has none of these and reports Available=False
+            // with the qualification reason.
             let prior = obj.status.as_ref();
             write_status(
                 client,
@@ -1099,9 +1191,12 @@ async fn reconcile_inner(
                 prior.and_then(|s| s.gateway_ready_replicas),
                 prior.and_then(|s| s.query_ready_replicas),
                 prior.and_then(|s| s.maintain_ready_replicas),
-                None,
-                prior.and_then(|s| s.gc_bootstrap_waiting_since.clone()),
-                qualified_hash,
+                Some((unavailable_reason.0, unavailable_reason.1.as_str())),
+                PersistedStatus {
+                    gc_bootstrap_waiting_since: prior
+                        .and_then(|s| s.gc_bootstrap_waiting_since.clone()),
+                    store_qualified_hash: qualified_hash,
+                },
                 extra_conditions,
             )
             .await?;
@@ -1160,16 +1255,11 @@ async fn reconcile_inner(
         .await;
     }
 
-    // Read the resourceVersion of every credential Secret the spec references:
-    // the shared storage.s3 credential plus any per-tier override (ADR-0055
-    // section 5). Each Deployment's pod-template checksum is later computed (in
-    // reconcile) from the one Secret its tier resolves to, so a per-role
-    // credential rotation rolls only the Deployment(s) that consume it. The
-    // shared credential is always referenced (some tier falls back to it unless
-    // all three override); reading it always keeps the no-override path
-    // identical to before.
-    let credential_resource_versions =
-        resolve_credential_resource_versions(client, namespace, &obj.spec).await?;
+    // Reuse the credential resourceVersions resolved before the gate (finding 3):
+    // each Deployment's pod-template checksum is computed (in reconcile) from the
+    // one Secret its tier resolves to, so a per-role credential rotation rolls
+    // only the Deployment(s) that consume it. The shared credential is always
+    // referenced (some tier falls back to it unless all three override).
     let render_ctx = RenderCtx {
         tenant_names: token_secret.tenant_names,
         token_resource_version: token_secret.resource_version,
@@ -1512,8 +1602,10 @@ async fn reconcile_inner(
         query_ready,
         maintain_ready,
         available_hold.as_ref().map(|(r, m)| (*r, m.as_str())),
-        gc_bootstrap_waiting_since,
-        store_qualified_hash,
+        PersistedStatus {
+            gc_bootstrap_waiting_since,
+            store_qualified_hash,
+        },
         extra_conditions,
     )
     .await?;
@@ -1715,6 +1807,22 @@ fn spec_conditions(spec: &RavelClusterSpec, observed_generation: Option<i64>) ->
     )]
 }
 
+/// The two durable status fields that outlive a single reconcile pass and ride
+/// through every status writer: the `sys/gc` bootstrap-wait start timestamp and
+/// the qualified-inputs hash. Grouped in one named struct (finding 5) so the two
+/// adjacent `Option<String>` values cannot be swapped at a call site: a swap
+/// would persist the timestamp as the hash (and vice versa), silently
+/// re-triggering qualification or breaking stall tracking.
+#[derive(Debug, Clone, Default)]
+struct PersistedStatus {
+    /// `status.gcBootstrapWaitingSince`: the RFC3339 instant the current
+    /// bootstrap hold began, or `None` when not holding.
+    gc_bootstrap_waiting_since: Option<String>,
+    /// `status.storeQualifiedHash`: the inputs the store last qualified
+    /// against (issue #36), or `None` before the first qualification.
+    store_qualified_hash: Option<String>,
+}
+
 /// Build the success-path status: observed generation, per-mode ready replicas,
 /// an `Available` condition derived from whether the gateway and query tiers
 /// report ready replicas, and whatever spec-derived conditions this pass
@@ -1722,17 +1830,15 @@ fn spec_conditions(spec: &RavelClusterSpec, observed_generation: Option<i64>) ->
 ///
 /// `unavailable_reason` names a specific reason for `Available=False` when this
 /// pass knows one better than "not ready yet": today the `sys/gc` bootstrap
-/// hold and its unavailable case. It cannot make a ready cluster unavailable,
-/// only explain an unready one.
-#[allow(clippy::too_many_arguments)]
+/// hold and its unavailable case, and the store-qualification hold (finding 4).
+/// It cannot make a ready cluster unavailable, only explain an unready one.
 fn build_status(
     observed_generation: Option<i64>,
     gateway_ready: Option<i32>,
     query_ready: Option<i32>,
     maintain_ready: Option<i32>,
     unavailable_reason: Option<(&str, &str)>,
-    gc_bootstrap_waiting_since: Option<String>,
-    store_qualified_hash: Option<String>,
+    persisted: PersistedStatus,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let available = gateway_ready.unwrap_or(0) > 0 && query_ready.unwrap_or(0) > 0;
@@ -1762,8 +1868,8 @@ fn build_status(
         gateway_ready_replicas: gateway_ready,
         query_ready_replicas: query_ready,
         maintain_ready_replicas: maintain_ready,
-        gc_bootstrap_waiting_since,
-        store_qualified_hash,
+        gc_bootstrap_waiting_since: persisted.gc_bootstrap_waiting_since,
+        store_qualified_hash: persisted.store_qualified_hash,
         conditions,
     }
 }
@@ -1778,8 +1884,7 @@ fn build_degraded_status(
     observed_generation: Option<i64>,
     reason: &str,
     message: &str,
-    gc_bootstrap_waiting_since: Option<String>,
-    store_qualified_hash: Option<String>,
+    persisted: PersistedStatus,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let mut conditions = vec![
@@ -1792,8 +1897,8 @@ fn build_degraded_status(
         gateway_ready_replicas: None,
         query_ready_replicas: None,
         maintain_ready_replicas: None,
-        gc_bootstrap_waiting_since,
-        store_qualified_hash,
+        gc_bootstrap_waiting_since: persisted.gc_bootstrap_waiting_since,
+        store_qualified_hash: persisted.store_qualified_hash,
         conditions,
     }
 }
@@ -1813,8 +1918,7 @@ async fn write_status(
     query_ready: Option<i32>,
     maintain_ready: Option<i32>,
     unavailable_reason: Option<(&str, &str)>,
-    gc_bootstrap_waiting_since: Option<String>,
-    store_qualified_hash: Option<String>,
+    persisted: PersistedStatus,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_status(
@@ -1823,8 +1927,7 @@ async fn write_status(
         query_ready,
         maintain_ready,
         unavailable_reason,
-        gc_bootstrap_waiting_since,
-        store_qualified_hash,
+        persisted,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -1845,16 +1948,14 @@ async fn write_degraded_status(
     observed_generation: Option<i64>,
     reason: &str,
     message: &str,
-    gc_bootstrap_waiting_since: Option<String>,
-    store_qualified_hash: Option<String>,
+    persisted: PersistedStatus,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_degraded_status(
         observed_generation,
         reason,
         message,
-        gc_bootstrap_waiting_since,
-        store_qualified_hash,
+        persisted,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -2293,8 +2394,7 @@ mod tests {
             Some(2),
             Some(1),
             None,
-            None,
-            None,
+            PersistedStatus::default(),
             extra.clone(),
         );
         assert_eq!(
@@ -2317,8 +2417,7 @@ mod tests {
             Some(7),
             "SecretNotFound",
             "no such Secret",
-            None,
-            None,
+            PersistedStatus::default(),
             extra,
         );
         assert_eq!(
@@ -2382,13 +2481,17 @@ mod tests {
                 Some(1),
                 None,
                 None,
-                None,
-                None,
+                PersistedStatus::default(),
                 extra.clone(),
             );
             assert_eq!(condition_types(&ok.conditions), vec!["Available"]);
-            let degraded =
-                build_degraded_status(Some(2), "ReconcileError", "boom", None, None, extra);
+            let degraded = build_degraded_status(
+                Some(2),
+                "ReconcileError",
+                "boom",
+                PersistedStatus::default(),
+                extra,
+            );
             assert_eq!(
                 condition_types(&degraded.conditions),
                 vec!["Degraded", "Available"]
@@ -2398,6 +2501,13 @@ mod tests {
 
     /// A reconcile error during a bootstrap hold must not restart the stall
     /// clock: the persisted timestamp survives the Degraded write unchanged.
+    ///
+    /// Also the finding-5 guard: the timestamp and the qualified-inputs hash are
+    /// carried in one named [`PersistedStatus`], so a value handed in as the
+    /// timestamp lands in `gcBootstrapWaitingSince` and one handed in as the hash
+    /// lands in `storeQualifiedHash`. The two are deliberately distinct, non-swap
+    /// values here: if the struct fields were transposed this assertion would
+    /// catch it (a positional pair would not).
     #[test]
     fn degraded_status_carries_the_bootstrap_wait_timestamp() {
         let since = "2026-09-02T18:00:00Z".to_string();
@@ -2405,8 +2515,10 @@ mod tests {
             Some(3),
             "SecretNotFound",
             "no such Secret",
-            Some(since.clone()),
-            None,
+            PersistedStatus {
+                gc_bootstrap_waiting_since: Some(since.clone()),
+                store_qualified_hash: Some("qhash-9".to_string()),
+            },
             Vec::new(),
         );
         assert_eq!(
@@ -2414,8 +2526,18 @@ mod tests {
             Some(since.as_str()),
             "a transient error must leave the stall clock where it was"
         );
-        let cleared =
-            build_degraded_status(Some(3), "ReconcileError", "boom", None, None, Vec::new());
+        assert_eq!(
+            degraded.store_qualified_hash.as_deref(),
+            Some("qhash-9"),
+            "the qualified-inputs hash lands in its own field, never swapped with the timestamp"
+        );
+        let cleared = build_degraded_status(
+            Some(3),
+            "ReconcileError",
+            "boom",
+            PersistedStatus::default(),
+            Vec::new(),
+        );
         assert_eq!(cleared.gc_bootstrap_waiting_since, None);
     }
 
@@ -2437,8 +2559,7 @@ mod tests {
                 WAITING_FOR_GC_BOOTSTRAP_REASON,
                 WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
             )),
-            None,
-            None,
+            PersistedStatus::default(),
             vec![condition(
                 "Degraded",
                 false,
@@ -2471,8 +2592,7 @@ mod tests {
                 GC_BOOTSTRAP_UNAVAILABLE_REASON,
                 GC_BOOTSTRAP_UNAVAILABLE_MESSAGE,
             )),
-            None,
-            None,
+            PersistedStatus::default(),
             vec![condition(
                 "Degraded",
                 true,
@@ -2498,8 +2618,7 @@ mod tests {
                 WAITING_FOR_GC_BOOTSTRAP_REASON,
                 WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
             )),
-            None,
-            None,
+            PersistedStatus::default(),
             Vec::new(),
         );
         let available = find(&ready.conditions, "Available");
@@ -2522,8 +2641,7 @@ mod tests {
             Some(1),
             None,
             None,
-            None,
-            None,
+            PersistedStatus::default(),
             Vec::new(),
         );
         assert_eq!(condition_types(&running.conditions), vec!["Available"]);
@@ -2544,8 +2662,10 @@ mod tests {
             Some(1),
             None,
             None,
-            None,
-            Some("qhash".to_string()),
+            PersistedStatus {
+                store_qualified_hash: Some("qhash".to_string()),
+                ..PersistedStatus::default()
+            },
             Vec::new(),
         );
         assert_eq!(ok.store_qualified_hash.as_deref(), Some("qhash"));
@@ -2554,11 +2674,132 @@ mod tests {
             Some(1),
             "ReconcileError",
             "boom",
-            None,
-            Some("qhash".to_string()),
+            PersistedStatus {
+                store_qualified_hash: Some("qhash".to_string()),
+                ..PersistedStatus::default()
+            },
             Vec::new(),
         );
         assert_eq!(degraded.store_qualified_hash.as_deref(), Some("qhash"));
+    }
+
+    /// The stale qualify Job is deleted with FOREGROUND propagation (finding 2),
+    /// so Kubernetes keeps the Job object until its owned Pod is gone rather than
+    /// removing the Job while the Pod still runs the old inputs. The controller
+    /// only creates the replacement once it observes the Job fully absent, so
+    /// foreground propagation is what prevents a fresh Job's Pod starting
+    /// alongside a live stale one.
+    #[test]
+    fn stale_qualify_job_deletes_with_foreground_propagation() {
+        use kube::api::PropagationPolicy;
+        assert_eq!(
+            stale_qualify_job_delete_params().propagation_policy,
+            Some(PropagationPolicy::Foreground),
+            "the stale qualify Job must be deleted with foreground propagation"
+        );
+    }
+
+    /// During the qualification hold on a FRESH cluster (no prior ready
+    /// replicas), `Available=False` carries the qualification reason and message
+    /// (finding 4), not the generic MinimumReplicasUnavailable: `Pending` with
+    /// the qualifying message while the Job is created or running.
+    #[test]
+    fn qualification_hold_names_pending_on_available_for_a_fresh_cluster() {
+        let held = build_status(
+            Some(1),
+            None,
+            None,
+            None,
+            Some((STORE_QUALIFIED_PENDING_REASON, STORE_QUALIFYING_MESSAGE)),
+            PersistedStatus::default(),
+            vec![condition(
+                "StoreQualified",
+                false,
+                Some(1),
+                STORE_QUALIFIED_PENDING_REASON,
+                STORE_QUALIFYING_MESSAGE,
+            )],
+        );
+        let available = find(&held.conditions, "Available");
+        assert_eq!(available.status, "False");
+        assert_eq!(
+            available.reason, STORE_QUALIFIED_PENDING_REASON,
+            "Available names the qualification reason, not MinimumReplicasUnavailable"
+        );
+        assert_ne!(available.reason, "MinimumReplicasUnavailable");
+        assert!(
+            available.message.contains("ravel store qualify"),
+            "Available carries the qualifying message: {}",
+            available.message
+        );
+    }
+
+    /// A qualify Job that Failed (its `backoffLimit` exhausted, or the Job
+    /// controller's `DeadlineExceeded`) surfaces its own terminal message on
+    /// `Available=False` with reason `Failed` (finding 4), so an operator sees
+    /// why qualification did not finish, verbatim.
+    #[test]
+    fn qualification_failed_names_the_job_message_on_available() {
+        let message = "DeadlineExceeded: Job was active longer than specified deadline";
+        let held = build_status(
+            Some(2),
+            None,
+            None,
+            None,
+            Some((STORE_QUALIFIED_FAILED_REASON, message)),
+            PersistedStatus::default(),
+            Vec::new(),
+        );
+        let available = find(&held.conditions, "Available");
+        assert_eq!(available.status, "False");
+        assert_eq!(available.reason, STORE_QUALIFIED_FAILED_REASON);
+        assert_eq!(
+            available.message, message,
+            "the Job's failure message reaches Available verbatim"
+        );
+    }
+
+    /// A serving cluster under re-qualification stays `Available=True` (finding
+    /// 4): prior ready gateway and query replicas keep it available even though
+    /// the qualification hold passes an unavailable reason. A named reason can
+    /// only explain an unready cluster, never make a ready one unavailable.
+    #[test]
+    fn serving_cluster_stays_available_during_requalification() {
+        let serving = build_status(
+            Some(3),
+            Some(2),
+            Some(2),
+            Some(1),
+            Some((STORE_QUALIFIED_PENDING_REASON, STORE_QUALIFYING_MESSAGE)),
+            PersistedStatus::default(),
+            Vec::new(),
+        );
+        let available = find(&serving.conditions, "Available");
+        assert_eq!(available.status, "True");
+        assert_eq!(available.reason, "MinimumReplicasAvailable");
+    }
+
+    /// Finding 3: credential resourceVersions are resolved before the gate and
+    /// reused for the qualified-input hash. The value selected is the SHARED
+    /// storage.s3 credential's (the one the qualify Job authenticates with),
+    /// looked up by that Secret's name, never a per-tier override's. Absent from
+    /// the resolved map (unresolved) is None, not some other Secret's version.
+    #[test]
+    fn shared_credentials_rv_selects_the_shared_secret_not_a_tier_override() {
+        let spec = spec_with_affinity(None); // shared credential name is "ravel-s3"
+        let mut versions = BTreeMap::new();
+        versions.insert("ravel-s3".to_string(), "rv-shared".to_string());
+        versions.insert("query-creds".to_string(), "rv-override".to_string());
+        assert_eq!(
+            shared_credentials_rv(&spec, &versions),
+            Some("rv-shared"),
+            "the shared storage.s3 credential's resourceVersion is selected"
+        );
+        assert_eq!(
+            shared_credentials_rv(&spec, &BTreeMap::new()),
+            None,
+            "an unresolved shared credential is None, never a stand-in version"
+        );
     }
 
     /// The stall threshold as a signed second count, the unit
@@ -2710,8 +2951,7 @@ mod tests {
             Some(1),
             Some(1),
             None,
-            None,
-            None,
+            PersistedStatus::default(),
             Vec::new(),
         );
         assert_eq!(

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -1062,18 +1062,22 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
             // qualification succeeded); otherwise the failure is before the gate,
             // so carry the persisted retry state through unchanged rather than
             // resetting a real backoff on an unrelated error.
-            let (qualify_failure_count, qualify_next_retry_time) = if qualification_passed {
-                (None, None)
-            } else {
-                (
-                    obj.status
-                        .as_ref()
-                        .and_then(|status| status.qualify_failure_count),
-                    obj.status
-                        .as_ref()
-                        .and_then(|status| status.qualify_next_retry_time.clone()),
-                )
-            };
+            let (qualify_failure_count, qualify_next_retry_time, qualify_retry_hash) =
+                if qualification_passed {
+                    (None, None, None)
+                } else {
+                    (
+                        obj.status
+                            .as_ref()
+                            .and_then(|status| status.qualify_failure_count),
+                        obj.status
+                            .as_ref()
+                            .and_then(|status| status.qualify_next_retry_time.clone()),
+                        obj.status
+                            .as_ref()
+                            .and_then(|status| status.qualify_retry_hash.clone()),
+                    )
+                };
             if let Err(status_err) = write_degraded_status(
                 client,
                 &namespace,
@@ -1086,6 +1090,7 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                     store_qualified_hash,
                     qualify_failure_count,
                     qualify_next_retry_time,
+                    qualify_retry_hash,
                 },
                 extra_conditions,
                 obj.status
@@ -1201,8 +1206,11 @@ async fn reconcile_inner(
             let next_retry_unix = prior
                 .and_then(|s| s.qualify_next_retry_time.as_deref())
                 .and_then(parse_rfc3339_utc);
+            let retry_hash = prior.and_then(|s| s.qualify_retry_hash.as_deref());
             let plan = plan_qualify_gate(
                 &decision,
+                &desired_hash,
+                retry_hash,
                 failure_count,
                 next_retry_unix,
                 now_unix_secs(),
@@ -1270,6 +1278,7 @@ async fn reconcile_inner(
                     store_qualified_hash: qualified_hash,
                     qualify_failure_count: plan.failure_count,
                     qualify_next_retry_time: plan.next_retry_unix.map(format_rfc3339_utc),
+                    qualify_retry_hash: plan.retry_hash.clone(),
                 },
                 extra_conditions,
                 prior.map(|s| s.conditions.as_slice()).unwrap_or_default(),
@@ -1684,9 +1693,11 @@ async fn reconcile_inner(
             store_qualified_hash,
             // Qualification passed for these inputs this pass, so clear the retry
             // budget (issue #36, finding 3): the next failure, if any, starts a
-            // fresh backoff from one rather than resuming a stale count.
+            // fresh backoff from one rather than resuming a stale count. The retry
+            // hash is cleared with it; there is no live count for it to key.
             qualify_failure_count: None,
             qualify_next_retry_time: None,
+            qualify_retry_hash: None,
         },
         extra_conditions,
         obj.status
@@ -1937,6 +1948,10 @@ struct PersistedStatus {
     /// `status.qualifyNextRetryTime`: the RFC3339 instant before which no new
     /// qualify Job is created after a failure, or `None` when not holding.
     qualify_next_retry_time: Option<String>,
+    /// `status.qualifyRetryHash`: the qualified-input hash the persisted retry
+    /// count and next-retry time were recorded against (issue #36, finding 3), or
+    /// `None` when not in a retry hold.
+    qualify_retry_hash: Option<String>,
 }
 
 /// Build the success-path status: observed generation, per-mode ready replicas,
@@ -1988,6 +2003,7 @@ fn build_status(
         store_qualified_hash: persisted.store_qualified_hash,
         qualify_failure_count: persisted.qualify_failure_count,
         qualify_next_retry_time: persisted.qualify_next_retry_time,
+        qualify_retry_hash: persisted.qualify_retry_hash,
         conditions,
     }
 }
@@ -2019,6 +2035,7 @@ fn build_degraded_status(
         store_qualified_hash: persisted.store_qualified_hash,
         qualify_failure_count: persisted.qualify_failure_count,
         qualify_next_retry_time: persisted.qualify_next_retry_time,
+        qualify_retry_hash: persisted.qualify_retry_hash,
         conditions,
     }
 }

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use k8s_openapi::api::apps::v1::Deployment;
+use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::{Secret, Service, ServiceAccount};
 use k8s_openapi::api::networking::v1::Ingress;
 use k8s_openapi::api::policy::v1::PodDisruptionBudget;
@@ -37,11 +38,14 @@ use crate::crd::{
 use crate::reconcile::{
     DEPLOYMENT_KEY_SECRET_KEY, DeploymentTier, GC_BOOTSTRAP_STALL_AFTER,
     GC_BOOTSTRAP_STALLED_REASON, GC_BOOTSTRAP_UNAVAILABLE_MESSAGE, GC_BOOTSTRAP_UNAVAILABLE_REASON,
-    GcBootstrapGate, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
-    WAITING_FOR_GC_BOOTSTRAP_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_REASON, desired_objects,
-    grpcroute_api_resource, httproute_api_resource, possible_gateway_route_names,
-    possible_ingest_ingress_names, possible_pod_disruption_budget_names,
-    possible_router_object_names,
+    GcBootstrapGate, QUALIFY_COMPONENT, QUALIFY_SPEC_HASH_ANNOTATION, QualificationDecision,
+    QualifyJobObservation, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
+    STORE_QUALIFIED_FAILED_REASON, STORE_QUALIFIED_MESSAGE, STORE_QUALIFIED_PENDING_REASON,
+    STORE_QUALIFIED_SUCCEEDED_REASON, STORE_QUALIFYING_MESSAGE, WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
+    WAITING_FOR_GC_BOOTSTRAP_REASON, desired_objects, desired_qualify_job, grpcroute_api_resource,
+    httproute_api_resource, possible_gateway_route_names, possible_ingest_ingress_names,
+    possible_pod_disruption_budget_names, possible_router_object_names, qualification_decision,
+    qualify_job_input_hash, qualify_job_phase,
 };
 
 /// Server-side-apply field manager name.
@@ -952,6 +956,14 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 .status
                 .as_ref()
                 .and_then(|status| status.gc_bootstrap_waiting_since.clone());
+            // The qualified-inputs hash is owned by the qualification gate, not
+            // this error path: carry the persisted value through unchanged so a
+            // transient error after a cluster is already qualified does not drop
+            // the record and re-trigger qualification on the next pass.
+            let store_qualified_hash = obj
+                .status
+                .as_ref()
+                .and_then(|status| status.store_qualified_hash.clone());
             if let Err(status_err) = write_degraded_status(
                 client,
                 &namespace,
@@ -960,6 +972,7 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 &reason,
                 &message,
                 waiting_since,
+                store_qualified_hash,
                 extra_conditions,
             )
             .await
@@ -981,6 +994,121 @@ async fn reconcile_inner(
     instance: &str,
     mut extra_conditions: Vec<Condition>,
 ) -> Result<Action, Error> {
+    // Store qualification gate (issue #36). Before anything that would read or
+    // write the object store is created -- the sys/auth token map, the ingest
+    // router, and above all the serving Deployments -- prove the store passes
+    // `ravel store qualify`. A cluster brought up on a backend that fails the
+    // object-store contract (docs/object-store-contract.md) would otherwise
+    // crash-loop every server pod with an opaque runtime error; here it fails
+    // once, visibly, on a one-shot Job, and the `StoreQualified` condition says
+    // why. Qualification is proven for the current inputs and never re-run on a
+    // schedule: a durable `status.storeQualifiedHash` records the inputs it last
+    // passed against, so a finished Job garbage-collected by its TTL does not
+    // re-trigger it (ADR-0034).
+    let jobs: Api<Job> = Api::namespaced(client.clone(), namespace);
+    let qualify_name = child(instance, QUALIFY_COMPONENT);
+    let desired_hash = qualify_job_input_hash(&obj.spec);
+    let qualified_hash = obj
+        .status
+        .as_ref()
+        .and_then(|status| status.store_qualified_hash.clone());
+    let observation = observe_qualify_job(&jobs, &qualify_name).await?;
+    let decision = qualification_decision(&desired_hash, qualified_hash.as_deref(), &observation);
+
+    // The hash to persist on THIS pass's status: the current inputs once
+    // qualification proceeds, otherwise the last-qualified value unchanged (kept
+    // so an in-flight re-qualification does not drop the record and, with it, the
+    // gate that keeps existing Deployments up while the new inputs qualify).
+    let store_qualified_hash = match &decision {
+        QualificationDecision::Proceed => {
+            extra_conditions.push(condition(
+                "StoreQualified",
+                true,
+                obj.metadata.generation,
+                STORE_QUALIFIED_SUCCEEDED_REASON,
+                STORE_QUALIFIED_MESSAGE,
+            ));
+            Some(desired_hash.clone())
+        }
+        _ => {
+            // Not qualified for the current inputs: create or recreate the Job,
+            // record a `StoreQualified` condition, and return WITHOUT touching
+            // any Deployment. A fresh cluster gets none; a running cluster
+            // re-qualifying after a config edit keeps the ones it has (this pass
+            // never reaches the Deployment apply/sweep below), so a pending
+            // config change does not tear a serving cluster down.
+            let owner = obj.controller_owner_ref(&()).map(|owner| vec![owner]);
+            let (store_qualified_condition, action) = match &decision {
+                QualificationDecision::Qualify { recreate } => {
+                    if *recreate {
+                        // The Job's inputs changed; its pod template is immutable,
+                        // so delete the stale Job (its pods with it) and let the
+                        // next pass observe it absent and create a fresh one.
+                        delete_if_present(&jobs, &qualify_name).await?;
+                    } else {
+                        let mut job = desired_qualify_job(&obj.spec, instance);
+                        job.metadata.namespace = Some(namespace.to_string());
+                        job.metadata.owner_references = owner;
+                        apply(&jobs, &qualify_name, &job).await?;
+                    }
+                    (
+                        condition(
+                            "StoreQualified",
+                            false,
+                            obj.metadata.generation,
+                            STORE_QUALIFIED_PENDING_REASON,
+                            STORE_QUALIFYING_MESSAGE,
+                        ),
+                        Action::requeue(BOOTSTRAP_POLL),
+                    )
+                }
+                QualificationDecision::Waiting => (
+                    condition(
+                        "StoreQualified",
+                        false,
+                        obj.metadata.generation,
+                        STORE_QUALIFIED_PENDING_REASON,
+                        STORE_QUALIFYING_MESSAGE,
+                    ),
+                    Action::requeue(BOOTSTRAP_POLL),
+                ),
+                QualificationDecision::Failed(message) => (
+                    condition(
+                        "StoreQualified",
+                        false,
+                        obj.metadata.generation,
+                        STORE_QUALIFIED_FAILED_REASON,
+                        message,
+                    ),
+                    Action::requeue(RETRY),
+                ),
+                QualificationDecision::Proceed => unreachable!("Proceed handled above"),
+            };
+            extra_conditions.push(store_qualified_condition);
+
+            // Report the readiness a prior pass recorded, so a cluster already
+            // serving through a re-qualification keeps `Available=True` instead of
+            // flipping to "waiting for tiers" on every poll while the new inputs
+            // qualify. A fresh cluster has none of these and reports Available=False.
+            let prior = obj.status.as_ref();
+            write_status(
+                client,
+                namespace,
+                instance,
+                obj.metadata.generation,
+                prior.and_then(|s| s.gateway_ready_replicas),
+                prior.and_then(|s| s.query_ready_replicas),
+                prior.and_then(|s| s.maintain_ready_replicas),
+                None,
+                prior.and_then(|s| s.gc_bootstrap_waiting_since.clone()),
+                qualified_hash,
+                extra_conditions,
+            )
+            .await?;
+            return Ok(action);
+        }
+    };
+
     let token_secret = resolve_token_secret(
         client,
         namespace,
@@ -1385,6 +1513,7 @@ async fn reconcile_inner(
         maintain_ready,
         available_hold.as_ref().map(|(r, m)| (*r, m.as_str())),
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         extra_conditions,
     )
     .await?;
@@ -1469,6 +1598,29 @@ async fn live_deployment_exists(api: &Api<Deployment>, name: &str) -> Result<boo
     match api.get(name).await {
         Ok(_) => Ok(true),
         Err(err) if is_not_found(&err) => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Observe the live qualify Job for a cluster (issue #36): its recorded input
+/// hash (the [`QUALIFY_SPEC_HASH_ANNOTATION`] value, `None` when the annotation
+/// is missing) and its terminal phase, or [`QualifyJobObservation::Absent`] when
+/// no Job exists (a fresh cluster, or one whose finished Job has been
+/// TTL-garbage-collected). A not-found is `Absent`; any other error propagates.
+async fn observe_qualify_job(jobs: &Api<Job>, name: &str) -> Result<QualifyJobObservation, Error> {
+    match jobs.get(name).await {
+        Ok(job) => {
+            let spec_hash = job
+                .metadata
+                .annotations
+                .as_ref()
+                .and_then(|annotations| annotations.get(QUALIFY_SPEC_HASH_ANNOTATION).cloned());
+            Ok(QualifyJobObservation::Present {
+                spec_hash,
+                phase: qualify_job_phase(&job),
+            })
+        }
+        Err(err) if is_not_found(&err) => Ok(QualifyJobObservation::Absent),
         Err(err) => Err(err.into()),
     }
 }
@@ -1580,6 +1732,7 @@ fn build_status(
     maintain_ready: Option<i32>,
     unavailable_reason: Option<(&str, &str)>,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let available = gateway_ready.unwrap_or(0) > 0 && query_ready.unwrap_or(0) > 0;
@@ -1610,6 +1763,7 @@ fn build_status(
         query_ready_replicas: query_ready,
         maintain_ready_replicas: maintain_ready,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         conditions,
     }
 }
@@ -1625,6 +1779,7 @@ fn build_degraded_status(
     reason: &str,
     message: &str,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> RavelClusterStatus {
     let mut conditions = vec![
@@ -1638,6 +1793,7 @@ fn build_degraded_status(
         query_ready_replicas: None,
         maintain_ready_replicas: None,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         conditions,
     }
 }
@@ -1658,6 +1814,7 @@ async fn write_status(
     maintain_ready: Option<i32>,
     unavailable_reason: Option<(&str, &str)>,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_status(
@@ -1667,6 +1824,7 @@ async fn write_status(
         maintain_ready,
         unavailable_reason,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -1688,6 +1846,7 @@ async fn write_degraded_status(
     reason: &str,
     message: &str,
     gc_bootstrap_waiting_since: Option<String>,
+    store_qualified_hash: Option<String>,
     extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
     let status = build_degraded_status(
@@ -1695,6 +1854,7 @@ async fn write_degraded_status(
         reason,
         message,
         gc_bootstrap_waiting_since,
+        store_qualified_hash,
         extra_conditions,
     );
     patch_status(client, namespace, instance, &status).await
@@ -2134,6 +2294,7 @@ mod tests {
             Some(1),
             None,
             None,
+            None,
             extra.clone(),
         );
         assert_eq!(
@@ -2152,8 +2313,14 @@ mod tests {
             deprecated.message
         );
 
-        let degraded =
-            build_degraded_status(Some(7), "SecretNotFound", "no such Secret", None, extra);
+        let degraded = build_degraded_status(
+            Some(7),
+            "SecretNotFound",
+            "no such Secret",
+            None,
+            None,
+            extra,
+        );
         assert_eq!(
             condition_types(&degraded.conditions),
             vec!["Degraded", "Available", "IngestAffinityBackendDeprecated"]
@@ -2209,9 +2376,19 @@ mod tests {
                 "no spec-derived condition, got {:?}",
                 condition_types(&extra)
             );
-            let ok = build_status(Some(2), Some(1), Some(1), None, None, None, extra.clone());
+            let ok = build_status(
+                Some(2),
+                Some(1),
+                Some(1),
+                None,
+                None,
+                None,
+                None,
+                extra.clone(),
+            );
             assert_eq!(condition_types(&ok.conditions), vec!["Available"]);
-            let degraded = build_degraded_status(Some(2), "ReconcileError", "boom", None, extra);
+            let degraded =
+                build_degraded_status(Some(2), "ReconcileError", "boom", None, None, extra);
             assert_eq!(
                 condition_types(&degraded.conditions),
                 vec!["Degraded", "Available"]
@@ -2229,6 +2406,7 @@ mod tests {
             "SecretNotFound",
             "no such Secret",
             Some(since.clone()),
+            None,
             Vec::new(),
         );
         assert_eq!(
@@ -2236,7 +2414,8 @@ mod tests {
             Some(since.as_str()),
             "a transient error must leave the stall clock where it was"
         );
-        let cleared = build_degraded_status(Some(3), "ReconcileError", "boom", None, Vec::new());
+        let cleared =
+            build_degraded_status(Some(3), "ReconcileError", "boom", None, None, Vec::new());
         assert_eq!(cleared.gc_bootstrap_waiting_since, None);
     }
 
@@ -2258,6 +2437,7 @@ mod tests {
                 WAITING_FOR_GC_BOOTSTRAP_REASON,
                 WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
             )),
+            None,
             None,
             vec![condition(
                 "Degraded",
@@ -2292,6 +2472,7 @@ mod tests {
                 GC_BOOTSTRAP_UNAVAILABLE_MESSAGE,
             )),
             None,
+            None,
             vec![condition(
                 "Degraded",
                 true,
@@ -2318,6 +2499,7 @@ mod tests {
                 WAITING_FOR_GC_BOOTSTRAP_MESSAGE,
             )),
             None,
+            None,
             Vec::new(),
         );
         let available = find(&ready.conditions, "Available");
@@ -2334,11 +2516,49 @@ mod tests {
     /// effect, where the old plan withheld the tiers and nothing ever unblocked.
     #[test]
     fn gc_bootstrap_unavailable_clears_once_the_request_serving_tiers_report_ready() {
-        let running = build_status(Some(9), Some(1), Some(1), None, None, None, Vec::new());
+        let running = build_status(
+            Some(9),
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+        );
         assert_eq!(condition_types(&running.conditions), vec!["Available"]);
         let available = find(&running.conditions, "Available");
         assert_eq!(available.status, "True");
         assert_eq!(available.reason, "MinimumReplicasAvailable");
+    }
+
+    /// The durable qualified-inputs hash (issue #36) is written into the status
+    /// by both builders, so the qualification gate survives the Job's TTL-GC and
+    /// an operator restart. A dropped field here would silently re-run
+    /// qualification on the next pass.
+    #[test]
+    fn status_builders_carry_the_store_qualified_hash() {
+        let ok = build_status(
+            Some(1),
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+            Some("qhash".to_string()),
+            Vec::new(),
+        );
+        assert_eq!(ok.store_qualified_hash.as_deref(), Some("qhash"));
+
+        let degraded = build_degraded_status(
+            Some(1),
+            "ReconcileError",
+            "boom",
+            None,
+            Some("qhash".to_string()),
+            Vec::new(),
+        );
+        assert_eq!(degraded.store_qualified_hash.as_deref(), Some("qhash"));
     }
 
     /// The stall threshold as a signed second count, the unit
@@ -2484,7 +2704,16 @@ mod tests {
         );
         // reconcile therefore builds the status with no wait timestamp and no
         // stall condition.
-        let status = build_status(Some(2), Some(1), Some(1), Some(1), None, None, Vec::new());
+        let status = build_status(
+            Some(2),
+            Some(1),
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+            Vec::new(),
+        );
         assert_eq!(
             status.gc_bootstrap_waiting_since, None,
             "the timestamp is cleared once not waiting"

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -740,7 +740,7 @@ pub struct RavelClusterStatus {
 
     /// The qualify-Job input hash (bucket, region, endpoint, image, credentials
     /// Secret name) that store qualification last succeeded against (issue #36).
-    /// The operator gates serving on `ravel store qualify` before it creates any
+    /// The operator gates serving on `ravel-cli store qualify` before it creates any
     /// Deployment; recording the qualified inputs here makes that gate durable:
     /// a later pass whose inputs still hash to this value proceeds without
     /// re-running qualification even after the one-shot Job has been
@@ -751,6 +751,28 @@ pub struct RavelClusterStatus {
     /// change re-triggers it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub store_qualified_hash: Option<String>,
+
+    /// Consecutive qualify-Job failures for the current inputs (issue #36, finding
+    /// 3). Drives the capped exponential recreation backoff and the terminal
+    /// cooldown: the operator does not recreate a failing qualify Job unboundedly,
+    /// it spaces the recreations out and, past a threshold, holds. Reset to absent
+    /// on a successful qualification and on any input change (a moving
+    /// `storeQualifiedHash` input); never part of the qualified-input hash, so
+    /// counting failures never re-runs a qualification that would otherwise pass.
+    ///
+    /// Serialized even when absent (as explicit `null`) so the status merge patch
+    /// clears it on success; a skipped field would leave a stale count behind.
+    #[serde(default)]
+    pub qualify_failure_count: Option<i32>,
+
+    /// RFC3339 instant before which the operator creates no new qualify Job after
+    /// a failure (issue #36, finding 3): the next point on the capped exponential
+    /// backoff, or the terminal cooldown's expiry. Absent when not holding.
+    ///
+    /// Serialized even when absent (as explicit `null`) so the status merge patch
+    /// clears it; a skipped field would leave a stale deadline behind.
+    #[serde(default)]
+    pub qualify_next_retry_time: Option<String>,
 
     /// Standard Kubernetes conditions: `Available`, `Progressing`, `Degraded`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -774,6 +774,24 @@ pub struct RavelClusterStatus {
     #[serde(default)]
     pub qualify_next_retry_time: Option<String>,
 
+    /// The qualify-Job input hash the persisted `qualifyFailureCount` and
+    /// `qualifyNextRetryTime` were recorded against (issue #36, finding 3). The
+    /// retry state is meaningful only for the inputs that produced the failures:
+    /// when the desired inputs no longer hash to this value the operator resets
+    /// the count and next-retry and qualifies the new inputs at once, whether or
+    /// not the failing Job still exists. Without this key the operator cannot tell
+    /// a changed-input pass from an unchanged one once the Failed Job is
+    /// TTL-garbage-collected (both observe the Job absent), so a config edit made
+    /// after the Job's TTL collected it would wait out the old inputs' cooldown and
+    /// inherit their failure count. This is never part of the qualified-input hash
+    /// itself, so recording it never re-runs a qualification that would pass.
+    ///
+    /// Serialized even when absent (as explicit `null`) so the status merge patch
+    /// clears it on reset or success; a skipped field would leave a stale key
+    /// behind.
+    #[serde(default)]
+    pub qualify_retry_hash: Option<String>,
+
     /// Standard Kubernetes conditions: `Available`, `Progressing`, `Degraded`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -738,6 +738,20 @@ pub struct RavelClusterStatus {
     #[serde(default)]
     pub gc_bootstrap_waiting_since: Option<String>,
 
+    /// The qualify-Job input hash (bucket, region, endpoint, image, credentials
+    /// Secret name) that store qualification last succeeded against (issue #36).
+    /// The operator gates serving on `ravel store qualify` before it creates any
+    /// Deployment; recording the qualified inputs here makes that gate durable:
+    /// a later pass whose inputs still hash to this value proceeds without
+    /// re-running qualification even after the one-shot Job has been
+    /// TTL-garbage-collected, and a pass whose inputs no longer match re-runs it
+    /// (the `StoreQualified` condition flips back to `Pending`) without tearing
+    /// down the running Deployments. Absent until the first qualification
+    /// succeeds. Qualification is never re-run on a schedule; only an input
+    /// change re-triggers it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store_qualified_hash: Option<String>,
+
     /// Standard Kubernetes conditions: `Available`, `Progressing`, `Degraded`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -2049,10 +2049,22 @@ pub fn qualify_job_input_hash(
     spec: &RavelClusterSpec,
     credentials_resource_version: Option<&str>,
 ) -> String {
+    // Endpoint presence is significant (finding 3, issue #36): common_store_args
+    // and desired_qualify_job emit the endpoint flag/env only when Some, so
+    // endpoint: null and endpoint: "" select different stores, yet
+    // as_deref().unwrap_or("") fed the hasher the same "" for both and hashed
+    // them identically. A distinct presence byte in front of the value keeps the
+    // two forms apart, so editing between them re-qualifies: 0x01 then the value
+    // for Some, a lone 0x00 for None. The 0xff field separator fixes the field
+    // boundary; this byte fixes presence, which the separator alone cannot.
+    let endpoint = match spec.storage.s3.endpoint.as_deref() {
+        Some(value) => format!("\u{1}{value}"),
+        None => "\u{0}".to_string(),
+    };
     blake3_hex(&[
         spec.storage.s3.bucket.as_str(),
         spec.storage.s3.region.as_str(),
-        spec.storage.s3.endpoint.as_deref().unwrap_or(""),
+        endpoint.as_str(),
         spec.image.as_str(),
         spec.storage.s3.credentials_secret_ref.name.as_str(),
         credentials_resource_version.unwrap_or(""),
@@ -5788,11 +5800,12 @@ mod tests {
 
     /// Finding 1 verb sweep. Every operator write is server-side apply (a PATCH,
     /// with `create` for objects that do not yet exist) or a delete, never a
-    /// PUT, so no rule grants the `update` verb. The `batch`/`jobs` rule is
-    /// exactly the verbs the reconcile loop calls: `create`/`patch` (apply),
-    /// `get` (observe the qualify Job), and `delete` (foreground recreate); it is
-    /// not watched by an informer, so no `list`/`watch`. A text scan so a rule
-    /// that reintroduces a dead verb fails the gate.
+    /// PUT, so no rule grants the `update` verb. Each rule grants exactly the
+    /// verbs the reconcile loop calls (or that RBAC escalation prevention forces
+    /// for the router Role): the table below pins the exact verbs line for every
+    /// rule in rbac.yaml, so any verb change to any rule (a reintroduced dead
+    /// verb, a dropped read, a widened grant) fails the gate, not only the
+    /// batch/jobs rule.
     #[test]
     fn rbac_grants_only_the_verbs_the_reconcile_loop_calls() {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -5807,17 +5820,72 @@ mod tests {
             "server-side apply is a PATCH, not a PUT: no rule may grant the update verb"
         );
 
-        // The jobs rule grants exactly create/patch/get/delete.
-        let jobs_verbs = manifest
-            .lines()
-            .skip_while(|l| l.trim() != "resources: [\"jobs\"]")
-            .nth(1)
-            .map(str::trim)
-            .expect("rbac.yaml defines a batch/jobs rule with a verbs line");
-        assert_eq!(
-            jobs_verbs, "verbs: [\"create\", \"patch\", \"get\", \"delete\"]",
-            "the jobs rule grants only create/patch (apply), get (observe), and delete"
-        );
+        // Every rule's resources line paired with the exact verbs line that must
+        // follow it. The `resources:` line uniquely identifies each rule (the two
+        // ClusterRoles never repeat one), and the `verbs:` line is always the next
+        // line, matching rbac.yaml's apiGroups/resources/verbs ordering.
+        let rules: &[(&str, &str)] = &[
+            (
+                "resources: [\"deployments\"]",
+                "verbs: [\"create\", \"patch\", \"get\", \"list\", \"watch\", \"delete\"]",
+            ),
+            (
+                "resources: [\"services\"]",
+                "verbs: [\"create\", \"patch\", \"get\", \"list\", \"watch\", \"delete\"]",
+            ),
+            (
+                "resources: [\"ingresses\"]",
+                "verbs: [\"create\", \"patch\", \"list\", \"watch\", \"delete\"]",
+            ),
+            (
+                "resources: [\"httproutes\", \"grpcroutes\"]",
+                "verbs: [\"create\", \"patch\", \"delete\"]",
+            ),
+            (
+                "resources: [\"serviceaccounts\"]",
+                "verbs: [\"create\", \"patch\", \"delete\"]",
+            ),
+            (
+                "resources: [\"roles\", \"rolebindings\"]",
+                "verbs: [\"create\", \"patch\", \"delete\"]",
+            ),
+            (
+                "resources: [\"endpointslices\"]",
+                "verbs: [\"get\", \"list\", \"watch\"]",
+            ),
+            (
+                "resources: [\"ravelclusters\"]",
+                "verbs: [\"list\", \"watch\"]",
+            ),
+            (
+                "resources: [\"ravelclusters/status\"]",
+                "verbs: [\"patch\"]",
+            ),
+            (
+                "resources: [\"poddisruptionbudgets\"]",
+                "verbs: [\"create\", \"patch\", \"delete\"]",
+            ),
+            (
+                "resources: [\"jobs\"]",
+                "verbs: [\"create\", \"patch\", \"get\", \"delete\"]",
+            ),
+            ("resources: [\"secrets\"]", "verbs: [\"get\"]"),
+        ];
+
+        for (resources_line, expected_verbs) in rules {
+            let verbs = manifest
+                .lines()
+                .skip_while(|l| l.trim() != *resources_line)
+                .nth(1)
+                .map(str::trim)
+                .unwrap_or_else(|| {
+                    panic!("rbac.yaml defines a rule for {resources_line} with a verbs line")
+                });
+            assert_eq!(
+                verbs, *expected_verbs,
+                "the {resources_line} rule must grant exactly {expected_verbs}"
+            );
+        }
     }
 
     /// A job condition of the given type/status, the shape
@@ -5913,6 +5981,20 @@ mod tests {
             base,
             qualify_job_input_hash(&replicas, Some("rv-1")),
             "an unrelated spec edit (replica count) does not re-qualify"
+        );
+
+        // Endpoint presence is significant (finding 3): endpoint: null and
+        // endpoint: "" emit a different qualify Job and run the servers against a
+        // different store (the flag/env is omitted only for None), so the two must
+        // hash differently. as_deref().unwrap_or("") fed the hasher "" for both.
+        let mut endpoint_none = spec.clone();
+        endpoint_none.storage.s3.endpoint = None;
+        let mut endpoint_empty = spec.clone();
+        endpoint_empty.storage.s3.endpoint = Some(String::new());
+        assert_ne!(
+            qualify_job_input_hash(&endpoint_none, Some("rv-1")),
+            qualify_job_input_hash(&endpoint_empty, Some("rv-1")),
+            "endpoint: null and endpoint: \"\" are different stores and must hash differently"
         );
     }
 
@@ -6115,10 +6197,14 @@ mod tests {
         // excluding both knobs, through the same `blake3_hex` composition the
         // production hasher uses. If it folded either knob in, this reference
         // would diverge and the assertion would fail.
+        let endpoint = match spec.storage.s3.endpoint.as_deref() {
+            Some(value) => format!("\u{1}{value}"),
+            None => "\u{0}".to_string(),
+        };
         let expected = blake3_hex(&[
             spec.storage.s3.bucket.as_str(),
             spec.storage.s3.region.as_str(),
-            spec.storage.s3.endpoint.as_deref().unwrap_or(""),
+            endpoint.as_str(),
             spec.image.as_str(),
             spec.storage.s3.credentials_secret_ref.name.as_str(),
             "rv-1",
@@ -6165,12 +6251,14 @@ mod tests {
     /// Golden value for [`qualify_job_input_hash`] (finding 3): the six
     /// store-identity inputs of [`base_spec`] plus a fixed credentials
     /// `resourceVersion` hash to a fixed literal, stable by construction across
-    /// Rust releases.
+    /// Rust releases. The literal changed when the endpoint slot gained a
+    /// presence byte (0x01 before a Some value) so endpoint: null and
+    /// endpoint: "" no longer collide.
     #[test]
     fn qualify_job_input_hash_golden_is_stable_by_construction() {
         assert_eq!(
             qualify_job_input_hash(&base_spec(), Some("rv-golden")),
-            "adfd6df5df66464b2bdfa458c3af84ae1011a0c445d2e4823dfd02adda76bbf8",
+            "492577362c8a6c9f6057e4281937d8b7a90289116e21e496c0acc7ed55d3784d",
         );
     }
 
@@ -6435,10 +6523,14 @@ mod tests {
     #[test]
     fn qualify_input_hash_excludes_retry_state() {
         let spec = base_spec();
+        let endpoint = match spec.storage.s3.endpoint.as_deref() {
+            Some(value) => format!("\u{1}{value}"),
+            None => "\u{0}".to_string(),
+        };
         let expected = blake3_hex(&[
             spec.storage.s3.bucket.as_str(),
             spec.storage.s3.region.as_str(),
-            spec.storage.s3.endpoint.as_deref().unwrap_or(""),
+            endpoint.as_str(),
             spec.image.as_str(),
             spec.storage.s3.credentials_secret_ref.name.as_str(),
             "rv",

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1929,6 +1929,33 @@ pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 4;
 /// garbage-collected after success does not re-trigger qualification.
 pub const QUALIFY_JOB_TTL_SECONDS: i32 = 3600;
 
+/// `activeDeadlineSeconds` for the qualify Job: a wall-clock bound on a single
+/// attempt, so a qualify pod that hangs (an S3 endpoint that accepts the TCP
+/// connection and then never answers) becomes a `Failed` Job with reason
+/// `DeadlineExceeded` instead of running indefinitely. `backoffLimit` bounds
+/// only how many *failed* attempts run; it does nothing for one attempt that
+/// never terminates, which leaves `StoreQualified` stuck at `Pending` forever.
+///
+/// The value must clear a slow-but-healthy run with margin. `ravel store
+/// qualify` runs 28 sequential object operations against the bucket: probe
+/// create-if-absent (put, put, get = 3), probe CAS version (put, put, put,
+/// get = 4), probe read-after-write ([`super`]'s `CONSISTENCY_CYCLES` = 5
+/// put+get = 10), probe list-after-write (5 put+list = 10), and the final
+/// `sys/qualification` create-if-absent write (1); the two informational
+/// probes issue no request through the `ObjectStoreBackend` contract. Each
+/// operation's per-request ceiling is the S3 client's 20 s `request_timeout`
+/// (ravel-object-store `S3HttpConfig::default`), so a slow-but-healthy run
+/// whose every operation approaches that ceiling without retrying is bounded
+/// by 28 * 20 s = 560 s. 900 s adds a ~1.6x margin (340 s of slack) for pod
+/// scheduling, image pull, and the occasional single retry, while staying far
+/// below a hung endpoint's ~200 s-per-operation worst case (`retry_timeout`
+/// 180 s + `request_timeout` 20 s): a hang trips the deadline after roughly
+/// four stalled operations rather than exhausting all 28.
+///
+/// Not part of [`qualify_job_input_hash`]: tuning this deadline must not
+/// re-run a qualification that already passed.
+pub const QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS: i64 = 900;
+
 /// `StoreQualified` reason while the qualify Job is being created or is still
 /// running: serving is held until it reports success.
 pub const STORE_QUALIFIED_PENDING_REASON: &str = "Pending";
@@ -1993,8 +2020,10 @@ pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
 ///
 /// The Job carries [`QUALIFY_SPEC_HASH_ANNOTATION`] so the controller re-runs it
 /// when its inputs change and skips it when they do not, and sets
-/// `restartPolicy: Never`, a small [`QUALIFY_JOB_BACKOFF_LIMIT`], and
-/// [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not accumulate.
+/// `restartPolicy: Never`, a small [`QUALIFY_JOB_BACKOFF_LIMIT`],
+/// [`QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS`] so a hung attempt fails rather than
+/// runs forever, and [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not
+/// accumulate.
 pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
     let labels = labels(instance, QUALIFY_COMPONENT);
     let mut env = vec![
@@ -2048,6 +2077,7 @@ pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
         },
         spec: Some(JobSpec {
             backoff_limit: Some(QUALIFY_JOB_BACKOFF_LIMIT),
+            active_deadline_seconds: Some(QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS),
             ttl_seconds_after_finished: Some(QUALIFY_JOB_TTL_SECONDS),
             template: PodTemplateSpec {
                 metadata: Some(ObjectMeta {
@@ -2158,8 +2188,16 @@ pub fn qualification_decision(
 }
 
 /// The [`QualifyJobPhase`] a live Job reports, read from its status conditions:
-/// `Complete=True` is success, `Failed=True` is failure (its message carried
-/// through), anything else is still running.
+/// `Complete=True` is success, `Failed=True` is failure, anything else is still
+/// running.
+///
+/// A `Failed` condition's `reason` is prepended to its `message` (`"<reason>:
+/// <message>"`) so the `StoreQualified` condition names why the Job failed, not
+/// only the human message. This matters for a deadline-exceeded Job: the Job
+/// controller sets reason `DeadlineExceeded` with a generic message ("Job was
+/// active longer than specified deadline"), and the reason is the part an
+/// operator needs to see. When only one of reason/message is present that one
+/// is used verbatim; when neither is, a fixed fallback is.
 pub fn qualify_job_phase(job: &Job) -> QualifyJobPhase {
     let Some(conditions) = job.status.as_ref().and_then(|s| s.conditions.as_ref()) else {
         return QualifyJobPhase::Running;
@@ -2171,13 +2209,15 @@ pub fn qualify_job_phase(job: &Job) -> QualifyJobPhase {
         match c.type_.as_str() {
             "Complete" => return QualifyJobPhase::Succeeded,
             "Failed" => {
-                let message = c
-                    .message
-                    .clone()
-                    .filter(|m| !m.is_empty())
-                    .or_else(|| c.reason.clone())
-                    .unwrap_or_else(|| "the store qualification Job failed".to_string());
-                return QualifyJobPhase::Failed(message);
+                let reason = c.reason.clone().filter(|r| !r.is_empty());
+                let message = c.message.clone().filter(|m| !m.is_empty());
+                let text = match (reason, message) {
+                    (Some(reason), Some(message)) => format!("{reason}: {message}"),
+                    (Some(reason), None) => reason,
+                    (None, Some(message)) => message,
+                    (None, None) => "the store qualification Job failed".to_string(),
+                };
+                return QualifyJobPhase::Failed(text);
             }
             _ => {}
         }
@@ -5444,6 +5484,26 @@ mod tests {
         }
     }
 
+    /// A Job reporting `Failed=True` with the given `reason` and `message`, the
+    /// shape the Kubernetes Job controller sets when it fails a Job (a
+    /// deadline-exceeded Job carries reason `DeadlineExceeded`).
+    fn job_with_failed_reason(reason: &str, message: Option<&str>) -> Job {
+        use k8s_openapi::api::batch::v1::{JobCondition, JobStatus};
+        Job {
+            status: Some(JobStatus {
+                conditions: Some(vec![JobCondition {
+                    type_: "Failed".to_string(),
+                    status: "True".to_string(),
+                    reason: Some(reason.to_string()),
+                    message: message.map(str::to_string),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
     /// The input hash is stable for one spec and changes for each of the five
     /// inputs it covers, and only those. Pins the exact set of fields that
     /// re-trigger qualification (issue #36): a change to any of them is a
@@ -5602,6 +5662,99 @@ mod tests {
         assert_eq!(
             qualify_job_phase(&job_with_condition("Failed", "False", None)),
             QualifyJobPhase::Running
+        );
+    }
+
+    /// The rendered qualify Job sets `activeDeadlineSeconds` to the chosen value,
+    /// so a hung attempt (an endpoint that accepts the connection and never
+    /// answers) becomes a `Failed` Job rather than running forever. `backoffLimit`
+    /// bounds only failed attempts, not one attempt that never terminates.
+    #[test]
+    fn qualify_job_bounds_a_hung_attempt() {
+        let spec = base_spec();
+        let job = desired_qualify_job(&spec, "prod");
+        let job_spec = job.spec.as_ref().expect("qualify Job has a spec");
+        assert_eq!(
+            job_spec.active_deadline_seconds,
+            Some(QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS),
+            "the qualify Job bounds a single attempt with activeDeadlineSeconds"
+        );
+        assert_eq!(
+            QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS, 900,
+            "the chosen deadline is 900 s (28 sequential ops * 20 s request_timeout \
+             = 560 s slow-but-healthy, plus a ~1.6x margin)"
+        );
+    }
+
+    /// A Job the Kubernetes Job controller failed for exceeding its
+    /// `activeDeadlineSeconds` reports `Failed=True` with reason
+    /// `DeadlineExceeded`. That reads as [`QualificationDecision::Failed`] (which
+    /// the controller renders as `StoreQualified=False`), and its message names
+    /// the reason exactly so an operator sees why qualification did not finish.
+    #[test]
+    fn a_deadline_exceeded_job_reads_as_failed_with_its_reason() {
+        let job = job_with_failed_reason(
+            "DeadlineExceeded",
+            Some("Job was active longer than specified deadline"),
+        );
+        let phase = qualify_job_phase(&job);
+        let message = match &phase {
+            QualifyJobPhase::Failed(message) => message.clone(),
+            other => panic!("a Failed=True Job reads as Failed, got {other:?}"),
+        };
+        assert!(
+            message.contains("DeadlineExceeded"),
+            "the failure message names the DeadlineExceeded reason exactly: {message:?}"
+        );
+
+        // The gate reports a Present Job for the current inputs in the Failed
+        // phase as Failed, carrying that message; the controller turns Failed
+        // into StoreQualified=False with STORE_QUALIFIED_FAILED_REASON.
+        let decision = qualification_decision(
+            "h",
+            None,
+            &QualifyJobObservation::Present {
+                spec_hash: Some("h".to_string()),
+                phase,
+            },
+        );
+        assert_eq!(decision, QualificationDecision::Failed(message));
+    }
+
+    /// The `activeDeadlineSeconds` is a tuning knob, not a store-identity input:
+    /// [`qualify_job_input_hash`] covers exactly the five inputs qualification
+    /// proves against and never the deadline, so changing the deadline leaves the
+    /// hash equal and does not re-run a qualification that already passed.
+    #[test]
+    fn the_deadline_is_not_part_of_the_qualified_input_hash() {
+        use std::hash::{Hash, Hasher};
+        let spec = base_spec();
+
+        // Recompute the hash over exactly the five qualified inputs, deliberately
+        // excluding the deadline. If the production hasher folded the deadline in,
+        // this reference would diverge and the assertion would fail.
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        spec.storage.s3.bucket.hash(&mut hasher);
+        spec.storage.s3.region.hash(&mut hasher);
+        spec.storage
+            .s3
+            .endpoint
+            .as_deref()
+            .unwrap_or("")
+            .hash(&mut hasher);
+        spec.image.hash(&mut hasher);
+        spec.storage
+            .s3
+            .credentials_secret_ref
+            .name
+            .hash(&mut hasher);
+        let expected = format!("{:016x}", hasher.finish());
+
+        assert_eq!(
+            qualify_job_input_hash(&spec),
+            expected,
+            "the qualified-input hash covers exactly the five store-identity inputs, never the \
+             deadline"
         );
     }
 

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -179,23 +179,40 @@ fn tier_credentials_secret_name<'a>(
 /// content changes and are stable otherwise, so this value is stable across
 /// reconciles that see the same Secrets (no pod churn) and changes the moment a
 /// token is rotated, the tier's credential is rewritten, or the deployment key
-/// is rotated. The hash is `DefaultHasher` (SipHash with fixed keys),
-/// deterministic across processes, so an operator restart does not roll pods.
-/// It is not a security boundary, only a signal. Stamped onto the tier's pod
-/// template as [`SECRETS_CHECKSUM_ANNOTATION`]; when tiers resolve to
-/// different credential Secrets, a change to one rolls only the tier(s) that
-/// consume it.
+/// is rotated. The hash is `blake3`, a fixed algorithm, so the value depends
+/// only on the inputs and is stable across processes AND Rust toolchain
+/// versions: an operator restart or a compiler upgrade does not roll pods.
+/// (std's `DefaultHasher` is not stable across Rust releases, so an upgrade
+/// would have rolled every tier Deployment for unchanged inputs.) It is not a
+/// security boundary, only a signal. Stamped onto the tier's pod template as
+/// [`SECRETS_CHECKSUM_ANNOTATION`]; when tiers resolve to different credential
+/// Secrets, a change to one rolls only the tier(s) that consume it.
 pub fn secrets_checksum(
     token_rv: Option<&str>,
     credentials_rv: Option<&str>,
     deployment_key_rv: Option<&str>,
 ) -> String {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    token_rv.unwrap_or("").hash(&mut hasher);
-    credentials_rv.unwrap_or("").hash(&mut hasher);
-    deployment_key_rv.unwrap_or("").hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
+    blake3_hex(&[
+        token_rv.unwrap_or(""),
+        credentials_rv.unwrap_or(""),
+        deployment_key_rv.unwrap_or(""),
+    ])
+}
+
+/// A stable hex digest of an ordered list of string fields, using `blake3`
+/// (finding 3, issue #36). Each field is fed followed by a `0xff` separator
+/// byte, which cannot appear in UTF-8, so no concatenation of adjacent fields
+/// can collide with a different split (`"ab" + "c"` differs from `"a" + "bc"`).
+/// The digest is rendered as lowercase hex. Used by [`secrets_checksum`] and
+/// [`qualify_job_input_hash`]; both are change signals, not security
+/// boundaries.
+fn blake3_hex(fields: &[&str]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    for field in fields {
+        hasher.update(field.as_bytes());
+        hasher.update(&[0xff]);
+    }
+    hasher.finalize().to_hex().to_string()
 }
 
 /// The [`SECRETS_CHECKSUM_ANNOTATION`] value for a tier, resolving which
@@ -2022,31 +2039,24 @@ pub const STORE_QUALIFIED_MESSAGE: &str =
 /// `resourceVersion`, this hash changes, and the gate recreates the Job. The
 /// bound on noticing a rotation is therefore one `RESYNC` interval.
 ///
-/// `DefaultHasher` (SipHash with fixed keys) is deterministic across processes,
-/// so an operator restart does not spuriously re-qualify. It is a change signal,
-/// not a security boundary, exactly like [`secrets_checksum`].
+/// `blake3` is a fixed algorithm, so the hash depends only on the inputs and is
+/// stable across processes AND Rust toolchain versions: neither an operator
+/// restart nor a compiler upgrade spuriously re-qualifies. (std's
+/// `DefaultHasher` is not stable across Rust releases, so an upgrade would have
+/// re-run qualification for every cluster on unchanged inputs.) It is a change
+/// signal, not a security boundary, exactly like [`secrets_checksum`].
 pub fn qualify_job_input_hash(
     spec: &RavelClusterSpec,
     credentials_resource_version: Option<&str>,
 ) -> String {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    spec.storage.s3.bucket.hash(&mut hasher);
-    spec.storage.s3.region.hash(&mut hasher);
-    spec.storage
-        .s3
-        .endpoint
-        .as_deref()
-        .unwrap_or("")
-        .hash(&mut hasher);
-    spec.image.hash(&mut hasher);
-    spec.storage
-        .s3
-        .credentials_secret_ref
-        .name
-        .hash(&mut hasher);
-    credentials_resource_version.unwrap_or("").hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
+    blake3_hex(&[
+        spec.storage.s3.bucket.as_str(),
+        spec.storage.s3.region.as_str(),
+        spec.storage.s3.endpoint.as_deref().unwrap_or(""),
+        spec.image.as_str(),
+        spec.storage.s3.credentials_secret_ref.name.as_str(),
+        credentials_resource_version.unwrap_or(""),
+    ])
 }
 
 /// The one-shot store-qualification Job for a cluster (issue #36).
@@ -5840,35 +5850,68 @@ mod tests {
     /// equal and does not re-run a qualification that already passed.
     #[test]
     fn the_deadline_is_not_part_of_the_qualified_input_hash() {
-        use std::hash::{Hash, Hasher};
         let spec = base_spec();
 
         // Recompute the hash over exactly the six qualified inputs, deliberately
-        // excluding both knobs. If the production hasher folded either in, this
-        // reference would diverge and the assertion would fail.
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        spec.storage.s3.bucket.hash(&mut hasher);
-        spec.storage.s3.region.hash(&mut hasher);
-        spec.storage
-            .s3
-            .endpoint
-            .as_deref()
-            .unwrap_or("")
-            .hash(&mut hasher);
-        spec.image.hash(&mut hasher);
-        spec.storage
-            .s3
-            .credentials_secret_ref
-            .name
-            .hash(&mut hasher);
-        "rv-1".hash(&mut hasher);
-        let expected = format!("{:016x}", hasher.finish());
+        // excluding both knobs, through the same `blake3_hex` composition the
+        // production hasher uses. If it folded either knob in, this reference
+        // would diverge and the assertion would fail.
+        let expected = blake3_hex(&[
+            spec.storage.s3.bucket.as_str(),
+            spec.storage.s3.region.as_str(),
+            spec.storage.s3.endpoint.as_deref().unwrap_or(""),
+            spec.image.as_str(),
+            spec.storage.s3.credentials_secret_ref.name.as_str(),
+            "rv-1",
+        ]);
 
         assert_eq!(
             qualify_job_input_hash(&spec, Some("rv-1")),
             expected,
             "the qualified-input hash covers exactly the six store-identity inputs, never the \
              deadline or the backoff limit"
+        );
+    }
+
+    /// Golden value for [`blake3_hex`] (finding 3): a fixed input set hashes to
+    /// a fixed literal. This pins the algorithm (blake3), the `0xff` field
+    /// separator, and the lowercase-hex rendering by construction, so a future
+    /// change to any of them fails here instead of silently re-running
+    /// qualification and rolling every tier Deployment on a toolchain upgrade.
+    #[test]
+    fn blake3_hex_golden_is_stable_by_construction() {
+        assert_eq!(
+            blake3_hex(&["field-a", "field-b", "field-c"]),
+            "cef8162179abe2fd9467777a9e0957f18af3abff59960b15b0210ee312836274",
+        );
+        // The `0xff` separator makes the field split significant: no other
+        // grouping of the same bytes collides.
+        assert_ne!(
+            blake3_hex(&["field-a", "field-b", "field-c"]),
+            blake3_hex(&["field-afield-b", "field-c"]),
+        );
+    }
+
+    /// Golden value for [`secrets_checksum`] (finding 3): a fixed set of
+    /// resourceVersions hashes to a fixed literal, so a toolchain upgrade that
+    /// changed the algorithm would fail here rather than roll every tier's pods.
+    #[test]
+    fn secrets_checksum_golden_is_stable_by_construction() {
+        assert_eq!(
+            secrets_checksum(Some("100"), Some("200"), Some("300")),
+            "cea2e01fb489ecc4dac2f461605797406a50b29725416c6c6dd5ab97a18ea8a0",
+        );
+    }
+
+    /// Golden value for [`qualify_job_input_hash`] (finding 3): the six
+    /// store-identity inputs of [`base_spec`] plus a fixed credentials
+    /// `resourceVersion` hash to a fixed literal, stable by construction across
+    /// Rust releases.
+    #[test]
+    fn qualify_job_input_hash_golden_is_stable_by_construction() {
+        assert_eq!(
+            qualify_job_input_hash(&base_spec(), Some("rv-golden")),
+            "adfd6df5df66464b2bdfa458c3af84ae1011a0c445d2e4823dfd02adda76bbf8",
         );
     }
 

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy};
+use k8s_openapi::api::batch::v1::{Job, JobSpec};
 use k8s_openapi::api::core::v1::{
     Affinity, Capabilities, Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction,
     KeyToPath, PodAffinityTerm, PodAntiAffinity, PodSecurityContext, PodSpec, PodTemplateSpec,
@@ -1904,6 +1905,284 @@ pub fn gc_bootstrap_plan(spec: &RavelClusterSpec) -> GcBootstrapPlan {
         gate,
         maintain_enabled: spec.maintain.enabled,
     }
+}
+
+/// Component suffix of the one-shot store-qualification Job (issue #36): its
+/// child name is `<cluster>-qualify`.
+pub const QUALIFY_COMPONENT: &str = "qualify";
+
+/// Annotation on the qualify Job carrying [`qualify_job_input_hash`], so a
+/// change to the inputs qualification proves against (bucket, region, endpoint,
+/// image, credentials Secret name) re-runs it and a no-op reconcile does not.
+pub const QUALIFY_SPEC_HASH_ANNOTATION: &str = "ravel.nofire.ai/qualify-spec-hash";
+
+/// `backoffLimit` for the qualify Job: a few retries absorb a transient S3
+/// error (a backend still coming up) without spinning forever on a genuine
+/// qualification failure (a backend that fails conditional-create atomicity or
+/// list consistency). Four attempts, then the Job reports `Failed` and the
+/// controller surfaces it on the `StoreQualified` condition.
+pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 4;
+
+/// `ttlSecondsAfterFinished` for the qualify Job: one hour, so a finished Job
+/// does not accumulate across reconciles or re-qualifications. The qualified
+/// state itself is durable in `status.storeQualifiedHash`, so a Job
+/// garbage-collected after success does not re-trigger qualification.
+pub const QUALIFY_JOB_TTL_SECONDS: i32 = 3600;
+
+/// `StoreQualified` reason while the qualify Job is being created or is still
+/// running: serving is held until it reports success.
+pub const STORE_QUALIFIED_PENDING_REASON: &str = "Pending";
+
+/// `StoreQualified` reason once the store has been qualified for the current
+/// inputs; serving proceeds.
+pub const STORE_QUALIFIED_SUCCEEDED_REASON: &str = "Succeeded";
+
+/// `StoreQualified` reason when the qualify Job exhausted its `backoffLimit`
+/// without succeeding; serving stays held and the pass requeues on backoff.
+pub const STORE_QUALIFIED_FAILED_REASON: &str = "Failed";
+
+/// Message paired with [`STORE_QUALIFIED_PENDING_REASON`].
+pub const STORE_QUALIFYING_MESSAGE: &str = "running store qualification (ravel store qualify) against the cluster's bucket; the \
+     gateway, query, and maintain Deployments are held until it succeeds so the cluster never \
+     serves on a backend that fails the object-store contract (docs/object-store-contract.md)";
+
+/// Message paired with [`STORE_QUALIFIED_SUCCEEDED_REASON`].
+pub const STORE_QUALIFIED_MESSAGE: &str =
+    "the object store passed ravel store qualify; serving Deployments may be created";
+
+/// A deterministic change-detection hash over the inputs store qualification
+/// proves against (issue #36): the bucket, region, endpoint, server image, and
+/// the credentials Secret name. When any of these changes the store the cluster
+/// would serve on is a different one, so qualification is re-run; an unrelated
+/// spec edit (a replica count, a fold interval) leaves this stable and does not
+/// re-qualify.
+///
+/// `DefaultHasher` (SipHash with fixed keys) is deterministic across processes,
+/// so an operator restart does not spuriously re-qualify. It is a change signal,
+/// not a security boundary, exactly like [`secrets_checksum`].
+pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    spec.storage.s3.bucket.hash(&mut hasher);
+    spec.storage.s3.region.hash(&mut hasher);
+    spec.storage
+        .s3
+        .endpoint
+        .as_deref()
+        .unwrap_or("")
+        .hash(&mut hasher);
+    spec.image.hash(&mut hasher);
+    spec.storage
+        .s3
+        .credentials_secret_ref
+        .name
+        .hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// The one-shot store-qualification Job for a cluster (issue #36).
+///
+/// Runs `ravel store qualify` (the same `ravel-cli` binary the server image
+/// ships) against the cluster's bucket before any serving Deployment is created,
+/// so a backend that fails the object-store contract is caught at deploy time
+/// rather than crash-looping every server pod on a fresh bucket. Image and
+/// credentials mirror the server Deployment's shared
+/// `storage.s3.credentialsSecretRef`; the bucket, region, and endpoint reach
+/// `ravel-cli` through the same `RAVEL_S3_*` env vars it reads (clap `env`), the
+/// exact shape the kind lane's hand-run Job used.
+///
+/// The Job carries [`QUALIFY_SPEC_HASH_ANNOTATION`] so the controller re-runs it
+/// when its inputs change and skips it when they do not, and sets
+/// `restartPolicy: Never`, a small [`QUALIFY_JOB_BACKOFF_LIMIT`], and
+/// [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not accumulate.
+pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
+    let labels = labels(instance, QUALIFY_COMPONENT);
+    let mut env = vec![
+        EnvVar {
+            name: "RAVEL_S3_BUCKET".to_string(),
+            value: Some(spec.storage.s3.bucket.clone()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "RAVEL_S3_REGION".to_string(),
+            value: Some(spec.storage.s3.region.clone()),
+            ..Default::default()
+        },
+    ];
+    if let Some(endpoint) = &spec.storage.s3.endpoint {
+        env.push(EnvVar {
+            name: "RAVEL_S3_ENDPOINT".to_string(),
+            value: Some(endpoint.clone()),
+            ..Default::default()
+        });
+    }
+    // Credentials mirror the server Deployment exactly: sourced from the shared
+    // credentials Secret via secretKeyRef, never literal values.
+    env.extend(s3_credential_env(spec, None));
+
+    let container = Container {
+        name: "qualify".to_string(),
+        image: Some(spec.image.clone()),
+        image_pull_policy: spec.image_pull_policy.clone(),
+        command: Some(vec!["/usr/local/bin/ravel-cli".to_string()]),
+        args: Some(vec![
+            "--store".to_string(),
+            "s3".to_string(),
+            "store".to_string(),
+            "qualify".to_string(),
+        ]),
+        env: Some(env),
+        security_context: Some(container_security_context()),
+        ..Default::default()
+    };
+
+    Job {
+        metadata: ObjectMeta {
+            name: Some(child_name(instance, QUALIFY_COMPONENT)),
+            labels: Some(labels.clone()),
+            annotations: Some(BTreeMap::from([(
+                QUALIFY_SPEC_HASH_ANNOTATION.to_string(),
+                qualify_job_input_hash(spec),
+            )])),
+            ..Default::default()
+        },
+        spec: Some(JobSpec {
+            backoff_limit: Some(QUALIFY_JOB_BACKOFF_LIMIT),
+            ttl_seconds_after_finished: Some(QUALIFY_JOB_TTL_SECONDS),
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    restart_policy: Some("Never".to_string()),
+                    containers: vec![container],
+                    security_context: Some(pod_security_context()),
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        status: None,
+    }
+}
+
+/// The terminal state of the live qualify Job this reconcile pass observed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QualifyJobPhase {
+    /// Neither `Complete` nor `Failed` reported yet.
+    Running,
+    /// The Job reported `Complete=True`.
+    Succeeded,
+    /// The Job reported `Failed=True` (its `backoffLimit` was exhausted). Carries
+    /// the Job's terminal condition message for the `StoreQualified` condition.
+    Failed(String),
+}
+
+/// What the controller observed about the live qualify Job for a cluster.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QualifyJobObservation {
+    /// No qualify Job exists (a fresh cluster, or one whose finished Job has been
+    /// TTL-garbage-collected).
+    Absent,
+    /// A qualify Job exists. `spec_hash` is its [`QUALIFY_SPEC_HASH_ANNOTATION`]
+    /// value (`None` if the annotation is missing), `phase` its terminal state.
+    Present {
+        /// The Job's recorded input hash, or `None` when the annotation is
+        /// absent.
+        spec_hash: Option<String>,
+        /// The Job's terminal state this pass.
+        phase: QualifyJobPhase,
+    },
+}
+
+/// The gate decision one reconcile pass takes on store qualification (issue #36).
+///
+/// [`crate::controller`] acts on exactly this, so a test asserting on a decision
+/// here is asserting on the operator's real gating behavior.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QualificationDecision {
+    /// The store is qualified for the current inputs: create the serving
+    /// Deployments. No qualify-Job write this pass.
+    Proceed,
+    /// (Re)run qualification and hold the serving Deployments. `recreate` is
+    /// true when a Job for stale inputs must be deleted first (a config edit
+    /// landed); the controller deletes it and lets the next pass create a fresh
+    /// one. False when no Job exists and one must be created now.
+    Qualify {
+        /// Whether a stale Job must be deleted before a fresh one is created.
+        recreate: bool,
+    },
+    /// The qualify Job is still running: hold the serving Deployments, no write.
+    Waiting,
+    /// The qualify Job failed: hold the serving Deployments and requeue on
+    /// backoff. Carries the Job's terminal message.
+    Failed(String),
+}
+
+/// Decide the qualification gate for a pass, purely from the desired input hash,
+/// the durably-recorded qualified hash (`status.storeQualifiedHash`), and the
+/// live Job observation.
+///
+/// A recorded qualified hash equal to the desired one short-circuits to
+/// [`QualificationDecision::Proceed`]: qualification already passed for these
+/// inputs and is never re-run on a schedule, so the Job's absence (after TTL GC)
+/// is not a reason to re-qualify. Otherwise the decision follows the live Job:
+/// absent means create one; a Job for a different (or missing) hash means a
+/// config edit landed and the stale Job is recreated; a Job for the current hash
+/// reports the qualification's progress.
+pub fn qualification_decision(
+    desired_hash: &str,
+    qualified_hash: Option<&str>,
+    observation: &QualifyJobObservation,
+) -> QualificationDecision {
+    if qualified_hash == Some(desired_hash) {
+        return QualificationDecision::Proceed;
+    }
+    match observation {
+        QualifyJobObservation::Absent => QualificationDecision::Qualify { recreate: false },
+        QualifyJobObservation::Present { spec_hash, phase } => {
+            if spec_hash.as_deref() != Some(desired_hash) {
+                QualificationDecision::Qualify { recreate: true }
+            } else {
+                match phase {
+                    QualifyJobPhase::Running => QualificationDecision::Waiting,
+                    QualifyJobPhase::Succeeded => QualificationDecision::Proceed,
+                    QualifyJobPhase::Failed(message) => {
+                        QualificationDecision::Failed(message.clone())
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The [`QualifyJobPhase`] a live Job reports, read from its status conditions:
+/// `Complete=True` is success, `Failed=True` is failure (its message carried
+/// through), anything else is still running.
+pub fn qualify_job_phase(job: &Job) -> QualifyJobPhase {
+    let Some(conditions) = job.status.as_ref().and_then(|s| s.conditions.as_ref()) else {
+        return QualifyJobPhase::Running;
+    };
+    for c in conditions {
+        if c.status != "True" {
+            continue;
+        }
+        match c.type_.as_str() {
+            "Complete" => return QualifyJobPhase::Succeeded,
+            "Failed" => {
+                let message = c
+                    .message
+                    .clone()
+                    .filter(|m| !m.is_empty())
+                    .or_else(|| c.reason.clone())
+                    .unwrap_or_else(|| "the store qualification Job failed".to_string());
+                return QualifyJobPhase::Failed(message);
+            }
+            _ => {}
+        }
+    }
+    QualifyJobPhase::Running
 }
 
 /// A tier's PodDisruptionBudget (issue #126, deliverable 4), capping how many of
@@ -5144,6 +5423,268 @@ mod tests {
         assert!(
             secrets_binding.contains("namespace: ravel-system"),
             "the shipped secrets RoleBinding binds ravel-system, the operator's own namespace"
+        );
+    }
+
+    /// A job condition of the given type/status, the shape
+    /// [`qualify_job_phase`] reads.
+    fn job_with_condition(type_: &str, status: &str, message: Option<&str>) -> Job {
+        use k8s_openapi::api::batch::v1::{JobCondition, JobStatus};
+        Job {
+            status: Some(JobStatus {
+                conditions: Some(vec![JobCondition {
+                    type_: type_.to_string(),
+                    status: status.to_string(),
+                    message: message.map(str::to_string),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// The input hash is stable for one spec and changes for each of the five
+    /// inputs it covers, and only those. Pins the exact set of fields that
+    /// re-trigger qualification (issue #36): a change to any of them is a
+    /// different store to prove, an unrelated change is not.
+    #[test]
+    fn qualify_input_hash_tracks_exactly_the_qualified_inputs() {
+        let spec = base_spec();
+        let base = qualify_job_input_hash(&spec);
+        assert_eq!(
+            base,
+            qualify_job_input_hash(&spec),
+            "the hash is deterministic for one spec"
+        );
+
+        let mut bucket = spec.clone();
+        bucket.storage.s3.bucket = "other-bucket".to_string();
+        let mut region = spec.clone();
+        region.storage.s3.region = "us-east-1".to_string();
+        let mut endpoint = spec.clone();
+        endpoint.storage.s3.endpoint = Some("http://other:9000".to_string());
+        let mut image = spec.clone();
+        image.image = "registry.example/ravel:v2".to_string();
+        let mut creds = spec.clone();
+        creds.storage.s3.credentials_secret_ref.name = "other-s3".to_string();
+        for (label, changed) in [
+            ("bucket", &bucket),
+            ("region", &region),
+            ("endpoint", &endpoint),
+            ("image", &image),
+            ("credentials secret", &creds),
+        ] {
+            assert_ne!(
+                base,
+                qualify_job_input_hash(changed),
+                "a change to {label} re-triggers qualification"
+            );
+        }
+
+        // A field qualification does not depend on leaves the hash unchanged, so
+        // an unrelated spec edit does not re-run qualification.
+        let mut replicas = spec.clone();
+        replicas.gateway.replicas = spec.gateway.replicas + 5;
+        assert_eq!(
+            base,
+            qualify_job_input_hash(&replicas),
+            "an unrelated spec edit (replica count) does not re-qualify"
+        );
+    }
+
+    /// The rendered qualify Job: name, image, command/args, credentials, the
+    /// spec-hash annotation, and the one-shot execution shape. Exact values, so
+    /// the Job the operator applies is pinned (issue #36).
+    #[test]
+    fn qualify_job_renders_a_one_shot_store_qualify() {
+        let spec = base_spec();
+        let job = desired_qualify_job(&spec, "prod");
+
+        assert_eq!(job.metadata.name.as_deref(), Some("prod-qualify"));
+        assert_eq!(
+            job.metadata
+                .annotations
+                .as_ref()
+                .and_then(|a| a.get(QUALIFY_SPEC_HASH_ANNOTATION))
+                .map(String::as_str),
+            Some(qualify_job_input_hash(&spec).as_str()),
+            "the annotation records the input hash so a change re-runs the Job"
+        );
+
+        let job_spec = job.spec.as_ref().expect("qualify Job has a spec");
+        assert_eq!(job_spec.backoff_limit, Some(QUALIFY_JOB_BACKOFF_LIMIT));
+        assert_eq!(
+            job_spec.ttl_seconds_after_finished,
+            Some(QUALIFY_JOB_TTL_SECONDS)
+        );
+        let pod = job_spec
+            .template
+            .spec
+            .as_ref()
+            .expect("qualify Job has a pod spec");
+        assert_eq!(pod.restart_policy.as_deref(), Some("Never"));
+        assert_eq!(pod.containers.len(), 1, "one qualify container");
+        let container = &pod.containers[0];
+        assert_eq!(
+            container.image.as_deref(),
+            Some("registry.example/ravel:v1")
+        );
+        assert_eq!(
+            container.command.as_deref(),
+            Some(["/usr/local/bin/ravel-cli".to_string()].as_slice())
+        );
+        assert_eq!(
+            container.args.as_deref(),
+            Some(
+                [
+                    "--store".to_string(),
+                    "s3".to_string(),
+                    "store".to_string(),
+                    "qualify".to_string(),
+                ]
+                .as_slice()
+            )
+        );
+        let env = container.env.as_ref().expect("qualify container has env");
+        let env_value = |name: &str| {
+            env.iter()
+                .find(|e| e.name == name)
+                .and_then(|e| e.value.clone())
+        };
+        assert_eq!(env_value("RAVEL_S3_BUCKET").as_deref(), Some("ravel-data"));
+        assert_eq!(env_value("RAVEL_S3_REGION").as_deref(), Some("eu-west-1"));
+        assert_eq!(
+            env_value("RAVEL_S3_ENDPOINT").as_deref(),
+            Some("http://minio:9000")
+        );
+        // Credentials come from the shared Secret via secretKeyRef, never a
+        // literal value in the pod spec.
+        let access = env
+            .iter()
+            .find(|e| e.name == "RAVEL_S3_ACCESS_KEY")
+            .expect("access key env present");
+        assert!(access.value.is_none(), "the access key is never a literal");
+        assert_eq!(
+            access
+                .value_from
+                .as_ref()
+                .and_then(|s| s.secret_key_ref.as_ref())
+                .map(|r| (r.name.as_str(), r.key.as_str())),
+            Some(("ravel-s3", S3_ACCESS_KEY_ID_KEY)),
+        );
+    }
+
+    /// `qualify_job_phase` reads the Job's terminal condition: `Complete=True`
+    /// is success, `Failed=True` carries its message, nothing terminal is still
+    /// running.
+    #[test]
+    fn qualify_job_phase_reads_the_terminal_condition() {
+        assert_eq!(
+            qualify_job_phase(&Job::default()),
+            QualifyJobPhase::Running,
+            "a Job with no status is still running"
+        );
+        assert_eq!(
+            qualify_job_phase(&job_with_condition("Complete", "True", None)),
+            QualifyJobPhase::Succeeded
+        );
+        assert_eq!(
+            qualify_job_phase(&job_with_condition(
+                "Failed",
+                "True",
+                Some("backend rejected CAS")
+            )),
+            QualifyJobPhase::Failed("backend rejected CAS".to_string()),
+            "the failure carries the Job's own terminal message"
+        );
+        // A condition that is not True does not count as terminal.
+        assert_eq!(
+            qualify_job_phase(&job_with_condition("Failed", "False", None)),
+            QualifyJobPhase::Running
+        );
+    }
+
+    /// A cluster already qualified for the current inputs proceeds without
+    /// re-running qualification, whatever the live Job says -- even absent
+    /// (TTL-garbage-collected). This is what keeps qualification from re-running
+    /// on a schedule.
+    #[test]
+    fn qualified_inputs_proceed_without_rerunning() {
+        let hash = "abc123".to_string();
+        for observation in [
+            QualifyJobObservation::Absent,
+            QualifyJobObservation::Present {
+                spec_hash: Some(hash.clone()),
+                phase: QualifyJobPhase::Succeeded,
+            },
+        ] {
+            assert_eq!(
+                qualification_decision(&hash, Some(&hash), &observation),
+                QualificationDecision::Proceed,
+                "recorded qualified inputs short-circuit to Proceed"
+            );
+        }
+    }
+
+    /// A fresh cluster (nothing qualified, no Job) creates the qualify Job
+    /// without recreating anything, and holds serving until it completes.
+    #[test]
+    fn fresh_cluster_creates_the_qualify_job() {
+        assert_eq!(
+            qualification_decision("h", None, &QualifyJobObservation::Absent),
+            QualificationDecision::Qualify { recreate: false },
+        );
+    }
+
+    /// A running Job for the current inputs holds serving; a completed one lets
+    /// it proceed; a failed one surfaces the Job's message and stays held.
+    #[test]
+    fn matching_job_reports_its_progress() {
+        let present = |phase| QualifyJobObservation::Present {
+            spec_hash: Some("h".to_string()),
+            phase,
+        };
+        assert_eq!(
+            qualification_decision("h", None, &present(QualifyJobPhase::Running)),
+            QualificationDecision::Waiting,
+        );
+        assert_eq!(
+            qualification_decision("h", None, &present(QualifyJobPhase::Succeeded)),
+            QualificationDecision::Proceed,
+        );
+        assert_eq!(
+            qualification_decision(
+                "h",
+                None,
+                &present(QualifyJobPhase::Failed("boom".to_string()))
+            ),
+            QualificationDecision::Failed("boom".to_string()),
+        );
+    }
+
+    /// When the inputs change on an already-qualified cluster, a Job for the old
+    /// inputs (or one missing the annotation) is recreated, not read as the
+    /// current one. The old qualified hash does not short-circuit because it no
+    /// longer equals the desired hash.
+    #[test]
+    fn changed_inputs_recreate_a_stale_job() {
+        let stale = QualifyJobObservation::Present {
+            spec_hash: Some("old".to_string()),
+            phase: QualifyJobPhase::Succeeded,
+        };
+        assert_eq!(
+            qualification_decision("new", Some("old"), &stale),
+            QualificationDecision::Qualify { recreate: true },
+        );
+        // A Job with no recorded hash is also stale against any desired hash.
+        let unannotated = QualifyJobObservation::Present {
+            spec_hash: None,
+            phase: QualifyJobPhase::Succeeded,
+        };
+        assert_eq!(
+            qualification_decision("new", Some("old"), &unannotated),
+            QualificationDecision::Qualify { recreate: true },
         );
     }
 }

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1973,7 +1973,7 @@ pub const QUALIFY_JOB_TTL_SECONDS: i32 = 3600;
 /// `DeadlineExceeded` before the retry budget ([`QUALIFY_JOB_BACKOFF_LIMIT`])
 /// was ever spent.
 ///
-/// Arithmetic. `ravel store qualify` runs 28 sequential object operations
+/// Arithmetic. `ravel-cli store qualify` runs 28 sequential object operations
 /// against the bucket: probe create-if-absent (put, put, get = 3), probe CAS
 /// version (put, put, put, get = 4), probe read-after-write ([`super`]'s
 /// `CONSISTENCY_CYCLES` = 5 put+get = 10), probe list-after-write (5 put+list
@@ -2008,13 +2008,13 @@ pub const STORE_QUALIFIED_SUCCEEDED_REASON: &str = "Succeeded";
 pub const STORE_QUALIFIED_FAILED_REASON: &str = "Failed";
 
 /// Message paired with [`STORE_QUALIFIED_PENDING_REASON`].
-pub const STORE_QUALIFYING_MESSAGE: &str = "running store qualification (ravel store qualify) against the cluster's bucket; the \
+pub const STORE_QUALIFYING_MESSAGE: &str = "running store qualification (ravel-cli store qualify) against the cluster's bucket; the \
      gateway, query, and maintain Deployments are held until it succeeds so the cluster never \
      serves on a backend that fails the object-store contract (docs/object-store-contract.md)";
 
 /// Message paired with [`STORE_QUALIFIED_SUCCEEDED_REASON`].
 pub const STORE_QUALIFIED_MESSAGE: &str =
-    "the object store passed ravel store qualify; serving Deployments may be created";
+    "the object store passed ravel-cli store qualify; serving Deployments may be created";
 
 /// A deterministic change-detection hash over the inputs store qualification
 /// proves against (issue #36): the bucket, region, endpoint, server image, the
@@ -2061,7 +2061,7 @@ pub fn qualify_job_input_hash(
 
 /// The one-shot store-qualification Job for a cluster (issue #36).
 ///
-/// Runs `ravel store qualify` (the same `ravel-cli` binary the server image
+/// Runs `ravel-cli store qualify` (the same `ravel-cli` binary the server image
 /// ships) against the cluster's bucket before any serving Deployment is created,
 /// so a backend that fails the object-store contract is caught at deploy time
 /// rather than crash-looping every server pod on a fresh bucket. Image and
@@ -2244,6 +2244,227 @@ pub fn qualification_decision(
                     }
                 }
             }
+        }
+    }
+}
+
+/// Base delay of the qualify-Job recreation backoff (issue #36, finding 3): the
+/// first consecutive failure holds this long before a fresh Job is created. Equal
+/// to the controller's failure requeue, so a single failure behaves as it did
+/// before the backoff existed.
+pub const QUALIFY_RETRY_BASE_SECONDS: i64 = 30;
+
+/// Ceiling of the capped exponential qualify-Job recreation backoff: the
+/// per-failure hold doubles from [`QUALIFY_RETRY_BASE_SECONDS`] but never exceeds
+/// this, so a persistently failing store is retried at most this often before the
+/// terminal cooldown takes over.
+pub const QUALIFY_RETRY_CEILING_SECONDS: i64 = 480;
+
+/// Consecutive failures after which the gate stops recreating on the exponential
+/// backoff and holds in the terminal cooldown ([`QUALIFY_RETRY_COOLDOWN_SECONDS`])
+/// instead. Bounds cross-Job churn: `backoffLimit` and `activeDeadlineSeconds`
+/// bound attempts WITHIN one Job only, so without this an unchanged store that
+/// keeps failing qualification would be re-Jobbed forever on the backoff.
+pub const QUALIFY_RETRY_TERMINAL_THRESHOLD: i32 = 6;
+
+/// Terminal-cooldown hold once [`QUALIFY_RETRY_TERMINAL_THRESHOLD`] consecutive
+/// failures are reached: one hour. During it the gate creates no Job; only an
+/// input change (the qualified-input hash moving, which resets the count) or the
+/// cooldown's own expiry lets qualification run again. Equal to the qualify Job's
+/// [`QUALIFY_JOB_TTL_SECONDS`], so the Failed Job that records which inputs are
+/// failing survives most of the hold and a config edit during the cooldown is
+/// seen as a stale Job and resets at once.
+pub const QUALIFY_RETRY_COOLDOWN_SECONDS: i64 = 3600;
+
+/// Seconds to hold before the next qualify-Job recreation after `failure_count`
+/// consecutive failures (issue #36, finding 3).
+///
+/// Capped exponential for the first [`QUALIFY_RETRY_TERMINAL_THRESHOLD`] - 1
+/// failures: [`QUALIFY_RETRY_BASE_SECONDS`] doubling each failure, clamped to
+/// [`QUALIFY_RETRY_CEILING_SECONDS`]. At or beyond the threshold the hold is the
+/// terminal cooldown [`QUALIFY_RETRY_COOLDOWN_SECONDS`]. `failure_count` is the
+/// number of failures INCLUDING the one just observed (1 for the first). The
+/// exact sequence for counts 1..=7 is 30, 60, 120, 240, 480, 3600, 3600.
+pub fn qualify_retry_backoff_seconds(failure_count: i32) -> i64 {
+    if failure_count >= QUALIFY_RETRY_TERMINAL_THRESHOLD {
+        return QUALIFY_RETRY_COOLDOWN_SECONDS;
+    }
+    let doublings = u32::try_from(failure_count - 1).unwrap_or(0).min(31);
+    let scaled = QUALIFY_RETRY_BASE_SECONDS
+        .checked_shl(doublings)
+        .unwrap_or(QUALIFY_RETRY_CEILING_SECONDS);
+    scaled.clamp(QUALIFY_RETRY_BASE_SECONDS, QUALIFY_RETRY_CEILING_SECONDS)
+}
+
+/// The qualify-Job mutation a non-Proceed pass performs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QualifyJobAction {
+    /// Create the qualify Job for the current inputs: none exists and the backoff
+    /// (if any) has elapsed.
+    Create,
+    /// Delete the existing Job with foreground propagation. Used when a config
+    /// edit made the Job's inputs stale, and when a Failed Job's backoff has
+    /// elapsed and it must be recreated.
+    DeleteStale,
+    /// Leave the Job untouched: it is running, or it is the Failed record kept in
+    /// place during the backoff hold.
+    None,
+}
+
+/// The `StoreQualified` reason a non-Proceed pass records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QualifyStoreReason {
+    /// Qualification is in progress (creating or running the Job).
+    Pending,
+    /// The last attempt failed; the gate is holding on the retry backoff or the
+    /// terminal cooldown.
+    Failed,
+}
+
+/// The retry-aware plan for a reconcile pass that did NOT reach
+/// [`QualificationDecision::Proceed`] (issue #36, finding 3). Pure over the
+/// persisted retry state and an injected `now_unix`, so the backoff schedule, the
+/// terminal cooldown, and the input-change reset are unit-tested without a clock.
+/// The controller performs `action`, records a `StoreQualified=False` condition
+/// from `reason`/`job_message`, persists `failure_count`/`next_retry_unix`, and
+/// requeues after `requeue_seconds`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QualifyGatePlan {
+    /// The Job mutation to perform.
+    pub action: QualifyJobAction,
+    /// The `StoreQualified` reason.
+    pub reason: QualifyStoreReason,
+    /// The failed Job's terminal message when this pass observed it, carried onto
+    /// the condition; `None` on the Pending arms and while holding without a Job
+    /// to read.
+    pub job_message: Option<String>,
+    /// Failure count to persist (`None` clears the field, on the input-change
+    /// reset and on a fresh cluster).
+    pub failure_count: Option<i32>,
+    /// Next-retry instant to persist as RFC3339 (`None` clears the field).
+    pub next_retry_unix: Option<i64>,
+    /// Requeue delay in seconds.
+    pub requeue_seconds: i64,
+}
+
+/// Map a non-Proceed [`QualificationDecision`] plus the persisted retry state to
+/// its [`QualifyGatePlan`], bounding cross-Job churn (issue #36, finding 3).
+///
+/// The naive gate deleted a Failed Job, requeued on the failure backoff, saw the
+/// Job Absent next pass, and created a fresh one, forever: the Job's own
+/// `backoffLimit`/`activeDeadlineSeconds` bound attempts WITHIN one Job, never the
+/// number of Jobs. This function bounds the recreations. Each consecutive failure
+/// schedules the next recreation on a capped exponential backoff
+/// ([`qualify_retry_backoff_seconds`]); after [`QUALIFY_RETRY_TERMINAL_THRESHOLD`]
+/// failures the gate holds in a terminal cooldown that only an input change (which
+/// resets the count) or the cooldown's expiry clears.
+///
+/// The Failed Job is KEPT in place during the backoff hold as the record of which
+/// inputs are failing, so a config edit during a long cooldown reads as a stale
+/// Job ([`QualificationDecision::Qualify`] `recreate: true`) and resets at once;
+/// the Job is deleted only once its backoff elapses and it must be recreated.
+/// Deleting the Job clears no retry state: the count is cleared only on the
+/// success path (in the controller) or on an input change, and `next_retry_unix`
+/// is cleared only when the replacement Job is actually created (the Absent
+/// recreation arm), never in the delete arm, so a failed Job that lingers under
+/// foreground deletion is not counted twice.
+pub fn plan_qualify_gate(
+    decision: &QualificationDecision,
+    failure_count: i32,
+    next_retry_unix: Option<i64>,
+    now_unix: i64,
+    poll_seconds: i64,
+) -> QualifyGatePlan {
+    let kept_count = (failure_count > 0).then_some(failure_count);
+    match decision {
+        // A Job for stale inputs is present: a config edit landed. Delete it and
+        // reset the retry budget so the fresh inputs qualify from a clean slate,
+        // at once (the next pass sees Absent with a zero count and creates one).
+        QualificationDecision::Qualify { recreate: true } => QualifyGatePlan {
+            action: QualifyJobAction::DeleteStale,
+            reason: QualifyStoreReason::Pending,
+            job_message: None,
+            failure_count: None,
+            next_retry_unix: None,
+            requeue_seconds: poll_seconds,
+        },
+        // No Job exists: a fresh cluster (count 0) creates one now; after a failure
+        // this is the recreation point, gated on the backoff having elapsed.
+        QualificationDecision::Qualify { recreate: false } => match next_retry_unix {
+            Some(due) if now_unix < due => QualifyGatePlan {
+                action: QualifyJobAction::None,
+                reason: QualifyStoreReason::Failed,
+                job_message: None,
+                failure_count: kept_count,
+                next_retry_unix: Some(due),
+                requeue_seconds: (due - now_unix).max(1),
+            },
+            // Backoff elapsed (or never set): create the replacement Job and clear
+            // next_retry so the new attempt's failure is counted afresh. The count
+            // is kept; only success or an input change resets it.
+            _ => QualifyGatePlan {
+                action: QualifyJobAction::Create,
+                reason: if failure_count > 0 {
+                    QualifyStoreReason::Failed
+                } else {
+                    QualifyStoreReason::Pending
+                },
+                job_message: None,
+                failure_count: kept_count,
+                next_retry_unix: None,
+                requeue_seconds: poll_seconds,
+            },
+        },
+        // The Job is still running: hold, touch neither the Job nor the retry
+        // state.
+        QualificationDecision::Waiting => QualifyGatePlan {
+            action: QualifyJobAction::None,
+            reason: QualifyStoreReason::Pending,
+            job_message: None,
+            failure_count: kept_count,
+            next_retry_unix,
+            requeue_seconds: poll_seconds,
+        },
+        // The Job for the current inputs Failed and is Present.
+        QualificationDecision::Failed(message) => match next_retry_unix {
+            // A newly-observed failure (no backoff scheduled): count it once and
+            // schedule the backoff. Keep the Job as the failure record.
+            None => {
+                let count = failure_count.saturating_add(1);
+                let delay = qualify_retry_backoff_seconds(count);
+                QualifyGatePlan {
+                    action: QualifyJobAction::None,
+                    reason: QualifyStoreReason::Failed,
+                    job_message: Some(message.clone()),
+                    failure_count: Some(count),
+                    next_retry_unix: Some(now_unix + delay),
+                    requeue_seconds: delay,
+                }
+            }
+            // Still holding: keep the Job and the count, do not re-count.
+            Some(due) if now_unix < due => QualifyGatePlan {
+                action: QualifyJobAction::None,
+                reason: QualifyStoreReason::Failed,
+                job_message: Some(message.clone()),
+                failure_count: kept_count,
+                next_retry_unix: Some(due),
+                requeue_seconds: (due - now_unix).max(1),
+            },
+            // Backoff elapsed: delete the Failed Job so a later pass sees Absent
+            // and recreates. Keep next_retry set (the Absent arm clears it on the
+            // actual create) so a Job lingering under foreground deletion is not
+            // counted a second time.
+            Some(due) => QualifyGatePlan {
+                action: QualifyJobAction::DeleteStale,
+                reason: QualifyStoreReason::Failed,
+                job_message: Some(message.clone()),
+                failure_count: kept_count,
+                next_retry_unix: Some(due),
+                requeue_seconds: poll_seconds,
+            },
+        },
+        QualificationDecision::Proceed => {
+            unreachable!("Proceed is handled on the success path, never planned as a hold")
         }
     }
 }
@@ -5913,6 +6134,190 @@ mod tests {
             qualify_job_input_hash(&base_spec(), Some("rv-golden")),
             "adfd6df5df66464b2bdfa458c3af84ae1011a0c445d2e4823dfd02adda76bbf8",
         );
+    }
+
+    /// The qualify retry backoff is a capped exponential for the first
+    /// [`QUALIFY_RETRY_TERMINAL_THRESHOLD`] - 1 consecutive failures and the
+    /// terminal cooldown at or past the threshold (issue #36, finding 3). The
+    /// exact per-failure sequence is asserted, not a monotonicity band.
+    #[test]
+    fn qualify_retry_backoff_sequence_is_exact() {
+        let sequence: Vec<i64> = (1..=7).map(qualify_retry_backoff_seconds).collect();
+        assert_eq!(sequence, vec![30, 60, 120, 240, 480, 3600, 3600]);
+        // The ceiling caps the exponential region: the fifth failure is 480, the
+        // sixth crosses into the cooldown, never a doubled 960.
+        assert_eq!(
+            qualify_retry_backoff_seconds(5),
+            QUALIFY_RETRY_CEILING_SECONDS
+        );
+        assert_eq!(
+            qualify_retry_backoff_seconds(QUALIFY_RETRY_TERMINAL_THRESHOLD),
+            QUALIFY_RETRY_COOLDOWN_SECONDS
+        );
+    }
+
+    /// A newly-observed failure (no backoff scheduled) is counted exactly once,
+    /// schedules the next retry at `now + backoff(count)`, keeps the Failed Job in
+    /// place (no Job mutation), and requeues at the backoff. A second pass still
+    /// inside the window does not re-count.
+    #[test]
+    fn plan_first_failure_counts_once_and_schedules_backoff() {
+        let msg = "backend rejected CAS".to_string();
+        let first = plan_qualify_gate(
+            &QualificationDecision::Failed(msg.clone()),
+            0,
+            None,
+            1_000,
+            10,
+        );
+        assert_eq!(first.action, QualifyJobAction::None);
+        assert_eq!(first.reason, QualifyStoreReason::Failed);
+        assert_eq!(first.failure_count, Some(1));
+        assert_eq!(first.next_retry_unix, Some(1_030));
+        assert_eq!(first.requeue_seconds, 30);
+        assert_eq!(first.job_message.as_deref(), Some("backend rejected CAS"));
+
+        // Still holding at count 1: no re-count, requeue shrinks to time remaining.
+        let holding = plan_qualify_gate(
+            &QualificationDecision::Failed(msg),
+            1,
+            Some(1_030),
+            1_020,
+            10,
+        );
+        assert_eq!(holding.action, QualifyJobAction::None);
+        assert_eq!(holding.failure_count, Some(1));
+        assert_eq!(holding.next_retry_unix, Some(1_030));
+        assert_eq!(holding.requeue_seconds, 10);
+    }
+
+    /// Once the backoff elapses, the Failed Job is deleted (foreground) so a later
+    /// pass sees it Absent and recreates it; `next_retry_unix` is NOT cleared on
+    /// the delete, so a Job lingering under foreground deletion is not counted a
+    /// second time. The Absent recreation then creates the Job and clears
+    /// `next_retry_unix`, keeping the count.
+    #[test]
+    fn plan_recreates_after_backoff_without_double_counting() {
+        let msg = "still failing".to_string();
+        // Backoff elapsed with the Failed Job still present: delete it, keep the
+        // retry state so the recreation is not re-counted.
+        let deleting = plan_qualify_gate(
+            &QualificationDecision::Failed(msg),
+            2,
+            Some(1_030),
+            1_030,
+            10,
+        );
+        assert_eq!(deleting.action, QualifyJobAction::DeleteStale);
+        assert_eq!(deleting.failure_count, Some(2));
+        assert_eq!(deleting.next_retry_unix, Some(1_030));
+
+        // Next pass, Job Absent, backoff elapsed: create and clear next_retry so the
+        // new attempt's failure counts afresh; count is kept, reason stays Failed.
+        let creating = plan_qualify_gate(
+            &QualificationDecision::Qualify { recreate: false },
+            2,
+            Some(1_030),
+            1_030,
+            10,
+        );
+        assert_eq!(creating.action, QualifyJobAction::Create);
+        assert_eq!(creating.reason, QualifyStoreReason::Failed);
+        assert_eq!(creating.failure_count, Some(2));
+        assert_eq!(creating.next_retry_unix, None);
+        assert_eq!(creating.requeue_seconds, 10);
+    }
+
+    /// At the terminal threshold the gate holds in the cooldown: it creates NO Job
+    /// before the cooldown expires and DOES recreate one at (and after) expiry. The
+    /// hold is expressed on both the Failed-present and Absent arms.
+    #[test]
+    fn plan_terminal_hold_blocks_recreation_until_cooldown_expiry() {
+        let due = 1_000 + QUALIFY_RETRY_COOLDOWN_SECONDS;
+
+        // Failed Job present, before expiry: no mutation.
+        let held_present = plan_qualify_gate(
+            &QualificationDecision::Failed("terminal".to_string()),
+            QUALIFY_RETRY_TERMINAL_THRESHOLD,
+            Some(due),
+            1_000,
+            10,
+        );
+        assert_eq!(held_present.action, QualifyJobAction::None);
+
+        // Job Absent, before expiry: still no Create.
+        let held_absent = plan_qualify_gate(
+            &QualificationDecision::Qualify { recreate: false },
+            QUALIFY_RETRY_TERMINAL_THRESHOLD,
+            Some(due),
+            due - 1,
+            10,
+        );
+        assert_eq!(held_absent.action, QualifyJobAction::None);
+        assert_eq!(held_absent.reason, QualifyStoreReason::Failed);
+
+        // Job Absent, at expiry: recreate.
+        let released = plan_qualify_gate(
+            &QualificationDecision::Qualify { recreate: false },
+            QUALIFY_RETRY_TERMINAL_THRESHOLD,
+            Some(due),
+            due,
+            10,
+        );
+        assert_eq!(released.action, QualifyJobAction::Create);
+    }
+
+    /// An input change during any hold (a `recreate: true` decision, meaning a Job
+    /// for stale inputs is present) resets the retry budget and deletes the stale
+    /// Job at once: `failure_count` and `next_retry_unix` are cleared, so the next
+    /// pass creates a fresh Job immediately rather than waiting out the cooldown.
+    #[test]
+    fn plan_input_change_resets_count_and_recreates_at_once() {
+        let due = 1_000 + QUALIFY_RETRY_COOLDOWN_SECONDS;
+        let reset = plan_qualify_gate(
+            &QualificationDecision::Qualify { recreate: true },
+            QUALIFY_RETRY_TERMINAL_THRESHOLD,
+            Some(due),
+            1_000,
+            10,
+        );
+        assert_eq!(reset.action, QualifyJobAction::DeleteStale);
+        assert_eq!(reset.reason, QualifyStoreReason::Pending);
+        assert_eq!(reset.failure_count, None);
+        assert_eq!(reset.next_retry_unix, None);
+
+        // Next pass sees the fresh inputs' Job Absent with a zero count: create now.
+        let fresh = plan_qualify_gate(
+            &QualificationDecision::Qualify { recreate: false },
+            0,
+            None,
+            1_000,
+            10,
+        );
+        assert_eq!(fresh.action, QualifyJobAction::Create);
+        assert_eq!(fresh.reason, QualifyStoreReason::Pending);
+        assert_eq!(fresh.failure_count, None);
+        assert_eq!(fresh.requeue_seconds, 10);
+    }
+
+    /// The persisted retry bookkeeping (failure count, next-retry time) is NOT part
+    /// of the qualified-input hash (issue #36, finding 3): the hash is recomputed
+    /// here over exactly the store-identity inputs, so folding either retry field
+    /// into it would diverge from this reconstruction and fail the test. Keeping
+    /// them out is what lets a retry converge instead of reading every backoff pass
+    /// as a new input.
+    #[test]
+    fn qualify_input_hash_excludes_retry_state() {
+        let spec = base_spec();
+        let expected = blake3_hex(&[
+            spec.storage.s3.bucket.as_str(),
+            spec.storage.s3.region.as_str(),
+            spec.storage.s3.endpoint.as_deref().unwrap_or(""),
+            spec.image.as_str(),
+            spec.storage.s3.credentials_secret_ref.name.as_str(),
+            "rv",
+        ]);
+        assert_eq!(qualify_job_input_hash(&spec, Some("rv")), expected);
     }
 
     /// A cluster already qualified for the current inputs proceeds without

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -2343,6 +2343,11 @@ pub struct QualifyGatePlan {
     pub failure_count: Option<i32>,
     /// Next-retry instant to persist as RFC3339 (`None` clears the field).
     pub next_retry_unix: Option<i64>,
+    /// The qualified-input hash the persisted retry state is keyed to (`None`
+    /// clears the field). Set whenever `failure_count` is, so a later pass can
+    /// tell whether the desired inputs still match the ones the failures were
+    /// recorded against.
+    pub retry_hash: Option<String>,
     /// Requeue delay in seconds.
     pub requeue_seconds: i64,
 }
@@ -2359,10 +2364,19 @@ pub struct QualifyGatePlan {
 /// failures the gate holds in a terminal cooldown that only an input change (which
 /// resets the count) or the cooldown's expiry clears.
 ///
-/// The Failed Job is KEPT in place during the backoff hold as the record of which
-/// inputs are failing, so a config edit during a long cooldown reads as a stale
-/// Job ([`QualificationDecision::Qualify`] `recreate: true`) and resets at once;
-/// the Job is deleted only once its backoff elapses and it must be recreated.
+/// The persisted retry state is keyed by `retry_hash`, the qualified-input hash
+/// the failures were recorded against. An input change resets the budget and
+/// qualifies the new inputs at once whether or not the failing Job still exists:
+/// when `desired_hash` differs from `retry_hash` the count and next-retry are
+/// dropped before the decision is planned, so a config edit made AFTER the Failed
+/// Job's TTL collected it (both a changed and an unchanged pass then observe the
+/// Job absent, so the Job's presence cannot distinguish them) qualifies at once
+/// rather than waiting out the old inputs' cooldown and inheriting their count.
+/// The cooldown is kept only while the hashes match. A stale Job that is still
+/// present ([`QualificationDecision::Qualify`] `recreate: true`) is deleted on the
+/// same pass. The retry hash is set in the plan whenever the failure count is, so
+/// the controller persists the two together.
+///
 /// Deleting the Job clears no retry state: the count is cleared only on the
 /// success path (in the controller) or on an input change, and `next_retry_unix`
 /// is cleared only when the replacement Job is actually created (the Absent
@@ -2370,13 +2384,24 @@ pub struct QualifyGatePlan {
 /// foreground deletion is not counted twice.
 pub fn plan_qualify_gate(
     decision: &QualificationDecision,
+    desired_hash: &str,
+    retry_hash: Option<&str>,
     failure_count: i32,
     next_retry_unix: Option<i64>,
     now_unix: i64,
     poll_seconds: i64,
 ) -> QualifyGatePlan {
+    // The persisted retry budget was recorded against `retry_hash`. If the desired
+    // inputs have moved since, that budget belongs to inputs no longer desired:
+    // drop it so the new inputs qualify from a clean slate at once, independent of
+    // whether the failing Job survives. Keep it only when the hashes match.
+    let (failure_count, next_retry_unix) = if retry_hash == Some(desired_hash) {
+        (failure_count, next_retry_unix)
+    } else {
+        (0, None)
+    };
     let kept_count = (failure_count > 0).then_some(failure_count);
-    match decision {
+    let mut plan = match decision {
         // A Job for stale inputs is present: a config edit landed. Delete it and
         // reset the retry budget so the fresh inputs qualify from a clean slate,
         // at once (the next pass sees Absent with a zero count and creates one).
@@ -2386,6 +2411,7 @@ pub fn plan_qualify_gate(
             job_message: None,
             failure_count: None,
             next_retry_unix: None,
+            retry_hash: None,
             requeue_seconds: poll_seconds,
         },
         // No Job exists: a fresh cluster (count 0) creates one now; after a failure
@@ -2397,6 +2423,7 @@ pub fn plan_qualify_gate(
                 job_message: None,
                 failure_count: kept_count,
                 next_retry_unix: Some(due),
+                retry_hash: None,
                 requeue_seconds: (due - now_unix).max(1),
             },
             // Backoff elapsed (or never set): create the replacement Job and clear
@@ -2412,6 +2439,7 @@ pub fn plan_qualify_gate(
                 job_message: None,
                 failure_count: kept_count,
                 next_retry_unix: None,
+                retry_hash: None,
                 requeue_seconds: poll_seconds,
             },
         },
@@ -2423,6 +2451,7 @@ pub fn plan_qualify_gate(
             job_message: None,
             failure_count: kept_count,
             next_retry_unix,
+            retry_hash: None,
             requeue_seconds: poll_seconds,
         },
         // The Job for the current inputs Failed and is Present.
@@ -2438,6 +2467,7 @@ pub fn plan_qualify_gate(
                     job_message: Some(message.clone()),
                     failure_count: Some(count),
                     next_retry_unix: Some(now_unix + delay),
+                    retry_hash: None,
                     requeue_seconds: delay,
                 }
             }
@@ -2448,6 +2478,7 @@ pub fn plan_qualify_gate(
                 job_message: Some(message.clone()),
                 failure_count: kept_count,
                 next_retry_unix: Some(due),
+                retry_hash: None,
                 requeue_seconds: (due - now_unix).max(1),
             },
             // Backoff elapsed: delete the Failed Job so a later pass sees Absent
@@ -2460,13 +2491,20 @@ pub fn plan_qualify_gate(
                 job_message: Some(message.clone()),
                 failure_count: kept_count,
                 next_retry_unix: Some(due),
+                retry_hash: None,
                 requeue_seconds: poll_seconds,
             },
         },
         QualificationDecision::Proceed => {
             unreachable!("Proceed is handled on the success path, never planned as a hold")
         }
-    }
+    };
+    // Key the persisted retry state to the inputs it was recorded against: set the
+    // hash exactly when a failure count is persisted, so a later pass can compare
+    // the desired hash against it and reset on an input change even after the
+    // Failed Job's TTL collected it.
+    plan.retry_hash = plan.failure_count.map(|_| desired_hash.to_string());
+    plan
 }
 
 /// The [`QualifyJobPhase`] a live Job reports, read from its status conditions:
@@ -6165,6 +6203,8 @@ mod tests {
         let msg = "backend rejected CAS".to_string();
         let first = plan_qualify_gate(
             &QualificationDecision::Failed(msg.clone()),
+            "h",
+            Some("h"),
             0,
             None,
             1_000,
@@ -6180,6 +6220,8 @@ mod tests {
         // Still holding at count 1: no re-count, requeue shrinks to time remaining.
         let holding = plan_qualify_gate(
             &QualificationDecision::Failed(msg),
+            "h",
+            Some("h"),
             1,
             Some(1_030),
             1_020,
@@ -6203,6 +6245,8 @@ mod tests {
         // retry state so the recreation is not re-counted.
         let deleting = plan_qualify_gate(
             &QualificationDecision::Failed(msg),
+            "h",
+            Some("h"),
             2,
             Some(1_030),
             1_030,
@@ -6216,6 +6260,8 @@ mod tests {
         // new attempt's failure counts afresh; count is kept, reason stays Failed.
         let creating = plan_qualify_gate(
             &QualificationDecision::Qualify { recreate: false },
+            "h",
+            Some("h"),
             2,
             Some(1_030),
             1_030,
@@ -6238,6 +6284,8 @@ mod tests {
         // Failed Job present, before expiry: no mutation.
         let held_present = plan_qualify_gate(
             &QualificationDecision::Failed("terminal".to_string()),
+            "h",
+            Some("h"),
             QUALIFY_RETRY_TERMINAL_THRESHOLD,
             Some(due),
             1_000,
@@ -6248,6 +6296,8 @@ mod tests {
         // Job Absent, before expiry: still no Create.
         let held_absent = plan_qualify_gate(
             &QualificationDecision::Qualify { recreate: false },
+            "h",
+            Some("h"),
             QUALIFY_RETRY_TERMINAL_THRESHOLD,
             Some(due),
             due - 1,
@@ -6259,6 +6309,8 @@ mod tests {
         // Job Absent, at expiry: recreate.
         let released = plan_qualify_gate(
             &QualificationDecision::Qualify { recreate: false },
+            "h",
+            Some("h"),
             QUALIFY_RETRY_TERMINAL_THRESHOLD,
             Some(due),
             due,
@@ -6276,6 +6328,8 @@ mod tests {
         let due = 1_000 + QUALIFY_RETRY_COOLDOWN_SECONDS;
         let reset = plan_qualify_gate(
             &QualificationDecision::Qualify { recreate: true },
+            "h",
+            Some("h"),
             QUALIFY_RETRY_TERMINAL_THRESHOLD,
             Some(due),
             1_000,
@@ -6289,6 +6343,8 @@ mod tests {
         // Next pass sees the fresh inputs' Job Absent with a zero count: create now.
         let fresh = plan_qualify_gate(
             &QualificationDecision::Qualify { recreate: false },
+            "h",
+            Some("h"),
             0,
             None,
             1_000,
@@ -6298,6 +6354,76 @@ mod tests {
         assert_eq!(fresh.reason, QualifyStoreReason::Pending);
         assert_eq!(fresh.failure_count, None);
         assert_eq!(fresh.requeue_seconds, 10);
+    }
+
+    /// An input change observed AFTER the Failed Job's TTL collected it (the Job is
+    /// Absent, so the decision is `Qualify { recreate: false }` for a changed and an
+    /// unchanged hash alike) still resets and qualifies at once (issue #36): the
+    /// desired hash no longer matches the hash the failures were recorded against,
+    /// so the terminal cooldown is dropped, a Job is created this pass, and the
+    /// persisted retry state is cleared. Without the recorded-hash comparison this
+    /// pass would hold out the remaining cooldown and inherit the old count.
+    #[test]
+    fn plan_absent_changed_hash_qualifies_at_once() {
+        let due = 1_000 + QUALIFY_RETRY_COOLDOWN_SECONDS;
+        let changed = plan_qualify_gate(
+            &QualificationDecision::Qualify { recreate: false },
+            "new",
+            Some("old"),
+            QUALIFY_RETRY_TERMINAL_THRESHOLD,
+            Some(due),
+            1_000,
+            10,
+        );
+        assert_eq!(changed.action, QualifyJobAction::Create);
+        assert_eq!(changed.reason, QualifyStoreReason::Pending);
+        assert_eq!(changed.failure_count, None);
+        assert_eq!(changed.next_retry_unix, None);
+        assert_eq!(changed.retry_hash, None);
+        assert_eq!(changed.requeue_seconds, 10);
+    }
+
+    /// The converse of the reset (issue #36): with the Job Absent, the desired hash
+    /// still equal to the recorded retry hash, and the cooldown not yet expired, the
+    /// plan holds exactly as before. The count is kept, no Job is created, and the
+    /// requeue is the exact time remaining. This is the case the recorded-hash
+    /// comparison must NOT flip.
+    #[test]
+    fn plan_absent_unchanged_hash_holds_in_cooldown() {
+        let due = 1_000 + QUALIFY_RETRY_COOLDOWN_SECONDS;
+        let held = plan_qualify_gate(
+            &QualificationDecision::Qualify { recreate: false },
+            "same",
+            Some("same"),
+            QUALIFY_RETRY_TERMINAL_THRESHOLD,
+            Some(due),
+            1_000,
+            10,
+        );
+        assert_eq!(held.action, QualifyJobAction::None);
+        assert_eq!(held.reason, QualifyStoreReason::Failed);
+        assert_eq!(held.failure_count, Some(QUALIFY_RETRY_TERMINAL_THRESHOLD));
+        assert_eq!(held.next_retry_unix, Some(due));
+        assert_eq!(held.retry_hash.as_deref(), Some("same"));
+        assert_eq!(held.requeue_seconds, due - 1_000);
+    }
+
+    /// A newly-observed failure records the desired hash as the retry key alongside
+    /// the count (issue #36), so a later pass can compare against it once the Job is
+    /// gone. The key is the desired hash, not the (absent) prior one.
+    #[test]
+    fn plan_first_failure_records_retry_hash() {
+        let first = plan_qualify_gate(
+            &QualificationDecision::Failed("boom".to_string()),
+            "desired",
+            None,
+            0,
+            None,
+            1_000,
+            10,
+        );
+        assert_eq!(first.failure_count, Some(1));
+        assert_eq!(first.retry_hash.as_deref(), Some("desired"));
     }
 
     /// The persisted retry bookkeeping (failure count, next-retry time) is NOT part

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1913,15 +1913,27 @@ pub const QUALIFY_COMPONENT: &str = "qualify";
 
 /// Annotation on the qualify Job carrying [`qualify_job_input_hash`], so a
 /// change to the inputs qualification proves against (bucket, region, endpoint,
-/// image, credentials Secret name) re-runs it and a no-op reconcile does not.
+/// image, credentials Secret name and its resourceVersion) re-runs it and a
+/// no-op reconcile does not.
 pub const QUALIFY_SPEC_HASH_ANNOTATION: &str = "ravel.nofire.ai/qualify-spec-hash";
 
-/// `backoffLimit` for the qualify Job: a few retries absorb a transient S3
-/// error (a backend still coming up) without spinning forever on a genuine
-/// qualification failure (a backend that fails conditional-create atomicity or
-/// list consistency). Four attempts, then the Job reports `Failed` and the
-/// controller surfaces it on the `StoreQualified` condition.
-pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 4;
+/// `backoffLimit` for the qualify Job: one retry absorbs a transient S3 error
+/// (a backend still coming up) without spinning on a genuine qualification
+/// failure (a backend that fails conditional-create atomicity or list
+/// consistency). Two attempts total (the initial run plus one retry), then the
+/// Job reports `Failed` and the controller surfaces it on the `StoreQualified`
+/// condition.
+///
+/// Kept small deliberately: `activeDeadlineSeconds` is a Job-WIDE bound on the
+/// total active time across every retry (it takes precedence over
+/// `backoffLimit`), so the two knobs must be sized together. A larger retry
+/// count would either not fit under the deadline (a slow-but-healthy attempt
+/// plus a retry would trip `DeadlineExceeded` before the retry budget was
+/// spent) or force the deadline so high that a hung Job ran for many minutes
+/// before it was cut off. Two attempts is the value that lets one retry
+/// complete a full slow-but-healthy run within
+/// [`QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS`].
+pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 1;
 
 /// `ttlSecondsAfterFinished` for the qualify Job: one hour, so a finished Job
 /// does not accumulate across reconciles or re-qualifications. The qualified
@@ -1929,32 +1941,42 @@ pub const QUALIFY_JOB_BACKOFF_LIMIT: i32 = 4;
 /// garbage-collected after success does not re-trigger qualification.
 pub const QUALIFY_JOB_TTL_SECONDS: i32 = 3600;
 
-/// `activeDeadlineSeconds` for the qualify Job: a wall-clock bound on a single
-/// attempt, so a qualify pod that hangs (an S3 endpoint that accepts the TCP
-/// connection and then never answers) becomes a `Failed` Job with reason
-/// `DeadlineExceeded` instead of running indefinitely. `backoffLimit` bounds
-/// only how many *failed* attempts run; it does nothing for one attempt that
-/// never terminates, which leaves `StoreQualified` stuck at `Pending` forever.
+/// `activeDeadlineSeconds` for the qualify Job: a wall-clock bound so a qualify
+/// pod that hangs (an S3 endpoint that accepts the TCP connection and then
+/// never answers) becomes a `Failed` Job with reason `DeadlineExceeded`
+/// instead of running indefinitely. `backoffLimit` bounds only how many
+/// *failed* attempts run; it does nothing for one attempt that never
+/// terminates, which leaves `StoreQualified` stuck at `Pending` forever.
 ///
-/// The value must clear a slow-but-healthy run with margin. `ravel store
-/// qualify` runs 28 sequential object operations against the bucket: probe
-/// create-if-absent (put, put, get = 3), probe CAS version (put, put, put,
-/// get = 4), probe read-after-write ([`super`]'s `CONSISTENCY_CYCLES` = 5
-/// put+get = 10), probe list-after-write (5 put+list = 10), and the final
-/// `sys/qualification` create-if-absent write (1); the two informational
-/// probes issue no request through the `ObjectStoreBackend` contract. Each
-/// operation's per-request ceiling is the S3 client's 20 s `request_timeout`
-/// (ravel-object-store `S3HttpConfig::default`), so a slow-but-healthy run
-/// whose every operation approaches that ceiling without retrying is bounded
-/// by 28 * 20 s = 560 s. 900 s adds a ~1.6x margin (340 s of slack) for pod
-/// scheduling, image pull, and the occasional single retry, while staying far
-/// below a hung endpoint's ~200 s-per-operation worst case (`retry_timeout`
-/// 180 s + `request_timeout` 20 s): a hang trips the deadline after roughly
-/// four stalled operations rather than exhausting all 28.
+/// This deadline is JOB-WIDE, not per-attempt: Kubernetes counts it against
+/// the Job's total active time summed across every retry, and it takes
+/// precedence over `backoffLimit` (whichever limit is hit first fails the
+/// Job). So the value must fit the intended retries end to end, not just one
+/// attempt, or a slow-but-healthy first attempt plus a retry would trip
+/// `DeadlineExceeded` before the retry budget ([`QUALIFY_JOB_BACKOFF_LIMIT`])
+/// was ever spent.
 ///
-/// Not part of [`qualify_job_input_hash`]: tuning this deadline must not
-/// re-run a qualification that already passed.
-pub const QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS: i64 = 900;
+/// Arithmetic. `ravel store qualify` runs 28 sequential object operations
+/// against the bucket: probe create-if-absent (put, put, get = 3), probe CAS
+/// version (put, put, put, get = 4), probe read-after-write ([`super`]'s
+/// `CONSISTENCY_CYCLES` = 5 put+get = 10), probe list-after-write (5 put+list
+/// = 10), and the final `sys/qualification` create-if-absent write (1); the two
+/// informational probes issue no request through the `ObjectStoreBackend`
+/// contract. Each operation's per-request ceiling is the S3 client's 20 s
+/// `request_timeout` (ravel-object-store `S3HttpConfig::default`), so one
+/// slow-but-healthy attempt whose every operation approaches that ceiling
+/// without retrying is bounded by 28 * 20 s = 560 s. Adding ~140 s per attempt
+/// for pod scheduling and image pull gives a 700 s per-attempt budget. With
+/// `QUALIFY_JOB_BACKOFF_LIMIT` = 1 the Job runs at most two attempts, so the
+/// Job-wide deadline is 2 * 700 s = 1400 s: a slow-but-healthy initial attempt
+/// AND a full retry both complete before it fires. A single hung attempt still
+/// terminates, at the 1400 s Job-wide bound rather than running forever
+/// (a hung endpoint stalls each operation at ~200 s = `retry_timeout` 180 s +
+/// `request_timeout` 20 s).
+///
+/// Not part of [`qualify_job_input_hash`]: tuning this deadline (or the backoff
+/// limit) must not re-run a qualification that already passed.
+pub const QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS: i64 = 1400;
 
 /// `StoreQualified` reason while the qualify Job is being created or is still
 /// running: serving is held until it reports success.
@@ -1978,16 +2000,35 @@ pub const STORE_QUALIFIED_MESSAGE: &str =
     "the object store passed ravel store qualify; serving Deployments may be created";
 
 /// A deterministic change-detection hash over the inputs store qualification
-/// proves against (issue #36): the bucket, region, endpoint, server image, and
-/// the credentials Secret name. When any of these changes the store the cluster
-/// would serve on is a different one, so qualification is re-run; an unrelated
-/// spec edit (a replica count, a fold interval) leaves this stable and does not
-/// re-qualify.
+/// proves against (issue #36): the bucket, region, endpoint, server image, the
+/// credentials Secret NAME, and that credentials Secret's `resourceVersion`.
+/// When any of these changes the store the cluster would serve on, or the
+/// credentials it would serve with, is different, so qualification is re-run; an
+/// unrelated spec edit (a replica count, a fold interval) leaves this stable and
+/// does not re-qualify.
+///
+/// The `resourceVersion` is what makes a fixed-name credential ROTATION
+/// re-qualify (finding, issue #36): rotating the Secret in place keeps its name
+/// but bumps its `resourceVersion`, so without it a rotation to credentials that
+/// no longer pass the object-store contract would skip qualification entirely
+/// once the prior Job had been TTL-garbage-collected. Only the `resourceVersion`
+/// (opaque API metadata) enters the hash, never any Secret DATA: the operator
+/// never reads the credential values here (it resolves only the
+/// `resourceVersion`, see `controller::resolve_credential_resource_versions`),
+/// and this value reaches neither the status nor a log line. The operator does
+/// not watch Secrets (the per-namespace `ravel-operator-secrets` RoleBinding
+/// grants `get` only, not `watch`), so a rotation is noticed on the next
+/// periodic requeue (`controller::RESYNC`, 300 s): that pass reads the new
+/// `resourceVersion`, this hash changes, and the gate recreates the Job. The
+/// bound on noticing a rotation is therefore one `RESYNC` interval.
 ///
 /// `DefaultHasher` (SipHash with fixed keys) is deterministic across processes,
 /// so an operator restart does not spuriously re-qualify. It is a change signal,
 /// not a security boundary, exactly like [`secrets_checksum`].
-pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
+pub fn qualify_job_input_hash(
+    spec: &RavelClusterSpec,
+    credentials_resource_version: Option<&str>,
+) -> String {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     spec.storage.s3.bucket.hash(&mut hasher);
@@ -2004,6 +2045,7 @@ pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
         .credentials_secret_ref
         .name
         .hash(&mut hasher);
+    credentials_resource_version.unwrap_or("").hash(&mut hasher);
     format!("{:016x}", hasher.finish())
 }
 
@@ -2024,7 +2066,16 @@ pub fn qualify_job_input_hash(spec: &RavelClusterSpec) -> String {
 /// [`QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS`] so a hung attempt fails rather than
 /// runs forever, and [`QUALIFY_JOB_TTL_SECONDS`] so a finished Job does not
 /// accumulate.
-pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
+///
+/// `credentials_resource_version` is the shared credentials Secret's resolved
+/// `resourceVersion` (the controller reads it before the gate); it flows into
+/// [`qualify_job_input_hash`] so the recorded annotation matches the gate's
+/// desired hash and a fixed-name credential rotation re-qualifies.
+pub fn desired_qualify_job(
+    spec: &RavelClusterSpec,
+    instance: &str,
+    credentials_resource_version: Option<&str>,
+) -> Job {
     let labels = labels(instance, QUALIFY_COMPONENT);
     let mut env = vec![
         EnvVar {
@@ -2071,7 +2122,7 @@ pub fn desired_qualify_job(spec: &RavelClusterSpec, instance: &str) -> Job {
             labels: Some(labels.clone()),
             annotations: Some(BTreeMap::from([(
                 QUALIFY_SPEC_HASH_ANNOTATION.to_string(),
-                qualify_job_input_hash(spec),
+                qualify_job_input_hash(spec, credentials_resource_version),
             )])),
             ..Default::default()
         },
@@ -5466,6 +5517,40 @@ mod tests {
         );
     }
 
+    /// Finding 1 verb sweep. Every operator write is server-side apply (a PATCH,
+    /// with `create` for objects that do not yet exist) or a delete, never a
+    /// PUT, so no rule grants the `update` verb. The `batch`/`jobs` rule is
+    /// exactly the verbs the reconcile loop calls: `create`/`patch` (apply),
+    /// `get` (observe the qualify Job), and `delete` (foreground recreate); it is
+    /// not watched by an informer, so no `list`/`watch`. A text scan so a rule
+    /// that reintroduces a dead verb fails the gate.
+    #[test]
+    fn rbac_grants_only_the_verbs_the_reconcile_loop_calls() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../deploy/k8s/operator/rbac.yaml");
+        let manifest = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+        // No rule anywhere grants `update` (matched with its YAML quotes so the
+        // word "update" in a comment does not count).
+        assert!(
+            !manifest.contains("\"update\""),
+            "server-side apply is a PATCH, not a PUT: no rule may grant the update verb"
+        );
+
+        // The jobs rule grants exactly create/patch/get/delete.
+        let jobs_verbs = manifest
+            .lines()
+            .skip_while(|l| l.trim() != "resources: [\"jobs\"]")
+            .nth(1)
+            .map(str::trim)
+            .expect("rbac.yaml defines a batch/jobs rule with a verbs line");
+        assert_eq!(
+            jobs_verbs, "verbs: [\"create\", \"patch\", \"get\", \"delete\"]",
+            "the jobs rule grants only create/patch (apply), get (observe), and delete"
+        );
+    }
+
     /// A job condition of the given type/status, the shape
     /// [`qualify_job_phase`] reads.
     fn job_with_condition(type_: &str, status: &str, message: Option<&str>) -> Job {
@@ -5511,11 +5596,11 @@ mod tests {
     #[test]
     fn qualify_input_hash_tracks_exactly_the_qualified_inputs() {
         let spec = base_spec();
-        let base = qualify_job_input_hash(&spec);
+        let base = qualify_job_input_hash(&spec, Some("rv-1"));
         assert_eq!(
             base,
-            qualify_job_input_hash(&spec),
-            "the hash is deterministic for one spec"
+            qualify_job_input_hash(&spec, Some("rv-1")),
+            "the hash is deterministic for one spec and resourceVersion"
         );
 
         let mut bucket = spec.clone();
@@ -5537,10 +5622,19 @@ mod tests {
         ] {
             assert_ne!(
                 base,
-                qualify_job_input_hash(changed),
+                qualify_job_input_hash(changed, Some("rv-1")),
                 "a change to {label} re-triggers qualification"
             );
         }
+
+        // A fixed-name credential rotation (same Secret name, new
+        // resourceVersion) is a different credential and must re-trigger
+        // qualification, even though every spec field is unchanged.
+        assert_ne!(
+            base,
+            qualify_job_input_hash(&spec, Some("rv-2")),
+            "a new credentials resourceVersion (rotation in place) re-qualifies"
+        );
 
         // A field qualification does not depend on leaves the hash unchanged, so
         // an unrelated spec edit does not re-run qualification.
@@ -5548,7 +5642,7 @@ mod tests {
         replicas.gateway.replicas = spec.gateway.replicas + 5;
         assert_eq!(
             base,
-            qualify_job_input_hash(&replicas),
+            qualify_job_input_hash(&replicas, Some("rv-1")),
             "an unrelated spec edit (replica count) does not re-qualify"
         );
     }
@@ -5559,7 +5653,7 @@ mod tests {
     #[test]
     fn qualify_job_renders_a_one_shot_store_qualify() {
         let spec = base_spec();
-        let job = desired_qualify_job(&spec, "prod");
+        let job = desired_qualify_job(&spec, "prod", Some("rv-1"));
 
         assert_eq!(job.metadata.name.as_deref(), Some("prod-qualify"));
         assert_eq!(
@@ -5568,7 +5662,7 @@ mod tests {
                 .as_ref()
                 .and_then(|a| a.get(QUALIFY_SPEC_HASH_ANNOTATION))
                 .map(String::as_str),
-            Some(qualify_job_input_hash(&spec).as_str()),
+            Some(qualify_job_input_hash(&spec, Some("rv-1")).as_str()),
             "the annotation records the input hash so a change re-runs the Job"
         );
 
@@ -5672,17 +5766,35 @@ mod tests {
     #[test]
     fn qualify_job_bounds_a_hung_attempt() {
         let spec = base_spec();
-        let job = desired_qualify_job(&spec, "prod");
+        let job = desired_qualify_job(&spec, "prod", None);
         let job_spec = job.spec.as_ref().expect("qualify Job has a spec");
         assert_eq!(
             job_spec.active_deadline_seconds,
             Some(QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS),
-            "the qualify Job bounds a single attempt with activeDeadlineSeconds"
+            "the qualify Job bounds its total active time with activeDeadlineSeconds"
         );
         assert_eq!(
-            QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS, 900,
-            "the chosen deadline is 900 s (28 sequential ops * 20 s request_timeout \
-             = 560 s slow-but-healthy, plus a ~1.6x margin)"
+            job_spec.backoff_limit,
+            Some(QUALIFY_JOB_BACKOFF_LIMIT),
+            "the qualify Job caps its retries with backoffLimit"
+        );
+        // activeDeadlineSeconds is Job-wide (summed across every retry) and takes
+        // precedence over backoffLimit, so the deadline must fit the intended
+        // attempts end to end: 700 s per attempt (560 s of ops + ~140 s pod
+        // scheduling/pull) * (backoffLimit + 1) attempts.
+        assert_eq!(
+            QUALIFY_JOB_BACKOFF_LIMIT, 1,
+            "one retry (two attempts total)"
+        );
+        assert_eq!(
+            QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS, 1400,
+            "the Job-wide deadline is 1400 s = 700 s per attempt * 2 attempts, so a \
+             slow-but-healthy first attempt plus one full retry both fit before it fires"
+        );
+        assert_eq!(
+            QUALIFY_JOB_ACTIVE_DEADLINE_SECONDS,
+            700 * i64::from(QUALIFY_JOB_BACKOFF_LIMIT + 1),
+            "the deadline and the backoff limit are sized together"
         );
     }
 
@@ -5721,18 +5833,19 @@ mod tests {
         assert_eq!(decision, QualificationDecision::Failed(message));
     }
 
-    /// The `activeDeadlineSeconds` is a tuning knob, not a store-identity input:
-    /// [`qualify_job_input_hash`] covers exactly the five inputs qualification
-    /// proves against and never the deadline, so changing the deadline leaves the
-    /// hash equal and does not re-run a qualification that already passed.
+    /// The `activeDeadlineSeconds` and `backoffLimit` are tuning knobs, not
+    /// store-identity inputs: [`qualify_job_input_hash`] covers exactly the
+    /// bucket, region, endpoint, image, credentials Secret name, and credentials
+    /// `resourceVersion`, and never either knob, so tuning them leaves the hash
+    /// equal and does not re-run a qualification that already passed.
     #[test]
     fn the_deadline_is_not_part_of_the_qualified_input_hash() {
         use std::hash::{Hash, Hasher};
         let spec = base_spec();
 
-        // Recompute the hash over exactly the five qualified inputs, deliberately
-        // excluding the deadline. If the production hasher folded the deadline in,
-        // this reference would diverge and the assertion would fail.
+        // Recompute the hash over exactly the six qualified inputs, deliberately
+        // excluding both knobs. If the production hasher folded either in, this
+        // reference would diverge and the assertion would fail.
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         spec.storage.s3.bucket.hash(&mut hasher);
         spec.storage.s3.region.hash(&mut hasher);
@@ -5748,13 +5861,14 @@ mod tests {
             .credentials_secret_ref
             .name
             .hash(&mut hasher);
+        "rv-1".hash(&mut hasher);
         let expected = format!("{:016x}", hasher.finish());
 
         assert_eq!(
-            qualify_job_input_hash(&spec),
+            qualify_job_input_hash(&spec, Some("rv-1")),
             expected,
-            "the qualified-input hash covers exactly the five store-identity inputs, never the \
-             deadline"
+            "the qualified-input hash covers exactly the six store-identity inputs, never the \
+             deadline or the backoff limit"
         );
     }
 
@@ -5838,6 +5952,61 @@ mod tests {
         assert_eq!(
             qualification_decision("new", Some("old"), &unannotated),
             QualificationDecision::Qualify { recreate: true },
+        );
+    }
+
+    /// Fixed-name credential rotation (issue #36): the credentials Secret keeps
+    /// its name but its content is rotated in place, so its `resourceVersion`
+    /// bumps. The qualified-input hash changes, so an already-qualified cluster
+    /// whose last Job succeeded is driven back to `Qualify { recreate: true }`
+    /// (the controller renders `StoreQualified=Pending` and recreates the Job).
+    /// The converse: an unchanged `resourceVersion` yields the same hash and
+    /// `Proceed`, so a steady-state reconcile never re-runs qualification.
+    #[test]
+    fn fixed_name_credential_rotation_re_qualifies() {
+        let spec = base_spec();
+        let before = qualify_job_input_hash(&spec, Some("rv-1"));
+        let after = qualify_job_input_hash(&spec, Some("rv-2"));
+        assert_ne!(
+            before, after,
+            "a rotated credentials Secret (new resourceVersion) is a new qualified input"
+        );
+
+        // Rotation: the durable qualified hash is the pre-rotation one, the
+        // desired hash is the post-rotation one, and the live Job (if not yet
+        // GC'd) still carries the pre-rotation hash and succeeded.
+        let rotated = qualification_decision(
+            &after,
+            Some(&before),
+            &QualifyJobObservation::Present {
+                spec_hash: Some(before.clone()),
+                phase: QualifyJobPhase::Succeeded,
+            },
+        );
+        assert_eq!(
+            rotated,
+            QualificationDecision::Qualify { recreate: true },
+            "a fixed-name rotation must recreate the Job and flip StoreQualified to Pending"
+        );
+        // Even after the prior Job's TTL GC (Absent) a rotation re-runs.
+        assert_eq!(
+            qualification_decision(&after, Some(&before), &QualifyJobObservation::Absent),
+            QualificationDecision::Qualify { recreate: false },
+            "a rotation after TTL GC creates a fresh Job"
+        );
+
+        // Converse: same resourceVersion, same hash, no re-run.
+        assert_eq!(
+            qualification_decision(
+                &before,
+                Some(&before),
+                &QualifyJobObservation::Present {
+                    spec_hash: Some(before.clone()),
+                    phase: QualifyJobPhase::Succeeded,
+                },
+            ),
+            QualificationDecision::Proceed,
+            "an unchanged resourceVersion must not re-run qualification"
         );
     }
 }


### PR DESCRIPTION
The operator created a RavelCluster's Deployments as soon as the resource
existed; nothing ran `ravel store qualify` against the cluster's bucket
first, so the kind lane was qualified by a hand-run Job and production
was not. A backend that fails conditional-create atomicity or listing
order is exactly what qualification catches.

The reconcile loop now creates a one-shot <cluster>-qualify Job with the
server Deployment's image, env and credential Secret, and creates the
Deployments only after it succeeds. A StoreQualified status condition
carries Pending, Succeeded or Failed with the Job's terminal message; a
failed qualification creates no Deployment and requeues on the existing
backoff. The qualified inputs (bucket, region, endpoint, image, Secret
name and the Secret's resourceVersion) are hashed into
status.storeQualifiedHash, so a later pass with the same inputs proceeds
without re-running after the Job's TTL has collected it, and a change to
any of them, including a fixed-name credential rotation, recreates the
Job and flips the condition back to Pending without tearing down running
Deployments. The operator's secrets grant is get only, so a rotation is
noticed on the next periodic resync, within 300 seconds. Qualification
is never re-run on a schedule.

A hung attempt is bounded by activeDeadlineSeconds, which applies to the
whole Job across retries: 700 seconds per attempt (28 sequential object
operations at the client's 20 second request timeout plus scheduling and
image pull) times two attempts with backoffLimit 1, so 1400 seconds; a
deadline-exceeded Job reads as Failed with that reason in the condition,
and neither knob is part of the qualified input hash. The credential
Secret is resolved before the qualification gate, so a missing or
unreadable Secret reports SecretNotFound or SecretsUnreadable instead of
a deadline. A stale Job is deleted with foreground propagation and its
replacement created only once it is observed gone. While qualification
holds a fresh cluster, Available carries the qualification reason and
message rather than the generic replica message; a serving cluster under
re-qualification stays Available. The persisted status fields travel in
a named struct. The ClusterRole grants only the verbs the reconcile loop
calls, which drops update everywhere since server-side apply is patch,
and a test pins that set.

The CRD's status schema gains the hash field so the subresource does not
prune it; kind-up.sh drops its hand-run Job because the lane deploys
through the operator. ADR-0034 records the gate, the identity, and the
deadline as an amendment.

The operator has no fake-client harness, so the scenarios are pinned at
the qualification_decision layer the controller acts on. kind run
34166711817 passed on the previous round's head; the lane is re-run on
this branch before merge.

Supersedes #1454.

The fourth round makes both persisted hashes stable across toolchain
upgrades by moving storeQualifiedHash and the secrets checksum from the
standard library hasher to blake3, pinned by golden values; carries a
fresh qualification hash into the degraded status when a later step of
the same pass fails, so a successful qualification is never discarded;
and deletes a Failed current-hash Job with a short requeue so a fresh
cluster is not held for the hour until its TTL. The timer-based poll and
the Jobs verbs are unchanged. docs/architecture.md names the Secret
resourceVersion among the qualified inputs.

The fifth round stops the Failed branch from re-triggering itself: the
requeue moves to the failure backoff, the primary watch drops status-only
events through a generation predicate (which needs kube-runtime's
unstable-runtime-stream-control feature for Controller::for_stream, a
feature flag on an already-present crate), and a condition keeps its
lastTransitionTime unless its status actually changes. kind-up.sh now
waits for StoreQualified at the current generation and then for
Available, each bounded and each with its own failure message, so a
reused cluster does not pass before re-qualification and rollout finish.

The sixth round bounds qualification retries across Job recreations:
status persists a failure count and a next-retry time, recreations back
off with a capped exponential delay, and after a stated number of
consecutive failures the gate holds in a terminal cooldown that only an
input change or the cooldown's expiry clears, with the condition naming
the attempt count and the next retry; neither field is part of the
qualified input hash. kind-up.sh reads the condition, its observed
generation and the resource generation from one snapshot per iteration.
docs/architecture.md names the installed ravel-cli binary. The release
notes record the one-time rollout the checksum change causes on the first
reconcile after upgrading the operator.

The seventh round keys the retry state to the qualified-input hash it was
recorded against, persisted beside the failure count and next retry time,
so an input change resets the count and qualifies at once whether or not
the Failed Job still exists, and the cooldown applies only while the
hashes match.

A local review round closes three more findings: the degraded status
write after a successful qualification now carries the StoreQualified
condition instead of dropping it, so a later failing step no longer
leaves the condition absent; the RBAC test asserts the exact verb line of
every rule rather than one; and the qualified-input hash distinguishes an
absent endpoint from an empty one, since the two render differently.

Refs: #36
