### PR TITLE
fix(ravel-query): report the log lane's real segments_pruned

### DIFF
--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -1530,7 +1530,8 @@ impl QueryEngine {
         // `log_plan_class`): the catalog resolve passes no name filter to
         // prune against. Adding it anyway keeps a future resolve-side prune
         // from being silently dropped.
-        let log_segments_pruned = log_snapshot.segments.len() as u64 - log_segments_fetched;
+        let log_segments_pruned =
+            (log_snapshot.segments.len() as u64).saturating_sub(log_segments_fetched);
         stats.segments_fetched += log_segments_fetched;
         stats.segments_pruned += log_segments_pruned + log_snapshot.segments_pruned;
         stats.phase_accounting =

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -1469,8 +1469,16 @@ impl QueryEngine {
         // hand after each plan below -- otherwise two log selectors would
         // each see, and could each spend, the full remaining budget.
         let mut log_series_out: Vec<SeriesData> = Vec::new();
-        let mut log_segments_fetched: u64 = 0;
-        let mut log_segments_pruned: u64 = 0;
+        // Every plan below re-walks the SAME `log_snapshot.segments` slice
+        // (issue #1228): a segment one plan prunes at its own STREAM_DIR or
+        // time-range check can be exactly the segment another plan fetches,
+        // so a plan-summed or plan-maxed count over- or under-reports the
+        // lane's true fetched/pruned split. Unioning each plan's
+        // `fetched_segments` indexes (all indexes into this same slice, see
+        // the field doc on `LogSeriesOutput`) gives the lane's real fetched
+        // set regardless of plan count, and `segments_pruned` is the rest of
+        // the resolved set by construction.
+        let mut log_fetched_segments: HashSet<usize> = HashSet::new();
         let mut fed_metric_names: Vec<&'static str> = Vec::new();
         for plan in &log_plans {
             // `log_plans` was filtered by `log_metric_of(...).is_some()`
@@ -1503,8 +1511,7 @@ impl QueryEngine {
             let out_samples: usize = out.series.iter().map(|s| s.samples.len()).sum();
             samples_remaining = samples_remaining.saturating_sub(out_samples);
             series_remaining = series_remaining.saturating_sub(out.series.len());
-            log_segments_fetched = log_segments_fetched.max(out.segments_fetched as u64);
-            log_segments_pruned += out.segments_pruned as u64;
+            log_fetched_segments.extend(out.fetched_segments.iter().copied());
             log_series_out.extend(out.series);
             if !fed_metric_names.contains(&metric.name()) {
                 fed_metric_names.push(metric.name());
@@ -1512,14 +1519,19 @@ impl QueryEngine {
         }
 
         source.log_series = log_series_out;
+        let log_segments_fetched = log_fetched_segments.len() as u64;
+        // `log_snapshot.segments.len() - log_segments_fetched` rather than a
+        // per-plan sum/max (issue #1228): the union above already counts
+        // each segment at most once regardless of how many plans fetched
+        // it, so the rest of the resolved set is pruned by construction --
+        // `log_segments_fetched + this == log_snapshot.segments.len()`
+        // holds for any plan count. `log_snapshot.segments_pruned` is
+        // structurally 0 for this lane (comment below, at
+        // `log_plan_class`): the catalog resolve passes no name filter to
+        // prune against. Adding it anyway keeps a future resolve-side prune
+        // from being silently dropped.
+        let log_segments_pruned = log_snapshot.segments.len() as u64 - log_segments_fetched;
         stats.segments_fetched += log_segments_fetched;
-        // `log_snapshot.segments_pruned` is structurally 0 for this lane
-        // (comment below, at `log_plan_class`): the catalog resolve passes
-        // no name filter to prune against. `log_segments_pruned` is the
-        // figure that actually reflects pruning for the log lane --
-        // `fetch_log_series`'s own per-segment time-range and stream-label
-        // check, summed across every plan this lane ran. Adding both keeps
-        // a future resolve-side prune from being silently dropped.
         stats.segments_pruned += log_segments_pruned + log_snapshot.segments_pruned;
         stats.phase_accounting =
             combine_phase_accounting(&stats.phase_accounting, &log_accounting.snapshot());

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -1469,15 +1469,9 @@ impl QueryEngine {
         // hand after each plan below -- otherwise two log selectors would
         // each see, and could each spend, the full remaining budget.
         let mut log_series_out: Vec<SeriesData> = Vec::new();
-        // Every plan below re-walks the SAME `log_snapshot.segments` slice
-        // (issue #1228): a segment one plan prunes at its own STREAM_DIR or
-        // time-range check can be exactly the segment another plan fetches,
-        // so a plan-summed or plan-maxed count over- or under-reports the
-        // lane's true fetched/pruned split. Unioning each plan's
-        // `fetched_segments` indexes (all indexes into this same slice, see
-        // the field doc on `LogSeriesOutput`) gives the lane's real fetched
-        // set regardless of plan count, and `segments_pruned` is the rest of
-        // the resolved set by construction.
+        // Indexes into `log_snapshot.segments`, unioned across the lane's
+        // plans: every plan walks that same slice, and a segment one plan
+        // prunes can be the one another plan fetches (issue #1228).
         let mut log_fetched_segments: HashSet<usize> = HashSet::new();
         let mut fed_metric_names: Vec<&'static str> = Vec::new();
         for plan in &log_plans {
@@ -1511,7 +1505,7 @@ impl QueryEngine {
             let out_samples: usize = out.series.iter().map(|s| s.samples.len()).sum();
             samples_remaining = samples_remaining.saturating_sub(out_samples);
             series_remaining = series_remaining.saturating_sub(out.series.len());
-            log_fetched_segments.extend(out.fetched_segments.iter().copied());
+            log_fetched_segments.extend(out.fetched_segments);
             log_series_out.extend(out.series);
             if !fed_metric_names.contains(&metric.name()) {
                 fed_metric_names.push(metric.name());
@@ -1520,16 +1514,15 @@ impl QueryEngine {
 
         source.log_series = log_series_out;
         let log_segments_fetched = log_fetched_segments.len() as u64;
-        // `log_snapshot.segments.len() - log_segments_fetched` rather than a
-        // per-plan sum/max (issue #1228): the union above already counts
-        // each segment at most once regardless of how many plans fetched
-        // it, so the rest of the resolved set is pruned by construction --
-        // `log_segments_fetched + this == log_snapshot.segments.len()`
-        // holds for any plan count. `log_snapshot.segments_pruned` is
-        // structurally 0 for this lane (comment below, at
-        // `log_plan_class`): the catalog resolve passes no name filter to
-        // prune against. Adding it anyway keeps a future resolve-side prune
-        // from being silently dropped.
+        // The union counts each segment once however many plans fetched it,
+        // so the rest of the resolved set is pruned and
+        // `fetched + pruned == log_snapshot.segments.len()` for any plan
+        // count. Every caller today passes the whole slice, so the union
+        // cannot exceed its length; the subtraction saturates only so a
+        // future caller unioning indexes from a subslice cannot wrap.
+        // `log_snapshot.segments_pruned` is 0 for this lane (the resolve
+        // passes no name filter, see `log_plan_class` below); adding it keeps
+        // a future resolve-side prune from being dropped.
         let log_segments_pruned =
             (log_snapshot.segments.len() as u64).saturating_sub(log_segments_fetched);
         stats.segments_fetched += log_segments_fetched;

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -1470,6 +1470,7 @@ impl QueryEngine {
         // each see, and could each spend, the full remaining budget.
         let mut log_series_out: Vec<SeriesData> = Vec::new();
         let mut log_segments_fetched: u64 = 0;
+        let mut log_segments_pruned: u64 = 0;
         let mut fed_metric_names: Vec<&'static str> = Vec::new();
         for plan in &log_plans {
             // `log_plans` was filtered by `log_metric_of(...).is_some()`
@@ -1503,6 +1504,7 @@ impl QueryEngine {
             samples_remaining = samples_remaining.saturating_sub(out_samples);
             series_remaining = series_remaining.saturating_sub(out.series.len());
             log_segments_fetched = log_segments_fetched.max(out.segments_fetched as u64);
+            log_segments_pruned += out.segments_pruned as u64;
             log_series_out.extend(out.series);
             if !fed_metric_names.contains(&metric.name()) {
                 fed_metric_names.push(metric.name());
@@ -1511,7 +1513,14 @@ impl QueryEngine {
 
         source.log_series = log_series_out;
         stats.segments_fetched += log_segments_fetched;
-        stats.segments_pruned += log_snapshot.segments_pruned;
+        // `log_snapshot.segments_pruned` is structurally 0 for this lane
+        // (comment below, at `log_plan_class`): the catalog resolve passes
+        // no name filter to prune against. `log_segments_pruned` is the
+        // figure that actually reflects pruning for the log lane --
+        // `fetch_log_series`'s own per-segment time-range and stream-label
+        // check, summed across every plan this lane ran. Adding both keeps
+        // a future resolve-side prune from being silently dropped.
+        stats.segments_pruned += log_segments_pruned + log_snapshot.segments_pruned;
         stats.phase_accounting =
             combine_phase_accounting(&stats.phase_accounting, &log_accounting.snapshot());
         stats.accounting = stats.phase_accounting.pooled();

--- a/crates/ravel-query/src/log_series.rs
+++ b/crates/ravel-query/src/log_series.rs
@@ -322,14 +322,8 @@ pub struct LogSeriesOutput {
     pub segments_pruned: usize,
     /// Indexes into the `segments` slice this call was given, one per
     /// segment that reached a Scan-phase fetch (the same segments
-    /// `segments_fetched` counts). Indexes, not `SegmentRef`/data-object-key
-    /// values: every caller in this crate re-walks the SAME slice
-    /// (`log_snapshot.segments`) for every plan in a log lane, so an index
-    /// identifies a segment within that shared slice at the cost of a
-    /// `usize` copy, with no `String` clone or hash. A caller fetching more
-    /// than one selector against that slice (`QueryEngine::prefetch`'s log
-    /// lane) unions these across plans to get the lane's true fetched-set
-    /// size, rather than summing or maxing each plan's own count.
+    /// `segments_fetched` counts). A caller that runs several selectors over
+    /// one slice unions these to get the set of segments any of them fetched.
     pub fetched_segments: Vec<usize>,
     /// Blocks the reader decoded, from its own per-object `ScanStats`, summed
     /// over every segment this call actually opened a scan for. Zero for a

--- a/crates/ravel-query/src/log_series.rs
+++ b/crates/ravel-query/src/log_series.rs
@@ -320,6 +320,17 @@ pub struct LogSeriesOutput {
     pub records_scanned: u64,
     pub segments_fetched: usize,
     pub segments_pruned: usize,
+    /// Indexes into the `segments` slice this call was given, one per
+    /// segment that reached a Scan-phase fetch (the same segments
+    /// `segments_fetched` counts). Indexes, not `SegmentRef`/data-object-key
+    /// values: every caller in this crate re-walks the SAME slice
+    /// (`log_snapshot.segments`) for every plan in a log lane, so an index
+    /// identifies a segment within that shared slice at the cost of a
+    /// `usize` copy, with no `String` clone or hash. A caller fetching more
+    /// than one selector against that slice (`QueryEngine::prefetch`'s log
+    /// lane) unions these across plans to get the lane's true fetched-set
+    /// size, rather than summing or maxing each plan's own count.
+    pub fetched_segments: Vec<usize>,
     /// Blocks the reader decoded, from its own per-object `ScanStats`, summed
     /// over every segment this call actually opened a scan for. Zero for a
     /// segment pruned before Scan-phase (no bloom/skip-index pruning to
@@ -667,10 +678,11 @@ pub async fn fetch_log_series(
     let mut records_scanned: u64 = 0u64;
     let mut segments_fetched = 0usize;
     let mut segments_pruned = 0usize;
+    let mut fetched_segments: Vec<usize> = Vec::new();
     let mut blocks_scanned: u64 = 0u64;
     let mut blocks_total: u64 = 0u64;
 
-    for seg_ref in segments {
+    for (seg_idx, seg_ref) in segments.iter().enumerate() {
         if let Some(err) = deadline_exceeded(req.deadline) {
             return Err(err);
         }
@@ -751,6 +763,7 @@ pub async fn fetch_log_series(
             continue;
         };
         segments_fetched += 1;
+        fetched_segments.push(seg_idx);
 
         while let Some(records) = scan.next_block()? {
             if let Some(err) = deadline_exceeded(req.deadline) {
@@ -855,6 +868,7 @@ pub async fn fetch_log_series(
         records_scanned,
         segments_fetched,
         segments_pruned,
+        fetched_segments,
         blocks_scanned,
         blocks_total,
     })

--- a/crates/ravel-query/tests/log_series_engine.rs
+++ b/crates/ravel-query/tests/log_series_engine.rs
@@ -1281,6 +1281,13 @@ async fn logs_query_stats_report_the_lane_segments_pruned() {
          pruned by fetch_log_series's own time-range check, not the \
          catalog resolve's structural 0 for this lane"
     );
+    assert_eq!(
+        stats.segments_fetched, 2,
+        "seg2 (BASE+95s) and seg3 (BASE+105s) are the only two of the five \
+         resolved segments inside [BASE+90s, BASE+110s]; a single-plan \
+         query must report exactly the fetched set, not a count that lost \
+         track of which segments they were"
+    );
 }
 
 #[tokio::test]
@@ -1317,5 +1324,111 @@ async fn logs_query_stats_segments_pruned_zero_when_window_covers_every_segment(
         stats.segments_pruned, 0,
         "the window covers every segment, so the lane figure must be 0, \
          not the segment total"
+    );
+    assert_eq!(
+        stats.segments_fetched, 5,
+        "all 5 published segments are resolved and inside the window, so \
+         the lane must report all 5 as fetched -- a resolve that silently \
+         returned nothing must not pass the zero-pruned case above by \
+         also fetching nothing"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1228 fix-round: the log lane's fetched/pruned figures must be
+// set-based over the union of segments any plan in the lane fetched, not a
+// per-plan sum or max. Every plan in a log lane re-walks the SAME
+// `log_snapshot.segments` slice, so a plan-summed `segments_pruned` (the
+// pre-fix-round code) double-counts a segment pruned by more than one plan,
+// and a plan-maxed `segments_fetched` under-counts a segment fetched by only
+// one of several plans -- either way `segments_pruned + segments_fetched`
+// can land above or below `log_snapshot.segments.len()`.
+// ---------------------------------------------------------------------------
+
+/// The reviewer's worked example that blocked the previous fix-round commit
+/// (beb90166): two log plans over the two-object `fixture()`, each pruning
+/// the OTHER plan's segment at STREAM_DIR (`job="api"` prunes `fixture-b`,
+/// `job="worker"` prunes `fixture-a`) and fetching its own. Summing each
+/// plan's `segments_pruned` reports pruned=2 over a 2-segment snapshot on a
+/// query that pruned nothing at all; maxing `segments_fetched` across plans
+/// (fetched=1/pruned=0 for one plan, fetched=0/pruned=1 for the other, so
+/// max+max = 1+1 = 2) still lands pruned+fetched=4 over 2 segments. Against
+/// beb90166 this assertion fails with `segments_fetched == 1,
+/// segments_pruned == 2` (the flipped line is the `log_segments_pruned +=
+/// out.segments_pruned as u64;` next to `log_segments_fetched =
+/// log_segments_fetched.max(out.segments_fetched as u64);` in
+/// `QueryEngine::prefetch`'s log lane, `engine.rs`). The union-based fix
+/// reports the true set: both segments are fetched by SOME plan, so
+/// fetched=2 and pruned=0 exactly.
+#[tokio::test]
+async fn two_log_plans_that_prune_different_segments_report_the_union() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+
+    let (_value, stats) = engine
+        .instant_with_stats(
+            th,
+            r#"count_over_time(ravel_log_lines{job="api"}[1h]) or count_over_time(ravel_log_lines{job="worker"}[1h])"#,
+            ms(BASE + 20 * NS),
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+
+    assert_eq!(
+        stats.segments_fetched, 2,
+        "fixture-a is fetched by the job=\"api\" plan and fixture-b by the \
+         job=\"worker\" plan; the union of what any plan fetched is both \
+         segments"
+    );
+    assert_eq!(
+        stats.segments_pruned, 0,
+        "every segment in the 2-segment snapshot was fetched by some plan, \
+         so nothing was actually pruned from the lane's perspective, even \
+         though each individual plan pruned one segment of its own"
+    );
+}
+
+/// A single-plan query whose selector matches no stream in one of the two
+/// resolved segments, so the prune happens at STREAM_DIR (`matching_streams
+/// .is_empty()` in `fetch_log_series`) -- the path an ordinary query hits,
+/// as opposed to the time-window prune, which the catalog resolve already
+/// filters out before `fetch_log_series` ever sees the segment in normal
+/// operation (see `logs_query_stats_report_the_lane_segments_pruned`'s
+/// `min_tokens` workaround to force a time-window prune to reach this lane
+/// at all).
+#[tokio::test]
+async fn stream_dir_prune_counts_toward_segments_pruned() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+    fixture(&store, th).await;
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+
+    let (_value, stats) = engine
+        .instant_with_stats(
+            th,
+            r#"count_over_time(ravel_log_lines{job="api"}[1h])"#,
+            ms(BASE + 20 * NS),
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+
+    assert_eq!(
+        stats.segments_fetched, 1,
+        "only fixture-a matches job=\"api\" at STREAM_DIR"
+    );
+    assert_eq!(
+        stats.segments_pruned, 1,
+        "fixture-b is pruned at STREAM_DIR: its only stream is \
+         service.name=worker, which never matches job=\"api\""
     );
 }

--- a/crates/ravel-query/tests/log_series_engine.rs
+++ b/crates/ravel-query/tests/log_series_engine.rs
@@ -1335,29 +1335,24 @@ async fn logs_query_stats_segments_pruned_zero_when_window_covers_every_segment(
 }
 
 // ---------------------------------------------------------------------------
-// Issue #1228 fix-round: the log lane's fetched/pruned figures must be
-// set-based over the union of segments any plan in the lane fetched, not a
-// per-plan sum or max. Every plan in a log lane re-walks the SAME
-// `log_snapshot.segments` slice, so a plan-summed `segments_pruned` (the
-// pre-fix-round code) double-counts a segment pruned by more than one plan,
-// and a plan-maxed `segments_fetched` under-counts a segment fetched by only
-// one of several plans -- either way `segments_pruned + segments_fetched`
-// can land above or below `log_snapshot.segments.len()`.
+// The log lane's fetched/pruned figures are set-based over the union of
+// segments any plan in the lane fetched (issue #1228). Every plan walks the
+// same `log_snapshot.segments` slice, so a per-plan sum of `segments_pruned`
+// double-counts a segment pruned by more than one plan and a per-plan max of
+// `segments_fetched` under-counts a segment fetched by only one, and either
+// puts `segments_pruned + segments_fetched` off `log_snapshot.segments.len()`.
 // ---------------------------------------------------------------------------
 
-/// The reviewer's worked example that blocked the previous fix-round commit
-/// (beb90166): two log plans over the two-object `fixture()`, each pruning
-/// the OTHER plan's segment at STREAM_DIR (`job="api"` prunes `fixture-b`,
+/// Two log plans over the two-object `fixture()`, each pruning the OTHER
+/// plan's segment at STREAM_DIR (`job="api"` prunes `fixture-b`,
 /// `job="worker"` prunes `fixture-a`) and fetching its own, so each plan
 /// alone is fetched=1/pruned=1. A per-plan sum of `segments_pruned` reports
-/// pruned=2 over a 2-segment snapshot on a query that pruned nothing at all,
-/// and a per-plan max of `segments_fetched` reports fetched=1 for a query
-/// that fetched both segments; pruned+fetched=3 over 2 segments. Against
-/// beb90166 the `segments_fetched == 2` assertion fails first (the flipped
-/// line is `log_segments_fetched = log_segments_fetched.max(...)` in
-/// `QueryEngine::prefetch`'s log lane, `engine.rs`), then
-/// `segments_pruned == 0` fails on the `+=` beside it. The union-based fix
-/// reports the true set: both segments are fetched by SOME plan, so
+/// pruned=2 over a 2-segment snapshot on a query that pruned nothing, and a
+/// per-plan max of `segments_fetched` reports fetched=1 for a query that
+/// fetched both segments. Under those semantics `segments_fetched == 2`
+/// fails first (a `.max()` across plans in `QueryEngine::prefetch`'s log
+/// lane), then `segments_pruned == 0` fails on a `+=` beside it. The union
+/// reports the true set: both segments are fetched by some plan, so
 /// fetched=2 and pruned=0 exactly.
 #[tokio::test]
 async fn two_log_plans_that_prune_different_segments_report_the_union() {

--- a/crates/ravel-query/tests/log_series_engine.rs
+++ b/crates/ravel-query/tests/log_series_engine.rs
@@ -32,7 +32,7 @@ use ravel_query::distrib::client::{DistribError, SliceFetcher, SliceResponse};
 use ravel_query::distrib::{Federation, RemoteCluster};
 use ravel_query::http::{AppState, StaticBearerTokenResolver, router};
 use ravel_query::{EngineConfig, QueryEngine, QueryError, RequestLimit};
-use ravel_types::{Signal, TenantHash, TenantId, TimeRange};
+use ravel_types::{CommitToken, Signal, TenantHash, TenantId, TimeRange};
 use serde_json::Value as JsonValue;
 use tower::ServiceExt;
 use uuid::Uuid;
@@ -115,12 +115,15 @@ fn record(
 /// field by hand from `records` exactly as an ingest sink would (mirrors
 /// `services/ravel-cli/tests/catalog_signal.rs`'s `publish_rlog`,
 /// generalized to a caller-supplied record set spanning multiple streams).
+/// Returns the published record's `CommitToken`, so a caller can force the
+/// catalog to resolve this exact segment via `min_tokens` regardless of
+/// whether it overlaps a query's time window.
 async fn publish_log_segment(
     store: &MemoryStore,
     tenant_hash: TenantHash,
     seq: u64,
     records: &[LogRecord],
-) {
+) -> CommitToken {
     let mut writer = RlogWriter::new(RlogConfig::default(), identity(tenant_hash, seq));
     for r in records {
         writer.push(r.clone()).expect("push log record");
@@ -172,7 +175,7 @@ async fn publish_log_segment(
         .expect("put rlog data object");
     publish::publish(store, &commit, &RetryPolicy::default())
         .await
-        .expect("publish logs commit record");
+        .expect("publish logs commit record")
 }
 
 /// The two-stream, two-object fixture every test in this file builds on.
@@ -631,8 +634,11 @@ async fn log_lane_never_escalates_a_selectively_indexed_metrics_lane_to_exhausti
         .expect("query succeeds");
 
     assert_eq!(
-        stats.segments_pruned, 1,
-        "the unrelated metric segment must actually be pruned for this test to be meaningful"
+        stats.segments_pruned, 2,
+        "1 from the metrics lane's own unrelated-segment postings prune, plus 1 from the log \
+         lane's own fetch_log_series pruning the job=\"worker\" fixture segment (its \
+         STREAM_DIR doesn't match this query's job=\"api\" matcher); the log lane's own \
+         catalog resolve still contributes 0 (name_filter: None never prunes there)"
     );
     assert_eq!(
         stats.io_shape.plan_class,
@@ -1199,5 +1205,117 @@ async fn phase_accounting_reports_exact_get_counts_for_a_log_query() {
         pooled.s3_requests(AccountedOp::Get),
         6,
         "every GET this query issues is charged to exactly one phase"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1228: `stats.segments_pruned` for the logs lane must be
+// `fetch_log_series`'s own per-segment pruning count, not the catalog
+// resolve's `log_snapshot.segments_pruned`, which is structurally always 0
+// for this lane (`resolve_bounded` always passes `name_filter: None`).
+// ---------------------------------------------------------------------------
+
+/// Publishes one single-record log segment on stream `job="x"` at `ts`, as
+/// its own RLOG object (`writer_seq` distinguishes the five objects this
+/// test publishes), returning its `CommitToken`.
+async fn publish_single_record_segment(
+    store: &MemoryStore,
+    tenant_hash: TenantHash,
+    writer_seq: u64,
+    ts: i64,
+) -> CommitToken {
+    let s = [("service.name", AttrValue::Str("x".to_string()))];
+    let records = vec![record(&s, ts, "ERROR", "x", &[])];
+    publish_log_segment(store, tenant_hash, writer_seq, &records).await
+}
+
+#[tokio::test]
+async fn logs_query_stats_report_the_lane_segments_pruned() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+
+    // N=5 segments, one record each, all on the same `job="x"` stream so
+    // only the per-segment time-window check (not stream-label pruning)
+    // decides which are pruned. K=3 (seg0, seg1, seg4) lie outside the query
+    // window below; seg2 (BASE+95s) and seg3 (BASE+105s) are inside it.
+    //
+    // `Catalog::resolve` itself already excludes a segment whose event range
+    // does not overlap the query window before `fetch_log_series` ever runs
+    // (`Catalog::process_bucket`'s `event_range.overlaps(&range)` filter), so
+    // a segment genuinely outside the window never reaches this lane's own
+    // pruning check via ordinary time-based listing. The three out-of-window
+    // segments are instead forced into the resolved set via their
+    // `CommitToken`s passed as `min_tokens` -- the same read-your-write path
+    // a client uses to pin a specific just-published segment -- which
+    // resolves by explicit key regardless of window overlap
+    // (`Catalog::resolve_min_token`). `fetch_log_series` then applies its own
+    // time-range check to these token-forced segments exactly as it would
+    // to any other, pruning the three that don't overlap `[BASE+90s,
+    // BASE+110s]`.
+    let t0 = publish_single_record_segment(&store, th, 0, BASE).await;
+    let t1 = publish_single_record_segment(&store, th, 1, BASE + 40 * NS).await;
+    publish_single_record_segment(&store, th, 2, BASE + 95 * NS).await;
+    publish_single_record_segment(&store, th, 3, BASE + 105 * NS).await;
+    let t4 = publish_single_record_segment(&store, th, 4, BASE + 300 * NS).await;
+
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+
+    // `[20s]` at instant `BASE+110s` fetches the window `[BASE+90s,
+    // BASE+110s]` (`selector_fetch_window`: `[instant - range, instant]`).
+    let (_value, stats) = engine
+        .instant_with_stats(
+            th,
+            r#"count_over_time(ravel_log_lines{job="x"}[20s])"#,
+            ms(BASE + 110 * NS),
+            &[t0, t1, t4],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+
+    assert_eq!(
+        stats.segments_pruned, 3,
+        "3 of the 5 segments lie outside the query window and must be \
+         pruned by fetch_log_series's own time-range check, not the \
+         catalog resolve's structural 0 for this lane"
+    );
+}
+
+#[tokio::test]
+async fn logs_query_stats_segments_pruned_zero_when_window_covers_every_segment() {
+    let store = Arc::new(MemoryStore::new());
+    let tid = tenant("tenant-a");
+    let th = tid.hash();
+
+    publish_single_record_segment(&store, th, 0, BASE).await;
+    publish_single_record_segment(&store, th, 1, BASE + 40 * NS).await;
+    publish_single_record_segment(&store, th, 2, BASE + 95 * NS).await;
+    publish_single_record_segment(&store, th, 3, BASE + 105 * NS).await;
+    publish_single_record_segment(&store, th, 4, BASE + 300 * NS).await;
+
+    let (engine, _tid) = build_engine(store, EngineConfig::default());
+
+    // `[400s]` at instant `BASE+300s` fetches `[BASE-100s, BASE+300s]`,
+    // which covers every one of the five segments above, so ordinary
+    // time-based listing resolves all of them and no `min_tokens` are
+    // needed.
+    let (_value, stats) = engine
+        .instant_with_stats(
+            th,
+            r#"count_over_time(ravel_log_lines{job="x"}[400s])"#,
+            ms(BASE + 300 * NS),
+            &[],
+            NOW_NS,
+            DEADLINE,
+        )
+        .await
+        .expect("query succeeds");
+
+    assert_eq!(
+        stats.segments_pruned, 0,
+        "the window covers every segment, so the lane figure must be 0, \
+         not the segment total"
     );
 }

--- a/crates/ravel-query/tests/log_series_engine.rs
+++ b/crates/ravel-query/tests/log_series_engine.rs
@@ -1348,16 +1348,15 @@ async fn logs_query_stats_segments_pruned_zero_when_window_covers_every_segment(
 /// The reviewer's worked example that blocked the previous fix-round commit
 /// (beb90166): two log plans over the two-object `fixture()`, each pruning
 /// the OTHER plan's segment at STREAM_DIR (`job="api"` prunes `fixture-b`,
-/// `job="worker"` prunes `fixture-a`) and fetching its own. Summing each
-/// plan's `segments_pruned` reports pruned=2 over a 2-segment snapshot on a
-/// query that pruned nothing at all; maxing `segments_fetched` across plans
-/// (fetched=1/pruned=0 for one plan, fetched=0/pruned=1 for the other, so
-/// max+max = 1+1 = 2) still lands pruned+fetched=4 over 2 segments. Against
-/// beb90166 this assertion fails with `segments_fetched == 1,
-/// segments_pruned == 2` (the flipped line is the `log_segments_pruned +=
-/// out.segments_pruned as u64;` next to `log_segments_fetched =
-/// log_segments_fetched.max(out.segments_fetched as u64);` in
-/// `QueryEngine::prefetch`'s log lane, `engine.rs`). The union-based fix
+/// `job="worker"` prunes `fixture-a`) and fetching its own, so each plan
+/// alone is fetched=1/pruned=1. A per-plan sum of `segments_pruned` reports
+/// pruned=2 over a 2-segment snapshot on a query that pruned nothing at all,
+/// and a per-plan max of `segments_fetched` reports fetched=1 for a query
+/// that fetched both segments; pruned+fetched=3 over 2 segments. Against
+/// beb90166 the `segments_fetched == 2` assertion fails first (the flipped
+/// line is `log_segments_fetched = log_segments_fetched.max(...)` in
+/// `QueryEngine::prefetch`'s log lane, `engine.rs`), then
+/// `segments_pruned == 0` fails on the `+=` beside it. The union-based fix
 /// reports the true set: both segments are fetched by SOME plan, so
 /// fetched=2 and pruned=0 exactly.
 #[tokio::test]

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1892,9 +1892,12 @@ cost fields alongside the existing `segmentsFetched`/`segmentsPruned`:
   pre-existing per-run `rawF64Pages`/`rawF64Bytes`. No `segmentsPruned`
   here: `stats.segmentsPruned` (below) is the sole source. For the metrics
   lane it is `Catalog::resolve`'s own postings-pruning count; for the log
-  lane it is `fetch_log_series`'s own per-segment pruning (time-window and
-  stream-directory checks), since the log lane's own catalog resolve passes
-  no name filter and so never prunes there.
+  lane it is set-based over the lane's resolved snapshot, unioning each
+  plan's `fetch_log_series` fetch (time-window and stream-directory checks
+  survived) across every plan the lane ran: a segment fetched by any plan
+  counts once as fetched, and `segmentsPruned` is the rest of the resolved
+  set, since the log lane's own catalog resolve passes no name filter and
+  so never prunes there.
 - `stats.estimate`: the `CostEstimate`, carrying `estimatedRequests`,
   `estimatedStoreBytes`, `estimatedDecompressedBytes`, `segments`,
   `series`.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1890,10 +1890,11 @@ cost fields alongside the existing `segmentsFetched`/`segmentsPruned`:
   `cacheMisses`/`cacheBytes`, `decompressedBytes`, `segmentsOpened`,
   `seriesMatched`, `bytesReused`, `peakIntermediateBytes`, and the
   pre-existing per-run `rawF64Pages`/`rawF64Bytes`. No `segmentsPruned`
-  here: `stats.segmentsPruned` (below) is the sole source, sourced from
-  `Catalog::resolve`'s own count; `QueryAccounting`'s own
-  `segments_pruned` counter has no caller in `ravel-query` or
-  `ravel-catalog` and would only ever render 0.
+  here: `stats.segmentsPruned` (below) is the sole source. For the metrics
+  lane it is `Catalog::resolve`'s own postings-pruning count; for the log
+  lane it is `fetch_log_series`'s own per-segment pruning (time-window and
+  stream-directory checks), since the log lane's own catalog resolve passes
+  no name filter and so never prunes there.
 - `stats.estimate`: the `CostEstimate`, carrying `estimatedRequests`,
   `estimatedStoreBytes`, `estimatedDecompressedBytes`, `segments`,
   `series`.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1891,13 +1891,12 @@ cost fields alongside the existing `segmentsFetched`/`segmentsPruned`:
   `seriesMatched`, `bytesReused`, `peakIntermediateBytes`, and the
   pre-existing per-run `rawF64Pages`/`rawF64Bytes`. No `segmentsPruned`
   here: `stats.segmentsPruned` (below) is the sole source. For the metrics
-  lane it is `Catalog::resolve`'s own postings-pruning count; for the log
-  lane it is set-based over the lane's resolved snapshot, unioning each
-  plan's `fetch_log_series` fetch (time-window and stream-directory checks
-  survived) across every plan the lane ran: a segment fetched by any plan
-  counts once as fetched, and `segmentsPruned` is the rest of the resolved
-  set, since the log lane's own catalog resolve passes no name filter and
-  so never prunes there.
+  lane it is `Catalog::resolve`'s own postings-pruning count. For the log
+  lane it comes from the lane itself: a segment that any plan fetched (it
+  passed the time-window and stream-directory checks) counts once as
+  fetched, and `segmentsPruned` is the rest of the resolved snapshot. The
+  log lane's catalog resolve passes no name filter, so it prunes nothing
+  of its own.
 - `stats.estimate`: the `CostEstimate`, carrying `estimatedRequests`,
   `estimatedStoreBytes`, `estimatedDecompressedBytes`, `segments`,
   `series`.


### PR DESCRIPTION
The logs lane computes a real `segments_pruned` figure per `fetch_log_series` call (a segment whose window misses the request window, or whose stream directory matches no stream), and `prefetch` discarded it in favour of the catalog resolve's figure, which is structurally zero for this lane because the resolve passes no name filter. A logs query that pruned most of its segments reported `segments_pruned: 0`.

The figures are now set-based. `fetch_log_series` returns the indexes of the segments it fetched, `prefetch` unions them across the lane's plans, `segments_fetched` is the size of the union and `segments_pruned` is the rest of the resolved set, plus the resolve's own figure as before. Every plan re-walks the same resolved slice, so a per-plan sum over-counted a segment pruned by more than one plan and a per-plan max under-counted a segment fetched by only one; the union makes `pruned + fetched` equal the resolved count for any plan count, and the subtraction saturates so a future subslice caller cannot underflow it.

Tests pin the two-plan case (each plan prunes the other's segment at the stream directory: fetched 2, pruned 0, where the old code reported fetched 1, pruned 2), the stream-directory prune on a single plan (1 and 1), the five-segment acceptance case (pruned 3, fetched 2) and its all-inside twin (0 and 5). The stats documentation states the union semantics. `PlanClass` for the log lane is unchanged.

Fixes: #1228
