### PR TITLE
chore(release): prepare 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,82 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-09-08
+
+### Added
+
+- **The operator qualifies the object store before serving** (issue #36). Each
+  reconcile pass renders a one-shot `<cluster>-qualify` Job running
+  `ravel-cli store qualify` with the server image, credentials Secret, bucket,
+  region, and endpoint of the tiers it gates, and creates the gateway, query,
+  and maintain Deployments only once that Job reports Complete. A
+  `StoreQualified` status condition carries the gate state (Pending while the
+  Job runs, Succeeded on completion, Failed with the Job's message once its
+  backoffLimit is exhausted). The qualified inputs (bucket, region, endpoint,
+  image, credentials Secret name and resourceVersion) are hashed into
+  `status.storeQualifiedHash`, so a later pass with unchanged inputs proceeds
+  without re-running qualification even after the Job's TTL garbage-collects
+  it; an input change deletes and recreates the Job and flips the condition
+  back to Pending. The Job as a whole is bounded by `activeDeadlineSeconds`
+  (1400 s across both attempts), so a hung attempt fails rather than holding
+  `StoreQualified` at Pending; a Failed Job is
+  deleted and recreated on the next pass instead of sitting until its TTL,
+  and a status-only reconcile no longer re-triggers the gate. The kind
+  lane's hand-run qualification Job is removed since the lane now deploys
+  through the operator.
+- **The object-store conformance suite probes concurrent creates, listing
+  order, and deletes** (issue #1302). Four new probes close gaps the
+  qualification suite left open: `ConcurrentCreateIfAbsentSingleWinner` races
+  eight writers on one absent key and checks for exactly one winner,
+  `LexicographicListingOrder` and `CrossPageListing` check listing order and
+  `start_after` resumption across page boundaries, and `DeleteVisibility`
+  checks that a delete is reflected in both a follow-up get and a follow-up
+  listing. The suite tolerates the behaviors the object-store contract
+  explicitly permits: a key repeated across a listing page boundary, and a
+  losing racer's write landing before its own retryable-conflict response is
+  retried. The shipped Admin IAM template gains `s3:DeleteObject` on
+  `sys/qualify/*` so the delete probe can run under it; no other resource
+  gets a delete grant. `CONFORMANCE_SUITE_VERSION` stays at 1 on purpose, so
+  a bucket that already carries a `sys/qualification` record does not
+  re-qualify and never runs these four new probes.
+- **A derived per-tenant alert-state memo bounds alert evaluation cost**
+  (issue #1294). The alert evaluator previously re-folded a tenant's entire
+  `Signal::Alerts` transition history on every tick, so cost grew with the
+  cumulative transition count rather than the rule count. A durable memo at
+  `t/<tenant_hash>/a/state/latest` now seeds each tick's fold, and a tick
+  reads only the commit records after the memo's watermark. The watermark is
+  bound to the reader's own seal-bound hour: a watermark the memo carries
+  above that seal-bound hour is clamped down to it rather than trusted, so
+  an evaluator with a stale or ahead clock cannot skip a legally late
+  transition. A memo with a duplicate `alert_id` is treated as a decode
+  failure rather than served, and a failed memo encode leaves the previous
+  memo untouched instead of overwriting it with corrupt bytes. A missing or
+  unreadable memo falls back to a full fold.
+- **A bounded top-k optimizer rule for `GROUP BY ... ORDER BY ... LIMIT k`**
+  (issue #1402). A grouped aggregate whose only consumer is an
+  `ORDER BY ... LIMIT k` on a `min`/`max` aggregate over a non-nullable,
+  non-float column now keeps only the top k groups in a priority map instead
+  of materializing one accumulator per distinct group; ADR-0013's
+  exact-semantics contract is unaffected because the rule fires only for an
+  aggregate expression that is provably exact under the bound (max under
+  DESC, min under ASC).
+- **The operator hardens every rendered pod and scopes its own Secrets RBAC
+  per namespace, keeping a cluster-wide watch on `RavelCluster`.** Every
+  rendered gateway, query, maintain, and ingest-router container now carries
+  a `SecurityContext`: `runAsNonRoot`, no privilege escalation, every Linux
+  capability dropped, and a read-only root filesystem (safe because the only
+  local write any of these processes can opt into is the disk cache, and the
+  operator renders no `--cache-dir` flag). The operator's ServiceAccount no
+  longer holds a cluster-wide read on every Secret; it reads a
+  `RavelCluster`'s referenced Secrets through a namespaced grant in that
+  object's own namespace, while its watch on `RavelCluster` objects stays
+  cluster-wide so a cluster outside `ravel-system` still reconciles. Serving
+  a namespace other than `ravel-system` also needs the namespaced
+  RoleBinding this release ships (`deploy/k8s/operator/secrets-rolebinding.yaml`)
+  copied into that namespace, or Secret resolution 403s. The same change
+  adds a PodDisruptionBudget per tier (`maxUnavailable: 1`) and preferred
+  pod anti-affinity to every rendered Deployment.
+
 ### Changed
 
 - **`ravel-server` in mode `all` or `query` now installs the query-audit
@@ -16,14 +92,61 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`--tenant-hash-key-file`) derives the key and needs no action. Gateway and
   maintain processes are unaffected. The docker-compose quickstart now ships a
   development key.
-- **The operator's Secret change-detection checksum is now a `blake3` digest, 64
-  hex characters** (issue #36). It replaces a 16-character standard-hasher value
-  that was not stable across Rust toolchain versions. Because the annotation
-  value changes, the first reconcile after upgrading the operator rolls every
-  rendered gateway, query, and enabled maintain Deployment once, even when their
-  referenced Secrets are unchanged; subsequent reconciles are stable. Schedule
-  the operator upgrade in a maintenance window that tolerates one rolling restart
-  of each serving tier.
+- **CAS-mutable sys records (provisioning, tenant config, metric metadata)
+  move to format_version 2** (ADR-0066). An earlier release added fields to
+  these records without a version bump, so a lagging binary reading a
+  current record silently dropped the fields it did not model and wrote the
+  stripped record back under compare-and-swap. Every reader gate for these
+  three records now accepts exactly the version set {1, 2} instead of a
+  ceiling-only check, and a CAS rewrite now refuses a record whose version
+  exceeds what this build's writer stamps rather than re-encoding it through
+  an older field set. Every writer now stamps new records at version 2. The
+  background metric-metadata refresh reads through the same permissive
+  reader the cache miss path uses, so a tenant's record upgraded to version 2
+  during the writer rollout is no longer rejected by refresh and stuck
+  serving a stale pre-upgrade snapshot for the rest of the process's life.
+  The auth token map and key epoch record read gates gained the same floor:
+  a version-0, unstamped record now fails closed instead of being decoded
+  and rewritten.
+- **Every query transport (HTTP, gRPC, mTLS, Flight SQL) now runs through one
+  query service layer** (issue #1377). Each surface previously carried its
+  own copy of admission, cost accounting, and audit controls, and the copies
+  had drifted: analytics and exemplars ran outside the fleet-wide
+  concurrency ceiling, exemplars recorded no cost, only the SQL surface
+  billed a query a client disconnected mid-flight, admission was taken
+  before authentication on some routes, and a malformed `match[]` selector
+  could consume an admission permit before being rejected. All four
+  transports now authenticate, then admit, then run, then audit in the same
+  order; a malformed selector is rejected with 400 before any permit is
+  taken; a cancelled, timed-out, or failed PromQL, metadata, or analytics
+  query now bills the spend it reached instead of zero; `label_values` audit
+  events are tagged as their own audit language, distinguishable from the
+  other label route; an audit-sink submission failure is reported with the
+  audit pipeline's own failure message instead of the storage-outage string;
+  and the mTLS listener gets its own instance of the service layer so a
+  certificate-identified caller is resolved against the mTLS tenant resolver
+  rather than the public listener's bearer-token resolver.
+- **The store-request ceiling (`max_s3_requests`, `--max-s3-requests`)
+  is now checked immediately after catalog resolution, combining every
+  lane's spend so far, not only during segment fetches** (issue #1376). A
+  query whose snapshot resolved to zero segments never reached the
+  incremental checks in the fetch loop, so it could spend more catalog
+  requests during resolve than the ceiling allowed and still succeed; a
+  mixed metrics-and-logs query is now checked against its combined resolve
+  cost across both lanes. Applies to PromQL, SQL execute, SQL explain, and
+  the Flight SQL `resolve_snapshot` path.
+- **Metrics compaction releases each L1 segment's encoded bytes at PUT
+  instead of holding them until the record publishes.** Peak memory during
+  RSEG compaction previously carried a term that grew with the whole
+  bucket's L1 output; the RLOG path already had this shape (ADR-0979
+  decision 3), and this applies it to RSEG.
+- **The RLOG plan phase's whole-object read is carried into the scan, bound
+  by plan fan-out rather than the corpus.** On the whole-object fallback,
+  the plan phase and the scan each fetched the same object; the plan
+  phase's bytes are now handed to the scan and charged to `bytesReused`,
+  with retention bounded to the plan fan-out in objects times the object
+  size. On ClickBench q20 that was 6,785 GETs and 21.1 GB, where a
+  corpus-sized cache gives 4,533 GETs and 11.24 GB.
 - **The operator now bounds qualify-Job recreations for a store that keeps
   failing qualification** (issue #36). A failing `ravel-cli store qualify` Job is
   recreated on a capped exponential backoff (30 s doubling to a 480 s ceiling)
@@ -32,6 +155,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   delete/recreate every retry interval. The failure count and next-retry instant
   are persisted in `RavelCluster` status, and the `StoreQualified=False`
   condition names the attempt count and the next retry time.
+- **The operator's Secret change-detection checksum is now a `blake3` digest, 64
+  hex characters** (issue #36). It replaces a 16-character standard-hasher value
+  that was not stable across Rust toolchain versions. Because the annotation
+  value changes, the first reconcile after upgrading the operator rolls every
+  rendered gateway, query, and enabled maintain Deployment once, even when their
+  referenced Secrets are unchanged; subsequent reconciles are stable. Schedule
+  the operator upgrade in a maintenance window that tolerates one rolling restart
+  of each serving tier.
 - **`latency-first`'s published trade is re-measured and now names the commit it
   was taken on** (issue #1316). Over 3 reps on the reference corpus,
   42-statement basis, true cold in the warm-up-empty state, at concurrency 256:
@@ -45,6 +176,113 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   time, not a property of the policy. The timing half also carries more noise
   than previously assumed (6.7% to 14.8% per-arm spread across reps on the
   measurement host), so the figure is a mean with a range, not a constant.
+
+### Fixed
+
+- **OTLP HTTP gzip inflate is charged against the ingest byte budget as it
+  decompresses** (issue #1297). The OTLP HTTP metrics/logs/traces handlers
+  decompressed request bodies up to 64 MiB before the router's own buffer
+  charge ran, so up to `--max-inflight-ingest-requests` copies of a 64 MiB
+  inflate could exist at once, entirely outside `--max-ingest-buffer-bytes`.
+  Each chunk is now charged to the process-wide ingest budget before it is
+  retained, in exactly-sized allocations rather than a growing buffer, and a
+  decompression whose running total would cross the ceiling is shed
+  mid-inflate (429) rather than allocated in full; a body over
+  `MAX_DECOMPRESSED_OTLP_BODY_BYTES` is refused with 413 at the first byte
+  past the cap rather than after the whole body is decompressed.
+- **`--dev-insecure-tenant-header` is refused unless every listener (HTTP
+  and gRPC) binds loopback, not just `--listen-http`** (ADR-0009, issue #94).
+  The flag was reachable, unguarded, on a non-loopback `--listen-grpc`,
+  letting an unauthenticated request forge tenant identity on the gRPC and
+  Flight SQL surfaces. The same commit also refuses `--distributed-query`
+  and `--fragment-listener` under gateway-only and maintain mode; a
+  configuration that previously started with either flag set under one of
+  those modes now fails at startup.
+- **RLOG scan decompressed-byte accounting is complete** (issue #1401). A
+  logs scan now reports the zstd work it actually does: the directory
+  sections a segment open decompresses, each block page decode, the POSTINGS
+  probe's term-block decode, and the plan phase's fallback and eager-funnel
+  decodes (the alerts and audit scans) all charge `ScanStats.decompressed_bytes`.
+  Several of these sites previously charged nothing, so a query relying on a
+  text arm, a stream filter, or a below-threshold object could report zero
+  decompressed bytes however much it actually decoded.
+- **A column-stats object the reader refuses to decode (for example one
+  whose uncompressed body exceeds the 256 MiB decode ceiling) now logs one
+  warning per (tenant, signal, key) and degrades to no statistics, instead
+  of doing so silently.** Previously this folded into the same silent
+  "no statistics" outcome as a segment with no stats object at all. The
+  per-tenant refusal marks are swept so a tenant that never resolves does
+  not accumulate them without bound.
+- **Duplicate attribute keys within one record now resolve last-wins by a
+  fixed, documented order, consistently across SQL, ingest, and
+  maintenance.** The winner is fixed by the order `rebuild_record` lays a
+  record's attributes out: columnar occurrences first, ascending by
+  FIELD_DIR type byte, then `attrs_raw` overflow occurrences ascending by
+  canonical encoded value bytes, last entry wins. This is the record's
+  on-disk layout order, not its write order, which the format does not
+  preserve; four consumers of the merged attribute view previously
+  disagreed about which occurrence a query resolved to.
+- **RLOG corruption returns HTTP 500, not a retryable 503.** The local
+  PromQL log path folded every RLOG fault, including corruption, into the
+  same error class as a transient store error, so a Prometheus client
+  retried a query against corrupted stored data forever.
+- **Non-retryable OTLP HTTP write errors return 400 instead of 503** (issue
+  #1298). A permanent failure such as a series value-kind mismatch
+  previously fell through a catch-all that mapped it to 503, so a
+  well-behaved exporter retried a request that could never succeed; the HTTP
+  handlers now mirror the gRPC side's retryable/non-retryable distinction.
+- **A raced `CreateIfAbsent` write that the backend answers with a
+  retryable 409 is retried instead of reported as a permanent conflict.**
+  `object_store` 0.14 maps every raw 409 to `AlreadyExists`, including AWS's
+  own retryable `ConditionalRequestConflict` 409, which is distinct from a
+  genuine already-exists. The S3 adapter now disambiguates with a HEAD: key
+  present stays `AlreadyExists`, key absent becomes a retryable `Transient`.
+  A HEAD probe that itself fails transiently (throttled, timed out) is now
+  surfaced as retryable rather than folded into `AlreadyExists`, which had
+  made the commit-publish path treat a race it did not lose as lost.
+- **Erasure requests no longer complete while a bucket in their scope is
+  still unsealed at acknowledgement** (ADR-0064). A pending erasure request
+  could be marked done while an in-scope bucket was still unsealed,
+  including one that had not yet published a commit record at all and so
+  never appeared in the completion pass's own listing; the subject's
+  records then reappeared as soon as the request's exclusion filter was
+  released. Completion now blocks on every ack-time-open bucket, whether or
+  not the listing discovers it.
+- **The shipped KMS IAM templates scope their KMS actions to a placeholder
+  tenant key ARN instead of every key in the account and region.** The four
+  templates (gateway, query, maintain, admin) previously granted their KMS
+  actions on `key/*`: gateway, query, and maintain hold
+  `kms:Encrypt`/`GenerateDataKey*`/`Decrypt`, and admin holds `kms:Decrypt`
+  only. An operator using SSE-KMS must add, not replace: one array entry
+  for the `--s3-kms-key` ARN if that flag is set, plus one for every key in
+  `--tenant-kms-config`, in every role's KMS Resource array; otherwise
+  gateway, query, and maintain PUTs fail with AccessDenied and reads of
+  objects written under that key fail decryption for every role.
+- **`ravel-cli maintain migrate` reports a permanently blocked straggler
+  correctly and only counts a bucket as permanently blocked when it
+  actually is.** A below-target L0 segment that only a losing compaction
+  record names is live data the migration walk cannot touch, and CLI/guide
+  text now says re-running will not help instead of telling the operator to
+  re-run; conversely, a bucket flagged by a concurrent compaction or
+  erasure landing mid-walk is no longer counted as permanently blocked, and
+  a record retention deletes between the walk's listing and its read no
+  longer aborts the migration or produces a false permanent-block report.
+- **Compaction refuses to compact a bucket whose erasure-rewrite record is
+  already durable when the compactor lists it.** Publishing a second
+  compaction record set over inputs a rewrite already covered could
+  resurrect records the rewrite had erased once the pending-request filter
+  that was hiding them was removed. The two passes still list-then-act with
+  no CAS between them, so the maintenance driver's per-bucket serialization
+  stays load-bearing.
+- **The catalog's min-token fallback no longer serves parts from a losing
+  compaction record.** Two overlapping live compaction records in one
+  bucket could serve the losing record's parts in addition to the winning
+  record's already-resolved parts; logs and spans have no query-time dedup,
+  so this returned duplicate rows.
+- **A carried whole-object read is now bound to the exact segment and
+  tenant that produced it.** A carry could previously be handed to a read
+  of a different object with no error, decoding the wrong object's rows
+  wherever both objects were decodable.
 
 ## [0.14.0]
 
@@ -175,6 +413,9 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the corpus. The saving is therefore about one duplicate read per unit of
   plan fan-out; removing the rest needs the carry to stream per partition
   instead of being held at the plan barrier, tracked separately.
+  **Correction.** This change landed after the 0.14.0 tag and ships in
+  0.15.0, where the retention bound is the plan fan-out rather than the SQL
+  partition count.
 - **The RLOG raw prefetch is gated on the cursor budget before `try_join!`**
   (ADR-0979 decision 4). The merge cursor's refill fetched the next two
   row-group blocks before the budget had been checked, so up to twice the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4468,14 +4468,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-affinity"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
 ]
 
 [[package]]
 name = "ravel-alerting"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "hex",
@@ -4487,14 +4487,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-analytics"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ravel-bench"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arrow 59.1.0",
  "arrow-flight",
@@ -4547,7 +4547,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cache"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "crc32c",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-catalog"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-codec"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-commit"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-failure-tests"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "futures",
@@ -4686,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-fleet"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "futures",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest-router"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-logseg"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4781,7 +4781,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-maintain"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4809,11 +4809,11 @@ dependencies = [
 
 [[package]]
 name = "ravel-memory"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "ravel-object-store"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-operator"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "clap",
@@ -4860,7 +4860,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otap"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ipc 59.1.0",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otlp"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "promql-parser",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql-difftest"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-proto"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4955,7 +4955,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-query"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4999,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-remote-write"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "hex",
@@ -5017,7 +5017,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-rspan"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "crc32c",
  "proptest",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-segment"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -5050,7 +5050,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-server"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sim"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5137,7 +5137,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sql"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tenant-resolve"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "axum",
  "base64 0.23.0",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tracing-export"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "services/*"]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.97"
@@ -26,30 +26,30 @@ expect_used = "warn"
 # Version fields pin each path dependency so cargo-deny does not count them as
 # wildcards. allow-wildcard-paths is not usable here because these
 # crates are not marked publish = false, so it does not exempt them.
-ravel-types = { path = "crates/ravel-types", version = "0.14.0" }
-ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.14.0" }
-ravel-proto = { path = "crates/ravel-proto", version = "0.14.0" }
-ravel-codec = { path = "crates/ravel-codec", version = "0.14.0" }
-ravel-object-store = { path = "crates/ravel-object-store", version = "0.14.0" }
-ravel-segment = { path = "crates/ravel-segment", version = "0.14.0" }
-ravel-logseg = { path = "crates/ravel-logseg", version = "0.14.0" }
-ravel-rspan = { path = "crates/ravel-rspan", version = "0.14.0" }
-ravel-commit = { path = "crates/ravel-commit", version = "0.14.0" }
-ravel-catalog = { path = "crates/ravel-catalog", version = "0.14.0" }
-ravel-cache = { path = "crates/ravel-cache", version = "0.14.0" }
-ravel-maintain = { path = "crates/ravel-maintain", version = "0.14.0" }
-ravel-fleet = { path = "crates/ravel-fleet", version = "0.14.0" }
-ravel-otlp = { path = "crates/ravel-otlp", version = "0.14.0" }
-ravel-otap = { path = "crates/ravel-otap", version = "0.14.0" }
-ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.14.0" }
-ravel-alerting = { path = "crates/ravel-alerting", version = "0.14.0" }
-ravel-ingest = { path = "crates/ravel-ingest", version = "0.14.0" }
-ravel-promql = { path = "crates/ravel-promql", version = "0.14.0" }
-ravel-query = { path = "crates/ravel-query", version = "0.14.0" }
-ravel-analytics = { path = "crates/ravel-analytics", version = "0.14.0" }
-ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.14.0" }
-ravel-affinity = { path = "crates/ravel-affinity", version = "0.14.0" }
-ravel-memory = { path = "crates/ravel-memory", version = "0.14.0" }
+ravel-types = { path = "crates/ravel-types", version = "0.15.0" }
+ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.15.0" }
+ravel-proto = { path = "crates/ravel-proto", version = "0.15.0" }
+ravel-codec = { path = "crates/ravel-codec", version = "0.15.0" }
+ravel-object-store = { path = "crates/ravel-object-store", version = "0.15.0" }
+ravel-segment = { path = "crates/ravel-segment", version = "0.15.0" }
+ravel-logseg = { path = "crates/ravel-logseg", version = "0.15.0" }
+ravel-rspan = { path = "crates/ravel-rspan", version = "0.15.0" }
+ravel-commit = { path = "crates/ravel-commit", version = "0.15.0" }
+ravel-catalog = { path = "crates/ravel-catalog", version = "0.15.0" }
+ravel-cache = { path = "crates/ravel-cache", version = "0.15.0" }
+ravel-maintain = { path = "crates/ravel-maintain", version = "0.15.0" }
+ravel-fleet = { path = "crates/ravel-fleet", version = "0.15.0" }
+ravel-otlp = { path = "crates/ravel-otlp", version = "0.15.0" }
+ravel-otap = { path = "crates/ravel-otap", version = "0.15.0" }
+ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.15.0" }
+ravel-alerting = { path = "crates/ravel-alerting", version = "0.15.0" }
+ravel-ingest = { path = "crates/ravel-ingest", version = "0.15.0" }
+ravel-promql = { path = "crates/ravel-promql", version = "0.15.0" }
+ravel-query = { path = "crates/ravel-query", version = "0.15.0" }
+ravel-analytics = { path = "crates/ravel-analytics", version = "0.15.0" }
+ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.15.0" }
+ravel-affinity = { path = "crates/ravel-affinity", version = "0.15.0" }
+ravel-memory = { path = "crates/ravel-memory", version = "0.15.0" }
 
 # async runtime / rpc / http
 tokio = { version = "1.53", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ See the [Kubernetes guide](docs/guides/kubernetes.md).
 GitHub Container Registry on every `vX.Y.Z` release tag, built from the root
 `Dockerfile`. Both `linux/amd64` and `linux/arm64` are published. Each published
 object is an OCI image index that carries an SBOM and full build provenance. The
-quickstart pins `ghcr.io/nofireai/ravel-server:0.14.0`. Override it with
+quickstart pins `ghcr.io/nofireai/ravel-server:0.15.0`. Override it with
 `RAVEL_IMAGE`.
 
 ```sh
@@ -336,12 +336,12 @@ so that is the identity in the certificate:
 
 ```sh
 cosign verify \
-  --certificate-identity 'https://github.com/NOFireAI/ravel/.github/workflows/publish-images.yml@refs/tags/v0.14.0' \
+  --certificate-identity 'https://github.com/NOFireAI/ravel/.github/workflows/publish-images.yml@refs/tags/v0.15.0' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-  ghcr.io/nofireai/ravel-server:0.14.0
+  ghcr.io/nofireai/ravel-server:0.15.0
 ```
 
-Replace `v0.14.0` and `0.14.0` with the release you are verifying. The tag ref in
+Replace `v0.15.0` and `0.15.0` with the release you are verifying. The tag ref in
 `--certificate-identity` must be the exact tag that produced the image.
 
 ## How Ravel is verified

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -29,7 +29,7 @@ ravel-promql = { workspace = true }
 # (`metricsbench_gen`) runs the gate, which a dev-dependency would be invisible
 # to. It is already a workspace member, so a `--workspace` build compiled it
 # before this edge existed too.
-ravel-promql-difftest = { path = "../ravel-promql-difftest", version = "0.14.0" }
+ravel-promql-difftest = { path = "../ravel-promql-difftest", version = "0.15.0" }
 prost = { workspace = true }
 # MetricsBench Remote Write 1.0 ingest lane (ADR-0927, issue #937, task M5).
 # `ravel-remote-write` supplies the `prometheus.WriteRequest`/`TimeSeries`/
@@ -99,7 +99,7 @@ futures = { workspace = true, optional = true }
 # ravel-sql is an internal path crate not yet listed in the workspace
 # `[workspace.dependencies]`, so it is named by path here; every other dep
 # below reuses a workspace pin.
-ravel-sql = { path = "../ravel-sql", version = "0.14.0", optional = true, features = ["flight-sql"] }
+ravel-sql = { path = "../ravel-sql", version = "0.15.0", optional = true, features = ["flight-sql"] }
 # Gated behind `sql-latency`. The spans-scan bench lane (`src/spans_scan.rs`)
 # writes its RSPAN corpus with the real span writer and drives `SpansScanExec`
 # directly, so it needs the writer/record types (`RspanWriter`, `SpanRecord`,

--- a/crates/ravel-ingest/Cargo.toml
+++ b/crates/ravel-ingest/Cargo.toml
@@ -30,7 +30,7 @@ ravel-catalog = { workspace = true }
 # [workspace.dependencies]; the root Cargo.toml is out of this task's scope, so
 # this is a version-pinned path dependency (the pin keeps cargo-deny from
 # counting it as a wildcard, matching the workspace's path-dep convention).
-ravel-rspan = { path = "../ravel-rspan", version = "0.14.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.15.0" }
 # The router live switch (ADR-0052) decodes the provisioning record read for a
 # generation refresh; prost's Message trait provides `decode`.
 prost = { workspace = true }
@@ -54,7 +54,7 @@ ravel-promql = { workspace = true }
 # zero data GETs. ravel-sql depends on ravel-catalog/ravel-query/ravel-commit/
 # ravel-logseg, none of which depend on ravel-ingest, so this dev-only edge adds
 # no cycle. No feature flag: ravel-sql's SQL surface is unconditional.
-ravel-sql = { path = "../ravel-sql", version = "0.14.0" }
+ravel-sql = { path = "../ravel-sql", version = "0.15.0" }
 # Match ravel-sql's datafusion pin exactly (same arrow 58 line) so the test's
 # SessionContext/collect interop with ravel-sql's plan types.
 datafusion = { version = "54", default-features = false, features = ["sql"] }

--- a/crates/ravel-otlp/Cargo.toml
+++ b/crates/ravel-otlp/Cargo.toml
@@ -16,7 +16,7 @@ ravel-logseg = { workspace = true }
 # Used for the span record's StatusCode and the frozen resource+scope+span
 # attribute merge rule, so trace normalization and the RSPAN writer cannot
 # drift apart on either.
-ravel-rspan = { path = "../ravel-rspan", version = "0.14.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.15.0" }
 opentelemetry-proto = { workspace = true }
 # Span events and links are stored as an opaque serialized blob in RSPAN v1
 # (ADR-0041 decision 4), which needs prost's own length-delimited encoding.

--- a/crates/ravel-query/Cargo.toml
+++ b/crates/ravel-query/Cargo.toml
@@ -95,7 +95,7 @@ ravel-cache = { workspace = true }
 # proof (tests/differential_compaction.rs) drives P4's real compactor to
 # produce write_v4 L1 parts. ravel-maintain does not depend on ravel-query,
 # so this is acyclic.
-ravel-maintain = { path = "../ravel-maintain", version = "0.14.0" }
+ravel-maintain = { path = "../ravel-maintain", version = "0.15.0" }
 proptest = { workspace = true }
 # The ADR-0046 disk cache tier (crates/ravel-query/src/cache_correctness.rs)
 # needs a real on-disk directory to construct a `ravel_cache::DiskCache`; the

--- a/crates/ravel-rspan/fuzz/Cargo.lock
+++ b/crates/ravel-rspan/fuzz/Cargo.lock
@@ -498,7 +498,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ravel-codec"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-rspan"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "crc32c",
  "prost",

--- a/crates/ravel-segment/fuzz/Cargo.lock
+++ b/crates/ravel-segment/fuzz/Cargo.lock
@@ -587,7 +587,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ravel-codec"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-proto"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-segment"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "base64",
  "blake3",

--- a/deploy/docker-compose/ravel.yml
+++ b/deploy/docker-compose/ravel.yml
@@ -50,7 +50,7 @@ services:
   # already-qualified bucket it reports the existing record and exits 0, so this
   # tolerates a populated `minio-data/` across runs.
   qualify:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.14.0}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.15.0}
     depends_on:
       createbucket:
         condition: service_completed_successfully
@@ -72,7 +72,7 @@ services:
   # container boundary forbids, so the demo authenticates with a real bearer
   # token against a real tenant map, exactly as a deployment does.
   ravel-server:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.14.0}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.15.0}
     depends_on:
       qualify:
         condition: service_completed_successfully

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -32,7 +32,7 @@ That brings up five things, all from published images:
   bootstrap-and-continue path for it, so a freshly created bucket has to be
   qualified before the server starts. The step is idempotent: on an
   already-qualified bucket it reports the existing record and exits 0.
-- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.14.0` (override the pin
+- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.15.0` (override the pin
   with the `RAVEL_IMAGE` environment variable), listening on `127.0.0.1:4318`
   (HTTP) and `127.0.0.1:4317` (gRPC), with the tenant token `demo-token` mapped
   to tenant `demo-tenant`.

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -133,7 +133,7 @@ Two routes Grafana's built-in Prometheus datasource probes on every datasource
 save. They take no parameters.
 
 ```json
-{"status": "success", "data": {"version": "0.14.0", "revision": "", "branch": "", "buildUser": "", "buildDate": "", "goVersion": ""}}
+{"status": "success", "data": {"version": "0.15.0", "revision": "", "branch": "", "buildUser": "", "buildDate": "", "goVersion": ""}}
 ```
 
 `version` is Ravel's own version, not a Prometheus one. `revision` is the

--- a/services/ravel-cli/Cargo.toml
+++ b/services/ravel-cli/Cargo.toml
@@ -109,7 +109,7 @@ tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
 # `LogsTableProvider` logs path is in ravel-sql's default build (the
 # `flight-sql` feature only gates the Flight transport), so no feature is
 # needed here.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.14.0" }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.15.0" }
 # The reachability test builds a SqlExecutor's segment fetchers from ravel-query
 # (SegmentFetcher/LogSegmentFetcher/SpanSegmentFetcher); ravel-catalog is
 # already a normal dependency. Workspace pin, test construction only.
@@ -126,7 +126,7 @@ async-trait = { workspace = true }
 # ravel-server is a workspace path crate not listed in
 # `[workspace.dependencies]`, so it is named by path with a pinned version here,
 # exactly as ravel-sql above is; no new external crate enters Cargo.lock.
-ravel-server = { path = "../ravel-server", version = "0.14.0", features = ["sql"] }
+ravel-server = { path = "../ravel-server", version = "0.15.0", features = ["sql"] }
 # The reachability test's axum request/response plumbing (the same shape
 # ravel-server's own endpoint tests use). Already resolved in this workspace's
 # dependency graph; test-only.

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -154,14 +154,14 @@ reqwest = { version = "0.13", features = ["json"] }
 # ravel-rspan below are: the workspace root Cargo.toml is outside this task's
 # scope. The pin keeps cargo-deny from counting it as a wildcard path
 # dependency.
-ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.14.0" }
+ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.15.0" }
 
 # ravel-sql is declared here as a path dependency rather than through
 # `[workspace.dependencies]` because the workspace root Cargo.toml is outside
 # this task's scope. The version is pinned so cargo-deny does not count it as
 # a wildcard path dependency, matching how every other
 # internal crate is pinned.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.14.0", optional = true }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.15.0", optional = true }
 
 # Flight service codegen for the `flight-sql` feature. This is arrow 58's
 # arrow-flight, a different arrow major than the `arrow` dev-dependency below;
@@ -222,7 +222,7 @@ tokio = { workspace = true, features = ["test-util"] }
 # listed in the workspace [workspace.dependencies]; the root Cargo.toml is out
 # of this task's scope, so this is a version-pinned path dependency (the pin
 # keeps cargo-deny from counting it as a wildcard).
-ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.14.0" }
+ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.15.0" }
 uuid = { workspace = true }
 # Real-authn end-to-end test (tests/real_authn_e2e.rs): mint a JWT and build a
 # local oct (HMAC) JWKS so the OIDC resolver runs through a real HTTP request


### PR DESCRIPTION
Bump the workspace and every path dependency to 0.15.0, regenerate the lockfile, and move the changelog's unreleased section under a 0.15.0 heading; the quickstart pin, the cosign identity in the README, the compose image tags and the two guide references move with it.

The changelog section gains entries for everything user-visible since 0.14.0 that had none. Every entry was written from its commit and then checked against the tree at this commit, which moved three figures that a later commit in the same range had superseded (the qualify Job deadline, the alert-memo watermark handling, the compaction refusal's window).

One correction inside a released section: the 0.14.0 entry for the RLOG plan-carry described a fix that is not an ancestor of the v0.14.0 tag. The entry stays, with a correction sentence pointing at 0.15.0, where the fix shipped with a different retention bound. The published v0.14.0 release notes get the same correction after this merges.

No code changes. The tag v0.15.0 is cut at the merge commit; the publish workflow's release job then produces the binaries and SHA256SUMS the ClickBench entry will pin.

Refs: #1185
