### PR TITLE
docs: amend ADR-1374 so a cursor pins resolve inputs, not segments

### DIFF
--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -586,3 +586,37 @@ their 4 KiB allowance. D4 and D5 name the evidence digest field
 cannot be verified by a reader who trusts the name. D5 states that an
 evidence reference presented after its pin has passed redeems as unpinned,
 re-executing fresh, rather than failing as expired.
+
+**Amendment (2026-09-09, #1501).** D4 bounds the scalar fields, including
+`presentation.cursor`, to 4 KiB together. D5 requires the cursor to carry
+the pinned segment set, and one `SegmentPin` costs about 250 B plus
+base64: the 2,000-segment admission figure in D6 yields a token of several
+hundred KiB, over the whole 256 KiB response floor. This amendment
+replaces the segment-enumeration cursor with a resolve-input cursor and
+gives it its own bound.
+
+1. A cursor pins its snapshot by resolve inputs, not by segment
+   enumeration: the tenant hash, the signal, the half-open time range, the
+   minimum commit-token watermark the page was resolved against, the
+   pending erasure predicates in force, the declared column set, and the
+   keyset position (the last tuple of the page and the `ORDER BY` it was
+   taken under). Redemption re-resolves the snapshot against that
+   watermark deterministically. When the re-resolve cannot reproduce the
+   pinned watermark (a compaction past the protection horizon, a newer
+   erasure), redemption fails with `cursor_expired` and the caller re-runs
+   the query. A tampered or wrong-tenant token stays `cursor_invalid`. The
+   dead-process rule, the tenant binding, the tool and argument-hash
+   binding, and the deadline clamp are unchanged.
+2. The cursor leaves the 4 KiB scalar allowance of D4 and gets its own
+   4 KiB bound, accounted for in the fixed part of the envelope. The
+   maximal fixed part is now the D4 list bounds plus the 4 KiB scalar
+   allowance (102 KiB, unchanged) plus the new 4 KiB cursor bound, 106 KiB,
+   which stays under the 256 KiB floor. A cursor over its bound is a
+   server defect, not a client-visible degradation: the envelope reports
+   it as an `internal` failure rather than silently paging without a
+   cursor.
+3. Evidence references are unchanged: each pins one row's segment with a
+   `SegmentPin`, and the pin-codec reuse of D9 stays for them.
+4. The shipped cursor codec (segment enumeration) is replaced by the
+   resolve-input form before the first paging tool ships (#1380); until
+   then no tool mints a cursor.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -69,12 +69,12 @@ Three counters say what the fit removed outside `data.rows`.
 `metadata_elided` counts list entries dropped because their list was over
 its count bound. `entries_truncated` counts entries kept but cut because
 the entry was over its own size bound; a cut entry carries a truncation
-marker. `scalars_truncated` counts scalar cuts and the cursor drop.
-Sub-bounded scalars are cut to their own bounds first. The allowance pass
-then cuts `plan`, the failure message, and the budget values. If the
-scalars are still over, the cursor is dropped and announced with a
-warning and a next step. Cutting a token breaks its authentication code,
-so it is dropped rather than cut.
+marker. `scalars_truncated` counts scalar cuts. Sub-bounded scalars are
+cut to their own bounds first. The allowance pass then cuts `plan`, the
+failure message, and the budget values. The cursor carries its own 4 KiB
+bound, separate from the scalar allowance. A cursor over its bound is
+never cut, because cutting a token breaks its authentication code; it is
+a server defect reported as an `internal` failure.
 
 The first-row guarantee applies to the byte cap. It does not apply to
 the row cap. When the equal-group rule leaves no complete group inside
@@ -113,16 +113,22 @@ the protocol level instead.
 
 A cursor is a token with a keyed message authentication code, minted fresh
 for each call rather than stored server-side. It carries the tenant hash,
-the tool name, a hash of the arguments, the position to resume from, and
-the pinned snapshot, including which erasure predicates were pending and
-which typed attribute columns were declared at mint time.
+the tool name, a hash of the arguments, the signal, the half-open time
+range, the minimum commit-token watermark the page was resolved against,
+which erasure predicates were pending, which typed attribute columns were
+declared, and the position to resume from. It pins a snapshot by these
+resolve inputs, not by enumerating segments.
 
 A cursor stays valid until the earlier of the call's remaining deadline
 and the protection horizon minus the grace period. Redeeming a cursor
-re-executes the original statement against the pinned snapshot with a
-keyset predicate; the server holds nothing in between calls. Only the
-process that minted a cursor can redeem it, so a load balancer needs
-sticky routing to a paging client.
+re-resolves the snapshot deterministically from the pinned watermark and
+re-executes the original statement against it with a keyset predicate; the
+server holds nothing in between calls. Only the process that minted a
+cursor can redeem it, so a load balancer needs sticky routing to a paging
+client. When the re-resolve cannot reproduce the pinned watermark, because
+a compaction or a newer erasure moved past it, redemption fails with
+`cursor_expired` and the caller re-runs the query. A tampered or
+wrong-tenant token fails with `cursor_invalid`.
 
 `ravel_query_sql` mints a cursor only when the statement's `ORDER BY`,
 plus a tiebreak the tool appends, is a total order over the projection.
@@ -173,6 +179,7 @@ failure.
 | `max_response_bytes` | 512 KiB | floor 256 KiB | yes, raised to the floor if lower |
 | `max_response_bytes` ceiling | 4 MiB | an operator may configure a lower one | no; a larger request clamps to it |
 | cursor or evidence token length | 1 MiB | fixed | no; a longer token is refused unread |
+| `presentation.cursor` in the envelope | 4 KiB | fixed | no; a cursor over its bound is an `internal` failure |
 | metric families per `ravel_describe_data` page | 100 | fixed | no |
 | segments admitted for `ravel_find_labels` resolution | 2,000 | fixed | no |
 


### PR DESCRIPTION
The envelope bounds its scalar fields to 4 KiB together, and the cursor
was one of them, while the cursor decision required it to carry the
pinned segment set. A snapshot of the size the budget decision admits
encodes to several hundred kilobytes, larger than the whole response
floor, so the two rules could not both hold.

A cursor now pins its snapshot by the inputs that produced it: the
tenant, the signal, the time range, the commit-token watermark, the
erasure predicates in force, the declared columns, and the keyset
position. Redemption re-resolves against that watermark and fails as
expired when it cannot reproduce it. The cursor leaves the scalar
allowance and gets its own four kilobyte bound, and a cursor over that
bound is an internal failure rather than a silent page without a cursor.
Evidence references still pin one row's segment.

The reference page describes the new cursor contents, the redemption
outcomes, and the cursor's own bound.

Refs: #1501
Refs: #1374
