### PR TITLE
fix(fleet-task-spec): repair the executor preamble and the guard it calls

### DIFF
--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -83,6 +83,40 @@ tool-result can report a false "affected-tests passed" while a test
 actually failed. If the output is long, redirect it to a file and grep or
 read the file separately; the exit code check and the output-size problem
 are independent, solve them independently.
+Where that file goes is itself a rule, because both wrong answers have
+already cost a task. Run exactly these four commands first, substituting
+nothing:
+
+    LOGDIR="$HOME/gate-logs/$(basename "$PWD")"
+    mkdir -p "$LOGDIR"
+    scripts/guards/check-disk-headroom.sh "$LOGDIR" 5
+    df -h /tmp "$LOGDIR"
+
+If the guard exits non-zero, say so in your report and stop rather than
+picking another directory: a host without 5 GB for a log has no room for
+the gate either, and the run would die mid-link with a fake compiler
+error. Then redirect every long gate to `"$LOGDIR/<step>.log"`.
+The two constraints that path satisfies, both of which have cost a task:
+it is outside the git checkout, and it is not under `/tmp`. Inside the
+checkout, the harness's commit-on-death runs `git add -A`, so a killed
+task sweeps the log into a wip commit and the merge script folds it
+forward into the PR; `.gitignore` carries no `*.log`, and the executor's
+own stray-files self-check below cannot see a commit the harness makes.
+It is also per-task by construction, since the basename of the checkout
+carries the task id, which matters because several tasks can share a
+host. Under `/tmp`, the evidence says the harness's capture filesystem
+lives there rather than on the host disk: issue #1526 records the error
+(`the temp filesystem at /tmp/claude-996/... is full (0MB free)`) and
+`df -h /` reporting 56 GB available at the start of that same run. Once
+it fills, every Bash call fails with ENOSPC, including `true` and `df`,
+so the task cannot run a command to diagnose itself while the host's own
+disk figures look healthy. That is why `df -h /tmp` is in the block
+above: no run has yet captured it on an executor, and the next incident
+needs the datum this one lacked. Quote both `df` lines in your report.
+`CLAUDE_CODE_TMPDIR` is NOT the executor's lever: the harness reads it
+when it creates the per-call capture directory, before the task's first
+Bash call, so exporting it from inside a task changes nothing. Setting it
+on the executor image is the real fix and is tracked on #1526.
 Commit with trailer "Refs: #N".
 Self-check before the commit (see the checklist below): no tool-call
 artifacts in files, no debug_assert-only guards, generated docs

--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -84,18 +84,25 @@ actually failed. If the output is long, redirect it to a file and grep or
 read the file separately; the exit code check and the output-size problem
 are independent, solve them independently.
 Where that file goes is itself a rule, because both wrong answers have
-already cost a task. Run exactly these four commands first, substituting
+already cost a task. Run this first, as ONE command, substituting
 nothing:
 
-    LOGDIR="$HOME/gate-logs/$(basename "$PWD")"
-    mkdir -p "$LOGDIR"
-    scripts/guards/check-disk-headroom.sh "$LOGDIR" 5
-    df -h /tmp "$LOGDIR"
+    LOGDIR="$HOME/gate-logs/$(basename "$PWD")" && mkdir -p "$LOGDIR" &&
+      scripts/guards/check-disk-headroom.sh "$LOGDIR" 5 && df -h /tmp "$LOGDIR"
+
+One command because each tool call is its own shell: `LOGDIR` set in one
+call is empty in the next, and the guard was reached with an empty first
+argument, which it read as "no argument" and answered about the current
+directory instead. It now refuses an empty argument, so the split
+version fails loudly rather than passing about the wrong volume, but the
+single command is what you run.
 
 If the guard exits non-zero, say so in your report and stop rather than
 picking another directory: a host without 5 GB for a log has no room for
 the gate either, and the run would die mid-link with a fake compiler
-error. Then redirect every long gate to `"$LOGDIR/<step>.log"`.
+error. Then redirect every long gate to
+`"$HOME/gate-logs/$(basename "$PWD")/<step>.log"`, spelled out in full
+each time for the same reason: nothing carries over between calls.
 The two constraints that path satisfies, both of which have cost a task:
 it is outside the git checkout, and it is not under `/tmp`. Inside the
 checkout, the harness's commit-on-death runs `git add -A`, so a killed

--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -356,20 +356,37 @@ Record the returned task_id, arm the watch command from the dispatch
 response as a persistent Monitor, and merge with the merge-fleet-result
 skill when it lands.
 
-**Watch the transcript byte count, not just the status.** A task on a
-degraded box reports `running` for its whole life and then dies at the
-ceiling with an empty `result_ref` and only a start ref. The signal that
-separates it from a hard task is available in minutes:
+**Watch the transcript size, not just the status, and read the HTTP code
+beside it.** A task on a degraded box reports `running` for its whole
+life, then dies at the ceiling with an empty `result_ref` and only a
+start ref. An authorized, empty transcript separates it from a hard task
+within minutes:
 
-    curl -s "$FLEET_CP/v1/tasks/<id>/transcript" | wc -c
+    curl -s -o /dev/null -w "http=%{http_code} bytes=%{size_download}\n" \
+      "$FLEET_CP/v1/tasks/<id>/transcript?token=<per-task-jwt>"
 
-A healthy executor emits lines continuously; 13 bytes after three and a
-half hours is a dead box, and that exact figure cost 2h50m on 2026-09-10
-(#1308/#1309 on `pimox5`). Sample it every few minutes for the first
-quarter hour of any dispatch and cancel-and-redispatch on a near-zero
-count rather than waiting for the ceiling. Use the HTTP endpoint and the
-byte count, not the MCP `fleet_transcript`, which returns no output at
-all in this state and so reads as a broken tool rather than as evidence.
+Save the per-task JWT from the dispatch response; without it this check
+cannot be made. Healthy live task: `http=200 bytes=784005`. Dead box:
+`http=200 bytes=0`. Sample every few minutes for the first quarter hour
+and cancel-and-redispatch on an authorized zero rather than waiting for
+the ceiling.
+
+The size alone is NOT the signal, and reading it that way is how this
+was first written down here. With the operator token the endpoint answers
+`200` with the body `unauthorized`, which is exactly 13 bytes: through
+`wc -c` that reads as a plausible small measurement rather than as an
+error, and a probe built on it alarms on its first sample against any
+task, healthy or dead. It was caught only because a task that had
+finished SUCCESSFULLY also read 13 bytes. Two tasks in opposite states
+with identical readings is not a measurement. The MCP `fleet_transcript`
+returning nothing has the same ambiguity and reads as a broken tool, so
+use the HTTP form with the code and the per-task token.
+
+A start-only ref after hours is suggestive, not conclusive: an executor
+commits locally and pushes once at the end, so it can mean a lost final
+push rather than no work. Confirm with the authorized-empty transcript
+before cancelling, because cancelling on the weaker signal destroys
+committed work.
 
 Placement cannot be pre-checked: `GET /v1/tasks/<id>` carries no executor
 field while a task runs, and the executor name appears only in the

--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -44,6 +44,20 @@ UNATTENDED TASK: never ask for confirmation or approval; when your work
 passes the gates, commit it and end with a report. Committing
 (git commit -s) is part of the deliverable.
 
+DEGRADED-BOX TRIPWIRE, your very first command, before reading anything:
+
+    time git config user.email "fleet-executor@nofire.ai"
+    time git config user.name "Ravel Fleet Executor"
+
+You need both of these before your first commit anyway. Read the elapsed
+time. If either took more than 30 seconds, STOP: do not read a file, do
+not start the work. Report `DEGRADED EXECUTOR: git config took <N>s` and
+end the task. The pool contains at least one box where trivial commands
+take 90 to 120 seconds, and on it the four-hour ceiling arrives before a
+first commit does, so COMMIT EARLY below cannot save you. Ending in two
+minutes with a report costs a redispatch; carrying on costs the whole
+task, and 2h50m and 3h29m have each been lost that way.
+
 COMMIT EARLY: `git commit -s` the first state that compiles, before you
 go on to the rest. Never put any command in the background and never end
 your turn waiting for one. Nothing will wake you -- your turn ending ends
@@ -340,7 +354,27 @@ the same turn as the `fleet_dispatch` call, every time.
 
 Record the returned task_id, arm the watch command from the dispatch
 response as a persistent Monitor, and merge with the merge-fleet-result
-skill when it lands. `fleet_status` needs the full task UUID; an 8-char
+skill when it lands.
+
+**Watch the transcript byte count, not just the status.** A task on a
+degraded box reports `running` for its whole life and then dies at the
+ceiling with an empty `result_ref` and only a start ref. The signal that
+separates it from a hard task is available in minutes:
+
+    curl -s "$FLEET_CP/v1/tasks/<id>/transcript" | wc -c
+
+A healthy executor emits lines continuously; 13 bytes after three and a
+half hours is a dead box, and that exact figure cost 2h50m on 2026-09-10
+(#1308/#1309 on `pimox5`). Sample it every few minutes for the first
+quarter hour of any dispatch and cancel-and-redispatch on a near-zero
+count rather than waiting for the ceiling. Use the HTTP endpoint and the
+byte count, not the MCP `fleet_transcript`, which returns no output at
+all in this state and so reads as a broken tool rather than as evidence.
+
+Placement cannot be pre-checked: `GET /v1/tasks/<id>` carries no executor
+field while a task runs, and the executor name appears only in the
+terminal event's `results.executor`. That is why the tripwire in the spec
+and this probe both exist, rather than a label selector. `fleet_status` needs the full task UUID; an 8-char
 short form returns "not found". Result branches appear at
 refs/heads/task/<task-id>/result.
 

--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -371,16 +371,17 @@ cannot be made. Healthy live task: `http=200 bytes=784005`. Dead box:
 and cancel-and-redispatch on an authorized zero rather than waiting for
 the ceiling.
 
-The size alone is NOT the signal, and reading it that way is how this
-was first written down here. With the operator token the endpoint answers
-`200` with the body `unauthorized`, which is exactly 13 bytes: through
-`wc -c` that reads as a plausible small measurement rather than as an
-error, and a probe built on it alarms on its first sample against any
-task, healthy or dead. It was caught only because a task that had
-finished SUCCESSFULLY also read 13 bytes. Two tasks in opposite states
-with identical readings is not a measurement. The MCP `fleet_transcript`
-returning nothing has the same ambiguity and reads as a broken tool, so
-use the HTTP form with the code and the per-task token.
+Read the status code, and do not use the size alone. Fetched with the
+operator token rather than the task's own JWT, the endpoint refuses, and
+the refusal body is the 13-byte string `unauthorized`. Through `wc -c`
+that is a plausible small measurement rather than an error, so a probe
+built on the size alarms on its first sample against every task, healthy
+or dead. It was caught only because a task that had finished SUCCESSFULLY
+also read 13 bytes; two tasks in opposite states with identical readings
+is not a measurement. The status code is what separates a refusal from an
+authorized empty transcript, which is why the command above prints it
+first. The MCP `fleet_transcript` returning nothing carries the same
+ambiguity with no code to inspect, so prefer the HTTP form.
 
 A start-only ref after hours is suggestive, not conclusive: an executor
 commits locally and pushes once at the end, so it can mean a lost final

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,11 @@ jobs:
       # CLAUDE.md tells sessions to arm the guard and it would be inert.
       - name: Disk-watchdog guard cases
         run: bash scripts/guards/disk-watchdog.test.sh
+      # Same reason as the two above: a guard suite that runs in no job is
+      # decorative from the day it lands. Bash and coreutils only, and it
+      # sets FLEET_DISK_REAP=0 itself so it cannot reap a runner workspace.
+      - name: Disk-headroom guard cases
+        run: bash scripts/guards/check-disk-headroom.test.sh
       - name: Python script unit tests
         run: make test-python
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,12 @@ there before changing a rule.
   `linking with cc failed` (errno 28) that reads as a code bug, and a full
   disk can break the harness's own output capture so nothing runs at all.
   `FLEET_DISK_REAP=1` auto-runs `disk-reap.sh -y` when below the floor.
+  Exit 1 is "below the floor, or the path is unreadable"; exit 2 is an
+  argument it cannot use, which today means a directory argument that was
+  passed and is empty. That is a caller whose variable did not survive,
+  not a caller asking for the default, and `${1:-.}` cannot tell the two
+  apart: it measured the current directory and passed about a volume the
+  caller was never going to write to.
   The check proves headroom at one instant, not for the duration of the
   build. A session that read 82 GB free, started a cold gate, and took
   the volume to 886 MiB still passed this guard: another session was

--- a/scripts/guards/check-disk-headroom.sh
+++ b/scripts/guards/check-disk-headroom.sh
@@ -22,6 +22,15 @@ if [ "$#" -ge 1 ] && [ -z "$1" ]; then
   exit 2
 fi
 dir=${1:-.}
+# The same hole, on the other argument. `${2:-20}` cannot tell an absent floor
+# from a caller whose floor variable did not survive, and it fails in both
+# directions: a caller that meant 40 passes at 25 GB, and one that meant 5
+# aborts a task that had room. The block above fixed this for the directory
+# and left it here, which is half a defect class.
+if [ "$#" -ge 2 ] && [ -z "$2" ]; then
+  echo "guard: empty min_gb argument; pass a number or none at all" >&2
+  exit 2
+fi
 min_gb=${2:-20}
 
 if [ ! -e "$dir" ]; then

--- a/scripts/guards/check-disk-headroom.sh
+++ b/scripts/guards/check-disk-headroom.sh
@@ -11,6 +11,16 @@
 # Set FLEET_DISK_REAP=1 to auto-run scripts/disk-reap.sh -y when below floor.
 set -u
 
+# An argument that was passed and is empty is a caller whose variable did not
+# survive, not a caller asking for the default. `${1:-.}` cannot tell the two
+# apart, so the guard checked the current directory, found it healthy and
+# exited 0 about a volume the caller was never going to write to. The shape
+# that produced it: a shell variable set in one tool call and read in the
+# next, where each call is its own shell.
+if [ "$#" -ge 1 ] && [ -z "$1" ]; then
+  echo "guard: empty directory argument; pass a path or none at all" >&2
+  exit 2
+fi
 dir=${1:-.}
 min_gb=${2:-20}
 

--- a/scripts/guards/check-disk-headroom.test.sh
+++ b/scripts/guards/check-disk-headroom.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Cases for check-disk-headroom.sh. Run: bash scripts/guards/check-disk-headroom.test.sh
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "$0")" && pwd)/check-disk-headroom.sh"
+passes=0
+fails=0
+
+check_eq() {
+  local label="$1" want="$2" got="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    printf 'ok    %s\n' "${label}"
+    passes=$((passes + 1))
+  else
+    printf 'FAIL  %-52s want %s, got %s\n' "${label}" "${want}" "${got}"
+    fails=$((fails + 1))
+  fi
+}
+
+check_contains() {
+  local label="$1" needle="$2" hay="$3"
+  if [[ "${hay}" == *"${needle}"* ]]; then
+    printf 'ok    %s\n' "${label}"
+    passes=$((passes + 1))
+  else
+    printf 'FAIL  %-52s missing %q in %q\n' "${label}" "${needle}" "${hay}"
+    fails=$((fails + 1))
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# --- an empty argument is a caller's variable that did not survive ---------
+#
+# `${1:-.}` substitutes the default for an argument that is present and
+# empty as readily as for one that is absent, so the guard answered about
+# the current directory and exited 0 about a volume the caller was never
+# going to write to. The shape that produced it is a shell variable set in
+# one tool call and read in the next, where each call is its own shell.
+out="$("${GUARD}" "" 5 2>&1)"; rc=$?
+check_eq "an empty directory argument is refused" "2" "${rc}"
+check_contains "it says the argument was empty" "empty directory argument" "${out}"
+
+# The default still applies when no argument is passed at all, which is a
+# different thing and has to keep working.
+"${GUARD}" >/dev/null 2>&1; rc=$?
+check_eq "no argument at all still uses the default" "0" "$((rc == 2 ? 2 : 0))"
+
+# --- a path that does not exist is refused --------------------------------
+out="$("${GUARD}" "${TMP}/nope" 5 2>&1)"; rc=$?
+check_eq "a missing path is refused" "1" "${rc}"
+check_contains "it names the path it could not find" "does not exist" "${out}"
+
+# --- a real directory below the floor fails, above it passes --------------
+#
+# The floor is compared against real df output, so pin both directions with
+# floors that cannot be anything else on any host: nothing has 0 GB free by
+# this guard's own reading, and nothing has 10^9 GB.
+"${GUARD}" "${TMP}" 0 >/dev/null 2>&1
+check_eq "a healthy volume passes a floor of zero" "0" "$?"
+
+out="$("${GUARD}" "${TMP}" 1000000000 2>&1)"; rc=$?
+check_eq "an unreachable floor fails" "1" "${rc}"
+check_contains "it reports the shortfall" "free" "${out}"
+
+printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
+[[ "${fails}" -eq 0 ]]

--- a/scripts/guards/check-disk-headroom.test.sh
+++ b/scripts/guards/check-disk-headroom.test.sh
@@ -2,6 +2,15 @@
 # Cases for check-disk-headroom.sh. Run: bash scripts/guards/check-disk-headroom.test.sh
 set -uo pipefail
 
+# Every case here pins an unreachable floor, so every case takes the
+# below-floor branch, and that branch runs `disk-reap.sh -y` FOR REAL when
+# FLEET_DISK_REAP=1 is set in the environment. A session with that variable
+# exported reaps its peers' worktrees by running the tests, silently: the
+# guard's message goes to stderr inside a command substitution and the suite
+# still reports green. Neutralised for the whole file.
+FLEET_DISK_REAP=0
+export FLEET_DISK_REAP
+
 GUARD="$(cd "$(dirname "$0")" && pwd)/check-disk-headroom.sh"
 passes=0
 fails=0
@@ -44,8 +53,23 @@ check_contains "it says the argument was empty" "empty directory argument" "${ou
 
 # The default still applies when no argument is passed at all, which is a
 # different thing and has to keep working.
-"${GUARD}" >/dev/null 2>&1; rc=$?
-check_eq "no argument at all still uses the default" "0" "$((rc == 2 ? 2 : 0))"
+# Differenced against an explicit `.` rather than asserting a bare exit code:
+# free space on the host is unknown, so the old form collapsed everything that
+# was not 2 into 0 and asserted only "not refused". Deleting the default
+# outright left it green.
+out_default="$("${GUARD}" 2>&1)"; rc_default=$?
+out_explicit="$("${GUARD}" . 20 2>&1)"; rc_explicit=$?
+check_eq "no argument matches an explicit ." "${rc_explicit}" "${rc_default}"
+check_eq "...and reports the same thing" "${out_explicit}" "${out_default}"
+
+# --- an empty min_gb is refused too ---------------------------------------
+#
+# The directory argument was fixed and the floor was left with the identical
+# hole, which is half a defect class. `${2:-20}` cannot tell an absent floor
+# from a caller whose variable did not survive.
+out="$("${GUARD}" . "" 2>&1)"; rc=$?
+check_eq "an empty min_gb is refused" "2" "${rc}"
+check_contains "it says which argument was empty" "min_gb" "${out}"
 
 # --- a path that does not exist is refused --------------------------------
 out="$("${GUARD}" "${TMP}/nope" 5 2>&1)"; rc=$?
@@ -58,7 +82,7 @@ check_contains "it names the path it could not find" "does not exist" "${out}"
 # floors that cannot be anything else on any host: nothing has 0 GB free by
 # this guard's own reading, and nothing has 10^9 GB.
 "${GUARD}" "${TMP}" 0 >/dev/null 2>&1
-check_eq "a healthy volume passes a floor of zero" "0" "$?"
+check_eq "a readable volume reaches the floor comparison" "0" "$?"
 
 out="$("${GUARD}" "${TMP}" 1000000000 2>&1)"; rc=$?
 check_eq "an unreachable floor fails" "1" "${rc}"


### PR DESCRIPTION
docs(fleet-task-spec): send gate logs to the disk, not the capture tmpfs

The fleet task spec template tells executors to redirect long gate output to a file and does not say where. Both spec authors and executors reach for `/tmp`, which on a fleet executor is the harness's own capture filesystem rather than the 226 GB disk. A `cargo test --workspace` log fills it, and after that every Bash call in the task fails identically with ENOSPC, `true` and `df` included, so the task cannot diagnose itself while the host's real disk figures look healthy throughout.

That cost a full gate run on the ADR-1413 T2 result earlier tonight: `cargo fmt --all --check` and `cargo clippy --workspace --all-targets` had both passed, and the test lane died at 9m30s with its output lost rather than with a failure. The evidence and the better fix, setting `CLAUDE_CODE_TMPDIR` on the executor image so no spec has to remember this, are on #1526.

Refs: #1526
