### PR TITLE
refactor(server): route every query transport through one service layer

### DIFF
--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -330,6 +330,54 @@ fn estimate_cost(
     )
 }
 
+/// A running evaluation's spend, readable from outside the call.
+///
+/// The engine builds a fresh [`PhaseAccounting`] per attempt and returns its
+/// snapshot only inside a successful [`QueryStats`], so a caller whose future
+/// is dropped mid-query has nothing to read. An engine handed one of these
+/// through [`QueryEngine::with_live_usage`] points it at each attempt's handle
+/// before that attempt issues its first store call, so a drop guard can read
+/// what the abandoned query had spent by then. The mirror of
+/// `ravel_sql::LiveAccounting`, which is what the SQL surface reads on the
+/// same path.
+///
+/// A retried attempt re-points the view at its own handle, so a snapshot taken
+/// after the retry started reflects that attempt alone and never the discarded
+/// one, matching ADR-0044 decision 1.
+#[derive(Clone, Default)]
+pub struct LiveQueryAccounting(Arc<std::sync::Mutex<PhaseAccounting>>);
+
+impl LiveQueryAccounting {
+    /// A live view whose counters are all zero until an attempt installs its
+    /// handle.
+    pub fn new() -> Self {
+        LiveQueryAccounting::default()
+    }
+
+    /// The spend issued so far by whichever attempt is installed, pooled
+    /// across phases the way [`QueryStats::accounting`] is.
+    pub fn snapshot(&self) -> QueryAccountingSnapshot {
+        self.lock().snapshot().pooled()
+    }
+
+    /// Point this view at `accounting` (the attempt about to run). Clones the
+    /// handle, so the two share one counter block and every increment the
+    /// attempt makes is visible through [`Self::snapshot`].
+    fn install(&self, accounting: &PhaseAccounting) {
+        *self.lock() = accounting.clone();
+    }
+
+    /// Lock the inner slot, recovering a poisoned guard. The slot holds one
+    /// cheap-to-clone handle and no torn state, so recovering is strictly
+    /// better than failing every later snapshot.
+    fn lock(&self) -> std::sync::MutexGuard<'_, PhaseAccounting> {
+        match self.0.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
 /// Resolves snapshots, fetches segments, merges cross-segment duplicates,
 /// and evaluates PromQL over the result (docs/query-engine.md).
 pub struct QueryEngine {
@@ -357,6 +405,11 @@ pub struct QueryEngine {
     /// clusters and unioning their series into the merge pool; see
     /// [`QueryEngine::with_federation`].
     federation: Option<Arc<crate::distrib::Federation>>,
+    /// A caller's live view of this query's spend, installed per attempt in
+    /// `resolve_snapshot_with_retry`. `None` is the default: an engine nobody
+    /// asked for a live view from installs nothing. See
+    /// [`QueryEngine::with_live_usage`].
+    live_usage: Option<LiveQueryAccounting>,
 }
 
 impl QueryEngine {
@@ -415,6 +468,7 @@ impl QueryEngine {
             config,
             distributed: None,
             federation: None,
+            live_usage: None,
         }
     }
 
@@ -502,6 +556,33 @@ impl QueryEngine {
             config: budgets.clamp(&self.config).applied_to(&self.config),
             distributed: self.distributed.clone(),
             federation: self.federation.clone(),
+            live_usage: self.live_usage.clone(),
+        }
+    }
+
+    /// This engine, reporting every attempt's accounting handle into `live`
+    /// before that attempt issues a store call.
+    ///
+    /// The caller keeps `live` and can read it at any instant, including from
+    /// a drop guard after the query's future was dropped, which is the one
+    /// path that has no [`QueryStats`] to read a spend from. Without it a
+    /// cancelled PromQL, metadata, or analytics query records a spend of zero
+    /// no matter how many objects it had already fetched.
+    ///
+    /// The clone shares state exactly as [`Self::scoped_to`]'s does: same
+    /// catalog, same fetchers, same [`GetLimiter`]. Handing a request-scoped
+    /// engine to `instant_with_budgets` and friends keeps working, because
+    /// `scoped_to` carries the live view through.
+    pub fn with_live_usage(&self, live: &LiveQueryAccounting) -> QueryEngine {
+        QueryEngine {
+            catalog: Arc::clone(&self.catalog),
+            fetcher: self.fetcher.clone(),
+            log_fetcher: self.log_fetcher.clone(),
+            get_limiter: Arc::clone(&self.get_limiter),
+            config: self.config,
+            distributed: self.distributed.clone(),
+            federation: self.federation.clone(),
+            live_usage: Some(live.clone()),
         }
     }
 
@@ -1907,6 +1988,14 @@ impl QueryEngine {
         Ok((source, stats))
     }
 
+    /// Point a caller's live view, if it asked for one, at this attempt's
+    /// accounting handle.
+    fn install_live_usage(&self, accounting: &PhaseAccounting) {
+        if let Some(live) = &self.live_usage {
+            live.install(accounting);
+        }
+    }
+
     /// Resolves a snapshot, enforces `max_segments`, runs `attempt` once,
     /// and on a store `NotFound` (a pinned segment vanished under a
     /// concurrent GC/compaction) re-resolves and retries the whole query
@@ -1970,6 +2059,10 @@ impl QueryEngine {
         // discarded first attempt's in-flight counts must not bleed into the
         // attempt that actually produced the result.
         let first_accounting = PhaseAccounting::new();
+        // Before the resolve, not after it: a caller's future dropped during
+        // the first catalog LIST must still find this attempt's counters
+        // through the live view.
+        self.install_live_usage(&first_accounting);
         let (first, first_generations, first_unfolded) = self
             .resolve_bounded(
                 tenant_hash,
@@ -2012,6 +2105,7 @@ impl QueryEngine {
                 ..
             })) => {
                 let second_accounting = PhaseAccounting::new();
+                self.install_live_usage(&second_accounting);
                 let (second, second_generations, second_unfolded) = self
                     .resolve_bounded(
                         tenant_hash,

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -330,47 +330,56 @@ fn estimate_cost(
     )
 }
 
-/// A running evaluation's spend, readable from outside the call.
+/// A running request's spend, readable from outside the call.
 ///
-/// The engine builds a fresh [`PhaseAccounting`] per attempt and returns its
-/// snapshot only inside a successful [`QueryStats`], so a caller whose future
-/// is dropped mid-query has nothing to read. An engine handed one of these
-/// through [`QueryEngine::with_live_usage`] points it at each attempt's handle
-/// before that attempt issues its first store call, so a drop guard can read
-/// what the abandoned query had spent by then. The mirror of
+/// The engine builds a fresh [`PhaseAccounting`] per lane and per attempt and
+/// returns its snapshot only inside a successful [`QueryStats`], so a caller
+/// whose future is dropped mid-query has nothing to read. An engine handed one
+/// of these through [`QueryEngine::with_live_usage`] registers each of those
+/// handles here before it issues its first store call, so a drop guard can read
+/// what the abandoned request had spent by then. The mirror of
 /// `ravel_sql::LiveAccounting`, which is what the SQL surface reads on the
 /// same path.
 ///
-/// A retried attempt re-points the view at its own handle, so a snapshot taken
-/// after the retry started reflects that attempt alone and never the discarded
-/// one, matching ADR-0044 decision 1.
+/// The view is ADDITIVE: it keeps every handle registered during the request
+/// and [`Self::snapshot`] sums them. One request can spend through several
+/// handles -- the metrics lane and the log lane of one PromQL query, one per
+/// `match[]` selector of a metadata request, and one per attempt when a
+/// snapshot is invalidated and the query re-resolves -- and a cancelled request
+/// owes the total, not whichever handle happened to be installed last. Each
+/// site registers a handle it just built, exactly once, so no counter block is
+/// summed twice.
 #[derive(Clone, Default)]
-pub struct LiveQueryAccounting(Arc<std::sync::Mutex<PhaseAccounting>>);
+pub struct LiveQueryAccounting(Arc<std::sync::Mutex<Vec<PhaseAccounting>>>);
 
 impl LiveQueryAccounting {
-    /// A live view whose counters are all zero until an attempt installs its
-    /// handle.
+    /// A live view whose counters are all zero until a lane or an attempt
+    /// registers its handle.
     pub fn new() -> Self {
         LiveQueryAccounting::default()
     }
 
-    /// The spend issued so far by whichever attempt is installed, pooled
-    /// across phases the way [`QueryStats::accounting`] is.
+    /// The spend issued so far across every registered handle, each pooled
+    /// across phases the way [`QueryStats::accounting`] is and then summed.
     pub fn snapshot(&self) -> QueryAccountingSnapshot {
-        self.lock().snapshot().pooled()
+        self.lock()
+            .iter()
+            .fold(QueryAccountingSnapshot::default(), |total, accounting| {
+                total.saturating_add(&accounting.snapshot().pooled())
+            })
     }
 
-    /// Point this view at `accounting` (the attempt about to run). Clones the
-    /// handle, so the two share one counter block and every increment the
-    /// attempt makes is visible through [`Self::snapshot`].
+    /// Register `accounting` (the lane or attempt about to run) with this
+    /// view. Clones the handle, so the two share one counter block and every
+    /// increment the lane makes is visible through [`Self::snapshot`].
     fn install(&self, accounting: &PhaseAccounting) {
-        *self.lock() = accounting.clone();
+        self.lock().push(accounting.clone());
     }
 
-    /// Lock the inner slot, recovering a poisoned guard. The slot holds one
-    /// cheap-to-clone handle and no torn state, so recovering is strictly
+    /// Lock the inner slot, recovering a poisoned guard. The slot holds
+    /// cheap-to-clone handles and no torn state, so recovering is strictly
     /// better than failing every later snapshot.
-    fn lock(&self) -> std::sync::MutexGuard<'_, PhaseAccounting> {
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<PhaseAccounting>> {
         match self.0.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
@@ -405,10 +414,11 @@ pub struct QueryEngine {
     /// clusters and unioning their series into the merge pool; see
     /// [`QueryEngine::with_federation`].
     federation: Option<Arc<crate::distrib::Federation>>,
-    /// A caller's live view of this query's spend, installed per attempt in
-    /// `resolve_snapshot_with_retry`. `None` is the default: an engine nobody
-    /// asked for a live view from installs nothing. See
-    /// [`QueryEngine::with_live_usage`].
+    /// A caller's live view of this request's spend. Every site that builds a
+    /// `PhaseAccounting` registers it here: each attempt in
+    /// `resolve_snapshot_with_retry`, and the log lane in `prefetch`. `None`
+    /// is the default: an engine nobody asked for a live view from registers
+    /// nothing. See [`QueryEngine::with_live_usage`].
     live_usage: Option<LiveQueryAccounting>,
 }
 
@@ -560,14 +570,16 @@ impl QueryEngine {
         }
     }
 
-    /// This engine, reporting every attempt's accounting handle into `live`
-    /// before that attempt issues a store call.
+    /// This engine, registering every lane's and every attempt's accounting
+    /// handle with `live` before that lane issues a store call.
     ///
     /// The caller keeps `live` and can read it at any instant, including from
     /// a drop guard after the query's future was dropped, which is the one
     /// path that has no [`QueryStats`] to read a spend from. Without it a
     /// cancelled PromQL, metadata, or analytics query records a spend of zero
-    /// no matter how many objects it had already fetched.
+    /// no matter how many objects it had already fetched. `live` sums the
+    /// handles, so one engine handed to a multi-selector metadata request
+    /// reports every selector's spend and not only the last one's.
     ///
     /// The clone shares state exactly as [`Self::scoped_to`]'s does: same
     /// catalog, same fetchers, same [`GetLimiter`]. Handing a request-scoped
@@ -1359,6 +1371,13 @@ impl QueryEngine {
         // second attempt exists to paper over, not a case worth duplicating
         // that machinery for.
         let log_accounting = PhaseAccounting::new();
+        // Before the log lane's own resolve, for the reason the metrics lane
+        // installs before its own: this lane spends through a handle of its
+        // own, and a caller's future dropped inside the log resolve or the
+        // log fetch below must still find these counters through the live
+        // view. Without it a query naming only `ravel_log_lines` (ADR-1103)
+        // never registers a handle at all and a cancellation records zero.
+        self.install_live_usage(&log_accounting);
         let (log_snapshot, _log_generations, log_unfolded) = self
             .resolve_bounded(
                 tenant_hash,
@@ -1988,8 +2007,10 @@ impl QueryEngine {
         Ok((source, stats))
     }
 
-    /// Point a caller's live view, if it asked for one, at this attempt's
-    /// accounting handle.
+    /// Register this lane's or attempt's accounting handle with the caller's
+    /// live view, if it asked for one. The view sums every handle registered
+    /// with it, so calling this once per handle is what makes the live figure
+    /// the request's total rather than one lane's.
     fn install_live_usage(&self, accounting: &PhaseAccounting) {
         if let Some(live) = &self.live_usage {
             live.install(accounting);
@@ -2057,7 +2078,9 @@ impl QueryEngine {
         // once per query" -- here, per the query attempt that wins). A
         // retried attempt re-resolves and re-fetches from scratch, so the
         // discarded first attempt's in-flight counts must not bleed into the
-        // attempt that actually produced the result.
+        // `QueryStats` the successful attempt reports. The live view is the
+        // other side of that: it sums both attempts, because a caller that
+        // cancelled after a retry started owes what both of them issued.
         let first_accounting = PhaseAccounting::new();
         // Before the resolve, not after it: a caller's future dropped during
         // the first catalog LIST must still find this attempt's counters

--- a/crates/ravel-query/src/http/error.rs
+++ b/crates/ravel-query/src/http/error.rs
@@ -265,7 +265,7 @@ impl ApiError {
     /// The status, stable `errorType` tag, and message this error renders to.
     /// Extracted so both [`IntoResponse`] and the public
     /// [`QueryErrorResponse`] mapping share one table and cannot drift.
-    fn into_parts(self) -> QueryErrorResponse {
+    pub fn into_parts(self) -> QueryErrorResponse {
         let (status, error_type, message) = match self {
             ApiError::BadData(msg) => (StatusCode::BAD_REQUEST, "bad_data", msg),
             ApiError::Unsupported(msg) => (StatusCode::UNPROCESSABLE_ENTITY, "execution", msg),

--- a/crates/ravel-query/src/http/error.rs
+++ b/crates/ravel-query/src/http/error.rs
@@ -37,6 +37,14 @@ pub const MSG_CORRUPT: &str = "stored data failed integrity validation";
 /// outage apart from a permanent data fault without the leaked detail.
 pub const MSG_UNAVAILABLE: &str = "upstream storage temporarily unavailable";
 
+/// Stable client message for a query whose evidential audit event could not be
+/// made durable (ADR-0062 section 2a). Distinct from [`MSG_UNAVAILABLE`]: the
+/// read itself may have succeeded, and what failed is the audit trail, so an
+/// operator reading a client report can tell the two apart. Every query
+/// surface in the process, HTTP and Flight SQL alike, renders this exact
+/// string, so the wire contract cannot drift between transports.
+pub const MSG_AUDIT_UNAVAILABLE: &str = "query audit is temporarily unavailable; retry";
+
 /// Stable client message for a `min_commit_token` that did not resolve after
 /// the catalog's retry. The token fields come from the caller's own request,
 /// but the message is fixed for a stable, typed contract.

--- a/crates/ravel-query/src/http/handlers.rs
+++ b/crates/ravel-query/src/http/handlers.rs
@@ -1,27 +1,33 @@
 //! Prometheus-compatible HTTP handlers (docs/query-engine.md "HTTP API").
-
-use std::collections::{BTreeSet, HashMap};
+//!
+//! Every handler here is the same four steps: parse the request, authenticate
+//! it, hand it to the query service layer
+//! ([`crate::http::service`]), and encode the outcome. Admission,
+//! deadline and budget clamping, usage accounting, the audit event, the
+//! partial-coverage consent gate, and error redaction all live in the service
+//! layer, so this transport and the SQL, analytics, exemplars and (issue
+//! #1381) MCP transports run one implementation of them rather than five.
+//!
+//! Authentication precedes admission: an anonymous caller is rejected before
+//! it can consume a permit from the fleet-global concurrency ceiling.
 
 use axum::extract::{Path, Request, State};
 use axum::http::{Method, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::{Json, body::Body};
 
-use ravel_maintain::{QueryStatus, query_audit_event};
 use ravel_promql::LabelMatcher;
-use ravel_types::accounting::{CostEstimate, QueryAccountingSnapshot, QueryWorkloadClass};
-use ravel_types::{LabelSet, METRIC_NAME_LABEL, SeriesId, TenantHash, TimeRange};
+use ravel_types::{METRIC_NAME_LABEL, TenantHash, TimeRange};
 
-use crate::Coverage;
 use crate::engine::parse_match_selector;
-use crate::http::error::{ApiError, MSG_UNAVAILABLE};
+use crate::http::error::ApiError;
 use crate::http::json::{
-    ApiResponse, QueryResponseData, instant_value_to_json, range_value_to_json, series_to_json,
-    with_stats,
+    ApiResponse, instant_value_to_json, range_value_to_json, series_to_json, with_stats,
 };
 use crate::http::params::{
     Params, decode_commit_tokens, parse_allow_partial, parse_deadline, parse_timestamp_ms,
 };
+use crate::http::service::{self, InstantRequest, MetadataRequest, RangeRequest};
 use crate::http::{AppState, ONE_HOUR_NS};
 use crate::log_series;
 
@@ -47,18 +53,6 @@ async fn read_params(req: Request<Body>) -> Result<Params, ApiError> {
         query_string.as_deref(),
         body_bytes.as_deref(),
     ))
-}
-
-/// The response for a query refused by the fleet-global concurrency ceiling
-/// (ADR-0061 decision 2): a retryable HTTP 503 in the same Prometheus error
-/// envelope every other rejection here uses. The refusal happens before any
-/// snapshot resolve or object GET, so no work was done on the query's behalf.
-fn concurrency_rejected_response() -> Response {
-    let body: ApiResponse<()> = ApiResponse::Error {
-        error_type: "unavailable",
-        error: "fleet query concurrency ceiling reached; retry".to_string(),
-    };
-    (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response()
 }
 
 fn now_ns() -> i64 {
@@ -88,286 +82,87 @@ fn success_annotated<T: serde::Serialize>(
         .into_response()
 }
 
-/// The consent gate (ADR-0071 "partial results are consent-gated and
-/// envelope-visible" amendment, decision 1). Partial coverage the client did
-/// not opt into fails with the EXISTING typed `unavailable` error (HTTP 503,
-/// `errorType: "unavailable"`), so a consumer that never asked for partial
-/// answers fails safe instead of silently accepting one. Complete coverage, or
-/// partial coverage with `allow_partial=true`, passes and the response is a
-/// normal 200 whose top-level `partial` field states the coverage.
-///
-/// The refusal message names the degraded clusters (the same operator-facing,
-/// already-redacted names the `warnings` array carries) and names
-/// `allow_partial` as the remedy, so the fix is in the failure itself.
-fn gate_partial(coverage: &Coverage, allow_partial: bool) -> Result<(), ApiError> {
-    if coverage.is_partial() && !allow_partial {
-        return Err(ApiError::Unavailable(partial_refusal_message(
-            coverage.skipped(),
-        )));
-    }
-    Ok(())
-}
-
-/// Builds a [`Coverage`] from the metadata path's accumulated partial flag and
-/// its skipped-cluster warnings. The value-bearing endpoints derive coverage
-/// from a `QueryStats` via [`Coverage::from_stats`]; the metadata endpoints
-/// carry no `QueryStats` on their response envelope, so they thread the flag and
-/// warnings through directly and reconstruct the same shape here.
-fn coverage_of(partial: bool, skipped: &[String]) -> Coverage {
-    if partial {
-        Coverage::Partial {
-            skipped: skipped.to_vec(),
-        }
-    } else {
-        Coverage::Complete
-    }
-}
-
-fn partial_refusal_message(skipped: &[String]) -> String {
-    let clusters = if skipped.is_empty() {
-        "one or more federated clusters were skipped".to_string()
-    } else {
-        skipped.join("; ")
-    };
-    format!(
-        "partial results: coverage is incomplete ({clusters}); \
-         set allow_partial=true to receive partial results"
-    )
-}
-
-async fn authenticate(
-    state: &AppState,
-    headers: &axum::http::HeaderMap,
-) -> Result<ravel_types::TenantHash, ApiError> {
-    Ok(state.tenant_resolver.resolve(headers)?.hash())
-}
-
-/// Submit one evidential audit event for a query that reached execution for a
-/// resolved tenant, await its durability, and only then release `result` to
-/// the caller (ADR-0062 §2a).
-///
-/// `result` is the outcome of the surface's actual read: `Ok` audits
-/// `QueryStatus::Ok`, any `Err` audits `QueryStatus::Error`, so the audit trail
-/// records the attempt regardless of outcome, exactly as the SQL HTTP path
-/// does. The event is submitted through [`AppState::audit_sink`] and its
-/// durability is awaited before this returns, so a completed handler never
-/// releases its response ahead of its own audit record. When submission fails
-/// (`audit_mode=required` surfacing a flush error, or a stopped pipeline) the
-/// request fails closed with a retryable 503 rather than running unaudited --
-/// the deliberate inversion of "queries outlive the trail". A request rejected
-/// before it reached here (auth, param parse) never calls this and is not
-/// audited: there is no executed read to attribute.
-async fn audit_and_release<T>(
-    state: &AppState,
-    tenant_hash: TenantHash,
-    query_text: &str,
-    language: &str,
-    window: (i64, i64),
-    now_ns: i64,
-    result: Result<T, ApiError>,
-) -> Result<T, ApiError> {
-    let status = if result.is_ok() {
-        QueryStatus::Ok
-    } else {
-        QueryStatus::Error
-    };
-    let event = query_audit_event(
-        &tenant_hash,
-        now_ns,
-        query_text,
-        language,
-        status,
-        window.0,
-        window.1,
-    );
-    state
-        .audit_sink
-        .submit(event)
-        .await
-        .map_err(|_| ApiError::Unavailable(MSG_UNAVAILABLE.to_string()))?;
-    result
-}
-
-/// Nanosecond form of a millisecond timestamp for an audit window bound,
-/// saturating rather than overflowing (the audit record is best-effort
-/// informational for the window; the query itself already validated its
-/// range).
-fn ms_to_ns(ms: i64) -> i64 {
-    ms.saturating_mul(1_000_000)
+fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Result<TenantHash, ApiError> {
+    service::authenticate(state.tenant_resolver.as_ref(), headers)
 }
 
 pub async fn query(State(state): State<AppState>, req: Request<Body>) -> Response {
-    // Fleet-global concurrency admission (ADR-0061 decision 2): decide before any
-    // resolve or GET. The permit is held for the whole handler and released on
-    // return (success or error) or on a dropped request future, by its `Drop`.
-    let _permit = match state.query_admission.try_admit() {
-        Ok(permit) => permit,
-        Err(_) => return concurrency_rejected_response(),
-    };
     match handle_query(&state, req).await {
-        Ok((data, partial, warnings, infos)) => success_annotated(data, partial, warnings, infos),
+        Ok(response) => response,
         Err(e) => e.into_response(),
     }
 }
 
-async fn handle_query(
-    state: &AppState,
-    req: Request<Body>,
-) -> Result<(QueryResponseData, bool, Vec<String>, Vec<String>), ApiError> {
+async fn handle_query(state: &AppState, req: Request<Body>) -> Result<Response, ApiError> {
     let headers = req.headers().clone();
-    let tenant_hash = authenticate(state, &headers).await?;
+    let tenant_hash = authenticate(state, &headers)?;
     let params = read_params(req).await?;
-    let allow_partial = parse_allow_partial(&params);
-
-    let query = params.require("query")?;
     let now = now_ns();
-    let time_ms = match params.first("time") {
-        Some(s) => parse_timestamp_ms("time", s)?,
-        None => now / 1_000_000,
+    let request = InstantRequest {
+        query: params.require("query")?.to_string(),
+        time_ms: match params.first("time") {
+            Some(s) => parse_timestamp_ms("time", s)?,
+            None => now / 1_000_000,
+        },
+        min_tokens: decode_commit_tokens(params.all("min_commit_token"))?,
+        deadline: parse_deadline(&params, state.engine.config().deadline)?,
+        allow_partial: parse_allow_partial(&params),
+        now_ns: now,
+        budgets: None,
     };
-    let min_tokens = decode_commit_tokens(params.all("min_commit_token"))?;
-    let deadline = parse_deadline(&params, state.engine.config().deadline)?;
-
-    // The query now reaches execution for a resolved tenant, so it is
-    // auditable: run it, then submit one audit event for the outcome and await
-    // its durability before releasing the response (ADR-0062 §2a). The instant
-    // query's window is the single evaluation instant, recorded as a zero-width
-    // range.
-    let exec = state
-        .engine
-        .instant_with_stats_annotated(tenant_hash, query, time_ms, &min_tokens, now, deadline)
-        .await
-        .map_err(ApiError::from);
-    let time_ns = ms_to_ns(time_ms);
-    let (value, annotations, stats) = audit_and_release(
-        state,
-        tenant_hash,
-        query,
-        "promql",
-        (time_ns, time_ns),
-        now,
-        exec,
-    )
-    .await?;
-    // Consent gate (ADR-0071 amendment decision 1): the query executed and was
-    // audited, but partial coverage the client did not opt into is refused with
-    // a typed 503 before any body is built, so a naive consumer cannot mistake
-    // it for a complete answer. Coverage is derived from the stats the engine
-    // already produced (decision 4); the value is never released without it.
-    let coverage = Coverage::from_stats(&stats);
-    gate_partial(&coverage, allow_partial)?;
-    let partial = coverage.is_partial();
-    let (mut warnings, infos) = annotations.into_parts();
-    // Merge the federation fan-out's partial-coverage warnings (ADR-0071) into the top-level `warnings` array alongside the evaluator's own
-    // annotations, so a `skip_unavailable=true` federated query returns a
-    // response a client can tell is partial (the top-level `partial` field and
-    // the `partial` stats marker) and that names the skipped cluster. These are
-    // already redacted at the federation seam: they name the operator-facing
-    // cluster only, never its endpoint or transport error text.
-    for w in &stats.warnings {
-        if !warnings.contains(w) {
-            warnings.push(w.clone());
-        }
-    }
-    // Copy the counters out before `stats` is moved into the response body, so
-    // the numbers folded into /metrics are exactly the numbers the response
-    // reports; recording after the JSON render succeeds means a completed,
-    // fully-rendered query is what gets counted (ADR-0044 section 4). Both are `Copy`.
-    let accounting = stats.accounting;
-    let estimate = stats.estimate;
-    let data = with_stats(instant_value_to_json(value, time_ms)?, stats);
-    state.cost_recorder.record(
-        &accounting,
-        &estimate,
-        tenant_hash,
-        QueryWorkloadClass::Interactive,
+    let outcome =
+        service::promql_instant(&state.controls(), &state.engine, tenant_hash, &request).await?;
+    let data = with_stats(
+        instant_value_to_json(outcome.value, request.time_ms)?,
+        outcome.stats,
     );
-    Ok((data, partial, warnings, infos))
+    Ok(success_annotated(
+        data,
+        outcome.partial,
+        outcome.warnings,
+        outcome.infos,
+    ))
 }
 
 pub async fn query_range(State(state): State<AppState>, req: Request<Body>) -> Response {
-    let _permit = match state.query_admission.try_admit() {
-        Ok(permit) => permit,
-        Err(_) => return concurrency_rejected_response(),
-    };
     match handle_query_range(&state, req).await {
-        Ok((data, partial, warnings, infos)) => success_annotated(data, partial, warnings, infos),
+        Ok(response) => response,
         Err(e) => e.into_response(),
     }
 }
 
-async fn handle_query_range(
-    state: &AppState,
-    req: Request<Body>,
-) -> Result<(QueryResponseData, bool, Vec<String>, Vec<String>), ApiError> {
+async fn handle_query_range(state: &AppState, req: Request<Body>) -> Result<Response, ApiError> {
     let headers = req.headers().clone();
-    let tenant_hash = authenticate(state, &headers).await?;
+    let tenant_hash = authenticate(state, &headers)?;
     let params = read_params(req).await?;
-    let allow_partial = parse_allow_partial(&params);
-
-    let query = params.require("query")?;
-    let start_ms = parse_timestamp_ms("start", params.require("start")?)?;
-    let end_ms = parse_timestamp_ms("end", params.require("end")?)?;
-    let step_ms = parse_duration_ms_field(&params)?;
-    let min_tokens = decode_commit_tokens(params.all("min_commit_token"))?;
-    let deadline = parse_deadline(&params, state.engine.config().deadline)?;
-    let now = now_ns();
-
-    // Auditable once the range evaluation runs for a resolved tenant: run it,
-    // then submit one audit event for the outcome and await durability before
-    // releasing the response (ADR-0062 §2a). The recorded window is the
-    // request's resolved `[start, end]` range.
-    let exec = state
-        .engine
-        .range_hist_with_stats_annotated(
-            tenant_hash,
-            query,
-            start_ms,
-            end_ms,
-            step_ms,
-            &min_tokens,
-            now,
-            deadline,
-        )
-        .await
-        .map_err(ApiError::from);
-    let (value, annotations, stats) = audit_and_release(
-        state,
-        tenant_hash,
-        query,
-        "promql",
-        (ms_to_ns(start_ms), ms_to_ns(end_ms)),
-        now,
-        exec,
-    )
-    .await?;
-    // Consent gate (ADR-0071 amendment decision 1), same as handle_query.
-    let coverage = Coverage::from_stats(&stats);
-    gate_partial(&coverage, allow_partial)?;
-    let partial = coverage.is_partial();
-    let (mut warnings, infos) = annotations.into_parts();
-    // Merge the federation fan-out's partial-coverage warnings (ADR-0071) into the top-level `warnings` array, same as handle_query. Already
-    // redacted at the federation seam (cluster name only, no endpoint/errno).
-    for w in &stats.warnings {
-        if !warnings.contains(w) {
-            warnings.push(w.clone());
-        }
-    }
-    // See handle_query: record the same counters the response reports, once
-    // the range payload has rendered.
-    let accounting = stats.accounting;
-    let estimate = stats.estimate;
+    let request = RangeRequest {
+        query: params.require("query")?.to_string(),
+        start_ms: parse_timestamp_ms("start", params.require("start")?)?,
+        end_ms: parse_timestamp_ms("end", params.require("end")?)?,
+        step_ms: parse_duration_ms_field(&params)?,
+        min_tokens: decode_commit_tokens(params.all("min_commit_token"))?,
+        deadline: parse_deadline(&params, state.engine.config().deadline)?,
+        allow_partial: parse_allow_partial(&params),
+        now_ns: now_ns(),
+        budgets: None,
+    };
+    let outcome =
+        service::promql_range(&state.controls(), &state.engine, tenant_hash, &request).await?;
     let data = with_stats(
-        range_value_to_json(value, start_ms, end_ms, step_ms)?,
-        stats,
+        range_value_to_json(
+            outcome.value,
+            request.start_ms,
+            request.end_ms,
+            request.step_ms,
+        )?,
+        outcome.stats,
     );
-    state.cost_recorder.record(
-        &accounting,
-        &estimate,
-        tenant_hash,
-        QueryWorkloadClass::Interactive,
-    );
-    Ok((data, partial, warnings, infos))
+    Ok(success_annotated(
+        data,
+        outcome.partial,
+        outcome.warnings,
+        outcome.infos,
+    ))
 }
 
 fn parse_duration_ms_field(params: &Params) -> Result<i64, ApiError> {
@@ -376,39 +171,24 @@ fn parse_duration_ms_field(params: &Params) -> Result<i64, ApiError> {
 }
 
 pub async fn labels(State(state): State<AppState>, req: Request<Body>) -> Response {
-    let _permit = match state.query_admission.try_admit() {
-        Ok(permit) => permit,
-        Err(_) => return concurrency_rejected_response(),
-    };
     match handle_labels(&state, req).await {
-        Ok((data, partial, warnings)) => success_annotated(data, partial, warnings, Vec::new()),
+        Ok(response) => response,
         Err(e) => e.into_response(),
     }
 }
 
-async fn handle_labels(
-    state: &AppState,
-    req: Request<Body>,
-) -> Result<(Vec<String>, bool, Vec<String>), ApiError> {
+async fn handle_labels(state: &AppState, req: Request<Body>) -> Result<Response, ApiError> {
     let headers = req.headers().clone();
-    let tenant_hash = authenticate(state, &headers).await?;
+    let tenant_hash = authenticate(state, &headers)?;
     let params = read_params(req).await?;
-    let allow_partial = parse_allow_partial(&params);
-    let (series, partial, warnings) =
-        resolve_and_audit_series(state, tenant_hash, &params, "labels").await?;
-    // Consent gate (ADR-0071 amendment decisions 1 and 3): the metadata surface
-    // gates on `allow_partial` and carries the top-level `partial` field
-    // exactly as the value-bearing endpoints do, so the contract has no
-    // second-class endpoints.
-    gate_partial(&coverage_of(partial, &warnings), allow_partial)?;
-
-    let mut names: BTreeSet<String> = BTreeSet::new();
-    for (_, labels) in &series {
-        for label in labels.iter() {
-            names.insert(label.name.clone());
-        }
-    }
-    Ok((names.into_iter().collect(), partial, warnings))
+    let request = metadata_request(state, &params)?;
+    let outcome = service::labels(&state.controls(), &state.engine, tenant_hash, &request).await?;
+    Ok(success_annotated(
+        outcome.names,
+        outcome.partial,
+        outcome.warnings,
+        Vec::new(),
+    ))
 }
 
 pub async fn label_values(
@@ -416,12 +196,8 @@ pub async fn label_values(
     Path(name): Path<String>,
     req: Request<Body>,
 ) -> Response {
-    let _permit = match state.query_admission.try_admit() {
-        Ok(permit) => permit,
-        Err(_) => return concurrency_rejected_response(),
-    };
     match handle_label_values(&state, name, req).await {
-        Ok((data, partial, warnings)) => success_annotated(data, partial, warnings, Vec::new()),
+        Ok(response) => response,
         Err(e) => e.into_response(),
     }
 }
@@ -430,30 +206,31 @@ async fn handle_label_values(
     state: &AppState,
     name: String,
     req: Request<Body>,
-) -> Result<(Vec<String>, bool, Vec<String>), ApiError> {
+) -> Result<Response, ApiError> {
     let headers = req.headers().clone();
-    let tenant_hash = authenticate(state, &headers).await?;
+    let tenant_hash = authenticate(state, &headers)?;
     let params = read_params(req).await?;
-    let allow_partial = parse_allow_partial(&params);
-    let (series, partial, warnings) =
-        resolve_and_audit_series(state, tenant_hash, &params, "labels").await?;
-    gate_partial(&coverage_of(partial, &warnings), allow_partial)?;
-
-    let mut values: BTreeSet<String> = BTreeSet::new();
-    for (_, labels) in &series {
-        if let Some(v) = labels.get(&name) {
-            values.insert(v.to_string());
-        }
-    }
-    // ADR-1103: the two reserved log metric names never appear in any
-    // stored postings, so they only surface here explicitly. A request
-    // whose match[] selectors name metrics only asks about the metrics
-    // signal specifically and gets metrics names only.
-    if name == METRIC_NAME_LABEL && include_log_metric_names(&params)? {
-        values.insert(log_series::LOG_LINES_METRIC.to_string());
-        values.insert(log_series::LOG_BYTES_METRIC.to_string());
-    }
-    Ok((values.into_iter().collect(), partial, warnings))
+    let request = metadata_request(state, &params)?;
+    // ADR-1103: the two reserved log metric names never appear in any stored
+    // postings, so they only surface here explicitly. A request whose match[]
+    // selectors name metrics only asks about the metrics signal specifically
+    // and gets metrics names only.
+    let include_log_metrics = name == METRIC_NAME_LABEL && include_log_metric_names(&params)?;
+    let outcome = service::label_values(
+        &state.controls(),
+        &state.engine,
+        tenant_hash,
+        &request,
+        &name,
+        include_log_metrics,
+    )
+    .await?;
+    Ok(success_annotated(
+        outcome.values,
+        outcome.partial,
+        outcome.warnings,
+        Vec::new(),
+    ))
 }
 
 /// Whether `label/__name__/values` should include the two reserved log
@@ -465,7 +242,7 @@ fn include_log_metric_names(params: &Params) -> Result<bool, ApiError> {
         return Ok(true);
     }
     for selector in selectors {
-        let matchers = parse_match_selector(selector)?;
+        let matchers: Vec<LabelMatcher> = parse_match_selector(selector)?;
         if log_series::log_metric_of(&matchers).is_some() {
             return Ok(true);
         }
@@ -474,33 +251,46 @@ fn include_log_metric_names(params: &Params) -> Result<bool, ApiError> {
 }
 
 pub async fn series(State(state): State<AppState>, req: Request<Body>) -> Response {
-    let _permit = match state.query_admission.try_admit() {
-        Ok(permit) => permit,
-        Err(_) => return concurrency_rejected_response(),
-    };
     match handle_series(&state, req).await {
-        Ok((data, partial, warnings)) => success_annotated(data, partial, warnings, Vec::new()),
+        Ok(response) => response,
         Err(e) => e.into_response(),
     }
 }
 
-async fn handle_series(
-    state: &AppState,
-    req: Request<Body>,
-) -> Result<(Vec<HashMap<String, String>>, bool, Vec<String>), ApiError> {
+async fn handle_series(state: &AppState, req: Request<Body>) -> Result<Response, ApiError> {
     let headers = req.headers().clone();
-    let tenant_hash = authenticate(state, &headers).await?;
+    let tenant_hash = authenticate(state, &headers)?;
     let params = read_params(req).await?;
-    let allow_partial = parse_allow_partial(&params);
     if params.all("match[]").is_empty() {
         return Err(ApiError::BadData(
             "missing required parameter \"match[]\"".to_string(),
         ));
     }
-    let (series, partial, warnings) =
-        resolve_and_audit_series(state, tenant_hash, &params, "series").await?;
-    gate_partial(&coverage_of(partial, &warnings), allow_partial)?;
-    Ok((series_to_json(series), partial, warnings))
+    let request = metadata_request(state, &params)?;
+    let outcome = service::series(&state.controls(), &state.engine, tenant_hash, &request).await?;
+    Ok(success_annotated(
+        series_to_json(outcome.series),
+        outcome.partial,
+        outcome.warnings,
+        Vec::new(),
+    ))
+}
+
+/// The parsed form of a metadata request (`labels`, `label_values`,
+/// `series`). Every field a bad `start`/`end`/`timeout`/`min_commit_token`
+/// could reject is parsed here, before the service layer takes a permit, so a
+/// malformed request is a plain 400 that consumed nothing.
+fn metadata_request(state: &AppState, params: &Params) -> Result<MetadataRequest, ApiError> {
+    let now = now_ns();
+    Ok(MetadataRequest {
+        selectors: params.all("match[]").to_vec(),
+        window: resolve_window(params, now)?,
+        min_tokens: decode_commit_tokens(params.all("min_commit_token"))?,
+        deadline: parse_deadline(params, state.engine.config().deadline)?,
+        allow_partial: parse_allow_partial(params),
+        now_ns: now,
+        budgets: None,
+    })
 }
 
 fn resolve_window(params: &Params, now: i64) -> Result<TimeRange, ApiError> {
@@ -517,185 +307,4 @@ fn resolve_window(params: &Params, now: i64) -> Result<TimeRange, ApiError> {
         None => now,
     };
     Ok(TimeRange { start_ns, end_ns })
-}
-
-/// Resolve the matched series for a metadata request (labels / label_values /
-/// series) and audit the outcome before releasing it (ADR-0062 §2a). The
-/// metadata surfaces carry no single query string; the audited text is the
-/// request's `match[]` selectors joined, and the audited window is the resolved
-/// `[start, end]` these surfaces read over. `language` distinguishes the
-/// surface (`labels` or `series`) so the record shape stays one schema.
-async fn resolve_and_audit_series(
-    state: &AppState,
-    tenant_hash: TenantHash,
-    params: &Params,
-    language: &str,
-) -> Result<(Vec<(SeriesId, LabelSet)>, bool, Vec<String>), ApiError> {
-    // Window bounds parse before any read; a bad `start`/`end` is a request
-    // error, not an executed read, so it is not audited (it returns here).
-    let now = now_ns();
-    let window = resolve_window(params, now)?;
-    let selectors_text = params.all("match[]").join("; ");
-    let result = resolve_matched_series(state, tenant_hash, params).await;
-    audit_and_release(
-        state,
-        tenant_hash,
-        &selectors_text,
-        language,
-        (window.start_ns, window.end_ns),
-        now,
-        result,
-    )
-    .await
-}
-
-async fn resolve_matched_series(
-    state: &AppState,
-    tenant_hash: ravel_types::TenantHash,
-    params: &Params,
-) -> Result<(Vec<(SeriesId, LabelSet)>, bool, Vec<String>), ApiError> {
-    let now = now_ns();
-    let window = resolve_window(params, now)?;
-    let min_tokens = decode_commit_tokens(params.all("min_commit_token"))?;
-    let deadline = parse_deadline(params, state.engine.config().deadline)?;
-    let selectors = params.all("match[]");
-
-    // The wall deadline is a per-query budget (docs/query-engine.md
-    // "Budgets"), and one metadata request is one query. Convert the
-    // duration into a single absolute instant computed once here, then hand
-    // each resolve_series call only the time still remaining. Without this,
-    // each match[] selector would be granted the full `deadline` afresh, so
-    // N selectors would get N times the documented budget with no aggregate
-    // cap. The engine still enforces the timeout per call;
-    // sharing the remaining budget makes the whole request share one wall
-    // bound.
-    let request_deadline = tokio::time::Instant::now() + deadline;
-
-    // Accumulates every sub-query's cost so the whole metadata request folds
-    // once into the /metrics aggregator (ADR-0044 section 4). Each
-    // match[] selector resolves under its own accounting handle, so the
-    // request total is the field-wise sum of the per-selector snapshots.
-    // Recording once per request, not once per selector, keeps
-    // ravel_query_queries_total counting requests.
-    let mut combined: Option<(QueryAccountingSnapshot, CostEstimate)> = None;
-    // Cross-cluster federation partial-coverage warnings (ADR-0071),
-    // accumulated across selectors and surfaced in the Prometheus envelope's
-    // top-level `warnings` array -- the same surface the query path uses. Each
-    // per-selector resolve federates independently, so a skipped remote can be
-    // named once per selector; dedup here so the client sees one warning per
-    // skipped cluster regardless of how many `match[]` selectors the request
-    // carried.
-    let mut warnings: Vec<String> = Vec::new();
-    // Partial coverage (ADR-0071 amendment) accumulates across selectors: the
-    // whole request is partial if ANY selector's federated resolve skipped a
-    // remote, so a client cannot mistake a request that dropped one selector's
-    // remote coverage for a complete one.
-    let mut partial = false;
-
-    if selectors.is_empty() {
-        let remaining = remaining_budget(request_deadline, deadline)?;
-        let (series, stats) = state
-            .engine
-            .resolve_series_with_stats(tenant_hash, &[], window, &min_tokens, now, remaining)
-            .await?;
-        accumulate_cost(&mut combined, &stats);
-        partial |= stats.partial;
-        for w in stats.warnings {
-            if !warnings.contains(&w) {
-                warnings.push(w);
-            }
-        }
-        record_combined(state, tenant_hash, combined);
-        return Ok((series, partial, warnings));
-    }
-
-    // Deliberate deviation: each match[] selector resolves its own
-    // snapshot independently, rather than one shared snapshot for the
-    // whole request (docs in the task's pre-approved deviations list). The
-    // shared wall budget above is orthogonal to that: snapshots stay
-    // per-selector, but all selectors draw down one deadline.
-    //
-    // Per-selector segment stats are not
-    // surfaced on this path: the labels/label_values/series endpoints have
-    // no established response envelope for it (only the value-bearing
-    // query/query_range endpoints do), and
-    // aggregating per-selector counts here would double count segments any
-    // two selectors both matched.
-    let mut by_id: HashMap<SeriesId, LabelSet> = HashMap::new();
-    for selector in selectors {
-        let matchers: Vec<LabelMatcher> = parse_match_selector(selector)?;
-        let remaining = remaining_budget(request_deadline, deadline)?;
-        let (series, stats) = state
-            .engine
-            .resolve_series_with_stats(tenant_hash, &matchers, window, &min_tokens, now, remaining)
-            .await?;
-        accumulate_cost(&mut combined, &stats);
-        partial |= stats.partial;
-        for w in stats.warnings {
-            if !warnings.contains(&w) {
-                warnings.push(w);
-            }
-        }
-        for (id, labels) in series {
-            by_id.entry(id).or_insert(labels);
-        }
-    }
-    record_combined(state, tenant_hash, combined);
-    Ok((by_id.into_iter().collect(), partial, warnings))
-}
-
-/// Fold one sub-query's [`QueryStats`](crate::QueryStats) into the request's
-/// running cost total. The counters sum and the estimate sums
-/// ([`QueryAccountingSnapshot::saturating_add`]); the first call seeds the
-/// total because [`CostEstimate`] has no zero value (an estimate is only ever
-/// a real resolved snapshot's, ADR-0044).
-fn accumulate_cost(
-    combined: &mut Option<(QueryAccountingSnapshot, CostEstimate)>,
-    stats: &crate::QueryStats,
-) {
-    *combined = Some(match combined.take() {
-        None => (stats.accounting, stats.estimate),
-        Some((accounting, estimate)) => (
-            accounting.saturating_add(&stats.accounting),
-            estimate.saturating_add(&stats.estimate),
-        ),
-    });
-}
-
-/// Record the whole metadata request's summed cost into the aggregator, once.
-/// `combined` is `Some` whenever any resolve ran (every path above runs at
-/// least one), so a request that reached here without an error records exactly
-/// one query; a request that failed a resolve returned earlier through `?` and
-/// records nothing, the same rule the value-bearing handlers follow.
-fn record_combined(
-    state: &AppState,
-    tenant_hash: ravel_types::TenantHash,
-    combined: Option<(QueryAccountingSnapshot, CostEstimate)>,
-) {
-    if let Some((accounting, estimate)) = combined {
-        state.cost_recorder.record(
-            &accounting,
-            &estimate,
-            tenant_hash,
-            QueryWorkloadClass::Interactive,
-        );
-    }
-}
-
-/// Time left in the shared request wall budget, or a `DeadlineExceeded`
-/// error once it is spent. `configured` is the whole-request budget and is
-/// reported in the error so the client sees the query's deadline, not the
-/// residual slice handed to the last selector.
-fn remaining_budget(
-    request_deadline: tokio::time::Instant,
-    configured: std::time::Duration,
-) -> Result<std::time::Duration, ApiError> {
-    let remaining = request_deadline.saturating_duration_since(tokio::time::Instant::now());
-    if remaining.is_zero() {
-        return Err(crate::QueryError::DeadlineExceeded {
-            deadline: configured,
-        }
-        .into());
-    }
-    Ok(remaining)
 }

--- a/crates/ravel-query/src/http/handlers.rs
+++ b/crates/ravel-query/src/http/handlers.rs
@@ -279,11 +279,19 @@ async fn handle_series(state: &AppState, req: Request<Body>) -> Result<Response,
 /// The parsed form of a metadata request (`labels`, `label_values`,
 /// `series`). Every field a bad `start`/`end`/`timeout`/`min_commit_token`
 /// could reject is parsed here, before the service layer takes a permit, so a
-/// malformed request is a plain 400 that consumed nothing.
+/// malformed request is a plain 400 that consumed nothing. That includes each
+/// `match[]` selector: the service layer re-parses selectors on its own path
+/// (it needs the matchers, not just a yes/no), but validating them here first
+/// means a malformed selector is rejected before `admit()` and before any
+/// audit event, the same as every other field.
 fn metadata_request(state: &AppState, params: &Params) -> Result<MetadataRequest, ApiError> {
     let now = now_ns();
+    let selectors = params.all("match[]").to_vec();
+    for selector in &selectors {
+        parse_match_selector(selector)?;
+    }
     Ok(MetadataRequest {
-        selectors: params.all("match[]").to_vec(),
+        selectors,
         window: resolve_window(params, now)?,
         min_tokens: decode_commit_tokens(params.all("min_commit_token"))?,
         deadline: parse_deadline(params, state.engine.config().deadline)?,

--- a/crates/ravel-query/src/http/mod.rs
+++ b/crates/ravel-query/src/http/mod.rs
@@ -18,7 +18,10 @@ use axum::routing::get;
 use ravel_maintain::{NoopQueryAuditSink, QueryAuditSink};
 use ravel_types::accounting::{NoopQueryCostRecorder, QueryCostRecorder};
 
-pub use error::{ApiError, MSG_CORRUPT, MSG_UNAVAILABLE, MSG_UNSATISFIABLE, QueryErrorResponse};
+pub use error::{
+    ApiError, MSG_AUDIT_UNAVAILABLE, MSG_CORRUPT, MSG_UNAVAILABLE, MSG_UNSATISFIABLE,
+    QueryErrorResponse,
+};
 pub use metadata_cache::{
     MetadataCache, MetadataCacheConfig, MetadataCacheCounters, MetadataSnapshot,
 };

--- a/crates/ravel-query/src/http/mod.rs
+++ b/crates/ravel-query/src/http/mod.rs
@@ -8,6 +8,7 @@ mod handlers;
 mod json;
 mod metadata_cache;
 mod params;
+pub mod service;
 pub mod tenant;
 
 use std::sync::Arc;
@@ -17,9 +18,14 @@ use axum::routing::get;
 use ravel_maintain::{NoopQueryAuditSink, QueryAuditSink};
 use ravel_types::accounting::{NoopQueryCostRecorder, QueryCostRecorder};
 
-pub use error::{MSG_CORRUPT, MSG_UNAVAILABLE, MSG_UNSATISFIABLE, QueryErrorResponse};
+pub use error::{ApiError, MSG_CORRUPT, MSG_UNAVAILABLE, MSG_UNSATISFIABLE, QueryErrorResponse};
 pub use metadata_cache::{
     MetadataCache, MetadataCacheConfig, MetadataCacheCounters, MetadataSnapshot,
+};
+pub use service::{
+    InstantOutcome, InstantRequest, LabelValuesOutcome, LabelsOutcome, LiveUsage, MSG_CONCURRENCY,
+    MetadataOutcome, MetadataRequest, NoopQueryUsageSink, QueryControls, QueryUsageSink,
+    RangeOutcome, RangeRequest, UnobservedUsage, UsageGuard, UsageStatus, partial_refusal_message,
 };
 pub use tenant::{
     AuthError, DevHeaderTenantResolver, MtlsResolver, OidcError, OidcJwksCache, OidcResolver,
@@ -78,6 +84,14 @@ pub struct AppState {
     /// [`AppState::with_metadata_cache`], at which point the endpoint serves that
     /// process's cached view of each queried tenant's metadata.
     pub metadata_cache: Option<Arc<MetadataCache>>,
+    /// The sink each query's usage record is folded into on every exit path,
+    /// tagged with how the query ended (ADR-1374 decision 3, item 5). Separate
+    /// from [`AppState::cost_recorder`], which only ever sees a query that
+    /// produced an answer: this one also sees the cancelled, timed-out, and
+    /// failed queries. Defaults to [`NoopQueryUsageSink`] in [`AppState::new`];
+    /// a deployment attaches the `/metrics` aggregator with
+    /// [`AppState::with_usage_sink`].
+    pub usage_sink: Arc<dyn QueryUsageSink>,
 }
 
 impl AppState {
@@ -91,7 +105,29 @@ impl AppState {
             query_admission: QueryAdmissionController::shared(QueryConcurrencyLimit::Unlimited),
             audit_sink: Arc::new(NoopQueryAuditSink),
             metadata_cache: None,
+            usage_sink: Arc::new(NoopQueryUsageSink),
         }
+    }
+
+    /// The [`QueryControls`] every handler runs its query through: the one
+    /// admission controller, cost recorder, usage sink, and audit sink this
+    /// state carries. Handlers parse and encode; the controls do everything
+    /// between.
+    pub fn controls(&self) -> QueryControls {
+        QueryControls {
+            admission: Arc::clone(&self.query_admission),
+            cost_recorder: Arc::clone(&self.cost_recorder),
+            usage_sink: Arc::clone(&self.usage_sink),
+            audit_sink: Arc::clone(&self.audit_sink),
+        }
+    }
+
+    /// Set the sink each query's usage record is folded into on every exit
+    /// path (ADR-1374 decision 3, item 5). Returns `self` so it chains off
+    /// [`AppState::new`].
+    pub fn with_usage_sink(mut self, usage_sink: Arc<dyn QueryUsageSink>) -> Self {
+        self.usage_sink = usage_sink;
+        self
     }
 
     /// Set the recorder every completed query folds its cost into. Returns

--- a/crates/ravel-query/src/http/mod.rs
+++ b/crates/ravel-query/src/http/mod.rs
@@ -28,7 +28,7 @@ pub use metadata_cache::{
 pub use service::{
     InstantOutcome, InstantRequest, LabelValuesOutcome, LabelsOutcome, LiveUsage, MSG_CONCURRENCY,
     MetadataOutcome, MetadataRequest, NoopQueryUsageSink, QueryControls, QueryUsageSink,
-    RangeOutcome, RangeRequest, UnobservedUsage, UsageGuard, UsageStatus, partial_refusal_message,
+    RangeOutcome, RangeRequest, UsageGuard, UsageStatus, partial_refusal_message,
 };
 pub use tenant::{
     AuthError, DevHeaderTenantResolver, MtlsResolver, OidcError, OidcJwksCache, OidcResolver,

--- a/crates/ravel-query/src/http/service.rs
+++ b/crates/ravel-query/src/http/service.rs
@@ -48,7 +48,8 @@ use crate::http::error::{ApiError, MSG_AUDIT_UNAVAILABLE};
 use crate::log_series;
 use crate::request_budgets::RequestBudgets;
 use crate::{
-    Coverage, EngineConfig, QueryAdmissionController, QueryEngine, QueryPermit, QueryStats,
+    Coverage, EngineConfig, LiveQueryAccounting, QueryAdmissionController, QueryEngine,
+    QueryPermit, QueryStats,
 };
 
 /// Resolve the caller's credentials to a tenant, the one authentication step
@@ -122,19 +123,13 @@ pub trait LiveUsage: Send + Sync {
     fn snapshot(&self) -> QueryAccountingSnapshot;
 }
 
-/// A live-usage handle for a call that exposes none. Its snapshot is all
-/// zeros, so a cancelled query on that path records the cancellation itself
-/// without claiming a spend it cannot measure.
-///
-/// The Prometheus-shaped engine entry points build and own their
-/// `QueryAccounting` internally and return it only on success, so this is what
-/// they use. Replacing it needs a live handle on `QueryEngine`, which is a
-/// change to `engine.rs`.
-pub struct UnobservedUsage;
-
-impl LiveUsage for UnobservedUsage {
+/// `ravel-query`'s own live accounting view, as a [`LiveUsage`]. Every
+/// Prometheus-shaped operation below hands one to the engine through
+/// [`QueryEngine::with_live_usage`] and the same one to its usage guard, so a
+/// cancelled query records what it had actually spent.
+impl LiveUsage for LiveQueryAccounting {
     fn snapshot(&self) -> QueryAccountingSnapshot {
-        QueryAccountingSnapshot::default()
+        LiveQueryAccounting::snapshot(self)
     }
 }
 
@@ -453,7 +448,9 @@ pub async fn promql_instant(
     let _permit = controls.admit()?;
     let deadline = controls.clamp_deadline(request.deadline, engine.config().deadline);
     let budgets = controls.clamp_budgets(request.budgets.as_ref(), engine.config());
-    let guard = controls.usage_guard(tenant_hash, Arc::new(UnobservedUsage));
+    let live = LiveQueryAccounting::new();
+    let guard = controls.usage_guard(tenant_hash, Arc::new(live.clone()));
+    let engine = engine.with_live_usage(&live);
 
     let exec = engine
         .instant_with_budgets(
@@ -511,7 +508,9 @@ pub async fn promql_range(
     let _permit = controls.admit()?;
     let deadline = controls.clamp_deadline(request.deadline, engine.config().deadline);
     let budgets = controls.clamp_budgets(request.budgets.as_ref(), engine.config());
-    let guard = controls.usage_guard(tenant_hash, Arc::new(UnobservedUsage));
+    let live = LiveQueryAccounting::new();
+    let guard = controls.usage_guard(tenant_hash, Arc::new(live.clone()));
+    let engine = engine.with_live_usage(&live);
 
     let exec = engine
         .range_hist_with_budgets(
@@ -635,9 +634,11 @@ async fn metadata(
     let _permit = controls.admit()?;
     let deadline = controls.clamp_deadline(request.deadline, engine.config().deadline);
     let budgets = controls.clamp_budgets(request.budgets.as_ref(), engine.config());
-    let guard = controls.usage_guard(tenant_hash, Arc::new(UnobservedUsage));
+    let live = LiveQueryAccounting::new();
+    let guard = controls.usage_guard(tenant_hash, Arc::new(live.clone()));
+    let engine = engine.with_live_usage(&live);
 
-    let resolved = resolve_matched_series(engine, tenant_hash, request, deadline, &budgets).await;
+    let resolved = resolve_matched_series(&engine, tenant_hash, request, deadline, &budgets).await;
     let status = finish_usage(guard, &resolved, |resolved: &ResolvedSeries| {
         (resolved.accounting, resolved.estimate)
     });

--- a/crates/ravel-query/src/http/service.rs
+++ b/crates/ravel-query/src/http/service.rs
@@ -1,0 +1,870 @@
+//! The query controls every query transport shares (ADR-1374 decision 3,
+//! item 5).
+//!
+//! A query surface is two things: a transport (parse a request, encode a
+//! response) and a set of controls that must run in one order around the
+//! engine call. This module owns the controls; the transports own nothing but
+//! parsing and encoding.
+//!
+//! The order every operation here follows is fixed:
+//!
+//! 1. acquire an admission permit from the fleet-global controller, before any
+//!    resolve or GET;
+//! 2. clamp the wall deadline and the request budgets against the server
+//!    ceilings, lowering only;
+//! 3. run the engine call;
+//! 4. finalize usage through [`UsageGuard`] on every exit path, the dropped
+//!    one included;
+//! 5. submit the audit event and await its durability;
+//! 6. apply the partial-coverage consent gate;
+//! 7. map the outcome through the existing redaction.
+//!
+//! Usage is finalized at step 4, so an audit failure, a partial refusal, an
+//! evaluation failure, and a deadline all record what the query spent before
+//! the failure becomes a response. A cancellation (the caller's future
+//! dropped) never reaches step 5: it produces no result, and its usage record
+//! is its only trace. Nothing here spawns, so dropping the caller's future
+//! cancels the engine call itself.
+//!
+//! `ravel-server`'s `service::QueryService` is the façade a transport calls;
+//! it holds a [`QueryControls`] and delegates the five Prometheus-shaped
+//! operations to the functions here, so the SQL, analytics, exemplars, PromQL,
+//! and (issue #1381) MCP surfaces run one implementation of these controls
+//! rather than five copies.
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+
+use ravel_maintain::{QueryAuditSink, QueryStatus, query_audit_event};
+use ravel_promql::{Annotations, LabelMatcher, RangeValue, Value};
+use ravel_types::accounting::{
+    CostEstimate, QueryAccountingSnapshot, QueryCostRecorder, QueryWorkloadClass,
+};
+use ravel_types::{CommitToken, LabelSet, SeriesId, TenantHash, TimeRange};
+
+use crate::engine::parse_match_selector;
+use crate::http::error::{ApiError, MSG_UNAVAILABLE};
+use crate::log_series;
+use crate::request_budgets::RequestBudgets;
+use crate::{
+    Coverage, EngineConfig, QueryAdmissionController, QueryEngine, QueryPermit, QueryStats,
+};
+
+/// Resolve the caller's credentials to a tenant, the one authentication step
+/// every query transport runs before it asks the service layer for anything.
+///
+/// Authentication is a transport concern and stays outside the operations
+/// below: they take an already-authenticated [`TenantHash`]. It runs before
+/// admission on purpose, so an anonymous caller cannot consume a permit from
+/// the fleet-global concurrency ceiling.
+pub fn authenticate(
+    resolver: &dyn crate::http::tenant::TenantResolver,
+    headers: &axum::http::HeaderMap,
+) -> Result<TenantHash, ApiError> {
+    Ok(resolver.resolve(headers)?.hash())
+}
+
+/// Client message for a query the fleet-global concurrency ceiling refused.
+/// One constant so every transport's 503 body is the same string.
+pub const MSG_CONCURRENCY: &str = "fleet query concurrency ceiling reached; retry";
+
+/// How a query ended, for its usage record. Mirrors `ravel-server`'s
+/// `QueryOutcomeStatus`, which is the aggregator this feeds and which lives in
+/// the crate that owns `/metrics`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageStatus {
+    Success,
+    Error,
+    Timeout,
+    Canceled,
+}
+
+/// The sink one finished query's usage record is folded into, tagged with how
+/// the query ended.
+///
+/// Distinct from [`QueryCostRecorder`], which records the cost of a *completed*
+/// query and carries no outcome: this one is written from a drop guard on every
+/// exit path, so it also sees the cancelled, timed-out, and failed queries that
+/// never produce a response.
+pub trait QueryUsageSink: Send + Sync {
+    fn record_usage(
+        &self,
+        tenant_hash: TenantHash,
+        status: UsageStatus,
+        accounting: &QueryAccountingSnapshot,
+        estimate: &CostEstimate,
+    );
+}
+
+/// Records nothing. The default for a caller with no `/metrics` aggregator.
+pub struct NoopQueryUsageSink;
+
+impl QueryUsageSink for NoopQueryUsageSink {
+    fn record_usage(
+        &self,
+        _tenant_hash: TenantHash,
+        _status: UsageStatus,
+        _accounting: &QueryAccountingSnapshot,
+        _estimate: &CostEstimate,
+    ) {
+    }
+}
+
+/// A running query's spend, readable at any instant.
+///
+/// The drop path has no outcome to read counters from, so it reads them here
+/// instead: a query that fetched objects for two minutes and was then abandoned
+/// records what it actually spent, not zeros. Implemented over `ravel-sql`'s
+/// `LiveAccounting` for the SQL path and over a live `QueryAccounting` handle
+/// for the exemplars path.
+pub trait LiveUsage: Send + Sync {
+    fn snapshot(&self) -> QueryAccountingSnapshot;
+}
+
+/// A live-usage handle for a call that exposes none. Its snapshot is all
+/// zeros, so a cancelled query on that path records the cancellation itself
+/// without claiming a spend it cannot measure.
+///
+/// The Prometheus-shaped engine entry points build and own their
+/// `QueryAccounting` internally and return it only on success, so this is what
+/// they use. Replacing it needs a live handle on `QueryEngine`, which is a
+/// change to `engine.rs`.
+pub struct UnobservedUsage;
+
+impl LiveUsage for UnobservedUsage {
+    fn snapshot(&self) -> QueryAccountingSnapshot {
+        QueryAccountingSnapshot::default()
+    }
+}
+
+/// Folds exactly one usage record for one query, on whichever path it exits.
+///
+/// [`UsageGuard::finish`] records the real outcome and consumes the guard, so a
+/// second call is a compile error rather than a double fold. The only way not
+/// to call it is the guard itself being dropped without the operation reaching
+/// that line, which is the whole operation future being dropped mid-await:
+/// `Drop::drop` runs unconditionally and folds a [`UsageStatus::Canceled`]
+/// record whose cost is read live from [`LiveUsage`].
+pub struct UsageGuard {
+    sink: Arc<dyn QueryUsageSink>,
+    tenant_hash: TenantHash,
+    live: Arc<dyn LiveUsage>,
+    finished: bool,
+}
+
+impl UsageGuard {
+    pub fn new(
+        sink: Arc<dyn QueryUsageSink>,
+        tenant_hash: TenantHash,
+        live: Arc<dyn LiveUsage>,
+    ) -> Self {
+        UsageGuard {
+            sink,
+            tenant_hash,
+            live,
+            finished: false,
+        }
+    }
+
+    /// Record the real outcome. Consumes the guard.
+    pub fn finish(
+        mut self,
+        status: UsageStatus,
+        accounting: &QueryAccountingSnapshot,
+        estimate: &CostEstimate,
+    ) {
+        self.sink
+            .record_usage(self.tenant_hash, status, accounting, estimate);
+        self.finished = true;
+    }
+
+    /// Record a failed outcome whose spend is only knowable from the live
+    /// handle: the estimate is a success-path value, so it folds as zero.
+    pub fn finish_failed(self, status: UsageStatus) {
+        let snapshot = self.live.snapshot();
+        self.finish(status, &snapshot, &zero_estimate());
+    }
+}
+
+impl Drop for UsageGuard {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.sink.record_usage(
+                self.tenant_hash,
+                UsageStatus::Canceled,
+                &self.live.snapshot(),
+                &zero_estimate(),
+            );
+        }
+    }
+}
+
+/// The controls every query transport in the process shares: one admission
+/// controller, one cost recorder, one usage sink, one audit sink.
+///
+/// It carries no engine and no config. The server ceilings a request is clamped
+/// against are passed in per operation, because the SQL surface's ceilings come
+/// from its own state rather than from a [`QueryEngine`] config, and one
+/// controls value has to serve both.
+#[derive(Clone)]
+pub struct QueryControls {
+    pub admission: Arc<QueryAdmissionController>,
+    pub cost_recorder: Arc<dyn QueryCostRecorder>,
+    pub usage_sink: Arc<dyn QueryUsageSink>,
+    pub audit_sink: Arc<dyn QueryAuditSink>,
+}
+
+impl QueryControls {
+    /// Step 1: a permit from the fleet-global ceiling (ADR-0061 decision 2),
+    /// taken before any resolve or GET and released by its `Drop` on every
+    /// exit, the dropped-future one included.
+    pub fn admit(&self) -> Result<QueryPermit, ApiError> {
+        self.admission
+            .try_admit()
+            .map_err(|_| ApiError::Unavailable(MSG_CONCURRENCY.to_string()))
+    }
+
+    /// Step 2, deadlines: a caller may only lower the server's wall deadline.
+    pub fn clamp_deadline(&self, requested: Duration, ceiling: Duration) -> Duration {
+        requested.min(ceiling)
+    }
+
+    /// Step 2, budgets: a caller may only lower the server's per-request
+    /// budgets. The engine re-resolves the same clamp through
+    /// [`RequestBudgets::clamp_optional`], which is idempotent, so clamping
+    /// here makes the lowering visible at the service boundary without
+    /// changing what the query runs under.
+    pub fn clamp_budgets(
+        &self,
+        requested: Option<&RequestBudgets>,
+        config: &EngineConfig,
+    ) -> RequestBudgets {
+        let effective = RequestBudgets::clamp_optional(requested, config);
+        RequestBudgets {
+            max_bytes_scanned: Some(effective.max_bytes_scanned),
+            max_store_requests: Some(effective.max_store_requests),
+            max_segments: Some(effective.max_segments),
+        }
+    }
+
+    /// Step 4: the drop guard that folds this query's usage on every exit.
+    pub fn usage_guard(&self, tenant_hash: TenantHash, live: Arc<dyn LiveUsage>) -> UsageGuard {
+        UsageGuard::new(Arc::clone(&self.usage_sink), tenant_hash, live)
+    }
+
+    /// Step 5: submit one evidential audit event for a query that reached
+    /// execution for a resolved tenant and await its durability (ADR-0062
+    /// §2a).
+    ///
+    /// A submission failure (`audit_mode=required` surfacing a flush error, or
+    /// a stopped pipeline) fails the request closed with a retryable 503 rather
+    /// than releasing an unaudited answer. In best-effort mode the pipeline
+    /// resolves the submission to `Ok` and the response is released. A request
+    /// rejected before execution never calls this: there is no executed read to
+    /// attribute.
+    pub async fn audit(
+        &self,
+        tenant_hash: TenantHash,
+        now_ns: i64,
+        query_text: &str,
+        language: &str,
+        window: (i64, i64),
+        status: QueryStatus,
+    ) -> Result<(), ApiError> {
+        let event = query_audit_event(
+            &tenant_hash,
+            now_ns,
+            query_text,
+            language,
+            status,
+            window.0,
+            window.1,
+        );
+        self.audit_sink
+            .submit(event)
+            .await
+            .map_err(|_| ApiError::Unavailable(MSG_UNAVAILABLE.to_string()))?;
+        Ok(())
+    }
+
+    /// Step 6: the partial-coverage consent gate (ADR-0071 amendment
+    /// decision 1). Partial coverage the caller did not opt into is refused
+    /// with the typed 503 every query surface uses, so a consumer that never
+    /// asked for a partial answer fails safe instead of silently accepting one.
+    pub fn gate_partial(&self, coverage: &Coverage, allow_partial: bool) -> Result<(), ApiError> {
+        if coverage.is_partial() && !allow_partial {
+            return Err(ApiError::Unavailable(partial_refusal_message(
+                coverage.skipped(),
+            )));
+        }
+        Ok(())
+    }
+
+    /// Fold a completed query's cost into the `/metrics` aggregate
+    /// (ADR-0044 section 4). Separate from [`Self::usage_guard`]: this is the
+    /// pre-existing `ravel_query_*` family, fed only by a query that produced
+    /// an answer.
+    pub fn record_cost(
+        &self,
+        tenant_hash: TenantHash,
+        accounting: &QueryAccountingSnapshot,
+        estimate: &CostEstimate,
+    ) {
+        self.cost_recorder.record(
+            accounting,
+            estimate,
+            tenant_hash,
+            QueryWorkloadClass::Interactive,
+        );
+    }
+}
+
+/// The refusal message for partial coverage the caller did not opt into. It
+/// names the degraded clusters (the same operator-facing, already-redacted
+/// names the `warnings` array carries) and names `allow_partial` as the
+/// remedy, so the fix is in the failure itself.
+pub fn partial_refusal_message(skipped: &[String]) -> String {
+    let clusters = if skipped.is_empty() {
+        "one or more federated clusters were skipped".to_string()
+    } else {
+        skipped.join("; ")
+    };
+    format!(
+        "partial results: coverage is incomplete ({clusters}); \
+         set allow_partial=true to receive partial results"
+    )
+}
+
+/// Builds a [`Coverage`] from the metadata path's accumulated partial flag and
+/// its skipped-cluster warnings. The value-bearing operations derive coverage
+/// from a [`QueryStats`] via [`Coverage::from_stats`]; the metadata operations
+/// carry no `QueryStats` on their envelope, so they thread the flag and
+/// warnings through directly and reconstruct the same shape here.
+fn coverage_of(partial: bool, skipped: &[String]) -> Coverage {
+    if partial {
+        Coverage::Partial {
+            skipped: skipped.to_vec(),
+        }
+    } else {
+        Coverage::Complete
+    }
+}
+
+/// Nanosecond form of a millisecond timestamp for an audit window bound,
+/// saturating rather than overflowing (the audit record is best-effort
+/// informational for the window; the query itself already validated its
+/// range).
+fn ms_to_ns(ms: i64) -> i64 {
+    ms.saturating_mul(1_000_000)
+}
+
+/// One instant PromQL query, already parsed and authenticated.
+#[derive(Debug, Clone)]
+pub struct InstantRequest {
+    pub query: String,
+    pub time_ms: i64,
+    pub min_tokens: Vec<CommitToken>,
+    pub deadline: Duration,
+    pub allow_partial: bool,
+    pub now_ns: i64,
+    pub budgets: Option<RequestBudgets>,
+}
+
+/// One range PromQL query, already parsed and authenticated.
+#[derive(Debug, Clone)]
+pub struct RangeRequest {
+    pub query: String,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub step_ms: i64,
+    pub min_tokens: Vec<CommitToken>,
+    pub deadline: Duration,
+    pub allow_partial: bool,
+    pub now_ns: i64,
+    pub budgets: Option<RequestBudgets>,
+}
+
+/// One metadata query (`labels`, `label_values`, `series`), already parsed and
+/// authenticated.
+#[derive(Debug, Clone)]
+pub struct MetadataRequest {
+    pub selectors: Vec<String>,
+    pub window: TimeRange,
+    pub min_tokens: Vec<CommitToken>,
+    pub deadline: Duration,
+    pub allow_partial: bool,
+    pub now_ns: i64,
+    pub budgets: Option<RequestBudgets>,
+}
+
+/// The answer to an instant query, with its coverage already consented to.
+pub struct InstantOutcome {
+    pub value: Value,
+    pub stats: QueryStats,
+    pub partial: bool,
+    pub warnings: Vec<String>,
+    pub infos: Vec<String>,
+}
+
+/// The answer to a range query, with its coverage already consented to.
+pub struct RangeOutcome {
+    pub value: RangeValue,
+    pub stats: QueryStats,
+    pub partial: bool,
+    pub warnings: Vec<String>,
+    pub infos: Vec<String>,
+}
+
+/// The matched series behind a metadata query, with its coverage already
+/// consented to.
+pub struct MetadataOutcome {
+    pub series: Vec<(SeriesId, LabelSet)>,
+    pub partial: bool,
+    pub warnings: Vec<String>,
+}
+
+/// The label names a `labels` query matched.
+pub struct LabelsOutcome {
+    pub names: Vec<String>,
+    pub partial: bool,
+    pub warnings: Vec<String>,
+}
+
+/// The label values a `label_values` query matched.
+pub struct LabelValuesOutcome {
+    pub values: Vec<String>,
+    pub partial: bool,
+    pub warnings: Vec<String>,
+}
+
+/// `/api/v1/query`: one instant PromQL evaluation under the shared controls.
+pub async fn promql_instant(
+    controls: &QueryControls,
+    engine: &QueryEngine,
+    tenant_hash: TenantHash,
+    request: &InstantRequest,
+) -> Result<InstantOutcome, ApiError> {
+    let _permit = controls.admit()?;
+    let deadline = controls.clamp_deadline(request.deadline, engine.config().deadline);
+    let budgets = controls.clamp_budgets(request.budgets.as_ref(), engine.config());
+    let guard = controls.usage_guard(tenant_hash, Arc::new(UnobservedUsage));
+
+    let exec = engine
+        .instant_with_budgets(
+            tenant_hash,
+            &request.query,
+            request.time_ms,
+            &request.min_tokens,
+            request.now_ns,
+            deadline,
+            Some(&budgets),
+        )
+        .await
+        .map_err(ApiError::from);
+
+    let status = finish_usage(
+        guard,
+        &exec,
+        |(_, _, stats): &(Value, Annotations, QueryStats)| (stats.accounting, stats.estimate),
+    );
+
+    let time_ns = ms_to_ns(request.time_ms);
+    controls
+        .audit(
+            tenant_hash,
+            request.now_ns,
+            &request.query,
+            "promql",
+            (time_ns, time_ns),
+            status,
+        )
+        .await?;
+    let (value, annotations, stats) = exec?;
+
+    let coverage = Coverage::from_stats(&stats);
+    controls.gate_partial(&coverage, request.allow_partial)?;
+    let (warnings, infos) = merge_annotations(annotations, &stats);
+    controls.record_cost(tenant_hash, &stats.accounting, &stats.estimate);
+    Ok(InstantOutcome {
+        value,
+        partial: coverage.is_partial(),
+        stats,
+        warnings,
+        infos,
+    })
+}
+
+/// `/api/v1/query_range`: one range PromQL evaluation under the shared
+/// controls.
+pub async fn promql_range(
+    controls: &QueryControls,
+    engine: &QueryEngine,
+    tenant_hash: TenantHash,
+    request: &RangeRequest,
+) -> Result<RangeOutcome, ApiError> {
+    let _permit = controls.admit()?;
+    let deadline = controls.clamp_deadline(request.deadline, engine.config().deadline);
+    let budgets = controls.clamp_budgets(request.budgets.as_ref(), engine.config());
+    let guard = controls.usage_guard(tenant_hash, Arc::new(UnobservedUsage));
+
+    let exec = engine
+        .range_hist_with_budgets(
+            tenant_hash,
+            &request.query,
+            request.start_ms,
+            request.end_ms,
+            request.step_ms,
+            &request.min_tokens,
+            request.now_ns,
+            deadline,
+            Some(&budgets),
+        )
+        .await
+        .map_err(ApiError::from);
+
+    let status = finish_usage(
+        guard,
+        &exec,
+        |(_, _, stats): &(RangeValue, Annotations, QueryStats)| (stats.accounting, stats.estimate),
+    );
+
+    controls
+        .audit(
+            tenant_hash,
+            request.now_ns,
+            &request.query,
+            "promql",
+            (ms_to_ns(request.start_ms), ms_to_ns(request.end_ms)),
+            status,
+        )
+        .await?;
+    let (value, annotations, stats) = exec?;
+
+    let coverage = Coverage::from_stats(&stats);
+    controls.gate_partial(&coverage, request.allow_partial)?;
+    let (warnings, infos) = merge_annotations(annotations, &stats);
+    controls.record_cost(tenant_hash, &stats.accounting, &stats.estimate);
+    Ok(RangeOutcome {
+        value,
+        partial: coverage.is_partial(),
+        stats,
+        warnings,
+        infos,
+    })
+}
+
+/// `/api/v1/labels`: the label names carried by the matched series.
+pub async fn labels(
+    controls: &QueryControls,
+    engine: &QueryEngine,
+    tenant_hash: TenantHash,
+    request: &MetadataRequest,
+) -> Result<LabelsOutcome, ApiError> {
+    let outcome = metadata(controls, engine, tenant_hash, request, "labels").await?;
+    let mut names: BTreeSet<String> = BTreeSet::new();
+    for (_, labels) in &outcome.series {
+        for label in labels.iter() {
+            names.insert(label.name.clone());
+        }
+    }
+    Ok(LabelsOutcome {
+        names: names.into_iter().collect(),
+        partial: outcome.partial,
+        warnings: outcome.warnings,
+    })
+}
+
+/// `/api/v1/label/{name}/values`: the values of `name` across the matched
+/// series.
+///
+/// `include_log_metric_names` is the caller's already-parsed answer to ADR-1103:
+/// the two reserved log metric names appear in no stored postings, so they only
+/// surface when the request's selectors ask about the logs signal at all.
+pub async fn label_values(
+    controls: &QueryControls,
+    engine: &QueryEngine,
+    tenant_hash: TenantHash,
+    request: &MetadataRequest,
+    name: &str,
+    include_log_metric_names: bool,
+) -> Result<LabelValuesOutcome, ApiError> {
+    let outcome = metadata(controls, engine, tenant_hash, request, "labels").await?;
+    let mut values: BTreeSet<String> = BTreeSet::new();
+    for (_, labels) in &outcome.series {
+        if let Some(v) = labels.get(name) {
+            values.insert(v.to_string());
+        }
+    }
+    if include_log_metric_names {
+        values.insert(log_series::LOG_LINES_METRIC.to_string());
+        values.insert(log_series::LOG_BYTES_METRIC.to_string());
+    }
+    Ok(LabelValuesOutcome {
+        values: values.into_iter().collect(),
+        partial: outcome.partial,
+        warnings: outcome.warnings,
+    })
+}
+
+/// `/api/v1/series`: the matched series themselves.
+pub async fn series(
+    controls: &QueryControls,
+    engine: &QueryEngine,
+    tenant_hash: TenantHash,
+    request: &MetadataRequest,
+) -> Result<MetadataOutcome, ApiError> {
+    metadata(controls, engine, tenant_hash, request, "series").await
+}
+
+/// The one metadata read behind `labels`, `label_values`, and `series`, under
+/// the shared controls. `language` distinguishes the surface on the audit
+/// record so the record shape stays one schema.
+async fn metadata(
+    controls: &QueryControls,
+    engine: &QueryEngine,
+    tenant_hash: TenantHash,
+    request: &MetadataRequest,
+    language: &str,
+) -> Result<MetadataOutcome, ApiError> {
+    let _permit = controls.admit()?;
+    let deadline = controls.clamp_deadline(request.deadline, engine.config().deadline);
+    let budgets = controls.clamp_budgets(request.budgets.as_ref(), engine.config());
+    let guard = controls.usage_guard(tenant_hash, Arc::new(UnobservedUsage));
+
+    let resolved = resolve_matched_series(engine, tenant_hash, request, deadline, &budgets).await;
+    let status = finish_usage(guard, &resolved, |resolved: &ResolvedSeries| {
+        (resolved.accounting, resolved.estimate)
+    });
+
+    let selectors_text = request.selectors.join("; ");
+    controls
+        .audit(
+            tenant_hash,
+            request.now_ns,
+            &selectors_text,
+            language,
+            (request.window.start_ns, request.window.end_ns),
+            status,
+        )
+        .await?;
+    let resolved = resolved?;
+
+    let coverage = coverage_of(resolved.partial, &resolved.warnings);
+    controls.gate_partial(&coverage, request.allow_partial)?;
+    controls.record_cost(tenant_hash, &resolved.accounting, &resolved.estimate);
+    Ok(MetadataOutcome {
+        series: resolved.series,
+        partial: resolved.partial,
+        warnings: resolved.warnings,
+    })
+}
+
+/// One metadata request's matched series and its summed cost.
+struct ResolvedSeries {
+    series: Vec<(SeriesId, LabelSet)>,
+    partial: bool,
+    warnings: Vec<String>,
+    /// The field-wise sum of every selector's snapshot: one metadata request is
+    /// one query, so the whole request folds into the aggregator once.
+    accounting: QueryAccountingSnapshot,
+    estimate: CostEstimate,
+}
+
+async fn resolve_matched_series(
+    engine: &QueryEngine,
+    tenant_hash: TenantHash,
+    request: &MetadataRequest,
+    deadline: Duration,
+    budgets: &RequestBudgets,
+) -> Result<ResolvedSeries, ApiError> {
+    // The wall deadline is a per-query budget (docs/query-engine.md
+    // "Budgets"), and one metadata request is one query. Convert the duration
+    // into a single absolute instant computed once here, then hand each
+    // resolve_series call only the time still remaining. Without this, each
+    // match[] selector would be granted the full `deadline` afresh, so N
+    // selectors would get N times the documented budget with no aggregate cap.
+    let request_deadline = tokio::time::Instant::now() + deadline;
+
+    let mut combined: Option<(QueryAccountingSnapshot, CostEstimate)> = None;
+    // Cross-cluster federation partial-coverage warnings (ADR-0071),
+    // accumulated across selectors and deduplicated so the client sees one
+    // warning per skipped cluster regardless of how many selectors it sent.
+    let mut warnings: Vec<String> = Vec::new();
+    // The whole request is partial if ANY selector's federated resolve skipped
+    // a remote.
+    let mut partial = false;
+
+    if request.selectors.is_empty() {
+        let remaining = remaining_budget(request_deadline, deadline)?;
+        let (series, stats) = engine
+            .resolve_series_with_budgets(
+                tenant_hash,
+                &[],
+                request.window,
+                &request.min_tokens,
+                request.now_ns,
+                remaining,
+                Some(budgets),
+            )
+            .await?;
+        accumulate_cost(&mut combined, &stats);
+        partial |= stats.partial;
+        for w in stats.warnings {
+            if !warnings.contains(&w) {
+                warnings.push(w);
+            }
+        }
+        let (accounting, estimate) =
+            combined.unwrap_or((QueryAccountingSnapshot::default(), zero_estimate()));
+        return Ok(ResolvedSeries {
+            series,
+            partial,
+            warnings,
+            accounting,
+            estimate,
+        });
+    }
+
+    // Deliberate deviation: each match[] selector resolves its own snapshot
+    // independently, rather than one shared snapshot for the whole request. The
+    // shared wall budget above is orthogonal to that: snapshots stay
+    // per-selector, but all selectors draw down one deadline.
+    //
+    // Per-selector segment stats are not surfaced on this path: the
+    // labels/label_values/series endpoints have no established response
+    // envelope for it (only the value-bearing endpoints do), and aggregating
+    // per-selector counts here would double count segments any two selectors
+    // both matched.
+    let mut by_id: HashMap<SeriesId, LabelSet> = HashMap::new();
+    for selector in &request.selectors {
+        let matchers: Vec<LabelMatcher> = parse_match_selector(selector)?;
+        let remaining = remaining_budget(request_deadline, deadline)?;
+        let (series, stats) = engine
+            .resolve_series_with_budgets(
+                tenant_hash,
+                &matchers,
+                request.window,
+                &request.min_tokens,
+                request.now_ns,
+                remaining,
+                Some(budgets),
+            )
+            .await?;
+        accumulate_cost(&mut combined, &stats);
+        partial |= stats.partial;
+        for w in stats.warnings {
+            if !warnings.contains(&w) {
+                warnings.push(w);
+            }
+        }
+        for (id, labels) in series {
+            by_id.entry(id).or_insert(labels);
+        }
+    }
+    let (accounting, estimate) =
+        combined.unwrap_or((QueryAccountingSnapshot::default(), zero_estimate()));
+    Ok(ResolvedSeries {
+        series: by_id.into_iter().collect(),
+        partial,
+        warnings,
+        accounting,
+        estimate,
+    })
+}
+
+/// Fold one sub-query's [`QueryStats`] into the request's running cost total.
+/// The counters sum and the estimate sums; the first call seeds the total
+/// because [`CostEstimate`] has no zero value (an estimate is only ever a real
+/// resolved snapshot's, ADR-0044).
+fn accumulate_cost(
+    combined: &mut Option<(QueryAccountingSnapshot, CostEstimate)>,
+    stats: &QueryStats,
+) {
+    *combined = Some(match combined.take() {
+        None => (stats.accounting, stats.estimate),
+        Some((accounting, estimate)) => (
+            accounting.saturating_add(&stats.accounting),
+            estimate.saturating_add(&stats.estimate),
+        ),
+    });
+}
+
+/// Time left in the shared request wall budget, or a `DeadlineExceeded` error
+/// once it is spent. `configured` is the whole-request budget and is reported
+/// in the error so the client sees the query's deadline, not the residual slice
+/// handed to the last selector.
+fn remaining_budget(
+    request_deadline: tokio::time::Instant,
+    configured: Duration,
+) -> Result<Duration, ApiError> {
+    let remaining = request_deadline.saturating_duration_since(tokio::time::Instant::now());
+    if remaining.is_zero() {
+        return Err(crate::QueryError::DeadlineExceeded {
+            deadline: configured,
+        }
+        .into());
+    }
+    Ok(remaining)
+}
+
+/// Merge the federation fan-out's partial-coverage warnings (ADR-0071) into the
+/// top-level `warnings` array alongside the evaluator's own annotations, so a
+/// `skip_unavailable=true` federated query returns a response a client can tell
+/// is partial and that names the skipped cluster. These are already redacted at
+/// the federation seam: they name the operator-facing cluster only, never its
+/// endpoint or transport error text.
+fn merge_annotations(annotations: Annotations, stats: &QueryStats) -> (Vec<String>, Vec<String>) {
+    let (mut warnings, infos) = annotations.into_parts();
+    for w in &stats.warnings {
+        if !warnings.contains(w) {
+            warnings.push(w.clone());
+        }
+    }
+    (warnings, infos)
+}
+
+/// Step 4 for one operation: fold the usage record before the outcome is turned
+/// into anything else, and report the audit status the same outcome implies.
+///
+/// `cost_of` reads the success value's counters; a failure has none, so its
+/// spend comes from the guard's live handle instead. Every caller runs this
+/// before its `audit`, its `?`, and its consent gate, which is what makes "the
+/// usage record exists even when the request ends as an error" mechanical
+/// rather than remembered.
+fn finish_usage<T>(
+    guard: UsageGuard,
+    result: &Result<T, ApiError>,
+    cost_of: impl FnOnce(&T) -> (QueryAccountingSnapshot, CostEstimate),
+) -> QueryStatus {
+    match result {
+        Ok(value) => {
+            let (accounting, estimate) = cost_of(value);
+            guard.finish(UsageStatus::Success, &accounting, &estimate);
+            QueryStatus::Ok
+        }
+        Err(err) => {
+            guard.finish_failed(usage_status_of(err));
+            QueryStatus::Error
+        }
+    }
+}
+
+/// The usage status a failed operation records. A wall-deadline trip is a
+/// [`UsageStatus::Timeout`]; every other failure is a [`UsageStatus::Error`].
+/// The cost recorded alongside it is read from the live handle, not derived
+/// from the error, so a deadline carries the requests and bytes the query
+/// actually issued.
+pub fn usage_status_of(err: &ApiError) -> UsageStatus {
+    match err {
+        ApiError::Timeout(_) => UsageStatus::Timeout,
+        _ => UsageStatus::Error,
+    }
+}
+
+/// The zero cost estimate. [`CostEstimate`] has no zero value of its own: an
+/// estimate is only ever a real resolved snapshot's (ADR-0044), so a path with
+/// no successful resolve folds this instead.
+pub fn zero_estimate() -> CostEstimate {
+    CostEstimate::new(0, 0, 0, 0, 0)
+}

--- a/crates/ravel-query/src/http/service.rs
+++ b/crates/ravel-query/src/http/service.rs
@@ -597,7 +597,7 @@ pub async fn label_values(
     name: &str,
     include_log_metric_names: bool,
 ) -> Result<LabelValuesOutcome, ApiError> {
-    let outcome = metadata(controls, engine, tenant_hash, request, "labels").await?;
+    let outcome = metadata(controls, engine, tenant_hash, request, "label_values").await?;
     let mut values: BTreeSet<String> = BTreeSet::new();
     for (_, labels) in &outcome.series {
         if let Some(v) = labels.get(name) {

--- a/crates/ravel-query/src/http/service.rs
+++ b/crates/ravel-query/src/http/service.rs
@@ -126,7 +126,11 @@ pub trait LiveUsage: Send + Sync {
 /// `ravel-query`'s own live accounting view, as a [`LiveUsage`]. Every
 /// Prometheus-shaped operation below hands one to the engine through
 /// [`QueryEngine::with_live_usage`] and the same one to its usage guard, so a
-/// cancelled query records what it had actually spent.
+/// cancelled query records what it had actually spent. The view is additive
+/// over every lane, selector, and attempt the request spent through, so one
+/// view per operation is enough even where the operation makes several engine
+/// calls: `resolve_matched_series` below resolves each `match[]` selector
+/// separately and the guard still reads the whole request's spend.
 impl LiveUsage for LiveQueryAccounting {
     fn snapshot(&self) -> QueryAccountingSnapshot {
         LiveQueryAccounting::snapshot(self)

--- a/crates/ravel-query/src/http/service.rs
+++ b/crates/ravel-query/src/http/service.rs
@@ -44,7 +44,7 @@ use ravel_types::accounting::{
 use ravel_types::{CommitToken, LabelSet, SeriesId, TenantHash, TimeRange};
 
 use crate::engine::parse_match_selector;
-use crate::http::error::{ApiError, MSG_UNAVAILABLE};
+use crate::http::error::{ApiError, MSG_AUDIT_UNAVAILABLE};
 use crate::log_series;
 use crate::request_budgets::RequestBudgets;
 use crate::{
@@ -281,10 +281,15 @@ impl QueryControls {
             window.0,
             window.1,
         );
-        self.audit_sink
-            .submit(event)
-            .await
-            .map_err(|_| ApiError::Unavailable(MSG_UNAVAILABLE.to_string()))?;
+        self.audit_sink.submit(event).await.map_err(|err| {
+            tracing::warn!(
+                tenant = %tenant_hash.to_hex(),
+                error = %err,
+                language,
+                "query audit submission failed; failing the request closed",
+            );
+            ApiError::Unavailable(MSG_AUDIT_UNAVAILABLE.to_string())
+        })?;
         Ok(())
     }
 

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -28,7 +28,9 @@ pub use config::{
     LATENCY_FIRST_MEASURED_CONCURRENCY, LogsFetchPolicy, REQUEST_BUDGET_FIXED_OVERHEAD,
     RequestLimit, ResolvedLogsFetch, derive_max_s3_requests, resolve_logs_fetch,
 };
-pub use engine::{Coverage, QueryEngine, QueryStats, snapshot_erasure_predicates};
+pub use engine::{
+    Coverage, LiveQueryAccounting, QueryEngine, QueryStats, snapshot_erasure_predicates,
+};
 pub use error::QueryError;
 pub use fetcher::{
     CacheFetchError, FetchError, FetchStats, FetchedSeries, FetchedSeriesSoa, ReadCache,

--- a/crates/ravel-query/tests/query_audit_surfaces.rs
+++ b/crates/ravel-query/tests/query_audit_surfaces.rs
@@ -155,15 +155,18 @@ async fn labels_submits_one_labels_event() {
     assert_common(&one(&events), "labels", "ok");
 }
 
+/// Distinct from `labels`'s own tag (issue #1377): the two label routes share
+/// the same `metadata()` execution path, and the audit record is the only
+/// place that still tells an auditor which route a caller used.
 #[tokio::test]
-async fn label_values_submits_one_labels_event() {
+async fn label_values_submits_one_label_values_event() {
     let (app, events) = recording();
     let response = app
         .oneshot(get("/api/v1/label/job/values"))
         .await
         .expect("infallible");
     assert_eq!(response.status(), StatusCode::OK);
-    assert_common(&one(&events), "labels", "ok");
+    assert_common(&one(&events), "label_values", "ok");
 }
 
 #[tokio::test]

--- a/crates/ravel-sql/src/flight/service.rs
+++ b/crates/ravel-sql/src/flight/service.rs
@@ -643,7 +643,7 @@ impl FlightSqlService for RavelFlightSqlService {
                 );
                 if self.audit_sink.submit(event).await.is_err() {
                     return Err(Status::unavailable(
-                        "query audit is temporarily unavailable; retry",
+                        ravel_query::http::MSG_AUDIT_UNAVAILABLE,
                     ));
                 }
                 Err(status)

--- a/crates/ravel-sql/src/flight/stream.rs
+++ b/crates/ravel-sql/src/flight/stream.rs
@@ -386,8 +386,10 @@ impl Drop for RecordOnStreamEnd {
 }
 
 /// The fixed client message when a `required`-mode audit flush fails and the
-/// Flight stream must fail closed. Carries no server state.
-const AUDIT_UNAVAILABLE_MSG: &str = "query audit is temporarily unavailable; retry";
+/// Flight stream must fail closed. Carries no server state. The one definition
+/// lives in `ravel-query`, so this transport and the HTTP service layer cannot
+/// drift apart on the wire.
+const AUDIT_UNAVAILABLE_MSG: &str = ravel_query::http::MSG_AUDIT_UNAVAILABLE;
 
 /// The evidential-audit context one Flight statement submits at stream
 /// completion: the sink, the resolved tenant, the request timestamp, and the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,9 +237,9 @@ request cannot consume a permit. It is also the one thing the service layer
 does not share across listeners: a process serving both the public listener
 and the mTLS listener runs an instance of the layer per listener, identical
 in every control and differing only in the tenant resolver, because the two
-listeners derive tenant identity from different credentials. Adding a transport therefore cannot add a
-surface that queries outside the ceiling, spends without recording, or
-answers without an audit trail.
+listeners derive tenant identity from different credentials. Adding a
+transport therefore cannot add a surface that queries outside the ceiling,
+spends without recording, or answers without an audit trail.
 
 Two boundaries of the layer are deliberate. The admission permit is released
 when the operation returns, before the transport encodes the response, so a
@@ -252,10 +252,18 @@ and this one never did.
 
 The usage record a disconnect folds carries the spend the query had actually
 reached, not a zero. Every operation hands the engine a live view of the
-counters for the attempt in flight and hands the same view to its usage
-guard, so a future dropped in the middle of a resolve is billed for the
-store requests it had already issued. A surface that recorded zero there
-would let a client cancel its way out of the cost of the work it started.
+counters the read spends through and hands the same view to its usage guard,
+so a future dropped in the middle of a resolve is billed for the store
+requests it had already issued. On the PromQL, metadata, and analytics
+operations that view is additive, because one request can spend through
+several counter blocks: the metrics lane and the log lane of a query naming
+both signals, one block per `match[]` selector of a metadata request, and one
+block per attempt when a snapshot is invalidated and the read re-resolves. The
+record sums all of them. The exemplars and SQL operations hold one block at a
+time and replace it when an attempt retries, so a cancellation there is billed
+for the retried attempt alone and not also for the discarded one. A surface
+that recorded zero would let a client cancel its way out of the cost of the
+work it started.
 
 The failure boundaries are the two PUTs of a write and the compare-and-swap
 of a fold. A failure on either side of them has a defined outcome and never

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -241,6 +241,15 @@ listeners derive tenant identity from different credentials. Adding a transport 
 surface that queries outside the ceiling, spends without recording, or
 answers without an audit trail.
 
+Two boundaries of the layer are deliberate. The admission permit is released
+when the operation returns, before the transport encodes the response, so a
+slow client does not hold a fleet-wide slot for the length of its download;
+encoding is CPU-bound work over a result the query budgets already capped.
+And a request the transport rejects before it calls an operation, a metadata
+selector that does not parse for instance, produces no audit event, because
+the audit trail records queries that reached execution for a resolved tenant
+and this one never did.
+
 The usage record a disconnect folds carries the spend the query had actually
 reached, not a zero. Every operation hands the engine a live view of the
 counters for the attempt in flight and hands the same view to its usage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,7 +233,11 @@ consent gate, and the redaction a failure passes through on the way out. A
 transport parses its request, authenticates it, calls one operation, and
 encodes the outcome; it holds none of those controls itself. Authentication
 stays on the transport side and runs before admission, so an unauthenticated
-request cannot consume a permit. Adding a transport therefore cannot add a
+request cannot consume a permit. It is also the one thing the service layer
+does not share across listeners: a process serving both the public listener
+and the mTLS listener runs an instance of the layer per listener, identical
+in every control and differing only in the tenant resolver, because the two
+listeners derive tenant identity from different credentials. Adding a transport therefore cannot add a
 surface that queries outside the ceiling, spends without recording, or
 answers without an audit trail.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,6 +237,13 @@ request cannot consume a permit. Adding a transport therefore cannot add a
 surface that queries outside the ceiling, spends without recording, or
 answers without an audit trail.
 
+The usage record a disconnect folds carries the spend the query had actually
+reached, not a zero. Every operation hands the engine a live view of the
+counters for the attempt in flight and hands the same view to its usage
+guard, so a future dropped in the middle of a resolve is billed for the
+store requests it had already issued. A surface that recorded zero there
+would let a client cancel its way out of the cost of the work it started.
+
 The failure boundaries are the two PUTs of a write and the compare-and-swap
 of a fold. A failure on either side of them has a defined outcome and never
 an ambiguous one for Ravel, only sometimes for the client. Storage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -223,6 +223,20 @@ boundary. A slow or unreachable remote degrades to partial coverage, and that
 state is always visible in the query's stats and warnings
 ([guides/distributed-query.md](guides/distributed-query.md)).
 
+One query service layer sits between every query transport and the engine,
+and it is the single place the per-query controls live: admission against the
+fleet-global concurrency ceiling, the deadline and request-budget clamps
+(which may only lower a server ceiling), the usage record folded on every
+exit path including a client disconnect, the evidential audit event whose
+durability is awaited before an answer is released, the partial-coverage
+consent gate, and the redaction a failure passes through on the way out. A
+transport parses its request, authenticates it, calls one operation, and
+encodes the outcome; it holds none of those controls itself. Authentication
+stays on the transport side and runs before admission, so an unauthenticated
+request cannot consume a permit. Adding a transport therefore cannot add a
+surface that queries outside the ceiling, spends without recording, or
+answers without an audit trail.
+
 The failure boundaries are the two PUTs of a write and the compare-and-swap
 of a fold. A failure on either side of them has a defined outcome and never
 an ambiguous one for Ravel, only sometimes for the client. Storage

--- a/docs/guides/audit.md
+++ b/docs/guides/audit.md
@@ -28,7 +28,9 @@ deployment that has taken those actions.
 
 Attributes:
 
-- `query.language`: the query language, `sql` today.
+- `query.language`: the query language or surface that produced the record:
+  `sql`, `promql`, `labels`, `label_values`, `series`, `analytics`, or
+  `exemplars`.
 - `query.tenant`: the hex hash of the resolved tenant, so the record is
   attributed to the tenant Ravel authenticated rather than to any identity the
   client claimed.

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -99,7 +99,10 @@ than an error, and reads no object storage on that path.
 field: change point detection (`change_point`) and summary statistics
 (`summary`). An unknown `op`, a missing field, or a malformed body is 400; an
 analytics computation error or the per-call series cap is 422; partial federated
-coverage without `allow_partial: true` is 503.
+coverage without `allow_partial: true` is 503. `/api/v1/analytics` and
+`/api/v1/query_exemplars` take a permit from the same query concurrency
+ceiling as the other query routes, and a request refused by it gets the same
+503 body those routes return.
 
 `/api/v1/sql` is behind the `sql` cargo feature. The published server image
 builds that feature, so the route is available there. Its response envelope is

--- a/services/ravel-server/src/analytics.rs
+++ b/services/ravel-server/src/analytics.rs
@@ -97,23 +97,22 @@ use std::time::Duration;
 use axum::Router;
 use axum::body::Body;
 use axum::extract::{Request, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use ravel_analytics::{
     AnalyticsError, ChangeKind, ChangePointParams, ChangePointResult, SummaryParams, SummaryResult,
 };
 use ravel_ingest::Clock;
-use ravel_maintain::{QueryAuditSink, QueryStatus, query_audit_event};
+use ravel_maintain::QueryAuditSink;
 use ravel_promql::Value;
-use ravel_query::http::{QueryErrorResponse, TenantResolver};
-use ravel_query::{Coverage, QueryEngine, QueryError};
-use ravel_types::{CommitToken, LabelSet, Sample, TenantHash};
+use ravel_query::http::TenantResolver;
+use ravel_query::{QueryAdmissionController, QueryConcurrencyLimit, QueryEngine};
+use ravel_types::{CommitToken, LabelSet, Sample};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tracing::Instrument;
 
-use crate::metrics::WorkloadClass;
+use crate::service::{AnalyticsRequest, ApiError, QueryService, ServiceError};
 
 /// Cap on the request body. The analytics request is a query plus a few scalar
 /// parameters, never large in legitimate use; this mirrors the defensive bound
@@ -146,6 +145,33 @@ pub struct AnalyticsState {
     /// deployments with no pipeline; a deployment attaches the one shared
     /// pipeline.
     pub audit_sink: Arc<dyn QueryAuditSink>,
+    /// The fleet-global query concurrency ceiling (ADR-0061 decision 2). An
+    /// analytics call runs the same range evaluation `/api/v1/query_range`
+    /// runs, so it takes a permit from the same controller and is rejected with
+    /// the same 503 rather than running outside the ceiling.
+    pub query_admission: Arc<QueryAdmissionController>,
+}
+
+impl AnalyticsState {
+    /// The query service layer for this surface: the shared controls plus this
+    /// state. The handler below calls it, and so does the process-wide service
+    /// built in `lib.rs`, through one implementation of the controls.
+    pub fn service(&self) -> QueryService {
+        QueryService::with_metrics(
+            Arc::clone(&self.tenant_resolver),
+            Arc::clone(&self.clock),
+            Arc::clone(&self.query_admission),
+            Arc::clone(&self.query_accounting),
+            Arc::clone(&self.audit_sink),
+        )
+        .with_analytics(self.clone())
+    }
+
+    /// An unlimited (never-rejecting) admission controller, for a caller that
+    /// mounts this route without a fleet ceiling.
+    pub fn unlimited_admission() -> Arc<QueryAdmissionController> {
+        QueryAdmissionController::shared(QueryConcurrencyLimit::Unlimited)
+    }
 }
 
 /// The `/api/v1/analytics` router.
@@ -214,9 +240,15 @@ async fn handle(State(state): State<AnalyticsState>, req: Request<Body>) -> Resp
     }
 }
 
-async fn run(state: &AnalyticsState, req: Request<Body>) -> Result<Response, ApiError> {
+/// Parse, authenticate, ask the query service layer, encode. Admission, the
+/// deadline clamp, the usage record, the audit event, the partial-coverage
+/// consent gate, and error redaction all happen inside
+/// [`QueryService::analytics`], shared with every other query surface; what is
+/// left here is this endpoint's own response shape and its analytic op.
+async fn run(state: &AnalyticsState, req: Request<Body>) -> Result<Response, ServiceError> {
     let headers = req.headers().clone();
-    let tenant_hash = authenticate(state, &headers)?;
+    // Before the service takes a permit, so an anonymous request consumes none.
+    let tenant_hash = crate::service::authenticate(state.tenant_resolver.as_ref(), &headers)?;
 
     let body = axum::body::to_bytes(req.into_body(), MAX_BODY_BYTES)
         .await
@@ -226,21 +258,23 @@ async fn run(state: &AnalyticsState, req: Request<Body>) -> Result<Response, Api
 
     // start/end/step parse exactly as `/api/v1/query_range`: a parse failure is
     // a 400 with the offending field and value, before any query runs.
-    let start_ms = parse_timestamp_ms("start", &body.start)?;
-    let end_ms = parse_timestamp_ms("end", &body.end)?;
-    let step_ms = parse_duration_ms("step", &body.step)?;
-
-    let min_tokens = body
-        .min_commit_token
-        .iter()
-        .map(|raw| {
-            CommitToken::decode(raw)
-                .map_err(|_| ApiError::bad_request(format!("invalid min_commit_token: {raw:?}")))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let max_deadline = state.engine.config().deadline;
-    let deadline = parse_deadline(body.timeout, max_deadline)?;
+    let request = AnalyticsRequest {
+        query: body.query.clone(),
+        start_ms: parse_timestamp_ms("start", &body.start)?,
+        end_ms: parse_timestamp_ms("end", &body.end)?,
+        step_ms: parse_duration_ms("step", &body.step)?,
+        min_tokens: body
+            .min_commit_token
+            .iter()
+            .map(|raw| {
+                CommitToken::decode(raw).map_err(|_| {
+                    ApiError::bad_request(format!("invalid min_commit_token: {raw:?}"))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        deadline: parse_deadline(body.timeout, state.engine.config().deadline)?,
+        allow_partial: body.allow_partial,
+    };
 
     // Percentiles are a request-level parameter: validate them once up front so
     // an invalid quantile is rejected before an expensive range evaluation and
@@ -249,107 +283,30 @@ async fn run(state: &AnalyticsState, req: Request<Body>) -> Result<Response, Api
     if let OpSpec::Summary { percentiles } = &body.op {
         for &q in percentiles {
             if !(0.0..=1.0).contains(&q) {
-                return Err(ApiError::from_analytics(
-                    AnalyticsError::InvalidPercentile { got: q },
-                ));
+                return Err(
+                    ApiError::from_analytics(AnalyticsError::InvalidPercentile { got: q }).into(),
+                );
             }
         }
     }
 
-    let now_ns = state.clock.now_ns();
+    let outcome = state.service().analytics(tenant_hash, &request).await?;
 
-    // A request-level span carrying only bounded values (ADR-0044 section 5):
-    // the tenant hash, the workload class, and -- once the range evaluation
-    // finishes -- the final store request and byte counts. No query text, label
-    // values, or object keys ever become span fields. An analytics call is an
-    // interactive, client-driven query.
-    let span = tracing::info_span!(
-        "analytics_query",
-        tenant_hash = %tenant_hash.to_hex(),
-        workload_class = WorkloadClass::Interactive.name(),
-        s3_requests = tracing::field::Empty,
-        s3_bytes = tracing::field::Empty,
-    );
-    // The range evaluation now runs for a resolved tenant, so it is auditable
-    // (ADR-0062 §2a): run it, submit one audit event for the outcome, and await
-    // its durability before releasing the response. A request rejected earlier
-    // (auth, body parse, invalid parameters) never reached here and is not
-    // audited. The recorded window is the request's resolved `[start, end]`.
-    // Collect per-slice fragment observability (ADR-0071 stats.fragments[]) for the duration of the range evaluation. The sink is
-    // installed in task-local storage so every distributed slice the engine
-    // dispatches records into it; a non-distributed engine (or a query the cost
-    // gate declined to fan out) records nothing, and the field stays absent.
-    let fragment_sink = crate::distrib::FragmentStatsSink::new();
-    let eval = crate::distrib::with_fragment_stats(
-        fragment_sink.clone(),
-        state
-            .engine
-            .range_with_stats(
-                tenant_hash,
-                &body.query,
-                start_ms,
-                end_ms,
-                step_ms,
-                &min_tokens,
-                now_ns,
-                deadline,
-            )
-            .instrument(span.clone()),
-    )
-    .await;
-    let status = if eval.is_ok() {
-        QueryStatus::Ok
-    } else {
-        QueryStatus::Error
-    };
-    submit_audit(
-        state,
-        tenant_hash,
-        now_ns,
-        &body.query,
-        status,
-        ms_to_ns(start_ms),
-        ms_to_ns(end_ms),
-    )
-    .await?;
-    let (value, stats) = eval.map_err(ApiError::from_query)?;
-
-    // Consent gate (ADR-0071 "partial results are consent-gated and
-    // envelope-visible" amendment, section 2): the evaluation ran and was
-    // audited, but a partial answer the client did not opt into is refused with
-    // the typed 503 the HTTP query endpoints use, before any op runs and before
-    // any body is built. Coverage is knowable only now, and it is derived from
-    // the stats the engine already produced rather than newly tracked
-    // (amendment decision 4).
-    let coverage = Coverage::from_stats(&stats);
-    gate_partial(&coverage, body.allow_partial)?;
-
-    // Fold this query's actual cost and its pre-execution estimate into the
-    // process-global aggregator for `/metrics` (ADR-0044 section 4) and record
-    // the final counts on the span.
-    span.record("s3_requests", stats.accounting.total_s3_requests());
-    span.record("s3_bytes", stats.accounting.total_s3_bytes());
-    state.query_accounting.record(
-        tenant_hash,
-        WorkloadClass::Interactive,
-        &stats.accounting,
-        &stats.estimate,
-    );
-    let mut stats_json = crate::query::accounting_stats_json(&stats.accounting, &stats.estimate);
+    let mut stats_json =
+        crate::query::accounting_stats_json(&outcome.stats.accounting, &outcome.stats.estimate);
     // ADR-0071: a distributed run attaches a per-slice
     // `fragments[]` beside `accounting`/`estimate`; a non-distributed run
     // collected no entries, so the field is omitted rather than an empty array.
-    let fragments = fragment_sink.take();
-    if !fragments.is_empty()
+    if !outcome.fragments.is_empty()
         && let Some(object) = stats_json.as_object_mut()
     {
         object.insert(
             "fragments".to_string(),
-            crate::query::fragments_json(&fragments),
+            crate::query::fragments_json(&outcome.fragments),
         );
     }
 
-    let matrix = match value {
+    let matrix = match outcome.value {
         Value::Matrix(matrix) => matrix,
         // A range query that folds to a scalar, a string, or an instant vector
         // has no per-series matrix to analyze. Rejected as a request error,
@@ -359,14 +316,15 @@ async fn run(state: &AnalyticsState, req: Request<Body>) -> Result<Response, Api
             return Err(ApiError::bad_request(format!(
                 "query evaluates to {}, but the analytics endpoint requires a range vector",
                 other.type_name()
-            )));
+            ))
+            .into());
         }
     };
 
     // ADR-0028 decision 4: enforce the series cap before running any op, as a
     // typed error rather than a truncation.
     if matrix.len() > MAX_SERIES {
-        return Err(ApiError::series_cap(matrix.len()));
+        return Err(ApiError::series_cap(matrix.len()).into());
     }
 
     let result = apply_op(&body.op, matrix)?;
@@ -387,26 +345,11 @@ async fn run(state: &AnalyticsState, req: Request<Body>) -> Result<Response, Api
             // fan-out's already-redacted per-cluster warnings (empty on a
             // complete answer). Reaching here with `partial: true` means the
             // request opted in through `allow_partial`.
-            "partial": coverage.is_partial(),
-            "warnings": stats.warnings,
+            "partial": outcome.partial,
+            "warnings": outcome.stats.warnings,
         })),
     )
         .into_response())
-}
-
-/// The consent gate, the analytics mirror of `gate_partial` in
-/// `crates/ravel-query/src/http/handlers.rs` (ADR-0071 amendment, section 2).
-/// Partial coverage the client did not opt into fails with the same typed shape
-/// the HTTP query endpoints use, HTTP 503 with `errorType: "unavailable"`, so a
-/// consumer that never asked for a partial answer fails safe instead of
-/// silently accepting one. Complete coverage, or partial coverage with
-/// `allow_partial: true`, passes and the response is a 200 whose top-level
-/// `partial` field states the coverage.
-fn gate_partial(coverage: &Coverage, allow_partial: bool) -> Result<(), ApiError> {
-    if coverage.is_partial() && !allow_partial {
-        return Err(ApiError::partial_refusal(coverage.skipped()));
-    }
-    Ok(())
 }
 
 /// Apply the selected op to every series, converting each crate result into
@@ -446,56 +389,6 @@ fn apply_op(
             })
         })
         .collect()
-}
-
-/// Submit one query-audit event for an executed analytics query and await its
-/// durability before the response is released (ADR-0062 §2a). `language` is
-/// `analytics` so the record shape stays one schema across surfaces. On a
-/// submission failure the request fails closed with a retryable 503
-/// (`audit_mode=required`); in best-effort mode the pipeline resolves it to
-/// `Ok` and the response is released.
-#[allow(clippy::too_many_arguments)]
-async fn submit_audit(
-    state: &AnalyticsState,
-    tenant_hash: TenantHash,
-    now_ns: i64,
-    query_text: &str,
-    status: QueryStatus,
-    window_start_ns: i64,
-    window_end_ns: i64,
-) -> Result<(), ApiError> {
-    let event = query_audit_event(
-        &tenant_hash,
-        now_ns,
-        query_text,
-        "analytics",
-        status,
-        window_start_ns,
-        window_end_ns,
-    );
-    state.audit_sink.submit(event).await.map_err(|_| ApiError {
-        status: StatusCode::SERVICE_UNAVAILABLE,
-        error_type: "unavailable",
-        message: "query audit is temporarily unavailable; retry".to_string(),
-    })
-}
-
-/// Nanosecond form of a millisecond bound for an audit window, saturating
-/// rather than overflowing.
-fn ms_to_ns(ms: i64) -> i64 {
-    ms.saturating_mul(1_000_000)
-}
-
-fn authenticate(state: &AnalyticsState, headers: &HeaderMap) -> Result<TenantHash, ApiError> {
-    state
-        .tenant_resolver
-        .resolve(headers)
-        .map(|tenant| tenant.hash())
-        .map_err(|_| ApiError {
-            status: StatusCode::UNAUTHORIZED,
-            error_type: "unauthorized",
-            message: "authentication required".to_string(),
-        })
 }
 
 fn labels_to_map(labels: &LabelSet) -> BTreeMap<String, String> {
@@ -574,29 +467,7 @@ fn parse_deadline(timeout: Option<f64>, max: Duration) -> Result<Duration, ApiEr
 // Error boundary
 // ---------------------------------------------------------------------------
 
-/// A client-visible error: a status, a stable type tag, and a message that has
-/// already passed the redaction boundary. `Debug` is safe to derive because
-/// every field is already redacted.
-#[derive(Debug)]
-struct ApiError {
-    status: StatusCode,
-    error_type: &'static str,
-    message: String,
-}
-
 impl ApiError {
-    fn bad_request(message: String) -> Self {
-        ApiError {
-            status: StatusCode::BAD_REQUEST,
-            error_type: "bad_data",
-            message,
-        }
-    }
-
-    fn invalid_param(name: &str, value: &str) -> Self {
-        ApiError::bad_request(format!("invalid value for parameter {name:?}: {value:?}"))
-    }
-
     /// ADR-0028 decision 4: the per-call series cap is a budget breach, mapped
     /// to 422 like the query engine's own budget rejections.
     fn series_cap(count: usize) -> Self {
@@ -605,31 +476,6 @@ impl ApiError {
             error_type: "execution",
             message: format!(
                 "analytics call matched {count} series, exceeding the limit of {MAX_SERIES}"
-            ),
-        }
-    }
-
-    /// Partial coverage without `allow_partial` (ADR-0071 amendment, section
-    /// 2). The status, the `errorType` tag, and the message shape are the ones
-    /// `ApiError::Unavailable` and `partial_refusal_message` produce on the HTTP
-    /// query endpoints (`crates/ravel-query/src/http/error.rs`,
-    /// `handlers.rs`), reproduced here because both are private to that crate;
-    /// the wording is kept identical so one refusal contract covers every read
-    /// surface. `skipped` names the degraded clusters, already redacted at the
-    /// federation seam to operator-facing cluster names, and the remedy
-    /// (`allow_partial`) is named in the failure itself.
-    fn partial_refusal(skipped: &[String]) -> Self {
-        let clusters = if skipped.is_empty() {
-            "one or more federated clusters were skipped".to_string()
-        } else {
-            skipped.join("; ")
-        };
-        ApiError {
-            status: StatusCode::SERVICE_UNAVAILABLE,
-            error_type: "unavailable",
-            message: format!(
-                "partial results: coverage is incomplete ({clusters}); \
-                 set allow_partial=true to receive partial results"
             ),
         }
     }
@@ -643,37 +489,6 @@ impl ApiError {
             error_type: "execution",
             message: err.to_string(),
         }
-    }
-
-    /// Map a `QueryError` through `ravel-query`'s public HTTP mapping, so this
-    /// endpoint keeps the exact status contract of `/api/v1/query_range`,
-    /// including the redaction of storage-layer faults, from one shared
-    /// source rather than a copy that could drift.
-    fn from_query(err: QueryError) -> Self {
-        let QueryErrorResponse {
-            status,
-            error_type,
-            message,
-        } = QueryErrorResponse::from_query_error(err);
-        ApiError {
-            status,
-            error_type,
-            message,
-        }
-    }
-}
-
-impl IntoResponse for ApiError {
-    fn into_response(self) -> Response {
-        (
-            self.status,
-            axum::Json(json!({
-                "status": "error",
-                "errorType": self.error_type,
-                "error": self.message,
-            })),
-        )
-            .into_response()
     }
 }
 
@@ -784,6 +599,8 @@ impl From<SummaryResult> for SummaryDto {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use ravel_query::http::QueryControls;
+    use ravel_query::{Coverage, QueryError};
 
     fn body(json: &str) -> AnalyticsBody {
         serde_json::from_str(json).expect("valid body")
@@ -934,30 +751,43 @@ mod tests {
     }
 
     /// The consent gate's decision table (ADR-0071 amendment, section 2). The
-    /// end-to-end behavior is pinned through the real handler in
-    /// `tests/analytics_endpoint.rs`; this pins the branch table itself,
-    /// including the empty-`skipped` fallback a partial flag with no per-cluster
-    /// warning would take.
+    /// gate itself now lives in the shared query service layer, so this pins
+    /// that the analytics surface reaches the same branch table, including the
+    /// empty-`skipped` fallback a partial flag with no per-cluster warning would
+    /// take. The end-to-end behavior is pinned through the real handler in
+    /// `tests/analytics_endpoint.rs`.
     #[test]
     fn the_consent_gate_refuses_only_unconsented_partial_coverage() {
+        let controls = QueryControls {
+            admission: AnalyticsState::unlimited_admission(),
+            cost_recorder: Arc::new(ravel_types::accounting::NoopQueryCostRecorder),
+            usage_sink: Arc::new(ravel_query::http::NoopQueryUsageSink),
+            audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+        };
         let partial = Coverage::Partial {
             skipped: vec!["remote cluster west unavailable".to_string()],
         };
-        gate_partial(&Coverage::Complete, false).expect("complete coverage passes");
-        gate_partial(&Coverage::Complete, true).expect("complete coverage passes opted in");
-        gate_partial(&partial, true).expect("opted-in partial coverage passes");
+        controls
+            .gate_partial(&Coverage::Complete, false)
+            .expect("complete coverage passes");
+        controls
+            .gate_partial(&Coverage::Complete, true)
+            .expect("complete coverage passes opted in");
+        controls
+            .gate_partial(&partial, true)
+            .expect("opted-in partial coverage passes");
 
-        let err = gate_partial(&partial, false).expect_err("unconsented partial is refused");
+        let err = ApiError::from(ServiceError::from(
+            controls
+                .gate_partial(&partial, false)
+                .expect_err("unconsented partial is refused"),
+        ));
         assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(err.error_type, "unavailable");
         assert!(err.message.contains("west"), "{}", err.message);
         assert!(err.message.contains("allow_partial"), "{}", err.message);
 
-        let bare = ApiError::partial_refusal(&[]);
-        assert!(
-            bare.message.contains("one or more federated clusters"),
-            "{}",
-            bare.message
-        );
+        let bare = ravel_query::http::partial_refusal_message(&[]);
+        assert!(bare.contains("one or more federated clusters"), "{bare}");
     }
 }

--- a/services/ravel-server/src/exemplars.rs
+++ b/services/ravel-server/src/exemplars.rs
@@ -101,19 +101,19 @@ use std::time::Duration;
 use axum::Router;
 use axum::body::Body;
 use axum::extract::{Request, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use ravel_catalog::{Catalog, SegmentLevel, SegmentRef};
 use ravel_ingest::Clock;
-use ravel_maintain::{QueryAuditSink, QueryStatus, query_audit_event};
+use ravel_maintain::QueryAuditSink;
 use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
 use ravel_promql::{LabelMatcher, MatchOp, matches_series, plan_selectors};
 use ravel_query::erasure::ErasurePredicate;
-use ravel_query::http::{QueryErrorResponse, TenantResolver};
+use ravel_query::http::TenantResolver;
 use ravel_query::{
-    EngineConfig, QueryEngine, QueryError, admit, request_budget_exceeded,
-    snapshot_erasure_predicates,
+    EngineConfig, QueryAdmissionController, QueryConcurrencyLimit, QueryEngine, QueryError, admit,
+    request_budget_exceeded, snapshot_erasure_predicates,
 };
 use ravel_segment::{
     ExemplarRecord, ExpectedIdentity, Footer, ReaderLimits, SeriesEntryV4, check_identity,
@@ -124,7 +124,11 @@ use ravel_types::{
     CommitToken, LabelSet, METRIC_NAME_LABEL, SeriesId, Signal, TenantHash, TimeRange,
 };
 use serde::{Serialize, Serializer};
-use serde_json::json;
+
+use crate::metrics::QueryAccountingMetrics;
+use crate::service::{
+    ApiError, ExemplarsRequest, LiveCost, QueryService, ServiceError, default_query_accounting,
+};
 
 /// Cap on the request body: a query plus a few scalar parameters, never large
 /// in legitimate use. Mirrors the defensive bound the sibling `/api/v1/sql`
@@ -206,6 +210,21 @@ pub struct ExemplarsState {
     /// ([`from_engine`](Self::from_engine)); a deployment attaches the one
     /// shared pipeline with [`with_audit_sink`](Self::with_audit_sink).
     pub audit_sink: Arc<dyn QueryAuditSink>,
+    /// The fleet-global query concurrency ceiling (ADR-0061 decision 2). An
+    /// exemplar query is a snapshot resolve plus a segment walk, the same shape
+    /// and the same cost class as the sample query it illustrates, so it takes
+    /// a permit from the same controller rather than running outside the
+    /// ceiling. Defaults to an unlimited (never-rejecting) controller in
+    /// [`from_engine`](Self::from_engine); a deployment attaches the one shared
+    /// controller with
+    /// [`with_query_admission`](Self::with_query_admission).
+    pub query_admission: Arc<QueryAdmissionController>,
+    /// The `/metrics` aggregator this surface's cost and usage records fold
+    /// into (ADR-0044 section 4). Defaults to an aggregator with an empty
+    /// per-tenant allowlist in [`from_engine`](Self::from_engine); a deployment
+    /// attaches the process-wide one with
+    /// [`with_query_accounting`](Self::with_query_accounting).
+    pub query_accounting: Arc<QueryAccountingMetrics>,
 }
 
 impl ExemplarsState {
@@ -232,6 +251,8 @@ impl ExemplarsState {
             get_limiter,
             max_exemplars: DEFAULT_MAX_EXEMPLARS,
             audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+            query_admission: QueryAdmissionController::shared(QueryConcurrencyLimit::Unlimited),
+            query_accounting: default_query_accounting(),
         }
     }
 
@@ -240,6 +261,33 @@ impl ExemplarsState {
     pub fn with_audit_sink(mut self, audit_sink: Arc<dyn QueryAuditSink>) -> Self {
         self.audit_sink = audit_sink;
         self
+    }
+
+    /// Attach the one shared fleet-global admission controller, so this surface
+    /// competes for the same ceiling as `/api/v1/query` and `/api/v1/sql`.
+    pub fn with_query_admission(mut self, admission: Arc<QueryAdmissionController>) -> Self {
+        self.query_admission = admission;
+        self
+    }
+
+    /// Attach the process-wide `/metrics` aggregator.
+    pub fn with_query_accounting(mut self, accounting: Arc<QueryAccountingMetrics>) -> Self {
+        self.query_accounting = accounting;
+        self
+    }
+
+    /// The query service layer for this surface: the shared controls plus this
+    /// state. The handler below calls it, and so does the process-wide service
+    /// built in `lib.rs`, through one implementation of the controls.
+    pub fn service(&self) -> QueryService {
+        QueryService::with_metrics(
+            Arc::clone(&self.tenant_resolver),
+            Arc::clone(&self.clock),
+            Arc::clone(&self.query_admission),
+            Arc::clone(&self.query_accounting),
+            Arc::clone(&self.audit_sink),
+        )
+        .with_exemplars(self.clone())
     }
 }
 
@@ -260,10 +308,15 @@ async fn handle(State(state): State<ExemplarsState>, req: Request<Body>) -> Resp
     }
 }
 
-async fn run(state: ExemplarsState, req: Request<Body>) -> Result<Response, ApiError> {
+/// Parse, authenticate, ask the query service layer, encode. Admission, the
+/// wall deadline clamp, the usage record, the audit event, and error redaction
+/// all happen inside [`QueryService::exemplars`], shared with every other query
+/// surface.
+async fn run(state: ExemplarsState, req: Request<Body>) -> Result<Response, ServiceError> {
     let headers = req.headers().clone();
     let query_string = req.uri().query().map(str::to_owned);
-    let tenant_hash = authenticate(&state, &headers)?;
+    // Before the service takes a permit, so an anonymous request consumes none.
+    let tenant_hash = crate::service::authenticate(state.tenant_resolver.as_ref(), &headers)?;
 
     let body = axum::body::to_bytes(req.into_body(), MAX_BODY_BYTES)
         .await
@@ -274,59 +327,67 @@ async fn run(state: ExemplarsState, req: Request<Body>) -> Result<Response, ApiE
     let start_ns = parse_timestamp_ns("start", params.require("start")?)?;
     let end_ns = parse_timestamp_ns("end", params.require("end")?)?;
     if start_ns > end_ns {
-        return Err(ApiError::bad_request(format!(
-            "start {start_ns} ns is after end {end_ns} ns"
-        )));
+        return Err(
+            ApiError::bad_request(format!("start {start_ns} ns is after end {end_ns} ns")).into(),
+        );
     }
-    let deadline = parse_deadline(&params, state.deadline)?;
-    let min_tokens = params
-        .all("min_commit_token")
-        .iter()
-        .map(|raw| {
-            CommitToken::decode(raw)
-                .map_err(|_| ApiError::bad_request(format!("invalid min_commit_token: {raw:?}")))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    // The whole request runs under one wall deadline, exactly as the query
-    // engine wraps its own evaluation: an elapsed timeout is the same
-    // `DeadlineExceeded` (504) a sample query would surface.
-    //
-    // The read now runs for a resolved tenant, so it is auditable (ADR-0062
-    // §2a): capture its outcome, submit one audit event, and await durability
-    // before releasing the response. A request rejected earlier (auth, missing
-    // or invalid parameters) never reached here and is not audited. The
-    // recorded window is the request's `[start, end]`.
-    let audit_now = state.clock.now_ns();
-    let outcome = match tokio::time::timeout(
-        deadline,
-        collect_exemplars(&state, tenant_hash, &query, start_ns, end_ns, &min_tokens),
-    )
-    .await
-    {
-        Ok(inner) => inner,
-        Err(_) => Err(ApiError::from_query(QueryError::DeadlineExceeded {
-            deadline,
-        })),
-    };
-    let status = if outcome.is_ok() {
-        QueryStatus::Ok
-    } else {
-        QueryStatus::Error
-    };
-    submit_audit(
-        &state,
-        tenant_hash,
-        audit_now,
-        &query,
-        status,
+    let request = ExemplarsRequest {
+        query,
         start_ns,
         end_ns,
-    )
-    .await?;
-    let (series, stats) = outcome?;
+        min_tokens: params
+            .all("min_commit_token")
+            .iter()
+            .map(|raw| {
+                CommitToken::decode(raw).map_err(|_| {
+                    ApiError::bad_request(format!("invalid min_commit_token: {raw:?}"))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        deadline: parse_deadline(&params, state.deadline)?,
+    };
 
-    Ok((StatusCode::OK, axum::Json(Envelope::success(series, stats))).into_response())
+    let outcome = state.service().exemplars(tenant_hash, &request).await?;
+    Ok((
+        StatusCode::OK,
+        axum::Json(Envelope::success(outcome.series, outcome.stats)),
+    )
+        .into_response())
+}
+
+/// The exemplar read under one wall deadline, exactly as the query engine wraps
+/// its own evaluation: an elapsed timeout is the same `DeadlineExceeded` (504) a
+/// sample query would surface.
+///
+/// The service layer calls this between its admission permit and its usage
+/// record, so `live` sees whatever the read spent before a timeout or a
+/// cancellation cut it short.
+pub(crate) async fn collect_within_deadline(
+    state: &ExemplarsState,
+    tenant_hash: TenantHash,
+    request: &ExemplarsRequest,
+    deadline: Duration,
+    live: &LiveCost,
+) -> Result<(Vec<ExemplarSeriesJson>, QueryStatsJson), ServiceError> {
+    let collected = tokio::time::timeout(
+        deadline,
+        collect_exemplars(
+            state,
+            tenant_hash,
+            &request.query,
+            request.start_ns,
+            request.end_ns,
+            &request.min_tokens,
+            live,
+        ),
+    )
+    .await;
+    match collected {
+        Ok(inner) => inner,
+        Err(_) => Err(ServiceError::from_query(QueryError::DeadlineExceeded {
+            deadline,
+        })),
+    }
 }
 
 /// Resolves the snapshot over the query's `[start, end]` window (the fixed
@@ -342,7 +403,8 @@ async fn collect_exemplars(
     start_ns: i64,
     end_ns: i64,
     min_tokens: &[CommitToken],
-) -> Result<(Vec<ExemplarSeriesJson>, QueryStatsJson), ApiError> {
+    live: &LiveCost,
+) -> Result<(Vec<ExemplarSeriesJson>, QueryStatsJson), ServiceError> {
     // Parse the query into its selectors exactly as the engine's prefetch
     // does (`plan_selectors`), so the matcher sets and the equality-`__name__`
     // pruning line up with what a sample query over the same text would use. A
@@ -385,6 +447,7 @@ async fn collect_exemplars(
         end_ns,
         min_tokens,
         now_ns,
+        live,
     )
     .await
     {
@@ -400,13 +463,14 @@ async fn collect_exemplars(
             end_ns,
             min_tokens,
             now_ns,
+            live,
         )
         .await
         {
             Ok(result) => Ok(result),
             Err(CollectError::Api(e)) => Err(e),
             Err(CollectError::SnapshotStale) => {
-                Err(ApiError::from_query(QueryError::SnapshotInvalidated))
+                Err(ServiceError::from_query(QueryError::SnapshotInvalidated))
             }
         },
     }
@@ -431,8 +495,13 @@ async fn collect_once(
     end_ns: i64,
     min_tokens: &[CommitToken],
     now_ns: i64,
+    live: &LiveCost,
 ) -> Result<(Vec<ExemplarSeriesJson>, QueryStatsJson), CollectError> {
+    // Each attempt installs its own fresh accounting into the live view, so a
+    // cancelled or timed-out query records what the attempt that was running
+    // had spent, and a discarded first attempt's counters do not bleed into it.
     let accounting = QueryAccounting::new();
+    live.install(&accounting);
     let (snapshot, origins) = state
         .catalog
         .resolve_pruned_with_admission(
@@ -445,7 +514,7 @@ async fn collect_once(
             &accounting,
         )
         .await
-        .map_err(|e| CollectError::Api(ApiError::from_query(QueryError::from(e))))?;
+        .map_err(|e| CollectError::Api(ServiceError::from_query(QueryError::from(e))))?;
 
     // The same admission seam `/api/v1/query` and SQL enforce after resolve
     // (ADR-0073 decision 4): the sealed-set count against
@@ -453,7 +522,7 @@ async fn collect_once(
     // Their cost is bounded below instead, incrementally, by the S3 request
     // budget (decision 3).
     admit(&snapshot, &origins, &state.engine_config)
-        .map_err(|e| CollectError::Api(ApiError::from_query(e)))?;
+        .map_err(|e| CollectError::Api(ServiceError::from_query(e)))?;
 
     // Pending selective-erasure predicates carried on the resolved snapshot
     // (ADR-0064 decision 1). The resolver attaches every pending request to
@@ -499,7 +568,7 @@ async fn collect_once(
             accounting.snapshot().total_s3_requests(),
             state.engine_config.max_s3_requests,
         ) {
-            return Err(CollectError::Api(ApiError::from_query(err)));
+            return Err(CollectError::Api(ServiceError::from_query(err)));
         }
     }
 
@@ -542,11 +611,11 @@ enum CollectError {
     /// a concurrent publish-and-sweep. The caller re-resolves and retries once.
     SnapshotStale,
     /// Any other failure, already mapped to its client-visible form.
-    Api(ApiError),
+    Api(ServiceError),
 }
 
-impl From<ApiError> for CollectError {
-    fn from(e: ApiError) -> Self {
+impl From<ServiceError> for CollectError {
+    fn from(e: ServiceError) -> Self {
         CollectError::Api(e)
     }
 }
@@ -963,15 +1032,15 @@ fn section_slice<'a>(
 // Store/segment error mapping
 // ---------------------------------------------------------------------------
 
-fn fetch_store_error(key: &str, source: StoreError) -> ApiError {
-    ApiError::from_query(QueryError::Fetch(ravel_query::FetchError::Store {
+fn fetch_store_error(key: &str, source: StoreError) -> ServiceError {
+    ServiceError::from_query(QueryError::Fetch(ravel_query::FetchError::Store {
         key: key.to_string(),
         source,
     }))
 }
 
-fn corrupt(key: &str, source: ravel_segment::SegmentError) -> ApiError {
-    ApiError::from_query(QueryError::Fetch(ravel_query::FetchError::Corrupt {
+fn corrupt(key: &str, source: ravel_segment::SegmentError) -> ServiceError {
+    ServiceError::from_query(QueryError::Fetch(ravel_query::FetchError::Corrupt {
         key: key.to_string(),
         source,
     }))
@@ -987,8 +1056,8 @@ fn corrupt(key: &str, source: ravel_segment::SegmentError) -> ApiError {
 /// walk stops at the first exemplar over the line rather than counting the
 /// rest: the exact total is unknown, and materializing it is the thing the cap
 /// exists to prevent.
-fn too_many_exemplars(max: usize) -> ApiError {
-    let mut err = ApiError::from_query(QueryError::TooManySamples {
+fn too_many_exemplars(max: usize) -> ServiceError {
+    let mut err = ServiceError::from_query(QueryError::TooManySamples {
         count: max.saturating_add(1),
         max,
     });
@@ -1178,7 +1247,7 @@ impl Envelope {
 /// would be a permanently-zero field, which `ravel-query`'s own accounting
 /// JSON explicitly refuses to carry).
 #[derive(Debug, Default, Serialize)]
-struct QueryStatsJson {
+pub struct QueryStatsJson {
     #[serde(rename = "segmentsFetched")]
     segments_fetched: u64,
     #[serde(rename = "segmentsPruned")]
@@ -1243,7 +1312,7 @@ impl QueryAccountingJson {
 }
 
 #[derive(Debug, Serialize)]
-struct ExemplarSeriesJson {
+pub struct ExemplarSeriesJson {
     #[serde(rename = "seriesLabels")]
     series_labels: BTreeMap<String, String>,
     exemplars: Vec<ExemplarEntryJson>,
@@ -1290,107 +1359,6 @@ fn format_value(v: f64) -> String {
     } else {
         format!("{v}")
     }
-}
-
-// ---------------------------------------------------------------------------
-// Error boundary
-// ---------------------------------------------------------------------------
-
-/// A client-visible error: a status, a stable type tag, and a message that has
-/// already passed the redaction boundary (storage faults are redacted by
-/// `QueryErrorResponse`, never echoed).
-#[derive(Debug)]
-struct ApiError {
-    status: StatusCode,
-    error_type: &'static str,
-    message: String,
-}
-
-impl ApiError {
-    fn bad_request(message: String) -> Self {
-        ApiError {
-            status: StatusCode::BAD_REQUEST,
-            error_type: "bad_data",
-            message,
-        }
-    }
-
-    fn invalid_param(name: &str, value: &str) -> Self {
-        ApiError::bad_request(format!("invalid value for parameter {name:?}: {value:?}"))
-    }
-
-    /// Maps a `QueryError` through `ravel-query`'s public HTTP mapping, so this
-    /// endpoint keeps the exact status contract of `/api/v1/query`, including
-    /// the redaction of storage-layer faults, from one shared source.
-    fn from_query(err: QueryError) -> Self {
-        let QueryErrorResponse {
-            status,
-            error_type,
-            message,
-        } = QueryErrorResponse::from_query_error(err);
-        ApiError {
-            status,
-            error_type,
-            message,
-        }
-    }
-}
-
-impl IntoResponse for ApiError {
-    fn into_response(self) -> Response {
-        (
-            self.status,
-            axum::Json(json!({
-                "status": "error",
-                "errorType": self.error_type,
-                "error": self.message,
-            })),
-        )
-            .into_response()
-    }
-}
-
-/// Submit one query-audit event for an executed exemplar query and await its
-/// durability before the response is released (ADR-0062 §2a). `language` is
-/// `exemplars` so the record shape stays one schema across surfaces. On a
-/// submission failure the request fails closed with a retryable 503
-/// (`audit_mode=required`); in best-effort mode the pipeline resolves it to
-/// `Ok`.
-async fn submit_audit(
-    state: &ExemplarsState,
-    tenant_hash: TenantHash,
-    now_ns: i64,
-    query_text: &str,
-    status: QueryStatus,
-    window_start_ns: i64,
-    window_end_ns: i64,
-) -> Result<(), ApiError> {
-    let event = query_audit_event(
-        &tenant_hash,
-        now_ns,
-        query_text,
-        "exemplars",
-        status,
-        window_start_ns,
-        window_end_ns,
-    );
-    state.audit_sink.submit(event).await.map_err(|_| ApiError {
-        status: StatusCode::SERVICE_UNAVAILABLE,
-        error_type: "unavailable",
-        message: "query audit is temporarily unavailable; retry".to_string(),
-    })
-}
-
-fn authenticate(state: &ExemplarsState, headers: &HeaderMap) -> Result<TenantHash, ApiError> {
-    state
-        .tenant_resolver
-        .resolve(headers)
-        .map(|tenant| tenant.hash())
-        .map_err(|_| ApiError {
-            status: StatusCode::UNAUTHORIZED,
-            error_type: "unauthorized",
-            message: "authentication required".to_string(),
-        })
 }
 
 #[cfg(test)]
@@ -1810,6 +1778,8 @@ mod tests {
             get_limiter: Arc::new(ravel_query::GetLimiter::new(8).expect("nonzero permits")),
             max_exemplars,
             audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+            query_admission: QueryAdmissionController::shared(QueryConcurrencyLimit::Unlimited),
+            query_accounting: default_query_accounting(),
         };
         router(state)
     }
@@ -1859,6 +1829,8 @@ mod tests {
             audit_sink: Arc::new(RecordingSink {
                 events: Arc::clone(&events),
             }),
+            query_admission: QueryAdmissionController::shared(QueryConcurrencyLimit::Unlimited),
+            query_accounting: default_query_accounting(),
         };
         (router(state), events)
     }

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -1551,6 +1551,7 @@ pub async fn start(
             let mut mtls_app_state =
                 ravel_query::http::AppState::new(app_state.engine.clone(), mtls.resolver.clone())
                     .with_cost_recorder(query_accounting.clone())
+                    .with_usage_sink(query_accounting.clone())
                     .with_query_admission(query_admission.clone());
             // Same read-side metadata cache the primary listener serves from
             // (ADR-0085 decision 1): the mTLS `/api/v1/metadata` must serve the

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -48,6 +48,7 @@ pub mod query_admission_reconcile;
 pub mod query_postings_metrics;
 pub mod remote_write;
 pub mod scrub;
+pub mod service;
 #[cfg(feature = "sql")]
 pub mod sql;
 #[cfg(feature = "flight-sql")]
@@ -1326,6 +1327,10 @@ pub async fn start(
         // would be an assignment no reader ever sees.
         #[cfg(feature = "sql")]
         let alert_sql_executor: Option<Arc<ravel_sql::SqlExecutor>>;
+        // The SQL surface's state, kept for the process-wide `QueryService`
+        // assembled below.
+        #[cfg(feature = "sql")]
+        let sql_query_state: sql::SqlState;
         #[cfg(feature = "sql")]
         {
             // Mounted alongside the Prometheus-shaped routes on the same
@@ -1376,6 +1381,7 @@ pub async fn start(
                 Some(declared_columns),
             )?;
             alert_sql_executor = Some(state.executor.clone());
+            sql_query_state = state.clone();
             // The same executor the idle-tenant sweep evicts idle accountants
             // from (ADR-0069 decision 2): built once here, shared, never a
             // second instance with its own per-tenant accounting.
@@ -1410,7 +1416,12 @@ pub async fn start(
             // process-wide AuditPipeline install is a separate step, so this is
             // the no-op sink today (the handler already submits and awaits through it).
             audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+            // The one shared fleet ceiling: an analytics call is the same range
+            // evaluation /api/v1/query_range runs, so it competes for the same
+            // permits rather than running outside them.
+            query_admission: query_admission.clone(),
         };
+        let analytics_state_for_service = analytics_state.clone();
         http_router = http_router.merge(analytics::router(analytics_state));
         if let Some(mtls) = &config.mtls_listener {
             let mtls_analytics_state = analytics::AnalyticsState {
@@ -1419,6 +1430,7 @@ pub async fn start(
                 clock: Arc::new(SystemClock),
                 query_accounting: query_accounting.clone(),
                 audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+                query_admission: query_admission.clone(),
             };
             mtls_router = mtls_router.merge(analytics::router(mtls_analytics_state));
         }
@@ -1478,8 +1490,10 @@ pub async fn start(
             config.tenant_resolver.clone(),
             Arc::new(SystemClock),
             get_limiter.clone(),
-        );
-        http_router = http_router.merge(exemplars::router(exemplars_state));
+        )
+        .with_query_admission(query_admission.clone())
+        .with_query_accounting(query_accounting.clone());
+        http_router = http_router.merge(exemplars::router(exemplars_state.clone()));
         if let Some(mtls) = &config.mtls_listener {
             let mtls_exemplars_state = exemplars::ExemplarsState::from_engine(
                 &app_state.engine,
@@ -1488,8 +1502,36 @@ pub async fn start(
                 mtls.resolver.clone(),
                 Arc::new(SystemClock),
                 get_limiter.clone(),
-            );
+            )
+            .with_query_admission(query_admission.clone())
+            .with_query_accounting(query_accounting.clone());
             mtls_router = mtls_router.merge(exemplars::router(mtls_exemplars_state));
+        }
+
+        // The one query service layer for this process (ADR-1374 decision 3):
+        // the same controls every route mounted above runs its query through,
+        // with every query surface this process serves attached to it. Each
+        // route's own state builds an equivalent facade per request out of the
+        // same `Arc`s, so this instance and theirs share one admission
+        // controller, one cost recorder, one usage sink, and one audit sink.
+        // Layered as an extension so an in-process transport that is not an
+        // axum route (the MCP adapter, issue #1381) has one place to take it
+        // from rather than reassembling the controls itself.
+        let query_service = service::QueryService::with_metrics(
+            config.tenant_resolver.clone(),
+            Arc::new(SystemClock),
+            query_admission.clone(),
+            query_accounting.clone(),
+            Arc::new(ravel_maintain::NoopQueryAuditSink),
+        )
+        .with_engine(app_state.engine.clone())
+        .with_analytics(analytics_state_for_service)
+        .with_exemplars(exemplars_state);
+        #[cfg(feature = "sql")]
+        let query_service = query_service.with_sql(sql_query_state);
+        http_router = http_router.layer(axum::Extension(query_service.clone()));
+        if config.mtls_listener.is_some() {
+            mtls_router = mtls_router.layer(axum::Extension(query_service));
         }
 
         // Same `QueryEngine` (and, under the `sql` feature, the same

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -477,6 +477,15 @@ pub struct Running {
     /// The supervised background flush loop still owns the production cadence
     /// (`metadata_sink_task`); this handle shares the same `Arc`.
     pub metadata_sink: Option<Arc<ravel_ingest::MetadataSink>>,
+    /// The query service layer layered onto the public HTTP router, `Some` in
+    /// the query-serving modes that build one.
+    pub query_service: Option<service::QueryService>,
+    /// The query service layer layered onto the mTLS router, `Some` exactly
+    /// when a query-serving mode was configured with an mTLS listener. A
+    /// separate instance from [`Running::query_service`] because the two
+    /// listeners authenticate against different resolvers; everything else the
+    /// controls need is shared between them.
+    pub mtls_query_service: Option<service::QueryService>,
     log_ingest_router: Option<Arc<LogIngestRouter>>,
     span_ingest_router: Option<Arc<SpanIngestRouter>>,
     fold_tasks: fold::FoldTasks,
@@ -969,6 +978,11 @@ pub async fn start(
     // configured. Deliberately serves no health or metrics routes - those
     // carry no tenant identity and stay on the public listener only.
     let mut mtls_router = Router::new();
+    // The per-listener query service layers, kept on `Running` so an
+    // in-process transport takes the one belonging to the listener it serves
+    // rather than whichever instance it can reach.
+    let mut query_service_handle: Option<service::QueryService> = None;
+    let mut mtls_query_service_handle: Option<service::QueryService> = None;
     if let (Some(router), Some(log_router), Some(span_router)) =
         (&ingest_router, &log_ingest_router, &span_ingest_router)
     {
@@ -1331,6 +1345,11 @@ pub async fn start(
         // assembled below.
         #[cfg(feature = "sql")]
         let sql_query_state: sql::SqlState;
+        // The same state under the mTLS listener's resolver, kept for that
+        // listener's own `QueryService`. `None` when no mTLS listener is
+        // configured.
+        #[cfg(feature = "sql")]
+        let mtls_sql_query_state: Option<sql::SqlState>;
         #[cfg(feature = "sql")]
         {
             // Mounted alongside the Prometheus-shaped routes on the same
@@ -1391,11 +1410,11 @@ pub async fn start(
             // once above) rather than calling `build_sql_state` a second
             // time, which would stand up a second `Catalog`/`SqlExecutor`
             // pair with its own per-tenant memory accounting.
-            if let Some(mtls) = &config.mtls_listener {
-                let mtls_state = sql::SqlState {
-                    tenant_resolver: mtls.resolver.clone(),
-                    ..state.clone()
-                };
+            mtls_sql_query_state = config.mtls_listener.as_ref().map(|mtls| sql::SqlState {
+                tenant_resolver: mtls.resolver.clone(),
+                ..state.clone()
+            });
+            if let Some(mtls_state) = mtls_sql_query_state.clone() {
                 mtls_router = mtls_router.merge(sql::router(mtls_state));
             }
             #[cfg(feature = "flight-sql")]
@@ -1423,16 +1442,20 @@ pub async fn start(
         };
         let analytics_state_for_service = analytics_state.clone();
         http_router = http_router.merge(analytics::router(analytics_state));
-        if let Some(mtls) = &config.mtls_listener {
-            let mtls_analytics_state = analytics::AnalyticsState {
-                engine: app_state.engine.clone(),
-                tenant_resolver: mtls.resolver.clone(),
-                clock: Arc::new(SystemClock),
-                query_accounting: query_accounting.clone(),
-                audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
-                query_admission: query_admission.clone(),
-            };
-            mtls_router = mtls_router.merge(analytics::router(mtls_analytics_state));
+        let mtls_analytics_state =
+            config
+                .mtls_listener
+                .as_ref()
+                .map(|mtls| analytics::AnalyticsState {
+                    engine: app_state.engine.clone(),
+                    tenant_resolver: mtls.resolver.clone(),
+                    clock: Arc::new(SystemClock),
+                    query_accounting: query_accounting.clone(),
+                    audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+                    query_admission: query_admission.clone(),
+                });
+        if let Some(state) = mtls_analytics_state.clone() {
+            mtls_router = mtls_router.merge(analytics::router(state));
         }
 
         // POST /api/v1/admin/fold (issue #785): the on-demand form of the
@@ -1494,8 +1517,8 @@ pub async fn start(
         .with_query_admission(query_admission.clone())
         .with_query_accounting(query_accounting.clone());
         http_router = http_router.merge(exemplars::router(exemplars_state.clone()));
-        if let Some(mtls) = &config.mtls_listener {
-            let mtls_exemplars_state = exemplars::ExemplarsState::from_engine(
+        let mtls_exemplars_state = config.mtls_listener.as_ref().map(|mtls| {
+            exemplars::ExemplarsState::from_engine(
                 &app_state.engine,
                 catalog.clone(),
                 store.clone(),
@@ -1504,8 +1527,10 @@ pub async fn start(
                 get_limiter.clone(),
             )
             .with_query_admission(query_admission.clone())
-            .with_query_accounting(query_accounting.clone());
-            mtls_router = mtls_router.merge(exemplars::router(mtls_exemplars_state));
+            .with_query_accounting(query_accounting.clone())
+        });
+        if let Some(state) = mtls_exemplars_state.clone() {
+            mtls_router = mtls_router.merge(exemplars::router(state));
         }
 
         // The one query service layer for this process (ADR-1374 decision 3):
@@ -1530,8 +1555,41 @@ pub async fn start(
         #[cfg(feature = "sql")]
         let query_service = query_service.with_sql(sql_query_state);
         http_router = http_router.layer(axum::Extension(query_service.clone()));
-        if config.mtls_listener.is_some() {
-            mtls_router = mtls_router.layer(axum::Extension(query_service));
+        query_service_handle = Some(query_service);
+
+        // The mTLS listener gets its own instance. Everything a control needs
+        // is shared with the primary one (the same admission controller, cost
+        // recorder, usage sink, audit sink, and engine), but the tenant
+        // resolver is not: `mtls.resolver` derives the tenant from the peer
+        // certificate, and `config.tenant_resolver` from a bearer token. An
+        // in-process transport that took the primary listener's instance off an
+        // mTLS request would authenticate a certificate-identified caller
+        // against the bearer-token resolver, which is the wrong credential and,
+        // where both are configured, the wrong tenant.
+        if let Some(mtls) = &config.mtls_listener {
+            let mtls_query_service = service::QueryService::with_metrics(
+                mtls.resolver.clone(),
+                Arc::new(SystemClock),
+                query_admission.clone(),
+                query_accounting.clone(),
+                Arc::new(ravel_maintain::NoopQueryAuditSink),
+            )
+            .with_engine(app_state.engine.clone());
+            let mtls_query_service = match mtls_analytics_state {
+                Some(state) => mtls_query_service.with_analytics(state),
+                None => mtls_query_service,
+            };
+            let mtls_query_service = match mtls_exemplars_state {
+                Some(state) => mtls_query_service.with_exemplars(state),
+                None => mtls_query_service,
+            };
+            #[cfg(feature = "sql")]
+            let mtls_query_service = match mtls_sql_query_state {
+                Some(state) => mtls_query_service.with_sql(state),
+                None => mtls_query_service,
+            };
+            mtls_router = mtls_router.layer(axum::Extension(mtls_query_service.clone()));
+            mtls_query_service_handle = Some(mtls_query_service);
         }
 
         // Same `QueryEngine` (and, under the `sql` feature, the same
@@ -2151,6 +2209,8 @@ pub async fn start(
         fragment_task,
         ingest_router,
         metadata_sink,
+        query_service: query_service_handle,
+        mtls_query_service: mtls_query_service_handle,
         log_ingest_router,
         span_ingest_router,
         fold_tasks,

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -477,14 +477,17 @@ pub struct Running {
     /// The supervised background flush loop still owns the production cadence
     /// (`metadata_sink_task`); this handle shares the same `Arc`.
     pub metadata_sink: Option<Arc<ravel_ingest::MetadataSink>>,
-    /// The query service layer layered onto the public HTTP router, `Some` in
-    /// the query-serving modes that build one.
+    /// The query service backing the public HTTP router's query surfaces,
+    /// `Some` in the query-serving modes that build one. Not layered onto the
+    /// router itself: the MCP adapter (issue #1381) is the in-process
+    /// transport that receives it, through its own router state rather than
+    /// an axum route.
     pub query_service: Option<service::QueryService>,
-    /// The query service layer layered onto the mTLS router, `Some` exactly
-    /// when a query-serving mode was configured with an mTLS listener. A
-    /// separate instance from [`Running::query_service`] because the two
-    /// listeners authenticate against different resolvers; everything else the
-    /// controls need is shared between them.
+    /// The query service backing the mTLS router's query surfaces, `Some`
+    /// exactly when a query-serving mode was configured with an mTLS
+    /// listener. A separate instance from [`Running::query_service`] because
+    /// the two listeners authenticate against different resolvers; everything
+    /// else the controls need is shared between them.
     pub mtls_query_service: Option<service::QueryService>,
     log_ingest_router: Option<Arc<LogIngestRouter>>,
     span_ingest_router: Option<Arc<SpanIngestRouter>>,
@@ -1539,9 +1542,9 @@ pub async fn start(
         // route's own state builds an equivalent facade per request out of the
         // same `Arc`s, so this instance and theirs share one admission
         // controller, one cost recorder, one usage sink, and one audit sink.
-        // Layered as an extension so an in-process transport that is not an
-        // axum route (the MCP adapter, issue #1381) has one place to take it
-        // from rather than reassembling the controls itself.
+        // Held on `Running::query_service` rather than layered onto the
+        // router: an in-process transport that is not an axum route (the MCP
+        // adapter, issue #1381) takes it from there instead.
         let query_service = service::QueryService::with_metrics(
             config.tenant_resolver.clone(),
             Arc::new(SystemClock),
@@ -1554,7 +1557,6 @@ pub async fn start(
         .with_exemplars(exemplars_state);
         #[cfg(feature = "sql")]
         let query_service = query_service.with_sql(sql_query_state);
-        http_router = http_router.layer(axum::Extension(query_service.clone()));
         query_service_handle = Some(query_service);
 
         // The mTLS listener gets its own instance. Everything a control needs
@@ -1588,7 +1590,6 @@ pub async fn start(
                 Some(state) => mtls_query_service.with_sql(state),
                 None => mtls_query_service,
             };
-            mtls_router = mtls_router.layer(axum::Extension(mtls_query_service.clone()));
             mtls_query_service_handle = Some(mtls_query_service);
         }
 

--- a/services/ravel-server/src/query.rs
+++ b/services/ravel-server/src/query.rs
@@ -202,8 +202,13 @@ pub fn build_app_state(
     // cache that backs `/api/v1/metadata`. `None` in a mode that serves no
     // Prometheus-shaped query routes; when absent the endpoint keeps its
     // pre-ADR behavior byte-for-byte (a `200` with an empty `data` object).
+    // The same aggregator is the usage sink as well as the cost recorder: the
+    // cost recorder only ever sees a query that produced an answer, so without
+    // this the drop guard's cancelled, timed-out, and failed records from every
+    // Prometheus-shaped route would be folded into a sink that discards them.
     let state = AppState::new(Arc::new(engine), tenant_resolver)
-        .with_cost_recorder(query_accounting)
+        .with_cost_recorder(query_accounting.clone())
+        .with_usage_sink(query_accounting)
         .with_query_admission(query_admission);
     match metadata_cache {
         Some(cache) => state.with_metadata_cache(cache),

--- a/services/ravel-server/src/service/error.rs
+++ b/services/ravel-server/src/service/error.rs
@@ -1,0 +1,330 @@
+//! The two error types every query surface in this crate shares.
+//!
+//! [`ApiError`] is the HTTP form: a status, a stable `errorType` tag, and a
+//! message that has already passed the redaction boundary. One type, so the
+//! `/api/v1/sql`, `/api/v1/analytics`, and `/api/v1/query_exemplars` bodies
+//! cannot drift from each other.
+//!
+//! [`ServiceError`] is the transport-independent form the query service layer
+//! returns: the same redacted message plus the ADR-1374 decision 4 failure
+//! class, so a non-HTTP transport (the MCP adapter, issue #1381) can map the
+//! failure to its own envelope without re-deriving it from a status code.
+//! `From<ServiceError> for ApiError` is the whole HTTP mapping, one function.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use ravel_query::QueryError;
+use ravel_query::http::{QueryErrorResponse, UsageStatus};
+use serde_json::json;
+
+/// A client-visible error: a status, a stable type tag, and a message that has
+/// already passed the redaction boundary. `Debug` is safe to derive because
+/// every field is already redacted.
+#[derive(Debug)]
+pub struct ApiError {
+    pub status: StatusCode,
+    pub error_type: &'static str,
+    pub message: String,
+}
+
+impl ApiError {
+    /// Errors raised before the query runs. The messages describe the caller's
+    /// own request and carry no server state.
+    pub fn bad_request(message: String) -> Self {
+        ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error_type: "bad_data",
+            message,
+        }
+    }
+
+    pub fn invalid_param(name: &str, value: &str) -> Self {
+        ApiError::bad_request(format!("invalid value for parameter {name:?}: {value:?}"))
+    }
+
+    /// Map a `QueryError` through `ravel-query`'s public HTTP mapping, so every
+    /// surface here keeps the exact status contract of `/api/v1/query_range`,
+    /// including the redaction of storage-layer faults, from one shared source
+    /// rather than a copy that could drift.
+    pub fn from_query(err: QueryError) -> Self {
+        let QueryErrorResponse {
+            status,
+            error_type,
+            message,
+        } = QueryErrorResponse::from_query_error(err);
+        ApiError {
+            status,
+            error_type,
+            message,
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            axum::Json(json!({
+                "status": "error",
+                "errorType": self.error_type,
+                "error": self.message,
+            })),
+        )
+            .into_response()
+    }
+}
+
+/// The failure classes ADR-1374 decision 4 defines. A transport maps these to
+/// its own envelope; nothing here is HTTP-specific.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceErrorKind {
+    /// No resolvable tenant credential.
+    Unauthorized,
+    /// A malformed or unparseable request parameter.
+    InvalidArgument,
+    /// A well-formed request whose values are out of contract (a percentile
+    /// outside `[0, 1]`, a non-positive step).
+    Validation,
+    /// A construct the engine does not implement.
+    Unsupported,
+    /// A per-request or per-server budget the query exceeded.
+    BudgetExceeded,
+    /// The wall deadline elapsed.
+    Deadline,
+    /// A transient fault: a storage outage, an audit trail that could not be
+    /// written, or partial coverage the caller did not consent to.
+    Unavailable,
+    /// The resolved snapshot was invalidated under the query.
+    SnapshotInvalidated,
+    /// A server-side fault, including a permanent data-integrity fault.
+    Internal,
+}
+
+/// A failed query service operation: its ADR-1374 failure class and the
+/// already-redacted client message, alongside the HTTP status and `errorType`
+/// tag the HTTP transports render.
+#[derive(Debug)]
+pub struct ServiceError {
+    pub kind: ServiceErrorKind,
+    pub message: String,
+    pub status: StatusCode,
+    pub error_type: &'static str,
+}
+
+impl ServiceError {
+    /// A failure whose HTTP shape is already decided (an audit-trail failure, a
+    /// partial-coverage refusal, a rejected admission), classified explicitly.
+    pub fn new(kind: ServiceErrorKind, api: ApiError) -> Self {
+        ServiceError {
+            kind,
+            message: api.message,
+            status: api.status,
+            error_type: api.error_type,
+        }
+    }
+
+    pub fn unauthorized() -> Self {
+        ServiceError::new(
+            ServiceErrorKind::Unauthorized,
+            ApiError {
+                status: StatusCode::UNAUTHORIZED,
+                error_type: "unauthorized",
+                message: "authentication required".to_string(),
+            },
+        )
+    }
+
+    pub fn invalid_argument(message: String) -> Self {
+        ServiceError::new(
+            ServiceErrorKind::InvalidArgument,
+            ApiError::bad_request(message),
+        )
+    }
+
+    /// A query surface this process does not serve. An ingest-only server
+    /// genuinely carries no engine, so a caller asking it for a query gets a
+    /// typed refusal naming the surface rather than a panic.
+    pub fn unsupported_surface(surface: &str) -> Self {
+        ServiceError::new(
+            ServiceErrorKind::Unsupported,
+            ApiError {
+                status: StatusCode::NOT_FOUND,
+                error_type: "not_found",
+                message: format!("{surface} queries are not served by this instance"),
+            },
+        )
+    }
+
+    /// How a query that ended in this error should be recorded in its usage
+    /// record: a deadline is its own outcome, everything else is an error.
+    pub fn usage_status(&self) -> UsageStatus {
+        match self.kind {
+            ServiceErrorKind::Deadline => UsageStatus::Timeout,
+            _ => UsageStatus::Error,
+        }
+    }
+
+    /// Classify and redact a `SqlError`, and log the unredacted form once at
+    /// the level its class deserves.
+    ///
+    /// Client-caused rejections are not operational events, so they log at
+    /// debug: a scripted client cannot flood the warn level. Everything else
+    /// keeps warn, because it is either a storage fault or a bug.
+    #[cfg(feature = "sql")]
+    pub fn from_sql(err: ravel_sql::SqlError, tenant_hash: ravel_types::TenantHash) -> Self {
+        use ravel_sql::ErrorClass;
+
+        let message = err.client_message();
+        let (kind, status, error_type) = match err.class() {
+            ErrorClass::BadRequest => (
+                ServiceErrorKind::InvalidArgument,
+                StatusCode::BAD_REQUEST,
+                "bad_data",
+            ),
+            ErrorClass::Unsupported => (
+                ServiceErrorKind::Unsupported,
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "execution",
+            ),
+            ErrorClass::Unavailable => (
+                ServiceErrorKind::Unavailable,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "unavailable",
+            ),
+            ErrorClass::Timeout => (
+                ServiceErrorKind::Deadline,
+                StatusCode::GATEWAY_TIMEOUT,
+                "timeout",
+            ),
+        };
+
+        if status == StatusCode::BAD_REQUEST {
+            tracing::debug!(
+                tenant = %tenant_hash.to_hex(),
+                error = %err,
+                client_message = %message,
+                "sql request rejected",
+            );
+        } else {
+            tracing::warn!(
+                tenant = %tenant_hash.to_hex(),
+                error = %err,
+                client_message = %message,
+                "sql query error redacted from client response",
+            );
+        }
+
+        ServiceError {
+            kind,
+            message,
+            status,
+            error_type,
+        }
+    }
+
+    /// Classify a `QueryError` before it is redacted, then take the status,
+    /// tag, and message from the same redaction every HTTP surface uses. The
+    /// class comes from the typed error and the body from the redacted
+    /// mapping, so a caller learns the class of a storage fault without
+    /// learning the object key.
+    pub fn from_query(err: QueryError) -> Self {
+        let kind = match &err {
+            QueryError::Parse(_)
+            | QueryError::NonPositiveStep { .. }
+            | QueryError::InvalidRange { .. }
+            | QueryError::TimeOverflow => ServiceErrorKind::InvalidArgument,
+            QueryError::Unsupported { .. } => ServiceErrorKind::Unsupported,
+            QueryError::TooManySegments { .. }
+            | QueryError::TooManySeries { .. }
+            | QueryError::TooManySamples { .. }
+            | QueryError::TooManyBytesScanned { .. }
+            | QueryError::RequestBudgetExceeded { .. } => ServiceErrorKind::BudgetExceeded,
+            QueryError::DeadlineExceeded { .. } => ServiceErrorKind::Deadline,
+            QueryError::SnapshotInvalidated => ServiceErrorKind::SnapshotInvalidated,
+            QueryError::Eval(_) => ServiceErrorKind::Validation,
+            _ => ServiceErrorKind::Unavailable,
+        };
+        let api = ApiError::from_query(err);
+        // A redacted storage fault can still resolve to a permanent 500; keep
+        // the class honest rather than reporting a retryable one.
+        let kind = if api.status == StatusCode::INTERNAL_SERVER_ERROR {
+            ServiceErrorKind::Internal
+        } else {
+            kind
+        };
+        ServiceError::new(kind, api)
+    }
+}
+
+/// A surface that already built the HTTP form (a parameter parse, a segment
+/// read that redacted a store fault) classifies it back from its status. The
+/// mapping is total: every status these surfaces can produce is one of the
+/// ADR-1374 classes, and a status outside the table is a server fault by
+/// definition.
+///
+/// [`ServiceErrorKind::SnapshotInvalidated`] is not reachable through here: a
+/// snapshot invalidation redacts to the same retryable 503 as a storage
+/// outage, so it is only distinguishable where the typed `QueryError` is still
+/// in hand ([`ServiceError::from_query`]).
+impl From<ApiError> for ServiceError {
+    fn from(api: ApiError) -> Self {
+        let kind = match api.status {
+            StatusCode::BAD_REQUEST => ServiceErrorKind::InvalidArgument,
+            StatusCode::UNAUTHORIZED => ServiceErrorKind::Unauthorized,
+            StatusCode::UNPROCESSABLE_ENTITY => ServiceErrorKind::Unsupported,
+            StatusCode::SERVICE_UNAVAILABLE => ServiceErrorKind::Unavailable,
+            StatusCode::GATEWAY_TIMEOUT => ServiceErrorKind::Deadline,
+            _ => ServiceErrorKind::Internal,
+        };
+        ServiceError::new(kind, api)
+    }
+}
+
+impl From<ServiceError> for ApiError {
+    fn from(err: ServiceError) -> Self {
+        ApiError {
+            status: err.status,
+            error_type: err.error_type,
+            message: err.message,
+        }
+    }
+}
+
+/// The service layer runs on `ravel-query`'s HTTP error type internally (it is
+/// what the shared controls return); this classifies one back into a
+/// [`ServiceError`] on the way out.
+impl From<ravel_query::http::ApiError> for ServiceError {
+    fn from(err: ravel_query::http::ApiError) -> Self {
+        let kind = match &err {
+            ravel_query::http::ApiError::BadData(_) => ServiceErrorKind::InvalidArgument,
+            ravel_query::http::ApiError::Unsupported(_) => ServiceErrorKind::Unsupported,
+            ravel_query::http::ApiError::Corrupt(_) => ServiceErrorKind::Internal,
+            ravel_query::http::ApiError::Unavailable(_) => ServiceErrorKind::Unavailable,
+            ravel_query::http::ApiError::Timeout(_) => ServiceErrorKind::Deadline,
+            ravel_query::http::ApiError::Unauthenticated => ServiceErrorKind::Unauthorized,
+        };
+        let QueryErrorResponse {
+            status,
+            error_type,
+            message,
+        } = err.into_parts();
+        ServiceError {
+            kind,
+            message,
+            status,
+            error_type,
+        }
+    }
+}
+
+impl From<ServiceError> for Response {
+    fn from(err: ServiceError) -> Self {
+        ApiError::from(err).into_response()
+    }
+}
+
+impl IntoResponse for ServiceError {
+    fn into_response(self) -> Response {
+        ApiError::from(self).into_response()
+    }
+}

--- a/services/ravel-server/src/service/mod.rs
+++ b/services/ravel-server/src/service/mod.rs
@@ -1,0 +1,691 @@
+//! The one query service layer every query transport in this process calls
+//! (ADR-1374 decision 3).
+//!
+//! A query surface used to be one handler that did everything: resolve the
+//! tenant, take an admission permit, clamp the deadline, run the engine,
+//! record the cost, audit the read, gate partial coverage, redact the error.
+//! Five surfaces meant five copies, and they had drifted: two of them took no
+//! admission permit, one recorded no cost, and only one recorded cost when the
+//! client disconnected mid-query.
+//!
+//! [`QueryService`] is where those controls now live, exactly once. A
+//! transport parses its request, authenticates it with [`authenticate`], calls
+//! one operation here, and encodes the outcome. The controls themselves are
+//! [`ravel_query::http::QueryControls`], shared with the Prometheus-shaped
+//! operations that must live in `ravel-query` (a crate that cannot depend on
+//! this one), so there is one implementation and not two.
+//!
+//! Every operation runs the same seven steps in the same order:
+//!
+//! 1. acquire an admission permit from the fleet-global controller, before any
+//!    resolve or GET;
+//! 2. clamp the wall deadline and the request budgets against the server
+//!    ceilings, lowering only;
+//! 3. run the engine call;
+//! 4. finalize usage through a drop guard on every exit path, the dropped one
+//!    included;
+//! 5. submit the audit event and await its durability;
+//! 6. apply the partial-coverage consent gate;
+//! 7. map the failure through the existing redaction.
+//!
+//! Step 4 precedes every way an operation can turn into an error, so an audit
+//! failure, a partial refusal, an evaluation failure, and a deadline all leave
+//! a usage record of what the query spent before it failed. A cancellation
+//! (the caller's future dropped) never reaches step 5: it produces no result,
+//! and its usage record is its only trace. Nothing here spawns, so dropping
+//! the transport's future cancels the engine call itself.
+//!
+//! Authentication is deliberately not one of the steps: it is a transport
+//! concern, it runs before step 1, and it takes no permit. [`authenticate`] is
+//! the one function every transport calls for it, so an anonymous caller
+//! cannot consume a permit from the fleet-global concurrency ceiling.
+//!
+//! The second caller of this layer is the MCP adapter (issue #1381). The HTTP
+//! transports are the first, and the unchanged end-to-end suites over them are
+//! the reachability proof that every existing query route runs through here.
+
+pub mod error;
+#[cfg(test)]
+mod tests;
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::http::HeaderMap;
+use ravel_ingest::Clock;
+use ravel_maintain::{QueryAuditSink, QueryStatus};
+use ravel_promql::Value;
+use ravel_query::http::service as core;
+use ravel_query::http::{
+    InstantOutcome, InstantRequest, LabelValuesOutcome, LabelsOutcome, LiveUsage, MetadataOutcome,
+    MetadataRequest, QueryControls, QueryUsageSink, RangeOutcome, RangeRequest, TenantResolver,
+    UsageStatus,
+};
+use ravel_query::{Coverage, QueryAdmissionController, QueryEngine, QueryStats};
+use ravel_types::accounting::{
+    CostEstimate, QueryAccounting, QueryAccountingSnapshot, QueryCostRecorder,
+};
+use ravel_types::{CommitToken, TenantHash};
+use tracing::Instrument;
+
+use crate::metrics::{QueryAccountingMetrics, QueryOutcomeStatus};
+
+pub use error::{ApiError, ServiceError, ServiceErrorKind};
+
+/// Resolve the caller's credentials to a tenant. The one authentication step
+/// every query transport runs, before it asks the service for anything.
+///
+/// It is outside every operation below (they take an already-authenticated
+/// [`TenantHash`]) and it takes no admission permit, so an anonymous request
+/// cannot consume one from the fleet-global concurrency ceiling.
+pub fn authenticate(
+    resolver: &dyn TenantResolver,
+    headers: &HeaderMap,
+) -> Result<TenantHash, ServiceError> {
+    resolver
+        .resolve(headers)
+        .map(|tenant| tenant.hash())
+        .map_err(|_| ServiceError::unauthorized())
+}
+
+/// A shared, cloneable view of the [`QueryAccounting`] handle a running query
+/// is spending through.
+///
+/// The drop path of a cancelled query has no outcome to read counters from, so
+/// it reads them here instead: a query that fetched objects for two minutes and
+/// was then abandoned records what it actually spent, not zeros. The mirror of
+/// `ravel_sql::LiveAccounting` for the surfaces that do not go through
+/// `ravel-sql` (`ravel-sql` is behind the `sql` feature, and its type is not
+/// reachable from a default build).
+#[derive(Clone, Default)]
+pub struct LiveCost(Arc<Mutex<QueryAccounting>>);
+
+impl LiveCost {
+    /// A live view whose counters are all zero until an attempt installs its
+    /// handle.
+    pub fn new() -> Self {
+        LiveCost::default()
+    }
+
+    /// Point this view at `accounting` (the attempt about to run). Clones the
+    /// handle, so the two share one atomic counter block and every increment
+    /// the attempt makes is visible through [`LiveUsage::snapshot`].
+    pub fn install(&self, accounting: &QueryAccounting) {
+        *self.lock() = accounting.clone();
+    }
+
+    /// Lock the inner slot, recovering a poisoned guard. The slot holds one
+    /// cheap-to-clone handle and no torn state, so recovering is strictly
+    /// better than failing every later snapshot.
+    fn lock(&self) -> std::sync::MutexGuard<'_, QueryAccounting> {
+        match self.0.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
+impl LiveUsage for LiveCost {
+    fn snapshot(&self) -> QueryAccountingSnapshot {
+        self.lock().snapshot()
+    }
+}
+
+/// The `/metrics` outcome aggregator, as the service layer's usage sink. This
+/// is the seam that makes the drop-guard record land in the same
+/// `ravel_query_outcome_*` family `/api/v1/sql` has always folded into, for
+/// every surface rather than one.
+impl QueryUsageSink for QueryAccountingMetrics {
+    fn record_usage(
+        &self,
+        tenant_hash: TenantHash,
+        status: UsageStatus,
+        accounting: &QueryAccountingSnapshot,
+        estimate: &CostEstimate,
+    ) {
+        self.record_outcome(tenant_hash, outcome_status(status), accounting, estimate);
+    }
+}
+
+fn outcome_status(status: UsageStatus) -> QueryOutcomeStatus {
+    match status {
+        UsageStatus::Success => QueryOutcomeStatus::Success,
+        UsageStatus::Error => QueryOutcomeStatus::Error,
+        UsageStatus::Timeout => QueryOutcomeStatus::Timeout,
+        UsageStatus::Canceled => QueryOutcomeStatus::Canceled,
+    }
+}
+
+/// The default `/metrics` aggregator for a surface state built without one:
+/// an empty per-tenant allowlist, so every tenant folds into the `other`
+/// bucket and nothing allocates a row of its own.
+pub fn default_query_accounting() -> Arc<QueryAccountingMetrics> {
+    Arc::new(QueryAccountingMetrics::new(HashSet::new()))
+}
+
+/// One analytics evaluation, already parsed and authenticated. The op itself
+/// is not here: the service runs the range evaluation the analytic is applied
+/// to, and applying it is the transport's encoding step.
+#[derive(Debug, Clone)]
+pub struct AnalyticsRequest {
+    pub query: String,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub step_ms: i64,
+    pub min_tokens: Vec<CommitToken>,
+    pub deadline: Duration,
+    pub allow_partial: bool,
+}
+
+/// The matrix an analytics call will be applied to, with its coverage already
+/// consented to and its cost already recorded.
+pub struct AnalyticsOutcome {
+    pub value: Value,
+    pub stats: QueryStats,
+    pub partial: bool,
+    /// Per-slice fragment observability for a distributed run (ADR-0071
+    /// `stats.fragments[]`), empty for a run the cost gate did not fan out.
+    pub fragments: Vec<crate::distrib::FragmentStatEntry>,
+}
+
+/// One exemplar query, already parsed and authenticated.
+#[derive(Debug, Clone)]
+pub struct ExemplarsRequest {
+    pub query: String,
+    pub start_ns: i64,
+    pub end_ns: i64,
+    pub min_tokens: Vec<CommitToken>,
+    pub deadline: Duration,
+}
+
+/// The exemplars a query matched, with its cost already recorded.
+pub struct ExemplarsOutcome {
+    pub series: Vec<crate::exemplars::ExemplarSeriesJson>,
+    pub stats: crate::exemplars::QueryStatsJson,
+}
+
+/// The query service layer: one value holding the shared controls plus the
+/// state of every query surface this process serves.
+///
+/// Cheap to clone (every field is an `Arc` or a clone-by-`Arc` state), so a
+/// transport that holds its own surface state can build the façade per request
+/// rather than threading a second handle through its router state.
+///
+/// An operation whose surface is not configured returns
+/// [`ServiceErrorKind::Unsupported`]: a `Mode::Ingest` server genuinely serves
+/// no query surface, and that is a typed refusal rather than a panic.
+#[derive(Clone)]
+pub struct QueryService {
+    tenant_resolver: Arc<dyn TenantResolver>,
+    controls: QueryControls,
+    clock: Arc<dyn Clock>,
+    engine: Option<Arc<QueryEngine>>,
+    analytics: Option<crate::analytics::AnalyticsState>,
+    exemplars: Option<crate::exemplars::ExemplarsState>,
+    #[cfg(feature = "sql")]
+    sql: Option<crate::sql::SqlState>,
+}
+
+impl QueryService {
+    /// The service with the shared controls and no surface configured. Each
+    /// `with_*` below attaches one; a surface's own state carries the pieces
+    /// its engine call needs, and the controls are shared across all of them.
+    pub fn new(
+        tenant_resolver: Arc<dyn TenantResolver>,
+        clock: Arc<dyn Clock>,
+        admission: Arc<QueryAdmissionController>,
+        cost_recorder: Arc<dyn QueryCostRecorder>,
+        usage_sink: Arc<dyn QueryUsageSink>,
+        audit_sink: Arc<dyn QueryAuditSink>,
+    ) -> Self {
+        QueryService {
+            tenant_resolver,
+            controls: QueryControls {
+                admission,
+                cost_recorder,
+                usage_sink,
+                audit_sink,
+            },
+            clock,
+            engine: None,
+            analytics: None,
+            exemplars: None,
+            #[cfg(feature = "sql")]
+            sql: None,
+        }
+    }
+
+    /// The service built from one process-global `/metrics` aggregator, which
+    /// is both the completed-query cost recorder and the every-exit usage
+    /// sink.
+    pub fn with_metrics(
+        tenant_resolver: Arc<dyn TenantResolver>,
+        clock: Arc<dyn Clock>,
+        admission: Arc<QueryAdmissionController>,
+        query_accounting: Arc<QueryAccountingMetrics>,
+        audit_sink: Arc<dyn QueryAuditSink>,
+    ) -> Self {
+        QueryService::new(
+            tenant_resolver,
+            clock,
+            admission,
+            Arc::clone(&query_accounting) as Arc<dyn QueryCostRecorder>,
+            query_accounting as Arc<dyn QueryUsageSink>,
+            audit_sink,
+        )
+    }
+
+    pub fn with_engine(mut self, engine: Arc<QueryEngine>) -> Self {
+        self.engine = Some(engine);
+        self
+    }
+
+    pub fn with_analytics(mut self, state: crate::analytics::AnalyticsState) -> Self {
+        self.analytics = Some(state);
+        self
+    }
+
+    pub fn with_exemplars(mut self, state: crate::exemplars::ExemplarsState) -> Self {
+        self.exemplars = Some(state);
+        self
+    }
+
+    #[cfg(feature = "sql")]
+    pub fn with_sql(mut self, state: crate::sql::SqlState) -> Self {
+        self.sql = Some(state);
+        self
+    }
+
+    /// The tenant resolver a transport authenticates against before it calls
+    /// any operation here.
+    pub fn tenant_resolver(&self) -> &dyn TenantResolver {
+        self.tenant_resolver.as_ref()
+    }
+
+    /// Resolve the caller's credentials, the transport's step before step 1.
+    pub fn authenticate(&self, headers: &HeaderMap) -> Result<TenantHash, ServiceError> {
+        authenticate(self.tenant_resolver.as_ref(), headers)
+    }
+
+    /// The shared controls, for a surface that runs its own engine call and
+    /// needs the same seven steps around it.
+    pub fn controls(&self) -> &QueryControls {
+        &self.controls
+    }
+
+    fn engine(&self) -> Result<&QueryEngine, ServiceError> {
+        match &self.engine {
+            Some(engine) => Ok(engine.as_ref()),
+            None => Err(ServiceError::unsupported_surface("PromQL")),
+        }
+    }
+
+    /// `/api/v1/query`.
+    pub async fn promql_instant(
+        &self,
+        tenant_hash: TenantHash,
+        request: &InstantRequest,
+    ) -> Result<InstantOutcome, ServiceError> {
+        let engine = self.engine()?;
+        Ok(core::promql_instant(&self.controls, engine, tenant_hash, request).await?)
+    }
+
+    /// `/api/v1/query_range`.
+    pub async fn promql_range(
+        &self,
+        tenant_hash: TenantHash,
+        request: &RangeRequest,
+    ) -> Result<RangeOutcome, ServiceError> {
+        let engine = self.engine()?;
+        Ok(core::promql_range(&self.controls, engine, tenant_hash, request).await?)
+    }
+
+    /// `/api/v1/labels`.
+    pub async fn labels(
+        &self,
+        tenant_hash: TenantHash,
+        request: &MetadataRequest,
+    ) -> Result<LabelsOutcome, ServiceError> {
+        let engine = self.engine()?;
+        Ok(core::labels(&self.controls, engine, tenant_hash, request).await?)
+    }
+
+    /// `/api/v1/label/{name}/values`.
+    pub async fn label_values(
+        &self,
+        tenant_hash: TenantHash,
+        request: &MetadataRequest,
+        name: &str,
+        include_log_metric_names: bool,
+    ) -> Result<LabelValuesOutcome, ServiceError> {
+        let engine = self.engine()?;
+        Ok(core::label_values(
+            &self.controls,
+            engine,
+            tenant_hash,
+            request,
+            name,
+            include_log_metric_names,
+        )
+        .await?)
+    }
+
+    /// `/api/v1/series`.
+    pub async fn series(
+        &self,
+        tenant_hash: TenantHash,
+        request: &MetadataRequest,
+    ) -> Result<MetadataOutcome, ServiceError> {
+        let engine = self.engine()?;
+        Ok(core::series(&self.controls, engine, tenant_hash, request).await?)
+    }
+
+    /// `/api/v1/analytics`: the range evaluation an analytic is applied to,
+    /// under the same seven steps as every other operation.
+    ///
+    /// The evaluation itself is `range_with_stats`, the same call
+    /// `/api/v1/query_range` made before per-request budgets existed, because
+    /// this surface exposes no per-request budget knob: step 2 clamps the wall
+    /// deadline and the engine's configured ceilings alone govern the rest.
+    pub async fn analytics(
+        &self,
+        tenant_hash: TenantHash,
+        request: &AnalyticsRequest,
+    ) -> Result<AnalyticsOutcome, ServiceError> {
+        let state = self
+            .analytics
+            .as_ref()
+            .ok_or_else(|| ServiceError::unsupported_surface("analytics"))?;
+
+        let _permit = self.controls.admit()?;
+        let deadline = self
+            .controls
+            .clamp_deadline(request.deadline, state.engine.config().deadline);
+        let now_ns = self.clock.now_ns();
+        let guard = self
+            .controls
+            .usage_guard(tenant_hash, Arc::new(ravel_query::http::UnobservedUsage));
+
+        // Per-slice fragment observability (ADR-0071 `stats.fragments[]`). The
+        // sink is installed in task-local storage so every distributed slice
+        // the engine dispatches records into it, which requires wrapping the
+        // engine call itself rather than the transport around it.
+        let fragment_sink = crate::distrib::FragmentStatsSink::new();
+        let span = query_span("analytics_query", tenant_hash);
+        let eval = crate::distrib::with_fragment_stats(
+            fragment_sink.clone(),
+            state
+                .engine
+                .range_with_stats(
+                    tenant_hash,
+                    &request.query,
+                    request.start_ms,
+                    request.end_ms,
+                    request.step_ms,
+                    &request.min_tokens,
+                    now_ns,
+                    deadline,
+                )
+                .instrument(span.clone()),
+        )
+        .await
+        .map_err(ServiceError::from_query);
+
+        let status = finish_usage(guard, &eval, |(_, stats): &(Value, QueryStats)| {
+            (stats.accounting, stats.estimate)
+        });
+
+        self.controls
+            .audit(
+                tenant_hash,
+                now_ns,
+                &request.query,
+                "analytics",
+                (ms_to_ns(request.start_ms), ms_to_ns(request.end_ms)),
+                status,
+            )
+            .await?;
+        let (value, stats) = eval?;
+
+        let coverage = Coverage::from_stats(&stats);
+        self.controls
+            .gate_partial(&coverage, request.allow_partial)?;
+        record_span_cost(&span, &stats.accounting);
+        self.controls
+            .record_cost(tenant_hash, &stats.accounting, &stats.estimate);
+        Ok(AnalyticsOutcome {
+            value,
+            partial: coverage.is_partial(),
+            stats,
+            fragments: fragment_sink.take(),
+        })
+    }
+
+    /// `/api/v1/query_exemplars`.
+    ///
+    /// This surface reports no [`CostEstimate`] (an estimate is only ever
+    /// computed from a real resolved snapshot, and this path resolves without
+    /// one), so its usage and cost records carry the zero estimate and the
+    /// counters the read actually issued.
+    pub async fn exemplars(
+        &self,
+        tenant_hash: TenantHash,
+        request: &ExemplarsRequest,
+    ) -> Result<ExemplarsOutcome, ServiceError> {
+        let state = self
+            .exemplars
+            .as_ref()
+            .ok_or_else(|| ServiceError::unsupported_surface("exemplars"))?;
+
+        let _permit = self.controls.admit()?;
+        let deadline = self
+            .controls
+            .clamp_deadline(request.deadline, state.deadline);
+        let now_ns = state.clock.now_ns();
+
+        // The live handle each read attempt installs its own accounting into,
+        // so a cancelled or timed-out exemplar query records the requests and
+        // bytes it issued rather than zeros.
+        let live = LiveCost::new();
+        let guard = self
+            .controls
+            .usage_guard(tenant_hash, Arc::new(live.clone()));
+
+        let collected =
+            crate::exemplars::collect_within_deadline(state, tenant_hash, request, deadline, &live)
+                .await;
+
+        let status = finish_usage(guard, &collected, |_| {
+            (live.snapshot(), core::zero_estimate())
+        });
+
+        self.controls
+            .audit(
+                tenant_hash,
+                now_ns,
+                &request.query,
+                "exemplars",
+                (request.start_ns, request.end_ns),
+                status,
+            )
+            .await?;
+        let (series, stats) = collected?;
+
+        self.controls
+            .record_cost(tenant_hash, &live.snapshot(), &core::zero_estimate());
+        Ok(ExemplarsOutcome { series, stats })
+    }
+
+    /// `POST /api/v1/sql`: one read-only SQL statement.
+    ///
+    /// The wall deadline and the per-request budgets are already clamped on
+    /// the [`SqlRequest`](ravel_sql::SqlRequest) the transport built (its
+    /// `timeout` can only lower `SqlState::max_deadline`), so step 2 is a
+    /// no-op reassertion here rather than a second clamp with a different
+    /// ceiling.
+    #[cfg(feature = "sql")]
+    pub async fn sql_execute(
+        &self,
+        tenant_hash: TenantHash,
+        request: &ravel_sql::SqlRequest,
+    ) -> Result<ravel_sql::SqlOutcome, ServiceError> {
+        let state = self
+            .sql
+            .as_ref()
+            .ok_or_else(|| ServiceError::unsupported_surface("SQL"))?;
+
+        let _permit = self.controls.admit()?;
+        let live = ravel_sql::LiveAccounting::new();
+        let guard = self
+            .controls
+            .usage_guard(tenant_hash, Arc::new(SqlLiveUsage(live.clone())));
+
+        let span = query_span("sql_query", tenant_hash);
+        let result = state
+            .executor
+            .execute_accounted(tenant_hash, request, &live)
+            .instrument(span.clone())
+            .await
+            .map_err(|err| ServiceError::from_sql(err, tenant_hash));
+
+        let status = finish_usage(guard, &result, |outcome: &ravel_sql::SqlOutcome| {
+            (outcome.accounting, outcome.estimate)
+        });
+
+        self.controls
+            .audit(
+                tenant_hash,
+                request.now_ns,
+                &request.sql,
+                "sql",
+                (request.window.start_ns, request.window.end_ns),
+                status,
+            )
+            .await?;
+        let outcome = result?;
+
+        // The SQL surface has no federated fan-out and therefore no partial
+        // coverage to consent to; step 6 is vacuous and step 7 already ran in
+        // `ServiceError::from_sql`.
+        record_span_cost(&span, &outcome.accounting);
+        self.controls
+            .record_cost(tenant_hash, &outcome.accounting, &outcome.estimate);
+        Ok(outcome)
+    }
+
+    /// The plan and cost of a statement, without running it. The MCP adapter
+    /// (issue #1381) is its caller; no HTTP route exposes it.
+    #[cfg(feature = "sql")]
+    pub async fn sql_explain(
+        &self,
+        tenant_hash: TenantHash,
+        request: &ravel_sql::SqlRequest,
+    ) -> Result<ravel_sql::ExplainReport, ServiceError> {
+        let state = self
+            .sql
+            .as_ref()
+            .ok_or_else(|| ServiceError::unsupported_surface("SQL"))?;
+
+        let _permit = self.controls.admit()?;
+        // An explain resolves a snapshot, so it spends store requests and is
+        // accounted like any other read.
+        let accounting = QueryAccounting::new();
+        let live = LiveCost::new();
+        live.install(&accounting);
+        let guard = self
+            .controls
+            .usage_guard(tenant_hash, Arc::new(live.clone()));
+
+        let result = state
+            .executor
+            .explain_accounted(tenant_hash, request, &accounting)
+            .await
+            .map_err(|err| ServiceError::from_sql(err, tenant_hash));
+
+        let status = finish_usage(guard, &result, |_| (live.snapshot(), core::zero_estimate()));
+
+        self.controls
+            .audit(
+                tenant_hash,
+                request.now_ns,
+                &request.sql,
+                "sql",
+                (request.window.start_ns, request.window.end_ns),
+                status,
+            )
+            .await?;
+        let report = result?;
+
+        self.controls
+            .record_cost(tenant_hash, &live.snapshot(), &core::zero_estimate());
+        Ok(report)
+    }
+}
+
+/// `ravel-sql`'s live accounting view, as the service layer's [`LiveUsage`].
+/// Both the trait and `LiveAccounting` are foreign to this crate, so the
+/// newtype is what makes the impl legal.
+#[cfg(feature = "sql")]
+struct SqlLiveUsage(ravel_sql::LiveAccounting);
+
+#[cfg(feature = "sql")]
+impl LiveUsage for SqlLiveUsage {
+    fn snapshot(&self) -> QueryAccountingSnapshot {
+        self.0.snapshot()
+    }
+}
+
+/// Step 4 for one operation: fold the usage record before the outcome becomes
+/// anything else, and report the audit status the same outcome implies.
+///
+/// `cost_of` reads the success value's counters; a failure has none, so its
+/// spend comes from the guard's live handle instead. Every operation runs this
+/// before its `audit`, its `?`, and its consent gate, which is what makes "the
+/// usage record exists even when the request ends as an error" mechanical
+/// rather than remembered.
+fn finish_usage<T>(
+    guard: ravel_query::http::UsageGuard,
+    result: &Result<T, ServiceError>,
+    cost_of: impl FnOnce(&T) -> (QueryAccountingSnapshot, CostEstimate),
+) -> QueryStatus {
+    match result {
+        Ok(value) => {
+            let (accounting, estimate) = cost_of(value);
+            guard.finish(UsageStatus::Success, &accounting, &estimate);
+            QueryStatus::Ok
+        }
+        Err(err) => {
+            guard.finish_failed(err.usage_status());
+            QueryStatus::Error
+        }
+    }
+}
+
+/// A request-level span carrying only bounded values (ADR-0044 section 5): the
+/// tenant hash, the workload class, and, once the query finishes, the final
+/// store request and byte counts. No query text, label values, or object keys
+/// ever become span fields. Every query over these transports is an
+/// interactive, client-driven one.
+fn query_span(name: &'static str, tenant_hash: TenantHash) -> tracing::Span {
+    tracing::info_span!(
+        "query",
+        otel.name = name,
+        tenant_hash = %tenant_hash.to_hex(),
+        workload_class = crate::metrics::WorkloadClass::Interactive.name(),
+        s3_requests = tracing::field::Empty,
+        s3_bytes = tracing::field::Empty,
+    )
+}
+
+fn record_span_cost(span: &tracing::Span, accounting: &QueryAccountingSnapshot) {
+    span.record("s3_requests", accounting.total_s3_requests());
+    span.record("s3_bytes", accounting.total_s3_bytes());
+}
+
+/// Nanosecond form of a millisecond timestamp for an audit window bound,
+/// saturating rather than overflowing (the audit record's window is
+/// informational; the query itself already validated its range).
+fn ms_to_ns(ms: i64) -> i64 {
+    ms.saturating_mul(1_000_000)
+}

--- a/services/ravel-server/src/service/mod.rs
+++ b/services/ravel-server/src/service/mod.rs
@@ -529,6 +529,11 @@ impl QueryService {
     /// MCP adapter (issue #1381) builds a `SqlRequest` directly, and an
     /// operation whose only clamp lives in one of its transports has no clamp
     /// at all from the others.
+    ///
+    /// A request that named no budgets keeps naming none. `None` is the
+    /// executor's documented per-request fast path, and filling it in with the
+    /// configured ceilings takes that path away from every caller: the clamp
+    /// exists to lower what a caller asked for, not to make every caller ask.
     #[cfg(feature = "sql")]
     pub(crate) fn clamped_sql_request(
         &self,
@@ -539,10 +544,10 @@ impl QueryService {
             deadline: self
                 .controls
                 .clamp_deadline(request.deadline, state.max_deadline),
-            budgets: Some(
+            budgets: request.budgets.as_ref().map(|budgets| {
                 self.controls
-                    .clamp_budgets(request.budgets.as_ref(), &state.executor.config().engine),
-            ),
+                    .clamp_budgets(Some(budgets), &state.executor.config().engine)
+            }),
             ..request.clone()
         }
     }

--- a/services/ravel-server/src/service/mod.rs
+++ b/services/ravel-server/src/service/mod.rs
@@ -518,13 +518,36 @@ impl QueryService {
         Ok(ExemplarsOutcome { series, stats })
     }
 
-    /// `POST /api/v1/sql`: one read-only SQL statement.
+    /// Step 2 for the SQL surface: the request as it will actually run, with
+    /// its wall deadline lowered to `SqlState::max_deadline` and its budgets
+    /// lowered to the executor's configured ceilings.
     ///
-    /// The wall deadline and the per-request budgets are already clamped on
-    /// the [`SqlRequest`](ravel_sql::SqlRequest) the transport built (its
-    /// `timeout` can only lower `SqlState::max_deadline`), so step 2 is a
-    /// no-op reassertion here rather than a second clamp with a different
-    /// ceiling.
+    /// The HTTP transport clamps the deadline too, and the executor re-clamps
+    /// the budgets through `RequestBudgets::clamp`, which is idempotent. Both
+    /// stay. What the layer owes is that the clamp holds for every caller of
+    /// the operation, not only for the ones that happen to clamp first: the
+    /// MCP adapter (issue #1381) builds a `SqlRequest` directly, and an
+    /// operation whose only clamp lives in one of its transports has no clamp
+    /// at all from the others.
+    #[cfg(feature = "sql")]
+    pub(crate) fn clamped_sql_request(
+        &self,
+        state: &crate::sql::SqlState,
+        request: &ravel_sql::SqlRequest,
+    ) -> ravel_sql::SqlRequest {
+        ravel_sql::SqlRequest {
+            deadline: self
+                .controls
+                .clamp_deadline(request.deadline, state.max_deadline),
+            budgets: Some(
+                self.controls
+                    .clamp_budgets(request.budgets.as_ref(), &state.executor.config().engine),
+            ),
+            ..request.clone()
+        }
+    }
+
+    /// `POST /api/v1/sql`: one read-only SQL statement.
     #[cfg(feature = "sql")]
     pub async fn sql_execute(
         &self,
@@ -537,6 +560,7 @@ impl QueryService {
             .ok_or_else(|| ServiceError::unsupported_surface("SQL"))?;
 
         let _permit = self.controls.admit()?;
+        let request = &self.clamped_sql_request(state, request);
         let live = ravel_sql::LiveAccounting::new();
         let guard = self
             .controls
@@ -589,6 +613,7 @@ impl QueryService {
             .ok_or_else(|| ServiceError::unsupported_surface("SQL"))?;
 
         let _permit = self.controls.admit()?;
+        let request = &self.clamped_sql_request(state, request);
         // An explain resolves a snapshot, so it spends store requests and is
         // accounted like any other read.
         let accounting = QueryAccounting::new();

--- a/services/ravel-server/src/service/mod.rs
+++ b/services/ravel-server/src/service/mod.rs
@@ -483,7 +483,7 @@ impl QueryService {
         let deadline = self
             .controls
             .clamp_deadline(request.deadline, state.deadline);
-        let now_ns = state.clock.now_ns();
+        let now_ns = self.clock.now_ns();
 
         // The live handle each read attempt installs its own accounting into,
         // so a cancelled or timed-out exemplar query records the requests and

--- a/services/ravel-server/src/service/mod.rs
+++ b/services/ravel-server/src/service/mod.rs
@@ -403,9 +403,11 @@ impl QueryService {
             .controls
             .clamp_deadline(request.deadline, state.engine.config().deadline);
         let now_ns = self.clock.now_ns();
+        let live = ravel_query::LiveQueryAccounting::new();
         let guard = self
             .controls
-            .usage_guard(tenant_hash, Arc::new(ravel_query::http::UnobservedUsage));
+            .usage_guard(tenant_hash, Arc::new(live.clone()));
+        let engine = state.engine.with_live_usage(&live);
 
         // Per-slice fragment observability (ADR-0071 `stats.fragments[]`). The
         // sink is installed in task-local storage so every distributed slice
@@ -415,8 +417,7 @@ impl QueryService {
         let span = query_span("analytics_query", tenant_hash);
         let eval = crate::distrib::with_fragment_stats(
             fragment_sink.clone(),
-            state
-                .engine
+            engine
                 .range_with_stats(
                     tenant_hash,
                     &request.query,

--- a/services/ravel-server/src/service/tests.rs
+++ b/services/ravel-server/src/service/tests.rs
@@ -882,3 +882,103 @@ async fn unauthenticated_request_consumes_no_permit() {
         .expect("the ceiling has its permit back");
     assert_eq!(h.usage.records().len(), 1);
 }
+
+/// Step 2 on the SQL surface, which used to skip it: `sql_execute` and
+/// `sql_explain` took the request's own deadline and budgets as given and
+/// relied on the HTTP transport having clamped them first.
+///
+/// The clamp is asserted on the request the layer builds, not on an executed
+/// statement, because the executor re-clamps the same budgets against the same
+/// config through `RequestBudgets::clamp`, which is idempotent: no outcome
+/// distinguishes a service that clamped from one that did not. What the layer
+/// owes is that the clamp holds for a caller that is not the HTTP transport,
+/// and the MCP adapter (issue #1381) building a `SqlRequest` directly is
+/// exactly that caller.
+#[cfg(feature = "sql")]
+#[tokio::test]
+async fn sql_explain_clamps_the_deadline_and_budgets() {
+    let h = harness_with_sql_deadline(
+        Arc::new(MemoryStore::new()),
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(NoopQueryAuditSink),
+        None,
+        Duration::from_secs(5),
+    );
+    let state = &h.transports.sql;
+
+    // A caller asking for more than the server allows on every dimension. Each
+    // value comes back as the server's own, exactly.
+    let greedy = ravel_sql::SqlRequest {
+        deadline: Duration::from_secs(600),
+        budgets: Some(ravel_query::RequestBudgets {
+            max_bytes_scanned: Some(ravel_query::ByteLimit::Unlimited),
+            max_store_requests: Some(ravel_query::RequestLimit::Unlimited),
+            max_segments: Some(1_000_000),
+        }),
+        ..sql_request("SELECT 1")
+    };
+    let clamped = h.service.clamped_sql_request(state, &greedy);
+    assert_eq!(clamped.deadline, Duration::from_secs(5));
+    let budgets = clamped
+        .budgets
+        .expect("the layer resolves budgets rather than leaving them absent");
+    assert_eq!(
+        budgets.max_bytes_scanned,
+        Some(ravel_query::ByteLimit::Bounded(64 << 20)),
+    );
+    assert_eq!(
+        budgets.max_store_requests,
+        Some(ravel_query::RequestLimit::Bounded(4_096)),
+    );
+    assert_eq!(budgets.max_segments, Some(512));
+
+    // Lowering only: a caller under every ceiling keeps its own values.
+    let modest = ravel_sql::SqlRequest {
+        deadline: Duration::from_secs(2),
+        budgets: Some(ravel_query::RequestBudgets {
+            max_bytes_scanned: Some(ravel_query::ByteLimit::Bounded(1 << 20)),
+            max_store_requests: Some(ravel_query::RequestLimit::Bounded(7)),
+            max_segments: Some(3),
+        }),
+        ..sql_request("SELECT 1")
+    };
+    let clamped = h.service.clamped_sql_request(state, &modest);
+    assert_eq!(clamped.deadline, Duration::from_secs(2));
+    let budgets = clamped.budgets.expect("budgets");
+    assert_eq!(
+        budgets.max_bytes_scanned,
+        Some(ravel_query::ByteLimit::Bounded(1 << 20)),
+    );
+    assert_eq!(
+        budgets.max_store_requests,
+        Some(ravel_query::RequestLimit::Bounded(7)),
+    );
+    assert_eq!(budgets.max_segments, Some(3));
+
+    // A caller that named no budgets at all still runs under concrete ones.
+    let clamped = h
+        .service
+        .clamped_sql_request(state, &sql_request("SELECT 1"));
+    let budgets = clamped.budgets.expect("budgets");
+    assert_eq!(
+        budgets.max_bytes_scanned,
+        Some(ravel_query::ByteLimit::Bounded(64 << 20)),
+    );
+    assert_eq!(
+        budgets.max_store_requests,
+        Some(ravel_query::RequestLimit::Bounded(4_096)),
+    );
+    assert_eq!(budgets.max_segments, Some(512));
+
+    // And both operations run the clamped request rather than the caller's:
+    // the greedy deadline above is beyond the ceiling, and neither call
+    // reports one.
+    h.service
+        .sql_explain(h.tenant_hash, &greedy)
+        .await
+        .expect("an explain over an empty store");
+    h.service
+        .sql_execute(h.tenant_hash, &greedy)
+        .await
+        .expect("a statement over an empty store");
+}

--- a/services/ravel-server/src/service/tests.rs
+++ b/services/ravel-server/src/service/tests.rs
@@ -1236,7 +1236,7 @@ async fn sql_explain_clamps_the_deadline_and_budgets() {
     assert_eq!(clamped.deadline, Duration::from_secs(5));
     let budgets = clamped
         .budgets
-        .expect("the layer resolves budgets rather than leaving them absent");
+        .expect("the caller named budgets, so the clamped request names them too");
     assert_eq!(
         budgets.max_bytes_scanned,
         Some(ravel_query::ByteLimit::Bounded(64 << 20)),
@@ -1270,20 +1270,15 @@ async fn sql_explain_clamps_the_deadline_and_budgets() {
     );
     assert_eq!(budgets.max_segments, Some(3));
 
-    // A caller that named no budgets at all still runs under concrete ones.
+    // A caller that named no budgets keeps naming none: the clamp lowers what
+    // was asked for and does not ask on the caller's behalf. Filling this in
+    // would take the executor's documented no-budgets path away from every
+    // caller of the operation.
     let clamped = h
         .service
         .clamped_sql_request(state, &sql_request("SELECT 1"));
-    let budgets = clamped.budgets.expect("budgets");
-    assert_eq!(
-        budgets.max_bytes_scanned,
-        Some(ravel_query::ByteLimit::Bounded(64 << 20)),
-    );
-    assert_eq!(
-        budgets.max_store_requests,
-        Some(ravel_query::RequestLimit::Bounded(4_096)),
-    );
-    assert_eq!(budgets.max_segments, Some(512));
+    assert!(clamped.budgets.is_none());
+    assert_eq!(clamped.deadline, Duration::from_secs(5));
 
     // And both operations run the clamped request rather than the caller's:
     // the greedy deadline above is beyond the ceiling, and neither call

--- a/services/ravel-server/src/service/tests.rs
+++ b/services/ravel-server/src/service/tests.rs
@@ -357,6 +357,23 @@ fn sql_request(sql: &str) -> ravel_sql::SqlRequest {
     }
 }
 
+/// The metadata family's equivalent of [`analytics_request`]: one selector
+/// over the same one-minute window.
+fn metadata_request(allow_partial: bool) -> ravel_query::http::MetadataRequest {
+    ravel_query::http::MetadataRequest {
+        selectors: vec!["up".to_string()],
+        window: ravel_types::TimeRange {
+            start_ns: NOW_NS - 60_000_000_000,
+            end_ns: NOW_NS,
+        },
+        min_tokens: Vec::new(),
+        deadline: Duration::from_secs(30),
+        allow_partial,
+        now_ns: NOW_NS,
+        budgets: None,
+    }
+}
+
 fn exemplars_request() -> ExemplarsRequest {
     ExemplarsRequest {
         query: "up".to_string(),
@@ -569,6 +586,32 @@ async fn usage_is_recorded_before_partial_refusal() {
     assert!(outcome.partial);
     assert_eq!(h.usage.records().len(), 2);
     assert_eq!(h.cost.records().len(), 1);
+
+    // The metadata family runs the same order on a path with no value to
+    // return, where "record what it spent" is the only thing the refusal can
+    // leave behind. `/api/v1/labels` and `/api/v1/series` share one
+    // implementation, so one of each pair of assertions covers both.
+    let err = err_of(
+        h.service
+            .labels(h.tenant_hash, &metadata_request(false))
+            .await,
+    );
+    assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(err.kind, ServiceErrorKind::Unavailable);
+    assert!(err.message.contains("set allow_partial=true"));
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 3);
+    assert_eq!(usage[2].1, UsageStatus::Success);
+    assert_eq!(h.cost.records().len(), 1);
+
+    let outcome = h
+        .service
+        .labels(h.tenant_hash, &metadata_request(true))
+        .await
+        .expect("consented partial coverage is served");
+    assert!(outcome.partial);
+    assert_eq!(h.usage.records().len(), 4);
+    assert_eq!(h.cost.records().len(), 2);
 }
 
 /// Step 4 before the evaluation failure becomes a response. A rejected query

--- a/services/ravel-server/src/service/tests.rs
+++ b/services/ravel-server/src/service/tests.rs
@@ -558,6 +558,128 @@ async fn usage_is_recorded_before_evaluation_error() {
     assert_eq!(h.cost.records().len(), 0);
 }
 
+/// The dropped-future path on a Prometheus-shaped route, which reads its spend
+/// from the engine's live accounting view rather than from a result it never
+/// gets. Before that view existed, this record was all zeros: the engine owned
+/// its `QueryAccounting` internally and returned it only on success.
+#[tokio::test]
+async fn usage_is_recorded_on_cancel_for_promql() {
+    let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
+    let gate: GateHandle = fault_store.hold(Op::List, None, Occurrence::Nth(1));
+    let h = harness(
+        fault_store,
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(NoopQueryAuditSink),
+        None,
+    );
+
+    let request = range_request("up");
+    let mut query = Box::pin(h.service.promql_range(h.tenant_hash, &request));
+
+    tokio::select! {
+        _ = &mut query => panic!("the query is held inside the store call"),
+        () = gate.wait_until_held(1) => {}
+    }
+    assert_eq!(gate.held_count(), 1);
+
+    drop(query);
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].0, h.tenant_hash);
+    assert_eq!(usage[0].1, UsageStatus::Canceled);
+    // The exact spend the resolve had reached when the gate held it: the two
+    // requests it issued before its first listing. Not a lower bound. Zero here
+    // is what a guard reading an unobserved live handle records.
+    assert_eq!(usage[0].2.total_s3_requests(), 2);
+    assert_eq!(h.cost.records().len(), 0);
+}
+
+/// The same, on the analytics surface, which reaches the engine through its
+/// own state rather than through the shared PromQL operations.
+#[tokio::test]
+async fn usage_is_recorded_on_cancel_for_analytics() {
+    let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
+    let gate: GateHandle = fault_store.hold(Op::List, None, Occurrence::Nth(1));
+    let h = harness(
+        fault_store,
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(NoopQueryAuditSink),
+        None,
+    );
+
+    let request = analytics_request("up", false);
+    let mut query = Box::pin(h.service.analytics(h.tenant_hash, &request));
+
+    tokio::select! {
+        _ = &mut query => panic!("the query is held inside the store call"),
+        () = gate.wait_until_held(1) => {}
+    }
+    assert_eq!(gate.held_count(), 1);
+
+    drop(query);
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].0, h.tenant_hash);
+    assert_eq!(usage[0].1, UsageStatus::Canceled);
+    assert_eq!(usage[0].2.total_s3_requests(), 2);
+    assert_eq!(h.cost.records().len(), 0);
+}
+
+/// The sink `build_app_state` wires. The whole PromQL route family folded its
+/// usage records into a discarding default before, so `ravel_query_outcome_*`
+/// stayed empty for PromQL traffic no matter how many queries ran; only the
+/// completed-query cost family moved.
+#[tokio::test]
+async fn promql_routes_record_usage_through_the_wired_sink() {
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
+    let query_accounting = default_query_accounting();
+    let mut tokens = HashMap::new();
+    tokens.insert(TOKEN.to_string(), tenant());
+    let resolver: Arc<dyn TenantResolver> = Arc::new(StaticBearerTokenResolver::new(tokens));
+
+    let state = crate::query::build_app_state(
+        catalog,
+        Arc::clone(&store),
+        resolver,
+        None,
+        EngineConfig::default(),
+        Arc::new(ravel_query::GetLimiter::new(8).expect("nonzero permits")),
+        Arc::clone(&query_accounting),
+        QueryAdmissionController::shared(QueryConcurrencyLimit::Unlimited),
+        None,
+        None,
+        None,
+    );
+
+    let start_s = NOW_MS / 1_000 - 60;
+    let end_s = NOW_MS / 1_000;
+    let request = Request::builder()
+        .uri(format!(
+            "/api/v1/query_range?query=up&start={start_s}&end={end_s}&step=60"
+        ))
+        .header(axum::http::header::AUTHORIZATION, format!("Bearer {TOKEN}"))
+        .body(Body::empty())
+        .expect("request");
+    let response = ravel_query::http::router(state)
+        .oneshot(request)
+        .await
+        .expect("the route answers");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let rows = query_accounting.outcome_snapshot();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].status, crate::metrics::QueryOutcomeStatus::Success);
+    assert_eq!(rows[0].counters.queries, 1);
+}
+
 /// The dropped-future path: a client that disconnects mid-query leaves exactly
 /// one trace, the usage record, and no error is ever mapped because there is no
 /// caller left to map one for.
@@ -566,7 +688,7 @@ async fn usage_is_recorded_before_evaluation_error() {
 /// query's completion: the operation is parked inside a store call whose
 /// occurrence the test asserts before it drops the future.
 #[tokio::test]
-async fn usage_is_recorded_on_cancel() {
+async fn usage_is_recorded_on_cancel_for_exemplars() {
     let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
     let gate: GateHandle = fault_store.hold(Op::List, None, Occurrence::Nth(1));
     let h = harness(

--- a/services/ravel-server/src/service/tests.rs
+++ b/services/ravel-server/src/service/tests.rs
@@ -135,6 +135,21 @@ struct Harness {
     cost: Arc<RecordingCost>,
     admission: Arc<QueryAdmissionController>,
     tenant_hash: TenantHash,
+    /// Each transport's own state, so a test can drive its router end to end
+    /// rather than call the service layer directly. What a handler does before
+    /// it reaches the service call is invisible from the service call itself,
+    /// and the order of authentication against admission is exactly that.
+    transports: Transports,
+}
+
+/// The router states of the four query transports this crate serves, all over
+/// the harness's one store, one resolver, and one admission controller.
+struct Transports {
+    promql: ravel_query::http::AppState,
+    analytics: crate::analytics::AnalyticsState,
+    exemplars: crate::exemplars::ExemplarsState,
+    #[cfg(feature = "sql")]
+    sql: crate::sql::SqlState,
 }
 
 /// The `SqlConfig` every harness here builds its executor with. The three
@@ -240,6 +255,26 @@ fn harness_with_sql_deadline(
         query_admission: Arc::clone(&admission),
     };
 
+    let transports = Transports {
+        promql: crate::query::build_app_state(
+            Arc::clone(&catalog),
+            Arc::clone(&store),
+            Arc::clone(&resolver),
+            None,
+            config,
+            Arc::new(ravel_query::GetLimiter::new(8).expect("nonzero permits")),
+            default_query_accounting(),
+            Arc::clone(&admission),
+            None,
+            None,
+            None,
+        ),
+        analytics: analytics.clone(),
+        exemplars: exemplars.clone(),
+        #[cfg(feature = "sql")]
+        sql: sql.clone(),
+    };
+
     let service = QueryService::new(
         resolver,
         clock,
@@ -261,6 +296,7 @@ fn harness_with_sql_deadline(
         cost,
         admission,
         tenant_hash: tenant().hash(),
+        transports,
     }
 }
 
@@ -659,12 +695,8 @@ async fn promql_routes_record_usage_through_the_wired_sink() {
         None,
     );
 
-    let start_s = NOW_MS / 1_000 - 60;
-    let end_s = NOW_MS / 1_000;
     let request = Request::builder()
-        .uri(format!(
-            "/api/v1/query_range?query=up&start={start_s}&end={end_s}&step=60"
-        ))
+        .uri(range_uri())
         .header(axum::http::header::AUTHORIZATION, format!("Bearer {TOKEN}"))
         .body(Body::empty())
         .expect("request");
@@ -725,22 +757,120 @@ async fn usage_is_recorded_on_cancel_for_exemplars() {
     assert_eq!(h.cost.records().len(), 0);
 }
 
+/// Drive one router with one request and answer with the status it produced.
+async fn route_status(
+    router: axum::Router,
+    request: axum::http::Request<axum::body::Body>,
+) -> StatusCode {
+    use tower::ServiceExt;
+
+    router
+        .oneshot(request)
+        .await
+        .expect("the route answers")
+        .status()
+}
+
+/// The PromQL range URI every ordering test drives, over the fixed clock's now.
+fn range_uri() -> String {
+    let start_s = NOW_MS / 1_000 - 60;
+    let end_s = NOW_MS / 1_000;
+    format!("/api/v1/query_range?query=up&start={start_s}&end={end_s}&step=60")
+}
+
 /// Authentication is outside the seven steps and runs before step 1, so an
-/// anonymous caller cannot take a permit from the fleet-global ceiling. With a
-/// ceiling of one, a rejected request followed by a valid one both succeed at
-/// what they are supposed to do.
+/// anonymous caller cannot take a permit from the fleet-global ceiling.
+///
+/// Calling `QueryService::authenticate` on its own cannot show this: that
+/// method takes no permit by construction, whatever order the handler that
+/// wraps it uses. What shows it is a saturated ceiling. With the one permit
+/// held, admission can only reject, so a handler that admitted before it
+/// authenticated would answer 503 to an anonymous request. Every transport
+/// answers 401 instead, and the positive control below proves 503 was the
+/// reachable alternative rather than an impossible one.
 #[tokio::test]
 async fn unauthenticated_request_consumes_no_permit() {
+    use axum::body::Body;
+    use axum::http::Request;
+
     let h = memory_harness(QueryConcurrencyLimit::Bounded(1));
 
-    let err = h
-        .service
-        .authenticate(&bearer("not-a-token"))
-        .expect_err("an unknown token resolves to no tenant");
-    assert_eq!(err.status, StatusCode::UNAUTHORIZED);
-    assert_eq!(err.kind, ServiceErrorKind::Unauthorized);
+    let held = h.admission.try_admit().expect("the ceiling's one permit");
+    assert_eq!(h.admission.in_flight(), 1);
+
+    let anonymous = |uri: String, body: &'static str| {
+        Request::builder()
+            .method(if body.is_empty() { "GET" } else { "POST" })
+            .uri(uri)
+            .header(axum::http::header::AUTHORIZATION, "Bearer not-a-token")
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .expect("request")
+    };
+
+    assert_eq!(
+        route_status(
+            ravel_query::http::router(h.transports.promql.clone()),
+            anonymous(range_uri(), ""),
+        )
+        .await,
+        StatusCode::UNAUTHORIZED,
+        "promql",
+    );
+    assert_eq!(
+        route_status(
+            crate::analytics::router(h.transports.analytics.clone()),
+            anonymous("/api/v1/analytics".to_string(), "{}"),
+        )
+        .await,
+        StatusCode::UNAUTHORIZED,
+        "analytics",
+    );
+    assert_eq!(
+        route_status(
+            crate::exemplars::router(h.transports.exemplars.clone()),
+            anonymous("/api/v1/query_exemplars?query=up".to_string(), ""),
+        )
+        .await,
+        StatusCode::UNAUTHORIZED,
+        "exemplars",
+    );
+    #[cfg(feature = "sql")]
+    assert_eq!(
+        route_status(
+            crate::sql::router(h.transports.sql.clone()),
+            anonymous("/api/v1/sql".to_string(), "{}"),
+        )
+        .await,
+        StatusCode::UNAUTHORIZED,
+        "sql",
+    );
+
+    // None of them reached admission, so the stock is still exactly the one
+    // permit this test holds.
+    assert_eq!(h.admission.in_flight(), 1);
     assert_eq!(h.usage.records().len(), 0);
 
+    // The positive control: the same route, the same saturated ceiling, a token
+    // that does resolve. This is the answer the assertions above would have got
+    // had authentication run second.
+    let authenticated = Request::builder()
+        .uri(range_uri())
+        .header(axum::http::header::AUTHORIZATION, format!("Bearer {TOKEN}"))
+        .body(Body::empty())
+        .expect("request");
+    assert_eq!(
+        route_status(
+            ravel_query::http::router(h.transports.promql.clone()),
+            authenticated,
+        )
+        .await,
+        StatusCode::SERVICE_UNAVAILABLE,
+    );
+
+    // And once the ceiling frees up, the same authenticated request is served.
+    drop(held);
+    assert_eq!(h.admission.in_flight(), 0);
     let tenant_hash = h
         .service
         .authenticate(&bearer(TOKEN))
@@ -749,6 +879,6 @@ async fn unauthenticated_request_consumes_no_permit() {
     h.service
         .analytics(tenant_hash, &analytics_request("up", false))
         .await
-        .expect("the ceiling still has its one permit");
+        .expect("the ceiling has its permit back");
     assert_eq!(h.usage.records().len(), 1);
 }

--- a/services/ravel-server/src/service/tests.rs
+++ b/services/ravel-server/src/service/tests.rs
@@ -1197,6 +1197,54 @@ async fn unauthenticated_request_consumes_no_permit() {
     assert_eq!(h.usage.records().len(), 1);
 }
 
+/// A malformed `match[]` selector on the metadata family (`/api/v1/series`
+/// here) is rejected by the transport before it ever calls the service, so it
+/// takes no admission permit and produces no audit or usage record: the same
+/// plain 400 the request gets on an unsaturated ceiling.
+///
+/// With the ceiling's one permit already held, a service-layer rejection
+/// would come back 503 ("the ceiling is full"), not 400: the assertion below
+/// only holds if the selector was rejected ahead of `admit()`. Moving the
+/// selector-parsing loop in `metadata_request`
+/// (crates/ravel-query/src/http/handlers.rs) back to after
+/// `let _permit = controls.admit()?;` in `metadata()`
+/// (crates/ravel-query/src/http/service.rs) reproduces the bug this test
+/// pins: the request then reaches `admit()` first, and with the one permit
+/// already held here it answers 503 SERVICE_UNAVAILABLE instead of 400 BAD
+/// REQUEST, failing this test's status assertion.
+#[tokio::test]
+async fn malformed_selector_rejected_before_admission_permit() {
+    use axum::body::Body;
+    use axum::http::Request;
+
+    let h = memory_harness(QueryConcurrencyLimit::Bounded(1));
+    let held = h.admission.try_admit().expect("the only permit");
+
+    let request = Request::builder()
+        .uri("/api/v1/series?match[]=%7B")
+        .header(axum::http::header::AUTHORIZATION, format!("Bearer {TOKEN}"))
+        .body(Body::empty())
+        .expect("request");
+
+    assert_eq!(
+        route_status(
+            ravel_query::http::router(h.transports.promql.clone()),
+            request,
+        )
+        .await,
+        StatusCode::BAD_REQUEST,
+        "a malformed selector is a 400, not a 503 from a saturated ceiling",
+    );
+
+    // The permit this test holds is still the only one ever taken: the
+    // malformed request never reached `admit()`.
+    assert_eq!(h.admission.in_flight(), 1);
+    // Nothing executed, so the usage sink recorded nothing either.
+    assert_eq!(h.usage.records().len(), 0);
+
+    drop(held);
+}
+
 /// Step 2 on the SQL surface, which used to skip it: `sql_execute` and
 /// `sql_explain` took the request's own deadline and budgets as given and
 /// relied on the HTTP transport having clamped them first.

--- a/services/ravel-server/src/service/tests.rs
+++ b/services/ravel-server/src/service/tests.rs
@@ -17,12 +17,14 @@ use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use ravel_catalog::{Catalog, CatalogConfig};
 use ravel_maintain::{AuditEvent, MaintainError, NoopQueryAuditSink};
 use ravel_object_store::ObjectStoreBackend;
-use ravel_object_store::fault::{FaultPlan, FaultStore, GateHandle, Occurrence, Op};
+use ravel_object_store::fault::{
+    FaultKind, FaultPlan, FaultStore, GateHandle, Occurrence, Op, Rule, ScriptedFault,
+};
 use ravel_object_store::memory::MemoryStore;
 use ravel_query::{EngineConfig, QueryConcurrencyLimit};
 use ravel_tenant_resolve::StaticBearerTokenResolver;
 use ravel_types::TenantId;
-use ravel_types::accounting::QueryWorkloadClass;
+use ravel_types::accounting::{AccountedOp, QueryWorkloadClass};
 
 use super::*;
 
@@ -703,6 +705,276 @@ async fn usage_is_recorded_on_cancel_for_analytics() {
     assert_eq!(usage[0].0, h.tenant_hash);
     assert_eq!(usage[0].1, UsageStatus::Canceled);
     assert_eq!(usage[0].2.total_s3_requests(), 2);
+    assert_eq!(h.cost.records().len(), 0);
+}
+
+/// The spend one metrics-lane resolve reaches before it issues its first
+/// listing, and its total once it finishes. The log lane's resolve has the same
+/// shape, which is what lets the mixed-lane and multi-selector figures below be
+/// written as a sum of named parts rather than one opaque number.
+const SPEND_BEFORE_FIRST_LIST: u64 = 2;
+const SPEND_PER_RESOLVE: u64 = 3;
+/// Every resolve issues this many listings: one bounded shard listing plus the
+/// unconditional pending-erasure listing. It is what turns "the Nth lane" into
+/// the occurrence a hold must name.
+const LISTS_PER_RESOLVE: u64 = 2;
+/// The same resolve against a tenant that has one published segment: the same
+/// listings, plus the get that reads the commit record they returned.
+const SPEND_PER_RESOLVE_WITH_ONE_SEGMENT: u64 = SPEND_PER_RESOLVE + 1;
+/// The fetch that finds its object gone and makes the engine resolve again.
+const SPEND_OF_THE_INVALIDATED_FETCH: u64 = 1;
+
+/// Publish one real RSEG segment plus its commit record for the harness's
+/// tenant, so a query for `up` resolves to an object and then fetches it.
+/// Against an empty tenant nothing is ever fetched, and the snapshot
+/// invalidation the engine retries on cannot happen at all.
+async fn publish_up_segment(store: &dyn ObjectStoreBackend) {
+    use ravel_commit::publish::RetryPolicy;
+    use ravel_commit::record::NewCommitRecord;
+    use ravel_commit::{keys, publish, record};
+    use ravel_object_store::PutOptions;
+    use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
+    use ravel_types::{Label, LabelSet, Sample, SeriesId, Signal};
+
+    const SAMPLE_TS_NS: i64 = NOW_NS - 30_000_000_000;
+    const NS_PER_HOUR: i64 = 3_600_000_000_000;
+
+    let tenant = tenant();
+    let tenant_hash = tenant.hash();
+    let labels = LabelSet::new(vec![Label {
+        name: "__name__".to_string(),
+        value: "up".to_string(),
+    }])
+    .expect("valid labels");
+    let series = vec![SeriesInput {
+        series_id: SeriesId::compute(&tenant, "up", &labels).expect("series id"),
+        labels,
+        samples: vec![Sample {
+            ts_ns: SAMPLE_TS_NS,
+            value: 1.0,
+        }],
+    }];
+
+    let writer_id = uuid::Uuid::from_u128(2_000);
+    let written = SegmentWriter::write(
+        series,
+        SegmentIdentity {
+            tenant_hash: tenant_hash.0,
+            shard: 0,
+            writer_id: writer_id.to_string(),
+            writer_epoch: 1,
+            writer_seq: 1,
+        },
+        IngestBounds {
+            min_ingest_ts_ns: SAMPLE_TS_NS,
+            max_ingest_ts_ns: SAMPLE_TS_NS,
+        },
+    )
+    .expect("write segment");
+
+    let rec = record::build(NewCommitRecord {
+        tenant_hash,
+        signal: Signal::Metrics,
+        shard: 0,
+        writer_id,
+        writer_epoch: 1,
+        writer_seq: 1,
+        object_size: written.bytes.len() as u64,
+        content_hash: written.summary.blake3,
+        sample_count: written.summary.sample_count,
+        series_count: written.summary.series_count,
+        min_event_ts_ns: written.summary.min_event_ts_ns,
+        max_event_ts_ns: written.summary.max_event_ts_ns,
+        min_ingest_ts_ns: written.summary.min_event_ts_ns,
+        max_ingest_ts_ns: written.summary.max_event_ts_ns,
+        segment_format_version: 1,
+        created_unix_ns: NOW_NS,
+        ingest_hour_bucket: u32::try_from(SAMPLE_TS_NS / NS_PER_HOUR).expect("hour bucket"),
+    })
+    .expect("valid commit record");
+
+    let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+    store
+        .put(&data_key, written.bytes, PutOptions::default())
+        .await
+        .expect("put data object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish");
+}
+
+/// A query naming only the log signal (ADR-1103). Its metrics lane has no plans
+/// and returns without touching the store, so before the log lane registered a
+/// handle of its own the request registered none at all and this record was a
+/// zero.
+#[tokio::test]
+async fn usage_is_recorded_on_cancel_for_a_log_only_promql_query() {
+    let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
+    // The first listing of the whole request is the log lane's: the metrics
+    // lane never reaches the store.
+    let gate: GateHandle = fault_store.hold(Op::List, None, Occurrence::Nth(1));
+    let h = harness(
+        fault_store,
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(NoopQueryAuditSink),
+        None,
+    );
+
+    let request = range_request("ravel_log_lines{service=\"x\"}");
+    let mut query = Box::pin(h.service.promql_range(h.tenant_hash, &request));
+
+    tokio::select! {
+        _ = &mut query => panic!("the query is held inside the store call"),
+        () = gate.wait_until_held(1) => {}
+    }
+    assert_eq!(gate.held_count(), 1);
+
+    drop(query);
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].0, h.tenant_hash);
+    assert_eq!(usage[0].1, UsageStatus::Canceled);
+    assert_eq!(usage[0].2.total_s3_requests(), SPEND_BEFORE_FIRST_LIST);
+    assert_eq!(h.cost.records().len(), 0);
+}
+
+/// A query naming both signals spends through two handles, one per lane. The
+/// record owes their sum: billing the lane that happened to register last
+/// forgives whichever one the cancellation did not land in.
+#[tokio::test]
+async fn usage_on_cancel_sums_the_metrics_and_log_lanes() {
+    let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
+    // The metrics lane runs first and issues both of its listings, so the log
+    // lane's first listing is the request's third.
+    let gate: GateHandle = fault_store.hold(Op::List, None, Occurrence::Nth(LISTS_PER_RESOLVE + 1));
+    let h = harness(
+        fault_store,
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(NoopQueryAuditSink),
+        None,
+    );
+
+    let request = range_request("up + ravel_log_lines{service=\"x\"}");
+    let mut query = Box::pin(h.service.promql_range(h.tenant_hash, &request));
+
+    tokio::select! {
+        _ = &mut query => panic!("the query is held inside the log lane's store call"),
+        () = gate.wait_until_held(1) => {}
+    }
+    assert_eq!(gate.held_count(), 1);
+
+    drop(query);
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].1, UsageStatus::Canceled);
+    // The metrics lane in full, plus what the log lane had reached when the
+    // gate held it. Either part alone is a figure a lane-at-a-time view
+    // reports.
+    assert_eq!(
+        usage[0].2.total_s3_requests(),
+        SPEND_PER_RESOLVE + SPEND_BEFORE_FIRST_LIST
+    );
+    assert_eq!(h.cost.records().len(), 0);
+}
+
+/// A `/api/v1/series` request resolves each `match[]` selector separately, each
+/// through a handle of its own. A cancellation during the last one owes every
+/// selector's spend, not the last selector's.
+#[tokio::test]
+async fn usage_on_cancel_sums_every_selector_of_a_series_request() {
+    let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
+    // Two selectors resolve in full ahead of it, so the third selector's first
+    // listing is the request's fifth.
+    let gate: GateHandle =
+        fault_store.hold(Op::List, None, Occurrence::Nth(2 * LISTS_PER_RESOLVE + 1));
+    let h = harness(
+        fault_store,
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(NoopQueryAuditSink),
+        None,
+    );
+
+    let request = ravel_query::http::MetadataRequest {
+        selectors: vec!["up".to_string(), "down".to_string(), "other".to_string()],
+        ..metadata_request(false)
+    };
+    let mut query = Box::pin(h.service.series(h.tenant_hash, &request));
+
+    tokio::select! {
+        _ = &mut query => panic!("the query is held inside the third selector's store call"),
+        () = gate.wait_until_held(1) => {}
+    }
+    assert_eq!(gate.held_count(), 1);
+
+    drop(query);
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].1, UsageStatus::Canceled);
+    assert_eq!(
+        usage[0].2.total_s3_requests(),
+        2 * SPEND_PER_RESOLVE + SPEND_BEFORE_FIRST_LIST
+    );
+    assert_eq!(h.cost.records().len(), 0);
+}
+
+/// A snapshot invalidated under a running read: the object the resolve listed
+/// is gone by the time the fetch asks for it, so the engine discards the
+/// attempt and resolves again. `QueryStats` reports the surviving attempt
+/// alone, which is right, but the spend a cancellation owes is both: the
+/// discarded attempt's requests were issued and billed by the store.
+#[tokio::test]
+async fn usage_on_cancel_sums_both_attempts_of_a_retry() {
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(Op::Get, ScriptedFault::NotFoundBlip)
+            .with_key_contains(".rseg")
+            .with_occurrence(Occurrence::Nth(1)),
+    );
+    let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), plan));
+    publish_up_segment(fault_store.as_ref()).await;
+    // The first attempt resolves and then 404s on its fetch, so the second
+    // attempt's first listing is the query's third.
+    let gate: GateHandle = fault_store.hold(Op::List, None, Occurrence::Nth(LISTS_PER_RESOLVE + 1));
+    let h = harness(
+        Arc::clone(&fault_store) as Arc<dyn ObjectStoreBackend>,
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(NoopQueryAuditSink),
+        None,
+    );
+
+    let request = range_request("up");
+    let mut query = Box::pin(h.service.promql_range(h.tenant_hash, &request));
+
+    tokio::select! {
+        _ = &mut query => panic!("the query is held inside the second attempt's store call"),
+        () = gate.wait_until_held(1) => {}
+    }
+    assert_eq!(gate.held_count(), 1);
+    // The retry happened because the fault fired, not because of a race.
+    assert_eq!(fault_store.fault_count(Op::Get, FaultKind::NotFoundBlip), 1);
+
+    drop(query);
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].1, UsageStatus::Canceled);
+    // The discarded attempt in full, its 404'd fetch included, plus what the
+    // second attempt had reached. A view that replaces on each attempt reports
+    // the second part alone.
+    assert_eq!(
+        usage[0].2.total_s3_requests(),
+        SPEND_PER_RESOLVE_WITH_ONE_SEGMENT
+            + SPEND_OF_THE_INVALIDATED_FETCH
+            + SPEND_BEFORE_FIRST_LIST
+    );
+    // The same figure split by operation, so the sum above is checked against
+    // its parts rather than against itself: the discarded attempt's two
+    // listings and the held attempt's one, and four gets (two commit-record
+    // reads, the 404, and the second attempt's first read).
+    assert_eq!(usage[0].2.s3_requests(AccountedOp::List), 3);
+    assert_eq!(usage[0].2.s3_requests(AccountedOp::Get), 4);
     assert_eq!(h.cost.records().len(), 0);
 }
 

--- a/services/ravel-server/src/service/tests.rs
+++ b/services/ravel-server/src/service/tests.rs
@@ -137,6 +137,23 @@ struct Harness {
     tenant_hash: TenantHash,
 }
 
+/// The `SqlConfig` every harness here builds its executor with. The three
+/// request budgets are bounded rather than `EngineConfig::default()`'s, so a
+/// clamp against them is a real lowering a test can assert on.
+#[cfg(feature = "sql")]
+fn sql_config() -> ravel_sql::SqlConfig {
+    let base = ravel_sql::SqlConfig::default();
+    ravel_sql::SqlConfig {
+        engine: EngineConfig {
+            max_bytes_scanned: ravel_query::ByteLimit::Bounded(64 << 20),
+            max_s3_requests: ravel_query::RequestLimit::Bounded(4_096),
+            max_segments: 512,
+            ..base.engine
+        },
+        ..base
+    }
+}
+
 /// The shape every test here builds: a service over `store` with both query
 /// surfaces attached, a recording usage sink and cost recorder, and whatever
 /// admission ceiling, audit sink, and federation the test needs.
@@ -146,6 +163,29 @@ fn harness(
     audit_sink: Arc<dyn QueryAuditSink>,
     federation: Option<ravel_query::distrib::Federation>,
 ) -> Harness {
+    harness_with_sql_deadline(
+        store,
+        limit,
+        audit_sink,
+        federation,
+        Duration::from_secs(30),
+    )
+}
+
+/// [`harness`] with the SQL surface's wall-deadline ceiling chosen by the
+/// caller, for the tests that assert a request deadline is clamped to it.
+fn harness_with_sql_deadline(
+    store: Arc<dyn ObjectStoreBackend>,
+    limit: QueryConcurrencyLimit,
+    audit_sink: Arc<dyn QueryAuditSink>,
+    federation: Option<ravel_query::distrib::Federation>,
+    sql_max_deadline: Duration,
+) -> Harness {
+    // The SQL surface is behind a feature; without it there is no state to
+    // carry the ceiling.
+    #[cfg(not(feature = "sql"))]
+    let _ = sql_max_deadline;
+
     let catalog =
         Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
     let config = EngineConfig::default();
@@ -174,12 +214,31 @@ fn harness(
     };
     let exemplars = crate::exemplars::ExemplarsState::from_engine(
         engine.as_ref(),
-        catalog,
+        Arc::clone(&catalog),
         Arc::clone(&store),
         Arc::clone(&resolver),
         Arc::clone(&clock),
         Arc::new(ravel_query::GetLimiter::new(8).expect("nonzero permits")),
     );
+
+    #[cfg(feature = "sql")]
+    let sql = crate::sql::SqlState {
+        executor: Arc::new(ravel_sql::SqlExecutor::new(
+            Arc::clone(&catalog),
+            ravel_query::SegmentFetcher::new(Arc::clone(&store)),
+            ravel_query::LogSegmentFetcher::new(Arc::clone(&store)),
+            ravel_sql::SpanSegmentFetcher::new(Arc::clone(&store)),
+            sql_config(),
+            1 << 30,
+        )),
+        tenant_resolver: Arc::clone(&resolver),
+        store: Arc::clone(&store),
+        audit_sink: Arc::clone(&audit_sink),
+        clock: Arc::clone(&clock),
+        max_deadline: sql_max_deadline,
+        query_accounting: default_query_accounting(),
+        query_admission: Arc::clone(&admission),
+    };
 
     let service = QueryService::new(
         resolver,
@@ -192,6 +251,9 @@ fn harness(
     .with_engine(engine)
     .with_analytics(analytics)
     .with_exemplars(exemplars);
+
+    #[cfg(feature = "sql")]
+    let service = service.with_sql(sql);
 
     Harness {
         service,
@@ -222,6 +284,40 @@ fn analytics_request(query: &str, allow_partial: bool) -> AnalyticsRequest {
         min_tokens: Vec::new(),
         deadline: Duration::from_secs(30),
         allow_partial,
+    }
+}
+
+/// The PromQL range request the analytics one mirrors, over the same window.
+fn range_request(query: &str) -> RangeRequest {
+    RangeRequest {
+        query: query.to_string(),
+        start_ms: NOW_MS - 60_000,
+        end_ms: NOW_MS,
+        step_ms: 60_000,
+        min_tokens: Vec::new(),
+        deadline: Duration::from_secs(30),
+        allow_partial: false,
+        now_ns: NOW_NS,
+        budgets: None,
+    }
+}
+
+/// A statement over the same window, asking for nothing the server ceilings do
+/// not already allow.
+#[cfg(feature = "sql")]
+fn sql_request(sql: &str) -> ravel_sql::SqlRequest {
+    ravel_sql::SqlRequest {
+        sql: sql.to_string(),
+        window: ravel_types::TimeRange {
+            start_ns: NOW_NS - 60_000_000_000,
+            end_ns: NOW_NS,
+        },
+        min_tokens: Vec::new(),
+        now_ns: NOW_NS,
+        deadline: Duration::from_secs(30),
+        row_window: false,
+        max_rows: None,
+        budgets: None,
     }
 }
 
@@ -352,6 +448,52 @@ async fn usage_is_recorded_before_audit_failure_maps_to_error() {
     assert_eq!(usage[0].0, h.tenant_hash);
     assert_eq!(usage[0].1, UsageStatus::Success);
     assert_eq!(h.cost.records().len(), 0);
+}
+
+/// The wire contract of an audit-trail failure: the caller is told the audit
+/// is unavailable, not that storage is. The two are different operational
+/// events, and the storage string would send an operator reading a client
+/// report at the object store instead of the audit pipeline.
+///
+/// Asserted on three surfaces at once because they reach the same control
+/// through different operations; a per-surface copy of the message is exactly
+/// the drift this pins.
+#[tokio::test]
+async fn audit_failure_reports_the_audit_string_not_storage() {
+    let h = harness(
+        Arc::new(MemoryStore::new()),
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(FailingAuditSink),
+        None,
+    );
+
+    let analytics = err_of(
+        h.service
+            .analytics(h.tenant_hash, &analytics_request("up", false))
+            .await,
+    );
+    assert_eq!(analytics.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(analytics.message, ravel_query::http::MSG_AUDIT_UNAVAILABLE);
+    assert_ne!(analytics.message, ravel_query::http::MSG_UNAVAILABLE);
+
+    let promql = err_of(
+        h.service
+            .promql_range(h.tenant_hash, &range_request("up"))
+            .await,
+    );
+    assert_eq!(promql.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(promql.message, ravel_query::http::MSG_AUDIT_UNAVAILABLE);
+
+    #[cfg(feature = "sql")]
+    {
+        let sql = err_of(
+            h.service
+                .sql_execute(h.tenant_hash, &sql_request("SELECT * FROM metrics"))
+                .await,
+        );
+        assert_eq!(sql.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(sql.message, ravel_query::http::MSG_AUDIT_UNAVAILABLE);
+    }
 }
 
 /// Step 4 before step 6: a query whose coverage came back partial without the

--- a/services/ravel-server/src/service/tests.rs
+++ b/services/ravel-server/src/service/tests.rs
@@ -1,0 +1,490 @@
+//! The control ordering every query operation in this module promises.
+//!
+//! Each test here pins one step of the seven, on the path where that step used
+//! to be missing or out of order: analytics and exemplars ran outside the
+//! admission ceiling, exemplars recorded no cost at all, and only the SQL
+//! surface recorded a spend when a client disconnected mid-query. The
+//! wire-level behavior of each surface stays pinned by its own end-to-end
+//! suite; what is pinned here is the order, which no end-to-end assertion can
+//! see.
+
+#![allow(clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use ravel_catalog::{Catalog, CatalogConfig};
+use ravel_maintain::{AuditEvent, MaintainError, NoopQueryAuditSink};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::fault::{FaultPlan, FaultStore, GateHandle, Occurrence, Op};
+use ravel_object_store::memory::MemoryStore;
+use ravel_query::{EngineConfig, QueryConcurrencyLimit};
+use ravel_tenant_resolve::StaticBearerTokenResolver;
+use ravel_types::TenantId;
+use ravel_types::accounting::QueryWorkloadClass;
+
+use super::*;
+
+const TOKEN: &str = "acme-token";
+const NOW_NS: i64 = 1_700_000_000_000_000_000;
+const NOW_MS: i64 = NOW_NS / 1_000_000;
+
+/// The failure of a call whose success value is not `Debug` (an outcome
+/// carries a whole matrix), so a test can assert on the error without the
+/// service's outcome types having to derive `Debug` for it.
+fn err_of<T>(result: Result<T, ServiceError>) -> ServiceError {
+    match result {
+        Ok(_) => panic!("expected a failure"),
+        Err(err) => err,
+    }
+}
+
+fn tenant() -> TenantId {
+    TenantId::new("acme".to_string())
+}
+
+struct FixedClock;
+
+impl Clock for FixedClock {
+    fn now_ns(&self) -> i64 {
+        NOW_NS
+    }
+}
+
+fn bearer(token: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {token}")).expect("header value"),
+    );
+    headers
+}
+
+/// Every usage record the guard folded, in order, with the outcome status and
+/// the spend it carried.
+#[derive(Default)]
+struct RecordingUsage {
+    records: Mutex<Vec<(TenantHash, UsageStatus, QueryAccountingSnapshot)>>,
+}
+
+impl RecordingUsage {
+    fn records(&self) -> Vec<(TenantHash, UsageStatus, QueryAccountingSnapshot)> {
+        self.records.lock().expect("lock").clone()
+    }
+}
+
+impl QueryUsageSink for RecordingUsage {
+    fn record_usage(
+        &self,
+        tenant_hash: TenantHash,
+        status: UsageStatus,
+        accounting: &QueryAccountingSnapshot,
+        _estimate: &CostEstimate,
+    ) {
+        self.records
+            .lock()
+            .expect("lock")
+            .push((tenant_hash, status, *accounting));
+    }
+}
+
+/// Every completed-query cost record, which only a query that produced an
+/// answer folds.
+#[derive(Default)]
+struct RecordingCost {
+    records: Mutex<Vec<(TenantHash, QueryAccountingSnapshot)>>,
+}
+
+impl RecordingCost {
+    fn records(&self) -> Vec<(TenantHash, QueryAccountingSnapshot)> {
+        self.records.lock().expect("lock").clone()
+    }
+}
+
+impl QueryCostRecorder for RecordingCost {
+    fn record(
+        &self,
+        accounting: &QueryAccountingSnapshot,
+        _estimate: &CostEstimate,
+        tenant_hash: TenantHash,
+        _workload_class: QueryWorkloadClass,
+    ) {
+        self.records
+            .lock()
+            .expect("lock")
+            .push((tenant_hash, *accounting));
+    }
+}
+
+/// An audit pipeline that cannot accept the event, which is what
+/// `audit_mode=required` surfaces when its flush fails.
+struct FailingAuditSink;
+
+#[async_trait::async_trait]
+impl QueryAuditSink for FailingAuditSink {
+    async fn submit(&self, _event: AuditEvent) -> Result<(), MaintainError> {
+        Err(MaintainError::Write("audit pipeline stopped".to_string()))
+    }
+}
+
+/// One service over one store, with the sinks readable afterwards.
+struct Harness {
+    service: QueryService,
+    usage: Arc<RecordingUsage>,
+    cost: Arc<RecordingCost>,
+    admission: Arc<QueryAdmissionController>,
+    tenant_hash: TenantHash,
+}
+
+/// The shape every test here builds: a service over `store` with both query
+/// surfaces attached, a recording usage sink and cost recorder, and whatever
+/// admission ceiling, audit sink, and federation the test needs.
+fn harness(
+    store: Arc<dyn ObjectStoreBackend>,
+    limit: QueryConcurrencyLimit,
+    audit_sink: Arc<dyn QueryAuditSink>,
+    federation: Option<ravel_query::distrib::Federation>,
+) -> Harness {
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
+    let config = EngineConfig::default();
+    let engine = QueryEngine::new(Arc::clone(&catalog), Arc::clone(&store), config);
+    let engine = match federation {
+        Some(federation) => engine.with_federation(Arc::new(federation)),
+        None => engine,
+    };
+    let engine = Arc::new(engine);
+
+    let mut tokens = HashMap::new();
+    tokens.insert(TOKEN.to_string(), tenant());
+    let resolver: Arc<dyn TenantResolver> = Arc::new(StaticBearerTokenResolver::new(tokens));
+    let clock: Arc<dyn Clock> = Arc::new(FixedClock);
+    let admission = QueryAdmissionController::shared(limit);
+    let usage = Arc::new(RecordingUsage::default());
+    let cost = Arc::new(RecordingCost::default());
+
+    let analytics = crate::analytics::AnalyticsState {
+        engine: Arc::clone(&engine),
+        tenant_resolver: Arc::clone(&resolver),
+        clock: Arc::clone(&clock),
+        query_accounting: default_query_accounting(),
+        audit_sink: Arc::clone(&audit_sink),
+        query_admission: Arc::clone(&admission),
+    };
+    let exemplars = crate::exemplars::ExemplarsState::from_engine(
+        engine.as_ref(),
+        catalog,
+        Arc::clone(&store),
+        Arc::clone(&resolver),
+        Arc::clone(&clock),
+        Arc::new(ravel_query::GetLimiter::new(8).expect("nonzero permits")),
+    );
+
+    let service = QueryService::new(
+        resolver,
+        clock,
+        Arc::clone(&admission),
+        Arc::clone(&cost) as Arc<dyn QueryCostRecorder>,
+        Arc::clone(&usage) as Arc<dyn QueryUsageSink>,
+        audit_sink,
+    )
+    .with_engine(engine)
+    .with_analytics(analytics)
+    .with_exemplars(exemplars);
+
+    Harness {
+        service,
+        usage,
+        cost,
+        admission,
+        tenant_hash: tenant().hash(),
+    }
+}
+
+fn memory_harness(limit: QueryConcurrencyLimit) -> Harness {
+    harness(
+        Arc::new(MemoryStore::new()),
+        limit,
+        Arc::new(NoopQueryAuditSink),
+        None,
+    )
+}
+
+/// A one-minute range over the fixed clock's now, opted out of partial
+/// coverage unless the test says otherwise.
+fn analytics_request(query: &str, allow_partial: bool) -> AnalyticsRequest {
+    AnalyticsRequest {
+        query: query.to_string(),
+        start_ms: NOW_MS - 60_000,
+        end_ms: NOW_MS,
+        step_ms: 60_000,
+        min_tokens: Vec::new(),
+        deadline: Duration::from_secs(30),
+        allow_partial,
+    }
+}
+
+fn exemplars_request() -> ExemplarsRequest {
+    ExemplarsRequest {
+        query: "up".to_string(),
+        start_ns: NOW_NS - 60_000_000_000,
+        end_ns: NOW_NS,
+        min_tokens: Vec::new(),
+        deadline: Duration::from_secs(30),
+    }
+}
+
+/// A federation over one unavailable, skippable remote cluster, dialed by the
+/// production fetcher exactly as `--remote-cluster` wires it. The fan-out skips
+/// it and marks the coverage partial, which is the only way an evaluation can
+/// come back partial at all (intra-cluster execution never does).
+async fn dead_federation() -> ravel_query::distrib::Federation {
+    use ravel_query::distrib::{Federation, RemoteCluster};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let endpoint = listener.local_addr().expect("local addr").to_string();
+    drop(listener);
+
+    let config = crate::config::RemoteClusterConfig {
+        name: "west".to_string(),
+        endpoint,
+        credential: "operator-west-credential".to_string(),
+        tls: false,
+        tls_ca_file: None,
+        skip_unavailable: true,
+        soft_timeout: Duration::from_secs(3),
+    };
+    let fetcher = crate::distrib::FederationSliceFetcher::connect(&config)
+        .expect("federation client connects lazily");
+    Federation::new(vec![RemoteCluster {
+        name: "west".to_string(),
+        fetcher: Arc::new(fetcher),
+        skip_unavailable: true,
+        soft_timeout: Duration::from_secs(3),
+    }])
+}
+
+/// Step 1 on the analytics surface, which used to run entirely outside the
+/// fleet-global ceiling. The refusal is the same 503 body every other query
+/// surface returns, and it costs no usage record: nothing executed.
+#[tokio::test]
+async fn analytics_takes_a_query_admission_permit() {
+    let h = memory_harness(QueryConcurrencyLimit::Bounded(1));
+    let held = h.admission.try_admit().expect("the only permit");
+
+    let err = err_of(
+        h.service
+            .analytics(h.tenant_hash, &analytics_request("up", false))
+            .await,
+    );
+    // the ceiling is full
+    assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(err.kind, ServiceErrorKind::Unavailable);
+    assert_eq!(err.message, ravel_query::http::MSG_CONCURRENCY);
+    assert_eq!(h.usage.records().len(), 0);
+
+    drop(held);
+    h.service
+        .analytics(h.tenant_hash, &analytics_request("up", false))
+        .await
+        .expect("the released permit admits the next query");
+    assert_eq!(h.usage.records().len(), 1);
+}
+
+/// Step 4 and the cost fold on the exemplars surface, which recorded neither
+/// before. The two records agree: the completed-query cost is the same spend
+/// the usage record carries.
+#[tokio::test]
+async fn exemplars_records_cost() {
+    let h = memory_harness(QueryConcurrencyLimit::Unlimited);
+
+    let outcome = h
+        .service
+        .exemplars(h.tenant_hash, &exemplars_request())
+        .await
+        .expect("empty tenant resolves to an empty result");
+    assert_eq!(outcome.series.len(), 0);
+
+    let cost = h.cost.records();
+    assert_eq!(cost.len(), 1);
+    assert_eq!(cost[0].0, h.tenant_hash);
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].1, UsageStatus::Success);
+    assert_eq!(
+        cost[0].1.total_s3_requests(),
+        usage[0].2.total_s3_requests()
+    );
+    // The exact spend of a resolve against an empty tenant. Pinned rather than
+    // bounded: a cost record built from a fresh handle instead of the query's
+    // own would read zero here and still satisfy any lower bound.
+    assert_eq!(cost[0].1.total_s3_requests(), 3);
+}
+
+/// Step 4 before step 5: the audit submission fails after the query already
+/// ran and spent, so the usage record exists even though the caller gets a
+/// retryable failure. The completed-query cost fold is on the far side of the
+/// audit and does not happen: no answer was released.
+#[tokio::test]
+async fn usage_is_recorded_before_audit_failure_maps_to_error() {
+    let h = harness(
+        Arc::new(MemoryStore::new()),
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(FailingAuditSink),
+        None,
+    );
+
+    let err = err_of(
+        h.service
+            .analytics(h.tenant_hash, &analytics_request("up", false))
+            .await,
+    );
+    // an unauditable read is refused
+    assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(err.kind, ServiceErrorKind::Unavailable);
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].0, h.tenant_hash);
+    assert_eq!(usage[0].1, UsageStatus::Success);
+    assert_eq!(h.cost.records().len(), 0);
+}
+
+/// Step 4 before step 6: a query whose coverage came back partial without the
+/// caller's consent is refused, and the work it did on the way there is still
+/// recorded.
+#[tokio::test]
+async fn usage_is_recorded_before_partial_refusal() {
+    let h = harness(
+        Arc::new(MemoryStore::new()),
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(NoopQueryAuditSink),
+        Some(dead_federation().await),
+    );
+
+    let err = err_of(
+        h.service
+            .analytics(h.tenant_hash, &analytics_request("up", false))
+            .await,
+    );
+    // unconsented partial coverage is refused
+    assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(err.kind, ServiceErrorKind::Unavailable);
+    assert!(err.message.contains("set allow_partial=true"));
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].1, UsageStatus::Success);
+    assert_eq!(h.cost.records().len(), 0);
+
+    // The same evaluation with consent passes the gate, which is what makes the
+    // refusal above the gate's decision and not a failed evaluation.
+    let outcome = h
+        .service
+        .analytics(h.tenant_hash, &analytics_request("up", true))
+        .await
+        .expect("consented partial coverage is served");
+    assert!(outcome.partial);
+    assert_eq!(h.usage.records().len(), 2);
+    assert_eq!(h.cost.records().len(), 1);
+}
+
+/// Step 4 before the evaluation failure becomes a response. A rejected query
+/// records what it spent under the failed status rather than vanishing.
+#[tokio::test]
+async fn usage_is_recorded_before_evaluation_error() {
+    let h = memory_harness(QueryConcurrencyLimit::Unlimited);
+
+    let err = err_of(
+        h.service
+            .analytics(h.tenant_hash, &analytics_request("sum(", false))
+            .await,
+    );
+    // An unparseable expression is rejected during evaluation, so it carries
+    // the validation class rather than the request-parameter one.
+    assert_eq!(err.status, StatusCode::BAD_REQUEST);
+    assert_eq!(err.kind, ServiceErrorKind::Validation);
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].0, h.tenant_hash);
+    assert_eq!(usage[0].1, UsageStatus::Error);
+    assert_eq!(h.cost.records().len(), 0);
+}
+
+/// The dropped-future path: a client that disconnects mid-query leaves exactly
+/// one trace, the usage record, and no error is ever mapped because there is no
+/// caller left to map one for.
+///
+/// The hold gate is what makes the drop land mid-flight rather than racing the
+/// query's completion: the operation is parked inside a store call whose
+/// occurrence the test asserts before it drops the future.
+#[tokio::test]
+async fn usage_is_recorded_on_cancel() {
+    let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
+    let gate: GateHandle = fault_store.hold(Op::List, None, Occurrence::Nth(1));
+    let h = harness(
+        fault_store,
+        QueryConcurrencyLimit::Unlimited,
+        Arc::new(NoopQueryAuditSink),
+        None,
+    );
+
+    let request = exemplars_request();
+    // Boxed rather than `tokio::pin!`, because dropping a `Pin<&mut Future>`
+    // drops the borrow and leaves the future itself alive: the cancellation
+    // this test is about would never happen.
+    let mut query = Box::pin(h.service.exemplars(h.tenant_hash, &request));
+
+    tokio::select! {
+        _ = &mut query => panic!("the query is held inside the store call"),
+        () = gate.wait_until_held(1) => {}
+    }
+    assert_eq!(gate.held_count(), 1);
+
+    drop(query);
+
+    let usage = h.usage.records();
+    assert_eq!(usage.len(), 1);
+    assert_eq!(usage[0].0, h.tenant_hash);
+    assert_eq!(usage[0].1, UsageStatus::Canceled);
+    // The exact spend the resolve had reached when the gate held it: the two
+    // requests it issued before its first listing. Not a lower bound. Zero here
+    // would mean the drop path read a fresh handle instead of the live one.
+    assert_eq!(usage[0].2.total_s3_requests(), 2);
+    // No answer was released, so nothing folded into the completed-query cost,
+    // and no error mapping ran: the usage record is the whole trace.
+    assert_eq!(h.cost.records().len(), 0);
+}
+
+/// Authentication is outside the seven steps and runs before step 1, so an
+/// anonymous caller cannot take a permit from the fleet-global ceiling. With a
+/// ceiling of one, a rejected request followed by a valid one both succeed at
+/// what they are supposed to do.
+#[tokio::test]
+async fn unauthenticated_request_consumes_no_permit() {
+    let h = memory_harness(QueryConcurrencyLimit::Bounded(1));
+
+    let err = h
+        .service
+        .authenticate(&bearer("not-a-token"))
+        .expect_err("an unknown token resolves to no tenant");
+    assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(err.kind, ServiceErrorKind::Unauthorized);
+    assert_eq!(h.usage.records().len(), 0);
+
+    let tenant_hash = h
+        .service
+        .authenticate(&bearer(TOKEN))
+        .expect("the configured token resolves");
+    assert_eq!(tenant_hash, h.tenant_hash);
+    h.service
+        .analytics(tenant_hash, &analytics_request("up", false))
+        .await
+        .expect("the ceiling still has its one permit");
+    assert_eq!(h.usage.records().len(), 1);
+}

--- a/services/ravel-server/src/service/tests.rs
+++ b/services/ravel-server/src/service/tests.rs
@@ -1164,7 +1164,6 @@ async fn unauthenticated_request_consumes_no_permit() {
     // None of them reached admission, so the stock is still exactly the one
     // permit this test holds.
     assert_eq!(h.admission.in_flight(), 1);
-    assert_eq!(h.usage.records().len(), 0);
 
     // The positive control: the same route, the same saturated ceiling, a token
     // that does resolve. This is the answer the assertions above would have got

--- a/services/ravel-server/src/sql.rs
+++ b/services/ravel-server/src/sql.rs
@@ -58,18 +58,16 @@ use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use ravel_ingest::Clock;
-use ravel_maintain::{QueryAuditSink, QueryStatus, query_audit_event};
+use ravel_maintain::QueryAuditSink;
 use ravel_object_store::ObjectStoreBackend;
 use ravel_query::QueryAdmissionController;
 use ravel_query::http::TenantResolver;
-use ravel_sql::{ErrorClass, LiveAccounting, SqlError, SqlExecutor, SqlRequest};
-use ravel_types::accounting::{CostEstimate, QueryAccountingSnapshot};
+use ravel_sql::{SqlExecutor, SqlRequest};
 use ravel_types::{CommitToken, TenantHash, TimeRange};
 use serde::Deserialize;
 use serde_json::json;
-use tracing::Instrument;
 
-use crate::metrics::{QueryOutcomeStatus, WorkloadClass};
+use crate::service::{ApiError, QueryService, ServiceError};
 
 /// The Arrow IPC stream media type, as registered by the Arrow project.
 pub const ARROW_STREAM_MEDIA_TYPE: &str = "application/vnd.apache.arrow.stream";
@@ -120,6 +118,22 @@ pub struct SqlState {
     pub query_admission: Arc<QueryAdmissionController>,
 }
 
+impl SqlState {
+    /// The query service layer for this surface: the shared controls plus this
+    /// state. The handler below calls it, and so does the process-wide service
+    /// built in `lib.rs`, through one implementation of the controls.
+    pub fn service(&self) -> QueryService {
+        QueryService::with_metrics(
+            Arc::clone(&self.tenant_resolver),
+            Arc::clone(&self.clock),
+            Arc::clone(&self.query_admission),
+            Arc::clone(&self.query_accounting),
+            Arc::clone(&self.audit_sink),
+        )
+        .with_sql(self.clone())
+    }
+}
+
 /// The `/api/v1/sql` router.
 pub fn router(state: SqlState) -> Router {
     Router::new()
@@ -144,121 +158,24 @@ struct SqlBody {
     min_commit_token: Vec<String>,
 }
 
-/// Guarantees `run`'s query cost and outcome status reach
-/// `state.query_accounting` exactly once, on every exit from `run` -- success,
-/// error, and the one exit no `return` or `?` can reach: the enclosing
-/// request future being dropped mid-`.await` on `execute` (a client
-/// disconnect while the query is still doing object-store work). This is the
-/// same guard/`Drop` shape as `handle`'s `_permit`
-/// (`QueryAdmissionController`, ADR-0061 decision 2), applied to cost
-/// recording instead of concurrency admission.
-///
-/// `finish` is called immediately once `result` is known, before
-/// `submit_audit(..).await?` or `result.map_err(..)?` get a chance to return
-/// early, so both of those early returns run after the fold has already
-/// happened and cannot skip it. If `finish` is never reached -- the only way
-/// is the guard itself being dropped without `run` reaching that line, i.e.
-/// the whole `run` future dropped mid-`execute().await` -- `Drop::drop` runs
-/// unconditionally (Rust guarantees this for every value dropped by scope
-/// exit, `return`, `?`, panic, or an abandoned `.await`) and folds a
-/// `Canceled` record whose cost is read live from the executor's accounting
-/// handle, so a query that fetched objects for two minutes and was then
-/// dropped records what it actually spent, not zeros.
-///
-/// The guard holds a [`LiveAccounting`] handed to `SqlExecutor::execute_accounted`,
-/// which re-points it at the running attempt's counters. Both `finish` and
-/// `drop` snapshot it, so a timeout, a mid-fetch drop, and every error path
-/// record the requests and bytes issued up to that instant with the right
-/// status.
-struct CostGuard<'a> {
-    metrics: &'a crate::metrics::QueryAccountingMetrics,
-    tenant_hash: TenantHash,
-    live: LiveAccounting,
-    finished: bool,
-}
-
-impl<'a> CostGuard<'a> {
-    fn new(
-        metrics: &'a crate::metrics::QueryAccountingMetrics,
-        tenant_hash: TenantHash,
-        live: LiveAccounting,
-    ) -> Self {
-        CostGuard {
-            metrics,
-            tenant_hash,
-            live,
-            finished: false,
-        }
-    }
-
-    /// Record the real outcome. Consumes the guard so a second call is a
-    /// compile error, not a double fold.
-    fn finish(
-        mut self,
-        status: QueryOutcomeStatus,
-        accounting: &QueryAccountingSnapshot,
-        estimate: &CostEstimate,
-    ) {
-        self.metrics
-            .record_outcome(self.tenant_hash, status, accounting, estimate);
-        self.finished = true;
-    }
-}
-
-impl Drop for CostGuard<'_> {
-    fn drop(&mut self) {
-        if !self.finished {
-            // The run future was dropped mid-`execute` (a client disconnect
-            // while the query was still doing object-store work). Record the
-            // cost issued up to this instant, read live from the executor's
-            // accounting handle -- not zeros.
-            self.metrics.record_outcome(
-                self.tenant_hash,
-                QueryOutcomeStatus::Canceled,
-                &self.live.snapshot(),
-                &CostEstimate::new(0, 0, 0, 0, 0),
-            );
-        }
-    }
-}
-
-/// The outcome status for a failed query, from the `SqlError` class alone. A
-/// wall-deadline trip is a `Timeout`; every other error is an `Error`. The cost
-/// recorded alongside it is read from the live accounting handle, not derived
-/// from the error variant, so `DeadlineExceeded` and a dropped future carry the
-/// real requests and bytes the query issued rather than zeros.
-fn error_status(err: &SqlError) -> QueryOutcomeStatus {
-    match err.class() {
-        ErrorClass::Timeout => QueryOutcomeStatus::Timeout,
-        _ => QueryOutcomeStatus::Error,
-    }
-}
-
 async fn handle(State(state): State<SqlState>, req: Request<Body>) -> Response {
-    // Fleet-global concurrency admission (ADR-0061 decision 2): decide before
-    // `run` does any resolve or GET. The permit is held for the whole request and
-    // released on return (success or error) or on a dropped request future, by
-    // its `Drop`.
-    let _permit = match state.query_admission.try_admit() {
-        Ok(permit) => permit,
-        Err(_) => {
-            return ApiError {
-                status: StatusCode::SERVICE_UNAVAILABLE,
-                error_type: "unavailable",
-                message: "fleet query concurrency ceiling reached; retry".to_string(),
-            }
-            .into_response();
-        }
-    };
     match run(&state, req).await {
         Ok(response) => response,
         Err(err) => err.into_response(),
     }
 }
 
-async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError> {
+/// Parse, authenticate, ask the query service layer, encode. Fleet-global
+/// admission, the usage record on every exit path (the dropped-future exit
+/// included), the audit event and its durability wait, and error redaction all
+/// happen inside [`QueryService::sql_execute`], shared with every other query
+/// surface.
+///
+/// Authentication runs here, before the service takes a permit, so an anonymous
+/// caller no longer consumes one from the fleet-global concurrency ceiling.
+async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ServiceError> {
     let headers = req.headers().clone();
-    let tenant_hash = authenticate(state, &headers)?;
+    let tenant_hash = crate::service::authenticate(state.tenant_resolver.as_ref(), &headers)?;
 
     let body = axum::body::to_bytes(req.into_body(), MAX_BODY_BYTES)
         .await
@@ -269,106 +186,14 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
     let now_ns = state.clock.now_ns();
     let request = build_request(&body, now_ns, state.max_deadline)?;
 
-    // A request-level span carrying only bounded values (ADR-0044 section 5):
-    // the tenant hash, the workload class, and -- recorded once the query
-    // finishes -- the final store request and byte counts. No query text, label
-    // values, or object keys ever become span fields. Every SQL statement over
-    // this transport is an interactive, client-driven query.
-    let span = tracing::info_span!(
-        "sql_query",
-        tenant_hash = %tenant_hash.to_hex(),
-        workload_class = WorkloadClass::Interactive.name(),
-        s3_requests = tracing::field::Empty,
-        s3_bytes = tracing::field::Empty,
-    );
-
-    // The live accounting handle: the executor re-points it at the running
-    // query's counters, and the guard snapshots it on every exit -- including
-    // the dropped-future and timeout exits that carry no `SqlOutcome`.
-    let live = LiveAccounting::new();
-
-    // Constructed before `execute` is awaited so a dropped `run` future
-    // (client disconnect mid-query) still folds a Canceled record through its
-    // `Drop` -- see `CostGuard`'s doc comment for the full mechanism.
-    let cost_guard = CostGuard::new(&state.query_accounting, tenant_hash, live.clone());
-
-    // The query has now reached execution for a resolved tenant, so it is
-    // auditable (ADR-0042 decision 4, ADR-0062 §2a). Run it, then submit
-    // exactly one query-audit event for the outcome - success or the specific
-    // SqlError - through the shared sink and await its durability before
-    // mapping the result to a response. Requests rejected earlier (no tenant,
-    // an unreadable body, or invalid request parameters) never reach here and
-    // are not audited: there is no executed query to attribute.
-    let result = state
-        .executor
-        .execute_accounted(tenant_hash, &request, &live)
-        .instrument(span.clone())
-        .await;
-    let status = match &result {
-        Ok(_) => QueryStatus::Ok,
-        Err(_) => QueryStatus::Error,
-    };
-
-    // Fold the real outcome on EVERY exit past this point (issue #809): this
-    // runs before `submit_audit`'s `?` and `result.map_err(..)?` below, so an
-    // audit-write failure or a redacted `SqlError` can no longer skip cost
-    // recording the way only the success path used to reach it.
-    match &result {
-        Ok(outcome) => {
-            cost_guard.finish(
-                QueryOutcomeStatus::Success,
-                &outcome.accounting,
-                &outcome.estimate,
-            );
-        }
-        Err(err) => {
-            // The live handle carries the requests and bytes the query issued
-            // before it failed, including a fetch still outstanding when a
-            // deadline tripped. The estimate is only known on the success path.
-            cost_guard.finish(
-                error_status(err),
-                &live.snapshot(),
-                &CostEstimate::new(0, 0, 0, 0, 0),
-            );
-        }
-    }
-
-    submit_audit(
-        state,
-        tenant_hash,
-        now_ns,
-        &request.sql,
-        status,
-        request.window.start_ns,
-        request.window.end_ns,
-    )
-    .await?;
-
-    let outcome = result.map_err(|err| ApiError::from_sql(err, tenant_hash))?;
-
-    // Fold this query's actual cost and its pre-execution estimate into the
-    // process-global aggregator for `/metrics` (ADR-0044 section 4), and record
-    // the final counts on the span. The executor already built and dropped a
-    // fresh `QueryAccounting` per attempt; `outcome.accounting` is the
-    // successful attempt's snapshot, so a retried attempt's counters never
-    // bleed in. Unchanged by the outcome-status fold above: this is the
-    // pre-existing `ravel_query_*` family, fed only on success as before, and
-    // `CostGuard` folds into its own independent map.
-    span.record("s3_requests", outcome.accounting.total_s3_requests());
-    span.record("s3_bytes", outcome.accounting.total_s3_bytes());
-    state.query_accounting.record(
-        tenant_hash,
-        WorkloadClass::Interactive,
-        &outcome.accounting,
-        &outcome.estimate,
-    );
+    let outcome = state.service().sql_execute(tenant_hash, &request).await?;
 
     // Fold this query's LogsScanExec block counters into the process-global
     // prune-selectivity totals. These are the scan's own
     // DataFusion counters, read off the plan in ravel-sql and surfaced on
     // `stats`; a metrics query passes zeros and moves nothing. Separate from
-    // the cost aggregator above: that one answers "what did this query
-    // spend", this one answers "how much did POSTINGS let it skip".
+    // the cost aggregator in the service layer: that one answers "what did this
+    // query spend", this one answers "how much did POSTINGS let it skip".
     crate::query_postings_metrics::record(
         outcome.stats.blocks_total,
         outcome.stats.blocks_scanned,
@@ -377,62 +202,6 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
 
     let stats = crate::query::accounting_stats_json(&outcome.accounting, &outcome.estimate);
     encode(&headers, &outcome, tenant_hash, stats)
-}
-
-/// Submit the query-audit event for one request through the shared sink and
-/// await its durability (ADR-0062 §2a). Unlike a direct-write path
-/// that logs and swallows a write failure so a successful
-/// query stays a success, the audit trail is a release gate: in
-/// `audit_mode=required` a flush failure (or a stopped pipeline) returns an
-/// error here and the request fails closed with a retryable 503, the
-/// deliberate inversion of "queries outlive the trail". In
-/// `audit_mode=best-effort` the pipeline resolves the submission to `Ok`, so
-/// this returns `Ok` and the response is released. The record is written by the
-/// server from the resolved tenant, never derived from a client body, so a
-/// tenant cannot forge or suppress it.
-#[allow(clippy::too_many_arguments)]
-async fn submit_audit(
-    state: &SqlState,
-    tenant_hash: TenantHash,
-    now_ns: i64,
-    query_text: &str,
-    status: QueryStatus,
-    window_start_ns: i64,
-    window_end_ns: i64,
-) -> Result<(), ApiError> {
-    let event = query_audit_event(
-        &tenant_hash,
-        now_ns,
-        query_text,
-        "sql",
-        status,
-        window_start_ns,
-        window_end_ns,
-    );
-    state.audit_sink.submit(event).await.map_err(|err| {
-        tracing::warn!(
-            tenant = %tenant_hash.to_hex(),
-            error = %err,
-            "query-audit submission failed; failing the request closed (audit_mode=required)",
-        );
-        ApiError {
-            status: StatusCode::SERVICE_UNAVAILABLE,
-            error_type: "unavailable",
-            message: "query audit is temporarily unavailable; retry".to_string(),
-        }
-    })
-}
-
-fn authenticate(state: &SqlState, headers: &HeaderMap) -> Result<TenantHash, ApiError> {
-    state
-        .tenant_resolver
-        .resolve(headers)
-        .map(|tenant| tenant.hash())
-        .map_err(|_| ApiError {
-            status: StatusCode::UNAUTHORIZED,
-            error_type: "unauthorized",
-            message: "authentication required".to_string(),
-        })
 }
 
 /// Turn the request body into a [`SqlRequest`], resolving the window and
@@ -526,12 +295,12 @@ fn encode(
     outcome: &ravel_sql::SqlOutcome,
     tenant_hash: TenantHash,
     stats: serde_json::Value,
-) -> Result<Response, ApiError> {
+) -> Result<Response, ServiceError> {
     if wants_arrow(headers) {
         let bytes = outcome
             .output
             .to_arrow_ipc()
-            .map_err(|err| ApiError::from_sql(err, tenant_hash))?;
+            .map_err(|err| ServiceError::from_sql(err, tenant_hash))?;
         return Ok((
             StatusCode::OK,
             [(header::CONTENT_TYPE, ARROW_STREAM_MEDIA_TYPE)],
@@ -543,7 +312,7 @@ fn encode(
     let data = outcome
         .output
         .to_json()
-        .map_err(|err| ApiError::from_sql(err, tenant_hash))?;
+        .map_err(|err| ServiceError::from_sql(err, tenant_hash))?;
     Ok((
         StatusCode::OK,
         axum::Json(json!({ "status": "success", "data": data, "stats": stats })),
@@ -558,88 +327,11 @@ fn wants_arrow(headers: &HeaderMap) -> bool {
         .is_some_and(|accept| accept.contains(ARROW_STREAM_MEDIA_TYPE))
 }
 
-/// A client-visible error: a status, a stable type tag, and a message that
-/// has already passed the redaction boundary.
-///
-/// `Debug` is safe to derive precisely because every field is already
-/// redacted: there is no unredacted source error held here to leak through a
-/// stray `{:?}`.
-#[derive(Debug)]
-struct ApiError {
-    status: StatusCode,
-    error_type: &'static str,
-    message: String,
-}
-
-impl ApiError {
-    /// Errors raised by this module before the query runs. The messages
-    /// describe the caller's own request and carry no server state.
-    fn bad_request(message: String) -> Self {
-        ApiError {
-            status: StatusCode::BAD_REQUEST,
-            error_type: "bad_data",
-            message,
-        }
-    }
-
-    /// The redaction boundary. The full error is logged here, once, with the
-    /// tenant hash as a structured field (server-side logs may carry it; a
-    /// client body may not). The body gets `client_message()` and nothing
-    /// else -- in particular never `{err}`.
-    fn from_sql(err: SqlError, tenant_hash: TenantHash) -> Self {
-        let message = err.client_message();
-        let (status, error_type) = match err.class() {
-            ErrorClass::BadRequest => (StatusCode::BAD_REQUEST, "bad_data"),
-            ErrorClass::Unsupported => (StatusCode::UNPROCESSABLE_ENTITY, "execution"),
-            ErrorClass::Unavailable => (StatusCode::SERVICE_UNAVAILABLE, "unavailable"),
-            ErrorClass::Timeout => (StatusCode::GATEWAY_TIMEOUT, "timeout"),
-        };
-
-        // Client-caused rejections are not operational events; log them at
-        // debug so a scripted client cannot flood warn-level logs. Everything
-        // else keeps warn, because it is either a storage fault or a bug.
-        if status == StatusCode::BAD_REQUEST {
-            tracing::debug!(
-                tenant = %tenant_hash.to_hex(),
-                error = %err,
-                client_message = %message,
-                "sql request rejected",
-            );
-        } else {
-            tracing::warn!(
-                tenant = %tenant_hash.to_hex(),
-                error = %err,
-                client_message = %message,
-                "sql query error redacted from client response",
-            );
-        }
-
-        ApiError {
-            status,
-            error_type,
-            message,
-        }
-    }
-}
-
-impl IntoResponse for ApiError {
-    fn into_response(self) -> Response {
-        (
-            self.status,
-            axum::Json(json!({
-                "status": "error",
-                "errorType": self.error_type,
-                "error": self.message,
-            })),
-        )
-            .into_response()
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use ravel_sql::SqlError;
 
     fn body(json: &str) -> SqlBody {
         serde_json::from_str(json).expect("valid body")
@@ -749,7 +441,7 @@ mod tests {
             ),
         ];
         for (err, status, error_type) in cases {
-            let api = ApiError::from_sql(err, tenant);
+            let api = ServiceError::from_sql(err, tenant);
             assert_eq!(api.status, status);
             assert_eq!(api.error_type, error_type);
         }

--- a/services/ravel-server/tests/analytics_endpoint.rs
+++ b/services/ravel-server/tests/analytics_endpoint.rs
@@ -153,6 +153,7 @@ fn build_router_with_sink(
             std::collections::HashSet::new(),
         )),
         audit_sink,
+        query_admission: AnalyticsState::unlimited_admission(),
     })
 }
 
@@ -216,6 +217,7 @@ fn build_router_distributed(
             std::collections::HashSet::new(),
         )),
         audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+        query_admission: AnalyticsState::unlimited_admission(),
     })
 }
 
@@ -876,6 +878,7 @@ async fn federated_app(metric: &str, samples: &[(i64, f64)]) -> Router {
             std::collections::HashSet::new(),
         )),
         audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+        query_admission: AnalyticsState::unlimited_admission(),
     })
 }
 

--- a/services/ravel-server/tests/mtls_query_service.rs
+++ b/services/ravel-server/tests/mtls_query_service.rs
@@ -1,0 +1,147 @@
+//! The mTLS listener's query service layer authenticates with the mTLS
+//! resolver (ADR-0050 section 1, ADR-1374 decision 3).
+//!
+//! The two listeners share one admission controller, one cost recorder, one
+//! usage sink, and one engine, but never one tenant resolver: the public
+//! listener derives the tenant from a bearer token and the mTLS listener from
+//! the peer certificate its terminator presents. A single service instance
+//! reachable from both would authenticate a certificate-identified caller
+//! against the bearer-token resolver.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use ravel_object_store::memory::MemoryStore;
+use ravel_server::{FoldTaskConfig, Mode, ServerConfig};
+use ravel_types::TenantId;
+
+const TOKEN: &str = "public-token";
+const TENANT: &str = "acme";
+const MTLS_TOKEN: &str = "mtls-token";
+const MTLS_TENANT: &str = "beta";
+
+fn bearer(token: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {token}")).expect("header value"),
+    );
+    headers
+}
+
+/// A query-serving process with both listeners bound, each on its own resolver
+/// over a disjoint token set, so a credential that works on one is invalid on
+/// the other.
+async fn start_test_server() -> ravel_server::Running {
+    let mut tokens = HashMap::new();
+    tokens.insert(TOKEN.to_string(), TenantId::new(TENANT));
+    let tenant_resolver = ravel_server::tenant::build_resolver(tokens, false);
+
+    let mut mtls_tokens = HashMap::new();
+    mtls_tokens.insert(MTLS_TOKEN.to_string(), TenantId::new(MTLS_TENANT));
+    let mtls_resolver = ravel_server::tenant::build_resolver(mtls_tokens, false);
+
+    let store = Arc::new(MemoryStore::new());
+    let config = ServerConfig {
+        query_budgets: Default::default(),
+        max_inflight_flushes: 1,
+        adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
+        mode: Mode::All,
+        listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
+        listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
+        shard_count: 1,
+        tenant_resolver,
+        mtls_listener: Some(ravel_server::MtlsListenerConfig {
+            addr: "127.0.0.1:0".parse().expect("valid loopback addr"),
+            resolver: mtls_resolver,
+        }),
+        fold_tenants: Vec::new(),
+        fold: FoldTaskConfig {
+            enabled: false,
+            ..FoldTaskConfig::default()
+        },
+        maintain: ravel_server::MaintenanceTaskConfig::default(),
+        alerting: ravel_server::AlertEvalConfig::default(),
+        oidc_refresh: None,
+        otap: false,
+        metrics_tenant_labels: false,
+        limits: ravel_server::LimitsConfig::default(),
+        deployment_key: None,
+        gc: ravel_maintain::GcConfigValues::maintain_defaults(),
+        query_deadline: ravel_query::EngineConfig::default().deadline,
+        store_probe_interval: ravel_server::store_probe::DEFAULT_STORE_PROBE_INTERVAL,
+        admission_reconcile_interval: ravel_ingest::DEFAULT_ADMISSION_RECONCILE_INTERVAL,
+        query_concurrency_limit: ravel_query::QueryConcurrencyLimit::Unlimited,
+        max_s3_requests: ravel_query::EngineConfig::default().max_s3_requests,
+        scrub_period: std::time::Duration::from_secs(7 * 86_400),
+        indexed_fields: Default::default(),
+        typed_attr_columns: Default::default(),
+        disable_cache: false,
+        cache_max_bytes: 256 * 1024 * 1024,
+        catalog_cache_max_bytes: 256 * 1024 * 1024,
+        cache_dir: None,
+        catalog_resolve_concurrency: None,
+        ingest_buffer_budget_limit: ravel_server::IngestByteBudgetLimit::Unlimited,
+        idle_tenant_state_ttl: std::time::Duration::from_secs(3600),
+        distrib: None,
+        remote_clusters: Vec::new(),
+        ingest_concurrency_limit: ravel_server::ingest_concurrency::IngestConcurrencyLimit::Bounded(
+            1024,
+        ),
+    };
+    ravel_server::start(
+        config,
+        store.clone(),
+        store.clone(),
+        Arc::new(ravel_object_store::StoreMetrics::default()),
+        None,
+    )
+    .await
+    .expect("server starts")
+}
+
+#[tokio::test]
+async fn mtls_router_service_authenticates_with_the_mtls_resolver() {
+    let running = start_test_server().await;
+
+    let mtls_service = running
+        .mtls_query_service
+        .as_ref()
+        .expect("an mTLS listener was configured on a query-serving mode");
+    let public_service = running
+        .query_service
+        .as_ref()
+        .expect("a query-serving mode builds the public listener's service");
+
+    // The two instances are not the same one: each accepts its own listener's
+    // credential and rejects the other's.
+    assert_eq!(
+        mtls_service
+            .authenticate(&bearer(MTLS_TOKEN))
+            .expect("the mTLS resolver knows the mTLS credential"),
+        TenantId::new(MTLS_TENANT).hash(),
+    );
+    assert_eq!(
+        public_service
+            .authenticate(&bearer(TOKEN))
+            .expect("the public resolver knows the public credential"),
+        TenantId::new(TENANT).hash(),
+    );
+
+    let err = mtls_service
+        .authenticate(&bearer(TOKEN))
+        .expect_err("the public listener's credential is not an mTLS identity");
+    assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+    let err = public_service
+        .authenticate(&bearer(MTLS_TOKEN))
+        .expect_err("the mTLS credential is not a public-listener identity");
+    assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+
+    running.shutdown().await.expect("clean shutdown");
+}


### PR DESCRIPTION
T2a of epic #1374 (ADR-1374 D1). One query service layer now holds the
controls every query route shares: the admission permit, tenant
authentication before admission, the lower-only deadline and budget
clamps, usage finalization on every exit path including a dropped future,
the audit submit-and-await, the partial-coverage consent gate, and the
error redaction. The policy core sits in ravel-query's http module so the
Prometheus-shaped handlers can use it, and QueryService in ravel-server is
the facade the HTTP handlers and the coming MCP adapter call. Analytics
and exemplars now take an admission permit, exemplars records cost, the
label routes submit an audit event, and PromQL records usage when a client
disconnects. Wire-visible behavior is otherwise unchanged and the existing
end-to-end suites pass unmodified.

After the checkpoint review, two fix rounds landed on the same branch: the
audit-failure body string shared with Flight, the usage sink wired for the
PromQL routes with an additive live view that bills a cancelled query for
every lane, selector, and attempt, a service for the mTLS listener built
from its own resolver, clamping on the SQL operations, and a
non-vacuous authenticate-before-admit test.

Fixes: #1377
Refs: #1374
