### PR TITLE
fix(check-tla): cap TLC workers and JVM heap instead of auto/unbounded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,11 +242,24 @@ jobs:
           # The job executes scripts/check-tla.sh from the PR itself; do not
           # leave the checkout token in .git/config for it to read.
           persist-credentials: false
+      # Self-test the harness's own resource-resolution and timeout logic
+      # before running any model. It drives shell functions only, needs no
+      # JVM and no TLC jar, so it runs here rather than in a compiling lane.
+      - name: check-tla.sh self-test
+        run: bash scripts/check-tla.test.sh
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
           java-version: "21"
       - name: Fast lane (smoke, negatives, traceability)
+        # State CI's resource choice rather than inheriting the script's
+        # laptop-safe default of 2 workers: at workers=2 the
+        # maintenance/MCCompactionClaims smoke config timed out at the 300s
+        # budget on this runner class, where -workers auto finished in ~246s.
+        # `auto` is the previous behaviour on GitHub runners, where claiming
+        # every core is fine.
+        env:
+          RAVEL_TLA_WORKERS: auto
         run: scripts/check-tla.sh ci
       - name: Upload TLC logs on failure
         if: failure()

--- a/.github/workflows/tla-nightly.yml
+++ b/.github/workflows/tla-nightly.yml
@@ -37,6 +37,12 @@ jobs:
           distribution: temurin
           java-version: "21"
       - name: Exhaustive model check
+        # State CI's resource choice rather than inheriting the script's
+        # laptop-safe default of 2 workers: `auto` is the previous behaviour
+        # on these dedicated runners, where claiming every core is fine and
+        # the default of 2 is too slow for the exhaustive budget.
+        env:
+          RAVEL_TLA_WORKERS: auto
         run: scripts/check-tla.sh exhaustive
       - name: Upload TLC logs on failure
         if: failure()

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -70,15 +70,19 @@ later if TERM was ignored. Either way the run is reported as a timeout, not
 left running and not read as a pass. CI runs on Ubuntu, which ships GNU
 `timeout`, so it needs no extra setup.
 
-TLC's worker count and JVM heap cap are fixed, not left to `-workers auto`
-(which claims every core on the host) or an uncapped `-Xmx`:
-`RAVEL_TLA_WORKERS` (default `2`) and `RAVEL_TLA_XMX` (default `2g`) control
-them. Both are validated before any model runs -- `RAVEL_TLA_WORKERS` must
-be a positive integer and `RAVEL_TLA_XMX` must match the JVM's `-Xmx`
-grammar (digits then `k`, `m`, or `g`) -- and a bad value exits 2 with a
-one-line refusal rather than reaching TLC as a silently wrong flag. The
-resolved values are printed once per run (`check-tla: resources:
-workers=<n> xmx=<size>`), next to the figures they produced.
+TLC's worker count and JVM heap cap default to small, laptop-safe values
+rather than `-workers auto` (which claims every core on the host) or an
+uncapped `-Xmx`: `RAVEL_TLA_WORKERS` (default `2`) and `RAVEL_TLA_XMX`
+(default `2g`) control them. CI overrides `RAVEL_TLA_WORKERS` to `auto` on
+its dedicated runners, where claiming every core is fine and the default of
+`2` is too slow for the budget. Both are validated before any model runs --
+`RAVEL_TLA_WORKERS` must be `auto` or a positive integer, and
+`RAVEL_TLA_XMX` must be digits then `k`, `m`, or `g` for a nonzero size (not
+the full JVM `-Xmx` grammar, so `2048` and `1t` are rejected even though the
+JVM accepts them) -- and a bad value exits 2 with a one-line refusal rather
+than reaching TLC as a silently wrong flag. An empty or unset value takes
+the default. The resolved values are printed once per run (`check-tla:
+resources: workers=<n> xmx=<size>`), next to the figures they produced.
 
 ```sh
 scripts/check-tla.sh smoke            # fast safety, every area (budget 300s/cfg)
@@ -123,10 +127,12 @@ model-check run truncates and rewrites `.cache/tla/last-run.tsv`, one row per
 config:
 
 ```
-run-id  area  cfg  states  distinct  depth  seconds  result
+run-id  area  cfg  states  distinct  depth  seconds  workers  xmx  result
 ```
 
-`run-id` is a UTC timestamp joined to the working tree hash
+`workers` and `xmx` are the resolved `RAVEL_TLA_WORKERS` / `RAVEL_TLA_XMX`
+that produced the row, so the artifact carries the configuration alongside
+the figures. `run-id` is a UTC timestamp joined to the working tree hash
 (`git rev-parse HEAD^{tree}`), so a row names the exact source it measured.
 `result` is `PASS`, `FAIL`, `TIMEOUT`, `BAND` (a PASS run whose figures fell
 outside its band), or `VIOLATED` (a negative control that failed as intended).

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -70,6 +70,16 @@ later if TERM was ignored. Either way the run is reported as a timeout, not
 left running and not read as a pass. CI runs on Ubuntu, which ships GNU
 `timeout`, so it needs no extra setup.
 
+TLC's worker count and JVM heap cap are fixed, not left to `-workers auto`
+(which claims every core on the host) or an uncapped `-Xmx`:
+`RAVEL_TLA_WORKERS` (default `2`) and `RAVEL_TLA_XMX` (default `2g`) control
+them. Both are validated before any model runs -- `RAVEL_TLA_WORKERS` must
+be a positive integer and `RAVEL_TLA_XMX` must match the JVM's `-Xmx`
+grammar (digits then `k`, `m`, or `g`) -- and a bad value exits 2 with a
+one-line refusal rather than reaching TLC as a silently wrong flag. The
+resolved values are printed once per run (`check-tla: resources:
+workers=<n> xmx=<size>`), next to the figures they produced.
+
 ```sh
 scripts/check-tla.sh smoke            # fast safety, every area (budget 300s/cfg)
 scripts/check-tla.sh negative         # every negative control must fail correctly
@@ -82,9 +92,10 @@ scripts/check-tla.sh smoke -a common  # scope any subcommand to one area
 
 `ci` and `all` record every model under a single run id, so `last-run.tsv` is
 one coherent run rather than a config's rows overwriting the previous config's.
-Exit codes: `0` pass, `1` a check failed, `2` no usable Java or GNU
-timeout(1) unavailable. A subcommand or
-`-a` area that does not exist, and `-a` with no value, fail immediately.
+Exit codes: `0` pass, `1` a check failed, `2` no usable Java, GNU timeout(1)
+unavailable, or an invalid `RAVEL_TLA_WORKERS`/`RAVEL_TLA_XMX` value. A
+subcommand or `-a` area that does not exist, and `-a` with no value, fail
+immediately.
 
 ### The TLC jar
 
@@ -125,7 +136,7 @@ Bands are optional and live in each area's `bands.tsv`, one row per config
 exists the harness enforces it on a PASS run and fails outside it; a run
 outside the band is a regression to investigate, not a band to widen.
 Negative controls stop at the first counterexample TLC finds, which under
-`-workers auto` is not deterministic, so they carry no band. `results.md`
+multiple workers is not deterministic, so they carry no band. `results.md`
 records the figures a run produced and the bands they must stay in.
 
 ## Negative controls

--- a/formal/tla/catalog/results.md
+++ b/formal/tla/catalog/results.md
@@ -192,7 +192,7 @@ pass, not the banded gate config, and its full graph (4,481,272 distinct
 states, depth 37, recorded here from the prior round) was not re-run this
 round; it is not one of this task's required gates. The negative configs are
 NOT deterministic: they stop at the first counterexample TLC finds, and under
-`-workers auto` which state that is varies between runs, so a negative gets no
+multiple workers which state that is varies between runs, so a negative gets no
 band. Each negative is pinned instead by its `.expect` file.
 
 Issue #1121 round five (finding 1: `DedupSurvivors`, replacing the

--- a/formal/tla/lifecycle/results.md
+++ b/formal/tla/lifecycle/results.md
@@ -971,8 +971,8 @@ controls.
 ### Figures
 
 Every figure below is from a run recorded in this session. All lanes ran with
-`scripts/check-tla.sh`, which invokes TLC with `-workers auto` on this
-16-core host; the scratch probes ran with `-workers 2 -Xmx2g`.
+`scripts/check-tla.sh`, which ran with `-workers auto`, the harness default at
+the time, on this 16-core host; the scratch probes ran with `-workers 2 -Xmx2g`.
 
 | config | spec | result | states generated | distinct | depth | wall |
 |---|---|---|---|---|---|---|

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -22,6 +22,12 @@
 # is fetched once into .cache/tla (gitignored). A checksum mismatch refuses to
 # run. Java is taken from RAVEL_TLA_JAVA if set, else the `java` on PATH;
 # version 17 or newer is required.
+#
+# TLC's worker count and JVM heap cap come from RAVEL_TLA_WORKERS (default 2)
+# and RAVEL_TLA_XMX (default 2g). Both are validated (a positive integer; a
+# size matching the JVM's -Xmx grammar: digits then k, m, or g) and refused
+# with a one-line message otherwise; the resolved values are printed once
+# per run.
 set -u
 
 TLA_VERSION="1.7.4"
@@ -65,6 +71,26 @@ resolve_java() {
     fi
     JAVA="$java"
     note "java: $java (version $ver)"
+}
+
+# resolve_tla_resources: read the TLC worker count and JVM heap cap from
+# RAVEL_TLA_WORKERS / RAVEL_TLA_XMX (defaults 2 / 2g). `-workers auto` claims
+# every core on the host, and an uncapped heap on a loaded or shared machine
+# is the failure this guards: both are fixed and small unless overridden, and
+# both are validated so a typo fails closed instead of reaching TLC as a
+# silently wrong flag.
+resolve_tla_resources() {
+    TLA_WORKERS="${RAVEL_TLA_WORKERS:-2}"
+    if ! printf '%s' "$TLA_WORKERS" | grep -qE '^[0-9]+$' || [ "$TLA_WORKERS" -eq 0 ]; then
+        note "RAVEL_TLA_WORKERS must be a positive integer, got '$TLA_WORKERS'"
+        exit 2
+    fi
+    TLA_XMX="${RAVEL_TLA_XMX:-2g}"
+    if ! printf '%s' "$TLA_XMX" | grep -qE '^[0-9]+[kKmMgG]$'; then
+        note "RAVEL_TLA_XMX must match the JVM -Xmx grammar (digits then k, m, or g), got '$TLA_XMX'"
+        exit 2
+    fi
+    note "resources: workers=$TLA_WORKERS xmx=$TLA_XMX"
 }
 
 # resolve_timeout: pick GNU timeout(1) once, before any lane launches
@@ -222,8 +248,8 @@ run_tlc() {
     local libpath="$FORMAL_DIR/common:$area_dir"
     local code=0
     ( cd "$area_dir" && "$TIMEOUT_BIN" "--kill-after=$TIMEOUT_KILL_AFTER" "$budget" \
-        "$JAVA" -XX:+UseParallelGC -DTLA-Library="$libpath" -cp "$JAR" tlc2.TLC \
-        -config "$cfg" -metadir "$metadir" -workers auto $deadlock "$module" ) > "$logfile" 2>&1 || code=$?
+        "$JAVA" -XX:+UseParallelGC -Xmx"$TLA_XMX" -DTLA-Library="$libpath" -cp "$JAR" tlc2.TLC \
+        -config "$cfg" -metadir "$metadir" -workers "$TLA_WORKERS" $deadlock "$module" ) > "$logfile" 2>&1 || code=$?
     if [ "$code" -eq 137 ]; then
         note "$area/$module: ignored TERM at the ${budget}s budget, needed the ${TIMEOUT_KILL_AFTER}s kill-after grace period"
         code=124
@@ -582,7 +608,7 @@ main() {
     # at all.
     case "$cmd" in
         traceability) : ;;
-        *) resolve_timeout; resolve_java ;;
+        *) resolve_timeout; resolve_java; resolve_tla_resources ;;
     esac
 
     local areas

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -24,10 +24,11 @@
 # version 17 or newer is required.
 #
 # TLC's worker count and JVM heap cap come from RAVEL_TLA_WORKERS (default 2)
-# and RAVEL_TLA_XMX (default 2g). Both are validated (a positive integer; a
-# size matching the JVM's -Xmx grammar: digits then k, m, or g) and refused
-# with a one-line message otherwise; the resolved values are printed once
-# per run.
+# and RAVEL_TLA_XMX (default 2g). Both are validated (workers: `auto` or a
+# positive integer; xmx: digits then k, m, or g, a nonzero size) and refused
+# with a one-line message otherwise; the resolved values are printed once per
+# run. An empty or unset value takes the default. CI overrides workers to
+# `auto` on its dedicated runners, where claiming every core is fine.
 set -u
 
 TLA_VERSION="1.7.4"
@@ -76,18 +77,32 @@ resolve_java() {
 # resolve_tla_resources: read the TLC worker count and JVM heap cap from
 # RAVEL_TLA_WORKERS / RAVEL_TLA_XMX (defaults 2 / 2g). `-workers auto` claims
 # every core on the host, and an uncapped heap on a loaded or shared machine
-# is the failure this guards: both are fixed and small unless overridden, and
-# both are validated so a typo fails closed instead of reaching TLC as a
-# silently wrong flag.
+# is the failure this guards: both default small unless overridden, and both
+# are validated so a typo fails closed instead of reaching TLC as a silently
+# wrong flag. `auto` is the one non-numeric worker value accepted (TLC's own
+# "use every core" setting), which CI opts into on its dedicated runners; an
+# empty or unset value takes the default.
 resolve_tla_resources() {
     TLA_WORKERS="${RAVEL_TLA_WORKERS:-2}"
-    if ! printf '%s' "$TLA_WORKERS" | grep -qE '^[0-9]+$' || [ "$TLA_WORKERS" -eq 0 ]; then
-        note "RAVEL_TLA_WORKERS must be a positive integer, got '$TLA_WORKERS'"
-        exit 2
+    if [ "$TLA_WORKERS" != auto ]; then
+        # Bound the digit count before the numeric test: an over-long run of
+        # digits passes a bare ^[0-9]+$ but overflows `[ -eq ]`, which aborts
+        # with "integer expression expected" and would otherwise leak past
+        # the guard as a silently accepted value.
+        if ! printf '%s' "$TLA_WORKERS" | grep -qE '^[0-9]{1,9}$' || [ "$TLA_WORKERS" -eq 0 ]; then
+            note "RAVEL_TLA_WORKERS must be 'auto' or a positive integer (1-999999999), got '$TLA_WORKERS'"
+            exit 2
+        fi
     fi
     TLA_XMX="${RAVEL_TLA_XMX:-2g}"
-    if ! printf '%s' "$TLA_XMX" | grep -qE '^[0-9]+[kKmMgG]$'; then
-        note "RAVEL_TLA_XMX must match the JVM -Xmx grammar (digits then k, m, or g), got '$TLA_XMX'"
+    # digits then k, m, or g, and nonzero. Not the full JVM -Xmx grammar: the
+    # JVM also takes a bare byte count and a `t` suffix, but accepting only
+    # k/m/g makes a typo like `2048` or `1t` fail here, and a zero heap
+    # (`0g`/`0m`) passes the size shape yet the JVM refuses to start, so it is
+    # rejected too.
+    if ! printf '%s' "$TLA_XMX" | grep -qE '^[0-9]+[kKmMgG]$' \
+        || printf '%s' "$TLA_XMX" | grep -qE '^0+[kKmMgG]$'; then
+        note "RAVEL_TLA_XMX must be digits then k, m, or g (a nonzero size), got '$TLA_XMX'"
         exit 2
     fi
     note "resources: workers=$TLA_WORKERS xmx=$TLA_XMX"
@@ -213,12 +228,16 @@ module_cfg() {
 
 truncate_tsv() {
     mkdir -p "$CACHE_DIR"
-    printf 'run-id\tarea\tcfg\tstates\tdistinct\tdepth\tseconds\tresult\n' > "$LAST_RUN"
+    printf 'run-id\tarea\tcfg\tstates\tdistinct\tdepth\tseconds\tworkers\txmx\tresult\n' > "$LAST_RUN"
 }
 
+# The workers/xmx columns carry the resolved resource configuration next to
+# the figures it produced, so a last-run.tsv row reads without the run's
+# environment beside it. resolve_tla_resources always sets both before any
+# model-check subcommand records a row.
 record_row() {
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$RUN_ID" "$1" "$2" "$3" "$4" "$5" "$6" "$7" >> "$LAST_RUN"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$RUN_ID" "$1" "$2" "$3" "$4" "$5" "$6" "${TLA_WORKERS:--}" "${TLA_XMX:--}" "$7" >> "$LAST_RUN"
 }
 
 # --- TLC invocation ---------------------------------------------------------

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -334,9 +334,13 @@ args_has_flag_value() {
 
 echo "--- (g) default resources: -workers 2 -Xmx2g"
 unset RAVEL_TLA_WORKERS RAVEL_TLA_XMX
-resolve_tla_resources
-gcode=$?
-if [ "$gcode" -eq 0 ]; then ok; else bad "g: resolve_tla_resources exited $gcode on defaults"; fi
+# Capture the exit code in a subshell: resolve_tla_resources calls `exit` on a
+# bad value, so an in-process call can only ever leave $? at 0 (a real failure
+# would kill this test), which makes the assertion vacuous. bash -c isolates
+# the exit so a regression that made the defaults invalid would be caught.
+gout="$(bash -c "source '$LIB_SRC'; resolve_tla_resources" 2>&1)"; gcode=$?
+if [ "$gcode" -eq 0 ]; then ok; else bad "g: resolve_tla_resources exited $gcode on defaults; out: $gout"; fi
+resolve_tla_resources  # sets TLA_WORKERS/TLA_XMX in this shell for run_tlc_args_case
 run_tlc_args_case
 if grep -qxF -- '-Xmx2g' "$CASE_ARGS_FILE" 2>/dev/null; then
     ok
@@ -351,9 +355,9 @@ fi
 rm -rf "$CASE_TMP"
 
 echo "--- (h) override RAVEL_TLA_WORKERS=4 RAVEL_TLA_XMX=4g"
+hout="$(RAVEL_TLA_WORKERS=4 RAVEL_TLA_XMX=4g bash -c "source '$LIB_SRC'; resolve_tla_resources" 2>&1)"; hcode=$?
+if [ "$hcode" -eq 0 ]; then ok; else bad "h: resolve_tla_resources exited $hcode on a valid override; out: $hout"; fi
 RAVEL_TLA_WORKERS=4 RAVEL_TLA_XMX=4g resolve_tla_resources
-hcode=$?
-if [ "$hcode" -eq 0 ]; then ok; else bad "h: resolve_tla_resources exited $hcode on a valid override"; fi
 run_tlc_args_case
 if grep -qxF -- '-Xmx4g' "$CASE_ARGS_FILE" 2>/dev/null; then
     ok
@@ -368,17 +372,21 @@ fi
 rm -rf "$CASE_TMP"
 unset RAVEL_TLA_WORKERS RAVEL_TLA_XMX
 
-echo "--- (i) RAVEL_TLA_WORKERS=auto is rejected"
+echo "--- (i) RAVEL_TLA_WORKERS=auto is accepted (CI opt-in) and reaches TLC"
 iout=""
 iout="$(RAVEL_TLA_WORKERS=auto bash -c "source '$LIB_SRC'; resolve_tla_resources" 2>&1)"
 icode=$?
 echo "    measured: exit=$icode"
-if [ "$icode" -eq 2 ]; then ok; else bad "i: expected exit 2, got $icode"; fi
-if printf '%s' "$iout" | grep -qF 'RAVEL_TLA_WORKERS'; then
+if [ "$icode" -eq 0 ]; then ok; else bad "i: expected exit 0 (auto accepted), got $icode; out: $iout"; fi
+RAVEL_TLA_WORKERS=auto resolve_tla_resources
+run_tlc_args_case
+if args_has_flag_value "$CASE_ARGS_FILE" -workers auto; then
     ok
 else
-    bad "i: refusal message missing RAVEL_TLA_WORKERS; got: $iout"
+    bad "i: expected -workers auto in argv; got: $(cat "$CASE_ARGS_FILE" 2>/dev/null)"
 fi
+rm -rf "$CASE_TMP"
+unset RAVEL_TLA_WORKERS
 
 echo "--- (j) RAVEL_TLA_XMX=lots is rejected"
 jout=""
@@ -390,6 +398,33 @@ if printf '%s' "$jout" | grep -qF 'RAVEL_TLA_XMX'; then
     ok
 else
     bad "j: refusal message missing RAVEL_TLA_XMX; got: $jout"
+fi
+
+# --- (k)-(m) issue #1421 item 6: a zero heap and an out-of-range worker count
+# must be rejected with a message, not passed through to a JVM that refuses to
+# start (a FAIL row per config) or a leaked raw bash "[: integer expression
+# expected" -----------------------------------------------------------------
+echo "--- (k) RAVEL_TLA_XMX=0g is rejected (zero heap)"
+kout="$(RAVEL_TLA_XMX=0g bash -c "source '$LIB_SRC'; resolve_tla_resources" 2>&1)"; kcode=$?
+echo "    measured: exit=$kcode"
+if [ "$kcode" -eq 2 ]; then ok; else bad "k: expected exit 2, got $kcode; out: $kout"; fi
+if printf '%s' "$kout" | grep -qF 'RAVEL_TLA_XMX'; then ok; else bad "k: refusal missing RAVEL_TLA_XMX; got: $kout"; fi
+
+echo "--- (l) RAVEL_TLA_XMX=0m is rejected (zero heap)"
+lout="$(RAVEL_TLA_XMX=0m bash -c "source '$LIB_SRC'; resolve_tla_resources" 2>&1)"; lcode=$?
+echo "    measured: exit=$lcode"
+if [ "$lcode" -eq 2 ]; then ok; else bad "l: expected exit 2, got $lcode; out: $lout"; fi
+if printf '%s' "$lout" | grep -qF 'RAVEL_TLA_XMX'; then ok; else bad "l: refusal missing RAVEL_TLA_XMX; got: $lout"; fi
+
+echo "--- (m) RAVEL_TLA_WORKERS=999999999999999999999 is rejected without leaking a bash error"
+mout="$(RAVEL_TLA_WORKERS=999999999999999999999 bash -c "source '$LIB_SRC'; resolve_tla_resources" 2>&1)"; mcode=$?
+echo "    measured: exit=$mcode"
+if [ "$mcode" -eq 2 ]; then ok; else bad "m: expected exit 2, got $mcode; out: $mout"; fi
+if printf '%s' "$mout" | grep -qF 'RAVEL_TLA_WORKERS'; then ok; else bad "m: refusal missing RAVEL_TLA_WORKERS; got: $mout"; fi
+if printf '%s' "$mout" | grep -qF 'integer expression expected'; then
+    bad "m: leaked raw bash '[: integer expression expected' to stderr; out: $mout"
+else
+    ok
 fi
 
 rm -f "$LIB_SRC"

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -21,13 +21,11 @@ bad()  { printf 'FAIL  %s\n' "$1"; fail=$((fail + 1)); }
 # `main "$@"` call on the last line) so run_tlc can be driven directly,
 # against a throwaway FORMAL_DIR/CACHE_DIR, without needing the real TLC jar
 # or network access.
+LIB_SRC="$(mktemp)"
 source_lib() {
-    local tmp_src
-    tmp_src="$(mktemp)"
-    sed '$d' "$SCRIPT" > "$tmp_src"
+    sed '$d' "$SCRIPT" > "$LIB_SRC"
     # shellcheck disable=SC1090
-    source "$tmp_src"
-    rm -f "$tmp_src"
+    source "$LIB_SRC"
 }
 source_lib
 
@@ -50,6 +48,7 @@ run_tlc_case() {
     JAVA="$shim"
     JAR="/dev/null"
     resolve_timeout
+    resolve_tla_resources
 
     logfile="$tmp/tlc.log"
     start=$(date +%s)
@@ -290,5 +289,109 @@ echo "(c) is proved manually and reported, not replayed here: it needs the" \
      "real TLC jar, network on first fetch, and a JDK, none of which this" \
      "unit test provisions."
 
+# --- (g)-(j) issue #1421: RAVEL_TLA_WORKERS / RAVEL_TLA_XMX -----------------
+# `-workers auto` claims every core on the host and TLC's heap was left
+# uncapped; a shared or loaded box needs both fixed. A java shim that never
+# launches TLC, only records its own argv, proves what run_tlc actually
+# constructs without needing the real jar.
+run_tlc_args_case() {
+    # run_tlc_args_case -> sets CASE_ARGS_FILE (one argv token per line) and
+    # CASE_TMP, via a java shim that records "$@" and exits 0.
+    local tmp area_dir shim logfile
+    tmp="$(mktemp -d)"
+    area_dir="$tmp/area"
+    mkdir -p "$area_dir"
+    : > "$area_dir/smoke.cfg"
+    shim="$tmp/java"
+    cat > "$shim" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$tmp/args"
+exit 0
+EOF
+    chmod +x "$shim"
+
+    FORMAL_DIR="$tmp"
+    CACHE_DIR="$tmp/cache"
+    mkdir -p "$CACHE_DIR"
+    JAVA="$shim"
+    JAR="/dev/null"
+    resolve_timeout
+
+    logfile="$tmp/tlc.log"
+    run_tlc area module "$area_dir/smoke.cfg" 5 "$logfile" >/dev/null 2>&1
+    CASE_ARGS_FILE="$tmp/args"
+    CASE_TMP="$tmp"
+}
+
+# args_has_flag_value <file> <flag> <value> -> true if <flag> is followed by
+# <value> on the next line (a space-separated pair, e.g. "-workers" "2").
+args_has_flag_value() {
+    awk -v f="$2" -v v="$3" '
+        $0 == f { getline nxt; if (nxt == v) { found = 1 } }
+        END { exit !found }
+    ' "$1"
+}
+
+echo "--- (g) default resources: -workers 2 -Xmx2g"
+unset RAVEL_TLA_WORKERS RAVEL_TLA_XMX
+resolve_tla_resources
+gcode=$?
+if [ "$gcode" -eq 0 ]; then ok; else bad "g: resolve_tla_resources exited $gcode on defaults"; fi
+run_tlc_args_case
+if grep -qxF -- '-Xmx2g' "$CASE_ARGS_FILE" 2>/dev/null; then
+    ok
+else
+    bad "g: expected -Xmx2g in argv; got: $(cat "$CASE_ARGS_FILE" 2>/dev/null)"
+fi
+if args_has_flag_value "$CASE_ARGS_FILE" -workers 2; then
+    ok
+else
+    bad "g: expected -workers 2 in argv; got: $(cat "$CASE_ARGS_FILE" 2>/dev/null)"
+fi
+rm -rf "$CASE_TMP"
+
+echo "--- (h) override RAVEL_TLA_WORKERS=4 RAVEL_TLA_XMX=4g"
+RAVEL_TLA_WORKERS=4 RAVEL_TLA_XMX=4g resolve_tla_resources
+hcode=$?
+if [ "$hcode" -eq 0 ]; then ok; else bad "h: resolve_tla_resources exited $hcode on a valid override"; fi
+run_tlc_args_case
+if grep -qxF -- '-Xmx4g' "$CASE_ARGS_FILE" 2>/dev/null; then
+    ok
+else
+    bad "h: expected -Xmx4g in argv; got: $(cat "$CASE_ARGS_FILE" 2>/dev/null)"
+fi
+if args_has_flag_value "$CASE_ARGS_FILE" -workers 4; then
+    ok
+else
+    bad "h: expected -workers 4 in argv; got: $(cat "$CASE_ARGS_FILE" 2>/dev/null)"
+fi
+rm -rf "$CASE_TMP"
+unset RAVEL_TLA_WORKERS RAVEL_TLA_XMX
+
+echo "--- (i) RAVEL_TLA_WORKERS=auto is rejected"
+iout=""
+iout="$(RAVEL_TLA_WORKERS=auto bash -c "source '$LIB_SRC'; resolve_tla_resources" 2>&1)"
+icode=$?
+echo "    measured: exit=$icode"
+if [ "$icode" -eq 2 ]; then ok; else bad "i: expected exit 2, got $icode"; fi
+if printf '%s' "$iout" | grep -qF 'RAVEL_TLA_WORKERS'; then
+    ok
+else
+    bad "i: refusal message missing RAVEL_TLA_WORKERS; got: $iout"
+fi
+
+echo "--- (j) RAVEL_TLA_XMX=lots is rejected"
+jout=""
+jout="$(RAVEL_TLA_XMX=lots bash -c "source '$LIB_SRC'; resolve_tla_resources" 2>&1)"
+jcode=$?
+echo "    measured: exit=$jcode"
+if [ "$jcode" -eq 2 ]; then ok; else bad "j: expected exit 2, got $jcode"; fi
+if printf '%s' "$jout" | grep -qF 'RAVEL_TLA_XMX'; then
+    ok
+else
+    bad "j: refusal message missing RAVEL_TLA_XMX; got: $jout"
+fi
+
+rm -f "$LIB_SRC"
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
scripts/check-tla.sh ran every TLC lane with -workers auto and no -Xmx.
On the shared build box every session is told never to let TLC pick its
own worker count and always to cap the heap, because a state space grows
without bound and an uncapped JVM on a loaded host is the failure that
rule exists for; on a sixteen-core executor the lifecycle lane took
sixteen workers.

The script now reads RAVEL_TLA_WORKERS (default 2) and RAVEL_TLA_XMX
(default 2g), validates both and fails closed on anything else, passes
them on every TLC invocation it makes, and prints the two values once per
run in its log line so a band mismatch can be read against the
configuration that produced it. The self-test asserts the exact defaults,
a verbatim override, and the two rejections, and the README documents the
knobs.

A local review found that the two-worker default alone made the tla CI
job time out on the largest smoke config, so both workflows now state
RAVEL_TLA_WORKERS explicitly (auto, the behaviour those runners had) and
the laptop-safe defaults stay in the script. The same round records the
worker count and heap in last-run.tsv beside the figures they produced,
rejects a zero heap and an out-of-range worker count with the documented
message, replaces two assertions that could not fail, wires the self-test
into the tla job, and updates the two results files that still described
the old worker setting in the present tense. The workflow change is
unproven until this pull request's own tla job is green.

Supersedes #1466.

Fixes: #1421
