### PR TITLE
fix(check-tla): cap TLC workers and JVM heap instead of auto/unbounded

### DIFF
--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -70,6 +70,16 @@ later if TERM was ignored. Either way the run is reported as a timeout, not
 left running and not read as a pass. CI runs on Ubuntu, which ships GNU
 `timeout`, so it needs no extra setup.
 
+TLC's worker count and JVM heap cap are fixed, not left to `-workers auto`
+(which claims every core on the host) or an uncapped `-Xmx`:
+`RAVEL_TLA_WORKERS` (default `2`) and `RAVEL_TLA_XMX` (default `2g`) control
+them. Both are validated before any model runs -- `RAVEL_TLA_WORKERS` must
+be a positive integer and `RAVEL_TLA_XMX` must match the JVM's `-Xmx`
+grammar (digits then `k`, `m`, or `g`) -- and a bad value exits 2 with a
+one-line refusal rather than reaching TLC as a silently wrong flag. The
+resolved values are printed once per run (`check-tla: resources:
+workers=<n> xmx=<size>`), next to the figures they produced.
+
 ```sh
 scripts/check-tla.sh smoke            # fast safety, every area (budget 300s/cfg)
 scripts/check-tla.sh negative         # every negative control must fail correctly
@@ -82,9 +92,10 @@ scripts/check-tla.sh smoke -a common  # scope any subcommand to one area
 
 `ci` and `all` record every model under a single run id, so `last-run.tsv` is
 one coherent run rather than a config's rows overwriting the previous config's.
-Exit codes: `0` pass, `1` a check failed, `2` no usable Java or GNU
-timeout(1) unavailable. A subcommand or
-`-a` area that does not exist, and `-a` with no value, fail immediately.
+Exit codes: `0` pass, `1` a check failed, `2` no usable Java, GNU timeout(1)
+unavailable, or an invalid `RAVEL_TLA_WORKERS`/`RAVEL_TLA_XMX` value. A
+subcommand or `-a` area that does not exist, and `-a` with no value, fail
+immediately.
 
 ### The TLC jar
 
@@ -125,7 +136,7 @@ Bands are optional and live in each area's `bands.tsv`, one row per config
 exists the harness enforces it on a PASS run and fails outside it; a run
 outside the band is a regression to investigate, not a band to widen.
 Negative controls stop at the first counterexample TLC finds, which under
-`-workers auto` is not deterministic, so they carry no band. `results.md`
+multiple workers is not deterministic, so they carry no band. `results.md`
 records the figures a run produced and the bands they must stay in.
 
 ## Negative controls

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -22,6 +22,12 @@
 # is fetched once into .cache/tla (gitignored). A checksum mismatch refuses to
 # run. Java is taken from RAVEL_TLA_JAVA if set, else the `java` on PATH;
 # version 17 or newer is required.
+#
+# TLC's worker count and JVM heap cap come from RAVEL_TLA_WORKERS (default 2)
+# and RAVEL_TLA_XMX (default 2g). Both are validated (a positive integer; a
+# size matching the JVM's -Xmx grammar: digits then k, m, or g) and refused
+# with a one-line message otherwise; the resolved values are printed once
+# per run.
 set -u
 
 TLA_VERSION="1.7.4"
@@ -65,6 +71,26 @@ resolve_java() {
     fi
     JAVA="$java"
     note "java: $java (version $ver)"
+}
+
+# resolve_tla_resources: read the TLC worker count and JVM heap cap from
+# RAVEL_TLA_WORKERS / RAVEL_TLA_XMX (defaults 2 / 2g). `-workers auto` claims
+# every core on the host, and an uncapped heap on a loaded or shared machine
+# is the failure this guards: both are fixed and small unless overridden, and
+# both are validated so a typo fails closed instead of reaching TLC as a
+# silently wrong flag.
+resolve_tla_resources() {
+    TLA_WORKERS="${RAVEL_TLA_WORKERS:-2}"
+    if ! printf '%s' "$TLA_WORKERS" | grep -qE '^[0-9]+$' || [ "$TLA_WORKERS" -eq 0 ]; then
+        note "RAVEL_TLA_WORKERS must be a positive integer, got '$TLA_WORKERS'"
+        exit 2
+    fi
+    TLA_XMX="${RAVEL_TLA_XMX:-2g}"
+    if ! printf '%s' "$TLA_XMX" | grep -qE '^[0-9]+[kKmMgG]$'; then
+        note "RAVEL_TLA_XMX must match the JVM -Xmx grammar (digits then k, m, or g), got '$TLA_XMX'"
+        exit 2
+    fi
+    note "resources: workers=$TLA_WORKERS xmx=$TLA_XMX"
 }
 
 # resolve_timeout: pick GNU timeout(1) once, before any lane launches
@@ -222,8 +248,8 @@ run_tlc() {
     local libpath="$FORMAL_DIR/common:$area_dir"
     local code=0
     ( cd "$area_dir" && "$TIMEOUT_BIN" "--kill-after=$TIMEOUT_KILL_AFTER" "$budget" \
-        "$JAVA" -XX:+UseParallelGC -DTLA-Library="$libpath" -cp "$JAR" tlc2.TLC \
-        -config "$cfg" -metadir "$metadir" -workers auto $deadlock "$module" ) > "$logfile" 2>&1 || code=$?
+        "$JAVA" -XX:+UseParallelGC -Xmx"$TLA_XMX" -DTLA-Library="$libpath" -cp "$JAR" tlc2.TLC \
+        -config "$cfg" -metadir "$metadir" -workers "$TLA_WORKERS" $deadlock "$module" ) > "$logfile" 2>&1 || code=$?
     if [ "$code" -eq 137 ]; then
         note "$area/$module: ignored TERM at the ${budget}s budget, needed the ${TIMEOUT_KILL_AFTER}s kill-after grace period"
         code=124
@@ -582,7 +608,7 @@ main() {
     # at all.
     case "$cmd" in
         traceability) : ;;
-        *) resolve_timeout; resolve_java ;;
+        *) resolve_timeout; resolve_java; resolve_tla_resources ;;
     esac
 
     local areas

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -21,13 +21,11 @@ bad()  { printf 'FAIL  %s\n' "$1"; fail=$((fail + 1)); }
 # `main "$@"` call on the last line) so run_tlc can be driven directly,
 # against a throwaway FORMAL_DIR/CACHE_DIR, without needing the real TLC jar
 # or network access.
+LIB_SRC="$(mktemp)"
 source_lib() {
-    local tmp_src
-    tmp_src="$(mktemp)"
-    sed '$d' "$SCRIPT" > "$tmp_src"
+    sed '$d' "$SCRIPT" > "$LIB_SRC"
     # shellcheck disable=SC1090
-    source "$tmp_src"
-    rm -f "$tmp_src"
+    source "$LIB_SRC"
 }
 source_lib
 
@@ -50,6 +48,7 @@ run_tlc_case() {
     JAVA="$shim"
     JAR="/dev/null"
     resolve_timeout
+    resolve_tla_resources
 
     logfile="$tmp/tlc.log"
     start=$(date +%s)
@@ -290,5 +289,109 @@ echo "(c) is proved manually and reported, not replayed here: it needs the" \
      "real TLC jar, network on first fetch, and a JDK, none of which this" \
      "unit test provisions."
 
+# --- (g)-(j) issue #1421: RAVEL_TLA_WORKERS / RAVEL_TLA_XMX -----------------
+# `-workers auto` claims every core on the host and TLC's heap was left
+# uncapped; a shared or loaded box needs both fixed. A java shim that never
+# launches TLC, only records its own argv, proves what run_tlc actually
+# constructs without needing the real jar.
+run_tlc_args_case() {
+    # run_tlc_args_case -> sets CASE_ARGS_FILE (one argv token per line) and
+    # CASE_TMP, via a java shim that records "$@" and exits 0.
+    local tmp area_dir shim logfile
+    tmp="$(mktemp -d)"
+    area_dir="$tmp/area"
+    mkdir -p "$area_dir"
+    : > "$area_dir/smoke.cfg"
+    shim="$tmp/java"
+    cat > "$shim" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$tmp/args"
+exit 0
+EOF
+    chmod +x "$shim"
+
+    FORMAL_DIR="$tmp"
+    CACHE_DIR="$tmp/cache"
+    mkdir -p "$CACHE_DIR"
+    JAVA="$shim"
+    JAR="/dev/null"
+    resolve_timeout
+
+    logfile="$tmp/tlc.log"
+    run_tlc area module "$area_dir/smoke.cfg" 5 "$logfile" >/dev/null 2>&1
+    CASE_ARGS_FILE="$tmp/args"
+    CASE_TMP="$tmp"
+}
+
+# args_has_flag_value <file> <flag> <value> -> true if <flag> is followed by
+# <value> on the next line (a space-separated pair, e.g. "-workers" "2").
+args_has_flag_value() {
+    awk -v f="$2" -v v="$3" '
+        $0 == f { getline nxt; if (nxt == v) { found = 1 } }
+        END { exit !found }
+    ' "$1"
+}
+
+echo "--- (g) default resources: -workers 2 -Xmx2g"
+unset RAVEL_TLA_WORKERS RAVEL_TLA_XMX
+resolve_tla_resources
+gcode=$?
+if [ "$gcode" -eq 0 ]; then ok; else bad "g: resolve_tla_resources exited $gcode on defaults"; fi
+run_tlc_args_case
+if grep -qxF -- '-Xmx2g' "$CASE_ARGS_FILE" 2>/dev/null; then
+    ok
+else
+    bad "g: expected -Xmx2g in argv; got: $(cat "$CASE_ARGS_FILE" 2>/dev/null)"
+fi
+if args_has_flag_value "$CASE_ARGS_FILE" -workers 2; then
+    ok
+else
+    bad "g: expected -workers 2 in argv; got: $(cat "$CASE_ARGS_FILE" 2>/dev/null)"
+fi
+rm -rf "$CASE_TMP"
+
+echo "--- (h) override RAVEL_TLA_WORKERS=4 RAVEL_TLA_XMX=4g"
+RAVEL_TLA_WORKERS=4 RAVEL_TLA_XMX=4g resolve_tla_resources
+hcode=$?
+if [ "$hcode" -eq 0 ]; then ok; else bad "h: resolve_tla_resources exited $hcode on a valid override"; fi
+run_tlc_args_case
+if grep -qxF -- '-Xmx4g' "$CASE_ARGS_FILE" 2>/dev/null; then
+    ok
+else
+    bad "h: expected -Xmx4g in argv; got: $(cat "$CASE_ARGS_FILE" 2>/dev/null)"
+fi
+if args_has_flag_value "$CASE_ARGS_FILE" -workers 4; then
+    ok
+else
+    bad "h: expected -workers 4 in argv; got: $(cat "$CASE_ARGS_FILE" 2>/dev/null)"
+fi
+rm -rf "$CASE_TMP"
+unset RAVEL_TLA_WORKERS RAVEL_TLA_XMX
+
+echo "--- (i) RAVEL_TLA_WORKERS=auto is rejected"
+iout=""
+iout="$(RAVEL_TLA_WORKERS=auto bash -c "source '$LIB_SRC'; resolve_tla_resources" 2>&1)"
+icode=$?
+echo "    measured: exit=$icode"
+if [ "$icode" -eq 2 ]; then ok; else bad "i: expected exit 2, got $icode"; fi
+if printf '%s' "$iout" | grep -qF 'RAVEL_TLA_WORKERS'; then
+    ok
+else
+    bad "i: refusal message missing RAVEL_TLA_WORKERS; got: $iout"
+fi
+
+echo "--- (j) RAVEL_TLA_XMX=lots is rejected"
+jout=""
+jout="$(RAVEL_TLA_XMX=lots bash -c "source '$LIB_SRC'; resolve_tla_resources" 2>&1)"
+jcode=$?
+echo "    measured: exit=$jcode"
+if [ "$jcode" -eq 2 ]; then ok; else bad "j: expected exit 2, got $jcode"; fi
+if printf '%s' "$jout" | grep -qF 'RAVEL_TLA_XMX'; then
+    ok
+else
+    bad "j: refusal message missing RAVEL_TLA_XMX; got: $jout"
+fi
+
+rm -f "$LIB_SRC"
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
scripts/check-tla.sh ran every TLC lane with -workers auto and no -Xmx.
On the shared build box every session is told never to let TLC pick its
own worker count and always to cap the heap, because a state space grows
without bound and an uncapped JVM on a loaded host is the failure that
rule exists for; on a sixteen-core executor the lifecycle lane took
sixteen workers.

The script now reads RAVEL_TLA_WORKERS (default 2) and RAVEL_TLA_XMX
(default 2g), validates both and fails closed on anything else, passes
them on every TLC invocation it makes, and prints the two values once per
run in its log line so a band mismatch can be read against the
configuration that produced it. The self-test asserts the exact defaults,
a verbatim override, and the two rejections, and the README documents the
knobs.

Fixes: #1421
