### PR TITLE
feat(commit): gate CompactionRecord and RetentionTombstone reads on format_version

### DIFF
--- a/crates/ravel-bench/src/bin/compaction_bench.rs
+++ b/crates/ravel-bench/src/bin/compaction_bench.rs
@@ -301,7 +301,7 @@ async fn fetch_compaction_record(
         .first()
         .expect("a compaction record exists");
     let got = store.get(key, GetRange::Full).await.expect("get record");
-    CompactionRecord::decode(got.data.as_ref()).expect("decode record")
+    record::decode_compaction(got.data.as_ref()).expect("decode record")
 }
 
 /// Stored-byte + object-count scenario (§9 gate).

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use futures::stream::{self, StreamExt};
 use parking_lot::Mutex;
+#[cfg(test)]
 use prost::Message;
 use ravel_cache::{
     Cache, CacheKey, CacheLimits, DiskCache, SingleFlightError, Source, TieredCache,
@@ -2979,7 +2980,7 @@ impl Catalog {
         }
         let got = self.guarded_get(key, GetRange::Full, accounting).await?;
         let bytes = got.data.len() as u64;
-        let record = CompactionRecord::decode(got.data.as_ref()).map_err(|e| {
+        let record = record::decode_compaction(got.data.as_ref()).map_err(|e| {
             CatalogError::CompactionRecordDecode {
                 key: key.to_string(),
                 source: e,
@@ -8208,5 +8209,60 @@ mod tests {
             "the covered part set is unchanged by eviction"
         );
         assert_eq!(loaded_value(&reloaded_a), 42, "and carry tenant A's value");
+    }
+
+    /// A compaction record stamped a future `format_version` is refused by the
+    /// resolve read path (`load_and_validate_compaction`, docs/catalog-and-mvcc.md
+    /// step 2), not read as version 1. The record is otherwise fully
+    /// self-consistent: its identity fields reconstruct its own key, so the
+    /// only thing that can reject it is the ADR-0066 decision 2 version gate.
+    /// Removing that gate (making `check_format_version` always `Ok`) makes
+    /// this test fail: the record then decodes and validates as version 1 and
+    /// the call returns `Ok`.
+    #[tokio::test]
+    async fn resolve_refuses_a_future_version_compaction_record() {
+        let store = Arc::new(MemoryStore::new());
+        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+        let accounting = QueryAccounting::new();
+        let tenant = tenant();
+        let signal = Signal::Metrics;
+
+        let record = ravel_proto::commit::v1::CompactionRecord {
+            format_version: 2,
+            tenant_hash: tenant.0.to_vec(),
+            signal: signal::to_proto(signal).into(),
+            shard: 0,
+            ingest_hour_bucket: 1,
+            input_set_hash: vec![0x11; 32],
+            ..Default::default()
+        };
+        let key = ravel_commit::keys::compaction_record_key_for(&record).expect("key");
+        store
+            .put(
+                &key,
+                ravel_commit::record::encode_compaction(&record),
+                PutOptions::default(),
+            )
+            .await
+            .expect("seed put");
+
+        let err = catalog
+            .load_and_validate_compaction(&tenant, signal, 0, &key, &accounting)
+            .await
+            .expect_err("a version-2 compaction record must be refused, not read as v1");
+        assert!(
+            err.to_string().contains("compaction record"),
+            "the error names the record kind: {err}"
+        );
+        match err {
+            CatalogError::CompactionRecordDecode { source, .. } => match source {
+                ravel_commit::record::RecordError::UnsupportedRecordFormatVersion {
+                    actual,
+                    ..
+                } => assert_eq!(actual, 2, "the error carries the version seen"),
+                other => panic!("expected UnsupportedRecordFormatVersion, got {other:?}"),
+            },
+            other => panic!("expected CompactionRecordDecode, got {other:?}"),
+        }
     }
 }

--- a/crates/ravel-catalog/src/error.rs
+++ b/crates/ravel-catalog/src/error.rs
@@ -18,13 +18,14 @@ pub enum CatalogError {
     Key(#[from] KeyError),
     #[error("commit record decode/validation error: {0}")]
     Record(#[from] RecordError),
-    /// A compaction record failed protobuf decode (docs/catalog-and-mvcc.md
-    /// step 2). Fatal: layout drift or corruption, never silently skipped.
+    /// A compaction record failed decode or its `format_version` gate
+    /// (docs/catalog-and-mvcc.md step 2, ADR-0066 decision 2). Fatal: layout
+    /// drift, corruption, or an unsupported version, never silently skipped.
     #[error("compaction record at {key:?} failed to decode: {source}")]
     CompactionRecordDecode {
         key: String,
         #[source]
-        source: prost::DecodeError,
+        source: RecordError,
     },
     /// Fatal: a commit record's own identity fields do not reconstruct to
     /// its stored `object_key` (ADR-0010 §7). Never silently prefer either

--- a/crates/ravel-catalog/src/seal_divergence.rs
+++ b/crates/ravel-catalog/src/seal_divergence.rs
@@ -25,12 +25,12 @@
 
 use std::collections::{BTreeMap, HashSet};
 
+#[cfg(test)]
 use prost::Message;
 use ravel_commit::erasure::compute_compaction_input_set_hash;
 use ravel_commit::keys::{self, KeyError};
 use ravel_commit::record::{self, RecordError};
 use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
-use ravel_proto::commit::v1::CompactionRecord;
 use ravel_types::{Signal, TenantHash};
 use uuid::Uuid;
 
@@ -138,7 +138,7 @@ pub enum SealDivergenceError {
     CompactionRecordCorrupt {
         key: String,
         #[source]
-        source: prost::DecodeError,
+        source: RecordError,
     },
     #[error(
         "compaction record at {key} declares input_set_hash {declared} but its own inputs \
@@ -286,7 +286,7 @@ pub async fn verify_seal_divergence(
                         key: object.key.clone(),
                         source,
                     })?;
-                let rec = CompactionRecord::decode(got.data.as_ref()).map_err(|source| {
+                let rec = record::decode_compaction(got.data.as_ref()).map_err(|source| {
                     SealDivergenceError::CompactionRecordCorrupt {
                         key: object.key.clone(),
                         source,

--- a/crates/ravel-commit/src/record.rs
+++ b/crates/ravel-commit/src/record.rs
@@ -2,7 +2,7 @@
 //! (docs/catalog-and-mvcc.md, ADR-0010 §1).
 
 use prost::Message;
-use ravel_proto::commit::v1::CommitRecord;
+use ravel_proto::commit::v1::{CommitRecord, CompactionRecord, RetentionTombstone};
 use ravel_types::{CommitToken, Signal, TenantHash};
 use uuid::Uuid;
 
@@ -11,7 +11,55 @@ use crate::signal;
 
 /// The only supported `CommitRecord.format_version`.
 pub const FORMAT_VERSION: u32 = 1;
+/// The only supported `CompactionRecord.format_version` (ADR-0066 decision 2).
+pub const COMPACTION_FORMAT_VERSION: u32 = 1;
+/// The only supported `RetentionTombstone.format_version` (ADR-0066 decision 2).
+pub const TOMBSTONE_FORMAT_VERSION: u32 = 1;
 const NS_PER_HOUR: i64 = 3_600_000_000_000;
+
+/// A durable commit-protocol record kind that carries a `format_version`.
+/// Every variant here must have a decode-and-validate pair that rejects an
+/// out-of-range version through [`check_format_version`]; the enumeration
+/// guard test asserts it, so a fourth kind cannot ship ungated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordKind {
+    Commit,
+    Compaction,
+    RetentionTombstone,
+}
+
+impl RecordKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            RecordKind::Commit => "commit record",
+            RecordKind::Compaction => "compaction record",
+            RecordKind::RetentionTombstone => "retention tombstone",
+        }
+    }
+}
+
+/// The shared supported-set gate for every versioned record kind: `actual`
+/// must fall within the inclusive `[min, max]` band. A version below the
+/// floor (a writer that failed to stamp, leaving proto3's default 0) and a
+/// version above the ceiling (a future writer whose meaning this reader does
+/// not know) are both refused with the typed error naming the kind and the
+/// version seen, never read as the supported version.
+fn check_format_version(
+    kind: RecordKind,
+    actual: u32,
+    min: u32,
+    max: u32,
+) -> Result<(), RecordError> {
+    if actual < min || actual > max {
+        return Err(RecordError::UnsupportedRecordFormatVersion {
+            kind,
+            min,
+            max,
+            actual,
+        });
+    }
+    Ok(())
+}
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum RecordError {
@@ -21,6 +69,16 @@ pub enum RecordError {
     InvalidContentHashLen(usize),
     #[error("unsupported format_version: expected {expected}, got {actual}")]
     UnsupportedFormatVersion { expected: u32, actual: u32 },
+    #[error(
+        "unsupported {kind} format_version: supported {min}..={max}, got {actual}",
+        kind = kind.as_str()
+    )]
+    UnsupportedRecordFormatVersion {
+        kind: RecordKind,
+        min: u32,
+        max: u32,
+        actual: u32,
+    },
     #[error("event ts out of order: min_event_ts_ns {min} > max_event_ts_ns {max}")]
     EventTsOutOfOrder { min: i64, max: i64 },
     #[error("ingest ts out of order: min_ingest_ts_ns {min} > max_ingest_ts_ns {max}")]
@@ -185,6 +243,68 @@ pub fn token_for(record: &CommitRecord) -> Result<CommitToken, RecordError> {
     })
 }
 
+/// Structural invariants every `CompactionRecord` must satisfy on read. The
+/// primary gate is the supported-set `format_version` check (ADR-0066
+/// decision 2): a record stamped with an unknown version is refused, never
+/// read as version 1. Mirrors [`validate`] for `CommitRecord`; like it, the
+/// distinct `object_key`/identity reconstruction is a separate reader check
+/// (see [`crate::keys::verify_compaction_record_key`]), not repeated here.
+pub fn validate_compaction(record: &CompactionRecord) -> Result<(), RecordError> {
+    check_format_version(
+        RecordKind::Compaction,
+        record.format_version,
+        COMPACTION_FORMAT_VERSION,
+        COMPACTION_FORMAT_VERSION,
+    )?;
+    if record.tenant_hash.len() != 16 {
+        return Err(RecordError::InvalidTenantHashLen(record.tenant_hash.len()));
+    }
+    Ok(())
+}
+
+/// Serialize a `CompactionRecord`. Infallible, like [`encode`].
+pub fn encode_compaction(record: &CompactionRecord) -> bytes::Bytes {
+    record.encode_to_vec().into()
+}
+
+/// Deserialize and validate a `CompactionRecord`. The only decode path
+/// production code may use: the raw prost `Message::decode` skips the
+/// `format_version` gate and reads a future record as version 1.
+pub fn decode_compaction(bytes: &[u8]) -> Result<CompactionRecord, RecordError> {
+    let record = CompactionRecord::decode(bytes)?;
+    validate_compaction(&record)?;
+    Ok(record)
+}
+
+/// Structural invariants every `RetentionTombstone` must satisfy on read.
+/// Same supported-set `format_version` gate and rationale as
+/// [`validate_compaction`].
+pub fn validate_tombstone(record: &RetentionTombstone) -> Result<(), RecordError> {
+    check_format_version(
+        RecordKind::RetentionTombstone,
+        record.format_version,
+        TOMBSTONE_FORMAT_VERSION,
+        TOMBSTONE_FORMAT_VERSION,
+    )?;
+    if record.tenant_hash.len() != 16 {
+        return Err(RecordError::InvalidTenantHashLen(record.tenant_hash.len()));
+    }
+    Ok(())
+}
+
+/// Serialize a `RetentionTombstone`. Infallible, like [`encode`].
+pub fn encode_tombstone(record: &RetentionTombstone) -> bytes::Bytes {
+    record.encode_to_vec().into()
+}
+
+/// Deserialize and validate a `RetentionTombstone`. The only decode path
+/// production code may use, for the same reason as [`decode_compaction`].
+pub fn decode_tombstone(bytes: &[u8]) -> Result<RetentionTombstone, RecordError> {
+    let record = RetentionTombstone::decode(bytes)?;
+    validate_tombstone(&record)?;
+    Ok(record)
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
@@ -326,5 +446,161 @@ mod tests {
         input.ingest_hour_bucket = u32::MAX;
         let record = build(input).expect("zero created_unix_ns skips the cross-check");
         assert!(validate(&record).is_ok());
+    }
+
+    fn sample_compaction() -> CompactionRecord {
+        CompactionRecord {
+            format_version: COMPACTION_FORMAT_VERSION,
+            tenant_hash: vec![0x33; 16],
+            signal: signal::to_proto(Signal::Metrics) as i32,
+            shard: 1,
+            ingest_hour_bucket: 495_734,
+            level: 1,
+            inputs: Vec::new(),
+            input_set_hash: vec![0x44; 32],
+            parts: Vec::new(),
+            created_unix_ns: 495_734 * NS_PER_HOUR,
+        }
+    }
+
+    fn sample_tombstone() -> RetentionTombstone {
+        RetentionTombstone {
+            format_version: TOMBSTONE_FORMAT_VERSION,
+            tenant_hash: vec![0x55; 16],
+            signal: signal::to_proto(Signal::Metrics) as i32,
+            shard: 1,
+            ingest_hour_bucket: 495_734,
+            retired_at_ns: 495_734 * NS_PER_HOUR,
+            retention_window_ns: 720 * NS_PER_HOUR as u64,
+            record_count_observed: 3,
+        }
+    }
+
+    #[test]
+    fn compaction_version_one_accepted_and_round_trips() {
+        let record = sample_compaction();
+        assert!(validate_compaction(&record).is_ok());
+        let bytes = encode_compaction(&record);
+        let decoded = decode_compaction(&bytes).expect("decode");
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn compaction_version_two_refused_with_typed_error() {
+        let mut record = sample_compaction();
+        record.format_version = 2;
+        let bytes = record.encode_to_vec();
+        assert_eq!(
+            decode_compaction(&bytes),
+            Err(RecordError::UnsupportedRecordFormatVersion {
+                kind: RecordKind::Compaction,
+                min: 1,
+                max: 1,
+                actual: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn compaction_version_zero_refused_with_typed_error() {
+        let mut record = sample_compaction();
+        record.format_version = 0;
+        let bytes = record.encode_to_vec();
+        assert_eq!(
+            decode_compaction(&bytes),
+            Err(RecordError::UnsupportedRecordFormatVersion {
+                kind: RecordKind::Compaction,
+                min: 1,
+                max: 1,
+                actual: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn tombstone_version_one_accepted_and_round_trips() {
+        let record = sample_tombstone();
+        assert!(validate_tombstone(&record).is_ok());
+        let bytes = encode_tombstone(&record);
+        let decoded = decode_tombstone(&bytes).expect("decode");
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn tombstone_version_two_refused_with_typed_error() {
+        let mut record = sample_tombstone();
+        record.format_version = 2;
+        let bytes = record.encode_to_vec();
+        assert_eq!(
+            decode_tombstone(&bytes),
+            Err(RecordError::UnsupportedRecordFormatVersion {
+                kind: RecordKind::RetentionTombstone,
+                min: 1,
+                max: 1,
+                actual: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn tombstone_version_zero_refused_with_typed_error() {
+        let mut record = sample_tombstone();
+        record.format_version = 0;
+        let bytes = record.encode_to_vec();
+        assert_eq!(
+            decode_tombstone(&bytes),
+            Err(RecordError::UnsupportedRecordFormatVersion {
+                kind: RecordKind::RetentionTombstone,
+                min: 1,
+                max: 1,
+                actual: 0,
+            })
+        );
+    }
+
+    /// Enumeration guard: every `RecordKind` must have a decode-and-validate
+    /// pair that refuses an out-of-range `format_version`. The exhaustive
+    /// match makes a fourth kind fail to compile here until it is wired to a
+    /// validate pair, so no versioned record can ship ungated (ADR-0066).
+    #[test]
+    fn every_record_kind_has_a_versioned_validate_pair() {
+        for kind in [
+            RecordKind::Commit,
+            RecordKind::Compaction,
+            RecordKind::RetentionTombstone,
+        ] {
+            match kind {
+                RecordKind::Commit => {
+                    let mut record = build(base_input()).expect("valid");
+                    record.format_version = 2;
+                    assert!(matches!(
+                        validate(&record),
+                        Err(RecordError::UnsupportedFormatVersion { .. })
+                    ));
+                }
+                RecordKind::Compaction => {
+                    let mut record = sample_compaction();
+                    record.format_version = 2;
+                    assert!(matches!(
+                        validate_compaction(&record),
+                        Err(RecordError::UnsupportedRecordFormatVersion {
+                            kind: RecordKind::Compaction,
+                            ..
+                        })
+                    ));
+                }
+                RecordKind::RetentionTombstone => {
+                    let mut record = sample_tombstone();
+                    record.format_version = 2;
+                    assert!(matches!(
+                        validate_tombstone(&record),
+                        Err(RecordError::UnsupportedRecordFormatVersion {
+                            kind: RecordKind::RetentionTombstone,
+                            ..
+                        })
+                    ));
+                }
+            }
+        }
     }
 }

--- a/crates/ravel-maintain/src/audit_retention.rs
+++ b/crates/ravel-maintain/src/audit_retention.rs
@@ -66,6 +66,7 @@ use ravel_object_store::{GetRange, ObjectStoreBackend, list_all};
 use ravel_proto::commit::v1::CompactionRecord;
 use ravel_types::{Signal, TenantHash};
 
+#[cfg(test)]
 use prost::Message;
 
 use crate::clock::Clock;
@@ -274,7 +275,7 @@ async fn get_compaction_record(
     key: &str,
 ) -> Result<CompactionRecord> {
     let got = store.get(key, GetRange::Full).await?;
-    let record = CompactionRecord::decode(got.data.as_ref())
+    let record = record::decode_compaction(got.data.as_ref())
         .map_err(|e| MaintainError::Invariant(format!("compaction record decode failed: {e}")))?;
     keys::verify_compaction_record_key(&record, key)?;
     Ok(record)

--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -399,7 +399,7 @@ async fn get_compaction_record(
     key: &str,
 ) -> Result<CompactionRecord> {
     let got = store.get(key, GetRange::Full).await?;
-    let record = CompactionRecord::decode(got.data.as_ref())
+    let record = ravel_commit::record::decode_compaction(got.data.as_ref())
         .map_err(|e| MaintainError::Invariant(format!("compaction record decode failed: {e}")))?;
     keys::verify_compaction_record_key(&record, key)?;
     Ok(record)

--- a/crates/ravel-maintain/src/migrate.rs
+++ b/crates/ravel-maintain/src/migrate.rs
@@ -422,7 +422,7 @@ pub async fn count_below_target(
                 keys::BucketEntry::CommitRecord(_) => commit_keys.push(key),
                 keys::BucketEntry::CompactionRecord(_) => {
                     let got = store.get(&key, GetRange::Full).await?;
-                    let rec = CompactionRecord::decode(got.data.as_ref()).map_err(|err| {
+                    let rec = record::decode_compaction(got.data.as_ref()).map_err(|err| {
                         MaintainError::Invariant(format!(
                             "compaction record {key} is corrupt during migration re-audit: \
                              {err}"
@@ -608,7 +608,7 @@ async fn raw_served_commit_keys(
             Err(ravel_object_store::StoreError::NotFound) => continue,
             Err(err) => return Err(err.into()),
         };
-        let rec = CompactionRecord::decode(got.data.as_ref()).map_err(|err| {
+        let rec = record::decode_compaction(got.data.as_ref()).map_err(|err| {
             MaintainError::Invariant(format!(
                 "compaction record {key} is corrupt during the migrate walk: {err}"
             ))

--- a/crates/ravel-maintain/src/publish.rs
+++ b/crates/ravel-maintain/src/publish.rs
@@ -296,7 +296,7 @@ async fn resolve_already_exists(
     let existing = store.get(record_key, GetRange::Full).await;
     note_get(ledger, RequestPhase::Publish, &existing);
     let existing = existing?;
-    let winner = CompactionRecord::decode(existing.data.as_ref())
+    let winner = ravel_commit::record::decode_compaction(existing.data.as_ref())
         .map_err(|e| MaintainError::Invariant(format!("winner record decode failed: {e}")))?;
     // The winner's key must reconstruct to the key we fetched it at.
     keys::verify_compaction_record_key(&winner, record_key)?;

--- a/crates/ravel-maintain/src/retention.rs
+++ b/crates/ravel-maintain/src/retention.rs
@@ -519,7 +519,7 @@ async fn get_compaction_record(
     key: &str,
 ) -> Result<CompactionRecord> {
     let got = store.get(key, GetRange::Full).await?;
-    let record = CompactionRecord::decode(got.data.as_ref())
+    let record = record::decode_compaction(got.data.as_ref())
         .map_err(|e| MaintainError::Invariant(format!("compaction record decode failed: {e}")))?;
     keys::verify_compaction_record_key(&record, key)?;
     Ok(record)
@@ -528,8 +528,103 @@ async fn get_compaction_record(
 /// GET, decode, and key-verify one retention tombstone (ADR-0010 §7 discipline).
 async fn get_tombstone(store: &dyn ObjectStoreBackend, key: &str) -> Result<RetentionTombstone> {
     let got = store.get(key, GetRange::Full).await?;
-    let tombstone = RetentionTombstone::decode(got.data.as_ref())
+    let tombstone = record::decode_tombstone(got.data.as_ref())
         .map_err(|e| MaintainError::Invariant(format!("tombstone decode failed: {e}")))?;
     keys::verify_retention_tombstone_key(&tombstone, key)?;
     Ok(tombstone)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_types::Signal;
+
+    use super::*;
+
+    fn tenant() -> TenantHash {
+        TenantHash([0u8; 16])
+    }
+
+    /// The retention read of a compaction record refuses a future
+    /// `format_version` (ADR-0066 decision 2), not reads it as version 1. The
+    /// record is otherwise self-consistent (its identity fields reconstruct its
+    /// own key), so the version gate is the only thing that can reject it.
+    /// Removing that gate makes this test fail: the record then decodes and
+    /// key-verifies as version 1 and the call returns `Ok`.
+    #[tokio::test]
+    async fn retention_refuses_a_future_version_compaction_record() {
+        let store = MemoryStore::new();
+        let tenant = tenant();
+        let signal = Signal::Metrics;
+        let record = CompactionRecord {
+            format_version: 2,
+            tenant_hash: tenant.0.to_vec(),
+            signal: ravel_commit::signal::to_proto(signal) as i32,
+            shard: 0,
+            ingest_hour_bucket: 1,
+            input_set_hash: vec![0x33; 32],
+            ..Default::default()
+        };
+        let key = keys::compaction_record_key_for(&record).expect("key");
+        store
+            .put(
+                &key,
+                record::encode_compaction(&record),
+                PutOptions::default(),
+            )
+            .await
+            .expect("seed put");
+
+        let err = get_compaction_record(&store, &key)
+            .await
+            .expect_err("a version-2 compaction record must be refused, not read as v1");
+        match &err {
+            MaintainError::Invariant(msg) => assert!(
+                msg.contains("format_version") && msg.contains("2"),
+                "the failure names the version gate and the version seen: {msg}"
+            ),
+            other => panic!("expected Invariant from the version gate, got {other:?}"),
+        }
+    }
+
+    /// The retention read of a tombstone refuses a future `format_version`
+    /// (ADR-0066 decision 2), not reads it as version 1. Same self-consistent
+    /// record and same gate-flip failure argument as the compaction case.
+    #[tokio::test]
+    async fn retention_refuses_a_future_version_tombstone() {
+        let store = MemoryStore::new();
+        let tenant = tenant();
+        let signal = Signal::Metrics;
+        let tombstone = RetentionTombstone {
+            format_version: 2,
+            tenant_hash: tenant.0.to_vec(),
+            signal: ravel_commit::signal::to_proto(signal) as i32,
+            shard: 0,
+            ingest_hour_bucket: 1,
+            retired_at_ns: 1,
+            retention_window_ns: 1,
+            record_count_observed: 0,
+        };
+        let key = keys::retention_tombstone_key_for(&tombstone).expect("key");
+        store
+            .put(
+                &key,
+                record::encode_tombstone(&tombstone),
+                PutOptions::default(),
+            )
+            .await
+            .expect("seed put");
+
+        let err = get_tombstone(&store, &key)
+            .await
+            .expect_err("a version-2 tombstone must be refused, not read as v1");
+        match &err {
+            MaintainError::Invariant(msg) => assert!(
+                msg.contains("format_version") && msg.contains("2"),
+                "the failure names the version gate and the version seen: {msg}"
+            ),
+            other => panic!("expected Invariant from the version gate, got {other:?}"),
+        }
+    }
 }

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -104,7 +104,6 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 
-use prost::Message;
 use ravel_catalog::select_authoritative_compaction_records;
 use ravel_commit::keys::{self, BucketEntry, KeyError, parse_ingest_hour_string};
 use ravel_commit::record;
@@ -1590,7 +1589,7 @@ async fn get_compaction_record_opt(
 ) -> Result<Option<CompactionRecord>> {
     match store.get(key, GetRange::Full).await {
         Ok(got) => {
-            let record = CompactionRecord::decode(got.data.as_ref()).map_err(|e| {
+            let record = record::decode_compaction(got.data.as_ref()).map_err(|e| {
                 MaintainError::Invariant(format!("compaction record decode failed: {e}"))
             })?;
             keys::verify_compaction_record_key(&record, key)?;
@@ -2591,7 +2590,7 @@ async fn get_compaction_record(
     key: &str,
 ) -> Result<CompactionRecord> {
     let got = store.get(key, GetRange::Full).await?;
-    let record = CompactionRecord::decode(got.data.as_ref())
+    let record = record::decode_compaction(got.data.as_ref())
         .map_err(|e| MaintainError::Invariant(format!("compaction record decode failed: {e}")))?;
     keys::verify_compaction_record_key(&record, key)?;
     Ok(record)
@@ -4103,6 +4102,59 @@ mod tests {
         assert!(
             present(&store, &part).await,
             "no object is deleted when the HEAD cannot be decoded"
+        );
+    }
+
+    /// A compaction record stamped a future `format_version` in a bucket is
+    /// refused by the superseded sweep's bucket read (ADR-0066 decision 2), not
+    /// read as version 1: the pass fails before it deletes anything, so the
+    /// record and every input it would have named survive. The record is
+    /// otherwise fully self-consistent (its identity fields reconstruct its own
+    /// key), so the version gate is the only thing that can reject it. Removing
+    /// that gate makes this test fail: the record then decodes as version 1,
+    /// the pass proceeds, and `sweep_superseded` returns `Ok`.
+    #[tokio::test]
+    async fn superseded_sweep_refuses_a_future_version_compaction_record() {
+        let tenant = tenant();
+        let signal = Signal::Metrics;
+        let shard = 0;
+        let store = MemoryStore::new();
+
+        let mut record = CompactionRecord {
+            format_version: 2,
+            tenant_hash: tenant.0.to_vec(),
+            signal: ravel_commit::signal::to_proto(signal).into(),
+            shard,
+            ingest_hour_bucket: 1,
+            input_set_hash: vec![0x22; 32],
+            ..Default::default()
+        };
+        record.parts.clear();
+        let key = keys::compaction_record_key_for(&record).expect("key");
+        store
+            .put(
+                &key,
+                record::encode_compaction(&record),
+                PutOptions::default(),
+            )
+            .await
+            .expect("seed put");
+
+        let config = CompactorConfig::default();
+        let clock = FixedClock::new(config.orphan_age_gate_ns() + 1);
+        let err = sweep_superseded(&store, &clock, &config, &NoLeases, &tenant, signal, shard)
+            .await
+            .expect_err("a version-2 compaction record must fail the pass, not read as v1");
+        match &err {
+            MaintainError::Invariant(msg) => assert!(
+                msg.contains("format_version") && msg.contains("2"),
+                "the failure names the version gate and the version seen: {msg}"
+            ),
+            other => panic!("expected Invariant from the version gate, got {other:?}"),
+        }
+        assert!(
+            present(&store, &key).await,
+            "a failed superseded pass deletes nothing from the bucket"
         );
     }
 }

--- a/docs/adrs/0066-format-migration-machinery.md
+++ b/docs/adrs/0066-format-migration-machinery.md
@@ -377,3 +377,39 @@ that could go wrong here are single-record decode properties — which versions 
 gate admits, and whether a refused rewrite leaves the object untouched — and
 those are pinned by tests over the real code, including a `MemoryStore`
 byte-identity assertion after each refusal.
+
+## Amendment (2026-09-08, #1301): the Context claim made true for all three commit-family records
+
+The Context above (under "What is already versioned, per format") stated that
+`CommitRecord`, `CompactionRecord`, and `RetentionTombstone` "each carry their
+own `format_version` (= 1) with a typed check". That was true only for
+`CommitRecord`: its `validate`/`decode` pair in `crates/ravel-commit/src/record.rs`
+refused an unsupported version, but `CompactionRecord` and `RetentionTombstone`
+had no decode-and-validate pair. Every production reader decoded them with the
+raw `prost` `Message::decode` and checked identity and key consistency only, so a
+record a future writer stamped `format_version` 2 would have been read as version
+1 with no error — the exact fail-open this ADR's decision 2 forbids. The claim
+was latent, not enforced: nothing writes a version 2 today (both writers,
+`ravel-maintain::publish` and `ravel-maintain::retention`, stamp 1 explicitly),
+so the gap was invisible until a compaction-record change shipped.
+
+This change makes the claim true. `ravel-commit::record` now exports
+`decode_compaction`/`validate_compaction` and `decode_tombstone`/`validate_tombstone`,
+mirroring the `CommitRecord` pair, each routing through a shared supported-set
+check with a floor and a ceiling ({1} for both) and a typed
+`RecordError::UnsupportedRecordFormatVersion` naming the record kind and the
+version seen. Every production decode site in `ravel-catalog`, `ravel-maintain`,
+`ravel-cli`, and `ravel-bench` is routed through the new pair; the raw `prost`
+decode survives only in test helpers. An enumeration guard test asserts every
+record kind that carries a `format_version` has a versioned validate pair, so a
+fourth kind cannot ship ungated.
+
+**Formal method: RUST_ONLY.** A reader gate on a frozen record. The RSEG layout,
+the protobuf schemas, series identity, commit tokens, and the object key layout
+are all unchanged: no persistent format moves, only the reader stops admitting a
+version it does not support. There is no new interleaving to model — the property
+is the single-record decode property this ADR already pins for `CommitRecord`,
+and it is checked by tests over the real code (a version-2 and a version-0 record
+of each kind refused with the typed error, version 1 accepted, and, at each
+enforcement layer, a version-2 compaction record neither swept nor resolved as
+version 1).

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -377,6 +377,16 @@ and the CAS read/write helpers.
   unclassified `rw.` key would have had its supersession of the erased inputs
   ignored by the index fold, letting erased records reappear in a folded
   snapshot.
+- Format-version gate on read (ADR-0066 decision 2). A compaction record and a
+  retention tombstone each carry a `format_version` (= 1), and every production
+  reader decodes them through `ravel_commit::record::decode_compaction` and
+  `decode_tombstone`, which validate that version against the supported set {1}
+  and return a typed `RecordError::UnsupportedRecordFormatVersion` naming the
+  record kind and the version seen. A record a future writer stamps at a version
+  this build does not know is refused, never read as version 1: supersession is
+  the load-bearing consumer, so a misread compaction record would let the sweeper
+  delete a live L0 input or the resolver skip one. The raw `prost` decode, which
+  skips this gate, is confined to test helpers.
 - Selective-erasure request and completion records (ADR-0064 decision 1) live
   under a separate `t/<tenant_hash>/<signal>/del/` prefix, not in `c/`, so the
   bucket-resolution LIST never sees them; the resolver LISTs `del/` once per

--- a/services/ravel-cli/src/maintain.rs
+++ b/services/ravel-cli/src/maintain.rs
@@ -9,7 +9,6 @@ use std::io::Write;
 use std::sync::Arc;
 
 use clap::ValueEnum;
-use prost::Message;
 use ravel_commit::keys;
 use ravel_maintain::{
     Bucket, CompactionOutcome, CompactorConfig, FamilyMigrateReport, FixedClock, LegalHoldCheck,
@@ -18,7 +17,6 @@ use ravel_maintain::{
 };
 use ravel_object_store::conformance::NoncurrentVersionSource;
 use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError, list_all};
-use ravel_proto::commit::v1::{CompactionRecord, RetentionTombstone};
 use ravel_types::{Signal, TenantHash, TenantId};
 use tokio::task::JoinSet;
 use uuid::Uuid;
@@ -964,7 +962,7 @@ pub async fn status(
             .get(key, GetRange::Full)
             .await
             .map_err(|err| anyhow::anyhow!("failed to fetch compaction record {key}: {err}"))?;
-        let record = CompactionRecord::decode(got.data.as_ref())
+        let record = ravel_commit::record::decode_compaction(got.data.as_ref())
             .map_err(|err| anyhow::anyhow!("compaction record {key} is corrupt: {err}"))?;
         superseded_inputs += record.inputs.len();
         for part in &record.parts {
@@ -1113,8 +1111,8 @@ pub async fn audit_versions(
                         let got = store.get(&meta.key, GetRange::Full).await.map_err(|err| {
                             anyhow::anyhow!("failed to fetch {}: {err}", meta.key)
                         })?;
-                        let record =
-                            CompactionRecord::decode(got.data.as_ref()).map_err(|err| {
+                        let record = ravel_commit::record::decode_compaction(got.data.as_ref())
+                            .map_err(|err| {
                                 anyhow::anyhow!("compaction record {} is corrupt: {err}", meta.key)
                             })?;
                         for part in &record.parts {
@@ -1677,8 +1675,8 @@ pub async fn verify_custody(
                         let got = store.get(&meta.key, GetRange::Full).await.map_err(|err| {
                             anyhow::anyhow!("failed to fetch {}: {err}", meta.key)
                         })?;
-                        let record =
-                            CompactionRecord::decode(got.data.as_ref()).map_err(|err| {
+                        let record = ravel_commit::record::decode_compaction(got.data.as_ref())
+                            .map_err(|err| {
                                 anyhow::anyhow!("compaction record {} is corrupt: {err}", meta.key)
                             })?;
 
@@ -1939,7 +1937,7 @@ pub async fn check_noncurrent_versions<S: NoncurrentVersionSource + ?Sized>(
 /// field-by-field style. Reports the compaction identity plus every input
 /// identity and every part's summary and level/part_index/version.
 pub fn decode_compaction_record(bytes: &[u8]) -> anyhow::Result<()> {
-    let record = CompactionRecord::decode(bytes)
+    let record = ravel_commit::record::decode_compaction(bytes)
         .map_err(|err| anyhow::anyhow!("failed to decode compaction record: {err}"))?;
     println!("format_version: {}", record.format_version);
     println!("tenant_hash: {}", hex::encode(&record.tenant_hash));
@@ -1980,7 +1978,7 @@ pub fn decode_compaction_record(bytes: &[u8]) -> anyhow::Result<()> {
 
 /// Decode and print a `RetentionTombstone` (proto).
 pub fn decode_retention_tombstone(bytes: &[u8]) -> anyhow::Result<()> {
-    let tombstone = RetentionTombstone::decode(bytes)
+    let tombstone = ravel_commit::record::decode_tombstone(bytes)
         .map_err(|err| anyhow::anyhow!("failed to decode retention tombstone: {err}"))?;
     println!("format_version: {}", tombstone.format_version);
     println!("tenant_hash: {}", hex::encode(&tombstone.tenant_hash));
@@ -2277,5 +2275,60 @@ mod tests {
             "the trait-contract default cannot enumerate versions"
         );
         assert_eq!(report.recoverable_versions, 0);
+    }
+
+    /// The `maintain inspect` decode path refuses a compaction record stamped a
+    /// future `format_version` (ADR-0066 decision 2), rather than printing it as
+    /// a version-1 record. Routing the bytes back through the raw prost
+    /// `Message::decode` (the pre-fix path) makes this test fail: the record
+    /// decodes silently and the call returns `Ok`.
+    #[test]
+    fn inspect_refuses_a_future_version_compaction_record() {
+        let record = ravel_proto::commit::v1::CompactionRecord {
+            format_version: 2,
+            tenant_hash: vec![0u8; 16],
+            signal: ravel_commit::signal::to_proto(Signal::Metrics) as i32,
+            shard: 0,
+            ingest_hour_bucket: 1,
+            input_set_hash: vec![0x44; 32],
+            ..Default::default()
+        };
+        let bytes = record::encode_compaction(&record);
+        let err = decode_compaction_record(bytes.as_ref())
+            .expect_err("a version-2 compaction record must be refused, not printed as v1");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("compaction record")
+                && msg.contains("format_version")
+                && msg.contains('2'),
+            "the error names the record kind, the gate, and the version seen: {msg}"
+        );
+    }
+
+    /// The `maintain inspect` decode path refuses a retention tombstone stamped
+    /// a future `format_version`. Same raw-prost-decode failure argument as the
+    /// compaction case.
+    #[test]
+    fn inspect_refuses_a_future_version_tombstone() {
+        let tombstone = ravel_proto::commit::v1::RetentionTombstone {
+            format_version: 2,
+            tenant_hash: vec![0u8; 16],
+            signal: ravel_commit::signal::to_proto(Signal::Metrics) as i32,
+            shard: 0,
+            ingest_hour_bucket: 1,
+            retired_at_ns: 1,
+            retention_window_ns: 1,
+            record_count_observed: 0,
+        };
+        let bytes = record::encode_tombstone(&tombstone);
+        let err = decode_retention_tombstone(bytes.as_ref())
+            .expect_err("a version-2 tombstone must be refused, not printed as v1");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("retention tombstone")
+                && msg.contains("format_version")
+                && msg.contains('2'),
+            "the error names the record kind, the gate, and the version seen: {msg}"
+        );
     }
 }

--- a/services/ravel-cli/tests/maintain.rs
+++ b/services/ravel-cli/tests/maintain.rs
@@ -722,7 +722,7 @@ async fn verify_custody_catches_a_compaction_input_with_a_mismatched_hash() {
 fn decode_compaction_record_prints_fields() {
     let record = CompactionRecord {
         format_version: 1,
-        tenant_hash: vec![0u8; 32],
+        tenant_hash: vec![0u8; 16],
         signal: 1,
         shard: 3,
         ingest_hour_bucket: 42,
@@ -862,7 +862,7 @@ async fn migrate_exits_nonzero_and_holds_the_floor_when_a_straggler_survives() {
 fn decode_retention_tombstone_prints_fields() {
     let tombstone = RetentionTombstone {
         format_version: 1,
-        tenant_hash: vec![0u8; 32],
+        tenant_hash: vec![0u8; 16],
         signal: 2,
         shard: 1,
         ingest_hour_bucket: 7,


### PR DESCRIPTION
CommitRecord reads already refuse a record whose format_version is outside
the reader's supported range. CompactionRecord and RetentionTombstone were
decoded raw, so a future-version record produced by a newer writer was read
as version 1 and its fields trusted. This adds validate_compaction and
validate_tombstone in ravel-commit mirroring CommitRecord::validate (version
floor and ceiling, tenant_hash length), an enumeration guard that keeps raw
prost decode confined to the two decode helpers, and routes all 17 production
decode sites in ravel-catalog, ravel-maintain, ravel-cli and ravel-bench
through the pair. Both writers already stamp format_version 1, so the new floor refuses nothing already in storage.

Enforcement tests cover catalog resolve, retention, superseded sweep and the
CLI inspect path with a version 2 record, each shown failing with the gate
body replaced by Ok(()). Two ravel-cli fixtures that seeded a 32 byte
tenant_hash the raw decode silently accepted now seed 16 bytes.

ADR-0066 records the gate and docs/catalog-and-mvcc.md the reader rule.

Local pre-flight was scoped to ravel-commit, ravel-catalog, ravel-maintain
and ravel-cli; the one-line ravel-bench change compiles under the workspace
lint the pull request checks run.

Fixes: #1301
Refs: #1313

