### PR TITLE
fix(ravel-bench): mark the MetricsBench artifact and fix its figures

### DIFF
--- a/benchmarks/metrics/README.md
+++ b/benchmarks/metrics/README.md
@@ -67,8 +67,8 @@ never mistakes a non-comparable or unbilled run for a publishable result.
   (`samples_per_series`).
 - `samples_per_series`, `scrape_interval_secs`, `duration_secs`,
   `total_samples`, `churn_basis_points_per_hour`: as declared.
-- `label_cardinalities`: distinct values per label dimension, name to count,
-  including the scaling label.
+- `label_cardinalities`: distinct values per label, the scaling label
+  included.
 - `families`: one entry per metric family, each with `name`, `instances`,
   `series_per_instance`.
 - `run`: figures scoped to `steps_run`, never the declared full profile:

--- a/benchmarks/metrics/README.md
+++ b/benchmarks/metrics/README.md
@@ -50,6 +50,39 @@ refusal: it exits non-zero for a non-comparable profile, and also for a run
 that covers only part of a comparable profile, because a truncated run is not
 that profile. The gate refuses a manifest that marks `ci` comparable at all.
 
+## Ingest artifact (`metricsbench_ingest`, ADR-0927 decision 11)
+
+The bin's JSON report carries a `profile` and a `substrate` block so a reader
+never mistakes a non-comparable or unbilled run for a publishable result.
+
+`profile`:
+- `name`: the `--profile` name.
+- `comparable`: whether these figures may be published. Forced `false` when
+  `steps_run` is less than `steps_declared`, regardless of the profile's own
+  verdict.
+- `comparability_reason`: why not, present only when `comparable` is `false`.
+- `active_series`: series alive at any one instant, as declared.
+- `steps_run`: steps this run actually generated.
+- `steps_declared`: the profile's full declared step count
+  (`samples_per_series`).
+- `samples_per_series`, `scrape_interval_secs`, `duration_secs`,
+  `total_samples`, `churn_basis_points_per_hour`: as declared.
+- `label_cardinalities`: distinct values per label dimension, name to count,
+  including the scaling label.
+- `families`: one entry per metric family, each with `name`, `instances`,
+  `series_per_instance`.
+- `run`: figures scoped to `steps_run`, never the declared full profile:
+  `steps`, `total_series_created`, `logical_input_bytes`,
+  `total_samples_generated`, all the generator's exact counts for this run.
+
+`substrate`:
+- `store_backend`: the `--store` kind (`memory` or `s3`).
+- `endpoint_host`: the configured S3 endpoint's host, when `--store s3` and
+  `RAVEL_S3_ENDPOINT` is set; absent for `memory` regardless of the env var.
+- `backend_bills_requests`: true only for real S3 with no endpoint override
+  (decision 10); false on `memory` and on any store behind a configured
+  endpoint, such as the nightly lane's local MinIO.
+
 ## Determinism
 
 One seed (`927000933`) drives everything. Every value and every injected

--- a/benchmarks/metrics/README.md
+++ b/benchmarks/metrics/README.md
@@ -67,13 +67,20 @@ never mistakes a non-comparable or unbilled run for a publishable result.
   (`samples_per_series`).
 - `samples_per_series`, `scrape_interval_secs`, `duration_secs`,
   `total_samples`, `churn_basis_points_per_hour`: as declared.
-- `label_cardinalities`: distinct values per label, the scaling label
-  included.
+- `label_cardinalities`: distinct values per FIXED label dimension, the
+  scaling label not included: it is not a dimension (the manifest gate
+  refuses to let it be declared as one), and its cardinality depends on the
+  run's churn epochs rather than being a fixed, manifest-only count.
+- `scaling_label`: the scaling label's `name` and its `cardinality_declared`,
+  the distinct scaling-label values the profile's full declared run would
+  emit, the generator's exact count.
 - `families`: one entry per metric family, each with `name`, `instances`,
   `series_per_instance`.
 - `run`: figures scoped to `steps_run`, never the declared full profile:
   `steps`, `total_series_created`, `logical_input_bytes`,
-  `total_samples_generated`, all the generator's exact counts for this run.
+  `total_samples_generated`, `scaling_label_cardinality` (distinct
+  scaling-label values this run actually emitted), all the generator's exact
+  counts for this run.
 
 `substrate`:
 - `store_backend`: the `--store` kind (`memory` or `s3`).

--- a/crates/ravel-bench/src/bin/bench_report.rs
+++ b/crates/ravel-bench/src/bin/bench_report.rs
@@ -6,8 +6,9 @@
 //! `--store memory|s3` selects the backend (`ravel_bench::harness`); the `s3`
 //! store reads `RAVEL_S3_*` env vars. The emitted `environment.store_backend`
 //! records which backend actually ran, and `s3_requests.backend_bills_requests`
-//! records whether its requests are billed -- true only for S3, per ADR-0075
-//! decision 3.
+//! records whether its requests are billed -- true only for real S3 with no
+//! `RAVEL_S3_ENDPOINT` override (`harness::backend_bills_requests`; a
+//! MinIO-backed S3 endpoint bills nothing, per ADR-0927 decision 10).
 //!
 //! Provenance (`git_commit`, `toolchain`) is gathered here, not in the library:
 //! `git rev-parse HEAD` (overridable via `GITHUB_SHA`, which CI sets) and
@@ -19,7 +20,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use clap::Parser;
-use ravel_bench::harness::{StoreKind, store_and_metrics_from_env};
+use ravel_bench::harness::{StoreKind, backend_bills_requests, store_and_metrics_from_env};
 use ravel_bench::report::{ReportRunConfig, WorkloadShape, run};
 use ravel_types::cost_profile::StoreCostProfile;
 
@@ -92,7 +93,7 @@ fn toolchain() -> String {
 async fn main() {
     let args = Args::parse();
 
-    let bills = matches!(args.store, StoreKind::S3);
+    let bills = backend_bills_requests(args.store);
     let region = match args.store {
         StoreKind::Memory => "n/a-memory".to_string(),
         StoreKind::S3 => std::env::var("RAVEL_S3_REGION").unwrap_or_else(|_| "unknown".to_string()),

--- a/crates/ravel-bench/src/bin/metricsbench_ingest.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_ingest.rs
@@ -224,7 +224,7 @@ async fn run(args: &Args) -> Result<MetricsIngestReport, RunError> {
     let backend_bills_requests = backend_bills_requests(args.store);
     let substrate = Substrate {
         store_backend: args.store.to_string(),
-        endpoint_host: endpoint_host_from_env(),
+        endpoint_host: endpoint_host_from_env(args.store),
         backend_bills_requests,
     };
     let ravel_cfg = RavelReplayConfig {

--- a/crates/ravel-bench/src/bin/metricsbench_ingest.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_ingest.rs
@@ -188,13 +188,13 @@ async fn run(args: &Args) -> Result<MetricsIngestReport, RunError> {
     // profile's own comparability verdict.
     let comparable = profile.is_publishable() && !truncated;
     let comparability_reason = if truncated {
-        format!(
+        Some(format!(
             "this run generated {steps} of profile `{}`'s {steps_declared} steps, so it is not \
              that profile and its figures cannot be published",
             profile.name
-        )
+        ))
     } else {
-        profile.comparability.to_string()
+        profile.comparability.reason().map(String::from)
     };
     let run_record = RunRecord {
         steps,

--- a/crates/ravel-bench/src/bin/metricsbench_ingest.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_ingest.rs
@@ -27,8 +27,9 @@ use ravel_bench::harness::{
 };
 use ravel_bench::metrics_gen::Generator;
 use ravel_bench::metrics_ingest::{
-    HttpReplayConfig, LogicalSample, MetricsIngestReport, ProfileRecord, RavelReplayConfig,
-    Substrate, parse_logical_stream, query_after_replay, replay_into_ravel, replay_over_http,
+    FamilyRecord, HttpReplayConfig, LogicalSample, MetricsIngestReport, ProfileRecord,
+    RavelReplayConfig, Substrate, parse_logical_stream, query_after_replay, replay_into_ravel,
+    replay_over_http,
 };
 use ravel_bench::metrics_workload::{WorkloadFile, load_workload};
 use ravel_ingest::{Clock, SystemClock};
@@ -172,6 +173,15 @@ async fn run(args: &Args) -> Result<MetricsIngestReport, RunError> {
     let profile = workload.profile(&args.profile).ok_or_else(|| {
         RunError::Generate(format!("manifest declares no profile `{}`", args.profile))
     })?;
+    let families = workload
+        .families
+        .iter()
+        .map(|family| FamilyRecord {
+            name: family.name.clone(),
+            instances: workload.family_instances(profile, family),
+            series_per_instance: workload.series_per_instance(family.kind),
+        })
+        .collect();
     let profile_record = ProfileRecord {
         name: profile.name.clone(),
         comparable: profile.is_publishable(),
@@ -182,9 +192,10 @@ async fn run(args: &Args) -> Result<MetricsIngestReport, RunError> {
         scrape_interval_secs: profile.scrape_interval_secs,
         duration_secs: profile.duration_secs,
         total_samples: profile.total_samples,
-        label_cardinalities: workload.label_cardinalities(),
+        label_cardinalities: workload.label_cardinalities(profile),
         logical_input_bytes,
         churn_basis_points_per_hour: profile.churn_basis_points_per_hour,
+        families,
     };
 
     // The in-process Ravel path: strict, durable-on-ack, commit tokens.

--- a/crates/ravel-bench/src/bin/metricsbench_ingest.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_ingest.rs
@@ -22,11 +22,13 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use ravel_bench::harness::{StoreKind, store_and_metrics_from_env};
+use ravel_bench::harness::{
+    StoreKind, backend_bills_requests, endpoint_host_from_env, store_and_metrics_from_env,
+};
 use ravel_bench::metrics_gen::Generator;
 use ravel_bench::metrics_ingest::{
-    HttpReplayConfig, LogicalSample, MetricsIngestReport, RavelReplayConfig, parse_logical_stream,
-    query_after_replay, replay_into_ravel, replay_over_http,
+    HttpReplayConfig, LogicalSample, MetricsIngestReport, ProfileRecord, RavelReplayConfig,
+    Substrate, parse_logical_stream, query_after_replay, replay_into_ravel, replay_over_http,
 };
 use ravel_bench::metrics_workload::{WorkloadFile, load_workload};
 use ravel_ingest::{Clock, SystemClock};
@@ -155,16 +157,44 @@ async fn run(args: &Args) -> Result<MetricsIngestReport, RunError> {
     let now_ms = SystemClock.now_ns() / 1_000_000;
     let base_ts_ms = now_ms - steps as i64 * scrape_ms;
 
-    let (bytes, _report) = Generator::new(&workload, &args.profile, base_ts_ms)
+    let (bytes, gen_report) = Generator::new(&workload, &args.profile, base_ts_ms)
         .map_err(|e| RunError::Generate(e.to_string()))?
         .generate_bytes(steps)
         .map_err(|e| RunError::Generate(e.to_string()))?;
+    let logical_input_bytes = bytes.len() as u64;
     let text = String::from_utf8(bytes).map_err(|e| RunError::Generate(e.to_string()))?;
     let stream: Vec<LogicalSample> = parse_logical_stream(&text);
 
+    // ADR-0927 decision 11: the profile's own pre-registered figures, plus the
+    // generator's exact counts for the two figures that are not directly
+    // declared (total series created, logical input bytes) -- never derived
+    // from the offered sample count.
+    let profile = workload.profile(&args.profile).ok_or_else(|| {
+        RunError::Generate(format!("manifest declares no profile `{}`", args.profile))
+    })?;
+    let profile_record = ProfileRecord {
+        name: profile.name.clone(),
+        comparable: profile.is_publishable(),
+        comparability_reason: profile.comparability.to_string(),
+        active_series: profile.active_series,
+        total_series_created: gen_report.total_series_created,
+        samples_per_series: profile.samples_per_series,
+        scrape_interval_secs: profile.scrape_interval_secs,
+        duration_secs: profile.duration_secs,
+        total_samples: profile.total_samples,
+        label_cardinalities: workload.label_cardinalities(),
+        logical_input_bytes,
+        churn_basis_points_per_hour: profile.churn_basis_points_per_hour,
+    };
+
     // The in-process Ravel path: strict, durable-on-ack, commit tokens.
     let (store, store_metrics) = store_and_metrics_from_env(args.store);
-    let backend_bills_requests = matches!(args.store, StoreKind::S3);
+    let backend_bills_requests = backend_bills_requests(args.store);
+    let substrate = Substrate {
+        store_backend: args.store.to_string(),
+        endpoint_host: endpoint_host_from_env(),
+        backend_bills_requests,
+    };
     let ravel_cfg = RavelReplayConfig {
         store,
         store_metrics,
@@ -232,7 +262,10 @@ async fn run(args: &Args) -> Result<MetricsIngestReport, RunError> {
         rows.push(row);
     }
 
-    Ok(MetricsIngestReport::new(rows).with_query(query))
+    Ok(MetricsIngestReport::new(rows)
+        .with_query(query)
+        .with_profile(profile_record)
+        .with_substrate(substrate))
 }
 
 #[tokio::main]

--- a/crates/ravel-bench/src/bin/metricsbench_ingest.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_ingest.rs
@@ -28,8 +28,8 @@ use ravel_bench::harness::{
 use ravel_bench::metrics_gen::Generator;
 use ravel_bench::metrics_ingest::{
     FamilyRecord, HttpReplayConfig, LogicalSample, MetricsIngestReport, ProfileRecord,
-    RavelReplayConfig, Substrate, parse_logical_stream, query_after_replay, replay_into_ravel,
-    replay_over_http,
+    RavelReplayConfig, RunRecord, Substrate, parse_logical_stream, query_after_replay,
+    replay_into_ravel, replay_over_http,
 };
 use ravel_bench::metrics_workload::{WorkloadFile, load_workload};
 use ravel_ingest::{Clock, SystemClock};
@@ -182,20 +182,41 @@ async fn run(args: &Args) -> Result<MetricsIngestReport, RunError> {
             series_per_instance: workload.series_per_instance(family.kind),
         })
         .collect();
+    let steps_declared = profile.samples_per_series;
+    let truncated = steps < steps_declared;
+    // A truncated run is never that profile's figures, regardless of the
+    // profile's own comparability verdict.
+    let comparable = profile.is_publishable() && !truncated;
+    let comparability_reason = if truncated {
+        format!(
+            "this run generated {steps} of profile `{}`'s {steps_declared} steps, so it is not \
+             that profile and its figures cannot be published",
+            profile.name
+        )
+    } else {
+        profile.comparability.to_string()
+    };
+    let run_record = RunRecord {
+        steps,
+        total_series_created: gen_report.total_series_created,
+        logical_input_bytes,
+        total_samples_generated: gen_report.emitted_samples,
+    };
     let profile_record = ProfileRecord {
         name: profile.name.clone(),
-        comparable: profile.is_publishable(),
-        comparability_reason: profile.comparability.to_string(),
+        comparable,
+        comparability_reason,
         active_series: profile.active_series,
-        total_series_created: gen_report.total_series_created,
+        steps_run: steps,
+        steps_declared,
         samples_per_series: profile.samples_per_series,
         scrape_interval_secs: profile.scrape_interval_secs,
         duration_secs: profile.duration_secs,
         total_samples: profile.total_samples,
         label_cardinalities: workload.label_cardinalities(profile),
-        logical_input_bytes,
         churn_basis_points_per_hour: profile.churn_basis_points_per_hour,
         families,
+        run: run_record,
     };
 
     // The in-process Ravel path: strict, durable-on-ack, commit tokens.

--- a/crates/ravel-bench/src/bin/metricsbench_ingest.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_ingest.rs
@@ -27,9 +27,9 @@ use ravel_bench::harness::{
 };
 use ravel_bench::metrics_gen::Generator;
 use ravel_bench::metrics_ingest::{
-    FamilyRecord, HttpReplayConfig, LogicalSample, MetricsIngestReport, ProfileRecord,
-    RavelReplayConfig, RunRecord, Substrate, parse_logical_stream, query_after_replay,
-    replay_into_ravel, replay_over_http,
+    HttpReplayConfig, LogicalSample, MetricsIngestReport, RavelReplayConfig, Substrate,
+    build_profile_record, parse_logical_stream, query_after_replay, replay_into_ravel,
+    replay_over_http,
 };
 use ravel_bench::metrics_workload::{WorkloadFile, load_workload};
 use ravel_ingest::{Clock, SystemClock};
@@ -173,51 +173,8 @@ async fn run(args: &Args) -> Result<MetricsIngestReport, RunError> {
     let profile = workload.profile(&args.profile).ok_or_else(|| {
         RunError::Generate(format!("manifest declares no profile `{}`", args.profile))
     })?;
-    let families = workload
-        .families
-        .iter()
-        .map(|family| FamilyRecord {
-            name: family.name.clone(),
-            instances: workload.family_instances(profile, family),
-            series_per_instance: workload.series_per_instance(family.kind),
-        })
-        .collect();
-    let steps_declared = profile.samples_per_series;
-    let truncated = steps < steps_declared;
-    // A truncated run is never that profile's figures, regardless of the
-    // profile's own comparability verdict.
-    let comparable = profile.is_publishable() && !truncated;
-    let comparability_reason = if truncated {
-        Some(format!(
-            "this run generated {steps} of profile `{}`'s {steps_declared} steps, so it is not \
-             that profile and its figures cannot be published",
-            profile.name
-        ))
-    } else {
-        profile.comparability.reason().map(String::from)
-    };
-    let run_record = RunRecord {
-        steps,
-        total_series_created: gen_report.total_series_created,
-        logical_input_bytes,
-        total_samples_generated: gen_report.emitted_samples,
-    };
-    let profile_record = ProfileRecord {
-        name: profile.name.clone(),
-        comparable,
-        comparability_reason,
-        active_series: profile.active_series,
-        steps_run: steps,
-        steps_declared,
-        samples_per_series: profile.samples_per_series,
-        scrape_interval_secs: profile.scrape_interval_secs,
-        duration_secs: profile.duration_secs,
-        total_samples: profile.total_samples,
-        label_cardinalities: workload.label_cardinalities(profile),
-        churn_basis_points_per_hour: profile.churn_basis_points_per_hour,
-        families,
-        run: run_record,
-    };
+    let profile_record =
+        build_profile_record(&workload, profile, steps, logical_input_bytes, &gen_report);
 
     // The in-process Ravel path: strict, durable-on-ack, commit tokens.
     let (store, store_metrics) = store_and_metrics_from_env(args.store);

--- a/crates/ravel-bench/src/harness.rs
+++ b/crates/ravel-bench/src/harness.rs
@@ -113,11 +113,8 @@ pub fn store_and_metrics_from_env(
 /// this -- MinIO is valid for correctness, conformance and CI, never for a
 /// performance or cost claim, because removing per-request fees is what
 /// makes a request-count defect invisible), true only for real S3 with no
-/// endpoint override. The one place every `--store`-driven bin derives this
-/// instead of re-deriving it from `StoreKind` alone (issue #1352: two sites,
-/// `metricsbench_ingest` and `bench_report`, derived it as `matches!(store,
-/// StoreKind::S3)`, which is also true against a billed-nothing MinIO
-/// endpoint).
+/// endpoint override. The one place every `--store`-driven bin derives this,
+/// rather than re-deriving it from `StoreKind` alone.
 pub fn backend_bills_requests(kind: StoreKind) -> bool {
     backend_bills_requests_from_lookup(kind, |key| std::env::var(key).ok())
 }
@@ -239,9 +236,6 @@ mod tests {
         assert_eq!(cfg.auth, S3AuthMode::Static);
     }
 
-    /// Issue #1352: `matches!(args.store, StoreKind::S3)` alone reported the
-    /// nightly MinIO lane (S3 protocol, `RAVEL_S3_ENDPOINT=http://
-    /// localhost:9000`) as billing requests, when MinIO bills nothing.
     /// `backend_bills_requests` is true only for real S3 with no endpoint
     /// override; a configured endpoint or a `MemoryStore` are both false.
     #[test]

--- a/crates/ravel-bench/src/harness.rs
+++ b/crates/ravel-bench/src/harness.rs
@@ -136,20 +136,38 @@ fn backend_bills_requests_from_lookup(
     }
 }
 
-/// The configured S3 endpoint's host, when `RAVEL_S3_ENDPOINT` is set. Host
-/// only: never the scheme, path, or any embedded userinfo credentials, so a
-/// report can name the substrate without ever carrying a secret.
-pub fn endpoint_host_from_env() -> Option<String> {
-    endpoint_host_from_lookup(|key| std::env::var(key).ok())
+/// The configured S3 endpoint's host, when `kind` is [`StoreKind::S3`] and
+/// `RAVEL_S3_ENDPOINT` is set. `None` for [`StoreKind::Memory`] regardless of
+/// the env var: a memory-backed run never touched an endpoint, so it must
+/// never name one. Host only: never the scheme, path, or any embedded
+/// userinfo credentials, so a report can name the substrate without ever
+/// carrying a secret.
+pub fn endpoint_host_from_env(kind: StoreKind) -> Option<String> {
+    endpoint_host_from_lookup(kind, |key| std::env::var(key).ok())
 }
 
 /// [`endpoint_host_from_env`]'s logic over an injected lookup; see
 /// [`backend_bills_requests_from_lookup`].
-fn endpoint_host_from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Option<String> {
+fn endpoint_host_from_lookup(
+    kind: StoreKind,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Option<String> {
+    if !matches!(kind, StoreKind::S3) {
+        return None;
+    }
     let raw = lookup("RAVEL_S3_ENDPOINT")?;
+    // `RAVEL_S3_ENDPOINT` is commonly given without a scheme (`localhost:9000`),
+    // which `Url::parse` treats as a `localhost:`-scheme URL rather than a host:
+    // port and returns no `host_str`. Retry with an assumed `http://` prefix so a
+    // scheme-less value still reports the right host.
     reqwest::Url::parse(&raw)
         .ok()
         .and_then(|u| u.host_str().map(str::to_string))
+        .or_else(|| {
+            reqwest::Url::parse(&format!("http://{raw}"))
+                .ok()
+                .and_then(|u| u.host_str().map(str::to_string))
+        })
 }
 
 #[cfg(test)]
@@ -245,6 +263,38 @@ mod tests {
                 lookup(&[("RAVEL_S3_ENDPOINT", "http://localhost:9000")]),
             ),
             "MemoryStore requests are free regardless of any configured S3 endpoint"
+        );
+    }
+
+    #[test]
+    fn endpoint_host_extracts_the_host_with_or_without_a_scheme() {
+        assert_eq!(
+            endpoint_host_from_lookup(
+                StoreKind::S3,
+                lookup(&[("RAVEL_S3_ENDPOINT", "http://localhost:9000")]),
+            ),
+            Some("localhost".to_string()),
+            "a scheme-carrying endpoint's host is extracted directly"
+        );
+        assert_eq!(
+            endpoint_host_from_lookup(
+                StoreKind::S3,
+                lookup(&[("RAVEL_S3_ENDPOINT", "localhost:9000")]),
+            ),
+            Some("localhost".to_string()),
+            "a scheme-less endpoint must still report its host, not silently omit it"
+        );
+    }
+
+    #[test]
+    fn endpoint_host_is_absent_for_memory_regardless_of_the_env_var() {
+        assert_eq!(
+            endpoint_host_from_lookup(
+                StoreKind::Memory,
+                lookup(&[("RAVEL_S3_ENDPOINT", "http://localhost:9000")]),
+            ),
+            None,
+            "a memory-backed run never touched an endpoint, so it must never name one"
         );
     }
 }

--- a/crates/ravel-bench/src/harness.rs
+++ b/crates/ravel-bench/src/harness.rs
@@ -107,6 +107,51 @@ pub fn store_and_metrics_from_env(
     }
 }
 
+/// Whether a request against `kind`'s backend is billed: false on
+/// `MemoryStore` and on any store behind a configured endpoint (a local
+/// MinIO reached over `RAVEL_S3_ENDPOINT`; ADR-0927 decision 10 is exactly
+/// this -- MinIO is valid for correctness, conformance and CI, never for a
+/// performance or cost claim, because removing per-request fees is what
+/// makes a request-count defect invisible), true only for real S3 with no
+/// endpoint override. The one place every `--store`-driven bin derives this
+/// instead of re-deriving it from `StoreKind` alone (issue #1352: two sites,
+/// `metricsbench_ingest` and `bench_report`, derived it as `matches!(store,
+/// StoreKind::S3)`, which is also true against a billed-nothing MinIO
+/// endpoint).
+pub fn backend_bills_requests(kind: StoreKind) -> bool {
+    backend_bills_requests_from_lookup(kind, |key| std::env::var(key).ok())
+}
+
+/// [`backend_bills_requests`]'s logic over an injected lookup, for the same
+/// reason [`s3_config_from_lookup`] exists: testable without
+/// `std::env::set_var` (`unsafe` under the 2024 edition) and without racing
+/// other tests over global process env state.
+fn backend_bills_requests_from_lookup(
+    kind: StoreKind,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> bool {
+    match kind {
+        StoreKind::Memory => false,
+        StoreKind::S3 => lookup("RAVEL_S3_ENDPOINT").is_none(),
+    }
+}
+
+/// The configured S3 endpoint's host, when `RAVEL_S3_ENDPOINT` is set. Host
+/// only: never the scheme, path, or any embedded userinfo credentials, so a
+/// report can name the substrate without ever carrying a secret.
+pub fn endpoint_host_from_env() -> Option<String> {
+    endpoint_host_from_lookup(|key| std::env::var(key).ok())
+}
+
+/// [`endpoint_host_from_env`]'s logic over an injected lookup; see
+/// [`backend_bills_requests_from_lookup`].
+fn endpoint_host_from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Option<String> {
+    let raw = lookup("RAVEL_S3_ENDPOINT")?;
+    reqwest::Url::parse(&raw)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_string))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,5 +219,32 @@ mod tests {
     fn unrecognized_auth_value_defaults_to_static() {
         let cfg = s3_config_from_lookup(lookup(&[("RAVEL_S3_AUTH", "Instance-Role")]));
         assert_eq!(cfg.auth, S3AuthMode::Static);
+    }
+
+    /// Issue #1352: `matches!(args.store, StoreKind::S3)` alone reported the
+    /// nightly MinIO lane (S3 protocol, `RAVEL_S3_ENDPOINT=http://
+    /// localhost:9000`) as billing requests, when MinIO bills nothing.
+    /// `backend_bills_requests` is true only for real S3 with no endpoint
+    /// override; a configured endpoint or a `MemoryStore` are both false.
+    #[test]
+    fn backend_bills_requests_is_false_behind_a_configured_endpoint() {
+        assert!(
+            !backend_bills_requests_from_lookup(
+                StoreKind::S3,
+                lookup(&[("RAVEL_S3_ENDPOINT", "http://localhost:9000")]),
+            ),
+            "S3 behind a configured endpoint (MinIO) must not report billing"
+        );
+        assert!(
+            backend_bills_requests_from_lookup(StoreKind::S3, lookup(&[])),
+            "S3 with no endpoint override is real S3 and must report billing"
+        );
+        assert!(
+            !backend_bills_requests_from_lookup(
+                StoreKind::Memory,
+                lookup(&[("RAVEL_S3_ENDPOINT", "http://localhost:9000")]),
+            ),
+            "MemoryStore requests are free regardless of any configured S3 endpoint"
+        );
     }
 }

--- a/crates/ravel-bench/src/metrics_gen.rs
+++ b/crates/ravel-bench/src/metrics_gen.rs
@@ -336,6 +336,16 @@ impl<'a> Generator<'a> {
                     name: profile_name.to_string(),
                     available: workload.profiles.iter().map(|p| p.name.clone()).collect(),
                 })?;
+        Ok(Self::for_profile(workload, profile, base_ts_ms))
+    }
+
+    /// Build a generator for an explicit `profile`, bypassing the by-name
+    /// lookup [`Self::new`] does. Lets a caller compute generator-exact
+    /// figures for a [`Profile`] value it holds directly (for example one
+    /// mutated from the manifest's own, as `build_profile_record`'s callers
+    /// do), without requiring it to be stored in `workload` under its own
+    /// name.
+    pub fn for_profile(workload: &'a WorkloadFile, profile: &'a Profile, base_ts_ms: i64) -> Self {
         let mut plans = Vec::with_capacity(workload.families.len());
         for (index, family) in workload.families.iter().enumerate() {
             let instances = workload.family_instances(profile, family);
@@ -357,12 +367,12 @@ impl<'a> Generator<'a> {
                 state: BTreeMap::new(),
             });
         }
-        Ok(Generator {
+        Generator {
             workload,
             profile,
             base_ts_ms,
             plans,
-        })
+        }
     }
 
     /// The profile this generator runs.
@@ -388,6 +398,42 @@ impl<'a> Generator<'a> {
         }
         let last_secs = (steps - 1) * self.profile.scrape_interval_secs;
         last_secs / CHURN_EPOCH_SECS + 1
+    }
+
+    /// Distinct scaling-label values (`instance` in the checked-in manifest)
+    /// the run emits across every family, over the churn epochs `steps`
+    /// spans. Derived from the same variables `generate_into`/`labels_for`
+    /// read, not a re-typed formula: at epoch `e`, a family's global instance
+    /// ordinals range over `[churned_per_epoch * e, churned_per_epoch * e +
+    /// instances)` (`generate_into`'s `base`/`local`/`global`), and
+    /// `labels_for` stamps each ordinal's scaling-label value as the ordinal
+    /// divided by the family's `fixed_product`. That division maps each
+    /// epoch's ordinal range onto one closed value range `[lo, hi]`.
+    ///
+    /// Every family shares one label-value prefix (`labels_for` never mixes
+    /// in a family id), so two families', or one family's own across two
+    /// epochs, value ranges can collide or overlap: `gate_workload` does not
+    /// bound `churn_basis_points_per_hour`, so a family's later-epoch range
+    /// can even extend past its own epoch-0 range. The true count is
+    /// therefore the union of every (family, epoch) value range, not a sum
+    /// (would double-count overlaps) and not a per-family max (would miss
+    /// values a later epoch adds beyond another family's range).
+    pub fn scaling_label_cardinality(&self, steps: usize) -> u64 {
+        let steps = steps as u64;
+        let epochs = self.epochs_spanned(steps);
+        let mut ranges: Vec<(u64, u64)> = Vec::new();
+        for plan in &self.plans {
+            if plan.instances == 0 {
+                continue;
+            }
+            for epoch in 0..epochs {
+                let base = plan.churned_per_epoch * epoch;
+                let lo = base / plan.fixed_product;
+                let hi = (base + plan.instances - 1) / plan.fixed_product;
+                ranges.push((lo, hi));
+            }
+        }
+        union_size(ranges)
     }
 
     /// Generate `steps` scrapes into `sink`, returning the run's exact figures.
@@ -794,6 +840,29 @@ impl<'a> Generator<'a> {
 /// churn-free stays clean.
 fn fires(one_in: u64, seed: u64, tag: u64, family: u64, instance: u64, step: u64) -> bool {
     one_in != 0 && mix(seed, &[tag, family, instance, step]).is_multiple_of(one_in)
+}
+
+/// Total count of distinct integers covered by the union of closed ranges
+/// `[lo, hi]`. Exact via a sort-and-merge sweep, regardless of whether the
+/// input ranges are disjoint, overlapping, adjacent, or nested.
+fn union_size(mut ranges: Vec<(u64, u64)>) -> u64 {
+    if ranges.is_empty() {
+        return 0;
+    }
+    ranges.sort_unstable();
+    let mut total = 0u64;
+    let (mut cur_lo, mut cur_hi) = ranges[0];
+    for &(lo, hi) in &ranges[1..] {
+        if lo <= cur_hi + 1 {
+            cur_hi = cur_hi.max(hi);
+        } else {
+            total += cur_hi - cur_lo + 1;
+            cur_lo = lo;
+            cur_hi = hi;
+        }
+    }
+    total += cur_hi - cur_lo + 1;
+    total
 }
 
 #[cfg(test)]
@@ -1632,49 +1701,126 @@ mod tests {
         })
     }
 
-    /// `WorkloadFile::label_cardinalities`' `instance` figure must be the
-    /// UNION of distinct scaling-label values the generator actually emits,
-    /// never the sum of the families' per-family counts: every family shares
-    /// one `scaling_label_value_prefix`
+    /// [`Generator::scaling_label_cardinality`] must equal the distinct
+    /// scaling-label values the generator actually emits, one churn epoch
+    /// (the checked-in manifest's `ci` profile, no churn): the UNION of the
+    /// families' per-family, single-epoch ranges, never their sum -- every
+    /// family shares one `scaling_label_value_prefix`
     /// (`benchmarks/metrics/workload.json`'s `"metricsbench-instance-"`), so
     /// two families routinely emit the same value.
     ///
-    /// Under the checked-in manifest's `ci` profile (1,000 active series),
-    /// `WorkloadFile::family_scaling_label_cardinality` per family is:
+    /// Under the checked-in manifest's `ci` profile (1,000 active series,
+    /// churn-free so `base == 0` for every family), each family's range is
+    /// `[0, instances / fixed_product]`:
     /// `metricsbench_gauge_cpu_percent`: 400 instances / 12 (job x region)
-    /// fixed combos = ceil(400/12) = 34, values 0..33.
-    /// `metricsbench_requests_total`: 300 / 64 (job x method x status) =
-    /// ceil(300/64) = 5, values 0..4.
+    /// fixed combos, values 0..33, 34 distinct.
+    /// `metricsbench_requests_total`: 300 / 64 (job x method x status),
+    /// values 0..4, 5 distinct.
     /// `metricsbench_request_duration_seconds`: 15 instances (150 series / 10
-    /// series-per-classic-histogram-instance) / 4 (job) = ceil(15/4) = 4,
-    /// values 0..3.
-    /// `metricsbench_latency_native`: 100 / 4 (job) = ceil(100/4) = 25, values
-    /// 0..24.
-    /// `metricsbench_build_info`: 50 instances / 8 (job x version) =
-    /// ceil(50/8) = 7, values 0..6.
-    /// Every one of those ranges starts at 0 (`Generator::labels_for` assigns
-    /// `global / fixed_product`, and `global` itself starts at 0 for every
-    /// family), so their union is exactly the widest range: 34 distinct
-    /// values, not the sum of the five counts (34 + 5 + 4 + 25 + 7 = 75).
-    ///
-    /// TO SEE THIS FAIL against the pre-fix `label_cardinalities` (summing
-    /// the per-family counts): change its `.max().unwrap_or(0)` back to
-    /// `.sum()`; this test then observes 75 != 34.
+    /// series-per-classic-histogram-instance) / 4 (job), values 0..3, 4
+    /// distinct.
+    /// `metricsbench_latency_native`: 100 / 4 (job), values 0..24, 25
+    /// distinct.
+    /// `metricsbench_build_info`: 50 instances / 8 (job x version), values
+    /// 0..6, 7 distinct.
+    /// Every one of those ranges starts at 0, so their union is exactly the
+    /// widest range: 34 distinct values, not the sum of the five counts
+    /// (34 + 5 + 4 + 25 + 7 = 75).
     #[test]
-    fn scaling_label_cardinality_equals_the_distinct_values_the_generator_emits() {
+    fn scaling_label_cardinality_matches_the_generators_distinct_emitted_values_for_ci() {
         let workload = load_workload(std::path::Path::new(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../benchmarks/metrics/workload.json"
         )))
         .expect("load the checked-in workload manifest");
-        let profile = workload.profile("ci").expect("ci profile declared");
 
-        let (bytes, _report) = Generator::new(&workload, "ci", 0)
-            .expect("generator builds")
-            .generate_bytes(1)
-            .expect("generates one step");
+        let mut generator = Generator::new(&workload, "ci", 0).expect("generator builds");
+        assert_eq!(
+            generator.scaling_label_cardinality(1),
+            34,
+            "the ci profile's one-epoch scaling-label cardinality is 34 (see derivation above)"
+        );
+
+        let (bytes, _report) = generator.generate_bytes(1).expect("generates one step");
         let text = String::from_utf8(bytes).expect("utf8");
+        let distinct_instances: std::collections::BTreeSet<&str> = text
+            .lines()
+            .filter_map(|line| line.split('\t').nth(1))
+            .filter_map(instance_label)
+            .collect();
+        assert_eq!(
+            distinct_instances.len(),
+            34,
+            "the ci profile's generator emits 34 distinct instance values: {distinct_instances:?}"
+        );
+    }
 
+    /// The churn case: churn epochs must grow the distinct scaling-label set
+    /// past one epoch's worth, which a single-epoch, manifest-only formula
+    /// cannot see (issue #1352). The pre-fix formula this issue replaces
+    /// (`bfb501ea`'s `crates/ravel-bench/src/metrics_workload.rs:330`,
+    /// `WorkloadFile::family_scaling_label_cardinality`, `ceil(instances /
+    /// family_fixed_product)`, maxed over families with no notion of an
+    /// epoch at `metrics_workload.rs:287`) reports one number for the whole
+    /// run regardless of how many epochs it spans. But
+    /// `Generator::generate_into` offsets every family's instance ordinal by
+    /// `churned_per_epoch * epoch` each epoch, so the true distinct-value
+    /// set grows every epoch: the union of every (family, epoch) range.
+    ///
+    /// A local profile tunes the shared 4-family test manifest (job x region
+    /// = 4 fixed combos, job = 2, family permilles 300/150/500/50) to 400
+    /// active series and 50%/hour churn, fast enough to generate here.
+    /// `STEPS = 481` (`(2 * CHURN_EPOCH_SECS) / scrape_interval_secs + 1` =
+    /// `(2 * 3_600) / 15 + 1`) spans exactly 3 churn epochs (0, 1, 2).
+    ///
+    /// Per family, `instances` (churn-free, so this count itself does not
+    /// change across epochs) and `churned_per_epoch` (`instances *
+    /// churn_basis_points_per_hour / 10_000`):
+    /// gauge: 400*300/1000 = 120 series / 1 = 120 instances, `fixed_product`
+    /// = 2 (job) x 2 (region) = 4, `churned_per_epoch` = 120*5_000/10_000 =
+    /// 60.
+    /// counter: 400*150/1000 = 60 instances, `fixed_product` = 2 (job),
+    /// `churned_per_epoch` = 30.
+    /// classic: 400*500/1000 = 200 series / 10 (7 bounds + 3) = 20
+    /// instances, `fixed_product` = 2 (job), `churned_per_epoch` = 10.
+    /// native: 400*50/1000 = 20 instances, `fixed_product` = 2 (job),
+    /// `churned_per_epoch` = 10.
+    ///
+    /// Each family's per-epoch value range is `[base/fixed_product, (base +
+    /// instances - 1)/fixed_product]` with `base = churned_per_epoch *
+    /// epoch`:
+    /// gauge: epoch 0 `[0,29]`, epoch 1 `[15,44]`, epoch 2 `[30,59]`, union
+    /// `[0,59]`, 60 values.
+    /// counter: epoch 0 `[0,29]`, epoch 1 `[15,44]`, epoch 2 `[30,59]`,
+    /// union `[0,59]`, a subset of gauge's.
+    /// classic and native: epoch 0 `[0,9]`, epoch 1 `[5,14]`, epoch 2
+    /// `[10,19]`, union `[0,19]`, a subset of gauge's.
+    /// Grand union across all four families: `[0,59]`, 60 distinct values.
+    ///
+    /// The pre-fix formula instead reports, per family, `ceil(instances /
+    /// fixed_product)` at epoch 0 only: gauge `ceil(120/4)=30`, counter
+    /// `ceil(60/2)=30`, classic `ceil(20/2)=10`, native `ceil(20/2)=10`,
+    /// maxed to 30, half the true 60.
+    ///
+    /// TO SEE THIS FAIL against the pre-fix formula: reintroduce
+    /// `WorkloadFile::family_scaling_label_cardinality` and
+    /// `WorkloadFile::family_fixed_product` (deleted by this fix) and assert
+    /// `workload.label_cardinalities(&profile)["instance"] == 60` in their
+    /// place below; that formula reports 30, not 60.
+    #[test]
+    fn scaling_label_cardinality_unions_every_family_and_epoch_under_churn() {
+        let w = workload(1, clean());
+        let base = w.profile("churn").expect("churn profile declared").clone();
+        let profile = Profile {
+            active_series: 400,
+            churn_basis_points_per_hour: 5_000,
+            ..base
+        };
+        const STEPS: u64 = 481;
+
+        let mut generator = Generator::for_profile(&w, &profile, 0);
+        let (bytes, _report) = generator.generate_bytes(STEPS).expect("generates");
+        let text = String::from_utf8(bytes).expect("utf8");
         let distinct_instances: std::collections::BTreeSet<&str> = text
             .lines()
             .filter_map(|line| line.split('\t').nth(1))
@@ -1683,14 +1829,14 @@ mod tests {
 
         assert_eq!(
             distinct_instances.len(),
-            34,
-            "the ci profile's generator emits 34 distinct instance values: {distinct_instances:?}"
+            60,
+            "3 churn epochs must grow the distinct instance-value set past one epoch's \
+             (see derivation above): {distinct_instances:?}"
         );
         assert_eq!(
-            workload.label_cardinalities(profile)["instance"],
+            generator.scaling_label_cardinality(STEPS as usize),
             distinct_instances.len() as u64,
-            "label_cardinalities must report the distinct values the generator emits, not a sum \
-             that double-counts values shared across families"
+            "scaling_label_cardinality must equal the generator's own distinct emitted values"
         );
     }
 }

--- a/crates/ravel-bench/src/metrics_gen.rs
+++ b/crates/ravel-bench/src/metrics_gen.rs
@@ -419,6 +419,12 @@ impl<'a> Generator<'a> {
     /// (would double-count overlaps) and not a per-family max (would miss
     /// values a later epoch adds beyond another family's range).
     pub fn scaling_label_cardinality(&self, steps: u64) -> u64 {
+        // A zero-step run emits no series at all, so it carries no scaling
+        // label values; `epochs_spanned` reports one epoch for it, which is
+        // right for churn arithmetic and wrong for this count.
+        if steps == 0 {
+            return 0;
+        }
         let epochs = self.epochs_spanned(steps);
         let mut ranges: Vec<(u64, u64)> = Vec::new();
         for plan in &self.plans {
@@ -1751,6 +1757,27 @@ mod tests {
             distinct_instances.len(),
             34,
             "the ci profile's generator emits 34 distinct instance values: {distinct_instances:?}"
+        );
+    }
+
+    /// A zero-step run emits no series, so it carries no scaling-label
+    /// values. `epochs_spanned` reports one epoch for `steps == 0` (the
+    /// right answer for churn arithmetic, since epoch 0 is where a run
+    /// starts), so the cardinality has to special-case it or it reports the
+    /// first epoch's values for a run that emitted nothing.
+    #[test]
+    fn scaling_label_cardinality_is_zero_for_a_run_that_emits_nothing() {
+        let workload = workload(1, clean());
+        let profile = workload.profile("ci").expect("ci profile").clone();
+        let generator = Generator::for_profile(&workload, &profile, 0);
+        assert!(
+            generator.scaling_label_cardinality(1) > 0,
+            "the one-step run is the control: it does emit series"
+        );
+        assert_eq!(
+            generator.scaling_label_cardinality(0),
+            0,
+            "a run that generates no steps emits no scaling-label values"
         );
     }
 

--- a/crates/ravel-bench/src/metrics_gen.rs
+++ b/crates/ravel-bench/src/metrics_gen.rs
@@ -802,7 +802,7 @@ mod tests {
     use super::*;
     use crate::metrics_workload::{
         AnomalyRates, Comparability, GeneratorConfig, LabelDimension, WORKLOAD_FORMAT_VERSION,
-        gate_workload,
+        gate_workload, load_workload,
     };
 
     /// A four-family manifest at the `ci` scale, small enough that every figure
@@ -1619,5 +1619,78 @@ mod tests {
             assert!((0.0..100.0).contains(&v), "{v} out of range");
             assert_eq!(v, f64::from_bits(v.to_bits()));
         }
+    }
+
+    /// The value of a rendered series' `instance="..."` label, or `None` if
+    /// `series` (`metric{k="v",...}`) carries no such label.
+    fn instance_label(series: &str) -> Option<&str> {
+        let open = series.find('{')?;
+        let inner = series[open + 1..].strip_suffix('}')?;
+        inner.split(',').find_map(|pair| {
+            let (k, v) = pair.split_once('=')?;
+            (k == "instance").then(|| v.trim_matches('"'))
+        })
+    }
+
+    /// `WorkloadFile::label_cardinalities`' `instance` figure must be the
+    /// UNION of distinct scaling-label values the generator actually emits,
+    /// never the sum of the families' per-family counts: every family shares
+    /// one `scaling_label_value_prefix`
+    /// (`benchmarks/metrics/workload.json`'s `"metricsbench-instance-"`), so
+    /// two families routinely emit the same value.
+    ///
+    /// Under the checked-in manifest's `ci` profile (1,000 active series),
+    /// `WorkloadFile::family_scaling_label_cardinality` per family is:
+    /// `metricsbench_gauge_cpu_percent`: 400 instances / 12 (job x region)
+    /// fixed combos = ceil(400/12) = 34, values 0..33.
+    /// `metricsbench_requests_total`: 300 / 64 (job x method x status) =
+    /// ceil(300/64) = 5, values 0..4.
+    /// `metricsbench_request_duration_seconds`: 15 instances (150 series / 10
+    /// series-per-classic-histogram-instance) / 4 (job) = ceil(15/4) = 4,
+    /// values 0..3.
+    /// `metricsbench_latency_native`: 100 / 4 (job) = ceil(100/4) = 25, values
+    /// 0..24.
+    /// `metricsbench_build_info`: 50 instances / 8 (job x version) =
+    /// ceil(50/8) = 7, values 0..6.
+    /// Every one of those ranges starts at 0 (`Generator::labels_for` assigns
+    /// `global / fixed_product`, and `global` itself starts at 0 for every
+    /// family), so their union is exactly the widest range: 34 distinct
+    /// values, not the sum of the five counts (34 + 5 + 4 + 25 + 7 = 75).
+    ///
+    /// TO SEE THIS FAIL against the pre-fix `label_cardinalities` (summing
+    /// the per-family counts): change its `.max().unwrap_or(0)` back to
+    /// `.sum()`; this test then observes 75 != 34.
+    #[test]
+    fn scaling_label_cardinality_equals_the_distinct_values_the_generator_emits() {
+        let workload = load_workload(std::path::Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../benchmarks/metrics/workload.json"
+        )))
+        .expect("load the checked-in workload manifest");
+        let profile = workload.profile("ci").expect("ci profile declared");
+
+        let (bytes, _report) = Generator::new(&workload, "ci", 0)
+            .expect("generator builds")
+            .generate_bytes(1)
+            .expect("generates one step");
+        let text = String::from_utf8(bytes).expect("utf8");
+
+        let distinct_instances: std::collections::BTreeSet<&str> = text
+            .lines()
+            .filter_map(|line| line.split('\t').nth(1))
+            .filter_map(instance_label)
+            .collect();
+
+        assert_eq!(
+            distinct_instances.len(),
+            34,
+            "the ci profile's generator emits 34 distinct instance values: {distinct_instances:?}"
+        );
+        assert_eq!(
+            workload.label_cardinalities(profile)["instance"],
+            distinct_instances.len() as u64,
+            "label_cardinalities must report the distinct values the generator emits, not a sum \
+             that double-counts values shared across families"
+        );
     }
 }

--- a/crates/ravel-bench/src/metrics_gen.rs
+++ b/crates/ravel-bench/src/metrics_gen.rs
@@ -1756,12 +1756,10 @@ mod tests {
 
     /// The churn case: churn epochs must grow the distinct scaling-label set
     /// past one epoch's worth, which a single-epoch, manifest-only formula
-    /// cannot see (issue #1352). The pre-fix formula this issue replaces
-    /// (`bfb501ea`'s `crates/ravel-bench/src/metrics_workload.rs:330`,
-    /// `WorkloadFile::family_scaling_label_cardinality`, `ceil(instances /
-    /// family_fixed_product)`, maxed over families with no notion of an
-    /// epoch at `metrics_workload.rs:287`) reports one number for the whole
-    /// run regardless of how many epochs it spans. But
+    /// cannot see (issue #1352). A per-family `ceil(instances /
+    /// fixed_product)` maxed over families has no notion of an epoch and
+    /// reports one number for the whole run however many epochs it spans.
+    /// But
     /// `Generator::generate_into` offsets every family's instance ordinal by
     /// `churned_per_epoch * epoch` each epoch, so the true distinct-value
     /// set grows every epoch: the union of every (family, epoch) range.
@@ -1801,11 +1799,8 @@ mod tests {
     /// `ceil(60/2)=30`, classic `ceil(20/2)=10`, native `ceil(20/2)=10`,
     /// maxed to 30, half the true 60.
     ///
-    /// TO SEE THIS FAIL against the pre-fix formula: reintroduce
-    /// `WorkloadFile::family_scaling_label_cardinality` and
-    /// `WorkloadFile::family_fixed_product` (deleted by this fix) and assert
-    /// `workload.label_cardinalities(&profile)["instance"] == 60` in their
-    /// place below; that formula reports 30, not 60.
+    /// A single-epoch formula fails here: it reports 30 against the 60 this
+    /// run emits.
     #[test]
     fn scaling_label_cardinality_unions_every_family_and_epoch_under_churn() {
         let w = workload(1, clean());

--- a/crates/ravel-bench/src/metrics_gen.rs
+++ b/crates/ravel-bench/src/metrics_gen.rs
@@ -339,18 +339,10 @@ impl<'a> Generator<'a> {
         let mut plans = Vec::with_capacity(workload.families.len());
         for (index, family) in workload.families.iter().enumerate() {
             let instances = workload.family_instances(profile, family);
-            let mut fixed = Vec::with_capacity(family.labels.len());
+            let cardinalities = workload.family_dimension_cardinalities(family);
+            let mut fixed = Vec::with_capacity(cardinalities.len());
             let mut stride = 1u64;
-            for label in &family.labels {
-                // `gate_workload` already refused a family naming an
-                // undeclared dimension, so an absent one here would be a
-                // manifest that never passed the gate; treat it as a
-                // single-valued dimension rather than panicking.
-                let card = workload
-                    .dimension(label)
-                    .map(|d| d.values.len() as u64)
-                    .unwrap_or(1)
-                    .max(1);
+            for card in cardinalities {
                 fixed.push((card, stride));
                 stride *= card;
             }

--- a/crates/ravel-bench/src/metrics_gen.rs
+++ b/crates/ravel-bench/src/metrics_gen.rs
@@ -418,8 +418,7 @@ impl<'a> Generator<'a> {
     /// therefore the union of every (family, epoch) value range, not a sum
     /// (would double-count overlaps) and not a per-family max (would miss
     /// values a later epoch adds beyond another family's range).
-    pub fn scaling_label_cardinality(&self, steps: usize) -> u64 {
-        let steps = steps as u64;
+    pub fn scaling_label_cardinality(&self, steps: u64) -> u64 {
         let epochs = self.epochs_spanned(steps);
         let mut ranges: Vec<(u64, u64)> = Vec::new();
         for plan in &self.plans {
@@ -1834,7 +1833,7 @@ mod tests {
              (see derivation above): {distinct_instances:?}"
         );
         assert_eq!(
-            generator.scaling_label_cardinality(STEPS as usize),
+            generator.scaling_label_cardinality(STEPS),
             distinct_instances.len() as u64,
             "scaling_label_cardinality must equal the generator's own distinct emitted values"
         );

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -453,13 +453,37 @@ pub struct ProfileRecord {
     pub duration_secs: u64,
     /// Total samples the profile declares over its full duration.
     pub total_samples: u64,
-    /// Distinct values per label dimension, name to count, straight from the
-    /// workload manifest (`WorkloadFile::label_cardinalities`).
+    /// Distinct values per label, name to count, straight from the workload
+    /// manifest (`WorkloadFile::label_cardinalities`) -- including the
+    /// scaling label (`instance`), whose total is the sum of `families`'
+    /// per-family instance cardinalities below.
     pub label_cardinalities: BTreeMap<String, u64>,
     /// Logical (uncompressed, pre-wire) input bytes the generator produced.
     pub logical_input_bytes: u64,
     /// Declared series churn, in basis points per hour.
     pub churn_basis_points_per_hour: u64,
+    /// Per-family instance counts, so `label_cardinalities`' `instance` total
+    /// is reconstructible: combined with the manifest's own label
+    /// dimensions and `family.labels`, a reader can recompute each family's
+    /// scaling-label cardinality (`WorkloadFile::family_scaling_label_
+    /// cardinality`) and its sum.
+    pub families: Vec<FamilyRecord>,
+}
+
+/// One metric family's exact instance count under the run's profile, and the
+/// series each instance emits (`WorkloadFile::family_instances`,
+/// `WorkloadFile::series_per_instance`) -- the generator's own counts, never a
+/// formula re-typed against the manifest.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FamilyRecord {
+    /// The family name.
+    pub name: String,
+    /// Instances (histograms, or plain series) the family emits under this
+    /// profile.
+    pub instances: u64,
+    /// Series one instance emits: 1 for a gauge, a counter, or a native
+    /// histogram; bounds-plus-3 for a classic histogram.
+    pub series_per_instance: u64,
 }
 
 /// The storage backend a run replayed against, and whether it bills for

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -615,7 +615,7 @@ pub fn build_profile_record(
         label_cardinalities: workload.label_cardinalities(),
         scaling_label: ScalingLabelRecord {
             name: workload.generator.scaling_label.clone(),
-            cardinality_declared: generator.scaling_label_cardinality(steps_declared as usize),
+            cardinality_declared: generator.scaling_label_cardinality(steps_declared),
         },
         churn_basis_points_per_hour: profile.churn_basis_points_per_hour,
         families,
@@ -624,7 +624,7 @@ pub fn build_profile_record(
             total_series_created: gen_report.total_series_created,
             logical_input_bytes,
             total_samples_generated: gen_report.emitted_samples,
-            scaling_label_cardinality: generator.scaling_label_cardinality(steps_run as usize),
+            scaling_label_cardinality: generator.scaling_label_cardinality(steps_run),
         },
     }
 }
@@ -2046,12 +2046,12 @@ mod tests {
         let generator = Generator::for_profile(&workload, &profile, 0);
         assert_eq!(
             record.scaling_label.cardinality_declared,
-            generator.scaling_label_cardinality(record.steps_declared as usize),
+            generator.scaling_label_cardinality(record.steps_declared),
             "cardinality_declared must be the generator's own figure at steps_declared"
         );
         assert_eq!(
             record.run.scaling_label_cardinality,
-            generator.scaling_label_cardinality(steps as usize),
+            generator.scaling_label_cardinality(steps),
             "run.scaling_label_cardinality must be the generator's own figure at steps_run"
         );
     }
@@ -2120,12 +2120,12 @@ mod tests {
         );
         assert_eq!(
             record.scaling_label.cardinality_declared,
-            generator.scaling_label_cardinality(steps_declared as usize),
+            generator.scaling_label_cardinality(steps_declared),
             "cardinality_declared must be the generator's own figure at steps_declared"
         );
         assert_eq!(
             record.run.scaling_label_cardinality,
-            generator.scaling_label_cardinality(steps_run as usize),
+            generator.scaling_label_cardinality(steps_run),
             "run.scaling_label_cardinality must be the generator's own figure at steps_run, \
              not steps_declared"
         );

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -55,12 +55,13 @@
 //! this run's actual scope, and the comparability verdict:
 //! - `name`: the `--profile` name.
 //! - `comparable`: whether these figures may be published (decision 11).
-//!   Forced `false` when `steps_run < steps_declared`, regardless of the
-//!   profile's own verdict: a truncated run is never that profile.
+//!   Forced `false` when `steps_run != steps_declared`, regardless of the
+//!   profile's own verdict: a run that stopped short or ran long is not that
+//!   profile.
 //! - `comparability_reason`: why not, present exactly when `comparable` is
 //!   `false`, absent when `true`. The workload's own `Comparability` reason,
-//!   never a second hand-written copy of it, unless the run itself was
-//!   truncated, in which case this states that instead.
+//!   never a second hand-written copy of it, unless the run's step count is
+//!   off the profile's, in which case this states that instead.
 //! - `active_series`: series alive at any one instant, as declared.
 //! - `steps_run`: steps this run actually generated (the `--steps` flag, or
 //!   `steps_declared` when unset).
@@ -592,12 +593,12 @@ pub fn build_profile_record(
     let steps_declared = profile.samples_per_series;
     // Any step count other than the profile's own: a short run is not that
     // profile's figures, and an over-long one is not either.
-    let truncated = steps_run != steps_declared;
-    let comparable = profile.is_publishable() && !truncated;
-    let comparability_reason = if truncated {
+    let off_profile = steps_run != steps_declared;
+    let comparable = profile.is_publishable() && !off_profile;
+    let comparability_reason = if off_profile {
         Some(format!(
-            "this run generated {steps_run} of profile `{}`'s {steps_declared} steps, so it is \
-             not that profile and its figures cannot be published",
+            "this run generated {steps_run} steps against profile `{}`'s {steps_declared}, so it \
+             is not that profile and its figures cannot be published",
             profile.name
         ))
     } else {
@@ -2059,6 +2060,65 @@ mod tests {
         );
     }
 
+    /// The other direction: a run PAST the profile's declared step count is
+    /// not that profile either, and `--steps` takes any value. Without this
+    /// the rule would read `steps_run < steps_declared` and an over-long run
+    /// of a comparable profile would publish as that profile.
+    #[test]
+    fn profile_record_is_non_comparable_when_the_run_exceeds_the_declared_steps() {
+        use crate::metrics_gen::Generator;
+        use crate::metrics_workload::Comparability;
+
+        let workload = ci_workload();
+        let ci = workload.profile("ci").expect("ci profile declared");
+        let steps_declared = 10;
+        let steps_run = 12;
+        let profile = Profile {
+            comparability: Comparability::Comparable,
+            samples_per_series: steps_declared,
+            ..ci.clone()
+        };
+        assert!(
+            profile.is_publishable(),
+            "this test's premise is a profile that IS comparable"
+        );
+        assert!(
+            steps_run > steps_declared,
+            "this test's premise is a run PAST the declared step count"
+        );
+
+        let (bytes, gen_report) = Generator::new(&workload, "ci", 0)
+            .expect("generator builds")
+            .generate_bytes(steps_run)
+            .expect("generates steps");
+        let record = build_profile_record(
+            &workload,
+            &profile,
+            steps_run,
+            bytes.len() as u64,
+            &gen_report,
+        );
+
+        assert!(
+            !record.comparable,
+            "a run past the declared step count is never comparable, even when the profile is"
+        );
+        let expected_reason = format!(
+            "this run generated {steps_run} steps against profile `{}`'s {steps_declared}, so it \
+             is not that profile and its figures cannot be published",
+            profile.name
+        );
+        assert_eq!(
+            record.comparability_reason,
+            Some(expected_reason),
+            "the reason names both step counts"
+        );
+        assert_eq!(
+            record.run.steps, steps_run,
+            "run.steps is what this run generated, not the declared count"
+        );
+    }
+
     /// The mirror case: a profile whose own verdict IS comparable, but the
     /// run truncates it. `comparable` must still be `false`, and the reason
     /// must be the truncation message, not the (absent) profile reason --
@@ -2106,8 +2166,8 @@ mod tests {
             "a truncated run is never comparable, even when the profile itself is"
         );
         let expected_reason = format!(
-            "this run generated {steps_run} of profile `{}`'s {steps_declared} steps, so it is \
-             not that profile and its figures cannot be published",
+            "this run generated {steps_run} steps against profile `{}`'s {steps_declared}, so it \
+             is not that profile and its figures cannot be published",
             profile.name
         );
         assert_eq!(

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -45,6 +45,36 @@
 //!
 //! Report-only: like the rest of `ravel-bench`, this lane never changes library
 //! behaviour, it only measures it.
+//!
+//! ## `profile` and `substrate` (ADR-0927 decision 11, issue #1352)
+//!
+//! [`MetricsIngestReport`] carries two blocks so a reader never mistakes a
+//! non-comparable or unbilled run for a publishable result:
+//!
+//! [`ProfileRecord`] (`profile`), the workload's own pre-registered figures
+//! and comparability verdict:
+//! - `name`: the `--profile` name.
+//! - `comparable`: whether these figures may be published (decision 11).
+//! - `comparability_reason`: why not, when `comparable` is `false`; the
+//!   workload's own `Comparability` reason, never a second hand-written copy.
+//! - `active_series`: series alive at any one instant, as declared.
+//! - `total_series_created`: distinct series the generator actually created,
+//!   the generator's exact count.
+//! - `samples_per_series`, `scrape_interval_secs`, `duration_secs`,
+//!   `total_samples`, `churn_basis_points_per_hour`: as declared.
+//! - `label_cardinalities`: distinct values per label dimension, name to
+//!   count, read from the manifest.
+//! - `logical_input_bytes`: uncompressed input bytes the generator produced,
+//!   the generator's exact count.
+//!
+//! [`Substrate`] (`substrate`), the storage backend a run replayed against:
+//! - `store_backend`: the `--store` kind (`memory` or `s3`).
+//! - `endpoint_host`: the configured S3 endpoint's host, when
+//!   `RAVEL_S3_ENDPOINT` is set; absent otherwise. Host only, never
+//!   credentials.
+//! - `backend_bills_requests`: true only for real S3 with no endpoint
+//!   override (decision 10); false on `MemoryStore` and on any store behind a
+//!   configured endpoint, such as the nightly lane's local MinIO.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -394,10 +424,73 @@ pub struct SystemQueryResult {
     pub elapsed_secs: f64,
 }
 
+/// The nine ADR-0927 decision-11 profile figures, plus the workload's own
+/// comparability verdict. Every figure here is the profile's pre-registered
+/// value or the generator's exact count -- never derived from the offered
+/// sample count, so a reader can compare this row against the workload
+/// definition directly instead of trusting the run that produced it.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProfileRecord {
+    /// The `--profile` name (`cardinality`, `history`, `churn`, `ci`, ...).
+    pub name: String,
+    /// Whether this profile's figures may be compared across runs or
+    /// systems (ADR-0927 decision 11). `ci` is `false`: it exists for
+    /// reachability, not for a performance or cost claim.
+    pub comparable: bool,
+    /// The stated reason when `comparable` is `false`, or `"comparable"`
+    /// otherwise -- [`crate::metrics_workload::Comparability`]'s own
+    /// `Display`, never a second, hand-written copy of it.
+    pub comparability_reason: String,
+    /// Active series the profile declares.
+    pub active_series: u64,
+    /// Total series the generator actually created over the run.
+    pub total_series_created: u64,
+    /// Samples per series per scrape, as declared.
+    pub samples_per_series: u64,
+    /// Scrape interval, as declared.
+    pub scrape_interval_secs: u64,
+    /// Run duration, as declared.
+    pub duration_secs: u64,
+    /// Total samples the profile declares over its full duration.
+    pub total_samples: u64,
+    /// Distinct values per label dimension, name to count, straight from the
+    /// workload manifest (`WorkloadFile::label_cardinalities`).
+    pub label_cardinalities: BTreeMap<String, u64>,
+    /// Logical (uncompressed, pre-wire) input bytes the generator produced.
+    pub logical_input_bytes: u64,
+    /// Declared series churn, in basis points per hour.
+    pub churn_basis_points_per_hour: u64,
+}
+
+/// The storage backend a run replayed against, and whether it bills for
+/// requests (ADR-0927 decision 10): named at the top level so a reader never
+/// mistakes a MinIO-backed `ci` run's request counts for a real S3 cost.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Substrate {
+    /// The `--store` kind (`memory` or `s3`), as `StoreKind`'s `Display`.
+    pub store_backend: String,
+    /// The configured S3 endpoint's host, when `RAVEL_S3_ENDPOINT` is set.
+    /// Host only: never the scheme, path, or embedded credentials.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_host: Option<String>,
+    /// Whether this substrate bills for requests: false on `MemoryStore` and
+    /// on any store behind a configured endpoint, true only for real S3 with
+    /// no endpoint override (`harness::backend_bills_requests`).
+    pub backend_bills_requests: bool,
+}
+
 /// The whole ingest-lane report: one row per participating system, plus the
 /// separately-recorded query-phase rows.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MetricsIngestReport {
+    /// The profile this run replayed, and its ADR-0927 decision-11 figures.
+    /// Absent only for the internal unit-test rows built directly from
+    /// `SystemIngestResult`s with no profile context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<ProfileRecord>,
+    /// The storage substrate this run replayed against.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub substrate: Option<Substrate>,
     /// Report rows, in the order the systems were replayed.
     pub systems: Vec<SystemIngestResult>,
     /// Query-phase rows, recorded separately from ingest (ADR-0927 decision 9).
@@ -407,9 +500,12 @@ pub struct MetricsIngestReport {
 }
 
 impl MetricsIngestReport {
-    /// Assemble a report from its ingest rows, with no query phase yet.
+    /// Assemble a report from its ingest rows, with no query phase, profile,
+    /// or substrate attached yet.
     pub fn new(systems: Vec<SystemIngestResult>) -> Self {
         MetricsIngestReport {
+            profile: None,
+            substrate: None,
             systems,
             queries: Vec::new(),
         }
@@ -419,6 +515,18 @@ impl MetricsIngestReport {
     /// figures in separate columns.
     pub fn with_query(mut self, query: SystemQueryResult) -> Self {
         self.queries.push(query);
+        self
+    }
+
+    /// Attach the ADR-0927 decision-11 profile record (builder style).
+    pub fn with_profile(mut self, profile: ProfileRecord) -> Self {
+        self.profile = Some(profile);
+        self
+    }
+
+    /// Attach the storage substrate record (builder style).
+    pub fn with_substrate(mut self, substrate: Substrate) -> Self {
+        self.substrate = Some(substrate);
         self
     }
 

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -51,27 +51,44 @@
 //! [`MetricsIngestReport`] carries two blocks so a reader never mistakes a
 //! non-comparable or unbilled run for a publishable result:
 //!
-//! [`ProfileRecord`] (`profile`), the workload's own pre-registered figures
-//! and comparability verdict:
+//! [`ProfileRecord`] (`profile`), the workload's own pre-registered figures,
+//! this run's actual scope, and the comparability verdict:
 //! - `name`: the `--profile` name.
 //! - `comparable`: whether these figures may be published (decision 11).
-//! - `comparability_reason`: why not, when `comparable` is `false`; the
-//!   workload's own `Comparability` reason, never a second hand-written copy.
+//!   Forced `false` when `steps_run < steps_declared`, regardless of the
+//!   profile's own verdict: a truncated run is never that profile.
+//! - `comparability_reason`: why not, present exactly when `comparable` is
+//!   `false`, absent when `true`. The workload's own `Comparability` reason,
+//!   never a second hand-written copy of it, unless the run itself was
+//!   truncated, in which case this states that instead.
 //! - `active_series`: series alive at any one instant, as declared.
-//! - `total_series_created`: distinct series the generator actually created,
-//!   the generator's exact count.
+//! - `steps_run`: steps this run actually generated (the `--steps` flag, or
+//!   `steps_declared` when unset).
+//! - `steps_declared`: the profile's full declared step count
+//!   (`samples_per_series`).
 //! - `samples_per_series`, `scrape_interval_secs`, `duration_secs`,
 //!   `total_samples`, `churn_basis_points_per_hour`: as declared.
 //! - `label_cardinalities`: distinct values per label dimension, name to
-//!   count, read from the manifest.
-//! - `logical_input_bytes`: uncompressed input bytes the generator produced,
-//!   the generator's exact count.
+//!   count, read from the manifest, including the scaling label.
+//! - `families`: one [`FamilyRecord`] per metric family (`name`, `instances`,
+//!   `series_per_instance`), as declared.
+//! - `run`: a [`RunRecord`], scoped to `steps_run`, never the declared full
+//!   profile:
+//!   - `steps`: equal to `steps_run`.
+//!   - `total_series_created`: distinct series the generator actually
+//!     created over these steps, the generator's exact count.
+//!   - `logical_input_bytes`: uncompressed input bytes the generator
+//!     produced over these steps, the generator's exact count.
+//!   - `total_samples_generated`: samples the generator emitted over these
+//!     steps, the generator's exact count.
 //!
 //! [`Substrate`] (`substrate`), the storage backend a run replayed against:
 //! - `store_backend`: the `--store` kind (`memory` or `s3`).
-//! - `endpoint_host`: the configured S3 endpoint's host, when
-//!   `RAVEL_S3_ENDPOINT` is set; absent otherwise. Host only, never
-//!   credentials.
+//! - `endpoint_host`: the configured S3 endpoint's host, when `--store s3`
+//!   and `RAVEL_S3_ENDPOINT` is set; absent for `MemoryStore` regardless of
+//!   the env var, and absent when the var is unset. A scheme-less endpoint
+//!   (`localhost:9000`) still resolves to its host. Host only, never the
+//!   scheme, path, or credentials.
 //! - `backend_bills_requests`: true only for real S3 with no endpoint
 //!   override (decision 10); false on `MemoryStore` and on any store behind a
 //!   configured endpoint, such as the nightly lane's local MinIO.

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -68,8 +68,16 @@
 //!   (`samples_per_series`).
 //! - `samples_per_series`, `scrape_interval_secs`, `duration_secs`,
 //!   `total_samples`, `churn_basis_points_per_hour`: as declared.
-//! - `label_cardinalities`: distinct values per label dimension, name to
-//!   count, read from the manifest, including the scaling label.
+//! - `label_cardinalities`: distinct values per FIXED label dimension, name
+//!   to count, read from the manifest. The scaling label is not a dimension
+//!   (the manifest gate refuses to let it be declared as one) and is never
+//!   in this map; its cardinality depends on the run's churn epochs, so it
+//!   is reported separately below.
+//! - `scaling_label`: the scaling label's name and its declared cardinality:
+//!   - `name`: the scaling label ([`crate::metrics_workload::GeneratorConfig::scaling_label`]).
+//!   - `cardinality_declared`: distinct scaling-label values the profile's
+//!     full declared run (`steps_declared`) would emit, the generator's
+//!     exact count.
 //! - `families`: one [`FamilyRecord`] per metric family (`name`, `instances`,
 //!   `series_per_instance`), as declared.
 //! - `run`: a [`RunRecord`], scoped to `steps_run`, never the declared full
@@ -81,6 +89,8 @@
 //!     produced over these steps, the generator's exact count.
 //!   - `total_samples_generated`: samples the generator emitted over these
 //!     steps, the generator's exact count.
+//!   - `scaling_label_cardinality`: distinct scaling-label values this run
+//!     actually emitted over `steps_run`, the generator's exact count.
 //!
 //! [`Substrate`] (`substrate`), the storage backend a run replayed against:
 //! - `store_backend`: the `--store` kind (`memory` or `s3`).
@@ -479,20 +489,17 @@ pub struct ProfileRecord {
     pub duration_secs: u64,
     /// Total samples the profile declares over its full duration.
     pub total_samples: u64,
-    /// Distinct values per label, name to count, straight from the workload
-    /// manifest (`WorkloadFile::label_cardinalities`) -- including the
-    /// scaling label (`instance`), whose count is the UNION of `families`'
-    /// per-family instance cardinalities below, not their sum: every family
-    /// shares one scaling-label value prefix, so two families' instance
-    /// ranges (each contiguous from 0) routinely overlap.
+    /// Distinct values per FIXED label dimension, name to count, straight
+    /// from the workload manifest (`WorkloadFile::label_cardinalities`). The
+    /// scaling label is never in this map -- the manifest gate refuses to
+    /// let it be declared as an ordinary dimension -- and is reported
+    /// instead under `scaling_label` and `run.scaling_label_cardinality`.
     pub label_cardinalities: BTreeMap<String, u64>,
+    /// The scaling label's name and its declared (full-run) cardinality.
+    pub scaling_label: ScalingLabelRecord,
     /// Declared series churn, in basis points per hour.
     pub churn_basis_points_per_hour: u64,
-    /// Per-family instance counts, so `label_cardinalities`' `instance` count
-    /// is reconstructible: combined with the manifest's own label
-    /// dimensions and `family.labels`, a reader can recompute each family's
-    /// scaling-label cardinality (`WorkloadFile::family_scaling_label_
-    /// cardinality`) and take their maximum.
+    /// Per-family instance counts, as declared.
     pub families: Vec<FamilyRecord>,
     /// Figures scoped to this run's actual `steps_run`, never the declared
     /// full profile: the generator's exact counts over exactly the steps
@@ -515,6 +522,25 @@ pub struct RunRecord {
     /// Samples the generator emitted over these steps (after omissions and
     /// stale markers; the generator's exact count).
     pub total_samples_generated: u64,
+    /// Distinct scaling-label values the generator actually emitted over
+    /// these steps (`Generator::scaling_label_cardinality`), across every
+    /// family and every churn epoch these steps span.
+    pub scaling_label_cardinality: u64,
+}
+
+/// The scaling label's identity and its cardinality over a profile's full
+/// declared run. Named separately from `label_cardinalities` because the
+/// scaling label is not a dimension: the manifest gate refuses to let it be
+/// declared as one, and its cardinality depends on churn epochs rather than
+/// being a fixed, manifest-only count.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScalingLabelRecord {
+    /// The scaling label's name (`GeneratorConfig::scaling_label`).
+    pub name: String,
+    /// Distinct scaling-label values the profile's full declared run
+    /// (`steps_declared`) would emit, across every family and every churn
+    /// epoch it spans (`Generator::scaling_label_cardinality`).
+    pub cardinality_declared: u64,
 }
 
 /// One metric family's exact instance count under the run's profile, and the
@@ -574,6 +600,7 @@ pub fn build_profile_record(
     } else {
         profile.comparability.reason().map(String::from)
     };
+    let generator = crate::metrics_gen::Generator::for_profile(workload, profile, 0);
     ProfileRecord {
         name: profile.name.clone(),
         comparable,
@@ -585,7 +612,11 @@ pub fn build_profile_record(
         scrape_interval_secs: profile.scrape_interval_secs,
         duration_secs: profile.duration_secs,
         total_samples: profile.total_samples,
-        label_cardinalities: workload.label_cardinalities(profile),
+        label_cardinalities: workload.label_cardinalities(),
+        scaling_label: ScalingLabelRecord {
+            name: workload.generator.scaling_label.clone(),
+            cardinality_declared: generator.scaling_label_cardinality(steps_declared as usize),
+        },
         churn_basis_points_per_hour: profile.churn_basis_points_per_hour,
         families,
         run: RunRecord {
@@ -593,6 +624,7 @@ pub fn build_profile_record(
             total_series_created: gen_report.total_series_created,
             logical_input_bytes,
             total_samples_generated: gen_report.emitted_samples,
+            scaling_label_cardinality: generator.scaling_label_cardinality(steps_run as usize),
         },
     }
 }
@@ -2006,6 +2038,22 @@ mod tests {
             "the reason must be the manifest's own reason, not a truncation message, since \
              this run was not truncated"
         );
+
+        assert_eq!(
+            record.scaling_label.name, workload.generator.scaling_label,
+            "scaling_label.name must name the manifest's own scaling label"
+        );
+        let generator = Generator::for_profile(&workload, &profile, 0);
+        assert_eq!(
+            record.scaling_label.cardinality_declared,
+            generator.scaling_label_cardinality(record.steps_declared as usize),
+            "cardinality_declared must be the generator's own figure at steps_declared"
+        );
+        assert_eq!(
+            record.run.scaling_label_cardinality,
+            generator.scaling_label_cardinality(steps as usize),
+            "run.scaling_label_cardinality must be the generator's own figure at steps_run"
+        );
     }
 
     /// The mirror case: a profile whose own verdict IS comparable, but the
@@ -2063,6 +2111,23 @@ mod tests {
             record.comparability_reason,
             Some(expected_reason),
             "the truncation reason must state the run's actual vs declared step counts"
+        );
+
+        let generator = Generator::for_profile(&workload, &profile, 0);
+        assert_eq!(
+            record.scaling_label.name, workload.generator.scaling_label,
+            "scaling_label.name must name the manifest's own scaling label"
+        );
+        assert_eq!(
+            record.scaling_label.cardinality_declared,
+            generator.scaling_label_cardinality(steps_declared as usize),
+            "cardinality_declared must be the generator's own figure at steps_declared"
+        );
+        assert_eq!(
+            record.run.scaling_label_cardinality,
+            generator.scaling_label_cardinality(steps_run as usize),
+            "run.scaling_label_cardinality must be the generator's own figure at steps_run, \
+             not steps_declared"
         );
     }
 }

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -440,11 +440,12 @@ pub struct ProfileRecord {
     /// regardless of the profile's own verdict, when `steps_run <
     /// steps_declared`: a truncated run's figures are not that profile's.
     pub comparable: bool,
-    /// The stated reason when `comparable` is `false`, or `"comparable"`
-    /// otherwise -- [`crate::metrics_workload::Comparability`]'s own
-    /// `Display`, never a second, hand-written copy of it, unless the run
-    /// itself was truncated, in which case this states that instead.
-    pub comparability_reason: String,
+    /// Why `comparable` is `false`; absent when it is `true`. The workload's
+    /// own [`crate::metrics_workload::Comparability::reason`], never a
+    /// second, hand-written copy of it, unless the run itself was
+    /// truncated, in which case this states that instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comparability_reason: Option<String>,
     /// Active series the profile declares.
     pub active_series: u64,
     /// Steps this run actually generated (the `--steps` flag, or

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -561,12 +561,13 @@ pub struct FamilyRecord {
 
 /// Builds the ADR-0927 decision-11 profile block for one run.
 ///
-/// `comparable` is forced `false` whenever `steps_run` truncates `profile`'s
-/// declared `samples_per_series`, regardless of the profile's own verdict --
-/// a truncated run is never that profile's figures. `comparability_reason`
-/// then states the truncation, not the profile's own (possibly `None`)
-/// reason. When the run is not truncated, `comparable` and
-/// `comparability_reason` come straight from `profile.comparability`.
+/// `comparable` is forced `false` whenever `steps_run` differs from
+/// `profile`'s declared `samples_per_series`, regardless of the profile's
+/// own verdict: a run that stopped short or ran long is not that profile's
+/// figures either way. `comparability_reason` then states the step counts,
+/// not the profile's own (possibly `None`) reason. When the run matches the
+/// declared count, `comparable` and `comparability_reason` come straight
+/// from `profile.comparability`.
 ///
 /// A caller passes `steps_run` and `logical_input_bytes` separately from
 /// `gen_report` because both are known before the report is built: the
@@ -589,7 +590,9 @@ pub fn build_profile_record(
         })
         .collect();
     let steps_declared = profile.samples_per_series;
-    let truncated = steps_run < steps_declared;
+    // Any step count other than the profile's own: a short run is not that
+    // profile's figures, and an over-long one is not either.
+    let truncated = steps_run != steps_declared;
     let comparable = profile.is_publishable() && !truncated;
     let comparability_reason = if truncated {
         Some(format!(

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -480,16 +480,18 @@ pub struct ProfileRecord {
     pub total_samples: u64,
     /// Distinct values per label, name to count, straight from the workload
     /// manifest (`WorkloadFile::label_cardinalities`) -- including the
-    /// scaling label (`instance`), whose total is the sum of `families`'
-    /// per-family instance cardinalities below.
+    /// scaling label (`instance`), whose count is the UNION of `families`'
+    /// per-family instance cardinalities below, not their sum: every family
+    /// shares one scaling-label value prefix, so two families' instance
+    /// ranges (each contiguous from 0) routinely overlap.
     pub label_cardinalities: BTreeMap<String, u64>,
     /// Declared series churn, in basis points per hour.
     pub churn_basis_points_per_hour: u64,
-    /// Per-family instance counts, so `label_cardinalities`' `instance` total
+    /// Per-family instance counts, so `label_cardinalities`' `instance` count
     /// is reconstructible: combined with the manifest's own label
     /// dimensions and `family.labels`, a reader can recompute each family's
     /// scaling-label cardinality (`WorkloadFile::family_scaling_label_
-    /// cardinality`) and its sum.
+    /// cardinality`) and take their maximum.
     pub families: Vec<FamilyRecord>,
     /// Figures scoped to this run's actual `steps_run`, never the declared
     /// full profile: the generator's exact counts over exactly the steps

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -98,6 +98,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::metrics_workload::{Profile, WorkloadFile};
 use prost::Message;
 use ravel_catalog::{Catalog, CatalogConfig};
 use ravel_ingest::{
@@ -530,6 +531,70 @@ pub struct FamilyRecord {
     /// Series one instance emits: 1 for a gauge, a counter, or a native
     /// histogram; bounds-plus-3 for a classic histogram.
     pub series_per_instance: u64,
+}
+
+/// Builds the ADR-0927 decision-11 profile block for one run.
+///
+/// `comparable` is forced `false` whenever `steps_run` truncates `profile`'s
+/// declared `samples_per_series`, regardless of the profile's own verdict --
+/// a truncated run is never that profile's figures. `comparability_reason`
+/// then states the truncation, not the profile's own (possibly `None`)
+/// reason. When the run is not truncated, `comparable` and
+/// `comparability_reason` come straight from `profile.comparability`.
+///
+/// A caller passes `steps_run` and `logical_input_bytes` separately from
+/// `gen_report` because both are known before the report is built: the
+/// former is the `--steps` the run resolved to, the latter is the encoded
+/// stream's length before it is parsed back into [`LogicalSample`]s.
+pub fn build_profile_record(
+    workload: &WorkloadFile,
+    profile: &Profile,
+    steps_run: u64,
+    logical_input_bytes: u64,
+    gen_report: &crate::metrics_gen::GenerationReport,
+) -> ProfileRecord {
+    let families = workload
+        .families
+        .iter()
+        .map(|family| FamilyRecord {
+            name: family.name.clone(),
+            instances: workload.family_instances(profile, family),
+            series_per_instance: workload.series_per_instance(family.kind),
+        })
+        .collect();
+    let steps_declared = profile.samples_per_series;
+    let truncated = steps_run < steps_declared;
+    let comparable = profile.is_publishable() && !truncated;
+    let comparability_reason = if truncated {
+        Some(format!(
+            "this run generated {steps_run} of profile `{}`'s {steps_declared} steps, so it is \
+             not that profile and its figures cannot be published",
+            profile.name
+        ))
+    } else {
+        profile.comparability.reason().map(String::from)
+    };
+    ProfileRecord {
+        name: profile.name.clone(),
+        comparable,
+        comparability_reason,
+        active_series: profile.active_series,
+        steps_run,
+        steps_declared,
+        samples_per_series: profile.samples_per_series,
+        scrape_interval_secs: profile.scrape_interval_secs,
+        duration_secs: profile.duration_secs,
+        total_samples: profile.total_samples,
+        label_cardinalities: workload.label_cardinalities(profile),
+        churn_basis_points_per_hour: profile.churn_basis_points_per_hour,
+        families,
+        run: RunRecord {
+            steps: steps_run,
+            total_series_created: gen_report.total_series_created,
+            logical_input_bytes,
+            total_samples_generated: gen_report.emitted_samples,
+        },
+    }
 }
 
 /// The storage backend a run replayed against, and whether it bills for
@@ -1886,6 +1951,118 @@ mod tests {
                 ("instance".to_string(), "mb-instance-0".to_string()),
                 ("job".to_string(), "api".to_string()),
             ]
+        );
+    }
+
+    fn ci_workload() -> WorkloadFile {
+        crate::metrics_workload::load_workload(std::path::Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../benchmarks/metrics/workload.json"
+        )))
+        .expect("load the checked-in workload manifest")
+    }
+
+    /// Covers the nightly full-steps path that the JSON smoke test's
+    /// `--steps 5` run cannot reach: with `steps_run == steps_declared`, the
+    /// truncation branch never fires, so `comparable == false` can only be
+    /// explained by the `ci` profile's own manifest verdict. Before this test
+    /// existed, `--steps 5` forced `comparable` false through truncation on
+    /// every run, and the profile's-own-reason branch in
+    /// `build_profile_record` had zero coverage.
+    #[test]
+    fn profile_record_is_non_comparable_for_the_profiles_own_reason_when_not_truncated() {
+        use crate::metrics_gen::Generator;
+
+        let workload = ci_workload();
+        let ci = workload.profile("ci").expect("ci profile declared");
+        // Small enough to generate fast; steps_run below is set equal to this
+        // so the truncation branch never fires.
+        let steps = 3;
+        let profile = Profile {
+            samples_per_series: steps,
+            ..ci.clone()
+        };
+
+        let (bytes, gen_report) = Generator::new(&workload, "ci", 0)
+            .expect("generator builds")
+            .generate_bytes(steps)
+            .expect("generates steps");
+        let logical_input_bytes = bytes.len() as u64;
+
+        let record =
+            build_profile_record(&workload, &profile, steps, logical_input_bytes, &gen_report);
+
+        assert_eq!(
+            record.steps_run, record.steps_declared,
+            "this test's premise is steps_run == steps_declared"
+        );
+        assert!(
+            !record.comparable,
+            "the ci profile is non-comparable by its own manifest verdict, not by truncation"
+        );
+        assert_eq!(
+            record.comparability_reason.as_deref(),
+            ci.comparability.reason(),
+            "the reason must be the manifest's own reason, not a truncation message, since \
+             this run was not truncated"
+        );
+    }
+
+    /// The mirror case: a profile whose own verdict IS comparable, but the
+    /// run truncates it. `comparable` must still be `false`, and the reason
+    /// must be the truncation message, not the (absent) profile reason --
+    /// the forcing rule in `build_profile_record` applies regardless of the
+    /// profile's own verdict.
+    #[test]
+    fn profile_record_is_non_comparable_from_truncation_even_when_the_profile_is_comparable() {
+        use crate::metrics_gen::Generator;
+        use crate::metrics_workload::Comparability;
+
+        let workload = ci_workload();
+        let ci = workload.profile("ci").expect("ci profile declared");
+        let steps_declared = 10;
+        let steps_run = 3;
+        let profile = Profile {
+            comparability: Comparability::Comparable,
+            samples_per_series: steps_declared,
+            ..ci.clone()
+        };
+        assert!(
+            profile.is_publishable(),
+            "this test's premise is a profile that IS comparable"
+        );
+
+        let (bytes, gen_report) = Generator::new(&workload, "ci", 0)
+            .expect("generator builds")
+            .generate_bytes(steps_run)
+            .expect("generates steps");
+        let logical_input_bytes = bytes.len() as u64;
+
+        let record = build_profile_record(
+            &workload,
+            &profile,
+            steps_run,
+            logical_input_bytes,
+            &gen_report,
+        );
+
+        assert!(
+            steps_run < steps_declared,
+            "this test's premise is a truncated run"
+        );
+        assert!(
+            !record.comparable,
+            "a truncated run is never comparable, even when the profile itself is"
+        );
+        let expected_reason = format!(
+            "this run generated {steps_run} of profile `{}`'s {steps_declared} steps, so it is \
+             not that profile and its figures cannot be published",
+            profile.name
+        );
+        assert_eq!(
+            record.comparability_reason,
+            Some(expected_reason),
+            "the truncation reason must state the run's actual vs declared step counts"
         );
     }
 }

--- a/crates/ravel-bench/src/metrics_ingest.rs
+++ b/crates/ravel-bench/src/metrics_ingest.rs
@@ -424,27 +424,34 @@ pub struct SystemQueryResult {
     pub elapsed_secs: f64,
 }
 
-/// The nine ADR-0927 decision-11 profile figures, plus the workload's own
+/// The ADR-0927 decision-11 profile figures, plus the workload's own
 /// comparability verdict. Every figure here is the profile's pre-registered
-/// value or the generator's exact count -- never derived from the offered
-/// sample count, so a reader can compare this row against the workload
-/// definition directly instead of trusting the run that produced it.
+/// value, the generator's exact count for a run-scoped one (under `run`), or
+/// derived from either -- never from the offered sample count, so a reader
+/// can compare this row against the workload definition directly instead of
+/// trusting the run that produced it.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProfileRecord {
     /// The `--profile` name (`cardinality`, `history`, `churn`, `ci`, ...).
     pub name: String,
     /// Whether this profile's figures may be compared across runs or
     /// systems (ADR-0927 decision 11). `ci` is `false`: it exists for
-    /// reachability, not for a performance or cost claim.
+    /// reachability, not for a performance or cost claim. Also `false`,
+    /// regardless of the profile's own verdict, when `steps_run <
+    /// steps_declared`: a truncated run's figures are not that profile's.
     pub comparable: bool,
     /// The stated reason when `comparable` is `false`, or `"comparable"`
     /// otherwise -- [`crate::metrics_workload::Comparability`]'s own
-    /// `Display`, never a second, hand-written copy of it.
+    /// `Display`, never a second, hand-written copy of it, unless the run
+    /// itself was truncated, in which case this states that instead.
     pub comparability_reason: String,
     /// Active series the profile declares.
     pub active_series: u64,
-    /// Total series the generator actually created over the run.
-    pub total_series_created: u64,
+    /// Steps this run actually generated (the `--steps` flag, or
+    /// `steps_declared` when unset).
+    pub steps_run: u64,
+    /// The profile's full, declared step count (`samples_per_series`).
+    pub steps_declared: u64,
     /// Samples per series per scrape, as declared.
     pub samples_per_series: u64,
     /// Scrape interval, as declared.
@@ -458,8 +465,6 @@ pub struct ProfileRecord {
     /// scaling label (`instance`), whose total is the sum of `families`'
     /// per-family instance cardinalities below.
     pub label_cardinalities: BTreeMap<String, u64>,
-    /// Logical (uncompressed, pre-wire) input bytes the generator produced.
-    pub logical_input_bytes: u64,
     /// Declared series churn, in basis points per hour.
     pub churn_basis_points_per_hour: u64,
     /// Per-family instance counts, so `label_cardinalities`' `instance` total
@@ -468,6 +473,27 @@ pub struct ProfileRecord {
     /// scaling-label cardinality (`WorkloadFile::family_scaling_label_
     /// cardinality`) and its sum.
     pub families: Vec<FamilyRecord>,
+    /// Figures scoped to this run's actual `steps_run`, never the declared
+    /// full profile: the generator's exact counts over exactly the steps
+    /// this run generated.
+    pub run: RunRecord,
+}
+
+/// Figures scoped to the run's actual step count (`ProfileRecord::steps_run`),
+/// as opposed to the profile's declared full-run figures: the generator's
+/// exact counts, never derived from the offered sample count.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RunRecord {
+    /// Steps this run generated. Equal to `ProfileRecord::steps_run`.
+    pub steps: u64,
+    /// Distinct series the generator actually created over these steps.
+    pub total_series_created: u64,
+    /// Logical (uncompressed, pre-wire) input bytes the generator produced
+    /// over these steps.
+    pub logical_input_bytes: u64,
+    /// Samples the generator emitted over these steps (after omissions and
+    /// stale markers; the generator's exact count).
+    pub total_samples_generated: u64,
 }
 
 /// One metric family's exact instance count under the run's profile, and the

--- a/crates/ravel-bench/src/metrics_workload.rs
+++ b/crates/ravel-bench/src/metrics_workload.rs
@@ -253,41 +253,26 @@ impl WorkloadFile {
         self.label_dimensions.iter().find(|d| d.name == name)
     }
 
-    /// Distinct values each label carries under `profile` (ADR-0927 decision
-    /// 11): every declared label dimension's value count, plus the scaling
-    /// label ([`GeneratorConfig::scaling_label`]), which `Generator::labels_for`
-    /// stamps on every series but which the manifest never declares as an
-    /// ordinary dimension.
-    ///
-    /// The scaling label's cardinality is the UNION of the families' distinct
-    /// values, not their sum: every family shares the same
-    /// [`GeneratorConfig::scaling_label_value_prefix`], so two families
-    /// routinely emit the same scaling-label value (under the checked-in
-    /// manifest's `ci` profile, both the gauge family and the native-histogram
-    /// family emit `metricsbench-instance-0`). `Generator::labels_for` assigns
-    /// family `f`'s global instance `i` the value `prefix + i /
-    /// family_fixed_product(f)`, and `i` itself ranges over the contiguous
-    /// `0..family_instances(f)`, so the value ranges over the contiguous
-    /// `0..family_scaling_label_cardinality(f)` -- always starting at 0.  The
-    /// union of a set of ranges that all start at 0 is exactly the widest one,
-    /// so this is the MAXIMUM of [`Self::family_scaling_label_cardinality`]
-    /// over the families, never their sum -- the same figure the generator
-    /// itself would produce by counting distinct emitted values, never a
-    /// formula re-typed against the manifest.
-    pub fn label_cardinalities(&self, profile: &Profile) -> BTreeMap<String, u64> {
-        let mut out: BTreeMap<String, u64> = self
-            .label_dimensions
+    /// Distinct values each FIXED label dimension carries: every dimension
+    /// the manifest declares in `label_dimensions`, name to value count. This
+    /// deliberately excludes the scaling label
+    /// ([`GeneratorConfig::scaling_label`]): its cardinality depends on the
+    /// run's churn epochs (`Generator::generate_into` offsets each family's
+    /// instance ordinal per epoch), a single-epoch, manifest-only formula
+    /// cannot state it, and the manifest gate (`gate_workload`) refuses to
+    /// let the scaling label be declared as an ordinary dimension here in
+    /// the first place. The artifact reports the scaling label's
+    /// cardinality separately, computed by
+    /// [`crate::metrics_gen::Generator::scaling_label_cardinality`] for a
+    /// concrete step count: as `profile.scaling_label.cardinality_declared`
+    /// (evaluated at the profile's declared step count) and as
+    /// `profile.run.scaling_label_cardinality` (evaluated at the steps the
+    /// run actually generated).
+    pub fn label_cardinalities(&self) -> BTreeMap<String, u64> {
+        self.label_dimensions
             .iter()
             .map(|d| (d.name.clone(), d.values.len() as u64))
-            .collect();
-        let scaling_distinct: u64 = self
-            .families
-            .iter()
-            .map(|family| self.family_scaling_label_cardinality(profile, family))
-            .max()
-            .unwrap_or(0);
-        out.insert(self.generator.scaling_label.clone(), scaling_distinct);
-        out
+            .collect()
     }
 
     /// Cardinality of each of `family`'s fixed label dimensions, in
@@ -306,28 +291,6 @@ impl WorkloadFile {
                     .max(1)
             })
             .collect()
-    }
-
-    /// Distinct label combinations one scaling-label ordinal spans before
-    /// `Generator::labels_for` advances it: the product of `family`'s fixed
-    /// label-dimension cardinalities.
-    pub fn family_fixed_product(&self, family: &MetricFamily) -> u64 {
-        self.family_dimension_cardinalities(family)
-            .into_iter()
-            .product()
-    }
-
-    /// Distinct scaling-label values `family` uses under `profile`:
-    /// `Generator::labels_for` assigns the scaling label
-    /// `global / fixed_product`, so this is `ceil(instances /
-    /// family_fixed_product)`.
-    pub fn family_scaling_label_cardinality(
-        &self,
-        profile: &Profile,
-        family: &MetricFamily,
-    ) -> u64 {
-        let instances = self.family_instances(profile, family);
-        instances.div_ceil(self.family_fixed_product(family).max(1))
     }
 
     /// Time series one instance of `kind` emits: one for a gauge, a counter, or

--- a/crates/ravel-bench/src/metrics_workload.rs
+++ b/crates/ravel-bench/src/metrics_workload.rs
@@ -257,23 +257,36 @@ impl WorkloadFile {
     /// 11): every declared label dimension's value count, plus the scaling
     /// label ([`GeneratorConfig::scaling_label`]), which `Generator::labels_for`
     /// stamps on every series but which the manifest never declares as an
-    /// ordinary dimension. The scaling label's cardinality varies by
-    /// profile (it depends on `family_instances`), so it is derived per
-    /// family and summed here from [`Self::family_scaling_label_cardinality`]
-    /// -- the same figures the generator itself computes -- never a formula
-    /// re-typed against the manifest.
+    /// ordinary dimension.
+    ///
+    /// The scaling label's cardinality is the UNION of the families' distinct
+    /// values, not their sum: every family shares the same
+    /// [`GeneratorConfig::scaling_label_value_prefix`], so two families
+    /// routinely emit the same scaling-label value (under the checked-in
+    /// manifest's `ci` profile, both the gauge family and the native-histogram
+    /// family emit `metricsbench-instance-0`). `Generator::labels_for` assigns
+    /// family `f`'s global instance `i` the value `prefix + i /
+    /// family_fixed_product(f)`, and `i` itself ranges over the contiguous
+    /// `0..family_instances(f)`, so the value ranges over the contiguous
+    /// `0..family_scaling_label_cardinality(f)` -- always starting at 0.  The
+    /// union of a set of ranges that all start at 0 is exactly the widest one,
+    /// so this is the MAXIMUM of [`Self::family_scaling_label_cardinality`]
+    /// over the families, never their sum -- the same figure the generator
+    /// itself would produce by counting distinct emitted values, never a
+    /// formula re-typed against the manifest.
     pub fn label_cardinalities(&self, profile: &Profile) -> BTreeMap<String, u64> {
         let mut out: BTreeMap<String, u64> = self
             .label_dimensions
             .iter()
             .map(|d| (d.name.clone(), d.values.len() as u64))
             .collect();
-        let scaling_total: u64 = self
+        let scaling_distinct: u64 = self
             .families
             .iter()
             .map(|family| self.family_scaling_label_cardinality(profile, family))
-            .sum();
-        out.insert(self.generator.scaling_label.clone(), scaling_total);
+            .max()
+            .unwrap_or(0);
+        out.insert(self.generator.scaling_label.clone(), scaling_distinct);
         out
     }
 

--- a/crates/ravel-bench/src/metrics_workload.rs
+++ b/crates/ravel-bench/src/metrics_workload.rs
@@ -266,16 +266,68 @@ impl WorkloadFile {
         self.label_dimensions.iter().find(|d| d.name == name)
     }
 
-    /// Distinct values each label dimension declares, name to count
-    /// (ADR-0927 decision 11). A direct read of the manifest: every label
-    /// value a generated series carries comes from exactly these dimensions
-    /// (`Generator::labels_for`), so this is the generator's own source, not
-    /// a re-derivation from generated output.
-    pub fn label_cardinalities(&self) -> BTreeMap<String, u64> {
-        self.label_dimensions
+    /// Distinct values each label carries under `profile` (ADR-0927 decision
+    /// 11): every declared label dimension's value count, plus the scaling
+    /// label ([`GeneratorConfig::scaling_label`]), which `Generator::labels_for`
+    /// stamps on every series but which the manifest never declares as an
+    /// ordinary dimension. The scaling label's cardinality varies by
+    /// profile (it depends on `family_instances`), so it is derived per
+    /// family and summed here from [`Self::family_scaling_label_cardinality`]
+    /// -- the same figures the generator itself computes -- never a formula
+    /// re-typed against the manifest.
+    pub fn label_cardinalities(&self, profile: &Profile) -> BTreeMap<String, u64> {
+        let mut out: BTreeMap<String, u64> = self
+            .label_dimensions
             .iter()
             .map(|d| (d.name.clone(), d.values.len() as u64))
+            .collect();
+        let scaling_total: u64 = self
+            .families
+            .iter()
+            .map(|family| self.family_scaling_label_cardinality(profile, family))
+            .sum();
+        out.insert(self.generator.scaling_label.clone(), scaling_total);
+        out
+    }
+
+    /// Cardinality of each of `family`'s fixed label dimensions, in
+    /// `family.labels` order. Falls back to a single-valued dimension for a
+    /// name `gate_workload` would have refused as undeclared, matching
+    /// [`crate::metrics_gen::Generator::new`]'s own fallback so the two never
+    /// disagree about a manifest that never passed the gate.
+    pub(crate) fn family_dimension_cardinalities(&self, family: &MetricFamily) -> Vec<u64> {
+        family
+            .labels
+            .iter()
+            .map(|label| {
+                self.dimension(label)
+                    .map(|d| d.values.len() as u64)
+                    .unwrap_or(1)
+                    .max(1)
+            })
             .collect()
+    }
+
+    /// Distinct label combinations one scaling-label ordinal spans before
+    /// `Generator::labels_for` advances it: the product of `family`'s fixed
+    /// label-dimension cardinalities.
+    pub fn family_fixed_product(&self, family: &MetricFamily) -> u64 {
+        self.family_dimension_cardinalities(family)
+            .into_iter()
+            .product()
+    }
+
+    /// Distinct scaling-label values `family` uses under `profile`:
+    /// `Generator::labels_for` assigns the scaling label
+    /// `global / fixed_product`, so this is `ceil(instances /
+    /// family_fixed_product)`.
+    pub fn family_scaling_label_cardinality(
+        &self,
+        profile: &Profile,
+        family: &MetricFamily,
+    ) -> u64 {
+        let instances = self.family_instances(profile, family);
+        instances.div_ceil(self.family_fixed_product(family).max(1))
     }
 
     /// Time series one instance of `kind` emits: one for a gauge, a counter, or

--- a/crates/ravel-bench/src/metrics_workload.rs
+++ b/crates/ravel-bench/src/metrics_workload.rs
@@ -72,19 +72,6 @@ impl Comparability {
     }
 }
 
-impl std::fmt::Display for Comparability {
-    /// `"comparable"` for [`Comparability::Comparable`], the stated reason
-    /// for [`Comparability::NonComparable`]. The single formatting a reader
-    /// of an artifact's `comparability_reason` field is built from, so that
-    /// field is never a second, hand-written copy of this reason.
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Comparability::Comparable => write!(f, "comparable"),
-            Comparability::NonComparable { reason } => write!(f, "{reason}"),
-        }
-    }
-}
-
 /// One workload profile: one axis varied, the others pinned.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/ravel-bench/src/metrics_workload.rs
+++ b/crates/ravel-bench/src/metrics_workload.rs
@@ -15,7 +15,7 @@
 //! [`Profile::is_publishable`] is that check, and [`gate_workload`] refuses a
 //! manifest that marks `ci` comparable at all.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -68,6 +68,19 @@ impl Comparability {
         match self {
             Comparability::Comparable => None,
             Comparability::NonComparable { reason } => Some(reason),
+        }
+    }
+}
+
+impl std::fmt::Display for Comparability {
+    /// `"comparable"` for [`Comparability::Comparable`], the stated reason
+    /// for [`Comparability::NonComparable`]. The single formatting a reader
+    /// of an artifact's `comparability_reason` field is built from, so that
+    /// field is never a second, hand-written copy of this reason.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Comparability::Comparable => write!(f, "comparable"),
+            Comparability::NonComparable { reason } => write!(f, "{reason}"),
         }
     }
 }
@@ -251,6 +264,18 @@ impl WorkloadFile {
     /// The label dimension named `name`, or `None`.
     pub fn dimension(&self, name: &str) -> Option<&LabelDimension> {
         self.label_dimensions.iter().find(|d| d.name == name)
+    }
+
+    /// Distinct values each label dimension declares, name to count
+    /// (ADR-0927 decision 11). A direct read of the manifest: every label
+    /// value a generated series carries comes from exactly these dimensions
+    /// (`Generator::labels_for`), so this is the generator's own source, not
+    /// a re-derivation from generated output.
+    pub fn label_cardinalities(&self) -> BTreeMap<String, u64> {
+        self.label_dimensions
+            .iter()
+            .map(|d| (d.name.clone(), d.values.len() as u64))
+            .collect()
     }
 
     /// Time series one instance of `kind` emits: one for a gauge, a counter, or

--- a/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
+++ b/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
@@ -40,6 +40,35 @@ fn run_lane() -> serde_json::Value {
     serde_json::from_slice(&output.stdout).expect("stdout is a JSON report")
 }
 
+/// Run the bin over the `ci` profile's FULL step count (no `--steps`
+/// override): the two decision-11 figures sourced from the generator's exact
+/// output (`total_series_created`, `logical_input_bytes`) are only
+/// comparable to the profile's declared figures over a complete run, not a
+/// truncated one.
+fn run_lane_full_profile() -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_metricsbench_ingest");
+    let output = Command::new(bin)
+        .args([
+            "--profile",
+            "ci",
+            "--store",
+            "memory",
+            "--shards",
+            "2",
+            "--batch-size",
+            "4096",
+        ])
+        .output()
+        .expect("spawn metricsbench_ingest");
+    assert!(
+        output.status.success(),
+        "metricsbench_ingest exited non-zero: status={:?} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("stdout is a JSON report")
+}
+
 #[test]
 fn the_ingest_lane_is_reachable_from_the_bin_and_ravel_is_durable_on_ack() {
     let report = run_lane();
@@ -114,4 +143,104 @@ fn the_ingest_lane_is_reachable_from_the_bin_and_ravel_is_durable_on_ack() {
         ravel_query["eval_ts_ms"].as_i64().is_some(),
         "the query records the instant it evaluated at (the replay's newest sample)"
     );
+}
+
+/// ADR-0927 decision 11: the artifact carries a top-level `profile` block
+/// naming the `ci` profile as non-comparable, with its reason, and the nine
+/// pre-registered/generator-exact figures -- not a set of numbers a reader
+/// could mistake for a comparable result.
+///
+/// TO SEE THIS FAIL against the pre-fix binary: drop `.with_profile(profile_record)`
+/// in `metricsbench_ingest`'s `run`; the top-level `profile` key is then absent
+/// and the first assertion below fails.
+#[test]
+fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures() {
+    let workload = ravel_bench::metrics_workload::load_workload(std::path::Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/metrics/workload.json"
+    )))
+    .expect("load the same workload manifest the binary loads");
+    let expected = workload
+        .profile("ci")
+        .expect("manifest declares a `ci` profile");
+    let expected_label_cardinalities = workload.label_cardinalities();
+
+    // No `--steps` override: the generator-exact figures (`total_series_created`,
+    // `logical_input_bytes`) are only comparable to the profile's declared
+    // figures over a full run.
+    let report = run_lane_full_profile();
+    let profile = &report["profile"];
+
+    assert_eq!(
+        profile["comparable"].as_bool(),
+        Some(false),
+        "the `ci` profile is never comparable (ADR-0927 decision 11)"
+    );
+    let reason = profile["comparability_reason"]
+        .as_str()
+        .expect("comparability_reason is a string");
+    assert!(
+        !reason.is_empty(),
+        "a non-comparable profile must state why, not leave the reason blank"
+    );
+    assert_eq!(profile["name"].as_str(), Some("ci"));
+    assert_eq!(
+        profile["active_series"].as_u64(),
+        Some(expected.active_series)
+    );
+    assert_eq!(
+        profile["samples_per_series"].as_u64(),
+        Some(expected.samples_per_series)
+    );
+    assert_eq!(
+        profile["scrape_interval_secs"].as_u64(),
+        Some(expected.scrape_interval_secs)
+    );
+    assert_eq!(
+        profile["duration_secs"].as_u64(),
+        Some(expected.duration_secs)
+    );
+    assert_eq!(
+        profile["total_samples"].as_u64(),
+        Some(expected.total_samples)
+    );
+    assert_eq!(
+        profile["churn_basis_points_per_hour"].as_u64(),
+        Some(expected.churn_basis_points_per_hour)
+    );
+    // `ci` declares zero churn, so the generator creates exactly the active
+    // set and no churned-in cohorts: the generator's exact count and the
+    // manifest's declared count coincide, and either is the correct
+    // expectation here.
+    assert_eq!(
+        profile["total_series_created"].as_u64(),
+        Some(expected.active_series),
+        "with zero churn, total series created must equal the declared active set"
+    );
+    assert!(
+        profile["logical_input_bytes"]
+            .as_u64()
+            .is_some_and(|b| b > 0),
+        "the generator produced a non-empty logical input stream"
+    );
+    let label_cardinalities = profile["label_cardinalities"]
+        .as_object()
+        .expect("label_cardinalities is present");
+    assert_eq!(
+        label_cardinalities.len(),
+        expected_label_cardinalities.len(),
+        "every label dimension the manifest declares must be reported"
+    );
+    for (name, count) in &expected_label_cardinalities {
+        assert_eq!(
+            label_cardinalities.get(name).and_then(|v| v.as_u64()),
+            Some(*count),
+            "label dimension `{name}`'s distinct-value count must match the manifest"
+        );
+    }
+
+    // The substrate block: an in-process MemoryStore never bills.
+    let substrate = &report["substrate"];
+    assert_eq!(substrate["store_backend"].as_str(), Some("memory"));
+    assert_eq!(substrate["backend_bills_requests"].as_bool(), Some(false));
 }

--- a/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
+++ b/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
@@ -163,7 +163,7 @@ fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures(
     let expected = workload
         .profile("ci")
         .expect("manifest declares a `ci` profile");
-    let expected_label_cardinalities = workload.label_cardinalities();
+    let expected_label_cardinalities = workload.label_cardinalities(expected);
 
     // No `--steps` override: the generator-exact figures (`total_series_created`,
     // `logical_input_bytes`) are only comparable to the profile's declared

--- a/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
+++ b/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
@@ -208,20 +208,41 @@ fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures(
         profile["churn_basis_points_per_hour"].as_u64(),
         Some(expected.churn_basis_points_per_hour)
     );
+    // A full, untruncated run: steps_run equals the profile's own declared
+    // step count.
+    assert_eq!(
+        profile["steps_declared"].as_u64(),
+        Some(expected.samples_per_series)
+    );
+    assert_eq!(
+        profile["steps_run"].as_u64(),
+        profile["steps_declared"].as_u64(),
+        "run_lane_full_profile() takes no --steps override, so the run is complete"
+    );
+    let run = &profile["run"];
+    assert_eq!(
+        run["steps"].as_u64(),
+        profile["steps_run"].as_u64(),
+        "run.steps must name the same basis as steps_run"
+    );
     // `ci` declares zero churn, so the generator creates exactly the active
     // set and no churned-in cohorts: the generator's exact count and the
     // manifest's declared count coincide, and either is the correct
     // expectation here.
     assert_eq!(
-        profile["total_series_created"].as_u64(),
+        run["total_series_created"].as_u64(),
         Some(expected.active_series),
         "with zero churn, total series created must equal the declared active set"
     );
     assert!(
-        profile["logical_input_bytes"]
-            .as_u64()
-            .is_some_and(|b| b > 0),
+        run["logical_input_bytes"].as_u64().is_some_and(|b| b > 0),
         "the generator produced a non-empty logical input stream"
+    );
+    assert!(
+        run["total_samples_generated"]
+            .as_u64()
+            .is_some_and(|s| s > 0),
+        "the generator emitted a non-empty sample count"
     );
     let label_cardinalities = profile["label_cardinalities"]
         .as_object()

--- a/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
+++ b/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
@@ -184,10 +184,15 @@ fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures(
     let report = run_lane_with_steps(STEPS);
     let profile = &report["profile"];
 
+    // This run truncates the profile (STEPS < samples_per_series, asserted
+    // below), so this only exercises the truncation branch of
+    // `build_profile_record`, not the `ci` profile's own non-comparable
+    // verdict -- a full, untruncated `ci` run is covered separately by
+    // `metrics_ingest::tests::profile_record_is_non_comparable_for_the_profiles_own_reason_when_not_truncated`.
     assert_eq!(
         profile["comparable"].as_bool(),
         Some(false),
-        "the `ci` profile is never comparable (ADR-0927 decision 11)"
+        "a truncated run is never comparable, regardless of the profile's own verdict"
     );
     let reason = profile["comparability_reason"]
         .as_str()
@@ -195,6 +200,10 @@ fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures(
     assert!(
         !reason.is_empty(),
         "a non-comparable profile must state why, not leave the reason blank"
+    );
+    assert!(
+        reason.contains("steps"),
+        "a truncated run's reason must state the truncation, not the profile's own verdict: {reason}"
     );
     assert_eq!(profile["name"].as_str(), Some("ci"));
     assert_eq!(

--- a/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
+++ b/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
@@ -40,12 +40,9 @@ fn run_lane() -> serde_json::Value {
     serde_json::from_slice(&output.stdout).expect("stdout is a JSON report")
 }
 
-/// Run the bin over the `ci` profile's FULL step count (no `--steps`
-/// override): the two decision-11 figures sourced from the generator's exact
-/// output (`total_series_created`, `logical_input_bytes`) are only
-/// comparable to the profile's declared figures over a complete run, not a
-/// truncated one.
-fn run_lane_full_profile() -> serde_json::Value {
+/// Run the bin over the `ci` profile for exactly `steps` scrapes (no
+/// assumption that `steps` covers the profile's full declared step count).
+fn run_lane_with_steps(steps: u64) -> serde_json::Value {
     let bin = env!("CARGO_BIN_EXE_metricsbench_ingest");
     let output = Command::new(bin)
         .args([
@@ -53,6 +50,8 @@ fn run_lane_full_profile() -> serde_json::Value {
             "ci",
             "--store",
             "memory",
+            "--steps",
+            &steps.to_string(),
             "--shards",
             "2",
             "--batch-size",
@@ -146,9 +145,18 @@ fn the_ingest_lane_is_reachable_from_the_bin_and_ravel_is_durable_on_ack() {
 }
 
 /// ADR-0927 decision 11: the artifact carries a top-level `profile` block
-/// naming the `ci` profile as non-comparable, with its reason, and the nine
-/// pre-registered/generator-exact figures -- not a set of numbers a reader
-/// could mistake for a comparable result.
+/// naming the `ci` profile as non-comparable, with its reason, the
+/// pre-registered declared figures, and (under `run`) the generator-exact
+/// figures for the steps this run actually generated -- not a set of numbers
+/// a reader could mistake for a comparable result.
+///
+/// The `ci` profile's full declared run (120 steps, `samples_per_series`)
+/// measures ~64s unoptimized on this host, over the 60s this test must stay
+/// under, so this drives the bin over a short, deliberately truncated
+/// `--steps` count instead and asserts `run`'s figures against the
+/// generator's own [`ravel_bench::metrics_gen::Generator::total_series_created`]
+/// for that exact step count -- never a re-typed formula -- while the
+/// declared figures are still asserted against the manifest.
 ///
 /// TO SEE THIS FAIL against the pre-fix binary: drop `.with_profile(profile_record)`
 /// in `metricsbench_ingest`'s `run`; the top-level `profile` key is then absent
@@ -165,10 +173,15 @@ fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures(
         .expect("manifest declares a `ci` profile");
     let expected_label_cardinalities = workload.label_cardinalities(expected);
 
-    // No `--steps` override: the generator-exact figures (`total_series_created`,
-    // `logical_input_bytes`) are only comparable to the profile's declared
-    // figures over a full run.
-    let report = run_lane_full_profile();
+    // A deliberate truncation: far under the profile's declared
+    // `samples_per_series` (120), so the run finishes fast regardless of host
+    // load.
+    const STEPS: u64 = 5;
+    let generator = ravel_bench::metrics_gen::Generator::new(&workload, "ci", 0)
+        .expect("generator builds for the ci profile");
+    let expected_total_series_created = generator.total_series_created(STEPS);
+
+    let report = run_lane_with_steps(STEPS);
     let profile = &report["profile"];
 
     assert_eq!(
@@ -208,16 +221,16 @@ fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures(
         profile["churn_basis_points_per_hour"].as_u64(),
         Some(expected.churn_basis_points_per_hour)
     );
-    // A full, untruncated run: steps_run equals the profile's own declared
-    // step count.
+    // A deliberately truncated run: steps_run is this test's short STEPS, not
+    // the profile's full declared step count.
     assert_eq!(
         profile["steps_declared"].as_u64(),
         Some(expected.samples_per_series)
     );
-    assert_eq!(
-        profile["steps_run"].as_u64(),
-        profile["steps_declared"].as_u64(),
-        "run_lane_full_profile() takes no --steps override, so the run is complete"
+    assert_eq!(profile["steps_run"].as_u64(), Some(STEPS));
+    assert!(
+        STEPS < expected.samples_per_series,
+        "STEPS must actually truncate the profile for this test to exercise that path"
     );
     let run = &profile["run"];
     assert_eq!(
@@ -225,14 +238,10 @@ fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures(
         profile["steps_run"].as_u64(),
         "run.steps must name the same basis as steps_run"
     );
-    // `ci` declares zero churn, so the generator creates exactly the active
-    // set and no churned-in cohorts: the generator's exact count and the
-    // manifest's declared count coincide, and either is the correct
-    // expectation here.
     assert_eq!(
         run["total_series_created"].as_u64(),
-        Some(expected.active_series),
-        "with zero churn, total series created must equal the declared active set"
+        Some(expected_total_series_created),
+        "total series created must match the generator's own count for this run's steps"
     );
     assert!(
         run["logical_input_bytes"].as_u64().is_some_and(|b| b > 0),

--- a/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
+++ b/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
@@ -289,12 +289,12 @@ fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures(
     );
     assert_eq!(
         scaling_label["cardinality_declared"].as_u64(),
-        Some(generator.scaling_label_cardinality(expected.samples_per_series as usize)),
+        Some(generator.scaling_label_cardinality(expected.samples_per_series)),
         "cardinality_declared must match the generator's own figure at the declared step count"
     );
     assert_eq!(
         run["scaling_label_cardinality"].as_u64(),
-        Some(generator.scaling_label_cardinality(STEPS as usize)),
+        Some(generator.scaling_label_cardinality(STEPS)),
         "run.scaling_label_cardinality must match the generator's own figure at steps_run"
     );
 

--- a/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
+++ b/crates/ravel-bench/tests/metricsbench_ingest_smoke.rs
@@ -171,7 +171,7 @@ fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures(
     let expected = workload
         .profile("ci")
         .expect("manifest declares a `ci` profile");
-    let expected_label_cardinalities = workload.label_cardinalities(expected);
+    let expected_label_cardinalities = workload.label_cardinalities();
 
     // A deliberate truncation: far under the profile's declared
     // `samples_per_series` (120), so the run finishes fast regardless of host
@@ -277,6 +277,26 @@ fn ci_profile_artifact_is_marked_non_comparable_and_carries_the_profile_figures(
             "label dimension `{name}`'s distinct-value count must match the manifest"
         );
     }
+    assert!(
+        !label_cardinalities.contains_key(&workload.generator.scaling_label),
+        "the scaling label is not a fixed dimension and must not appear in label_cardinalities"
+    );
+
+    let scaling_label = &profile["scaling_label"];
+    assert_eq!(
+        scaling_label["name"].as_str(),
+        Some(workload.generator.scaling_label.as_str())
+    );
+    assert_eq!(
+        scaling_label["cardinality_declared"].as_u64(),
+        Some(generator.scaling_label_cardinality(expected.samples_per_series as usize)),
+        "cardinality_declared must match the generator's own figure at the declared step count"
+    );
+    assert_eq!(
+        run["scaling_label_cardinality"].as_u64(),
+        Some(generator.scaling_label_cardinality(STEPS as usize)),
+        "run.scaling_label_cardinality must match the generator's own figure at steps_run"
+    );
 
     // The substrate block: an in-process MemoryStore never bills.
     let substrate = &report["substrate"];


### PR DESCRIPTION
The MetricsBench ingest artifact carried throughput and latency figures with nothing in it saying the `ci` profile is non-comparable, none of the profile figures ADR-0927 decision 11 requires, and `backend_bills_requests: true` on a MinIO endpoint that bills nothing.

The artifact now carries a `profile` block: the profile name, `comparable`, `comparability_reason` taken from the workload's own `Comparability` and present only when it is false, the declared figures (`active_series`, `samples_per_series`, `scrape_interval_secs`, `duration_secs`, `total_samples`, `churn_basis_points_per_hour`, `label_cardinalities` for the fixed dimensions), a `families` list, and a `scaling_label` block. Figures scoped to the run sit under `run` (`steps`, `total_series_created`, `logical_input_bytes`, `total_samples_generated`, `scaling_label_cardinality`) beside `steps_run` and `steps_declared`, so no figure's basis is ambiguous; a truncated run is forced non-comparable whatever the profile says. A `substrate` block names the store backend, the endpoint host when one is configured (host only) and `backend_bills_requests`, which is now true only for S3 with no endpoint override, through one helper both binaries call.

The scaling label needed its own treatment. It is stamped on every series by the generator and is not a manifest dimension, so it is reported separately, and its cardinality comes from the generator rather than a formula: the emitted ordinal ranges are offset per churn epoch, so a manifest-derived figure is right only for a single-epoch run and under-reports the `churn` profile by about 8x. `Generator::scaling_label_cardinality(steps)` unions the per-family, per-epoch ranges from the same variables the emitting loop reads, and two tests check it against the distinct values a real generation emits: the zero-churn `ci` case at 34, and a three-epoch churn fixture at 60 where the old formula gives 30.

Fixes: #1352
