### PR TITLE
fix(tla): per-config exhaustive budgets and a per-area nightly matrix

### DIFF
--- a/.github/workflows/tla-nightly.yml
+++ b/.github/workflows/tla-nightly.yml
@@ -11,11 +11,20 @@
 # Areas run as a matrix, one job per area (issue #1358): every area used to
 # run sequentially inside one job, and a single slow area (maintenance)
 # exceeding its per-config budget put the whole job over its own
-# timeout-minutes. Each area now gets its own job and its own 110-minute
+# timeout-minutes. Each area now gets its own job and its own 160-minute
 # ceiling, and fail-fast is off so one area's failure or timeout does not
 # cancel the others mid-run. check-tla.sh's own per-config TLC budget still
 # applies inside each job (3600s default, overridable per cfg via bands.tsv's
-# budget_s column).
+# budget_s column); an area can run more than one exhaustive config
+# sequentially (maintenance runs two), so the job ceiling must bound the sum
+# of that area's budgets, not any single config's. Maintenance is the
+# largest: 5400s (MCMaintenanceOwnership.exhaustive.cfg's budget_s) + 3600s
+# (MCCompactionClaims.exhaustive.cfg's default) = 9000s = 150 minutes, so
+# 160 minutes leaves 10 minutes of headroom. check-tla.test.sh's (u) case
+# sums each area's exhaustive budgets from its bands.tsv and asserts this
+# value stays at least 10 minutes above the largest sum, so a future budget
+# change that outgrows this ceiling fails the test instead of timing out
+# silently on the next nightly run.
 #
 # The area list below is the same list scripts/check-tla.sh's discover_areas
 # would find under formal/tla (every directory carrying a smoke config);
@@ -45,7 +54,7 @@ jobs:
       matrix:
         area: [catalog, commit, common, lifecycle, maintenance, resharding]
     runs-on: ubuntu-latest
-    timeout-minutes: 110
+    timeout-minutes: 160
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:

--- a/.github/workflows/tla-nightly.yml
+++ b/.github/workflows/tla-nightly.yml
@@ -8,6 +8,20 @@
 # state-count regression, never a retry: TLC is deterministic for a fixed
 # config.
 #
+# Areas run as a matrix, one job per area (issue #1358): every area used to
+# run sequentially inside one job, and a single slow area (maintenance)
+# exceeding its per-config budget put the whole job over its own
+# timeout-minutes. Each area now gets its own job and its own 110-minute
+# ceiling, and fail-fast is off so one area's failure or timeout does not
+# cancel the others mid-run. check-tla.sh's own per-config TLC budget still
+# applies inside each job (3600s default, overridable per cfg via bands.tsv's
+# budget_s column).
+#
+# The area list below is the same list scripts/check-tla.sh's discover_areas
+# would find under formal/tla (every directory carrying a smoke config);
+# scripts/check-tla.test.sh asserts the two stay in sync, so a new area
+# cannot be silently skipped by the nightly matrix.
+#
 # workflow_dispatch exists to verify the job on a pushed branch (no local gate
 # can execute a workflow) and to run it ad hoc.
 name: tla-nightly
@@ -26,8 +40,12 @@ permissions:
 
 jobs:
   exhaustive:
+    strategy:
+      fail-fast: false
+      matrix:
+        area: [catalog, commit, common, lifecycle, maintenance, resharding]
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 110
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -43,11 +61,11 @@ jobs:
         # the default of 2 is too slow for the exhaustive budget.
         env:
           RAVEL_TLA_WORKERS: auto
-        run: scripts/check-tla.sh exhaustive
+        run: scripts/check-tla.sh exhaustive -a ${{ matrix.area }}
       - name: Upload TLC logs on failure
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: tla-nightly-logs
+          name: tla-nightly-logs-${{ matrix.area }}
           path: .cache/tla/logs
           if-no-files-found: ignore

--- a/docs/guides/formal-verification.md
+++ b/docs/guides/formal-verification.md
@@ -34,19 +34,47 @@ proved. The traceability index records the rows still without one.
 
 ## What TLC checked
 
-Every exhaustive configuration runs under a 3600-second ceiling per
-configuration. The table below names each area, its specification module, and
-the exhaustive configuration's distinct-state count and wall time.
+Every exhaustive configuration runs under a per-configuration wall-clock
+ceiling: 3600 seconds by default, or the value the config's `bands.tsv` row
+sets in its optional `budget_s` column when one config on a given runner
+measurably needs more than the rest (see "Per-configuration budgets"
+below). The table below names each area, its specification module, the host
+the figures were measured on, and the exhaustive configuration's
+distinct-state count and wall time.
 
-| Area | Specification | Distinct states | Wall time |
-|---|---|---|---|
-| common | `RavelObjectStore.tla` | 3845952 | 252 seconds |
-| commit | `CommitProtocol.tla` | 5466239 | 131 seconds |
-| catalog | `CatalogMVCC.tla` | 3422524 | 510 seconds |
-| lifecycle | `LifecycleGC.tla` | 230815 | 30 seconds |
-| resharding | `OnlineResharding.tla` | 1179718 | under 300 seconds |
-| maintenance | `MaintenanceOwnership.tla` | 13183990 | 1769 seconds |
-| maintenance | `CompactionClaims.tla` | 543 | 2 seconds |
+| Area | Specification | Host | Distinct states | Wall time |
+|---|---|---|---|---|
+| common | `RavelObjectStore.tla` | fleet executor | 3845952 | 252 seconds |
+| commit | `CommitProtocol.tla` | fleet executor | 5466239 | 131 seconds |
+| catalog | `CatalogMVCC.tla` | fleet executor | 3422524 | 510 seconds |
+| lifecycle | `LifecycleGC.tla` | fleet executor | 230815 | 30 seconds |
+| resharding | `OnlineResharding.tla` | fleet executor | 1179718 | under 300 seconds |
+| maintenance | `MaintenanceOwnership.tla` | fleet executor | 13183990 | 1769 seconds |
+| maintenance | `MaintenanceOwnership.tla` | GitHub hosted ubuntu-24.04, workers auto, Xmx2g | 12448134 (TIMEOUT at 3600 s, 1,450,354 states still queued; projected 4,000 to 4,200 s to finish) | 3600 seconds (killed) |
+| maintenance | `CompactionClaims.tla` | fleet executor | 543 | 2 seconds |
+
+The fleet executor and the GitHub-hosted runner are different machines: the
+1769-second `MaintenanceOwnership.tla` figure is what the fleet executor
+measured, and the hosted-runner row next to it is the nightly lane's own
+runner timing out on the same configuration before finishing, roughly 2.3x
+slower per distinct state. That gap is why this one configuration carries a
+per-configuration budget override rather than the default. See
+[`formal/tla/maintenance/results.md`](../../formal/tla/maintenance/results.md)
+for the full measurement this projection rests on.
+
+### Per-configuration budgets
+
+`bands.tsv`'s optional sixth column, `budget_s`, overrides the 3600-second
+default for one exhaustive config on the lane that reads it (`check_one_model`
+resolves it the same way it resolves the distinct/depth band, by cfg name).
+`MCMaintenanceOwnership.exhaustive.cfg` sets `budget_s = 5400` in
+`formal/tla/maintenance/bands.tsv`, about 30% headroom over the 4,000 to
+4,200 s hosted-runner projection above; every other exhaustive config in the
+suite keeps the 3600 s default. The nightly workflow
+(`.github/workflows/tla-nightly.yml`) runs the six areas as a matrix, one job
+per area, instead of one job running all six in sequence: a single area's
+larger budget then only extends that area's own job, not a shared job
+covering every area.
 
 Each area splits its negative configurations into two kinds. A control
 is a deliberately broken variant of the correct model. When TLC checks

--- a/docs/guides/formal-verification.md
+++ b/docs/guides/formal-verification.md
@@ -47,7 +47,7 @@ distinct-state count and wall time.
 | common | `RavelObjectStore.tla` | fleet executor | 3845952 | 252 seconds |
 | commit | `CommitProtocol.tla` | fleet executor | 5466239 | 131 seconds |
 | catalog | `CatalogMVCC.tla` | fleet executor | 3422524 | 510 seconds |
-| lifecycle | `LifecycleGC.tla` | fleet executor | 230815 | 30 seconds |
+| lifecycle | `LifecycleGC.tla` | GitHub hosted ubuntu-24.04, workers auto, Xmx2g | 3587643 | 1371 seconds |
 | resharding | `OnlineResharding.tla` | fleet executor | 1179718 | under 300 seconds |
 | maintenance | `MaintenanceOwnership.tla` | fleet executor | 13183990 | 1769 seconds |
 | maintenance | `MaintenanceOwnership.tla` | GitHub hosted ubuntu-24.04, workers auto, Xmx2g | 12448134 (TIMEOUT at 3600 s, 1,450,354 states still queued; projected 4,000 to 4,200 s to finish) | 3600 seconds (killed) |

--- a/docs/guides/formal-verification.md
+++ b/docs/guides/formal-verification.md
@@ -47,9 +47,9 @@ distinct-state count and wall time.
 | common | `RavelObjectStore.tla` | fleet executor | 3845952 | 252 seconds |
 | commit | `CommitProtocol.tla` | fleet executor | 5466239 | 131 seconds |
 | catalog | `CatalogMVCC.tla` | fleet executor | 3422524 | 510 seconds |
-| lifecycle | `LifecycleGC.tla` | GitHub hosted ubuntu-24.04, workers auto, Xmx2g | 3587643 | 1371 seconds |
+| lifecycle | `LifecycleGC.tla` | GitHub hosted ubuntu-24.04, workers auto, Xmx2g | 2835448 | 1048 seconds |
 | resharding | `OnlineResharding.tla` | fleet executor | 1179718 | under 300 seconds |
-| maintenance | `MaintenanceOwnership.tla` | fleet executor | 13183990 | 1769 seconds |
+| maintenance | `MaintenanceOwnership.tla` | fleet executor; GitHub hosted ubuntu-24.04, workers auto, Xmx2g | 13183990 | 1769 seconds; 4285 seconds on the hosted runner, under its 5400 s budget |
 | maintenance | `MaintenanceOwnership.tla` | GitHub hosted ubuntu-24.04, workers auto, Xmx2g | 12448134 (TIMEOUT at 3600 s, 1,450,354 states still queued; projected 4,000 to 4,200 s to finish) | 3600 seconds (killed) |
 | maintenance | `CompactionClaims.tla` | fleet executor | 543 | 2 seconds |
 

--- a/docs/guides/formal-verification.md
+++ b/docs/guides/formal-verification.md
@@ -148,9 +148,9 @@ negative` to check that every negative control fails the way its
 `.expect` file states. Run `scripts/check-tla.sh traceability` to check
 that every Rust path and symbol in every traceability table exists. Run
 `scripts/check-tla.sh exhaustive` to check full safety and liveness
-where a configuration states a `PROPERTY`, at a 3600-second budget per
-configuration. Add `-a <area>` to any of these commands to scope the
-check to one area.
+where a configuration states a `PROPERTY`, under each configuration's
+own budget (3600 seconds unless its `bands.tsv` row sets `budget_s`).
+Add `-a <area>` to any of these commands to scope the check to one area.
 
 Run `scripts/check-tla.sh ci` to run smoke, live, negative, and
 traceability under one run ID. Run `scripts/check-tla.sh all` to run

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -139,12 +139,26 @@ the figures. `run-id` is a UTC timestamp joined to the working tree hash
 outside its band), or `VIOLATED` (a negative control that failed as intended).
 
 Bands are optional and live in each area's `bands.tsv`, one row per config
-(`cfg`, `min_distinct`, `max_distinct`, `min_depth`, `max_depth`). When a row
-exists the harness enforces it on a PASS run and fails outside it; a run
-outside the band is a regression to investigate, not a band to widen.
-Negative controls stop at the first counterexample TLC finds, which under
-multiple workers is not deterministic, so they carry no band. `results.md`
-records the figures a run produced and the bands they must stay in.
+(`cfg`, `min_distinct`, `max_distinct`, `min_depth`, `max_depth`, and an
+optional sixth column `budget_s`). When a row exists the harness enforces
+the distinct/depth band on a PASS run and fails outside it; a run outside
+the band is a regression to investigate, not a band to widen. Negative
+controls stop at the first counterexample TLC finds, which under multiple
+workers is not deterministic, so they carry no band. `results.md` records
+the figures a run produced and the bands they must stay in.
+
+`budget_s` overrides the exhaustive lane's per-configuration wall-clock
+budget (`check_one_model` reads it via `cfg_budget`, the same awk-by-cfg-name
+lookup the distinct/depth band uses): a row that sets it replaces
+`EXHAUSTIVE_BUDGET` (3600 s) for that one config; a row with no `budget_s`,
+or no row at all, keeps the 3600 s default. `budget_s` has no effect on
+smoke or live, which always run at `SMOKE_BUDGET` (300 s) regardless of
+`bands.tsv`. Use it when one configuration is measured to need more time
+than the rest of its area's configs on the lane's actual runner (see
+`formal/tla/maintenance/bands.tsv` and its `results.md` for the worked
+example: a hosted-runner timeout measurement projecting 4,000-4,200 s
+justifies `MCMaintenanceOwnership.exhaustive.cfg`'s `budget_s = 5400`),
+rather than raising `EXHAUSTIVE_BUDGET` for every config in the lane.
 
 ## Negative controls
 

--- a/formal/tla/README.md
+++ b/formal/tla/README.md
@@ -91,7 +91,7 @@ scripts/check-tla.sh traceability     # every traceability.md source ref resolve
 scripts/check-tla.sh live             # each area's banded live.cfg (budget 300s/cfg)
 scripts/check-tla.sh ci               # smoke + negative + live + traceability, one run id (the CI lane)
 scripts/check-tla.sh all              # ci, then exhaustive, under one run id
-scripts/check-tla.sh exhaustive       # full safety + liveness (nightly, budget 3600s/cfg)
+scripts/check-tla.sh exhaustive       # full safety + liveness (nightly; 3600s/cfg unless bands.tsv sets budget_s)
 scripts/check-tla.sh smoke -a common  # scope any subcommand to one area
 ```
 
@@ -156,7 +156,7 @@ smoke or live, which always run at `SMOKE_BUDGET` (300 s) regardless of
 `bands.tsv`. Use it when one configuration is measured to need more time
 than the rest of its area's configs on the lane's actual runner (see
 `formal/tla/maintenance/bands.tsv` and its `results.md` for the worked
-example: a hosted-runner timeout measurement projecting 4,000-4,200 s
+example: a hosted-runner timeout measurement projecting 4,000 to 4,200 s
 justifies `MCMaintenanceOwnership.exhaustive.cfg`'s `budget_s = 5400`),
 rather than raising `EXHAUSTIVE_BUDGET` for every config in the lane.
 

--- a/formal/tla/maintenance/bands.tsv
+++ b/formal/tla/maintenance/bands.tsv
@@ -1,5 +1,5 @@
-cfg	min_distinct	max_distinct	min_depth	max_depth
+cfg	min_distinct	max_distinct	min_depth	max_depth	budget_s
 MCMaintenanceOwnership.smoke.cfg	2640000	2910000	18	22
-MCMaintenanceOwnership.exhaustive.cfg	12500000	13850000	18	22
+MCMaintenanceOwnership.exhaustive.cfg	12500000	13850000	18	22	5400
 MCCompactionClaims.smoke.cfg	11100000	11700000	14	20
 MCCompactionClaims.exhaustive.cfg	500	580	8	13

--- a/formal/tla/maintenance/results.md
+++ b/formal/tla/maintenance/results.md
@@ -79,18 +79,20 @@ hosted runner is slower per distinct state. Run 34230857065
 3600 s per-configuration budget on `MCMaintenanceOwnership.exhaustive.cfg`
 before it could finish: 116,707,410 states generated, 12,448,134 distinct,
 1,450,354 states left on the queue, search depth 17, at roughly 2.4M states
-per minute and 120k to 180k distinct states per minute in the last ten
-minutes before the kill (TLC also ran its temporal-property check every six
-minutes, for about a minute each time). The recorded complete run above
-(136,617,032 generated, 13,183,990 distinct, depth 20, 1769 s, fleet
-executor) reached 94% of its final distinct-state count by the time this run
-was killed; at this run's own distinct-state rate the remainder needs
-roughly 400 to 600 s more, a projected total of 4,000 to 4,200 s. That makes
-the hosted runner about 2.3x slower per distinct state than the fleet
-executor the 1769 s figure was recorded on. The other five areas all
-finished well inside 3600 s on the same run (catalog 1034 s, commit 96 s,
-common 287 s, lifecycle 1371 s, `MCCompactionClaims.exhaustive.cfg` 1 s), so
-only this one configuration needed headroom.
+per minute and a falling 116k to 181k distinct states per minute in the last
+ten minutes before the kill (181,101 / 157,388 / 151,690 / 157,848 / 124,073
+/ 116,020) (TLC also ran its temporal-property check every six minutes, for
+about a minute each time). The recorded complete run above (136,617,032
+generated, 13,183,990 distinct, depth 20, 1769 s, fleet executor) reached
+94% of its final distinct-state count by the time this run was killed; at
+this run's own distinct-state rate the remainder needs roughly 400 to 600 s
+more, a projected total of 4,000 to 4,200 s. That makes the hosted runner
+about 2.3x slower per distinct state than the fleet executor the 1769 s
+figure was recorded on. The other five areas all finished well inside
+3600 s on the same run (catalog 1034 s, commit 96 s, common 287 s,
+lifecycle 1371 s, resharding 59 s), as did the maintenance area's other
+config (`MCCompactionClaims.exhaustive.cfg` 1 s), so only this one
+configuration needed headroom.
 
 `scripts/check-tla.sh` now reads an optional per-configuration budget from
 `bands.tsv`'s `budget_s` column (`check_one_model` via `cfg_budget`) instead

--- a/formal/tla/maintenance/results.md
+++ b/formal/tla/maintenance/results.md
@@ -37,6 +37,7 @@ This verifies the protocol designs; implementation conformance is argued in
 | MCMaintenanceOwnership.smoke.cfg | 1.7.4 | 47377233 | 2773760 | 21 | 90 | fleet executor | PASS |
 | MCMaintenanceOwnership.exhaustive.cfg | 1.7.4 | 136617032 | 13183990 | 20 | 1769 | fleet executor | PASS |
 | MCMaintenanceOwnership.exhaustive.cfg | 1.7.4 | 116707410 | 12448134 | 17 | 3600 | GitHub hosted ubuntu-24.04, workers auto, Xmx2g | TIMEOUT at 3600 s, 12,448,134 distinct, 1,450,354 queued, projected 4,000 to 4,200 s |
+| MCMaintenanceOwnership.exhaustive.cfg | 1.7.4 | 136617032 | 13183990 | 19 | 4285 | GitHub hosted ubuntu-24.04, workers auto, Xmx2g | PASS under the 5400 s per-config budget (run 34246991138) |
 | MCCompactionClaims.smoke.cfg | 1.7.4 | 65454526 | 11155721 | 17 | 161 | fleet executor | PASS |
 | MCCompactionClaims.exhaustive.cfg | 1.7.4 | 1972 | 543 | 11 | 2 | fleet executor | PASS |
 | negative/ownership-as-publication-authority.cfg | 1.7.4 | - | - | - | - | fleet executor | VIOLATED (exit 12) |
@@ -79,11 +80,12 @@ hosted runner is slower per distinct state. Run 34230857065
 3600 s per-configuration budget on `MCMaintenanceOwnership.exhaustive.cfg`
 before it could finish: 116,707,410 states generated, 12,448,134 distinct,
 1,450,354 states left on the queue, search depth 17, at roughly 2.4M states
-per minute and a falling 116k to 181k distinct states per minute in the last
-ten minutes before the kill (181,101 / 157,388 / 151,690 / 157,848 / 124,073
-/ 116,020) (TLC also ran its temporal-property check every six minutes, for
-about a minute each time). The recorded complete run above (136,617,032
-generated, 13,183,990 distinct, depth 20, 1769 s, fleet executor) reached
+per minute and 116k to 181k distinct states per minute over the last six
+minutes before the kill, trending down (181,101 / 157,388 / 151,690 /
+157,848 / 124,073 / 116,020) (TLC also ran its temporal-property check every
+six minutes, for about a minute each time). The recorded complete run above
+(136,617,032 generated, 13,183,990 distinct, depth 20, 1769 s, fleet
+executor) reached
 94% of its final distinct-state count by the time this run was killed; at
 this run's own distinct-state rate the remainder needs roughly 400 to 600 s
 more, a projected total of 4,000 to 4,200 s. That makes the hosted runner
@@ -92,7 +94,10 @@ figure was recorded on. The other five areas all finished well inside
 3600 s on the same run (catalog 1034 s, commit 96 s, common 287 s,
 lifecycle 1371 s, resharding 59 s), as did the maintenance area's other
 config (`MCCompactionClaims.exhaustive.cfg` 1 s), so only this one
-configuration needed headroom.
+configuration needed headroom. With the per-configuration budget at 5400 s
+the same configuration completed on the hosted runner in 4285 s
+(136,617,032 generated, 13,183,990 distinct, depth 19; run 34246991138):
+about 2% above the projection's upper end and about 20% inside the budget.
 
 `scripts/check-tla.sh` now reads an optional per-configuration budget from
 `bands.tsv`'s `budget_s` column (`check_one_model` via `cfg_budget`) instead

--- a/formal/tla/maintenance/results.md
+++ b/formal/tla/maintenance/results.md
@@ -83,10 +83,9 @@ before it could finish: 116,707,410 states generated, 12,448,134 distinct,
 per minute and 116k to 181k distinct states per minute over the last six
 minutes before the kill, trending down (181,101 / 157,388 / 151,690 /
 157,848 / 124,073 / 116,020) (TLC also ran its temporal-property check every
-six minutes, for about a minute each time). The recorded complete run above
-(136,617,032 generated, 13,183,990 distinct, depth 20, 1769 s, fleet
-executor) reached
-94% of its final distinct-state count by the time this run was killed; at
+six minutes, for about a minute each time). By the time it was killed this
+run had reached 94% of the recorded complete run's distinct-state count
+(13,183,990 at depth 20 in 1769 s on the fleet executor, the row above); at
 this run's own distinct-state rate the remainder needs roughly 400 to 600 s
 more, a projected total of 4,000 to 4,200 s. That makes the hosted runner
 about 2.3x slower per distinct state than the fleet executor the 1769 s

--- a/formal/tla/maintenance/results.md
+++ b/formal/tla/maintenance/results.md
@@ -36,6 +36,7 @@ This verifies the protocol designs; implementation conformance is argued in
 |---|---|---|---|---|---|---|---|
 | MCMaintenanceOwnership.smoke.cfg | 1.7.4 | 47377233 | 2773760 | 21 | 90 | fleet executor | PASS |
 | MCMaintenanceOwnership.exhaustive.cfg | 1.7.4 | 136617032 | 13183990 | 20 | 1769 | fleet executor | PASS |
+| MCMaintenanceOwnership.exhaustive.cfg | 1.7.4 | 116707410 | 12448134 | 17 | 3600 | GitHub hosted ubuntu-24.04, workers auto, Xmx2g | TIMEOUT at 3600 s, 12,448,134 distinct, 1,450,354 queued, projected 4,000 to 4,200 s |
 | MCCompactionClaims.smoke.cfg | 1.7.4 | 65454526 | 11155721 | 17 | 161 | fleet executor | PASS |
 | MCCompactionClaims.exhaustive.cfg | 1.7.4 | 1972 | 543 | 11 | 2 | fleet executor | PASS |
 | negative/ownership-as-publication-authority.cfg | 1.7.4 | - | - | - | - | fleet executor | VIOLATED (exit 12) |
@@ -67,6 +68,40 @@ model. Only the invariant name and the exit code are stable facts for a VIOLATED
 row (exit 12: an `INVARIANT` failed; exit 13: a `PROPERTY` failed), so that is
 all this table records for one; see "Per-invariant audit" below for which
 invariant each negative control targets.
+
+## Hosted-runner exhaustive budget (issue #1358)
+
+The nightly exhaustive lane runs on a GitHub-hosted `ubuntu-24.04` runner,
+not the fleet executor the completed run above was measured on, and the
+hosted runner is slower per distinct state. Run 34230857065
+(`workflow_dispatch` of `tla-nightly` on `main` `8a85d76c`,
+`RAVEL_TLA_WORKERS=auto`, `-Xmx2g`, `tla2tools` as pinned) hit the harness's
+3600 s per-configuration budget on `MCMaintenanceOwnership.exhaustive.cfg`
+before it could finish: 116,707,410 states generated, 12,448,134 distinct,
+1,450,354 states left on the queue, search depth 17, at roughly 2.4M states
+per minute and 120k to 180k distinct states per minute in the last ten
+minutes before the kill (TLC also ran its temporal-property check every six
+minutes, for about a minute each time). The recorded complete run above
+(136,617,032 generated, 13,183,990 distinct, depth 20, 1769 s, fleet
+executor) reached 94% of its final distinct-state count by the time this run
+was killed; at this run's own distinct-state rate the remainder needs
+roughly 400 to 600 s more, a projected total of 4,000 to 4,200 s. That makes
+the hosted runner about 2.3x slower per distinct state than the fleet
+executor the 1769 s figure was recorded on. The other five areas all
+finished well inside 3600 s on the same run (catalog 1034 s, commit 96 s,
+common 287 s, lifecycle 1371 s, `MCCompactionClaims.exhaustive.cfg` 1 s), so
+only this one configuration needed headroom.
+
+`scripts/check-tla.sh` now reads an optional per-configuration budget from
+`bands.tsv`'s `budget_s` column (`check_one_model` via `cfg_budget`) instead
+of applying `EXHAUSTIVE_BUDGET` (3600 s) to every exhaustive config. This
+row's 4,000 to 4,200 s projection is what `MCMaintenanceOwnership.exhaustive.cfg`'s
+`budget_s = 5400` in `bands.tsv` rests on: roughly 30% headroom over the
+high end of the projection, without raising the ceiling for every other
+config that already finishes comfortably under 3600 s. The nightly workflow
+also moved from one sequential job covering every area to one job per area
+(a matrix), so a single area's larger budget cannot push the other areas'
+jobs past their own `timeout-minutes`.
 
 ## Constants chosen for exhaustive
 

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -14,7 +14,8 @@
 #                            measured band is the opt-in), same 300s budget
 #                            as smoke; an unbanded live.cfg is reported SKIP
 #                            and does not fail the lane
-#   exhaustive   [-a AREA]   full safety + liveness (budget 3600s per cfg)
+#   exhaustive   [-a AREA]   full safety + liveness (budget 3600s per cfg,
+#                            overridable per cfg via bands.tsv's budget_s)
 #   negative     [-a AREA]   run negative/*.cfg, assert the expected violation
 #   traceability [-a AREA]   check every traceability.md source ref resolves
 #   ci           [-a AREA]   smoke + live + negative + traceability under one run id
@@ -359,16 +360,39 @@ band_row_exists() {
     [ -n "$row" ]
 }
 
+# cfg_budget <area> <cfg-name> <default> -> the exhaustive per-config TLC
+# wall-clock budget in seconds: bands.tsv's optional 6th column (budget_s) on
+# this cfg's row, or <default> when the file, the row, or the column is
+# absent or non-numeric. Uses the same awk-by-cfg-name lookup check_bands
+# uses to find the row, so a config with no bands.tsv row resolves to the
+# default exactly the way an unbanded config already does for its figures.
+cfg_budget() {
+    local area="$1" cfg_name="$2" default="$3"
+    local bands="$FORMAL_DIR/$area/bands.tsv"
+    [ -f "$bands" ] || { echo "$default"; return 0; }
+    local b
+    b="$(awk -F'\t' -v c="$cfg_name" '$1==c {print $6; exit}' "$bands")"
+    case "$b" in
+        ''|*[!0-9]*) echo "$default" ;;
+        *) echo "$b" ;;
+    esac
+}
+
 # check_one_model <area> <module> <kind> <cfg>
 check_one_model() {
     local area="$1" module="$2" kind="$3" cfg="$4"
     local area_dir="$FORMAL_DIR/$area"
     local cfg_name budget logfile
     cfg_name="$(basename "$cfg")"
-    if [ "$kind" = exhaustive ]; then budget=$EXHAUSTIVE_BUDGET; else budget=$SMOKE_BUDGET; fi
+    if [ "$kind" = exhaustive ]; then
+        budget="$(cfg_budget "$area" "$cfg_name" "$EXHAUSTIVE_BUDGET")"
+    else
+        budget=$SMOKE_BUDGET
+    fi
     mkdir -p "$LOG_DIR"
     logfile="$LOG_DIR/${area}-${module}-${kind}.log"
     local label="$area/$module ${kind}"
+    note "$label: budget ${budget}s"
 
     local start=$SECONDS code=0
     run_tlc "$area" "$module" "$cfg" "$budget" "$logfile" || code=$?

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -363,19 +363,47 @@ band_row_exists() {
 # cfg_budget <area> <cfg-name> <default> -> the exhaustive per-config TLC
 # wall-clock budget in seconds: bands.tsv's optional 6th column (budget_s) on
 # this cfg's row, or <default> when the file, the row, or the column is
-# absent or non-numeric. Uses the same awk-by-cfg-name lookup check_bands
-# uses to find the row, so a config with no bands.tsv row resolves to the
-# default exactly the way an unbanded config already does for its figures.
+# absent, non-numeric, zero, or over 9 digits. Uses the same awk-by-cfg-name
+# lookup check_bands uses to find the row, so a config with no bands.tsv row
+# resolves to the default exactly the way an unbanded config already does for
+# its figures. Every fallback logs a note naming the area, cfg, and (for a
+# malformed or out-of-range value) the rejected value: a budget silently
+# falling back to 3600s on a typo reads as "the config is just slow" instead
+# of the row being wrong.
 cfg_budget() {
     local area="$1" cfg_name="$2" default="$3"
     local bands="$FORMAL_DIR/$area/bands.tsv"
-    [ -f "$bands" ] || { echo "$default"; return 0; }
+    if [ ! -f "$bands" ]; then
+        note "$area bands: no bands.tsv for $cfg_name; using default budget ${default}s"
+        echo "$default"
+        return 0
+    fi
+    local row
+    row="$(awk -F'\t' -v c="$cfg_name" '$1==c {print; exit}' "$bands")"
+    if [ -z "$row" ]; then
+        note "$area bands: no row for $cfg_name in bands.tsv; using default budget ${default}s"
+        echo "$default"
+        return 0
+    fi
     local b
-    b="$(awk -F'\t' -v c="$cfg_name" '$1==c {print $6; exit}' "$bands")"
-    case "$b" in
-        ''|*[!0-9]*) echo "$default" ;;
-        *) echo "$b" ;;
-    esac
+    b="$(echo "$row" | cut -f6)"
+    if [ -z "$b" ]; then
+        note "$area bands: $cfg_name has no budget_s column; using default budget ${default}s"
+        echo "$default"
+        return 0
+    fi
+    # Bound the digit count before the numeric test, the same shape
+    # resolve_tla_resources uses for RAVEL_TLA_WORKERS: an over-long run of
+    # digits passes a bare ^[0-9]+$ but overflows `[ -eq ]`, and coreutils
+    # timeout(1) disables its own ceiling on 0 and rejects an out-of-range
+    # duration outright, either of which would remove the budget instead of
+    # falling back to it.
+    if ! printf '%s' "$b" | grep -qE '^[0-9]{1,9}$' || [ "$b" -eq 0 ]; then
+        note "$area bands: $cfg_name budget_s '$b' invalid (must be 1-9 digits, nonzero); using default budget ${default}s"
+        echo "$default"
+        return 0
+    fi
+    echo "$b"
 }
 
 # check_one_model <area> <module> <kind> <cfg>

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -763,22 +763,26 @@ fi
 # sequentially, so an area with more than one exhaustive config (maintenance
 # runs MCMaintenanceOwnership.exhaustive.cfg and MCCompactionClaims.exhaustive.cfg)
 # needs its job's timeout-minutes to cover their sum, not just the largest
-# single budget_s. This sums each area's exhaustive-config budgets straight
-# from bands.tsv (default 3600s where budget_s is absent or invalid, the same
-# fallback cfg_budget applies) and asserts the workflow's timeout-minutes
-# exceeds the largest sum by at least 10 minutes, so a future budget_s bump
+# single budget_s. This walks every exhaustive config in the tree (both
+# spellings: a single-spec area's `exhaustive.cfg`, a multi-module area's
+# `MC<Spec>.exhaustive.cfg`), resolves each through cfg_budget exactly as the
+# harness does (so a config with no bands row counts at the 3600s default
+# rather than at zero), and asserts the workflow's timeout-minutes exceeds
+# the largest per-area sum by at least 10 minutes, so a future budget_s bump
 # that outgrows the ceiling fails here instead of timing out on the next
 # scheduled run.
 echo "--- (u) tla-nightly.yml timeout-minutes exceeds the largest per-area exhaustive-budget sum by >=10 minutes"
 max_sum=0
 max_area=""
+FORMAL_DIR="$REPO_ROOT/formal/tla"
 for adir in "$REPO_ROOT"/formal/tla/*/; do
     aname="$(basename "$adir")"
-    bands="$adir/bands.tsv"
-    [ -f "$bands" ] || continue
-    # Both spellings: a single-spec area names its config `exhaustive.cfg`,
-    # a multi-module area `MC<Spec>.exhaustive.cfg`.
-    asum="$(awk -F'\t' 'NR>1 && $1 ~ /(^|\.)exhaustive\.cfg$/ { b=$6; if (b !~ /^[0-9]{1,9}$/ || (b+0)==0) b=3600; sum+=b } END{print sum+0}' "$bands")"
+    asum=0
+    for cfg in "$adir"exhaustive.cfg "$adir"*.exhaustive.cfg; do
+        [ -f "$cfg" ] || continue
+        b="$(cfg_budget "$aname" "$(basename "$cfg")" 3600 2>/dev/null)"
+        asum=$((asum + b))
+    done
     if [ "$asum" -gt "$max_sum" ]; then max_sum="$asum"; max_area="$aname"; fi
 done
 echo "    largest area exhaustive-budget sum: $max_area = ${max_sum}s"

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -585,17 +585,71 @@ if [ "$qout" = "5400" ]; then ok; else bad "q: expected 5400, got '$qout'"; fi
 FORMAL_DIR="$orig_formal_dir4"
 rm -rf "$qdir"
 
-echo "--- (r) cfg_budget: row without a budget_s column falls back to the default"
-rdir="$(mktemp -d)"
-rarea_dir="$rdir/farea"
-mkdir -p "$rarea_dir"
-printf 'cfg\tmin_distinct\tmax_distinct\tmin_depth\tmax_depth\nBar.exhaustive.cfg\t1\t2\t3\t4\n' \
-    > "$rarea_dir/bands.tsv"
-FORMAL_DIR="$rdir"
-rout="$(cfg_budget farea Bar.exhaustive.cfg 3600)"
-if [ "$rout" = "3600" ]; then ok; else bad "r: expected 3600 (default), got '$rout'"; fi
-FORMAL_DIR="$orig_formal_dir4"
-rm -rf "$rdir"
+echo "--- (r) cfg_budget: every fallback branch uses the default and logs a note"
+# run_cfg_budget_case <bands-content-or-""> <cfg-name> <errfile> -> echoes
+# cfg_budget's stdout; "" for the bands-content means no bands.tsv at all
+# (the fourth branch), as opposed to a bands.tsv that exists but carries no
+# matching row or no budget_s column.
+run_cfg_budget_case() {
+    local bands_content="$1" cfg_name="$2" errfile="$3"
+    local tmp
+    tmp="$(mktemp -d)"
+    mkdir -p "$tmp/farea"
+    if [ -n "$bands_content" ]; then
+        printf '%s' "$bands_content" > "$tmp/farea/bands.tsv"
+    fi
+    FORMAL_DIR="$tmp"
+    cfg_budget farea "$cfg_name" 3600 2>"$errfile"
+    FORMAL_DIR="$orig_formal_dir4"
+    rm -rf "$tmp"
+}
+
+r1err="$(mktemp)"
+r1out="$(run_cfg_budget_case \
+    "$(printf 'cfg\tmin_distinct\tmax_distinct\tmin_depth\tmax_depth\nBar.exhaustive.cfg\t1\t2\t3\t4\n')" \
+    Bar.exhaustive.cfg "$r1err")"
+if [ "$r1out" = "3600" ]; then ok; else bad "r1 (column absent): expected 3600, got '$r1out'"; fi
+if grep -qF "has no budget_s column" "$r1err"; then ok; else bad "r1 (column absent): missing note; got: $(cat "$r1err")"; fi
+rm -f "$r1err"
+
+r2err="$(mktemp)"
+r2out="$(run_cfg_budget_case \
+    "$(printf 'cfg\tmin_distinct\tmax_distinct\tmin_depth\tmax_depth\tbudget_s\nBar.exhaustive.cfg\t1\t2\t3\t4\tabc\n')" \
+    Bar.exhaustive.cfg "$r2err")"
+if [ "$r2out" = "3600" ]; then ok; else bad "r2 (non-numeric): expected 3600, got '$r2out'"; fi
+if grep -qF "budget_s 'abc' invalid" "$r2err"; then ok; else bad "r2 (non-numeric): missing note; got: $(cat "$r2err")"; fi
+rm -f "$r2err"
+
+r3err="$(mktemp)"
+r3out="$(run_cfg_budget_case \
+    "$(printf 'cfg\tmin_distinct\tmax_distinct\tmin_depth\tmax_depth\tbudget_s\nOther.exhaustive.cfg\t1\t2\t3\t4\t5400\n')" \
+    Bar.exhaustive.cfg "$r3err")"
+if [ "$r3out" = "3600" ]; then ok; else bad "r3 (no matching row): expected 3600, got '$r3out'"; fi
+if grep -qF "no row for Bar.exhaustive.cfg" "$r3err"; then ok; else bad "r3 (no matching row): missing note; got: $(cat "$r3err")"; fi
+rm -f "$r3err"
+
+r4err="$(mktemp)"
+r4out="$(run_cfg_budget_case "" Bar.exhaustive.cfg "$r4err")"
+if [ "$r4out" = "3600" ]; then ok; else bad "r4 (no bands.tsv): expected 3600, got '$r4out'"; fi
+if grep -qF "no bands.tsv for Bar.exhaustive.cfg" "$r4err"; then ok; else bad "r4 (no bands.tsv): missing note; got: $(cat "$r4err")"; fi
+rm -f "$r4err"
+
+r5err="$(mktemp)"
+r5out="$(run_cfg_budget_case \
+    "$(printf 'cfg\tmin_distinct\tmax_distinct\tmin_depth\tmax_depth\tbudget_s\nBar.exhaustive.cfg\t1\t2\t3\t4\t0\n')" \
+    Bar.exhaustive.cfg "$r5err")"
+if [ "$r5out" = "3600" ]; then ok; else bad "r5 (zero): expected 3600, got '$r5out'"; fi
+if grep -qF "budget_s '0' invalid" "$r5err"; then ok; else bad "r5 (zero): missing note; got: $(cat "$r5err")"; fi
+rm -f "$r5err"
+
+r6err="$(mktemp)"
+r6val="12345678901234567890"
+r6out="$(run_cfg_budget_case \
+    "$(printf 'cfg\tmin_distinct\tmax_distinct\tmin_depth\tmax_depth\tbudget_s\nBar.exhaustive.cfg\t1\t2\t3\t4\t%s\n' "$r6val")" \
+    Bar.exhaustive.cfg "$r6err")"
+if [ "$r6out" = "3600" ]; then ok; else bad "r6 (20-digit): expected 3600, got '$r6out'"; fi
+if grep -qF "budget_s '$r6val' invalid" "$r6err"; then ok; else bad "r6 (20-digit): missing note; got: $(cat "$r6err")"; fi
+rm -f "$r6err"
 
 echo "--- (s) check_one_model: an exhaustive run honors bands.tsv's budget_s override (measured timeout)"
 sdir="$(mktemp -d)"
@@ -635,6 +689,7 @@ JAR="/dev/null"
 resolve_timeout
 resolve_tla_resources
 truncate_tsv
+# shellcheck disable=SC2034  # consumed by check-tla.sh's sourced record_row, not read in this file
 RUN_ID="test-run"
 
 sstart=$(date +%s)
@@ -700,6 +755,45 @@ if [ -f "$workflow" ]; then
     fi
 else
     bad "t: $workflow not found"
+fi
+
+# --- (u) issue #1358 hardening: tla-nightly.yml's timeout-minutes bounds the
+# sum of an area's exhaustive budgets, not any single config's -------------
+# check_model runs every MC*.tla module's exhaustive cfg in an area
+# sequentially, so an area with more than one exhaustive config (maintenance
+# runs MCMaintenanceOwnership.exhaustive.cfg and MCCompactionClaims.exhaustive.cfg)
+# needs its job's timeout-minutes to cover their sum, not just the largest
+# single budget_s. This sums each area's exhaustive-config budgets straight
+# from bands.tsv (default 3600s where budget_s is absent or invalid, the same
+# fallback cfg_budget applies) and asserts the workflow's timeout-minutes
+# exceeds the largest sum by at least 10 minutes, so a future budget_s bump
+# that outgrows the ceiling fails here instead of timing out on the next
+# scheduled run.
+echo "--- (u) tla-nightly.yml timeout-minutes exceeds the largest per-area exhaustive-budget sum by >=10 minutes"
+max_sum=0
+max_area=""
+for adir in "$REPO_ROOT"/formal/tla/*/; do
+    aname="$(basename "$adir")"
+    bands="$adir/bands.tsv"
+    [ -f "$bands" ] || continue
+    asum="$(awk -F'\t' 'NR>1 && $1 ~ /\.exhaustive\.cfg$/ { b=$6; if (b !~ /^[0-9]{1,9}$/ || (b+0)==0) b=3600; sum+=b } END{print sum+0}' "$bands")"
+    if [ "$asum" -gt "$max_sum" ]; then max_sum="$asum"; max_area="$aname"; fi
+done
+echo "    largest area exhaustive-budget sum: $max_area = ${max_sum}s"
+if [ -f "$workflow" ]; then
+    timeout_line="$(grep -E '^[[:space:]]*timeout-minutes:[[:space:]]*[0-9]+[[:space:]]*$' "$workflow" | head -1)"
+    timeout_minutes="$(printf '%s' "$timeout_line" | grep -oE '[0-9]+')"
+    if [ -n "$timeout_minutes" ]; then ok; else bad "u: no timeout-minutes line found in $workflow"; fi
+    timeout_secs=$((timeout_minutes * 60))
+    headroom=$((timeout_secs - max_sum))
+    echo "    workflow timeout-minutes=$timeout_minutes (${timeout_secs}s), headroom: ${headroom}s"
+    if [ "$headroom" -ge 600 ]; then
+        ok
+    else
+        bad "u: timeout-minutes=$timeout_minutes leaves only ${headroom}s headroom over $max_area's ${max_sum}s exhaustive-budget sum, want >= 600s (10 min)"
+    fi
+else
+    bad "u: $workflow not found"
 fi
 
 rm -f "$LIB_SRC"

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -566,6 +566,142 @@ LAST_RUN="$orig_last_run3"
 JAVA="$orig_java3"
 JAR="$orig_jar3"
 
+# --- (q)-(s) issue #1358: per-config exhaustive budget via bands.tsv's
+# optional budget_s column -----------------------------------------------
+# cfg_budget resolves the override from bands.tsv the same way check_bands
+# resolves its figures; (s) proves check_one_model actually wires that
+# result into run_tlc's budget rather than only cfg_budget returning the
+# right number in isolation.
+echo "--- (q) cfg_budget: bands.tsv row with a budget_s column returns it"
+qdir="$(mktemp -d)"
+qarea_dir="$qdir/farea"
+mkdir -p "$qarea_dir"
+printf 'cfg\tmin_distinct\tmax_distinct\tmin_depth\tmax_depth\tbudget_s\nFoo.exhaustive.cfg\t1\t2\t3\t4\t5400\n' \
+    > "$qarea_dir/bands.tsv"
+orig_formal_dir4="$FORMAL_DIR"
+FORMAL_DIR="$qdir"
+qout="$(cfg_budget farea Foo.exhaustive.cfg 3600)"
+if [ "$qout" = "5400" ]; then ok; else bad "q: expected 5400, got '$qout'"; fi
+FORMAL_DIR="$orig_formal_dir4"
+rm -rf "$qdir"
+
+echo "--- (r) cfg_budget: row without a budget_s column falls back to the default"
+rdir="$(mktemp -d)"
+rarea_dir="$rdir/farea"
+mkdir -p "$rarea_dir"
+printf 'cfg\tmin_distinct\tmax_distinct\tmin_depth\tmax_depth\nBar.exhaustive.cfg\t1\t2\t3\t4\n' \
+    > "$rarea_dir/bands.tsv"
+FORMAL_DIR="$rdir"
+rout="$(cfg_budget farea Bar.exhaustive.cfg 3600)"
+if [ "$rout" = "3600" ]; then ok; else bad "r: expected 3600 (default), got '$rout'"; fi
+FORMAL_DIR="$orig_formal_dir4"
+rm -rf "$rdir"
+
+echo "--- (s) check_one_model: an exhaustive run honors bands.tsv's budget_s override (measured timeout)"
+sdir="$(mktemp -d)"
+sarea_dir="$sdir/formal/tla/fakebudget"
+mkdir -p "$sarea_dir"
+cat > "$sarea_dir/MCFake.tla" <<'EOF'
+---- MODULE MCFake ----
+====
+EOF
+cat > "$sarea_dir/MCFake.exhaustive.cfg" <<'EOF'
+SPECIFICATION Spec
+EOF
+# min/max_distinct and min/max_depth are irrelevant here (the run never
+# reaches check_bands: the shim java hangs and run_tlc times out first), so
+# they are set wide open.
+printf 'cfg\tmin_distinct\tmax_distinct\tmin_depth\tmax_depth\tbudget_s\nMCFake.exhaustive.cfg\t0\t999999999\t0\t999\t2\n' \
+    > "$sarea_dir/bands.tsv"
+sshim="$sdir/java"
+cat > "$sshim" <<'EOF'
+#!/usr/bin/env bash
+exec sleep 60
+EOF
+chmod +x "$sshim"
+
+orig_cache_dir4="$CACHE_DIR"
+orig_log_dir4="$LOG_DIR"
+orig_last_run4="$LAST_RUN"
+orig_java4="${JAVA:-}"
+orig_jar4="${JAR:-}"
+
+FORMAL_DIR="$sdir/formal/tla"
+CACHE_DIR="$sdir/cache"
+LOG_DIR="$CACHE_DIR/logs"
+LAST_RUN="$CACHE_DIR/last-run.tsv"
+JAVA="$sshim"
+JAR="/dev/null"
+resolve_timeout
+resolve_tla_resources
+truncate_tsv
+RUN_ID="test-run"
+
+sstart=$(date +%s)
+sout="$(check_one_model fakebudget MCFake exhaustive "$sarea_dir/MCFake.exhaustive.cfg" 2>&1)"
+scode=$?
+send=$(date +%s)
+selapsed=$((send - sstart))
+echo "    measured: exit=$scode elapsed=${selapsed}s"
+if [ "$scode" -ne 0 ]; then ok; else bad "s: expected a nonzero (timeout) exit, got 0; output: $sout"; fi
+# EXHAUSTIVE_BUDGET is 3600s; only a real budget_s override explains a
+# timeout this fast.
+if [ "$selapsed" -ge 1 ] && [ "$selapsed" -le 8 ]; then
+    ok
+else
+    bad "s: expected a ~2s timeout (budget_s override), took ${selapsed}s; output: $sout"
+fi
+if printf '%s' "$sout" | grep -qF "budget 2s"; then
+    ok
+else
+    bad "s: expected the per-config start line to log 'budget 2s'; output: $sout"
+fi
+if printf '%s' "$sout" | grep -qF "TIMEOUT after 2s"; then
+    ok
+else
+    bad "s: expected 'TIMEOUT after 2s' naming the overridden budget; output: $sout"
+fi
+
+FORMAL_DIR="$orig_formal_dir4"
+CACHE_DIR="$orig_cache_dir4"
+LOG_DIR="$orig_log_dir4"
+LAST_RUN="$orig_last_run4"
+JAVA="$orig_java4"
+JAR="$orig_jar4"
+rm -rf "$sdir"
+
+# --- (t) issue #1358: the nightly workflow's area matrix stays in sync with
+# discover_areas --------------------------------------------------------
+# The matrix in .github/workflows/tla-nightly.yml is a literal list (a
+# workflow step can't call discover_areas itself), so nothing stops it from
+# silently drifting from the areas the harness actually finds once a new one
+# is added. Parse the `area: [...]` line and diff it against discover_areas.
+echo "--- (t) tla-nightly.yml matrix names every area discover_areas finds"
+workflow="$REPO_ROOT/.github/workflows/tla-nightly.yml"
+if [ -f "$workflow" ]; then
+    matrix_line="$(grep -E '^[[:space:]]*area:[[:space:]]*\[' "$workflow" | head -1)"
+    matrix_areas="$(printf '%s\n' "$matrix_line" \
+        | sed -E 's/.*\[(.*)\].*/\1/' | tr ',' '\n' \
+        | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | sort)"
+    # FORMAL_DIR does not track REPO_ROOT here: run_tlc_case (used by tests
+    # a1/a2/g/h/i above) sets it as a side effect and never restores it, so by
+    # this point in the suite it may point at an already-removed temp dir.
+    # discover_areas only reads $FORMAL_DIR, so pin it to the real tree.
+    discovered_areas="$(FORMAL_DIR="$REPO_ROOT/formal/tla" discover_areas | sort)"
+    if [ -n "$matrix_line" ]; then
+        ok
+    else
+        bad "t: no 'area: [...]' matrix line found in $workflow"
+    fi
+    if [ "$matrix_areas" = "$discovered_areas" ]; then
+        ok
+    else
+        bad "t: matrix areas != discover_areas; matrix='$matrix_areas' discovered='$discovered_areas'"
+    fi
+else
+    bad "t: $workflow not found"
+fi
+
 rm -f "$LIB_SRC"
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/check-tla.test.sh
+++ b/scripts/check-tla.test.sh
@@ -776,7 +776,9 @@ for adir in "$REPO_ROOT"/formal/tla/*/; do
     aname="$(basename "$adir")"
     bands="$adir/bands.tsv"
     [ -f "$bands" ] || continue
-    asum="$(awk -F'\t' 'NR>1 && $1 ~ /\.exhaustive\.cfg$/ { b=$6; if (b !~ /^[0-9]{1,9}$/ || (b+0)==0) b=3600; sum+=b } END{print sum+0}' "$bands")"
+    # Both spellings: a single-spec area names its config `exhaustive.cfg`,
+    # a multi-module area `MC<Spec>.exhaustive.cfg`.
+    asum="$(awk -F'\t' 'NR>1 && $1 ~ /(^|\.)exhaustive\.cfg$/ { b=$6; if (b !~ /^[0-9]{1,9}$/ || (b+0)==0) b=3600; sum+=b } END{print sum+0}' "$bands")"
     if [ "$asum" -gt "$max_sum" ]; then max_sum="$asum"; max_area="$aname"; fi
 done
 echo "    largest area exhaustive-budget sum: $max_area = ${max_sum}s"


### PR DESCRIPTION
The nightly exhaustive TLA lane had been red since 2026-09-05: `maintenance/MCMaintenanceOwnership` exceeds the 3600 s per-configuration budget on the hosted runner. Measured on that runner (run 34230857065): 12,448,134 of 13,183,990 distinct states at the 3600 s kill, a projected 4,000 to 4,200 s, about 2.3x slower per distinct state than the fleet executor the recorded 1769 s figure came from.

`bands.tsv` gains an optional `budget_s` column for exhaustive rows, read by `check_one_model` through the same lookup the bands use, 5400 s for that configuration and the 3600 s default elsewhere; a zero, over-length or malformed value falls back to the default with a note, and six tests cover the fallback branches. The nightly workflow runs one job per area with `fail-fast: false`, a 160-minute job timeout and per-area log artifacts; a test asserts the matrix names every area `discover_areas` finds, and another sums each area's exhaustive budgets against the job timeout. A `workflow_dispatch` of the matrix from this branch (run 34246991138) passed every area, maintenance in 4285 s under its budget, and the six areas finished in 72 minutes of wall time where the sequential job needed 108 and still timed out.

The measurement and the completed run are recorded in `formal/tla/maintenance/results.md`; the guide's runtime table names the host beside every figure and carries the current lifecycle model's hosted-runner figure.

Fixes: #1358
