### PR TITLE
fix(scripts): count a skipped check as skipped, not as a pass

### DIFF
--- a/.claude/guards/pretooluse.mjs
+++ b/.claude/guards/pretooluse.mjs
@@ -125,17 +125,86 @@ function substitutionBodies(text) {
 // as openers, so `git commit -m "use << HEAD trick"` followed by a piped gate
 // disabled the guard for the rest of the command. That is this rule's own
 // motivating case, quoting shell in a commit message, turned into a hole.
+// The heredoc openers on one line, found by walking it with quote state
+// rather than by matching a regex over the whole line.
+//
+// A regex cannot do this. `<<` inside a quoted string is ordinary text, but a
+// pattern scanning the line parses a tag out of it anyway, and when a later
+// line coincidentally equals that tag a terminator IS found, so the real
+// commands between them are deleted from every rule. Fail-closed on a missing
+// terminator does not help, because the terminator exists. Six spellings of
+//
+//     git commit -m 'use << EOF here'
+//     cargo test -p x | tail -1
+//     EOF
+//
+// were refused by the guard on main and allowed here until this replaced the
+// pattern. Found by an uncurated corpus, not by cases written from the
+// findings: every case written by hand was two lines long and so exercised
+// the fail-closed path instead of this one.
+function heredocDelims(line) {
+  const delims = [];
+  let sq = false;
+  let dq = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (c === "\\" && !sq) {
+      i++;
+      continue;
+    }
+    if (c === "'" && !dq) {
+      sq = !sq;
+      continue;
+    }
+    if (c === '"' && !sq) {
+      dq = !dq;
+      continue;
+    }
+    if (sq || dq) continue;
+    if (c !== "<" || line[i + 1] !== "<") continue;
+    // `<<<` is a herestring, not a heredoc: no body follows. Consume the
+    // WHOLE run of `<`, not just three. Skipping a fixed two left the
+    // behaviour alternating with the run length: `<<<< EOF` parsed no tag
+    // (fail closed) while `<<<<< EOF` parsed `EOF` and stripped the lines
+    // after it (fail open). Neither spelling is valid shell, but only one of
+    // those two answers is safe, and a rule that alternates is not a rule.
+    // Found by enumerating 444,440 strings, which reported 30 differences
+    // where the argument said there would be none.
+    if (line[i + 2] === "<") {
+      let k = i + 2;
+      while (line[k] === "<") k++;
+      i = k - 1;
+      continue;
+    }
+    let j = i + 2;
+    let dash = false;
+    if (line[j] === "-") {
+      dash = true;
+      j++;
+    }
+    while (line[j] === " " || line[j] === "\t") j++;
+    const quote = line[j] === "'" || line[j] === '"' ? line[j] : "";
+    if (quote) j++;
+    let tag = "";
+    while (j < line.length && /[A-Za-z0-9_]/.test(line[j])) {
+      tag += line[j];
+      j++;
+    }
+    // Consume the delimiter's own closing quote so the walk does not read it
+    // as opening a string for the rest of the line.
+    if (quote && line[j] === quote) j++;
+    if (tag !== "" && /[A-Za-z_]/.test(tag[0])) delims.push({ tag, dash });
+    i = j - 1;
+  }
+  return delims;
+}
+
 function stripHeredocBodies(text) {
   const lines = text.split("\n");
   const kept = [];
   for (let i = 0; i < lines.length; i++) {
     kept.push(lines[i]);
-    const opener = /(?<!<)<<(?!<)(-?)\s*(["'])?([A-Za-z_][A-Za-z0-9_]*)\2?/g;
-    const delims = [];
-    let m;
-    while ((m = opener.exec(lines[i])) !== null) {
-      delims.push({ tag: m[3], dash: m[1] === "-" });
-    }
+    const delims = heredocDelims(lines[i]);
     for (const d of delims) {
       let j = i + 1;
       while (j < lines.length) {

--- a/.claude/guards/pretooluse.mjs
+++ b/.claude/guards/pretooluse.mjs
@@ -52,13 +52,58 @@ const GATE_HEAD =
 // pipe unseen. Ordered before the bare-assignment alternative, which is
 // guarded against `$(` so it cannot re-swallow it.
 const HARMLESS_PREFIX =
-  /^(\s*(cd\s+[^&;|]+&&|[A-Za-z_][A-Za-z0-9_]*=\$\(|[A-Za-z_][A-Za-z0-9_]*=(?!\$\()[^\s]*|time|nice(\s+-n\s*-?\d+)?|env|bash|sh|zsh)\s*)+/;
+  /^(\s*(cd\s+[^&;|]+&&|[A-Za-z_][A-Za-z0-9_]*=\$\(|[A-Za-z_][A-Za-z0-9_]*=(?!\$\()[^\s]*|time|nice(\s+-n\s*-?\d+)?|env|bash|sh|zsh|if|while|until|!)\s*)+/;
 const MASKING_FILTER = /^\s*(tail|head|grep|rg|sed)\b/;
 const MASKING_ECHO = /&&\s*echo\b/;
 
 // zsh marks these read-only; assigning to one kills the enclosing loop with
 // no output that looks like a failure.
 const RESERVED_ASSIGN = /(^|[;&|(]|\bdo\b|\bthen\b|\blocal\b|\bexport\b)\s*(status|path|argv|PWD)=/;
+
+// Command substitutions are checked as commands in their own right. Extending
+// the harmless-prefix list instead only ever covers the spellings someone
+// thought to enumerate: `out=$(gate | tail -1)` was covered and the same line
+// with quotes around the substitution, or in backticks, was not, though all
+// three run the gate and read the pipe's status. Single-quoted text is skipped
+// because no substitution happens inside it.
+function substitutionBodies(text) {
+  const bodies = [];
+  let sq = false;
+  let dq = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === "\\") {
+      i++;
+      continue;
+    }
+    if (c === "'" && !dq) {
+      sq = !sq;
+      continue;
+    }
+    if (c === '"' && !sq) {
+      dq = !dq;
+      continue;
+    }
+    if (sq) continue;
+    if (c === "$" && text[i + 1] === "(") {
+      let depth = 1;
+      let j = i + 2;
+      for (; j < text.length && depth > 0; j++) {
+        if (text[j] === "(") depth++;
+        else if (text[j] === ")") depth--;
+      }
+      bodies.push(text.slice(i + 2, depth === 0 ? j - 1 : text.length));
+      i = j - 1;
+      continue;
+    }
+    if (c === "`") {
+      const end = text.indexOf("`", i + 1);
+      bodies.push(text.slice(i + 1, end === -1 ? text.length : end));
+      i = end === -1 ? text.length : end;
+    }
+  }
+  return bodies;
+}
 
 function splitStatements(command) {
   // Rough statement split. Over-splitting only weakens a rule; it never
@@ -76,10 +121,24 @@ function startsWithGate(fragment) {
   return GATE_HEAD.test(fragment.replace(HARMLESS_PREFIX, ""));
 }
 
+// The command itself plus every command substitution nested inside it. The
+// depth cap is a backstop against pathological input, not a real limit: two
+// levels covers anything a session writes by hand.
+function scanTexts(command) {
+  const texts = [];
+  const queue = [command];
+  while (queue.length > 0 && texts.length < 64) {
+    const text = queue.shift();
+    texts.push(text);
+    for (const body of substitutionBodies(text)) queue.push(body);
+  }
+  return texts;
+}
+
 function checkBash(command) {
   if (typeof command !== "string" || command === "") return;
 
-  for (const raw of splitStatements(command)) {
+  for (const raw of scanTexts(command).flatMap(splitStatements)) {
     const stmt = raw.trim();
     if (stmt === "") continue;
 

--- a/.claude/guards/pretooluse.mjs
+++ b/.claude/guards/pretooluse.mjs
@@ -157,6 +157,21 @@ function stripHeredocBodies(text) {
 // containing a space (`TS=$(date +%s) cargo test | tail -1`) no longer hides
 // it either. The bodies themselves are scanned separately by `scanTexts`, so
 // nothing is lost by blanking them here.
+//
+// THIS is the load-bearing defence, and the single plain assignment
+// alternative in HARMLESS_PREFIX is the fallback. Reverting the alternation
+// alone leaves the suite green, which reads as "unpinned, delete it" and is
+// the opposite of the truth: neutering this function alone fails a case, and
+// reverting both fails four. If this is ever removed or reordered, the plain
+// `NAME=[^\s]*` alternative still catches every space-free value; the older
+// two-alternative form caught none of them. Keep both.
+//
+// A mis-slice here cannot produce a false ALLOW, and the reason is
+// structural rather than careful coding: this feeds only the prefix
+// decision, while `scanTexts` scans every substitution body as its own
+// command. When this swallows too much (an unterminated `$(` collapses the
+// tail to one token), the body scan still sees the gate. A false allow needs
+// both to miss at once.
 function blankSubstitutions(text) {
   let out = "";
   let sq = false;

--- a/.claude/guards/pretooluse.mjs
+++ b/.claude/guards/pretooluse.mjs
@@ -41,9 +41,18 @@ function readStdin() {
 
 // Commands whose exit code is a gate. Matched only in command position, so
 // a gate name quoted inside a grep pattern is not a gate.
-const GATE_HEAD = /^(cargo\s+(clippy|test|nextest|fmt|build|check)|(\.\/)?scripts\/(gates|affected-tests|verify-dispatch-gates)\.sh)\b/;
+const GATE_HEAD =
+  /^(cargo\s+(clippy|test|nextest|fmt|build|check)|(\.\/)?scripts\/((gates|affected-tests|verify-dispatch-gates)\.sh|guards\/[a-z0-9-]+\.sh))\b/;
 // Things that may legitimately precede a gate on the same command line.
-const HARMLESS_PREFIX = /^(\s*(cd\s+[^&;|]+&&|[A-Za-z_][A-Za-z0-9_]*=[^\s]+|time|nice(\s+-n\s*-?\d+)?|env|bash|sh|zsh)\s*)+/;
+// A bare assignment may precede a gate (`FOO=1 cargo test`). A command
+// substitution assignment is stripped too, but as its own alternative, so the
+// command INSIDE it is what gets matched: `out=$(scripts/guards/x.sh | tail
+// -1)` is a masked guard whose exit code the caller then reads, and a single
+// `[^\s]+` value swallowed `out=$(scripts/guards/x.sh` whole, leaving the
+// pipe unseen. Ordered before the bare-assignment alternative, which is
+// guarded against `$(` so it cannot re-swallow it.
+const HARMLESS_PREFIX =
+  /^(\s*(cd\s+[^&;|]+&&|[A-Za-z_][A-Za-z0-9_]*=\$\(|[A-Za-z_][A-Za-z0-9_]*=(?!\$\()[^\s]*|time|nice(\s+-n\s*-?\d+)?|env|bash|sh|zsh)\s*)+/;
 const MASKING_FILTER = /^\s*(tail|head|grep|rg|sed)\b/;
 const MASKING_ECHO = /&&\s*echo\b/;
 

--- a/.claude/guards/pretooluse.mjs
+++ b/.claude/guards/pretooluse.mjs
@@ -109,6 +109,36 @@ function substitutionBodies(text) {
   return bodies;
 }
 
+// A heredoc body is data, not shell. Statements split on newlines, so a
+// document that QUOTES a piped gate is otherwise refused line by line: the
+// commit message describing this rule could not be written by the tool that
+// writes commit messages. Only the body is dropped, so a real gate elsewhere
+// in the same command is still judged; exempting the whole command whenever
+// it contains `<<` is what the reserved-name rule did, and that let a real
+// `status=` through beside an unrelated heredoc.
+function stripHeredocBodies(text) {
+  const lines = text.split("\n");
+  const kept = [];
+  for (let i = 0; i < lines.length; i++) {
+    kept.push(lines[i]);
+    const opener = /<<(-?)\s*(["'])?([A-Za-z_][A-Za-z0-9_]*)\2?/g;
+    const delims = [];
+    let m;
+    while ((m = opener.exec(lines[i])) !== null) {
+      delims.push({ tag: m[3], dash: m[1] === "-" });
+    }
+    for (const d of delims) {
+      i++;
+      while (i < lines.length) {
+        const line = d.dash ? lines[i].replace(/^\t+/, "") : lines[i];
+        if (line === d.tag) break;
+        i++;
+      }
+    }
+  }
+  return kept.join("\n");
+}
+
 function splitStatements(command) {
   // Rough statement split. Over-splitting only weakens a rule; it never
   // invents a violation, because each rule needs its whole pattern in one
@@ -139,8 +169,9 @@ function scanTexts(command) {
   return texts;
 }
 
-function checkBash(command) {
-  if (typeof command !== "string" || command === "") return;
+function checkBash(rawCommand) {
+  if (typeof rawCommand !== "string" || rawCommand === "") return;
+  const command = stripHeredocBodies(rawCommand);
 
   for (const raw of scanTexts(command).flatMap(splitStatements)) {
     const stmt = raw.trim();
@@ -166,8 +197,10 @@ function checkBash(command) {
       );
     }
 
-    // A heredoc body is not shell, and scratchpad heredocs are allowed.
-    if (!command.includes("<<") && RESERVED_ASSIGN.test(stmt)) {
+    // Heredoc bodies are already gone, so this judges real shell only. The
+    // condition here used to be `!command.includes("<<")`, which exempted a
+    // reserved assignment sitting beside an unrelated heredoc.
+    if (RESERVED_ASSIGN.test(stmt)) {
       deny(
         "zsh reserves status, path, argv and PWD. Assigning to one fails " +
           "with `read-only variable` and silently kills the enclosing " +

--- a/.claude/guards/pretooluse.mjs
+++ b/.claude/guards/pretooluse.mjs
@@ -41,8 +41,12 @@ function readStdin() {
 
 // Commands whose exit code is a gate. Matched only in command position, so
 // a gate name quoted inside a grep pattern is not a gate.
+// A guard's own test suite is a gate too: its exit code is the evidence that
+// a change to the guard is safe, and `[a-z0-9-]+\.sh` did not match
+// `disk-watchdog.test.sh`, whose extra dot falls outside the class. Both
+// guard directories are listed; the hook itself lives under `.claude`.
 const GATE_HEAD =
-  /^(cargo\s+(clippy|test|nextest|fmt|build|check)|(\.\/)?scripts\/((gates|affected-tests|verify-dispatch-gates)\.sh|guards\/[a-z0-9-]+\.sh))\b/;
+  /^(cargo\s+(clippy|test|nextest|fmt|build|check)|(\.\/)?(scripts\/((gates|affected-tests|verify-dispatch-gates)\.sh|guards\/[a-z0-9.-]+\.sh)|\.claude\/guards\/[a-z0-9.-]+\.sh))\b/;
 // Things that may legitimately precede a gate on the same command line.
 // A bare assignment may precede a gate (`FOO=1 cargo test`). A command
 // substitution assignment is stripped too, but as its own alternative, so the
@@ -52,7 +56,7 @@ const GATE_HEAD =
 // pipe unseen. Ordered before the bare-assignment alternative, which is
 // guarded against `$(` so it cannot re-swallow it.
 const HARMLESS_PREFIX =
-  /^(\s*(cd\s+[^&;|]+&&|[A-Za-z_][A-Za-z0-9_]*=\$\(|[A-Za-z_][A-Za-z0-9_]*=(?!\$\()[^\s]*|time|nice(\s+-n\s*-?\d+)?|env|bash|sh|zsh|if|while|until|!)\s*)+/;
+  /^(\s*(cd\s+[^&;|]+&&|[A-Za-z_][A-Za-z0-9_]*=\$\(|[A-Za-z_][A-Za-z0-9_]*=(?!\$\()[^\s]*|timeout(\s+-[A-Za-z-]+)*\s+\d+(\.\d+)?[smhd]?|time|nice(\s+-n\s*-?\d+)?|env|bash|sh|zsh|if|while|until|!)\s*)+/;
 const MASKING_FILTER = /^\s*(tail|head|grep|rg|sed)\b/;
 const MASKING_ECHO = /&&\s*echo\b/;
 

--- a/.claude/guards/pretooluse.mjs
+++ b/.claude/guards/pretooluse.mjs
@@ -48,15 +48,17 @@ function readStdin() {
 const GATE_HEAD =
   /^(cargo\s+(clippy|test|nextest|fmt|build|check)|(\.\/)?(scripts\/((gates|affected-tests|verify-dispatch-gates)\.sh|guards\/[a-z0-9.-]+\.sh)|\.claude\/guards\/[a-z0-9.-]+\.sh))\b/;
 // Things that may legitimately precede a gate on the same command line.
-// A bare assignment may precede a gate (`FOO=1 cargo test`). A command
-// substitution assignment is stripped too, but as its own alternative, so the
-// command INSIDE it is what gets matched: `out=$(scripts/guards/x.sh | tail
-// -1)` is a masked guard whose exit code the caller then reads, and a single
-// `[^\s]+` value swallowed `out=$(scripts/guards/x.sh` whole, leaving the
-// pipe unseen. Ordered before the bare-assignment alternative, which is
-// guarded against `$(` so it cannot re-swallow it.
+// A bare assignment may precede a gate (`FOO=1 cargo test`). One plain
+// alternative for it: an earlier version added a separate `NAME=$(`
+// alternative so the command inside a substitution would be matched, and
+// that made `FOO=$(date) cargo test | tail -1` ALLOW, because the prefix
+// consumed `FOO=$(` and left `date) cargo test`, which is not a gate. The
+// substitution case does not need an alternative here at all; `scanTexts`
+// scans substitution bodies as commands in their own right, and
+// `blankSubstitutions` below collapses a substitution to one word so the
+// gate AFTER it is still seen.
 const HARMLESS_PREFIX =
-  /^(\s*(cd\s+[^&;|]+&&|[A-Za-z_][A-Za-z0-9_]*=\$\(|[A-Za-z_][A-Za-z0-9_]*=(?!\$\()[^\s]*|timeout(\s+-[A-Za-z-]+)*\s+\d+(\.\d+)?[smhd]?|time|nice(\s+-n\s*-?\d+)?|env|bash|sh|zsh|if|while|until|!)\s*)+/;
+  /^(\s*(cd\s+[^&;|]+&&|[A-Za-z_][A-Za-z0-9_]*=[^\s]*|timeout(\s+-[A-Za-z-]+(=[^\s]+)?)*(\s+\d+[smhd]?)?\s+\d+(\.\d+)?[smhd]?|time|nice(\s+-n\s*-?\d+)?|env|bash|sh|zsh|if|while|until|!)\s*)+/;
 const MASKING_FILTER = /^\s*(tail|head|grep|rg|sed)\b/;
 const MASKING_ECHO = /&&\s*echo\b/;
 
@@ -116,27 +118,86 @@ function substitutionBodies(text) {
 // in the same command is still judged; exempting the whole command whenever
 // it contains `<<` is what the reserved-name rule did, and that let a real
 // `status=` through beside an unrelated heredoc.
+// Fails closed: a body is dropped only once its terminator is actually
+// found. An earlier version consumed to end-of-input when no terminator
+// existed, which silently deleted every remaining line from every rule. A
+// herestring (`<<<WORD`) and a bare `<<` inside a quoted string both matched
+// as openers, so `git commit -m "use << HEAD trick"` followed by a piped gate
+// disabled the guard for the rest of the command. That is this rule's own
+// motivating case, quoting shell in a commit message, turned into a hole.
 function stripHeredocBodies(text) {
   const lines = text.split("\n");
   const kept = [];
   for (let i = 0; i < lines.length; i++) {
     kept.push(lines[i]);
-    const opener = /<<(-?)\s*(["'])?([A-Za-z_][A-Za-z0-9_]*)\2?/g;
+    const opener = /(?<!<)<<(?!<)(-?)\s*(["'])?([A-Za-z_][A-Za-z0-9_]*)\2?/g;
     const delims = [];
     let m;
     while ((m = opener.exec(lines[i])) !== null) {
       delims.push({ tag: m[3], dash: m[1] === "-" });
     }
     for (const d of delims) {
-      i++;
-      while (i < lines.length) {
-        const line = d.dash ? lines[i].replace(/^\t+/, "") : lines[i];
+      let j = i + 1;
+      while (j < lines.length) {
+        const line = d.dash ? lines[j].replace(/^\t+/, "") : lines[j];
         if (line === d.tag) break;
-        i++;
+        j++;
       }
+      // No terminator: this was not a heredoc opener. Keep the lines.
+      if (j >= lines.length) break;
+      i = j;
     }
   }
   return kept.join("\n");
+}
+
+// Collapse a command substitution to a single whitespace-free token, for the
+// prefix decision only. An assignment whose VALUE is a substitution is then
+// one word, so the gate after the closing paren is still seen, and a value
+// containing a space (`TS=$(date +%s) cargo test | tail -1`) no longer hides
+// it either. The bodies themselves are scanned separately by `scanTexts`, so
+// nothing is lost by blanking them here.
+function blankSubstitutions(text) {
+  let out = "";
+  let sq = false;
+  let dq = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === "\\" && !sq) {
+      out += text.slice(i, i + 2);
+      i++;
+      continue;
+    }
+    if (c === "'" && !dq) {
+      sq = !sq;
+      out += c;
+      continue;
+    }
+    if (c === '"' && !sq) {
+      dq = !dq;
+      out += c;
+      continue;
+    }
+    if (!sq && c === "$" && text[i + 1] === "(") {
+      let depth = 1;
+      let j = i + 2;
+      for (; j < text.length && depth > 0; j++) {
+        if (text[j] === "(") depth++;
+        else if (text[j] === ")") depth--;
+      }
+      out += "SUB";
+      i = j - 1;
+      continue;
+    }
+    if (!sq && c === "`") {
+      const end = text.indexOf("`", i + 1);
+      out += "SUB";
+      i = end === -1 ? text.length : end;
+      continue;
+    }
+    out += c;
+  }
+  return out;
 }
 
 function splitStatements(command) {
@@ -152,7 +213,9 @@ function splitPipeline(stmt) {
 }
 
 function startsWithGate(fragment) {
-  return GATE_HEAD.test(fragment.replace(HARMLESS_PREFIX, ""));
+  return GATE_HEAD.test(
+    blankSubstitutions(fragment).replace(HARMLESS_PREFIX, ""),
+  );
 }
 
 // The command itself plus every command substitution nested inside it. The

--- a/.claude/guards/pretooluse.test.sh
+++ b/.claude/guards/pretooluse.test.sh
@@ -124,6 +124,58 @@ harmless text
 EOF
 status=0")"
 
+# --- a substitution VALUE must not hide the gate after it ----------------
+#
+# Found by review, and not by the 24-case battery written to look for it:
+# every case there put the gate INSIDE the substitution. This shape is an
+# assignment whose value is a NON-gate substitution, with the gate after the
+# closing paren. A `NAME=$(` prefix alternative consumed `FOO=$(` and left
+# `date) cargo test`, which is not a gate, so the guard ALLOWED a masked gate
+# that `main` denied. The second case has a space inside the substitution and
+# was a hole on `main` too.
+check deny  "substitution value, then a gate"  "$(bash_payload 'FOO=$(date) cargo test -p ravel-sql | tail -1')"
+check deny  "substitution value, then a guard" "$(bash_payload 'FOO=$(date) scripts/gates.sh | tail -1')"
+check deny  "substitution value, then && echo" "$(bash_payload 'FOO=$(date) cargo test -p ravel-sql && echo DONE')"
+check deny  "a space inside the substitution"  "$(bash_payload 'TS=$(date +%s) cargo test -p ravel-sql | tail -1')"
+check deny  "backtick value, then a gate"      "$(bash_payload 'FOO=`date` cargo test -p ravel-sql | tail -1')"
+
+# --- the heredoc strip must fail closed ----------------------------------
+#
+# Dropping a body to end-of-input when no terminator exists deletes every
+# remaining line from every rule. A herestring and a bare `<<` inside a
+# quoted string both matched as openers, so the rule's own motivating case,
+# quoting shell in a commit message, disabled the guard for the rest of the
+# command.
+check deny  "herestring is not a heredoc"      "$(bash_payload "cat <<<WORD
+${gate_pipe}")"
+check deny  "quoted herestring is not one"     "$(bash_payload "python3 - <<<'print(1)'
+${gate_pipe}")"
+check deny  "<< inside a commit message"       "$(bash_payload "git commit -m \"use << HEAD trick\"
+${gate_pipe}")"
+check deny  "<< inside single quotes"          "$(bash_payload "echo 'a << B'
+${gate_pipe}")"
+check deny  "unterminated heredoc keeps lines" "$(bash_payload "cat > /tmp/c.md <<EOF
+${gate_pipe}")"
+# A herestring whose word happens to match a later line. The terminator check
+# alone does not save this one, because a terminator IS found: only refusing
+# to read `<<<` as an opener does. Without that, the gate on line two is
+# stripped as a heredoc body and the command is allowed.
+check deny  "herestring whose word recurs"     "$(bash_payload "cat <<<EOF
+${gate_pipe}
+EOF")"
+
+# A terminator that IS found still ends the body, and the body's later lines
+# stay data. With terminator matching broken to stop at the first body line,
+# line two leaks out and is judged, so this flips to deny.
+check allow "second body line stays data"      "$(bash_payload "cat > /tmp/c.md <<'EOF'
+harmless first line
+${gate_pipe}
+EOF")"
+# `<<-` strips leading TABS from the terminator. Nothing pinned that branch.
+check allow "<<- with a tab-indented end"      "$(bash_payload "cat > /tmp/c.md <<-EOF
+${gate_pipe}
+	EOF")"
+
 # --- zsh reserved names -------------------------------------------------
 check deny  "bare status="                    "$(bash_payload 'status=0')"
 check deny  "local status="                   "$(bash_payload 'run_it || local status=$?')"

--- a/.claude/guards/pretooluse.test.sh
+++ b/.claude/guards/pretooluse.test.sh
@@ -163,6 +163,57 @@ ${gate_pipe}")"
 check deny  "herestring whose word recurs"     "$(bash_payload "cat <<<EOF
 ${gate_pipe}
 EOF")"
+# Longer runs of `<` are not valid shell, but the guard must answer the same
+# way for all of them. Skipping a fixed two characters made `<<<<` fail closed
+# and `<<<<<` fail open; consuming the whole run makes every length behave
+# like the herestring above. Both lengths, since one alone cannot see the
+# alternation.
+check deny  "four angles is not an opener"     "$(bash_payload "cat <<<<EOF
+${gate_pipe}
+EOF")"
+check deny  "five angles is not an opener"     "$(bash_payload "cat <<<<<EOF
+${gate_pipe}
+EOF")"
+
+# `<<` inside a QUOTED STRING is ordinary text, and a later line that happens
+# to equal the word parsed out of it is not a terminator. Fail-closed does not
+# save these, because a terminator is found; only tracking quote state does.
+# Every one was refused on main and allowed here until the opener scan stopped
+# being a regex. Note each needs THREE lines: the two-line versions above take
+# the fail-closed path instead and passed throughout, which is why hand-written
+# cases missed the whole class.
+check deny  "single-quoted << , tag recurs"    "$(bash_payload "git commit -m 'use << EOF here'
+${gate_pipe}
+EOF")"
+check deny  "single-quoted << , short tag"     "$(bash_payload "echo 'a << B'
+${gate_pipe}
+B")"
+check deny  "double-quoted << , tag recurs"    "$(bash_payload "echo \"shift << N\"
+${gate_pipe}
+N")"
+check deny  "quoted << , tab-indented body"    "$(bash_payload "git commit -m 'use << EOF here'
+	${gate_pipe}
+EOF")"
+check deny  "quoted << , reserved name after"  "$(bash_payload "echo 'a << B'
+status=0
+B")"
+# The delimiter's own quotes must not leak into the walk's quote state: if
+# `<<'EOF'` left the scanner inside a string, everything after it on the line
+# would be misread.
+check allow "quoted delimiter closes cleanly"  "$(bash_payload "cat > /tmp/c.md <<'EOF' && echo queued
+${gate_pipe}
+EOF")"
+# Two heredocs, the first with a QUOTED delimiter and the gate in the second
+# body. This is what pins consuming the delimiter's own closing quote: leave
+# it unconsumed and the walk thinks it is inside a string for the rest of the
+# line, never sees `<<B`, and judges B's body as live shell. The single-
+# heredoc case above cannot detect that, because nothing follows the
+# delimiter that the walk needs to read.
+check allow "a second heredoc after a quoted one" "$(bash_payload "cat <<'A' <<B
+first body
+A
+${gate_pipe}
+B")"
 
 # A terminator that IS found still ends the body, and the body's later lines
 # stay data. With terminator matching broken to stop at the first body line,

--- a/.claude/guards/pretooluse.test.sh
+++ b/.claude/guards/pretooluse.test.sh
@@ -49,7 +49,30 @@ check deny  "guard captured through a pipe"    "$(bash_payload 'out=$(scripts/gu
 check deny  "guard piped to grep"              "$(bash_payload 'scripts/guards/check-disk-headroom.sh . 20 | grep LOW')"
 check allow "guard with no pipe"               "$(bash_payload 'scripts/guards/assert-fresh-merge-base.sh 1556')"
 check allow "guard output read from a file"    "$(bash_payload 'scripts/guards/assert-fresh-merge-base.sh 1556 > /tmp/g.txt 2>&1')"
-check allow "an env prefix before a gate"      "$(bash_payload 'CARGO_INCREMENTAL=0 cargo test -p ravel-sql')"
+# An allow case only has teeth when something could deny it. This one carried
+# no pipe and no `&& echo`, so no rule could ever have fired on it and it
+# passed against every mutation of the prefix list. What the harmless-prefix
+# list actually has to do is let the gate BEHIND the prefix still be seen.
+check deny  "an env prefix does not launder a gate" \
+  "$(bash_payload 'CARGO_INCREMENTAL=0 cargo test -p ravel-sql | tail -20')"
+check allow "an env prefix before an unpiped gate" \
+  "$(bash_payload 'CARGO_INCREMENTAL=0 cargo test -p ravel-sql')"
+
+# Quoting the substitution, or spelling it with backticks, runs the same gate
+# and reads the same pipe status. Each of these was allowed while the bare
+# `out=$(...)` form above was denied.
+check deny  "guard in a quoted substitution"   "$(bash_payload 'out="$(scripts/guards/assert-fresh-merge-base.sh 1556 | tail -1)"')"
+check deny  "guard in a backtick substitution" "$(bash_payload 'out=`scripts/guards/assert-fresh-merge-base.sh 1556 | tail -1`')"
+check deny  "gate in a bare substitution"      "$(bash_payload 'echo "$(cargo test -p ravel-sql | tail -5)"')"
+check deny  "gate substituted inside a string" "$(bash_payload 'git commit -m "ran $(scripts/gates.sh | grep -c passed)"')"
+check deny  "gate in a nested substitution"    "$(bash_payload 'x=$(echo "$(cargo clippy --workspace | head -3)")')"
+check deny  "guard piped inside an if"         "$(bash_payload 'if scripts/guards/check-disk-headroom.sh . 20 | grep -q LOW; then echo low; fi')"
+# No substitution happens inside single quotes, so no gate runs and there is
+# nothing to mask.
+check allow "substitution syntax, single-quoted" "$(bash_payload "echo 'ran \$(cargo test | tail -1)'")"
+check allow "the text of a gate pipe, quoted"  "$(bash_payload "echo 'cargo test | tail -5'")"
+check allow "an unpiped guard in a quoted sub" "$(bash_payload 'out="$(scripts/guards/assert-fresh-merge-base.sh 1556)"')"
+check allow "jq inside a quoted substitution"  "$(bash_payload 'n="$(cargo metadata --format-version 1 | jq -r .packages)"')"
 
 check allow "git log into head"               "$(bash_payload 'git log --oneline | head -5')"
 check allow "grepping a saved gate log"       "$(bash_payload 'grep -c FAILED /tmp/gate.log')"

--- a/.claude/guards/pretooluse.test.sh
+++ b/.claude/guards/pretooluse.test.sh
@@ -40,6 +40,17 @@ check allow "cargo test alone"                "$(bash_payload 'cargo test -p rav
 check allow "cargo test redirected to a file" "$(bash_payload 'cargo test -p ravel-sql > /tmp/out.txt 2>&1')"
 check allow "grep for the words cargo test"   "$(bash_payload 'grep -rn "cargo test" docs/ | head -5')"
 check allow "cargo metadata into jq"          "$(bash_payload 'cargo metadata --format-version 1 | jq -r .packages')"
+# The rule reads as being about gates and is not: a guard's exit code is read
+# the same way. Both of these were run by real sessions on 2026-09-09 and both
+# reported a false pass, one on a stale branch and one on a guard that was not
+# in the checkout at all.
+check deny  "guard piped to head"              "$(bash_payload 'scripts/guards/assert-fresh-merge-base.sh 1556 | head -3')"
+check deny  "guard captured through a pipe"    "$(bash_payload 'out=$(scripts/guards/assert-fresh-merge-base.sh 1556 2>&1 | tail -1)')"
+check deny  "guard piped to grep"              "$(bash_payload 'scripts/guards/check-disk-headroom.sh . 20 | grep LOW')"
+check allow "guard with no pipe"               "$(bash_payload 'scripts/guards/assert-fresh-merge-base.sh 1556')"
+check allow "guard output read from a file"    "$(bash_payload 'scripts/guards/assert-fresh-merge-base.sh 1556 > /tmp/g.txt 2>&1')"
+check allow "an env prefix before a gate"      "$(bash_payload 'CARGO_INCREMENTAL=0 cargo test -p ravel-sql')"
+
 check allow "git log into head"               "$(bash_payload 'git log --oneline | head -5')"
 check allow "grepping a saved gate log"       "$(bash_payload 'grep -c FAILED /tmp/gate.log')"
 

--- a/.claude/guards/pretooluse.test.sh
+++ b/.claude/guards/pretooluse.test.sh
@@ -74,6 +74,18 @@ check allow "the text of a gate pipe, quoted"  "$(bash_payload "echo 'cargo test
 check allow "an unpiped guard in a quoted sub" "$(bash_payload 'out="$(scripts/guards/assert-fresh-merge-base.sh 1556)"')"
 check allow "jq inside a quoted substitution"  "$(bash_payload 'n="$(cargo metadata --format-version 1 | jq -r .packages)"')"
 
+# Both of these were run for real by this session on 2026-09-10, minutes after
+# the substitution hole above was closed, and both reported an empty exit code
+# through a `tail`. `timeout` was not a recognised prefix, and a guard's own
+# test suite did not match the guard pattern because `disk-watchdog.test.sh`
+# carries a second dot.
+check deny  "a gate behind timeout"            "$(bash_payload 'timeout 60 scripts/gates.sh | tail -5')"
+check deny  "a guard suite behind timeout+bash" "$(bash_payload 'timeout 300 bash scripts/guards/disk-watchdog.test.sh | tail -25')"
+check deny  "a guard test suite piped"         "$(bash_payload 'bash scripts/guards/disk-watchdog.test.sh | tail -25')"
+check deny  "the hook's own suite piped"       "$(bash_payload 'bash .claude/guards/pretooluse.test.sh | tail -5')"
+check allow "a guard suite redirected"         "$(bash_payload 'bash scripts/guards/disk-watchdog.test.sh > /tmp/w.txt 2>&1')"
+check allow "timeout on a non-gate"            "$(bash_payload 'timeout 5 curl -s https://example.com | head -3')"
+
 check allow "git log into head"               "$(bash_payload 'git log --oneline | head -5')"
 check allow "grepping a saved gate log"       "$(bash_payload 'grep -c FAILED /tmp/gate.log')"
 

--- a/.claude/guards/pretooluse.test.sh
+++ b/.claude/guards/pretooluse.test.sh
@@ -89,6 +89,41 @@ check allow "timeout on a non-gate"            "$(bash_payload 'timeout 5 curl -
 check allow "git log into head"               "$(bash_payload 'git log --oneline | head -5')"
 check allow "grepping a saved gate log"       "$(bash_payload 'grep -c FAILED /tmp/gate.log')"
 
+# --- heredoc bodies are data, not shell ----------------------------------
+#
+# Every payload above is a single line, which is why this class was invisible.
+# Statements split on newlines, so a document QUOTING a piped gate was refused
+# line by line: the commit message describing these very rules could not be
+# written by the tool that writes commit messages. The exemption has to drop
+# the BODY rather than the whole command, since `command.includes("<<")` also
+# excuses a real gate that happens to share a call with a heredoc.
+gate_pipe='cargo test -p ravel-sql | tail -5'
+check allow "a heredoc body quoting a piped gate" \
+  "$(bash_payload "cat > /tmp/c.md <<'EOF'
+${gate_pipe} was allowed because timeout was not a prefix.
+EOF")"
+check allow "a heredoc body quoting a piped suite" \
+  "$(bash_payload "cat > /tmp/c.md <<'EOF'
+bash scripts/guards/disk-watchdog.test.sh | tail -25 said nothing.
+EOF")"
+check allow "an unquoted heredoc delimiter" \
+  "$(bash_payload "cat > /tmp/c.md <<EOF
+${gate_pipe}
+EOF")"
+check deny  "a real piped gate on a later line" \
+  "$(bash_payload "echo hi
+${gate_pipe}")"
+check deny  "a heredoc beside a real piped gate" \
+  "$(bash_payload "cat > /tmp/c.md <<'EOF'
+harmless text
+EOF
+${gate_pipe}")"
+check deny  "a reserved name beside a heredoc" \
+  "$(bash_payload "cat > /tmp/c.md <<'EOF'
+harmless text
+EOF
+status=0")"
+
 # --- zsh reserved names -------------------------------------------------
 check deny  "bare status="                    "$(bash_payload 'status=0')"
 check deny  "local status="                   "$(bash_payload 'run_it || local status=$?')"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,8 +321,11 @@ merged, local last, so nothing is lost by splitting them.
 
 Four of these no longer depend on being remembered.
 `.claude/guards/pretooluse.mjs` runs as a PreToolUse hook and refuses the
-tool call outright: a gate piped into `tail`/`head`/`grep`/`rg`/`sed` or
-followed by `&& echo`, an assignment to zsh's reserved `status`/`path`/
+tool call outright: a gate or guard piped into `tail`/`head`/`grep`/`rg`/
+`sed` or followed by `&& echo`, in the command itself or inside any
+command substitution (`out="$(guard | tail -1)"` and its backtick
+spelling run the same gate and read the same pipe's status), an
+assignment to zsh's reserved `status`/`path`/
 `argv`/`PWD`, a `ScheduleWakeup` under 900 s, and an `Edit`/`Write`
 inside the primary checkout. It fails open on any internal error, and it
 exempts a dispatched fleet clone (which is itself the isolated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,10 +462,11 @@ into a false green. When you write or edit any such script:
   three commits behind, and `out=$(guard N 2>&1 | tail -1)` reported 0 for a
   guard that was not in that checkout and had really exited 127. A guard
   that reports fresh on a stale branch is worse than no guard, because it
-  retires the suspicion that would have caught it. In zsh, `$pipestatus`
-  holds every stage, so `guard N | tail -1` followed by
-  `code=${pipestatus[1]}` shortens the output without lying about the
-  result.
+  retires the suspicion that would have caught it. The PreToolUse hook now refuses both forms rather than
+  leaving this to memory. When you genuinely want short output and the
+  truth, redirect to a file and read it separately; if you must pipe, bash
+  keeps every stage in `${PIPESTATUS[0]}` (zsh spells it `${pipestatus[1]}`,
+  and every script under scripts/ is bash).
 - A plain `out=$(cmd)` DOES propagate cmd's status, including when `$?` is
   read on the next line; measured, not recalled. The two forms that lose it
   are `local o=$(cmd)`, where `local`'s own success becomes the status, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,7 +387,13 @@ there before changing a rule.
   proceed anyway. It exits 1 for a base that is behind and 2 when it could
   not tell (bad argument, no such pull request, git failed), so a caller
   reporting to a human can say which it got; a caller that only needs "may
-  I merge" treats any non-zero as no. Note it fetches with an explicit destination refspec: a
+  I merge" treats any non-zero as no, and MUST, because 126 and 127 come
+  from the shell rather than the guard and mean it never ran. That is not
+  hypothetical: the guard is newer than most checkouts, a primary checkout
+  here is routinely dozens of commits behind, and one lacking the file
+  exits 127, which a caller switching on 1 versus 2 falls straight
+  through. Run it from a worktree that is on current main; asking a stale
+  tree whether a branch is stale is the same mistake one level up. Note it fetches with an explicit destination refspec: a
   hand-rolled version using `git fetch origin main <other-ref>` and then
   `rev-parse FETCH_HEAD` reads back MAIN, so it compares main with itself
   and reports every branch fresh.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,13 +381,24 @@ there before changing a rule.
   when a PR's merge base is behind `origin/main`, printing how far and what
   it has not seen. `pr-review-status.sh` runs it, so a stale PR never gets
   the merge command printed; run it directly for any merge that bypasses
-  that script. Green CI on a stale base is not evidence about the merge:
-  `main` runs no CI of its own, so a PR green against an older base can
-  still break it (8a534f43 left main uncompilable exactly this way, a
-  five-argument call site landing minutes before another PR made the
-  function take six, both PRs green), and a gate added to `main` after a PR
-  went green has never run against that PR at all. Four PRs were CI-green
-  and behind simultaneously on 2026-09-06. `ALLOW_STALE_MERGE_BASE=1` to
+  that script. Green CI on a stale base is not evidence about the merge: a
+  PR green against an older base can still break `main` (8a534f43 left main
+  uncompilable exactly this way, a five-argument call site landing minutes
+  before another PR made the function take six, both PRs green), and a gate
+  added to `main` after a PR went green has never run against that PR at
+  all. Four PRs were CI-green and behind simultaneously on 2026-09-06.
+  `main` DOES run its own CI (`ci.yml` has `on: push: branches: [main]`;
+  the coverage lane and the publish gate both need it), so a break of the
+  8a534f43 kind is detected, but only once the merge has landed and anyone
+  pulling in between has a broken tree. Detection after the damage is not
+  prevention. One class survives main's push CI entirely and this guard is
+  its only detector: a landing loop that copies files against a list
+  derived from current main can DELETE a change another session landed
+  minutes earlier, and that revert is textually clean and green, because
+  removing lines compiles as well as never adding them and the tests for
+  the reverted work went in the same commit. Two were caught on 2026-09-09,
+  both only because the guard printed a merge-base the author did not
+  recognise. `ALLOW_STALE_MERGE_BASE=1` to
   proceed anyway. It exits 1 for a base that is behind and 2 when it could
   not tell (bad argument, no such pull request, git failed), so a caller
   reporting to a human can say which it got; a caller that only needs "may

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,8 +453,24 @@ into a false green. When you write or edit any such script:
   on everything).
 - Never name a variable `status`, `path`, `argv`, or `PWD`: zsh reserves
   them, and assignment kills the loop with `read-only variable`.
-- Never pipe a gate through `grep`, `head`, or `tail`, and never append
-  `&& echo MARKER`: the pipeline's exit code masks the gate's.
+- Never pipe a gate OR A GUARD through `grep`, `head`, or `tail`, and never
+  append `&& echo MARKER`: the pipeline's exit code masks the real one. The
+  rule reads as being about gates and is not. On 2026-09-09 two sessions
+  broke it on `assert-fresh-merge-base.sh` within the same hour, both while
+  shortening its output: `guard 1556 | head -3` reported exit 0 on a branch
+  three commits behind, and `out=$(guard N 2>&1 | tail -1)` reported 0 for a
+  guard that was not in that checkout and had really exited 127. A guard
+  that reports fresh on a stale branch is worse than no guard, because it
+  retires the suspicion that would have caught it. In zsh, `$pipestatus`
+  holds every stage, so `guard N | tail -1` followed by
+  `code=${pipestatus[1]}` shortens the output without lying about the
+  result.
+- A plain `out=$(cmd)` DOES propagate cmd's status, including when `$?` is
+  read on the next line; measured, not recalled. The two forms that lose it
+  are `local o=$(cmd)`, where `local`'s own success becomes the status, and
+  any pipe. Do not restructure a working assignment believing otherwise: a
+  session diagnosed its pipe bug as an assignment bug and wrote the wrong
+  mechanism into its notes.
 
 ## Fleet executor environment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,7 +274,8 @@ connection, a pushed-but-broken main).
   commit ids, not the tree, so the tree-hash-keyed receipt still matches.
 - `scripts/pr-review-status.sh <pr-number>`: one-line status for the
   wait-for-CodeRabbit-then-merge-by-hand flow -- `mergeStateStatus`, the
-  CI check rollup (pass/pending/fail counts, failing check names), and
+  CI check rollup (pass/pending/fail counts, a skipped count when it is
+  nonzero, and failing check names), and
   the `coderabbitai[bot]` review count plus its inline-comment count. The
   REST comments endpoint carries no resolved/unresolved field (that's a
   GraphQL review-thread concept), so a nonzero comment count needs a

--- a/scripts/guards/assert-fresh-merge-base.sh
+++ b/scripts/guards/assert-fresh-merge-base.sh
@@ -23,6 +23,12 @@
 # non-zero as no; one that reports to a human should say which of the two it
 # got, since "behind" and "could not tell" have different fixes.
 #
+# A caller must treat any non-zero as no rather than switching on 1 versus 2,
+# because 126 and 127 never reach this script: they come from the shell when
+# this file is not executable or not there at all, and a checkout behind the
+# commit that added it has neither. Run this from a worktree on current main
+# for the same reason.
+#
 # Fetches with an explicit destination refspec rather than reading FETCH_HEAD.
 # `git fetch origin main <other-ref>` leaves FETCH_HEAD naming main, so a check
 # written that way compares main with itself and reports success for any branch.

--- a/scripts/guards/assert-fresh-merge-base.sh
+++ b/scripts/guards/assert-fresh-merge-base.sh
@@ -4,11 +4,30 @@
 # in THIS invocation. Exit 0 when the branch already contains that tip; exit 1
 # when main has moved ahead of it, printing how far behind and what landed.
 #
-# Green CI on a stale base is not evidence about the merge. `main` runs no CI of
-# its own here, so a PR that passed against an older base can still break `main`
-# the moment it lands: that is how commit 8a534f43 left main uncompilable, when a
-# five-argument call site landed minutes before another PR made the same function
-# take six. Both PRs were green. Neither had seen the other.
+# Green CI on a stale base is not evidence about the merge. A PR that passed
+# against an older base can still break `main` the moment it lands: that is how
+# commit 8a534f43 left main uncompilable, when a five-argument call site landed
+# minutes before another PR made the same function take six. Both PRs were
+# green. Neither had seen the other.
+#
+# `main` DOES run its own CI (`ci.yml` carries `on: push: branches: [main]`,
+# and the coverage lane and the publish gate depend on it), so that break is
+# detected. Detected late and after the damage: the run starts once the merge
+# has landed, so whoever pulls in the meantime gets a broken tree, and nothing
+# is prevented. An earlier version of this comment said main runs no CI at all,
+# which overstated the case; the argument is that detection after the fact is
+# not prevention, not that no one would ever notice.
+#
+# One class does survive main's push CI completely, and this guard is its only
+# detector. A landing loop that copies files, working from a file list derived
+# from current main rather than from the branch's own base, can DELETE a change
+# another session landed minutes earlier. That diff is textually clean and
+# green: removing lines someone added compiles exactly as well as never adding
+# them, and the tests covering the reverted work were added in the same commit
+# being reverted. Nothing goes red, on the PR or on main. The only signal is
+# this guard printing a merge-base the author does not recognise, which is a
+# side effect of it reporting the base at all rather than something it looks
+# for. Two such reverts were caught that way on 2026-09-09.
 #
 # It also silently skips gates. A gate added to `main` after a PR went green has
 # never run against that PR, so the branch merges without the check its author

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -193,11 +193,16 @@ cr_comments=$(echo "${comments_json}" | jq '[.[] | select(.user.login=="coderabb
 cr_outside_diff=$(echo "${reviews_json}" | jq --arg sha "${head_sha}" \
   -f "$(dirname "$0")/lib/coderabbit-outside-diff.jq")
 
-# "CI green" is a claim about checks that RAN. On a pull request whose paths
-# excluded every one of them, the honest phrase is that nothing ran: the merge
-# is still allowed, since GitHub treats a skipped required check as satisfied,
-# but an operator reading "CI green" would conclude the suite covered this
-# change when it did not.
+# "CI green" is a claim about checks that RAN, so a rollup of nothing but
+# skips should not make it. This branch is DEFENSIVE, not a case this
+# repository currently reaches: no workflow here carries an `on.*.paths`
+# filter, and ci.yml's `changes` job has neither `needs:` nor `if:`, so it and
+# the other ungated lanes run and pass on every pull request. A docs-only PR
+# therefore reads 4 pass / 15 skipped, not 0 / 19, and "CI green" is honest on
+# it. What was wrong there was only the COUNT, which said 19 pass. Keep this
+# branch anyway: it costs three lines and it is what stops the phrase lying if
+# a path filter is ever added, which is the change that would make it
+# reachable.
 ci_phrase="CI green"
 if [[ "${success}" == "0" && "${skipped}" != "0" ]]; then
   ci_phrase="every check skipped, nothing ran"

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -76,7 +76,8 @@ normalized="$(echo "${pr_json}" | jq '
          else "other" end)
       elif has("status") then
         (if .status!="COMPLETED" then "pending"
-         elif (.conclusion=="SUCCESS" or .conclusion=="NEUTRAL" or .conclusion=="SKIPPED") then "success"
+         elif .conclusion=="SKIPPED" then "skipped"
+         elif (.conclusion=="SUCCESS" or .conclusion=="NEUTRAL") then "success"
          elif (.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT") then "failing"
          else "other" end)
       else "other" end
@@ -86,7 +87,13 @@ pending=$(echo "${normalized}" | jq '[.[] | select(.class=="pending")] | length'
 success=$(echo "${normalized}" | jq '[.[] | select(.class=="success")] | length')
 failing=$(echo "${normalized}" | jq '[.[] | select(.class=="failing")] | length')
 failing_names=$(echo "${normalized}" | jq -r '[.[] | select(.class=="failing") | .name] | join(",")')
-# Every check must land in success/pending/failing above (an ACTION_REQUIRED
+# A skipped check is not a failure and does not block a merge -- GitHub's own
+# ruleset treats a path-filtered required check as satisfied -- but it is not
+# a pass either, and folding it into the pass count reports "19 pass" for a
+# pull request on which nothing ran at all. Counted on its own so the line
+# says which it was.
+skipped=$(echo "${normalized}" | jq '[.[] | select(.class=="skipped")] | length')
+# Every check must land in success/skipped/pending/failing above (an ACTION_REQUIRED
 # or STALE conclusion, an unrecognized state value, or a shape this script
 # has never seen) before CI counts as settled; this catches whatever falls
 # through all three.
@@ -186,7 +193,19 @@ cr_comments=$(echo "${comments_json}" | jq '[.[] | select(.user.login=="coderabb
 cr_outside_diff=$(echo "${reviews_json}" | jq --arg sha "${head_sha}" \
   -f "$(dirname "$0")/lib/coderabbit-outside-diff.jq")
 
+# "CI green" is a claim about checks that RAN. On a pull request whose paths
+# excluded every one of them, the honest phrase is that nothing ran: the merge
+# is still allowed, since GitHub treats a skipped required check as satisfied,
+# but an operator reading "CI green" would conclude the suite covered this
+# change when it did not.
+ci_phrase="CI green"
+if [[ "${success}" == "0" && "${skipped}" != "0" ]]; then
+  ci_phrase="every check skipped, nothing ran"
+fi
 summary="PR #${pr} @ ${head_sha}: state=${state} mergeState=${merge_state} CI=${success} pass/${pending} pending/${failing} fail"
+if [[ "${skipped}" != "0" ]]; then
+  summary="${summary}/${skipped} skipped"
+fi
 if [[ "${other}" != "0" ]]; then
   summary="${summary}/${other} unrecognized"
 fi
@@ -252,13 +271,13 @@ elif [[ "${merge_state}" != "CLEAN" && "${merge_state}" != "UNSTABLE" ]]; then
   echo "  -> every check and review looks clean, but mergeState is ${merge_state} (not CLEAN/UNSTABLE); verify by hand before merging"
 else
   if [[ "${cr_comments}" != "0" && "${cr_outside_diff}" != "0" ]]; then
-    echo "  -> clean (operator confirmed all ${cr_comments} inline comment(s) and ${cr_outside_diff} outside-diff body finding(s) addressed): CI green, CodeRabbit's risk line names the current head"
+    echo "  -> clean (operator confirmed all ${cr_comments} inline comment(s) and ${cr_outside_diff} outside-diff body finding(s) addressed): ${ci_phrase}, CodeRabbit's risk line names the current head"
   elif [[ "${cr_comments}" != "0" ]]; then
-    echo "  -> clean (operator confirmed all ${cr_comments} inline comment(s) addressed): CI green, CodeRabbit's risk line names the current head"
+    echo "  -> clean (operator confirmed all ${cr_comments} inline comment(s) addressed): ${ci_phrase}, CodeRabbit's risk line names the current head"
   elif [[ "${cr_outside_diff}" != "0" ]]; then
-    echo "  -> clean (operator confirmed all ${cr_outside_diff} outside-diff body finding(s) addressed): CI green, CodeRabbit's risk line names the current head"
+    echo "  -> clean (operator confirmed all ${cr_outside_diff} outside-diff body finding(s) addressed): ${ci_phrase}, CodeRabbit's risk line names the current head"
   else
-    echo "  -> clean: CI green, CodeRabbit's risk line names the current head with zero inline comments"
+    echo "  -> clean: ${ci_phrase}, CodeRabbit's risk line names the current head with zero inline comments"
   fi
   # The freshness check above proved the base current at the moment it ran, not
   # for however long the operator takes to run this line; `--match-head-commit`

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -261,10 +261,12 @@ elif [[ "${cr_outside_diff}" != "0" && "${confirm_addressed}" != "1" ]]; then
   echo "  -> ${cr_outside_diff} CodeRabbit outside-diff finding(s) in the review BODY at head, not inline; read the body with \`gh api repos/${repo}/pulls/${pr}/reviews --jq '.[] | select(.commit_id==\"${head_sha}\") | .body'\`, then re-run with --confirm-addressed once each is fixed or answered"
 # Ahead of the mergeState check on purpose. A stale base is always actionable
 # and the fix is always the same; mergeState UNKNOWN is often just GitHub still
-# computing. Green CI on a stale base says nothing about the merge: `main` runs
-# no CI of its own, so a PR that passed against an older base can still break
-# it, and a gate added to `main` after the PR went green has never run against
-# the PR at all. Costs one fetch.
+# computing. Green CI on a stale base says nothing about the merge: a PR that
+# passed against an older base can still break `main`, and a gate added to
+# `main` after the PR went green has never run against the PR at all. Main's
+# own push CI catches the first of those after the merge has landed, which is
+# detection rather than prevention, and it never catches a landing loop that
+# silently reverts a concurrent change. Costs one fetch.
 elif ! merge_base_guard; then
   if [[ "${guard_rc}" == "1" ]]; then
     echo "  -> merge base is behind origin/main; rebase and let CI re-run before merging"

--- a/scripts/pr-review-status.test.sh
+++ b/scripts/pr-review-status.test.sh
@@ -392,8 +392,12 @@ e2e() {
   local fx="${E2E_DIR}/fx"
   rm -rf "${fx}"
   mkdir -p "${fx}"
-  printf '{"state":"OPEN","mergeStateStatus":"CLEAN","statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"headRefOid":"%s"}\n' \
-    "${SHA}" >"${fx}/pr-view.json"
+  local rollup="${E2E_ROLLUP:-}"
+  if [[ -z "${rollup}" ]]; then
+    rollup='[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}]'
+  fi
+  printf '{"state":"OPEN","mergeStateStatus":"CLEAN","statusCheckRollup":%s,"headRefOid":"%s"}\n' \
+    "${rollup}" "${SHA}" >"${fx}/pr-view.json"
   printf '[{"user":{"login":"coderabbitai[bot]"},"state":"COMMENTED","commit_id":"%s","body":%s}]\n' \
     "${SHA}" "${review_body}" >"${fx}/reviews.json"
   printf '%s\n' "${E2E_ISSUE_COMMENTS:-${FRESH_WALKTHROUGH}}" >"${fx}/issue-comments.json"
@@ -710,6 +714,42 @@ guard_noarg_rc=0
 check_eq "the guard exits 2 when given no argument at all" \
   "2" \
   "${guard_noarg_rc}"
+
+# --- skipped checks are not passes -------------------------------------
+#
+# A path-filtered pull request (a docs-only change, say) comes back with every
+# required check COMPLETED/SKIPPED. GitHub treats that as satisfying the
+# ruleset, so the merge is allowed and nothing here should block it -- but
+# folding those into the pass count reported "19 pass" for a pull request on
+# which nothing ran, which is what an operator reads as "the suite covered
+# this change".
+
+E2E_ROLLUP='[{"name":"check","status":"COMPLETED","conclusion":"SKIPPED"},{"name":"lint","status":"COMPLETED","conclusion":"SKIPPED"}]'
+all_skipped_out="$(e2e "${CLEAN_BODY_JSON}")"
+unset E2E_ROLLUP
+
+check_eq "all checks skipped: counted as skipped, not as passes" \
+  "PR #908 @ ${SHA}: state=OPEN mergeState=CLEAN CI=0 pass/0 pending/0 fail/2 skipped | CodeRabbit: risk_line=head reviews@head=1 walkthroughs@head=0 last=COMMENTED inline_comments=0" \
+  "$(printf '%s\n' "${all_skipped_out}" | sed -n 1p)"
+check_eq "all checks skipped: the verdict does not claim CI green" \
+  "  -> clean: every check skipped, nothing ran, CodeRabbit's risk line names the current head with zero inline comments" \
+  "$(printf '%s\n' "${all_skipped_out}" | sed -n 2p)"
+check_eq "all checks skipped: the merge command is still offered" \
+  "  -> scripts/guards/assert-fresh-merge-base.sh 908 && gh pr merge 908 --rebase --delete-branch --match-head-commit ${SHA}" \
+  "$(printf '%s\n' "${all_skipped_out}" | sed -n 3p)"
+
+# The mirror: one real pass beside one skip still says CI green, so the case
+# above is not passing because the phrase changed unconditionally.
+E2E_ROLLUP='[{"name":"check","status":"COMPLETED","conclusion":"SUCCESS"},{"name":"k8s","status":"COMPLETED","conclusion":"SKIPPED"}]'
+mixed_out="$(e2e "${CLEAN_BODY_JSON}")"
+unset E2E_ROLLUP
+
+check_eq "one pass beside one skip: both counted, separately" \
+  "PR #908 @ ${SHA}: state=OPEN mergeState=CLEAN CI=1 pass/0 pending/0 fail/1 skipped | CodeRabbit: risk_line=head reviews@head=1 walkthroughs@head=0 last=COMMENTED inline_comments=0" \
+  "$(printf '%s\n' "${mixed_out}" | sed -n 1p)"
+check_eq "one pass beside one skip: the verdict still says CI green" \
+  "  -> clean: CI green, CodeRabbit's risk line names the current head with zero inline comments" \
+  "$(printf '%s\n' "${mixed_out}" | sed -n 2p)"
 
 printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
 [[ "${fails}" -eq 0 ]]


### PR DESCRIPTION
fix(scripts): count a skipped check as skipped, not as a pass

`pr-review-status.sh` classified `SKIPPED` alongside `SUCCESS` and `NEUTRAL`, so a pull request whose paths excluded every required check reported `CI=19 pass/0 pending/0 fail`. Nothing had run. That line is what an operator reads as "the suite covered this change", and on a path-filtered branch it covered nothing.

Found on #1527, a one-paragraph documentation change: all nineteen checks came back COMPLETED/SKIPPED within a minute of the push, and both this script and the CI watcher built on it called that green. Verified against the API before changing anything: `gh api repos/NOFireAI/ravel/commits/<head>/check-runs` shows nineteen runs, every one `completed / skipped`, all against the current head.

Skipped now has its own class and count, appended to the summary only when nonzero, so a pull request with no skips prints exactly the line it printed before. It still does not block: GitHub's ruleset treats a path-filtered required check as satisfied, `mergeStateStatus` reflects that, and the merge command is still offered. What changes is that the verdict no longer claims "CI green" when nothing ran.

Five cases, both directions. An all-skipped rollup pins the counts, the verdict wording, and that the merge command is still printed; a rollup with one real pass beside one skip pins that the phrase stays "CI green", so the first cannot pass merely because the wording changed unconditionally. Folding `SKIPPED` back into success fails three of the five. Suite is 73 passed, 0 failed, and it now runs in CI as of #1287.

Refs: #1199
