### PR TITLE
fix(object-store): bound list_all page drain against a spinning backend

### DIFF
--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -17,7 +17,10 @@ use ravel_cache::{
 };
 use ravel_commit::keys::BucketEntry;
 use ravel_commit::{erasure, keys, record, signal};
-use ravel_object_store::{GetOutcome, GetRange, ObjectMeta, ObjectStoreBackend, StoreError};
+use ravel_object_store::{
+    DrainStep, GetOutcome, GetRange, MAX_LIST_PAGES, ObjectMeta, ObjectStoreBackend, StoreError,
+    drain_pages,
+};
 use ravel_proto::commit::v1::{
     CommitRecord, CompactionPart, CompactionRecord, ErasureRequest, RewriteRecord,
 };
@@ -864,6 +867,14 @@ impl Catalog {
     /// returned key must begin with `tenant`'s prefix, or this is a hard
     /// isolation-breach `CatalogError::FieldMismatch`, never a silently
     /// dropped or served foreign key.
+    ///
+    /// The drain itself is [`ravel_object_store::drain_pages`], so a backend
+    /// that repeats a continuation token or exceeds
+    /// [`ravel_object_store::MAX_LIST_PAGES`] fails with a typed
+    /// [`StoreError`] instead of spinning here. Dedup is the contract's
+    /// constant-memory form: the raw delivery sequence never decreases, a
+    /// repeat re-delivers the last key delivered, and anything below it is a
+    /// typed order violation.
     async fn guarded_list_all(
         &self,
         tenant: &TenantHash,
@@ -872,36 +883,33 @@ impl Catalog {
     ) -> Result<Vec<ObjectMeta>, CatalogError> {
         let tenant_prefix = format!("t/{}/", tenant.to_hex());
         let mut out: Vec<ObjectMeta> = Vec::new();
-        let mut seen = std::collections::HashSet::new();
-        let mut page_token = None;
-        loop {
-            let page = {
+        drain_pages(
+            prefix,
+            None,
+            MAX_LIST_PAGES,
+            |_start_after, page_token| async move {
                 let _permit = self.request_semaphore.acquire().await.map_err(|_| {
                     StoreError::Transient("catalog request semaphore closed".to_string())
                 })?;
                 let page = self.store.list(prefix, page_token).await;
                 accounting.record_s3_request(AccountedOp::List);
-                page?
-            };
-            for meta in page.objects {
+                Ok(page?)
+            },
+            |meta: ObjectMeta| {
                 if !meta.key.starts_with(&tenant_prefix) {
                     self.record_isolation_breach();
                     return Err(CatalogError::FieldMismatch {
                         key: prefix.to_string(),
                         field: "list_prefix",
-                        expected: tenant_prefix,
+                        expected: tenant_prefix.clone(),
                         actual: meta.key,
                     });
                 }
-                if seen.insert(meta.key.clone()) {
-                    out.push(meta);
-                }
-            }
-            match page.next {
-                Some(next) => page_token = Some(next),
-                None => break,
-            }
-        }
+                out.push(meta);
+                Ok(DrainStep::Continue)
+            },
+        )
+        .await?;
         Ok(out)
     }
 
@@ -2156,35 +2164,46 @@ impl Catalog {
         let tenant_prefix = format!("t/{}/", tenant.to_hex());
         let prefix = keys::commit_shard_prefix(tenant, signal, shard)?;
         let cap = self.config.max_catalog_list_requests;
-        let mut lists_issued: u64 = 0;
+        // Shared rather than a plain local because the fetch hook's future
+        // cannot borrow from the hook itself (see `drain_pages`), and the
+        // counter spans every probe of this shard. An atomic, not a Cell, so
+        // the resolve future this sits inside stays `Send`.
+        let lists_issued = AtomicU64::new(0);
+        let prefix_ref = prefix.as_str();
         for width_hours in Self::LATEST_HOUR_PROBE_WINDOWS_HOURS {
             let floor_hour = max_hour.saturating_sub(width_hours);
             let start_after = keys::commit_shard_hour_prefix(tenant, signal, shard, floor_hour)?;
             let mut latest: Option<(u32, bool)> = None;
-            let mut page_token = None;
-            'pages: loop {
-                // Refuse before issuing a page that would exceed the
-                // ceiling, so at most `cap` LISTs are ever issued for this
-                // shard across all its probes (the request bound).
-                if lists_issued >= cap {
-                    return Err(CatalogError::WindowTooWide {
-                        estimate: lists_issued.saturating_add(1),
-                        limit: cap,
-                    });
-                }
-                let page = {
-                    let _permit = self.request_semaphore.acquire().await.map_err(|_| {
-                        StoreError::Transient("catalog request semaphore closed".to_string())
-                    })?;
-                    let page = self
-                        .store
-                        .list_after(&prefix, Some(&start_after), page_token)
-                        .await;
-                    accounting.record_s3_request(AccountedOp::List);
-                    lists_issued += 1;
-                    page?
-                };
-                for meta in &page.objects {
+            drain_pages(
+                prefix_ref,
+                Some(&start_after),
+                MAX_LIST_PAGES,
+                |start_after: Option<String>, page_token| {
+                    let lists_issued = &lists_issued;
+                    async move {
+                        // Refuse before issuing a page that would exceed the
+                        // ceiling, so at most `cap` LISTs are ever issued for
+                        // this shard across all its probes (the request bound).
+                        let issued = lists_issued.load(Ordering::Relaxed);
+                        if issued >= cap {
+                            return Err(CatalogError::WindowTooWide {
+                                estimate: issued.saturating_add(1),
+                                limit: cap,
+                            });
+                        }
+                        let _permit = self.request_semaphore.acquire().await.map_err(|_| {
+                            StoreError::Transient("catalog request semaphore closed".to_string())
+                        })?;
+                        let page = self
+                            .store
+                            .list_after(prefix_ref, start_after.as_deref(), page_token)
+                            .await;
+                        accounting.record_s3_request(AccountedOp::List);
+                        lists_issued.fetch_add(1, Ordering::Relaxed);
+                        Ok(page?)
+                    }
+                },
+                |meta: ObjectMeta| {
                     // ADR-0050 §2 isolation assertion, identical to
                     // `list_shard_hours` and `list_window_by_prefix`: every
                     // returned key is under this tenant's prefix or the scan
@@ -2194,7 +2213,7 @@ impl Catalog {
                         return Err(CatalogError::FieldMismatch {
                             key: prefix.clone(),
                             field: "list_prefix",
-                            expected: tenant_prefix,
+                            expected: tenant_prefix.clone(),
                             actual: meta.key.clone(),
                         });
                     }
@@ -2209,7 +2228,7 @@ impl Catalog {
                     // paging on would spend the budget on the future tail at
                     // every probe width, the same stop `list_shard_hours` takes.
                     if hour > max_hour {
-                        break 'pages;
+                        return Ok(DrainStep::Stop);
                     }
                     latest = Some(match latest {
                         None => (hour, !is_tombstone),
@@ -2219,12 +2238,10 @@ impl Catalog {
                         }
                         Some(existing) => existing,
                     });
-                }
-                match page.next {
-                    Some(next) => page_token = Some(next),
-                    None => break,
-                }
-            }
+                    Ok(DrainStep::Continue)
+                },
+            )
+            .await?;
             if latest.is_some() {
                 return Ok(latest);
             }
@@ -2386,21 +2403,23 @@ impl Catalog {
         let start_after =
             keys::commit_shard_hour_prefix(tenant, signal, shard, listing_start_hour)?;
         let mut grouped: ShardBuckets = HashMap::new();
-        let mut seen: HashSet<String> = HashSet::new();
-        let mut page_token = None;
-        'pages: loop {
-            let page = {
+        let prefix_ref = prefix.as_str();
+        drain_pages(
+            prefix_ref,
+            Some(&start_after),
+            MAX_LIST_PAGES,
+            |start_after: Option<String>, page_token| async move {
                 let _permit = self.request_semaphore.acquire().await.map_err(|_| {
                     StoreError::Transient("catalog request semaphore closed".to_string())
                 })?;
                 let page = self
                     .store
-                    .list_after(&prefix, Some(&start_after), page_token)
+                    .list_after(prefix_ref, start_after.as_deref(), page_token)
                     .await;
                 accounting.record_s3_request(AccountedOp::List);
-                page?
-            };
-            for meta in page.objects {
+                Ok(page?)
+            },
+            |meta: ObjectMeta| {
                 // ADR-0050 §2 isolation assertion, identical to
                 // `guarded_list_all`: every returned key is under this tenant's
                 // prefix or the scan hard-fails.
@@ -2409,15 +2428,9 @@ impl Catalog {
                     return Err(CatalogError::FieldMismatch {
                         key: prefix.clone(),
                         field: "list_prefix",
-                        expected: tenant_prefix,
+                        expected: tenant_prefix.clone(),
                         actual: meta.key,
                     });
-                }
-                // Dedup by key across pages (a key MAY repeat across pages),
-                // matching `guarded_list_all` so the grouped key set is
-                // identical to the per-bucket loop's.
-                if !seen.insert(meta.key.clone()) {
-                    continue;
                 }
                 let (bshard, bhour) = match keys::partition_bucket_entry(&meta.key)? {
                     BucketEntry::CommitRecord(k) => (k.shard, k.ingest_hour_bucket),
@@ -2428,21 +2441,19 @@ impl Catalog {
                 // Past the window's top hour: every later key in this shard is
                 // also past it, so stop paging (do not request the next page).
                 if bhour > window_end_hour {
-                    break 'pages;
+                    return Ok(DrainStep::Stop);
                 }
                 // `start_after` already excluded everything strictly below
                 // `listing_start_hour`; this guard is a belt for a marker key
                 // that shares the first page with in-window keys.
                 if bhour < listing_start_hour {
-                    continue;
+                    return Ok(DrainStep::Continue);
                 }
                 grouped.entry((bshard, bhour)).or_default().push(meta);
-            }
-            match page.next {
-                Some(next) => page_token = Some(next),
-                None => break,
-            }
-        }
+                Ok(DrainStep::Continue)
+            },
+        )
+        .await?;
         Ok(grouped)
     }
 
@@ -2739,8 +2750,10 @@ impl Catalog {
     /// That page-by-page ceiling, and the `list_after` start marker, are why
     /// this path records its own `AccountedOp::List` per page instead of
     /// calling [`Catalog::guarded_list_all`], which takes no start marker and
-    /// drains unconditionally. The permit, the accounting, and the ADR-0050
-    /// section 2 tenant-prefix assertion are the same either way
+    /// drains unconditionally. Both share the page loop itself
+    /// ([`ravel_object_store::drain_pages`]), so the permit, the accounting,
+    /// the ADR-0050 section 2 tenant-prefix assertion, the cross-page dedup,
+    /// and the typed refusal of a spinning backend are the same either way
     /// (docs/catalog-and-mvcc.md "Query cost accounting").
     #[allow(clippy::too_many_arguments)]
     async fn list_window_by_prefix(
@@ -2761,8 +2774,11 @@ impl Catalog {
         // the expensive per-bucket record GETs are what run concurrently below,
         // mirroring the per-bucket loop's concurrency model.
         let mut grouped: HashMap<(u32, u32), Vec<ObjectMeta>> = HashMap::new();
-        let mut seen: HashSet<String> = HashSet::new();
-        let mut lists_issued: u64 = 0;
+        // Shared rather than a plain local because the fetch hook's future
+        // cannot borrow from the hook itself (see `drain_pages`), and the
+        // counter spans every shard's drain. An atomic, not a Cell, so the
+        // resolve future this sits inside stays `Send`.
+        let lists_issued = AtomicU64::new(0);
         let cap = self.config.max_catalog_list_requests;
         let tenant_prefix = format!("t/{}/", tenant.to_hex());
         // Shard bound is the union scan set over every hour in the listing
@@ -2791,29 +2807,37 @@ impl Catalog {
             // key at or above it, so `list_after` resumes strictly past it.
             let start_after =
                 keys::commit_shard_hour_prefix(tenant, signal, shard, listing_start_hour)?;
-            let mut page_token = None;
-            loop {
-                // Refuse before issuing a page that would exceed the ceiling,
-                // so at most `cap` LISTs are ever issued (the request bound).
-                if lists_issued >= cap {
-                    return Err(CatalogError::WindowTooWide {
-                        estimate: lists_issued.saturating_add(1),
-                        limit: cap,
-                    });
-                }
-                let page = {
-                    let _permit = self.request_semaphore.acquire().await.map_err(|_| {
-                        StoreError::Transient("catalog request semaphore closed".to_string())
-                    })?;
-                    let page = self
-                        .store
-                        .list_after(&prefix, Some(&start_after), page_token)
-                        .await;
-                    accounting.record_s3_request(AccountedOp::List);
-                    lists_issued += 1;
-                    page?
-                };
-                for meta in page.objects {
+            let prefix_ref = prefix.as_str();
+            drain_pages(
+                prefix_ref,
+                Some(&start_after),
+                MAX_LIST_PAGES,
+                |start_after: Option<String>, page_token| {
+                    let lists_issued = &lists_issued;
+                    async move {
+                        // Refuse before issuing a page that would exceed the
+                        // ceiling, so at most `cap` LISTs are ever issued (the
+                        // request bound).
+                        let issued = lists_issued.load(Ordering::Relaxed);
+                        if issued >= cap {
+                            return Err(CatalogError::WindowTooWide {
+                                estimate: issued.saturating_add(1),
+                                limit: cap,
+                            });
+                        }
+                        let _permit = self.request_semaphore.acquire().await.map_err(|_| {
+                            StoreError::Transient("catalog request semaphore closed".to_string())
+                        })?;
+                        let page = self
+                            .store
+                            .list_after(prefix_ref, start_after.as_deref(), page_token)
+                            .await;
+                        accounting.record_s3_request(AccountedOp::List);
+                        lists_issued.fetch_add(1, Ordering::Relaxed);
+                        Ok(page?)
+                    }
+                },
+                |meta: ObjectMeta| {
                     // ADR-0050 §2 isolation assertion, identical to
                     // `guarded_list_all`: every returned key is under this
                     // tenant's prefix or the scan hard-fails.
@@ -2822,16 +2846,9 @@ impl Catalog {
                         return Err(CatalogError::FieldMismatch {
                             key: prefix.clone(),
                             field: "list_prefix",
-                            expected: tenant_prefix,
+                            expected: tenant_prefix.clone(),
                             actual: meta.key,
                         });
-                    }
-                    // Dedup by key across pages (the cross-page listing
-                    // guarantee: a key MAY repeat across pages), matching
-                    // `guarded_list_all` so the grouped key set is identical to
-                    // the per-bucket loop's.
-                    if !seen.insert(meta.key.clone()) {
-                        continue;
                     }
                     let (bshard, bhour) = match keys::partition_bucket_entry(&meta.key)? {
                         BucketEntry::CommitRecord(k) => (k.shard, k.ingest_hour_bucket),
@@ -2840,15 +2857,13 @@ impl Catalog {
                         BucketEntry::Tombstone(k) => (k.shard, k.ingest_hour_bucket),
                     };
                     if bhour < listing_start_hour || bhour > window_end_hour {
-                        continue;
+                        return Ok(DrainStep::Continue);
                     }
                     grouped.entry((bshard, bhour)).or_default().push(meta);
-                }
-                match page.next {
-                    Some(next) => page_token = Some(next),
-                    None => break,
-                }
-            }
+                    Ok(DrainStep::Continue)
+                },
+            )
+            .await?;
         }
 
         // Resolve each surviving bucket through the shared per-bucket path,
@@ -4520,8 +4535,8 @@ mod tests {
     /// and issue exactly 4 list calls, not 3: `MemoryStore::list_after`
     /// reports `next: Some` on any page that comes back completely full,
     /// even when that page happened to hold the last object, so a 4th,
-    /// empty page is required before the per-shard loop's `match page.next
-    /// { ... None => break }` can conclude the listing is exhausted. A
+    /// empty page is required before the shared drain sees a page with no
+    /// continuation token and concludes the listing is exhausted. A
     /// budget of 3 refuses on the would-be 4th call (that is exactly
     /// `latest_ingest_hour_refuses_past_the_list_request_budget`, one
     /// object fewer into the same scan); 4 is the true boundary.
@@ -7102,6 +7117,111 @@ mod tests {
             other => panic!("expected FieldMismatch, got {other:?}"),
         }
         assert_eq!(catalog.isolation_breaches(), 1);
+    }
+
+    /// Hands out the same continuation token on every `list` call, with one
+    /// in-order key per page: the spinning backend `guarded_list_all` used to
+    /// page against forever before it drained through
+    /// [`ravel_object_store::drain_pages`].
+    struct RepeatingTokenStore {
+        calls: AtomicU64,
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStoreBackend for RepeatingTokenStore {
+        async fn put(
+            &self,
+            _key: &str,
+            _data: Bytes,
+            _opts: ravel_object_store::PutOptions,
+        ) -> Result<ravel_object_store::PutOutcome, StoreError> {
+            Err(StoreError::Permanent("put not supported".to_string()))
+        }
+
+        async fn get(&self, _key: &str, _range: GetRange) -> Result<GetOutcome, StoreError> {
+            Err(StoreError::NotFound)
+        }
+
+        async fn head(&self, _key: &str) -> Result<ObjectMeta, StoreError> {
+            Err(StoreError::NotFound)
+        }
+
+        async fn list(
+            &self,
+            prefix: &str,
+            _page: Option<ravel_object_store::PageToken>,
+        ) -> Result<ravel_object_store::ListPage, StoreError> {
+            let seq = self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(ravel_object_store::ListPage {
+                objects: vec![ObjectMeta {
+                    key: format!("{prefix}{seq:08}"),
+                    size: 0,
+                    etag: ravel_object_store::Etag(String::new()),
+                    version: ravel_object_store::Version(String::new()),
+                    last_modified_unix_ms: 0,
+                }],
+                next: Some(ravel_object_store::PageToken("stuck".to_string())),
+            })
+        }
+
+        async fn list_delimited(
+            &self,
+            _prefix: &str,
+        ) -> Result<ravel_object_store::DelimitedList, StoreError> {
+            Err(StoreError::Permanent(
+                "list_delimited not supported".to_string(),
+            ))
+        }
+
+        async fn delete(&self, _key: &str) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        fn capabilities(&self) -> ravel_object_store::Capabilities {
+            ravel_object_store::Capabilities::mandatory()
+        }
+    }
+
+    impl RepeatingTokenStore {
+        fn list_calls(&self) -> u64 {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    /// #1448 finding 2: `guarded_list_all` is the sole LIST funnel for every
+    /// query (ADR-0044 decision 2), and it drained with no bound of its own.
+    /// A backend that repeats its continuation token must now stop it after
+    /// exactly two pages with the typed store error, having credited
+    /// `accounting` exactly one LIST per page issued.
+    #[tokio::test]
+    async fn guarded_list_all_refuses_a_repeated_continuation_token() {
+        let prefix = format!("t/{}/m/c/", tenant().to_hex());
+        let store = Arc::new(RepeatingTokenStore {
+            calls: AtomicU64::new(0),
+        });
+        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+        let accounting = QueryAccounting::new();
+
+        let err = catalog
+            .guarded_list_all(&tenant(), &prefix, &accounting)
+            .await
+            .expect_err("a repeated continuation token must be a typed error");
+        match err {
+            CatalogError::Store(StoreError::ListRepeatedToken { prefix: p }) => {
+                assert_eq!(p, prefix);
+            }
+            other => panic!("expected Store(ListRepeatedToken), got {other:?}"),
+        }
+        assert_eq!(
+            store.list_calls(),
+            2,
+            "the drain detects the repeat on the second page and issues no third"
+        );
+        assert_eq!(
+            accounting.snapshot().s3_requests(AccountedOp::List),
+            2,
+            "the per-page accounting hook fired once per page issued"
+        );
     }
 
     /// ADR-0050 §2: a commit record and a compaction record whose

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -128,6 +128,22 @@ fn clone_store_error(err: &StoreError) -> StoreError {
         StoreError::InvalidRange(msg) => StoreError::InvalidRange(msg.clone()),
         StoreError::Transient(msg) => StoreError::Transient(msg.clone()),
         StoreError::Permanent(msg) => StoreError::Permanent(msg.clone()),
+        StoreError::ListRepeatedToken { prefix } => StoreError::ListRepeatedToken {
+            prefix: prefix.clone(),
+        },
+        StoreError::ListPageCeiling { prefix, ceiling } => StoreError::ListPageCeiling {
+            prefix: prefix.clone(),
+            ceiling: *ceiling,
+        },
+        StoreError::ListOrderViolation {
+            prefix,
+            previous,
+            offending,
+        } => StoreError::ListOrderViolation {
+            prefix: prefix.clone(),
+            previous: previous.clone(),
+            offending: offending.clone(),
+        },
     }
 }
 

--- a/crates/ravel-maintain/src/read.rs
+++ b/crates/ravel-maintain/src/read.rs
@@ -23,7 +23,9 @@ use futures::stream::{StreamExt, TryStreamExt, iter as stream_iter};
 use ravel_commit::erasure::compute_compaction_input_set_hash;
 use ravel_commit::keys::{self, BucketEntry};
 use ravel_commit::record;
-use ravel_object_store::{GetRange, ObjectMeta, ObjectStoreBackend, StoreError};
+use ravel_object_store::{
+    DrainStep, GetRange, MAX_LIST_PAGES, ObjectMeta, ObjectStoreBackend, StoreError, drain_pages,
+};
 use ravel_proto::commit::v1::{CommitRecord, CompactionInputIdentity};
 use ravel_segment::{
     ExemplarInput, FooterLocation, FooterOutcome, ReaderLimits, ValueKind, decode_catalog_v4,
@@ -73,8 +75,9 @@ pub async fn list_bucket(store: &dyn ObjectStoreBackend, bucket: &Bucket) -> Res
 
 /// [`list_bucket`], counting each listing page into `ledger`'s
 /// [`RequestPhase::List`] (ADR-0996 task 996-8). The listing drain is the same
-/// one [`ravel_object_store::list_all`] performs; it is spelled out here only so
-/// the per-page request count is recorded where the page is fetched, rather than
+/// one [`ravel_object_store::list_all`] performs, through the same
+/// [`ravel_object_store::drain_pages`]; the only difference is a per-page hook,
+/// so the request count is recorded where the page is fetched rather than
 /// inferred afterwards from a total.
 pub async fn list_bucket_with_ledger(
     store: &dyn ObjectStoreBackend,
@@ -109,33 +112,36 @@ pub async fn list_bucket_with_ledger(
 }
 
 /// Drain every page of a listing, deduplicating by key per the cross-page
-/// guarantee, recording one [`RequestPhase::List`] request per page. Byte for
-/// byte the behaviour of [`ravel_object_store::list_all`]; only the counting
-/// hook is added, and a listing response body is not visible at the store seam,
-/// so no byte figure moves.
+/// guarantee, recording one [`RequestPhase::List`] request per page.
+///
+/// Byte for byte the behaviour of [`ravel_object_store::list_all`]: both drain
+/// through [`ravel_object_store::drain_pages`] with the same page ceiling, so
+/// the dedup, the order check, and the typed refusal of a backend that repeats
+/// its continuation token are identical. Only the counting hook is added, and a
+/// listing response body is not visible at the store seam, so no byte figure
+/// moves.
 async fn list_all_counted(
     store: &dyn ObjectStoreBackend,
     prefix: &str,
     ledger: Option<&RequestLedger>,
 ) -> Result<Vec<ObjectMeta>> {
     let mut out: Vec<ObjectMeta> = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    let mut page_token = None;
-    loop {
-        // Recorded before the error check: a failed page was still spent.
-        let page = store.list(prefix, page_token).await;
-        note_metadata(ledger, RequestPhase::List);
-        let page = page?;
-        for meta in page.objects {
-            if seen.insert(meta.key.clone()) {
-                out.push(meta);
-            }
-        }
-        match page.next {
-            Some(next) => page_token = Some(next),
-            None => break,
-        }
-    }
+    drain_pages(
+        prefix,
+        None,
+        MAX_LIST_PAGES,
+        |_start_after, page_token| async move {
+            // Recorded before the error check: a failed page was still spent.
+            let page = store.list(prefix, page_token).await;
+            note_metadata(ledger, RequestPhase::List);
+            Ok(page?)
+        },
+        |meta: ObjectMeta| -> Result<DrainStep> {
+            out.push(meta);
+            Ok(DrainStep::Continue)
+        },
+    )
+    .await?;
     Ok(out)
 }
 
@@ -779,5 +785,108 @@ mod tests {
                 "dropping section kind {dropped} must fail closed, got {got:?}"
             );
         }
+    }
+    /// Hands out the same continuation token on every `list` call, with one
+    /// in-order key per page: the spinning backend `list_all_counted` used to
+    /// page against forever before it drained through
+    /// [`ravel_object_store::drain_pages`].
+    struct RepeatingTokenStore {
+        calls: std::sync::atomic::AtomicU64,
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStoreBackend for RepeatingTokenStore {
+        async fn put(
+            &self,
+            _key: &str,
+            _data: bytes::Bytes,
+            _opts: ravel_object_store::PutOptions,
+        ) -> std::result::Result<ravel_object_store::PutOutcome, StoreError> {
+            Err(StoreError::Permanent("put not supported".to_string()))
+        }
+
+        async fn get(
+            &self,
+            _key: &str,
+            _range: GetRange,
+        ) -> std::result::Result<ravel_object_store::GetOutcome, StoreError> {
+            Err(StoreError::NotFound)
+        }
+
+        async fn head(&self, _key: &str) -> std::result::Result<ObjectMeta, StoreError> {
+            Err(StoreError::NotFound)
+        }
+
+        async fn list(
+            &self,
+            prefix: &str,
+            _page: Option<ravel_object_store::PageToken>,
+        ) -> std::result::Result<ravel_object_store::ListPage, StoreError> {
+            let seq = self
+                .calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(ravel_object_store::ListPage {
+                objects: vec![ObjectMeta {
+                    key: format!("{prefix}{seq:08}"),
+                    size: 0,
+                    etag: ravel_object_store::Etag(String::new()),
+                    version: ravel_object_store::Version(String::new()),
+                    last_modified_unix_ms: 0,
+                }],
+                next: Some(ravel_object_store::PageToken("stuck".to_string())),
+            })
+        }
+
+        async fn list_delimited(
+            &self,
+            _prefix: &str,
+        ) -> std::result::Result<ravel_object_store::DelimitedList, StoreError> {
+            Err(StoreError::Permanent(
+                "list_delimited not supported".to_string(),
+            ))
+        }
+
+        async fn delete(&self, _key: &str) -> std::result::Result<(), StoreError> {
+            Ok(())
+        }
+
+        fn capabilities(&self) -> ravel_object_store::Capabilities {
+            ravel_object_store::Capabilities::mandatory()
+        }
+    }
+
+    /// #1448 finding 2: `list_all_counted` claimed to be `list_all` plus a
+    /// counting hook while draining with no bound of its own. A backend that
+    /// repeats its continuation token must now stop it after exactly two
+    /// pages with the typed store error, having recorded exactly one
+    /// `RequestPhase::List` request per page issued.
+    #[tokio::test]
+    async fn list_all_counted_refuses_a_repeated_continuation_token() {
+        let store = RepeatingTokenStore {
+            calls: std::sync::atomic::AtomicU64::new(0),
+        };
+        let ledger = RequestLedger::new();
+
+        let err = list_all_counted(&store, "t/bucket/", Some(&ledger))
+            .await
+            .expect_err("a repeated continuation token must be a typed error");
+        assert!(
+            matches!(
+                &err,
+                MaintainError::Store(StoreError::ListRepeatedToken { prefix })
+                    if prefix == "t/bucket/"
+            ),
+            "got {err:?}"
+        );
+        assert_eq!(
+            store.calls.load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "the drain detects the repeat on the second page and issues no third"
+        );
+        assert_eq!(
+            ledger.report().phase(RequestPhase::List).requests,
+            2,
+            "the per-page counting hook fired once per page issued"
+        );
     }
 }

--- a/crates/ravel-object-store/src/conformance.rs
+++ b/crates/ravel-object-store/src/conformance.rs
@@ -762,13 +762,17 @@ async fn probe_consistent_list_after_write(
         {
             return ProbeResult::fail(property, format!("put {key} failed: {err}"));
         }
+        // Over `list`, the method `S3Store` implements separately and every
+        // catalog scan issues, so the suite exercises it and not only
+        // `list_after`.
+        //
         // A membership probe, deliberately order-tolerant: an unsorted backend
         // loses no key, so this must still observe the just-written one and
         // leave the ordering verdict to `probe_lexicographic_listing_order`.
         // `list_all` now rejects an out-of-order key with a typed error, which
         // would collapse membership into an ordering failure, so drain the raw
         // pages here instead.
-        match drain_pages(store, &list_prefix, None).await {
+        match drain_probe_pages(store, &list_prefix, ProbeListing::List).await {
             Ok((keys, _pages)) => {
                 if !keys.contains(&key) {
                     return ProbeResult::fail(
@@ -780,12 +784,9 @@ async fn probe_consistent_list_after_write(
                     );
                 }
             }
-            Err(detail) => {
-                return ProbeResult::fail(
-                    property,
-                    format!("listing {list_prefix} failed: {detail}"),
-                );
-            }
+            // Already a reportable detail naming the prefix and the backend's
+            // own error, like the sibling drains below.
+            Err(detail) => return ProbeResult::fail(property, detail),
         }
     }
     ProbeResult::pass(
@@ -1041,27 +1042,42 @@ async fn probe_concurrent_create_if_absent(
 /// qualification run that hangs.
 const MAX_PROBE_PAGES: usize = 64;
 
-/// Drain every page of `prefix` (from `start_after`, when given) and return
-/// the keys in delivery order together with the number of pages served.
+/// Which listing method a probe drain issues. A probe has to say: the two
+/// methods are implemented separately (`S3Store` has a native override for
+/// each, and `list_after`'s default is `list` plus a client-side filter), so a
+/// suite that only ever drained one qualified a backend on the strength of the
+/// other.
+#[derive(Clone, Copy)]
+enum ProbeListing<'a> {
+    /// [`ObjectStoreBackend::list`]: what every catalog scan issues.
+    List,
+    /// [`ObjectStoreBackend::list_after`], from `start_after` when given: how
+    /// callers skip a key sub-range server-side.
+    After(Option<&'a str>),
+}
+
+/// Drain every page of `prefix` through `listing` and return the keys in
+/// delivery order together with the number of pages served.
 ///
-/// Deliberately not [`crate::list_all`]: that helper deduplicates and discards both
-/// the delivery order and the page count, which are exactly what the two
-/// listing probes below examine. Errors come back as a ready-to-report detail
-/// string so a misbehaving backend produces a failed [`ProbeResult`] rather
-/// than an error the suite has to interpret twice.
-async fn drain_pages(
+/// Deliberately not [`crate::list_all`] or [`crate::drain_pages`]: those
+/// deduplicate and discard both the delivery order and the page count, which
+/// are exactly what the listing probes below examine. Errors come back as a
+/// ready-to-report detail string so a misbehaving backend produces a failed
+/// [`ProbeResult`] rather than an error the suite has to interpret twice.
+async fn drain_probe_pages(
     store: &dyn ObjectStoreBackend,
     prefix: &str,
-    start_after: Option<&str>,
+    listing: ProbeListing<'_>,
 ) -> Result<(Vec<String>, usize), String> {
     let mut delivered: Vec<String> = Vec::new();
     let mut pages = 0usize;
     let mut token = None;
     loop {
-        let page = store
-            .list_after(prefix, start_after, token)
-            .await
-            .map_err(|err| format!("listing {prefix} failed: {err}"))?;
+        let result = match listing {
+            ProbeListing::List => store.list(prefix, token).await,
+            ProbeListing::After(start_after) => store.list_after(prefix, start_after, token).await,
+        };
+        let page = result.map_err(|err| format!("listing {prefix} failed: {err}"))?;
         pages += 1;
         delivered.extend(page.objects.into_iter().map(|meta| meta.key));
         match page.next {
@@ -1078,8 +1094,9 @@ async fn drain_pages(
 }
 
 /// Keys in delivery order, with the repeats the cross-page guarantee allows
-/// collapsed, keeping first-delivery order so an ordering violation survives
-/// the deduplication.
+/// collapsed, keeping first-delivery order. For the set comparisons only: the
+/// order verdict is taken on the raw sequence, which the contract requires to
+/// be non-decreasing.
 fn distinct_in_delivery_order(delivered: &[String]) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
     delivered
@@ -1089,7 +1106,8 @@ fn distinct_in_delivery_order(delivered: &[String]) -> Vec<String> {
         .collect()
 }
 
-/// The first pair of adjacent deliveries that goes backwards, if any.
+/// The first pair of adjacent deliveries that goes backwards, if any. Equal
+/// adjacent keys are the repeat the contract permits and pass.
 fn first_order_violation(delivered: &[String]) -> Option<(&str, &str)> {
     delivered
         .windows(2)
@@ -1142,17 +1160,18 @@ async fn probe_lexicographic_listing_order(
         .collect();
     expected.sort();
 
-    let (delivered, _pages) = match drain_pages(store, &list_prefix, None).await {
-        Ok(result) => result,
-        Err(detail) => return ProbeResult::fail(property, detail),
-    };
-    // Deduplicate before checking order, never after: the contract lets a key
-    // appear more than once, so a compliant backend that re-delivers an
-    // already-delivered key at a page boundary produces a raw sequence that
-    // goes backwards. Deduplication keeps first-delivery order, so a real
-    // ordering violation still shows up in the distinct sequence.
-    let distinct = distinct_in_delivery_order(&delivered);
-    if let Some((before, after)) = first_order_violation(&distinct) {
+    let (delivered, _pages) =
+        match drain_probe_pages(store, &list_prefix, ProbeListing::After(None)).await {
+            Ok(result) => result,
+            Err(detail) => return ProbeResult::fail(property, detail),
+        };
+    // Check the order on the RAW delivery sequence, before deduplication: the
+    // contract's sequence never decreases, and the repeat it permits
+    // re-delivers the last key already delivered (equal adjacent keys pass
+    // here). A backend that re-delivers an EARLIER key is out of order, and
+    // `drain_pages` hard-fails every drain over it, so qualifying it here
+    // would admit a backend that no caller can list.
+    if let Some((before, after)) = first_order_violation(&delivered) {
         return ProbeResult::fail(
             property,
             format!(
@@ -1162,6 +1181,7 @@ async fn probe_lexicographic_listing_order(
             ),
         );
     }
+    let distinct = distinct_in_delivery_order(&delivered);
     if distinct != expected {
         return ProbeResult::fail(
             property,
@@ -1178,10 +1198,11 @@ async fn probe_lexicographic_listing_order(
     // exactly the last three, still in order.
     let marker = expected[1].clone();
     let expected_tail: Vec<String> = expected[2..].to_vec();
-    let (tail_delivered, _pages) = match drain_pages(store, &list_prefix, Some(&marker)).await {
-        Ok(result) => result,
-        Err(detail) => return ProbeResult::fail(property, detail),
-    };
+    let (tail_delivered, _pages) =
+        match drain_probe_pages(store, &list_prefix, ProbeListing::After(Some(&marker))).await {
+            Ok(result) => result,
+            Err(detail) => return ProbeResult::fail(property, detail),
+        };
     if let Some(key) = tail_delivered.iter().find(|key| *key <= &marker) {
         return ProbeResult::fail(
             property,
@@ -1192,10 +1213,9 @@ async fn probe_lexicographic_listing_order(
             ),
         );
     }
-    // Same order as the full drain above, and for the same reason: the raw
-    // tail may repeat a key across a page boundary and stay compliant.
-    let distinct_tail = distinct_in_delivery_order(&tail_delivered);
-    if let Some((before, after)) = first_order_violation(&distinct_tail) {
+    // Same raw sequence, same reason as the full drain above: a compliant tail
+    // never decreases, and a repeat re-delivers its last key.
+    if let Some((before, after)) = first_order_violation(&tail_delivered) {
         return ProbeResult::fail(
             property,
             format!(
@@ -1204,6 +1224,7 @@ async fn probe_lexicographic_listing_order(
             ),
         );
     }
+    let distinct_tail = distinct_in_delivery_order(&tail_delivered);
     if distinct_tail != expected_tail {
         return ProbeResult::fail(
             property,
@@ -1257,10 +1278,11 @@ async fn probe_cross_page_listing(store: &dyn ObjectStoreBackend, prefix: &str) 
     }
     expected.sort();
 
-    let (delivered, pages) = match drain_pages(store, &list_prefix, None).await {
-        Ok(result) => result,
-        Err(detail) => return ProbeResult::fail(property, detail),
-    };
+    let (delivered, pages) =
+        match drain_probe_pages(store, &list_prefix, ProbeListing::After(None)).await {
+            Ok(result) => result,
+            Err(detail) => return ProbeResult::fail(property, detail),
+        };
     let mut distinct = distinct_in_delivery_order(&delivered);
     distinct.sort();
     if distinct != expected {
@@ -1336,10 +1358,11 @@ async fn probe_delete_visibility(store: &dyn ObjectStoreBackend, prefix: &str) -
     }
 
     let expected = vec![kept.clone()];
-    let (delivered, _pages) = match drain_pages(store, &list_prefix, None).await {
-        Ok(result) => result,
-        Err(detail) => return ProbeResult::fail(property, detail),
-    };
+    let (delivered, _pages) =
+        match drain_probe_pages(store, &list_prefix, ProbeListing::After(None)).await {
+            Ok(result) => result,
+            Err(detail) => return ProbeResult::fail(property, detail),
+        };
     let distinct = distinct_in_delivery_order(&delivered);
     if distinct != expected {
         return ProbeResult::fail(
@@ -1362,10 +1385,11 @@ async fn probe_delete_visibility(store: &dyn ObjectStoreBackend, prefix: &str) -
             ),
         );
     }
-    let (delivered, _pages) = match drain_pages(store, &list_prefix, None).await {
-        Ok(result) => result,
-        Err(detail) => return ProbeResult::fail(property, detail),
-    };
+    let (delivered, _pages) =
+        match drain_probe_pages(store, &list_prefix, ProbeListing::After(None)).await {
+            Ok(result) => result,
+            Err(detail) => return ProbeResult::fail(property, detail),
+        };
     let distinct = distinct_in_delivery_order(&delivered);
     if distinct != expected {
         return ProbeResult::fail(
@@ -1628,6 +1652,192 @@ mod tests {
             .find(|r| r.property == Property::ConsistentListAfterWrite)
             .expect("listing probe result present");
         assert!(failure.detail.contains("not strongly consistent"));
+    }
+
+    /// [`WeakListStore`]'s defect confined to [`ObjectStoreBackend::list`]:
+    /// `list_after` delegates to the oracle and is strongly consistent, so a
+    /// probe that reaches `list` only through `list_after` sees nothing wrong.
+    /// `S3Store` implements the two separately, which is why the suite has to
+    /// drain `list` itself somewhere.
+    struct WeakOnlyOnListStore {
+        inner: MemoryStore,
+        hidden_from_next_list: Mutex<HashSet<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStoreBackend for WeakOnlyOnListStore {
+        async fn put(
+            &self,
+            key: &str,
+            data: Bytes,
+            opts: PutOptions,
+        ) -> Result<crate::PutOutcome, StoreError> {
+            let outcome = self.inner.put(key, data, opts).await?;
+            self.hidden_from_next_list.lock().insert(key.to_string());
+            Ok(outcome)
+        }
+
+        async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn list(
+            &self,
+            prefix: &str,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            let mut page_result = self.inner.list(prefix, page).await?;
+            let mut hidden = self.hidden_from_next_list.lock();
+            page_result.objects.retain(|meta| !hidden.remove(&meta.key));
+            Ok(page_result)
+        }
+
+        async fn list_after(
+            &self,
+            prefix: &str,
+            start_after: Option<&str>,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            self.inner.list_after(prefix, start_after, page).await
+        }
+
+        async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+            self.inner.list_delimited(prefix).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), StoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            self.inner.capabilities()
+        }
+    }
+
+    /// #1448 finding 3: the membership probe must issue
+    /// [`ObjectStoreBackend::list`], not reach it through `list_after`. This
+    /// backend's `list_after` is the oracle's, so every other listing probe
+    /// passes and only `ConsistentListAfterWrite` names the defect. A suite
+    /// whose every listing probe went through `list_after` would qualify it.
+    #[tokio::test]
+    async fn a_backend_weak_only_on_list_fails_qualification() {
+        let store = WeakOnlyOnListStore {
+            inner: MemoryStore::new(),
+            hidden_from_next_list: Mutex::new(HashSet::new()),
+        };
+        let report = run_conformance_suite(&store, "sys/qualify/weak-list-only/").await;
+        assert!(!report.passed());
+        let failed: Vec<Property> = report.failures().map(|r| r.property).collect();
+        assert_eq!(
+            failed,
+            vec![Property::ConsistentListAfterWrite],
+            "only the probe that drains `list` itself can see this defect"
+        );
+        let failure = report
+            .results
+            .iter()
+            .find(|r| r.property == Property::ConsistentListAfterWrite)
+            .expect("listing probe result present");
+        assert!(
+            failure.detail.contains("not strongly consistent"),
+            "got {:?}",
+            failure.detail
+        );
+    }
+
+    /// Hands out a fresh continuation token on every `list` page forever, so
+    /// the membership probe's drain trips [`MAX_PROBE_PAGES`]. `list_after` is
+    /// the oracle's, so only the probe that drains `list` sees it.
+    struct EndlessTokenListStore {
+        inner: MemoryStore,
+        pages: Mutex<u64>,
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStoreBackend for EndlessTokenListStore {
+        async fn put(
+            &self,
+            key: &str,
+            data: Bytes,
+            opts: PutOptions,
+        ) -> Result<crate::PutOutcome, StoreError> {
+            self.inner.put(key, data, opts).await
+        }
+
+        async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn list(
+            &self,
+            prefix: &str,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            let mut page_result = self.inner.list(prefix, page).await?;
+            let mut pages = self.pages.lock();
+            *pages += 1;
+            page_result.next = Some(PageToken(format!("endless-{pages}")));
+            Ok(page_result)
+        }
+
+        async fn list_after(
+            &self,
+            prefix: &str,
+            start_after: Option<&str>,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            self.inner.list_after(prefix, start_after, page).await
+        }
+
+        async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+            self.inner.list_delimited(prefix).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), StoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            self.inner.capabilities()
+        }
+    }
+
+    /// #1448 finding 4: the drain hands back a detail that already names the
+    /// prefix and the defect, so the membership probe reports it verbatim like
+    /// its three sibling drains, not wrapped in a second "listing ... failed"
+    /// sentence.
+    #[tokio::test]
+    async fn a_probe_drain_failure_is_reported_verbatim() {
+        let prefix = "sys/qualify/endless-token/";
+        let store = EndlessTokenListStore {
+            inner: MemoryStore::new(),
+            pages: Mutex::new(0),
+        };
+        let report = run_conformance_suite(&store, prefix).await;
+        assert!(!report.passed());
+        let failed: Vec<Property> = report.failures().map(|r| r.property).collect();
+        assert_eq!(failed, vec![Property::ConsistentListAfterWrite]);
+        let failure = report
+            .results
+            .iter()
+            .find(|r| r.property == Property::ConsistentListAfterWrite)
+            .expect("listing probe result present");
+        assert_eq!(
+            failure.detail,
+            format!(
+                "listing {prefix}law/ still returned a continuation token after \
+                 {MAX_PROBE_PAGES} pages over far fewer keys; this backend's pagination does \
+                 not terminate"
+            )
+        );
     }
 
     /// Wraps `MemoryStore` and drops every conditional-write precondition:
@@ -2401,16 +2611,25 @@ mod tests {
     #[derive(Clone, Copy)]
     enum PageBoundary {
         /// Re-delivers the previous page's first key as the first entry of the
-        /// next page: `[a, b]` then `[a, c, d]`. This is a permitted delivery
-        /// (docs/object-store-contract.md: "a key MAY appear more than once
-        /// and callers MUST dedup by key") and loses no key, so the only
-        /// thing wrong with it is the raw delivery order.
+        /// next page: `[a, b]` then `[a, c, d]`. It loses no key, but the
+        /// repeat is of a key that sorts before the page boundary, so the raw
+        /// delivery sequence decreases and the contract's permitted repeat is
+        /// the last key delivered, not an earlier one
+        /// (docs/object-store-contract.md, "Listing"). Every `list_all` over
+        /// this backend hard-fails with `ListOrderViolation`, so the suite
+        /// must not qualify it.
         ///
-        /// Re-delivering the page's own last key instead (`[a, b]` then
-        /// `[b, c]`) is permitted too, but its raw sequence never decreases,
-        /// so it cannot exercise an order check at all. The repeat has to be
-        /// of a key that sorts before the page boundary.
+        /// Re-delivering the page's own last key instead is the permitted
+        /// form: see [`PageBoundary::RepeatLastKey`].
         RepeatEarlierKey,
+        /// Re-delivers the page's own last key as the first entry of the next
+        /// page: `[a, b]` then `[b, c, d]`. This is the repeat the cross-page
+        /// guarantee permits ("a key MAY appear more than once and callers
+        /// MUST dedup by key"): the raw sequence never decreases, because the
+        /// repeat is of the last key delivered. It must qualify, and every
+        /// drain over it must return the same keys a non-repeating backend
+        /// returns.
+        RepeatLastKey,
         /// Holds each continued page's last key back and delivers it after the
         /// next page's first key: `[a]` then `[c, b]`. Every key arrives
         /// exactly once, so deduplication changes nothing and the distinct
@@ -2494,6 +2713,7 @@ mod tests {
             // always names a key this page really delivered.
             let held = match self.boundary {
                 PageBoundary::RepeatEarlierKey => result.objects.first().cloned(),
+                PageBoundary::RepeatLastKey => result.objects.last().cloned(),
                 PageBoundary::SwapAcrossBoundary => {
                     // Only a continued page can hand its last key to a later
                     // page; holding one back on the final page would lose it.
@@ -2506,7 +2726,7 @@ mod tests {
             };
             if let Some(meta) = carried {
                 let at = match self.boundary {
-                    PageBoundary::RepeatEarlierKey => 0,
+                    PageBoundary::RepeatEarlierKey | PageBoundary::RepeatLastKey => 0,
                     // After this page's own first key, so the two distinct
                     // keys arrive in the wrong order.
                     PageBoundary::SwapAcrossBoundary => 1.min(result.objects.len()),
@@ -2553,19 +2773,19 @@ mod tests {
             .expect("the ordering probe ran")
     }
 
-    /// A backend that re-delivers an already-delivered key across a page
-    /// boundary is compliant (docs/object-store-contract.md: "a key MAY appear
-    /// more than once and callers MUST dedup by key"), so it must qualify. The
-    /// probe therefore has to deduplicate before it judges order: the raw
-    /// delivery sequence here goes backwards while the distinct one does not.
+    /// The repeat the contract permits: a backend that re-delivers its own
+    /// last key across a page boundary keeps the raw sequence non-decreasing,
+    /// so it must qualify, and a drain over it must return the same five keys
+    /// once each. Qualification and the drain agree here too.
     #[tokio::test]
-    async fn listing_order_probe_accepts_a_contract_permitted_cross_page_repeat() {
-        let store = PageBoundaryStore::new(PageBoundary::RepeatEarlierKey, ListingPass::Full);
-        let prefix = "sys/qualify/order-repeat-full/";
+    async fn listing_order_probe_accepts_a_repeat_of_the_last_delivered_key() {
+        let store = PageBoundaryStore::new(PageBoundary::RepeatLastKey, ListingPass::Full);
+        let prefix = "sys/qualify/order-repeat-last-full/";
         let report = run_conformance_suite(&store, prefix).await;
         assert!(
             report.passed(),
-            "a cross-page repeat is a permitted delivery, so every probe must pass, got: {:?}",
+            "a repeat of the last delivered key is a permitted delivery, so every probe must \
+             pass, got: {:?}",
             report.failures().collect::<Vec<_>>()
         );
         let list_prefix = format!("{prefix}order/");
@@ -2574,10 +2794,90 @@ mod tests {
             expected_order_pass_detail(&list_prefix)
         );
 
+        // The repeat really fired: seven deliveries of five keys, never
+        // decreasing, with the two repeats adjacent to the key they repeat.
+        let (delivered, pages) = drain_probe_pages(&store, &list_prefix, ProbeListing::After(None))
+            .await
+            .expect("draining the probe's own prefix");
+        assert_eq!(
+            delivered,
+            vec![
+                format!("{list_prefix}a"),
+                format!("{list_prefix}b"),
+                format!("{list_prefix}b"),
+                format!("{list_prefix}c"),
+                format!("{list_prefix}d"),
+                format!("{list_prefix}d"),
+                format!("{list_prefix}e"),
+            ]
+        );
+        assert_eq!(pages, 3, "5 keys at page size 2 is exactly 3 pages");
+        assert_eq!(first_order_violation(&delivered), None);
+
+        // And the verdict a caller gets: the same five keys, once each.
+        let mut keys: Vec<String> = Vec::new();
+        let prefix_ref = list_prefix.as_str();
+        let store_ref = &store;
+        crate::drain_pages(
+            &list_prefix,
+            None,
+            crate::MAX_LIST_PAGES,
+            |start_after: Option<String>, token| async move {
+                store_ref
+                    .list_after(prefix_ref, start_after.as_deref(), token)
+                    .await
+            },
+            |meta| {
+                keys.push(meta.key);
+                Ok::<_, StoreError>(crate::DrainStep::Continue)
+            },
+        )
+        .await
+        .expect("a drain over a permitted repeat must succeed");
+        assert_eq!(
+            keys,
+            vec![
+                format!("{list_prefix}a"),
+                format!("{list_prefix}b"),
+                format!("{list_prefix}c"),
+                format!("{list_prefix}d"),
+                format!("{list_prefix}e"),
+            ]
+        );
+    }
+
+    /// A backend that re-delivers an EARLIER key across a page boundary loses
+    /// no key, but its raw delivery sequence decreases, and the contract's
+    /// permitted repeat is the last key already delivered
+    /// (docs/object-store-contract.md, "Listing"). Every drain over it fails
+    /// with `ListOrderViolation`, so the suite must refuse to qualify it:
+    /// qualification and the drain agree on one rule.
+    #[tokio::test]
+    async fn listing_order_probe_rejects_a_cross_page_repeat_of_an_earlier_key() {
+        let store = PageBoundaryStore::new(PageBoundary::RepeatEarlierKey, ListingPass::Full);
+        let prefix = "sys/qualify/order-repeat-full/";
+        let report = run_conformance_suite(&store, prefix).await;
+        assert!(!report.passed());
+        let failed: Vec<Property> = report.failures().map(|r| r.property).collect();
+        assert_eq!(
+            failed,
+            vec![Property::LexicographicListingOrder],
+            "no key is lost here, so only the ordering property may fail"
+        );
+        let list_prefix = format!("{prefix}order/");
+        assert_eq!(
+            order_probe_result(&report).detail,
+            format!(
+                "listing {list_prefix} delivered {list_prefix}a after {list_prefix}b, which sorts \
+                 before it; this backend's listing is not in lexicographic key order, so a \
+                 continuation token does not name a position in the key space"
+            )
+        );
+
         // The repeat really fired, and on the pass under test: the raw
         // sequence holds seven deliveries of five keys, and its first
         // backwards step is the repeated key after a larger one.
-        let (delivered, pages) = drain_pages(&store, &list_prefix, None)
+        let (delivered, pages) = drain_probe_pages(&store, &list_prefix, ProbeListing::After(None))
             .await
             .expect("draining the probe's own prefix");
         assert_eq!(
@@ -2597,8 +2897,10 @@ mod tests {
             first_order_violation(&delivered)
                 .map(|(before, after)| (before.to_string(), after.to_string())),
             Some((format!("{list_prefix}b"), format!("{list_prefix}a"))),
-            "the raw sequence goes backwards; only the deduplicated one does not"
+            "the raw sequence goes backwards, which is what the probe judges"
         );
+        // Deduplicating would have hidden it: the distinct sequence is in
+        // order, which is how this backend used to qualify.
         assert_eq!(
             distinct_in_delivery_order(&delivered),
             vec![
@@ -2609,14 +2911,43 @@ mod tests {
                 format!("{list_prefix}e"),
             ]
         );
+
+        // The verdict a caller gets over the same backend, which is why
+        // qualifying it would be wrong: the bounded drain rejects the same
+        // pair the probe reported. Last, because the drain aborts mid-listing
+        // and leaves this fixture's carried key behind.
+        let prefix_ref = list_prefix.as_str();
+        let store_ref = &store;
+        let err = crate::drain_pages(
+            &list_prefix,
+            None,
+            crate::MAX_LIST_PAGES,
+            |start_after: Option<String>, token| async move {
+                store_ref
+                    .list_after(prefix_ref, start_after.as_deref(), token)
+                    .await
+            },
+            |_meta| Ok::<_, StoreError>(crate::DrainStep::Continue),
+        )
+        .await
+        .expect_err("a drain over an earlier-key repeat must fail");
+        assert!(
+            matches!(
+                &err,
+                StoreError::ListOrderViolation { previous, offending, .. }
+                    if *previous == format!("{list_prefix}b")
+                        && *offending == format!("{list_prefix}a")
+            ),
+            "got {err:?}"
+        );
     }
 
-    /// Deduplicating first must not weaken the check: a backend whose distinct
-    /// delivery sequence goes backwards still fails, on the ordering property
-    /// and with the ordering message, even though it loses no key and repeats
-    /// nothing.
+    /// The other backward shape: a backend that delivers every key exactly
+    /// once in a swapped order fails too, on the ordering property and with
+    /// the ordering message. Nothing here repeats, so this one would fail
+    /// under either reading of the contract.
     #[tokio::test]
-    async fn listing_order_probe_still_rejects_backward_order_after_dedup() {
+    async fn listing_order_probe_rejects_a_swap_across_a_page_boundary() {
         let store = PageBoundaryStore::new(PageBoundary::SwapAcrossBoundary, ListingPass::Full);
         let prefix = "sys/qualify/order-swap-full/";
         let report = run_conformance_suite(&store, prefix).await;
@@ -2639,9 +2970,10 @@ mod tests {
 
         // Five keys, each delivered exactly once, in a swapped order: nothing
         // for deduplication to collapse.
-        let (delivered, _pages) = drain_pages(&store, &list_prefix, None)
-            .await
-            .expect("draining the probe's own prefix");
+        let (delivered, _pages) =
+            drain_probe_pages(&store, &list_prefix, ProbeListing::After(None))
+                .await
+                .expect("draining the probe's own prefix");
         assert_eq!(
             delivered,
             vec![
@@ -2656,30 +2988,32 @@ mod tests {
     }
 
     /// The `start_after` tail is the probe's second order check, so it needs
-    /// the same proof: a cross-page repeat confined to the tail listing is
-    /// permitted and must qualify.
+    /// the same rule: a repeat of an earlier key confined to the tail listing
+    /// decreases the raw sequence there, and must be refused there too.
     #[tokio::test]
-    async fn list_after_tail_accepts_a_contract_permitted_cross_page_repeat() {
+    async fn list_after_tail_rejects_a_cross_page_repeat_of_an_earlier_key() {
         let store = PageBoundaryStore::new(PageBoundary::RepeatEarlierKey, ListingPass::Tail);
         let prefix = "sys/qualify/order-repeat-tail/";
         let report = run_conformance_suite(&store, prefix).await;
-        assert!(
-            report.passed(),
-            "a cross-page repeat in the tail listing is a permitted delivery, got: {:?}",
-            report.failures().collect::<Vec<_>>()
-        );
+        assert!(!report.passed());
+        let failed: Vec<Property> = report.failures().map(|r| r.property).collect();
+        assert_eq!(failed, vec![Property::LexicographicListingOrder]);
         let list_prefix = format!("{prefix}order/");
         assert_eq!(
             order_probe_result(&report).detail,
-            expected_order_pass_detail(&list_prefix)
+            format!(
+                "list_after({list_prefix}, start_after={list_prefix}b) delivered {list_prefix}c \
+                 after {list_prefix}d, which sorts before it"
+            )
         );
 
         // The repeat fired in the tail pass only: four deliveries of the three
         // keys after the marker, going backwards once.
         let marker = format!("{list_prefix}b");
-        let (tail_delivered, pages) = drain_pages(&store, &list_prefix, Some(&marker))
-            .await
-            .expect("draining the probe's own tail");
+        let (tail_delivered, pages) =
+            drain_probe_pages(&store, &list_prefix, ProbeListing::After(Some(&marker)))
+                .await
+                .expect("draining the probe's own tail");
         assert_eq!(
             tail_delivered,
             vec![
@@ -2703,16 +3037,19 @@ mod tests {
                 format!("{list_prefix}e"),
             ]
         );
-        // The full drain was left alone, so this test's evidence is the tail.
-        let (delivered, _pages) = drain_pages(&store, &list_prefix, None)
-            .await
-            .expect("draining the probe's own prefix");
+        // The full drain was left alone, so this test's evidence is the tail:
+        // the full pass is in order and the probe still failed.
+        let (delivered, _pages) =
+            drain_probe_pages(&store, &list_prefix, ProbeListing::After(None))
+                .await
+                .expect("draining the probe's own prefix");
+        assert_eq!(first_order_violation(&delivered), None);
         assert_eq!(delivered, distinct_in_delivery_order(&delivered));
     }
 
-    /// The tail's order check keeps its teeth after deduplication too.
+    /// The tail's order check catches a swap as well as a repeat.
     #[tokio::test]
-    async fn list_after_tail_still_rejects_backward_order_after_dedup() {
+    async fn list_after_tail_rejects_a_swap_across_a_page_boundary() {
         let store = PageBoundaryStore::new(PageBoundary::SwapAcrossBoundary, ListingPass::Tail);
         let prefix = "sys/qualify/order-swap-tail/";
         let report = run_conformance_suite(&store, prefix).await;
@@ -2729,9 +3066,10 @@ mod tests {
         );
 
         let marker = format!("{list_prefix}b");
-        let (tail_delivered, _pages) = drain_pages(&store, &list_prefix, Some(&marker))
-            .await
-            .expect("draining the probe's own tail");
+        let (tail_delivered, _pages) =
+            drain_probe_pages(&store, &list_prefix, ProbeListing::After(Some(&marker)))
+                .await
+                .expect("draining the probe's own tail");
         assert_eq!(
             tail_delivered,
             vec![

--- a/crates/ravel-object-store/src/conformance.rs
+++ b/crates/ravel-object-store/src/conformance.rs
@@ -27,7 +27,7 @@
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
-use crate::{GetRange, ObjectStoreBackend, PutMode, PutOptions, StoreError, list_all};
+use crate::{GetRange, ObjectStoreBackend, PutMode, PutOptions, StoreError};
 
 /// Version of the probe set itself, recorded alongside a pass in
 /// `sys/qualification` (ADR-0050 section 6). Bump this whenever a probe is
@@ -762,9 +762,15 @@ async fn probe_consistent_list_after_write(
         {
             return ProbeResult::fail(property, format!("put {key} failed: {err}"));
         }
-        match list_all(store, &list_prefix).await {
-            Ok(objects) => {
-                if !objects.iter().any(|meta| meta.key == key) {
+        // A membership probe, deliberately order-tolerant: an unsorted backend
+        // loses no key, so this must still observe the just-written one and
+        // leave the ordering verdict to `probe_lexicographic_listing_order`.
+        // `list_all` now rejects an out-of-order key with a typed error, which
+        // would collapse membership into an ordering failure, so drain the raw
+        // pages here instead.
+        match drain_pages(store, &list_prefix, None).await {
+            Ok((keys, _pages)) => {
+                if !keys.contains(&key) {
                     return ProbeResult::fail(
                         property,
                         format!(
@@ -774,8 +780,11 @@ async fn probe_consistent_list_after_write(
                     );
                 }
             }
-            Err(err) => {
-                return ProbeResult::fail(property, format!("listing {list_prefix} failed: {err}"));
+            Err(detail) => {
+                return ProbeResult::fail(
+                    property,
+                    format!("listing {list_prefix} failed: {detail}"),
+                );
             }
         }
     }
@@ -1035,7 +1044,7 @@ const MAX_PROBE_PAGES: usize = 64;
 /// Drain every page of `prefix` (from `start_after`, when given) and return
 /// the keys in delivery order together with the number of pages served.
 ///
-/// Deliberately not [`list_all`]: that helper deduplicates and discards both
+/// Deliberately not [`crate::list_all`]: that helper deduplicates and discards both
 /// the delivery order and the page count, which are exactly what the two
 /// listing probes below examine. Errors come back as a ready-to-report detail
 /// string so a misbehaving backend produces a failed [`ProbeResult`] rather

--- a/crates/ravel-object-store/src/instrument.rs
+++ b/crates/ravel-object-store/src/instrument.rs
@@ -193,6 +193,15 @@ impl StoreErrorClass {
             StoreError::InvalidRange(_) => StoreErrorClass::InvalidRange,
             StoreError::Transient(_) => StoreErrorClass::Transient,
             StoreError::Permanent(_) => StoreErrorClass::Permanent,
+            // The drain helpers ([`crate::list_all`]) synthesize these when a
+            // backend violates the listing contract; they never flow through
+            // this decorator, which records raw `list` results, not drain
+            // outcomes. They are permanent, non-retryable client-side failures,
+            // so they classify as `Permanent`. Named explicitly, not via a
+            // wildcard, so a future variant still fails to compile here.
+            StoreError::ListRepeatedToken { .. }
+            | StoreError::ListPageCeiling { .. }
+            | StoreError::ListOrderViolation { .. } => StoreErrorClass::Permanent,
         }
     }
 

--- a/crates/ravel-object-store/src/lib.rs
+++ b/crates/ravel-object-store/src/lib.rs
@@ -575,7 +575,7 @@ impl<T: ObjectStoreBackend + ?Sized> ObjectStoreBackend for Arc<T> {
     }
 }
 
-/// Page ceiling for a single [`list_all`] drain.
+/// Page ceiling for a single [`list_all`] or [`drain_pages`] drain.
 ///
 /// At the contract's 1000-key page size (docs/object-store-contract.md,
 /// "Listing"), 100 000 pages bounds one drain to 100 million keys, far above
@@ -585,24 +585,128 @@ impl<T: ObjectStoreBackend + ?Sized> ObjectStoreBackend for Arc<T> {
 /// guard below catches the common spin (a backend handing back the same
 /// continuation token); this ceiling is the backstop for a token that keeps
 /// changing without advancing.
-const MAX_LIST_PAGES: usize = 100_000;
+pub const MAX_LIST_PAGES: usize = 100_000;
 
-/// Drain every page of a listing, deduplicating by key per the cross-page
-/// guarantee. Convenience for callers with bounded prefixes.
+/// What a [`drain_pages`] key hook wants the drain to do next.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DrainStep {
+    /// Keep going: finish this page, then request the next one if the backend
+    /// offers a continuation token.
+    Continue,
+    /// Stop the drain now, without visiting the rest of this page and without
+    /// requesting another page. For a caller whose keys sort past the range it
+    /// wants: the listing is ordered, so every later key is past it too.
+    Stop,
+}
+
+/// Drain a paged listing under `prefix` (resuming after `start_after`, when
+/// given), bounded, for every caller that pages a prefix.
 ///
-/// Two object-store contract guarantees (docs/object-store-contract.md,
-/// "Listing") drive the loop: keys arrive in lexicographic order, and a key
-/// MAY appear more than once so callers MUST dedup. Because a permitted repeat
-/// is therefore always equal to the last key already delivered, the dedup holds
-/// only that last key rather than a set of every key: an equal key is dropped,
-/// a strictly smaller key breaks the order guarantee and becomes
-/// [`StoreError::ListOrderViolation`], and a larger key is kept. That is
-/// constant extra memory over the returned set.
+/// The caller supplies the two hooks the drain has no business owning:
 ///
-/// The loop terminates on `page.next == None`. A backend that never terminates
-/// is a typed error, never a spin: a repeated continuation token is
-/// [`StoreError::ListRepeatedToken`], and a token that keeps changing without
-/// ending trips [`MAX_LIST_PAGES`] as [`StoreError::ListPageCeiling`].
+/// - `fetch` issues one page. It receives `start_after` and the continuation
+///   token to use, and is where the per-page work lives: an in-flight permit
+///   held across the request, request accounting, a caller's own request
+///   ceiling, and the choice of [`ObjectStoreBackend::list`] or
+///   [`ObjectStoreBackend::list_after`]. The permit is the reason the listing
+///   call sits here rather than inside the drain: it is acquired and released
+///   per page, so it has to wrap the request itself. It is a plain `FnMut`
+///   returning a future, and takes `start_after` owned, rather than an async
+///   closure over a borrow: both keep the future the drain builds free of
+///   higher-ranked lifetimes, so a caller whose own future is `tokio::spawn`ed
+///   stays `Send`. Anything the fetch hook must mutate across pages (a request
+///   counter) goes through a shared cell the future can hold by reference, such
+///   as an [`std::sync::atomic::AtomicU64`], since the future cannot borrow
+///   from the closure and must itself stay `Send`.
+/// - `keys` receives each key that survives the dedup, in delivery order. It
+///   returns [`DrainStep::Stop`] to end the drain early, or a caller error (a
+///   tenant-prefix isolation assertion, a malformed key).
+///
+/// What the drain owns is the bound and the contract's listing rules
+/// (docs/object-store-contract.md, "Listing"):
+///
+/// - The raw delivery sequence is non-decreasing, and a repeat re-delivers the
+///   last key already delivered, so the dedup holds only that last key rather
+///   than a set of every key: an equal key is dropped, a strictly smaller key
+///   breaks the order guarantee and becomes
+///   [`StoreError::ListOrderViolation`], and a larger key is passed to `keys`.
+///   That is constant extra memory whatever the prefix holds.
+/// - A backend that never terminates is a typed error, never a spin: a
+///   repeated continuation token is [`StoreError::ListRepeatedToken`], and a
+///   token that keeps changing without ending trips `max_pages` as
+///   [`StoreError::ListPageCeiling`]. Pass [`MAX_LIST_PAGES`] unless a test
+///   needs a smaller ceiling.
+pub async fn drain_pages<E, Fetch, Fut, Keys>(
+    prefix: &str,
+    start_after: Option<&str>,
+    max_pages: usize,
+    mut fetch: Fetch,
+    mut keys: Keys,
+) -> Result<(), E>
+where
+    E: From<StoreError>,
+    Fetch: FnMut(Option<String>, Option<PageToken>) -> Fut,
+    Fut: std::future::Future<Output = Result<ListPage, E>>,
+    Keys: FnMut(ObjectMeta) -> Result<DrainStep, E>,
+{
+    let start_after = start_after.map(str::to_string);
+    let mut last_key: Option<String> = None;
+    let mut page_token: Option<PageToken> = None;
+    let mut prev_token: Option<PageToken> = None;
+    let mut pages = 0usize;
+    loop {
+        if pages >= max_pages {
+            return Err(StoreError::ListPageCeiling {
+                prefix: prefix.to_string(),
+                ceiling: max_pages,
+            }
+            .into());
+        }
+        pages += 1;
+        let page = fetch(start_after.clone(), page_token).await?;
+        for meta in page.objects {
+            match last_key.as_deref() {
+                // The raw delivery sequence never decreases and a repeat
+                // re-delivers the last key, so a key at or below the last
+                // delivered one is either that same key again (dropped) or a
+                // backend that broke ordering (a typed error).
+                Some(last) if meta.key.as_str() < last => {
+                    return Err(StoreError::ListOrderViolation {
+                        prefix: prefix.to_string(),
+                        previous: last.to_string(),
+                        offending: meta.key,
+                    }
+                    .into());
+                }
+                Some(last) if meta.key.as_str() == last => {}
+                _ => {
+                    last_key = Some(meta.key.clone());
+                    if keys(meta)? == DrainStep::Stop {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        match page.next {
+            Some(next) => {
+                if prev_token.as_ref() == Some(&next) {
+                    return Err(StoreError::ListRepeatedToken {
+                        prefix: prefix.to_string(),
+                    }
+                    .into());
+                }
+                prev_token = Some(next.clone());
+                page_token = Some(next);
+            }
+            None => return Ok(()),
+        }
+    }
+}
+
+/// Drain every page of a [`ObjectStoreBackend::list`], deduplicating by key
+/// per the cross-page guarantee. Convenience for callers with bounded prefixes
+/// that need no per-page hook: [`drain_pages`] holds the bound and the listing
+/// rules, and this adds only "collect every key".
 pub async fn list_all(
     store: &dyn ObjectStoreBackend,
     prefix: &str,
@@ -618,51 +722,17 @@ async fn drain_list(
     max_pages: usize,
 ) -> Result<Vec<ObjectMeta>, StoreError> {
     let mut out: Vec<ObjectMeta> = Vec::new();
-    let mut last_key: Option<String> = None;
-    let mut page_token: Option<PageToken> = None;
-    let mut prev_token: Option<PageToken> = None;
-    let mut pages = 0usize;
-    loop {
-        if pages >= max_pages {
-            return Err(StoreError::ListPageCeiling {
-                prefix: prefix.to_string(),
-                ceiling: max_pages,
-            });
-        }
-        pages += 1;
-        let page = store.list(prefix, page_token).await?;
-        for meta in page.objects {
-            match last_key.as_deref() {
-                // Lexicographic order plus a permitted repeat means a key at or
-                // below the last delivered one is either that same key again
-                // (dropped) or a backend that broke ordering (a typed error).
-                Some(last) if meta.key.as_str() < last => {
-                    return Err(StoreError::ListOrderViolation {
-                        prefix: prefix.to_string(),
-                        previous: last.to_string(),
-                        offending: meta.key,
-                    });
-                }
-                Some(last) if meta.key.as_str() == last => {}
-                _ => {
-                    last_key = Some(meta.key.clone());
-                    out.push(meta);
-                }
-            }
-        }
-        match page.next {
-            Some(next) => {
-                if prev_token.as_ref() == Some(&next) {
-                    return Err(StoreError::ListRepeatedToken {
-                        prefix: prefix.to_string(),
-                    });
-                }
-                prev_token = Some(next.clone());
-                page_token = Some(next);
-            }
-            None => break,
-        }
-    }
+    drain_pages(
+        prefix,
+        None,
+        max_pages,
+        |_start_after, token| async move { store.list(prefix, token).await },
+        |meta| {
+            out.push(meta);
+            Ok(DrainStep::Continue)
+        },
+    )
+    .await?;
     Ok(out)
 }
 
@@ -889,6 +959,38 @@ mod list_all_tests {
         assert_eq!(store.call_count(), 2, "both scripted pages are drained");
     }
 
+    /// A page that overlaps its predecessor by more than one key is where the
+    /// two readings of the cross-page guarantee part. Under the contract's
+    /// rule (the raw sequence never decreases, and a repeat re-delivers the
+    /// last key delivered) the `p/b` after `p/c` is out of order and the drain
+    /// says so; under a looser "any key may repeat" reading it would be
+    /// dropped by a set dedup and the drain would return four keys. The
+    /// conformance suite certifies the same rule, so no backend it qualifies
+    /// reaches this error.
+    #[tokio::test]
+    async fn a_multi_key_page_overlap_is_a_typed_order_violation() {
+        let store = ScriptedList::new(&[&["p/a", "p/b", "p/c"], &["p/b", "p/c", "p/d"]]);
+        let err = drain_list(&store, "p/", MAX_LIST_PAGES)
+            .await
+            .expect_err("an overlap that re-delivers more than the last key must be rejected");
+        assert!(
+            matches!(
+                &err,
+                StoreError::ListOrderViolation {
+                    previous,
+                    offending,
+                    ..
+                } if previous == "p/c" && offending == "p/b"
+            ),
+            "got {err:?}"
+        );
+        assert_eq!(
+            store.call_count(),
+            2,
+            "the violation is detected on the second page, after both are fetched"
+        );
+    }
+
     /// A key strictly below the last delivered one breaks the contract's
     /// lexicographic-order guarantee. Folding out of order is wrong, so the
     /// drain returns a typed error rather than reordering.
@@ -916,12 +1018,75 @@ mod list_all_tests {
         );
     }
 
+    /// Counts `list` calls while delegating everything to the pagination
+    /// oracle, so a test can assert the exact number of pages a drain issued
+    /// rather than claim it in a comment.
+    struct CountingList {
+        inner: MemoryStore,
+        list_calls: AtomicUsize,
+    }
+
+    impl CountingList {
+        fn with_page_size(page_size: usize) -> Self {
+            CountingList {
+                inner: MemoryStore::with_page_size(page_size),
+                list_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn list_call_count(&self) -> usize {
+            self.list_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStoreBackend for CountingList {
+        async fn put(
+            &self,
+            key: &str,
+            data: Bytes,
+            opts: PutOptions,
+        ) -> Result<PutOutcome, StoreError> {
+            self.inner.put(key, data, opts).await
+        }
+
+        async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn list(
+            &self,
+            prefix: &str,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            self.list_calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.list(prefix, page).await
+        }
+
+        async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+            self.inner.list_delimited(prefix).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), StoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            self.inner.capabilities()
+        }
+    }
+
     /// A compliant backend drained over several real pages returns every key
-    /// once, in lexicographic order, identical to the pre-bound behavior.
+    /// once, in lexicographic order, identical to the pre-bound behavior. Page
+    /// size 2 over five keys really is a multi-page drain: exactly three pages,
+    /// counted at the store.
     #[tokio::test]
     async fn a_compliant_backend_returns_every_key_once_in_order() {
-        // Page size 2 forces three pages over five keys.
-        let store = MemoryStore::with_page_size(2);
+        let store = CountingList::with_page_size(2);
         for key in ["p/a", "p/b", "p/c", "p/d", "p/e"] {
             store
                 .put(
@@ -943,6 +1108,11 @@ mod list_all_tests {
             keys,
             vec!["p/a", "p/b", "p/c", "p/d", "p/e"],
             "the drain returns every key once, in order"
+        );
+        assert_eq!(
+            store.list_call_count(),
+            3,
+            "five keys at page size 2 is exactly three pages"
         );
     }
 }

--- a/crates/ravel-object-store/src/lib.rs
+++ b/crates/ravel-object-store/src/lib.rs
@@ -405,6 +405,28 @@ pub enum StoreError {
     Transient(String),
     #[error("permanent error: {0}")]
     Permanent(String),
+    /// A paged listing drain saw the same continuation token twice: the backend
+    /// reports "another page" while making no progress. Draining returns this
+    /// rather than spinning forever. Never retryable.
+    #[error("listing under {prefix:?} repeated its continuation token; refusing to spin")]
+    ListRepeatedToken { prefix: String },
+    /// A paged listing drain passed its page ceiling: a continuation token that
+    /// keeps changing without ever ending. Never retryable.
+    #[error("listing under {prefix:?} exceeded the {ceiling}-page listing ceiling")]
+    ListPageCeiling { prefix: String, ceiling: usize },
+    /// A paged listing delivered a key strictly below one already delivered,
+    /// breaking the contract's lexicographic-order guarantee. Folding out of
+    /// order is wrong, so draining returns this rather than silently
+    /// reordering. Never retryable.
+    #[error(
+        "listing under {prefix:?} delivered {offending:?} after {previous:?}, \
+         out of lexicographic order"
+    )]
+    ListOrderViolation {
+        prefix: String,
+        previous: String,
+        offending: String,
+    },
 }
 
 impl StoreError {
@@ -553,26 +575,374 @@ impl<T: ObjectStoreBackend + ?Sized> ObjectStoreBackend for Arc<T> {
     }
 }
 
+/// Page ceiling for a single [`list_all`] drain.
+///
+/// At the contract's 1000-key page size (docs/object-store-contract.md,
+/// "Listing"), 100 000 pages bounds one drain to 100 million keys, far above
+/// any prefix a caller drains: the widest is a whole-tenant or whole-store
+/// prefix during maintenance and benchmarks, orders of magnitude below this.
+/// It only ever trips on a backend that never terminates. The repeated-token
+/// guard below catches the common spin (a backend handing back the same
+/// continuation token); this ceiling is the backstop for a token that keeps
+/// changing without advancing.
+const MAX_LIST_PAGES: usize = 100_000;
+
 /// Drain every page of a listing, deduplicating by key per the cross-page
 /// guarantee. Convenience for callers with bounded prefixes.
+///
+/// Two object-store contract guarantees (docs/object-store-contract.md,
+/// "Listing") drive the loop: keys arrive in lexicographic order, and a key
+/// MAY appear more than once so callers MUST dedup. Because a permitted repeat
+/// is therefore always equal to the last key already delivered, the dedup holds
+/// only that last key rather than a set of every key: an equal key is dropped,
+/// a strictly smaller key breaks the order guarantee and becomes
+/// [`StoreError::ListOrderViolation`], and a larger key is kept. That is
+/// constant extra memory over the returned set.
+///
+/// The loop terminates on `page.next == None`. A backend that never terminates
+/// is a typed error, never a spin: a repeated continuation token is
+/// [`StoreError::ListRepeatedToken`], and a token that keeps changing without
+/// ending trips [`MAX_LIST_PAGES`] as [`StoreError::ListPageCeiling`].
 pub async fn list_all(
     store: &dyn ObjectStoreBackend,
     prefix: &str,
 ) -> Result<Vec<ObjectMeta>, StoreError> {
+    drain_list(store, prefix, MAX_LIST_PAGES).await
+}
+
+/// [`list_all`] with an explicit page ceiling, so a test can exercise the
+/// [`StoreError::ListPageCeiling`] path without draining 100 000 pages.
+async fn drain_list(
+    store: &dyn ObjectStoreBackend,
+    prefix: &str,
+    max_pages: usize,
+) -> Result<Vec<ObjectMeta>, StoreError> {
     let mut out: Vec<ObjectMeta> = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    let mut page_token = None;
+    let mut last_key: Option<String> = None;
+    let mut page_token: Option<PageToken> = None;
+    let mut prev_token: Option<PageToken> = None;
+    let mut pages = 0usize;
     loop {
+        if pages >= max_pages {
+            return Err(StoreError::ListPageCeiling {
+                prefix: prefix.to_string(),
+                ceiling: max_pages,
+            });
+        }
+        pages += 1;
         let page = store.list(prefix, page_token).await?;
         for meta in page.objects {
-            if seen.insert(meta.key.clone()) {
-                out.push(meta);
+            match last_key.as_deref() {
+                // Lexicographic order plus a permitted repeat means a key at or
+                // below the last delivered one is either that same key again
+                // (dropped) or a backend that broke ordering (a typed error).
+                Some(last) if meta.key.as_str() < last => {
+                    return Err(StoreError::ListOrderViolation {
+                        prefix: prefix.to_string(),
+                        previous: last.to_string(),
+                        offending: meta.key,
+                    });
+                }
+                Some(last) if meta.key.as_str() == last => {}
+                _ => {
+                    last_key = Some(meta.key.clone());
+                    out.push(meta);
+                }
             }
         }
         match page.next {
-            Some(next) => page_token = Some(next),
+            Some(next) => {
+                if prev_token.as_ref() == Some(&next) {
+                    return Err(StoreError::ListRepeatedToken {
+                        prefix: prefix.to_string(),
+                    });
+                }
+                prev_token = Some(next.clone());
+                page_token = Some(next);
+            }
             None => break,
         }
     }
     Ok(out)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod list_all_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::memory::MemoryStore;
+
+    /// A backend that never signals a last page: it always reports another page.
+    /// With `distinct` it hands back a fresh continuation token each call
+    /// (exercising the page ceiling); otherwise it repeats one token (exercising
+    /// the repeated-token guard). Every `list` call is counted.
+    struct NeverEndingList {
+        calls: AtomicUsize,
+        distinct: bool,
+    }
+
+    impl NeverEndingList {
+        fn new(distinct: bool) -> Self {
+            NeverEndingList {
+                calls: AtomicUsize::new(0),
+                distinct,
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStoreBackend for NeverEndingList {
+        async fn put(
+            &self,
+            _key: &str,
+            _data: Bytes,
+            _opts: PutOptions,
+        ) -> Result<PutOutcome, StoreError> {
+            unreachable!("NeverEndingList is list-only")
+        }
+
+        async fn get(&self, _key: &str, _range: GetRange) -> Result<GetOutcome, StoreError> {
+            unreachable!("NeverEndingList is list-only")
+        }
+
+        async fn head(&self, _key: &str) -> Result<ObjectMeta, StoreError> {
+            unreachable!("NeverEndingList is list-only")
+        }
+
+        async fn list(
+            &self,
+            _prefix: &str,
+            _page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            let token = if self.distinct {
+                PageToken(format!("tok-{n}"))
+            } else {
+                PageToken("stuck".to_string())
+            };
+            Ok(ListPage {
+                objects: Vec::new(),
+                next: Some(token),
+            })
+        }
+
+        async fn list_delimited(&self, _prefix: &str) -> Result<DelimitedList, StoreError> {
+            unreachable!("NeverEndingList is list-only")
+        }
+
+        async fn delete(&self, _key: &str) -> Result<(), StoreError> {
+            unreachable!("NeverEndingList is list-only")
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            Capabilities::mandatory()
+        }
+    }
+
+    /// A backend that replays a fixed script of pages, so a test can place an
+    /// exact key sequence across page boundaries: a contract-permitted repeat,
+    /// or a contract-violating backward key. `MemoryStore` cannot repeat a key,
+    /// so the dedup and order paths need a driver that can. Every `list` call is
+    /// counted; the last scripted page ends the listing (`next == None`).
+    struct ScriptedList {
+        pages: Vec<Vec<String>>,
+        calls: AtomicUsize,
+    }
+
+    impl ScriptedList {
+        fn new(pages: &[&[&str]]) -> Self {
+            ScriptedList {
+                pages: pages
+                    .iter()
+                    .map(|page| page.iter().map(|k| k.to_string()).collect())
+                    .collect(),
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+
+        fn meta(key: &str) -> ObjectMeta {
+            ObjectMeta {
+                key: key.to_string(),
+                size: 1,
+                etag: Etag("e".to_string()),
+                version: Version("v".to_string()),
+                last_modified_unix_ms: 0,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStoreBackend for ScriptedList {
+        async fn put(
+            &self,
+            _key: &str,
+            _data: Bytes,
+            _opts: PutOptions,
+        ) -> Result<PutOutcome, StoreError> {
+            unreachable!("ScriptedList is list-only")
+        }
+
+        async fn get(&self, _key: &str, _range: GetRange) -> Result<GetOutcome, StoreError> {
+            unreachable!("ScriptedList is list-only")
+        }
+
+        async fn head(&self, _key: &str) -> Result<ObjectMeta, StoreError> {
+            unreachable!("ScriptedList is list-only")
+        }
+
+        async fn list(
+            &self,
+            _prefix: &str,
+            _page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            let objects = self.pages[n].iter().map(|k| Self::meta(k)).collect();
+            let next = if n + 1 < self.pages.len() {
+                Some(PageToken(format!("tok-{n}")))
+            } else {
+                None
+            };
+            Ok(ListPage { objects, next })
+        }
+
+        async fn list_delimited(&self, _prefix: &str) -> Result<DelimitedList, StoreError> {
+            unreachable!("ScriptedList is list-only")
+        }
+
+        async fn delete(&self, _key: &str) -> Result<(), StoreError> {
+            unreachable!("ScriptedList is list-only")
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            Capabilities::mandatory()
+        }
+    }
+
+    /// A backend that repeats one continuation token is a typed error on the
+    /// second page, never an infinite loop.
+    #[tokio::test]
+    async fn a_repeated_continuation_token_is_a_typed_error_after_two_pages() {
+        let store = NeverEndingList::new(false);
+        let err = drain_list(&store, "p/", MAX_LIST_PAGES)
+            .await
+            .expect_err("a repeated token must not spin");
+        assert!(
+            matches!(err, StoreError::ListRepeatedToken { .. }),
+            "got {err:?}"
+        );
+        assert_eq!(
+            store.call_count(),
+            2,
+            "the repeat is detected on exactly the second page"
+        );
+    }
+
+    /// A backend whose token keeps changing without ever ending trips the page
+    /// ceiling at exactly `max_pages` pages.
+    #[tokio::test]
+    async fn an_ever_advancing_token_trips_the_page_ceiling_exactly() {
+        let store = NeverEndingList::new(true);
+        let err = drain_list(&store, "p/", 3)
+            .await
+            .expect_err("an unbounded listing must stop at the ceiling");
+        assert!(
+            matches!(err, StoreError::ListPageCeiling { ceiling: 3, .. }),
+            "got {err:?}"
+        );
+        assert_eq!(
+            store.call_count(),
+            3,
+            "exactly three pages are drained before the ceiling fires"
+        );
+    }
+
+    /// The object-store contract permits a key to appear more than once across
+    /// pages. When the last key of one page repeats as the first key of the
+    /// next, the fold keeps it exactly once.
+    #[tokio::test]
+    async fn a_repeat_at_a_page_boundary_is_folded_once() {
+        let store = ScriptedList::new(&[&["p/a", "p/b"], &["p/b", "p/c"]]);
+        let keys: Vec<String> = drain_list(&store, "p/", MAX_LIST_PAGES)
+            .await
+            .expect("a permitted repeat must not error")
+            .into_iter()
+            .map(|m| m.key)
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["p/a", "p/b", "p/c"],
+            "the boundary repeat of p/b is folded once, not twice"
+        );
+        assert_eq!(store.call_count(), 2, "both scripted pages are drained");
+    }
+
+    /// A key strictly below the last delivered one breaks the contract's
+    /// lexicographic-order guarantee. Folding out of order is wrong, so the
+    /// drain returns a typed error rather than reordering.
+    #[tokio::test]
+    async fn a_backward_key_is_a_typed_order_violation() {
+        let store = ScriptedList::new(&[&["p/a", "p/c"], &["p/b"]]);
+        let err = drain_list(&store, "p/", MAX_LIST_PAGES)
+            .await
+            .expect_err("a backward key must be rejected");
+        assert!(
+            matches!(
+                &err,
+                StoreError::ListOrderViolation {
+                    previous,
+                    offending,
+                    ..
+                } if previous == "p/c" && offending == "p/b"
+            ),
+            "got {err:?}"
+        );
+        assert_eq!(
+            store.call_count(),
+            2,
+            "the violation is detected on the second page, after both are fetched"
+        );
+    }
+
+    /// A compliant backend drained over several real pages returns every key
+    /// once, in lexicographic order, identical to the pre-bound behavior.
+    #[tokio::test]
+    async fn a_compliant_backend_returns_every_key_once_in_order() {
+        // Page size 2 forces three pages over five keys.
+        let store = MemoryStore::with_page_size(2);
+        for key in ["p/a", "p/b", "p/c", "p/d", "p/e"] {
+            store
+                .put(
+                    key,
+                    Bytes::from_static(b"x"),
+                    PutOptions::create_if_absent(),
+                )
+                .await
+                .expect("seed key");
+        }
+
+        let keys: Vec<String> = list_all(&store, "p/")
+            .await
+            .expect("full drain")
+            .into_iter()
+            .map(|m| m.key)
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["p/a", "p/b", "p/c", "p/d", "p/e"],
+            "the drain returns every key once, in order"
+        );
+    }
 }

--- a/crates/ravel-object-store/src/s3.rs
+++ b/crates/ravel-object-store/src/s3.rs
@@ -1338,6 +1338,17 @@ impl S3Store {
             Err(
                 e @ (StoreError::Throttled { .. } | StoreError::Timeout | StoreError::Transient(_)),
             ) => Err(e),
+            // The listing-drain variants are synthesized by `list_all`, never
+            // returned by `head`, so they are unreachable here. Pass them
+            // through unchanged rather than fold them into `AlreadyExists`:
+            // that keeps an impossible value honest without fabricating a
+            // terminal collision verdict. Named, not a wildcard, so a new
+            // variant still fails to compile here.
+            Err(
+                e @ (StoreError::ListRepeatedToken { .. }
+                | StoreError::ListPageCeiling { .. }
+                | StoreError::ListOrderViolation { .. }),
+            ) => Err(e),
             Err(
                 StoreError::AccessDenied(_)
                 | StoreError::PreconditionFailed

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -2649,6 +2649,22 @@ pub(crate) fn clone_store_error(err: &StoreError) -> StoreError {
         StoreError::InvalidRange(msg) => StoreError::InvalidRange(msg.clone()),
         StoreError::Transient(msg) => StoreError::Transient(msg.clone()),
         StoreError::Permanent(msg) => StoreError::Permanent(msg.clone()),
+        StoreError::ListRepeatedToken { prefix } => StoreError::ListRepeatedToken {
+            prefix: prefix.clone(),
+        },
+        StoreError::ListPageCeiling { prefix, ceiling } => StoreError::ListPageCeiling {
+            prefix: prefix.clone(),
+            ceiling: *ceiling,
+        },
+        StoreError::ListOrderViolation {
+            prefix,
+            previous,
+            offending,
+        } => StoreError::ListOrderViolation {
+            prefix: prefix.clone(),
+            previous: previous.clone(),
+            offending: offending.clone(),
+        },
     }
 }
 

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -170,15 +170,20 @@ trait honors cancellation by drop, so the query deadline (usually well under
 - Listing is paginated (S3 pages at 1000 keys). Cross-page guarantee: any
   key created before the first page request is returned; keys created
   during the scan may or may not appear; a key MAY appear more than once
-  and callers MUST dedup by key. Because keys arrive in lexicographic
-  order, a permitted repeat is always equal to the last key already
-  delivered, so a caller draining every page dedups at constant memory by
-  holding only that last key. A key strictly below the last delivered one
-  is an order violation, not a repeat, and the client rejects it. The
-  client also bounds the drain: a continuation token equal to the previous
-  one is a spinning backend and the client fails rather than looping
-  forever, and a token that keeps changing without ending is bounded by a
-  page ceiling (100 000 pages, 100 million keys at the 1000-key page size).
+  and callers MUST dedup by key. The RAW delivery sequence, across every
+  page of one drain and counting repeats, is non-decreasing, and a repeat
+  re-delivers the last key delivered, never an earlier one. That is what
+  `MemoryStore::list`, `S3Store::list`, and S3 itself do, and the
+  conformance suite's `LexicographicListingOrder` probe judges the raw
+  sequence on exactly this rule: equal adjacent keys pass, a decrease
+  fails qualification. So a caller draining every page dedups at constant
+  memory by holding only the last key: an equal key is dropped, and a key
+  strictly below it is an order violation, not a repeat, which the client
+  rejects rather than reordering. The client also bounds the drain: a
+  continuation token equal to the previous one is a spinning backend and
+  the client fails rather than looping forever, and a token that keeps
+  changing without ending is bounded by a page ceiling (100 000 pages,
+  100 million keys at the 1000-key page size).
 - `list_after(prefix, start_after, page)` returns exactly the keys `list`
   would, minus every key `<= start_after`: each returned key compares
   strictly greater than `start_after`, in the same lexicographic order and
@@ -551,13 +556,20 @@ throwaway key prefix:
   read-your-writes gap that only shows up intermittently.
 - `ConsistentListAfterWrite`: a `list` immediately following a `put`
   includes the new key, repeated the same way, to catch eventual-consistency
-  listing rather than trusting the `consistent_list` flag.
+  listing rather than trusting the `consistent_list` flag. This probe
+  drains `list` itself, which `S3Store` implements separately from
+  `list_after` and every catalog scan issues, so the suite covers both
+  methods rather than reaching one only through the other's default.
 - `LexicographicListingOrder`: five keys written in non-sorted order must
   come back in lexicographic key order, and `list_after` must resume
   strictly after its marker in that same order, delivering exactly the keys
   above it. A continuation token only names a position when the order is the
   lexicographic one, which is what `S3Store::list` pagination and every
-  catalog scan built on it assume.
+  catalog scan built on it assume. Both passes judge the raw delivery
+  sequence, repeats included, on the rule the listing bullet above states:
+  a repeat of the last delivered key passes, a repeat of an earlier one
+  fails. Judging a deduplicated sequence instead would qualify a backend
+  whose every drain then fails with `ListOrderViolation`.
 - `CrossPageListing`: five keys written before the first page request must
   all be delivered, as exactly five distinct keys across however many pages
   the backend serves, with none lost between pages. Repeat deliveries are

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -170,7 +170,15 @@ trait honors cancellation by drop, so the query deadline (usually well under
 - Listing is paginated (S3 pages at 1000 keys). Cross-page guarantee: any
   key created before the first page request is returned; keys created
   during the scan may or may not appear; a key MAY appear more than once
-  and callers MUST dedup by key.
+  and callers MUST dedup by key. Because keys arrive in lexicographic
+  order, a permitted repeat is always equal to the last key already
+  delivered, so a caller draining every page dedups at constant memory by
+  holding only that last key. A key strictly below the last delivered one
+  is an order violation, not a repeat, and the client rejects it. The
+  client also bounds the drain: a continuation token equal to the previous
+  one is a spinning backend and the client fails rather than looping
+  forever, and a token that keeps changing without ending is bounded by a
+  page ceiling (100 000 pages, 100 million keys at the 1000-key page size).
 - `list_after(prefix, start_after, page)` returns exactly the keys `list`
   would, minus every key `<= start_after`: each returned key compares
   strictly greater than `start_after`, in the same lexicographic order and


### PR DESCRIPTION
A backend that keeps returning a continuation token spun list_all forever,
and a repeated token or a key delivered below the last one was accepted as
a permitted duplicate. The drain is now one shared helper, drain_pages,
that caps the page count at MAX_LIST_PAGES, refuses a repeated continuation
token, drops a repeat of the last delivered key, and rejects a key strictly
below it as an order violation. Each case is a typed error.

The contract reading is strict: the raw delivery sequence across every page
of one drain is non-decreasing, and a repeat re-delivers the last key only.
docs/object-store-contract.md now says so, and the conformance suite's
LexicographicListingOrder probe judges the raw sequence on that rule instead
of a deduplicated view that would have qualified a backend whose every
drain then fails. guarded_list_all and three catalog siblings, and
ravel-maintain's list_all_counted, route through the shared helper with
their per-page accounting hooks kept.

Every guard is proven by a flipped-line failure in the tests; page counts
are asserted exactly.

Supersedes #1474, which carried the first round of this change without the
shared drain and with the contract text still ambiguous.

Local pre-flight was scoped to ravel-object-store, ravel-catalog and
ravel-maintain; the ravel-query fetcher change compiles under the workspace
lint the pull request checks run.

Fixes: #1448
Refs: #1313
