### PR TITLE
fix(tla): witness the fault probes, unvacate liveness, add a live lane

### DIFF
--- a/docs/guides/formal-verification.md
+++ b/docs/guides/formal-verification.md
@@ -77,7 +77,10 @@ reach a rewrite-of-rewrite predecessor. No shipped action produces a
 second rewrite object for a further rewrite to consume, so the model
 cannot reach that case. Issue 1221 tracks this gap. The maintenance
 model checks the two-worker ownership race for safety only. No lane in
-the suite checks liveness at two workers.
+the suite checks liveness at two workers. The commit model's exhaustive
+configuration checks safety only. Its liveness property is checked at
+the `live` lane's smaller bounds instead, since adding it to the
+exhaustive configuration did not finish inside that lane's time budget.
 
 One lifecycle case from an earlier retention decision stays open on the
 shipped retention path. The proposed compaction-claims design sits on a
@@ -108,17 +111,20 @@ missing, the harness exits with code 2 and prints the reason. The
 traceability lane runs without Java or GNU timeout.
 
 Run `scripts/check-tla.sh smoke` to check safety in every area, at a
-300-second budget per configuration. Run `scripts/check-tla.sh negative`
-to check that every negative control fails the way its `.expect` file
+300-second budget per configuration. Run `scripts/check-tla.sh live` to
+check liveness under fairness, at the same 300-second budget, in each
+area that defines a `live.cfg`. Run `scripts/check-tla.sh negative` to
+check that every negative control fails the way its `.expect` file
 states. Run `scripts/check-tla.sh traceability` to check that every Rust
 path and symbol in every traceability table exists. Run
-`scripts/check-tla.sh exhaustive` to check full safety and liveness, at
-a 3600-second budget per configuration. Add `-a <area>` to any of these
-commands to scope the check to one area.
+`scripts/check-tla.sh exhaustive` to check full safety and liveness
+where a configuration states a `PROPERTY`, at a 3600-second budget per
+configuration. Add `-a <area>` to any of these commands to
+scope the check to one area.
 
-Run `scripts/check-tla.sh ci` to run smoke, negative, and traceability
-under one run ID. Run `scripts/check-tla.sh all` to run `ci`, then
-`exhaustive`, under one run ID.
+Run `scripts/check-tla.sh ci` to run smoke, live, negative, and
+traceability under one run ID. Run `scripts/check-tla.sh all` to run
+`ci`, then `exhaustive`, under one run ID.
 
 Each command exits 0 on a pass. When a check fails, it exits 1. When no
 usable Java or GNU timeout exists, it exits 2. A single TLC run reports
@@ -185,8 +191,8 @@ the same commit as the model.
 Add one traceability row for the property, naming one Rust path and
 symbol. Never write a line number in a markdown file.
 
-Run the smoke, negative, traceability, and exhaustive lanes before you
-commit. See the [suite README](../../formal/tla/README.md) for the file
+Run the smoke, live, negative, traceability, and exhaustive lanes before
+you commit. See the [suite README](../../formal/tla/README.md) for the file
 layout.
 
 ## Background

--- a/docs/guides/formal-verification.md
+++ b/docs/guides/formal-verification.md
@@ -134,8 +134,9 @@ exit 12 for a safety violation. It reports exit 13 for a liveness
 violation. GNU timeout kills a run past its budget and reports exit
 124.
 
-The pull-request job runs smoke, negative, and traceability. The nightly
-job runs exhaustive.
+The pull-request job runs the `ci` kind: smoke, negative, live (for the
+areas that have banded a `live.cfg`), and traceability. The nightly job
+runs exhaustive.
 
 ## Read the results
 

--- a/docs/guides/formal-verification.md
+++ b/docs/guides/formal-verification.md
@@ -113,14 +113,16 @@ traceability lane runs without Java or GNU timeout.
 Run `scripts/check-tla.sh smoke` to check safety in every area, at a
 300-second budget per configuration. Run `scripts/check-tla.sh live` to
 check liveness under fairness, at the same 300-second budget, in each
-area that defines a `live.cfg`. Run `scripts/check-tla.sh negative` to
-check that every negative control fails the way its `.expect` file
-states. Run `scripts/check-tla.sh traceability` to check that every Rust
-path and symbol in every traceability table exists. Run
+area whose `live.cfg` has a matching row in that area's `bands.tsv` (a
+measured band is the opt-in); an area with a `live.cfg` and no band is
+reported SKIP and does not fail the lane. Run `scripts/check-tla.sh
+negative` to check that every negative control fails the way its
+`.expect` file states. Run `scripts/check-tla.sh traceability` to check
+that every Rust path and symbol in every traceability table exists. Run
 `scripts/check-tla.sh exhaustive` to check full safety and liveness
 where a configuration states a `PROPERTY`, at a 3600-second budget per
-configuration. Add `-a <area>` to any of these commands to
-scope the check to one area.
+configuration. Add `-a <area>` to any of these commands to scope the
+check to one area.
 
 Run `scripts/check-tla.sh ci` to run smoke, live, negative, and
 traceability under one run ID. Run `scripts/check-tla.sh all` to run

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -41,7 +41,7 @@ config. All areas planned by ADR-1113 are shipped:
 | Area | Contract modeled | Specification(s) | Config lanes | Status |
 |---|---|---|---|---|
 | [common](common/) | object-store put/get/delete/list/multipart | `RavelObjectStore.tla` | smoke, exhaustive, 3 negative | shipped |
-| [commit](commit/) | commit publication, acknowledgement, retry, read-your-write | `CommitProtocol.tla` | smoke, exhaustive, 11 negative, plus ungated dedup and liveness configs | shipped |
+| [commit](commit/) | commit publication, acknowledgement, retry, read-your-write | `CommitProtocol.tla` | smoke, exhaustive, live, 11 negative, plus an ungated dedup config | shipped |
 | [catalog](catalog/) | catalog fold, snapshots, compaction, MVCC | `CatalogMVCC.tla` | smoke, exhaustive, carryforward, overlap, 21 negative (14 broken-behavior, 7 reachability probes) | shipped |
 | [lifecycle](lifecycle/) | retention, erasure, legal holds, physical GC | `LifecycleGC.tla` | smoke, exhaustive, 7 negative, plus an ungated rejected-design candidate | shipped, with ADR-0064's out-of-window case open |
 | [resharding](resharding/) | generation-versioned online resharding | `OnlineResharding.tla` | smoke, exhaustive, 5 negative, plus several ungated liveness and simulation configs | shipped |
@@ -88,7 +88,8 @@ resources: workers=<n> xmx=<size>`), next to the figures they produced.
 scripts/check-tla.sh smoke            # fast safety, every area (budget 300s/cfg)
 scripts/check-tla.sh negative         # every negative control must fail correctly
 scripts/check-tla.sh traceability     # every traceability.md source ref resolves
-scripts/check-tla.sh ci               # smoke + negative + traceability, one run id (the CI lane)
+scripts/check-tla.sh live             # each area's banded live.cfg (budget 300s/cfg)
+scripts/check-tla.sh ci               # smoke + negative + live + traceability, one run id (the CI lane)
 scripts/check-tla.sh all              # ci, then exhaustive, under one run id
 scripts/check-tla.sh exhaustive       # full safety + liveness (nightly, budget 3600s/cfg)
 scripts/check-tla.sh smoke -a common  # scope any subcommand to one area

--- a/formal/tla/commit/CommitProtocol.tla
+++ b/formal/tla/commit/CommitProtocol.tla
@@ -133,7 +133,13 @@ VARIABLES
                  \* as it was when the query ran, because a token that is not
                  \* yet visible is a retryable failure, not a stale result
     queried,     \* BOOLEAN: whether the read-path query has run this behaviour
-    queryAnswer  \* SUBSET FlushIds: the flushes the read-path query returned
+    queryAnswer, \* SUBSET FlushIds: the flushes the read-path query returned
+    faultFired   \* SUBSET (FlushIds \X FaultKinds): execution witness, set only
+                 \* by the fault action it names, never by a state merely
+                 \* enabled to take it. PutDataLostResponse, PutCommitLostResponse
+                 \* and TransientFailure share every other field they touch
+                 \* (retries' = retries + 1), so none of those distinguishes
+                 \* "fired" from "could fire"; this is the field that does
 
 Store == INSTANCE RavelObjectStore
             WITH Keys <- ObjKeys, Content <- AllContent,
@@ -143,15 +149,19 @@ Phases == {"idle", "pinned", "data", "committed", "acked",
            "abandoned", "stopped", "retired"}
 AckKinds == {"none", "strict", "buffered", "timeout", "error"}
 
+\* Execution-witness tags, one per fault action instrumented below. Named for
+\* the action that alone sets its tag in faultFired.
+FaultKinds == {"putDataLost", "putCommitLost", "transient"}
+
 \* The store's own variables, named locally: an INSTANCE's tuple cannot be
 \* primed through the instance prefix.
 sVars == <<store, lastModified, versionCounter, uploads, listState>>
 
 protoVars == <<phase, pinned, openedAt, retries, clock, shardDead,
-               ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+               ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
 vars == <<store, lastModified, versionCounter, uploads, listState,
           phase, pinned, openedAt, retries, clock, shardDead,
-          ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+          ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
 
 \* The commit PUT witness: what the caller asked for, what the store already
 \* held, and what the operator returned. Invariants read THIS and the store,
@@ -182,6 +192,7 @@ TypeOK ==
     /\ publishedAt \in [FlushIds -> 0..(MaxTicks + 1)]
     /\ queried \in BOOLEAN
     /\ queryAnswer \subseteq FlushIds
+    /\ faultFired \subseteq (FlushIds \X FaultKinds)
 
 Init ==
     /\ Store!StoreInit
@@ -203,6 +214,7 @@ Init ==
     /\ publishedAt = [f \in FlushIds |-> MaxTicks + 1]
     /\ queried = FALSE
     /\ queryAnswer = {}
+    /\ faultFired = {}
 
 \* --- derived views ----------------------------------------------------------
 
@@ -251,7 +263,7 @@ PinFlush(f, c) ==
     \* action (BufferedAck) and is not what this switch models.
     /\ ackKind' = [ackKind EXCEPT ![f] =
                      IF AckAtEnqueue THEN "strict" ELSE @]
-    /\ UNCHANGED <<retries, clock, shardDead, marker, lastPut, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<retries, clock, shardDead, marker, lastPut, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 \* IngestRouter::write_points returning at enqueue in buffered mode: the client
@@ -260,7 +272,7 @@ BufferedAck(f) ==
     /\ phase[f] = "pinned"
     /\ ackKind[f] = "none"
     /\ ackKind' = [ackKind EXCEPT ![f] = "buffered"]
-    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 \* FlushCtx::put_data_object_with_retry -> publish::put_data_object.
@@ -272,7 +284,7 @@ PutData(f) ==
     /\ ~shardDead[f[2]]
     /\ Store!PutCreateIfAbsent(DataKey(f), pinned[f])
     /\ phase' = [phase EXCEPT ![f] = "data"]
-    /\ UNCHANGED <<pinned, openedAt, retries, clock, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<pinned, openedAt, retries, clock, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
 
 \* The response to the data PUT was lost: the effect landed, the caller saw a
 \* failure and retries the same pinned flush. The retry is the PutData step
@@ -284,6 +296,7 @@ PutDataLostResponse(f) ==
     /\ retries[f] < MaxRetries
     /\ Store!PutCreateIfAbsentLostResponse(DataKey(f), pinned[f])
     /\ retries' = [retries EXCEPT ![f] = @ + 1]
+    /\ faultFired' = faultFired \cup {<<f, "putDataLost">>}
     /\ UNCHANGED <<phase, pinned, openedAt, clock, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
 
 \* FlushCtx::publish_with_retry -> publish::publish_with_rng.
@@ -317,7 +330,7 @@ PutCommit(f) ==
                           ELSE shardDead
           /\ publishedAt' = [publishedAt EXCEPT ![f] =
                                 IF Store!Present(k) THEN @ ELSE clock]
-    /\ UNCHANGED <<pinned, openedAt, retries, clock, ackKind, marker, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<pinned, openedAt, retries, clock, ackKind, marker, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
 
 \* The commit PUT landed and its response was lost. The caller retries the same
 \* pinned flush; that retry takes the AlreadyExists path above.
@@ -331,6 +344,7 @@ PutCommitLostResponse(f) ==
                         IF Store!Present(CommitKey(f)) THEN @ ELSE clock]
     /\ Store!PutCreateIfAbsentLostResponse(CommitKey(f), pinned[f])
     /\ retries' = [retries EXCEPT ![f] = @ + 1]
+    /\ faultFired' = faultFired \cup {<<f, "putCommitLost">>}
     /\ UNCHANGED <<phase, pinned, openedAt, clock, shardDead, ackKind, marker, lastPut, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
 
 \* A transient store failure applies nothing; the caller retries.
@@ -340,6 +354,7 @@ TransientFailure(f) ==
     /\ retries[f] < MaxRetries
     /\ Store!TransientFailure
     /\ retries' = [retries EXCEPT ![f] = @ + 1]
+    /\ faultFired' = faultFired \cup {<<f, "transient">>}
     /\ UNCHANGED <<phase, pinned, openedAt, clock, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
 
 \* FlushCtx::ack_waiters, then the router's token collection and
@@ -350,7 +365,7 @@ StrictAck(f) ==
     /\ ackKind[f] \in {"none", "buffered"}
     /\ phase' = [phase EXCEPT ![f] = "acked"]
     /\ ackKind' = [ackKind EXCEPT ![f] = "strict"]
-    /\ UNCHANGED <<pinned, openedAt, retries, clock, shardDead, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<pinned, openedAt, retries, clock, shardDead, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 \* WriteError::AckTimeout. The client's wait is dropped while the flush task
@@ -359,7 +374,7 @@ AckTimeout(f) ==
     /\ phase[f] \in {"pinned", "data"}
     /\ ackKind[f] = "none"
     /\ ackKind' = [ackKind EXCEPT ![f] = "timeout"]
-    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 \* WriteError::Abandoned. FlushCtx::bound_to_deadline races every attempt
@@ -369,7 +384,7 @@ Abandon(f) ==
     /\ Expired(f)
     /\ phase' = [phase EXCEPT ![f] = "abandoned"]
     /\ ackKind' = [ackKind EXCEPT ![f] = IF @ = "none" THEN "error" ELSE @]
-    /\ UNCHANGED <<pinned, openedAt, retries, clock, shardDead, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<pinned, openedAt, retries, clock, shardDead, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 \* A crash loses everything in memory. Durable objects stay; the pinned flush
@@ -384,7 +399,7 @@ Crash(f) ==
     /\ pinned' = [pinned EXCEPT ![f] = @]
     /\ retries' = [retries EXCEPT ![f] = 0]
     /\ ackKind' = [ackKind EXCEPT ![f] = IF @ = "none" THEN "error" ELSE @]
-    /\ UNCHANGED <<openedAt, clock, shardDead, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<openedAt, clock, shardDead, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 \* ravel_ingest::write_marker, from the logs and traces handlers. The marker is
@@ -397,7 +412,7 @@ WriteMarker ==
        \/ (MarkerAfterFirstShard /\ DurableSet # {})   \* BROKEN switch
     /\ Store!PutCreateIfAbsent(MarkerKey, CHOOSE c \in Contents : TRUE)
     /\ marker' = "written"
-    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, ackKind, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, ackKind, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
 
 \* Accidental reuse of a commit identity with different content: the hazard
 \* ADR-0002 names. The protocol does not prevent it, it DETECTS it: the commit
@@ -413,7 +428,7 @@ ReuseIdentity(f, c) ==
     /\ openedAt' = [openedAt EXCEPT ![f] = clock]
     /\ retries' = [retries EXCEPT ![f] = 0]
     /\ publishedAt' = [publishedAt EXCEPT ![f] = MaxTicks + 1]
-    /\ UNCHANGED <<clock, shardDead, ackKind, marker, lastPut, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<clock, shardDead, ackKind, marker, lastPut, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 \* A CLIENT retry after a lost acknowledgement. The first attempt's client saw
@@ -449,7 +464,7 @@ ClientRetry(f, g) ==
     \* g is the client's resend of f, which is what makes a second durable
     \* record a duplicate rather than an unrelated write of equal content
     /\ retryOf' = [retryOf EXCEPT ![g] = f]
-    /\ UNCHANGED <<retries, clock, shardDead, ackKind, marker, lastPut, tombstoned, superseded, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<retries, clock, shardDead, ackKind, marker, lastPut, tombstoned, superseded, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 \* Retention tombstones a bucket (retention::write_tombstone), and a compaction
@@ -465,7 +480,7 @@ TombstoneBucket(f) ==
     /\ superseded = {}
     /\ f \notin tombstoned
     /\ tombstoned' = tombstoned \cup {f}
-    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, ackKind, marker, lastPut, publishedAt, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, ackKind, marker, lastPut, publishedAt, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 SupersedeRecord(f) ==
@@ -476,7 +491,7 @@ SupersedeRecord(f) ==
     /\ f \notin superseded
     /\ f \notin tombstoned
     /\ superseded' = superseded \cup {f}
-    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, retryOf, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 \* Catalog::resolve_min_token: an exact-key GET on the commit key the token
@@ -496,7 +511,7 @@ ResolveToken(f) ==
              present |-> Store!Present(CommitKey(f)),
              tomb    |-> f \in tombstoned,
              sup     |-> f \in superseded]]
-    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, queried, queryAnswer>>
+    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 \* The read path, abstracted to what an answer contains rather than how it was
@@ -514,13 +529,13 @@ RunQuery ==
                           IF QueryReadsDataDirectly
                           THEN Visible(f) \/ DataPresent(f)   \* BROKEN switch
                           ELSE Visible(f)}
-    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult>>
+    /\ UNCHANGED <<phase, pinned, openedAt, retries, clock, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, faultFired>>
     /\ UNCHANGED sVars
 
 Tick ==
     /\ clock < MaxTicks
     /\ clock' = clock + 1
-    /\ UNCHANGED <<phase, pinned, openedAt, retries, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer>>
+    /\ UNCHANGED <<phase, pinned, openedAt, retries, shardDead, ackKind, marker, lastPut, publishedAt, tombstoned, superseded, retryOf, tokenResult, queried, queryAnswer, faultFired>>
     /\ UNCHANGED sVars
 
 Next ==
@@ -563,6 +578,11 @@ Fairness ==
     /\ \A f \in FlushIds : WF_vars(PutData(f))
     /\ \A f \in FlushIds : WF_vars(PutCommit(f))
     /\ \A f \in FlushIds : WF_vars(StrictAck(f))
+    \* The flush task abandons an expired flush rather than retrying it
+    \* forever (crates/ravel-ingest/src/shard.rs::bound_to_deadline), so a
+    \* pinned flush past its deadline is fairly forced to abandon rather than
+    \* stutter.
+    /\ \A f \in FlushIds : WF_vars(Abandon(f))
 
 FairSpec == Spec /\ Fairness
 

--- a/formal/tla/commit/MCCommitProtocol.tla
+++ b/formal/tla/commit/MCCommitProtocol.tla
@@ -54,31 +54,19 @@ AbandonUnreachable == ~(\E f \in FlushIds : phase[f] = "abandoned")
 \* At MaxRetries=0 the three retry actions below are permanently disabled
 \* (their `retries[f] < MaxRetries` guard can never hold), so a cfg that
 \* never sets MaxRetries > 0 leaves them, and everything they alone
-\* exercise, unreachable. Each predicate restates the action's own
-\* enabling conjuncts (the store call itself has no further guard: every
-\* branch of PutCreateIfAbsent/TransientFailure always has a successor), so
-\* a VIOLATED report here proves the action fires, not merely that its
-\* precondition looks satisfiable on paper.
+\* exercise, unreachable. Each predicate is a post-state check on faultFired,
+\* the execution witness the named action alone sets (CommitProtocol.tla),
+\* in the same shape as AbandonUnreachable above: a VIOLATED report proves
+\* the action actually FIRED, not merely that its enabling conjuncts were
+\* satisfiable in some pre-state that never took the transition.
 PutDataLostResponseUnreachable ==
-    ~(\E f \in FlushIds :
-        /\ phase[f] = "pinned"
-        /\ ~Expired(f)
-        /\ ~shardDead[f[2]]
-        /\ retries[f] < MaxRetries)
+    ~(\E f \in FlushIds : <<f, "putDataLost">> \in faultFired)
 
 PutCommitLostResponseUnreachable ==
-    ~(\E f \in FlushIds :
-        /\ phase[f] = "data"
-        /\ ~DedupSuppressed(f)
-        /\ ~Expired(f)
-        /\ ~shardDead[f[2]]
-        /\ retries[f] < MaxRetries)
+    ~(\E f \in FlushIds : <<f, "putCommitLost">> \in faultFired)
 
 TransientFailureUnreachable ==
-    ~(\E f \in FlushIds :
-        /\ phase[f] \in {"pinned", "data"}
-        /\ ~Expired(f)
-        /\ retries[f] < MaxRetries)
+    ~(\E f \in FlushIds : <<f, "transient">> \in faultFired)
 
 \* --- Liveness --------------------------------------------------------------
 \* Under weak fairness on the store retry and the flush task only, a pinned

--- a/formal/tla/commit/README.md
+++ b/formal/tla/commit/README.md
@@ -121,9 +121,10 @@ are load-bearing:
 
 ```sh
 scripts/check-tla.sh smoke -a commit
+scripts/check-tla.sh live -a commit
 scripts/check-tla.sh negative -a commit
 scripts/check-tla.sh traceability -a commit
 ```
 
-`exhaustive.cfg`, `live.cfg` and `dedup-mutant.cfg` carry the remaining
-configurations; `results.md` records what each produced.
+`exhaustive.cfg` and `dedup-mutant.cfg` carry the remaining configurations;
+`results.md` records what each produced.

--- a/formal/tla/commit/bands.tsv
+++ b/formal/tla/commit/bands.tsv
@@ -1,3 +1,4 @@
 cfg	min_distinct	max_distinct	min_depth	max_depth
 smoke.cfg	426976	426976	25	25
 exhaustive.cfg	5466239	5466239	36	36
+live.cfg	1616	1616	11	11

--- a/formal/tla/commit/bands.tsv
+++ b/formal/tla/commit/bands.tsv
@@ -1,3 +1,3 @@
 cfg	min_distinct	max_distinct	min_depth	max_depth
-smoke.cfg	76212	76212	21	21
+smoke.cfg	426976	426976	25	25
 exhaustive.cfg	5466239	5466239	36	36

--- a/formal/tla/commit/counterexamples/put-commit-lost-response-reachable.md
+++ b/formal/tla/commit/counterexamples/put-commit-lost-response-reachable.md
@@ -8,11 +8,14 @@ after losing the commit PUT's response.
 Violated invariant: `PutCommitLostResponseUnreachable` (safety, TLC exit
 12).
 
-Trace, in prose: writer `w1` issues the commit PUT for its flush on shard
-`s1`; the object store durably writes the record but the response back to
-the writer is lost. The writer, having no acknowledgement, retries. That is
-the `PutCommitLostResponse` state the invariant says must not exist, and TLC
-finds it at depth 5 (21 states generated, 20 distinct).
+Trace, in prose: writer `w1` pins a flush, puts its data, then issues the
+commit PUT on shard `s1`; the object store durably writes the record but
+the response back to the writer is lost. The writer, having no
+acknowledgement, retries. The invariant is a post-state check on
+`faultFired`, the execution witness `PutCommitLostResponse` alone sets, so
+TLC reports it violated only once that transition actually fires, at depth
+4 (PinFlush, PutData, PutCommitLostResponse; 70 states generated, 63
+distinct).
 
 The obligation is correct exactly because TLC reports it violated: a model
 where a lost commit-PUT response could never happen would leave this green,

--- a/formal/tla/commit/counterexamples/put-data-lost-response-reachable.md
+++ b/formal/tla/commit/counterexamples/put-data-lost-response-reachable.md
@@ -7,11 +7,13 @@ the data PUT's response.
 
 Violated invariant: `PutDataLostResponseUnreachable` (safety, TLC exit 12).
 
-Trace, in prose: writer `w1` issues the data PUT for its flush on shard
-`s1`; the object store durably writes the object but the response back to
-the writer is lost. The writer, having no acknowledgement, retries. That is
-the `PutDataLostResponse` state the invariant says must not exist, and TLC
-finds it in two steps (2 states generated, 2 distinct, depth 2).
+Trace, in prose: writer `w1` pins a flush, issues the data PUT for it on
+shard `s1`; the object store durably writes the object but the response
+back to the writer is lost. The writer, having no acknowledgement, retries.
+The invariant is a post-state check on `faultFired`, the execution witness
+`PutDataLostResponse` alone sets, so TLC reports it violated only once that
+transition actually fires, at depth 3 (PinFlush, PutDataLostResponse; 11
+states generated, 11 distinct).
 
 The obligation is correct exactly because TLC reports it violated: a model
 where a lost data-PUT response could never happen would leave this green,

--- a/formal/tla/commit/counterexamples/transient-failure-reachable.md
+++ b/formal/tla/commit/counterexamples/transient-failure-reachable.md
@@ -6,10 +6,12 @@ for transient failure and retry is vacuous.
 
 Violated invariant: `TransientFailureUnreachable` (safety, TLC exit 12).
 
-Trace, in prose: writer `w1` attempts a PUT for its flush on shard `s1` and
-the object store reports a transient failure with no durable effect. That
-is the `TransientFailure` state the invariant says must not exist, and TLC
-finds it in two steps (2 states generated, 2 distinct, depth 2).
+Trace, in prose: writer `w1` pins a flush on shard `s1` and attempts a PUT;
+the object store reports a transient failure with no durable effect. The
+invariant is a post-state check on `faultFired`, the execution witness
+`TransientFailure` alone sets, so TLC reports it violated only once that
+transition actually fires, at depth 3 (PinFlush, then TransientFailure; 13
+states generated, 13 distinct).
 
 The obligation is correct exactly because TLC reports it violated: a model
 where a transient failure could never occur would leave this green, and the

--- a/formal/tla/commit/live.cfg
+++ b/formal/tla/commit/live.cfg
@@ -2,13 +2,19 @@
 \* Liveness. FairSpec adds weak fairness on the store retry and the flush task
 \* only. The property is a disjunction: durable, or stopped with an explicit
 \* failure, because the retry budget and the flush lifetime are bounded.
+\* Expired(f) needs clock > openedAt[f] + FlushLifetime; a flush opened at
+\* clock 0 with FlushLifetime = 3 only expires once clock reaches 4, and
+\* Tick's guard is clock < MaxTicks, so MaxTicks = 4 is the smallest bound
+\* at which a pinned flush can actually expire and Abandon fire. At
+\* MaxTicks = 3 the property was verified over a state space where no
+\* flush can expire, which is vacuous for that disjunct.
 CONSTANTS
     Writers = {w1}
     Shards = {s1}
     Contents = {c1}
     MaxRetries = 1
     FlushLifetime = 3
-    MaxTicks = 3
+    MaxTicks = 4
     Signal = "logs"
     HasIdemKey = FALSE
     CommitBeforeData = FALSE

--- a/formal/tla/commit/results.md
+++ b/formal/tla/commit/results.md
@@ -13,11 +13,17 @@ and are not banded. Run id
 otherwise, from a single `scripts/check-tla.sh all -a commit` invocation
 covering smoke, negative, traceability and exhaustive together.
 
+Rows marked "fleet executor" below are from a later session (issues #1356,
+#1357) on a different host: tla2tools 1.7.4 unchanged, `-workers 2`
+`-Xmx2g` throughout (this host's fixed resource cap, never `-workers
+auto`), 8 GB RAM / 4 cores.
+
 ## Configuration runs
 
 | Config | States generated | Distinct | Depth | Seconds | Result |
 |---|---|---|---|---|---|
-| smoke.cfg | 305165 | 76212 | 21 | 5 | PASS |
+| smoke.cfg | 1757215 | 426976 | 25 | 9 | PASS (fleet executor) |
+| live.cfg | 2696 | 1616 | 11 | 1 | PASS (fleet executor) |
 | negative/ack-before-commit.cfg | 2 | 2 | n/a | 1 | VIOLATED as required (StrictAckImpliesDurable) |
 | negative/at-least-once-duplicate-reachable.cfg | 64817 | 26486 | n/a | 2 | VIOLATED as required (DuplicateUnreachable) |
 | negative/commit-before-data.cfg | 44 | 41 | n/a | 1 | VIOLATED as required (NoCommitWithoutData) |
@@ -31,6 +37,33 @@ covering smoke, negative, traceability and exhaustive together.
 | negative/transient-failure-reachable.cfg | 2 | 2 | n/a | 1 | VIOLATED as required (TransientFailureUnreachable) |
 | traceability | n/a | n/a | n/a | n/a | PASS, 21 rows resolve |
 | exhaustive.cfg | 17892751 | 5466239 | 36 | 131 | PASS |
+
+`smoke.cfg` and `live.cfg` were re-verified on the fleet executor host
+after issues #1356 and #1357 (see below); the other rows are unchanged
+from the prior session and were not re-run there. `exhaustive.cfg` was
+re-run on the fleet executor host too, at `-workers 2`: 17892751
+generated, 5466239 distinct, depth 36, 114s, byte-identical to the row
+above. `faultFired` (added for #1356, see below) never becomes non-empty
+at `exhaustive.cfg`'s `MaxRetries=0`, since each of the three actions it
+records requires `retries[f] < MaxRetries`, so the reachable state graph,
+and `bands.tsv`'s row for it, are unaffected.
+
+`smoke.cfg`'s distinct-state count and depth grew (76212/21 to
+426976/25, `bands.tsv` updated to match) after issue #1356 added the
+`faultFired` history variable: `smoke.cfg` runs at `MaxRetries=1`, where
+the three fault actions this variable records are reachable, so
+`faultFired` taking on distinct values is itself new state, not
+regression. The safety invariants and their pass/fail outcomes are
+unchanged; only the state count grew.
+
+`live.cfg` moved from a by-hand run (see the retired row below) to the
+new `live` harness lane (issue #1357) and from `MaxTicks=3` to
+`MaxTicks=4`, the smallest bound at which `Expired` is reachable; see the
+comment in `live.cfg` itself. Its figures also moved, from
+42119/15812/depth 13 to 2696/1616/depth 11, because `MaxTicks=4` reaches
+one more tick per behaviour but `Fairness` now includes
+`WF_vars(Abandon(f))`, which prunes the non-fair stutter-after-expiry
+paths TLC previously had to enumerate before finding the property held.
 
 The negative rows are the required outcome: each config disables a guard,
 flips a broken-behaviour switch, or (the three new `*-reachable.cfg` rows)
@@ -155,12 +188,33 @@ carried over: `negative/deadline-reachable.cfg`, which pins these same
 constants, still reports `AbandonUnreachable` VIOLATED (exit 12) after the
 `CheckToken` change, at unchanged bounds.
 
+## Exhaustive liveness (issue #1357, not adopted)
+
+`exhaustive.cfg` was probed with `SPECIFICATION FairSpec` and `PROPERTY
+EveryPinnedFlushSettles` added, on the fleet executor host, to see
+whether full safety plus liveness fits the script's 3600s
+`EXHAUSTIVE_BUDGET`. Safety alone completes in 114s at these bounds (see
+above); with liveness added, the run had not completed after 590s (no
+result, no partial-progress line yet from TLC, process cleanly
+terminated) — the host's practical foreground observation window for
+this session, well short of the 3600s budget itself. Whether the run
+would complete somewhere between 590s and 3600s is not known; extending
+the observation window would need a background TLC run, which this task
+avoids by rule (TLC runs the full foreground window, never backgrounded).
+`exhaustive.cfg` is left unchanged (safety-only, `SPECIFICATION Spec`, no
+`PROPERTY`); liveness is now checked at the `live` kind's bounds instead
+(`live.cfg`, see above), matching the fallback the task originally
+allowed for this case.
+
 ## By-hand runs
 
 | Run | Spec/Invariant | States generated | Distinct | Depth | Result |
 |---|---|---|---|---|---|
 | dedup-mutant.cfg | DuplicateUnreachable only, RetryDedups=TRUE | 14974258 | 3443658 | 32 | PASS (exit 0), 1m24s |
-| live.cfg | FairSpec / EveryPinnedFlushSettles | 42119 | 15812 | 13 | PASS (exit 0), under 1s |
+
+`live.cfg` is retired from this table: it now runs through `scripts/
+check-tla.sh live -a commit` (see the configuration table above), not by
+hand.
 
 `dedup-mutant.cfg` used to complete in 25 minutes (433,976,430 generated,
 81,903,514 distinct, depth 34). After the `RunQuery` action and its

--- a/formal/tla/commit/results.md
+++ b/formal/tla/commit/results.md
@@ -31,16 +31,18 @@ auto`), 8 GB RAM / 4 cores.
 | negative/marker-before-all-shards.cfg | 779 | 505 | n/a | 1 | VIOLATED as required (MarkerImpliesAllShardsDurable) |
 | negative/mismatched-identity-idempotent.cfg | 26950 | 12816 | n/a | 2 | VIOLATED as required (OneIdentityOneContent) |
 | negative/no-cross-shard-atomicity.cfg | 243 | 174 | n/a | 1 | VIOLATED as required (NoCrossShardAtomicityUnreachable) |
-| negative/put-commit-lost-response-reachable.cfg | 21 | 20 | n/a | 1 | VIOLATED as required (PutCommitLostResponseUnreachable) |
-| negative/put-data-lost-response-reachable.cfg | 2 | 2 | n/a | 1 | VIOLATED as required (PutDataLostResponseUnreachable) |
+| negative/put-commit-lost-response-reachable.cfg | 70 | 63 | n/a | 1 | VIOLATED as required (PutCommitLostResponseUnreachable) |
+| negative/put-data-lost-response-reachable.cfg | 11 | 11 | n/a | 1 | VIOLATED as required (PutDataLostResponseUnreachable) |
 | negative/query-reads-uncommitted-data.cfg | 77 | 65 | n/a | 1 | VIOLATED as required (NoUncommittedDataVisible) |
-| negative/transient-failure-reachable.cfg | 2 | 2 | n/a | 1 | VIOLATED as required (TransientFailureUnreachable) |
+| negative/transient-failure-reachable.cfg | 13 | 13 | n/a | 1 | VIOLATED as required (TransientFailureUnreachable) |
 | traceability | n/a | n/a | n/a | n/a | PASS, 21 rows resolve |
 | exhaustive.cfg | 17892751 | 5466239 | 36 | 131 | PASS |
 
-`smoke.cfg` and `live.cfg` were re-verified on the fleet executor host
-after issues #1356 and #1357 (see below); the other rows are unchanged
-from the prior session and were not re-run there. `exhaustive.cfg` was
+`smoke.cfg`, `live.cfg` and the three `*-reachable.cfg` probes were
+re-verified on the fleet executor host after issues #1356 and #1357 (see
+below); the probes' figures are those of their counterexample documents,
+taken under the rewritten post-state predicates. The other negative rows
+are unchanged from the prior session and were not re-run there. `exhaustive.cfg` was
 re-run on the fleet executor host too, at `-workers 2`: 17892751
 generated, 5466239 distinct, depth 36, 114s, byte-identical to the row
 above. `faultFired` (added for #1356, see below) never becomes non-empty

--- a/formal/tla/commit/results.md
+++ b/formal/tla/commit/results.md
@@ -60,10 +60,14 @@ unchanged; only the state count grew.
 new `live` harness lane (issue #1357) and from `MaxTicks=3` to
 `MaxTicks=4`, the smallest bound at which `Expired` is reachable; see the
 comment in `live.cfg` itself. Its figures also moved, from
-42119/15812/depth 13 to 2696/1616/depth 11, because `MaxTicks=4` reaches
-one more tick per behaviour but `Fairness` now includes
-`WF_vars(Abandon(f))`, which prunes the non-fair stutter-after-expiry
-paths TLC previously had to enumerate before finding the property held.
+42119/15812/depth 13 to 2696/1616/depth 11, but the two runs are not
+comparable: TLC generates the reachable state graph from `Init` and
+`Next`, fairness only feeds the liveness check and never restricts state
+generation, and a new state variable plus one more tick cannot shrink
+that graph. The retired figures were measured before `live.cfg` gained
+`CheckQuery = FALSE` and `CheckToken = FALSE`; 2696/1616/depth 11 is the
+current measurement against the shipped config, on tla2tools 1.7.4
+(fleet executor host, `-workers 2 -Xmx2g`, per the table above).
 
 The negative rows are the required outcome: each config disables a guard,
 flips a broken-behaviour switch, or (the three new `*-reachable.cfg` rows)
@@ -196,15 +200,15 @@ whether full safety plus liveness fits the script's 3600s
 `EXHAUSTIVE_BUDGET`. Safety alone completes in 114s at these bounds (see
 above); with liveness added, the run had not completed after 590s (no
 result, no partial-progress line yet from TLC, process cleanly
-terminated) — the host's practical foreground observation window for
-this session, well short of the 3600s budget itself. Whether the run
-would complete somewhere between 590s and 3600s is not known; extending
-the observation window would need a background TLC run, which this task
-avoids by rule (TLC runs the full foreground window, never backgrounded).
-`exhaustive.cfg` is left unchanged (safety-only, `SPECIFICATION Spec`, no
-`PROPERTY`); liveness is now checked at the `live` kind's bounds instead
-(`live.cfg`, see above), matching the fallback the task originally
-allowed for this case.
+terminated), which was the host's practical foreground observation
+window for this session, well short of the 3600s budget itself. Whether
+the run would complete somewhere between 590s and 3600s is not known;
+extending the observation window would need a background TLC run, which
+this task avoids by rule (TLC runs the full foreground window, never
+backgrounded). `exhaustive.cfg` is left unchanged (safety-only,
+`SPECIFICATION Spec`, no `PROPERTY`); liveness is now checked at the
+`live` kind's bounds instead (`live.cfg`, see above), matching the
+fallback the task originally allowed for this case.
 
 ## By-hand runs
 

--- a/formal/tla/resharding/live.cfg
+++ b/formal/tla/resharding/live.cfg
@@ -1,8 +1,12 @@
-\* Not run by any check-tla.sh gate: no subcommand in that script checks a
-\* PROPERTY, so this config is run and its result recorded by hand (see
-\* results.md). FairSpec and EventuallyRoutedOnNewGeneration are defined in
-\* OnlineResharding.tla but until this file existed no .cfg anywhere
-\* referenced either one, so liveness had never actually been checked.
+\* The `live` kind runs this config once bands.tsv carries a row for it
+\* (a measured band is the opt-in); until then check-tla.sh reports it
+\* SKIP and it is not enrolled. Its last recorded runtime, 11 minutes 36
+\* seconds (see below), is why: that exceeds the 300s smoke/live budget
+\* every other cfg in this suite is measured against, so it stays a
+\* by-hand record in results.md rather than a banded gate. FairSpec and
+\* EventuallyRoutedOnNewGeneration are defined in OnlineResharding.tla
+\* but until this file existed no .cfg anywhere referenced either one, so
+\* liveness had never actually been checked.
 \*
 \* Same dimensions as smoke.cfg (frozen clock, two writers, two requesters,
 \* an increase and a decrease) so the only thing that changes is what gets

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -8,10 +8,12 @@
 #
 # Subcommands:
 #   smoke        [-a AREA]   fast reachability + safety (budget 300s per cfg)
+#   live         [-a AREA]   liveness under fairness, where a live.cfg exists
+#                            (budget 300s per cfg, same as smoke)
 #   exhaustive   [-a AREA]   full safety + liveness (budget 3600s per cfg)
 #   negative     [-a AREA]   run negative/*.cfg, assert the expected violation
 #   traceability [-a AREA]   check every traceability.md source ref resolves
-#   ci           [-a AREA]   smoke + negative + traceability under one run id
+#   ci           [-a AREA]   smoke + live + negative + traceability under one run id
 #   all          [-a AREA]   ci, then exhaustive, under one run id
 #
 # Exit codes: 0 pass; 1 a check failed; 2 toolchain missing (no usable Java
@@ -582,6 +584,10 @@ check_traceability() {
         done
     done < "$tfile"
 
+    if [ "$rc" -eq 0 ] && [ "$count" -eq 0 ]; then
+        note "$area traceability: FAIL (zero rows resolved)"
+        return 1
+    fi
     if [ "$rc" -eq 0 ]; then
         note "$area traceability: PASS ($count rows resolve)"
     fi
@@ -591,7 +597,7 @@ check_traceability() {
 # --- dispatch ---------------------------------------------------------------
 
 usage() {
-    sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,17p' "$0" | sed 's/^# \{0,1\}//'
     exit "${1:-1}"
 }
 
@@ -613,7 +619,7 @@ main() {
     done
 
     case "$cmd" in
-        smoke|exhaustive|negative|traceability|ci|all) : ;;
+        smoke|live|exhaustive|negative|traceability|ci|all) : ;;
         ""|-h|--help) usage 0 ;;
         *) die "unknown subcommand: $cmd" ;;
     esac
@@ -648,26 +654,29 @@ main() {
     RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse 'HEAD^{tree}')"
 
     local records_tsv=0
-    case "$cmd" in smoke|exhaustive|negative|ci|all) records_tsv=1 ;; esac
+    case "$cmd" in smoke|live|exhaustive|negative|ci|all) records_tsv=1 ;; esac
     [ "$records_tsv" -eq 1 ] && truncate_tsv
 
     # ci and all record every model under ONE run id, so last-run.tsv is a
-    # single coherent run: the smoke, negative, and (for all) exhaustive rows
-    # all carry the same run-id column.
+    # single coherent run: the smoke, live, negative, and (for all) exhaustive
+    # rows all carry the same run-id column.
     local rc=0 area
     for area in $areas; do
         case "$cmd" in
             smoke)        check_model "$area" smoke || rc=1 ;;
+            live)         check_model "$area" live || rc=1 ;;
             exhaustive)   check_model "$area" exhaustive || rc=1 ;;
             negative)     check_negative "$area" || rc=1 ;;
             traceability) check_traceability "$area" || rc=1 ;;
             ci)
                 check_model "$area" smoke || rc=1
+                check_model "$area" live || rc=1
                 check_negative "$area" || rc=1
                 check_traceability "$area" || rc=1
                 ;;
             all)
                 check_model "$area" smoke || rc=1
+                check_model "$area" live || rc=1
                 check_negative "$area" || rc=1
                 check_traceability "$area" || rc=1
                 check_model "$area" exhaustive || rc=1

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# check-tla usage: begin
 # TLA+ verification harness (ADR-1113 task T1).
 #
 # Runs TLC over every formal/tla area, or one named area. An "area" is any
@@ -8,13 +9,17 @@
 #
 # Subcommands:
 #   smoke        [-a AREA]   fast reachability + safety (budget 300s per cfg)
-#   live         [-a AREA]   liveness under fairness, where a live.cfg exists
-#                            (budget 300s per cfg, same as smoke)
+#   live         [-a AREA]   liveness under fairness; runs an area's live.cfg
+#                            only when bands.tsv carries a row for it (a
+#                            measured band is the opt-in), same 300s budget
+#                            as smoke; an unbanded live.cfg is reported SKIP
+#                            and does not fail the lane
 #   exhaustive   [-a AREA]   full safety + liveness (budget 3600s per cfg)
 #   negative     [-a AREA]   run negative/*.cfg, assert the expected violation
 #   traceability [-a AREA]   check every traceability.md source ref resolves
 #   ci           [-a AREA]   smoke + live + negative + traceability under one run id
 #   all          [-a AREA]   ci, then exhaustive, under one run id
+# check-tla usage: end
 #
 # Exit codes: 0 pass; 1 a check failed; 2 toolchain missing (no usable Java
 # or no GNU timeout(1)).
@@ -341,6 +346,19 @@ check_bands() {
     return $rc
 }
 
+# band_row_exists <area> <cfg-name>
+# True if bands.tsv carries a row for this cfg. The `live` kind uses this as
+# its opt-in gate: a live.cfg with no measured band is not run at all, rather
+# than running under check_bands's after-the-fact enforcement.
+band_row_exists() {
+    local area="$1" cfg_name="$2"
+    local bands="$FORMAL_DIR/$area/bands.tsv"
+    [ -f "$bands" ] || return 1
+    local row
+    row="$(awk -F'\t' -v c="$cfg_name" '$1==c {print; exit}' "$bands")"
+    [ -n "$row" ]
+}
+
 # check_one_model <area> <module> <kind> <cfg>
 check_one_model() {
     local area="$1" module="$2" kind="$3" cfg="$4"
@@ -402,6 +420,14 @@ check_model() {
                 note "$area/$module: no ${kind} cfg, skipping"
             fi
             continue
+        fi
+        if [ "$kind" = live ]; then
+            local cfg_name
+            cfg_name="$(basename "$cfg")"
+            if ! band_row_exists "$area" "$cfg_name"; then
+                note "$area live: SKIP (unbanded live.cfg; add a bands.tsv row to enrol)"
+                continue
+            fi
         fi
         check_one_model "$area" "$module" "$kind" "$cfg" || rc=1
     done <<< "$modules"
@@ -597,7 +623,11 @@ check_traceability() {
 # --- dispatch ---------------------------------------------------------------
 
 usage() {
-    sed -n '2,17p' "$0" | sed 's/^# \{0,1\}//'
+    # Marker-delimited, not a line-number slice: a line-number range goes
+    # stale the moment the banner between the markers grows or shrinks by a
+    # different amount than whoever last edited the range accounted for.
+    sed -n '/^# check-tla usage: begin$/,/^# check-tla usage: end$/p' "$0" \
+        | sed '1d;$d;s/^# \{0,1\}//'
     exit "${1:-1}"
 }
 

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -466,7 +466,7 @@ rm -rf "$nrepo"
 # log and a marker file (instead of the real jar) proves both which path ran
 # and whether TLC was actually launched.
 build_fake_live_area() {
-    # build_fake_live_area <with-band: yes|no> -> sets FAKE_TMP, FAKE_SHIM.
+    # build_fake_live_area <with-band: yes|no> -> sets FAKE_TMP.
     local with_band="$1"
     local tmp area_dir shim
     tmp="$(mktemp -d)"

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -427,6 +427,39 @@ else
     ok
 fi
 
+# --- (n) traceability: zero resolved rows fails, naming the area (issue #1356)
+# check_traceability used to report PASS on a table with only a header row
+# and no data rows, since it asserted rc -eq 0 without checking count > 0. An
+# area whose table lost every row (a bad edit, a rebase) would then pass
+# silently.
+echo "--- (n) traceability: zero resolved rows fails, naming the area"
+nrepo="$(mktemp -d)"
+mkdir -p "$nrepo/crates" "$nrepo/formal/tla/emptyarea"
+cat > "$nrepo/formal/tla/emptyarea/traceability.md" <<'EOF'
+# Empty area traceability
+
+| TLA+ action or property | meaning | Rust path and symbol | existing test | new test needed |
+|---|---|---|---|---|
+EOF
+
+orig_repo_root2="$REPO_ROOT"
+orig_formal_dir2="$FORMAL_DIR"
+REPO_ROOT="$nrepo"
+FORMAL_DIR="$nrepo/formal/tla"
+
+nout="$(check_traceability emptyarea 2>&1)"
+ncode=$?
+if [ "$ncode" -ne 0 ]; then ok; else bad "n: expected nonzero exit on zero resolved rows, got 0; output: $nout"; fi
+if printf '%s' "$nout" | grep -qF "emptyarea traceability"; then
+    ok
+else
+    bad "n: expected the failure message to name the area 'emptyarea'; output: $nout"
+fi
+
+REPO_ROOT="$orig_repo_root2"
+FORMAL_DIR="$orig_formal_dir2"
+rm -rf "$nrepo"
+
 rm -f "$LIB_SRC"
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -428,10 +428,9 @@ else
 fi
 
 # --- (n) traceability: zero resolved rows fails, naming the area (issue #1356)
-# check_traceability used to report PASS on a table with only a header row
-# and no data rows, since it asserted rc -eq 0 without checking count > 0. An
-# area whose table lost every row (a bad edit, a rebase) would then pass
-# silently.
+# A traceability.md with only a header row and no data rows must fail, not
+# pass: a table that lost every row (a bad edit, a rebase) is otherwise
+# indistinguishable from one that legitimately has nothing left to check.
 echo "--- (n) traceability: zero resolved rows fails, naming the area"
 nrepo="$(mktemp -d)"
 mkdir -p "$nrepo/crates" "$nrepo/formal/tla/emptyarea"
@@ -450,15 +449,122 @@ FORMAL_DIR="$nrepo/formal/tla"
 nout="$(check_traceability emptyarea 2>&1)"
 ncode=$?
 if [ "$ncode" -ne 0 ]; then ok; else bad "n: expected nonzero exit on zero resolved rows, got 0; output: $nout"; fi
-if printf '%s' "$nout" | grep -qF "emptyarea traceability"; then
+if printf '%s' "$nout" | grep -qF "emptyarea traceability: FAIL (zero rows resolved)"; then
     ok
 else
-    bad "n: expected the failure message to name the area 'emptyarea'; output: $nout"
+    bad "n: expected 'emptyarea traceability: FAIL (zero rows resolved)'; output: $nout"
 fi
 
 REPO_ROOT="$orig_repo_root2"
 FORMAL_DIR="$orig_formal_dir2"
 rm -rf "$nrepo"
+
+# --- (o)-(p) issue #1356/#1357 finding 1: live gated by bands.tsv ----------
+# check_model must not run an area's live.cfg unless bands.tsv carries a row
+# for it (a measured band is the opt-in): unbanded reports SKIP and never
+# launches TLC, banded runs it. A java shim that writes a canned TLC-shaped
+# log and a marker file (instead of the real jar) proves both which path ran
+# and whether TLC was actually launched.
+build_fake_live_area() {
+    # build_fake_live_area <with-band: yes|no> -> sets FAKE_TMP, FAKE_SHIM.
+    local with_band="$1"
+    local tmp area_dir shim
+    tmp="$(mktemp -d)"
+    area_dir="$tmp/formal/tla/fakelive"
+    mkdir -p "$area_dir"
+    cat > "$area_dir/MCFake.tla" <<'EOF'
+---- MODULE MCFake ----
+====
+EOF
+    cat > "$area_dir/smoke.cfg" <<'EOF'
+SPECIFICATION Spec
+EOF
+    cat > "$area_dir/live.cfg" <<'EOF'
+SPECIFICATION Spec
+PROPERTY Prop
+EOF
+    if [ "$with_band" = yes ]; then
+        printf 'cfg\tmin_distinct\tmax_distinct\tmin_depth\tmax_depth\nlive.cfg\t50\t50\t5\t5\n' \
+            > "$area_dir/bands.tsv"
+    fi
+    shim="$tmp/java"
+    cat > "$shim" <<EOF
+#!/usr/bin/env bash
+touch "$tmp/java-ran"
+cat <<'LOG'
+100 states generated, 50 distinct states found, 0 states left on queue.
+The depth of the complete state graph search is 5.
+Model checking completed. No error has been found.
+LOG
+exit 0
+EOF
+    chmod +x "$shim"
+    FAKE_TMP="$tmp"
+}
+
+orig_formal_dir3="$FORMAL_DIR"
+orig_cache_dir3="$CACHE_DIR"
+orig_log_dir3="$LOG_DIR"
+orig_last_run3="$LAST_RUN"
+orig_java3="${JAVA:-}"
+orig_jar3="${JAR:-}"
+
+echo "--- (o) live: no bands.tsv row -> SKIP, TLC never invoked, exit 0"
+build_fake_live_area no
+FORMAL_DIR="$FAKE_TMP/formal/tla"
+CACHE_DIR="$FAKE_TMP/cache"
+LOG_DIR="$CACHE_DIR/logs"
+LAST_RUN="$CACHE_DIR/last-run.tsv"
+JAVA="$FAKE_TMP/java"
+JAR="/dev/null"
+resolve_timeout
+resolve_tla_resources
+oout="$(check_model fakelive live 2>&1)"; ocode=$?
+echo "    measured: exit=$ocode"
+if [ "$ocode" -eq 0 ]; then ok; else bad "o: expected exit 0 on an unbanded live skip, got $ocode; output: $oout"; fi
+if printf '%s' "$oout" | grep -qF "fakelive live: SKIP (unbanded live.cfg; add a bands.tsv row to enrol)"; then
+    ok
+else
+    bad "o: expected the SKIP message; output: $oout"
+fi
+if [ -e "$FAKE_TMP/java-ran" ]; then
+    bad "o: java shim ran despite the cfg being unbanded"
+else
+    ok
+fi
+rm -rf "$FAKE_TMP"
+
+echo "--- (p) live: bands.tsv carries a matching row -> runs and PASSes"
+build_fake_live_area yes
+FORMAL_DIR="$FAKE_TMP/formal/tla"
+CACHE_DIR="$FAKE_TMP/cache"
+LOG_DIR="$CACHE_DIR/logs"
+LAST_RUN="$CACHE_DIR/last-run.tsv"
+JAVA="$FAKE_TMP/java"
+JAR="/dev/null"
+resolve_timeout
+resolve_tla_resources
+pout="$(check_model fakelive live 2>&1)"; pcode=$?
+echo "    measured: exit=$pcode"
+if [ "$pcode" -eq 0 ]; then ok; else bad "p: expected exit 0 on a banded live pass, got $pcode; output: $pout"; fi
+if [ -e "$FAKE_TMP/java-ran" ]; then
+    ok
+else
+    bad "p: expected the java shim to be launched once the cfg is banded; output: $pout"
+fi
+if printf '%s' "$pout" | grep -qF "fakelive/MCFake live: PASS"; then
+    ok
+else
+    bad "p: expected a PASS line for fakelive/MCFake; output: $pout"
+fi
+rm -rf "$FAKE_TMP"
+
+FORMAL_DIR="$orig_formal_dir3"
+CACHE_DIR="$orig_cache_dir3"
+LOG_DIR="$orig_log_dir3"
+LAST_RUN="$orig_last_run3"
+JAVA="$orig_java3"
+JAR="$orig_jar3"
 
 rm -f "$LIB_SRC"
 printf '\n%d passed, %d failed\n' "$pass" "$fail"


### PR DESCRIPTION
Fixes the three ways the TLA+ commit suite could report success on inputs it exists to reject (#1356) and the vacuous liveness check (#1357).

The three fault-coverage probes in `MCCommitProtocol.tla` were state predicates over the fault actions' enabling conjuncts, so they stayed VIOLATED (the negative harness's success) with the fault actions deleted from `Next`. `CommitProtocol.tla` gains a `faultFired` history variable set only by the three fault transitions and carried unchanged by the other sixteen actions, and the probes are post-state predicates over it, each for its own fault kind, in the shape `AbandonUnreachable` already had. Deleting a fault action now turns its probe's run from exit 12 into exit 0, which the negative harness reports as a failure; the executor's mutation table for all three is on #1356. `check_traceability` in `scripts/check-tla.sh` fails on zero resolved rows, with a case in `check-tla.test.sh`.

`live.cfg` had `MaxTicks = 3` with `FlushLifetime = 3`, so `Expired` was unreachable and `EveryPinnedFlushSettles` held vacuously; at `MaxTicks = 4` it failed with a stuttering trace after a flush expired. `Fairness` gains `WF_vars(Abandon(f))` under the per-flush quantifier, with the implementation fact it rests on cited from `crates/ravel-ingest/src/shard.rs`, and `live.cfg` uses the smallest bound at which the deadline is reachable. A `live` model kind runs each area's `live.cfg` under the smoke budget and is part of `check-tla.sh ci`; an area enrols by carrying a `live.cfg` row in its `bands.tsv`, so `formal/tla/resharding/live.cfg`, recorded at 11 minutes 36 seconds and never run by any lane, is reported as skipped rather than run against a 300 s budget. Both branches of that gate are under test. Adding a temporal property to `commit/exhaustive.cfg` was measured not to finish in 590 s on the executor and is recorded in `results.md` as not adopted.

No Rust changes. The per-PR TLA job runs the `ci` kind from this branch, which now includes the `live` lane; that run is the verification of the lane wiring.

Fixes: #1356
Fixes: #1357
