### PR TITLE
fix(operator): harden the store qualification gate and its rbac test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   key Secret through `spec.auditTokenKeySecretRef`.** Until they do, the
   operator reports `AuditTokenKeyMissing` and leaves the query Deployment as
   it is. Clusters with `deploymentKeySecretRef` need no action.
+- **The operator's qualified-input hash now distinguishes an absent credentials
+  `resourceVersion` from an empty one** (issue #36). The credentials
+  `resourceVersion` slot carries the same one-byte presence marker the S3
+  `endpoint` slot got in 0.15.0, so an unresolved credentials Secret no longer
+  collides with one whose `resourceVersion` resolved to the empty string. The
+  encoding of that slot changes for every cluster, so every persisted
+  `status.storeQualifiedHash` changes and the first reconcile after upgrading
+  the operator re-qualifies each existing cluster once against its unchanged
+  store. The qualify Job is a one-shot that touches no Deployment, so no serving
+  pod is restarted and there is no downtime. Subsequent reconciles are stable.
+
+### Fixed
+
+- **A `RavelCluster` held at the store-qualification gate keeps its
+  `StoreQualified` condition when the reconcile then fails** (issue #36). The
+  degraded status write replaces the whole `conditions` array and previously
+  reconstructed only the `StoreQualified=True` case, so a pass held at the gate
+  that then failed a write left a `Degraded` object carrying no `StoreQualified`
+  condition and nothing to say the store had not qualified. The gate now carries
+  out the exact condition it built, `True` or `False` with its Pending or Failed
+  reason, and records it before it creates or deletes the qualify Job, so a
+  failure in that API call cannot drop it either.
 
 ## [0.15.0] - 2026-09-08
 
@@ -154,15 +176,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   with retention bounded to the plan fan-out in objects times the object
   size. On ClickBench q20 that was 6,785 GETs and 21.1 GB, where a
   corpus-sized cache gives 4,533 GETs and 11.24 GB.
-- **The operator's qualified-input hash now distinguishes an absent field from an
-  empty one for the S3 `endpoint` and the credentials `resourceVersion`** (issue
-  #36). Each carries a one-byte presence marker before its value, so `endpoint:
-  null` no longer collides with `endpoint: ""` and an unresolved credentials
-  Secret no longer collides with one whose `resourceVersion` resolved to the empty
-  string. Because the hash changes, the first reconcile after upgrading the
-  operator re-qualifies each existing cluster once against its unchanged store; the
-  qualify Job is a one-shot that touches no Deployment, so no serving pod is
-  restarted and there is no downtime. Subsequent reconciles are stable.
+- **The operator's qualified-input hash distinguishes an absent S3 `endpoint`
+  from an empty one** (issue #36). The endpoint carries a one-byte presence
+  marker before its value, so `endpoint: null` no longer hashes the same as
+  `endpoint: ""`. The two select different stores, so editing between them now
+  re-runs qualification instead of being read as an unchanged input.
 - **The operator now bounds qualify-Job recreations for a store that keeps
   failing qualification** (issue #36). A failing `ravel-cli store qualify` Job is
   recreated on a capped exponential backoff (30 s doubling to a 480 s ceiling)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   with retention bounded to the plan fan-out in objects times the object
   size. On ClickBench q20 that was 6,785 GETs and 21.1 GB, where a
   corpus-sized cache gives 4,533 GETs and 11.24 GB.
+- **The operator's qualified-input hash now distinguishes an absent field from an
+  empty one for the S3 `endpoint` and the credentials `resourceVersion`** (issue
+  #36). Each carries a one-byte presence marker before its value, so `endpoint:
+  null` no longer collides with `endpoint: ""` and an unresolved credentials
+  Secret no longer collides with one whose `resourceVersion` resolved to the empty
+  string. Because the hash changes, the first reconcile after upgrading the
+  operator re-qualifies each existing cluster once against its unchanged store; the
+  qualify Job is a one-shot that touches no Deployment, so no serving pod is
+  restarted and there is no downtime. Subsequent reconciles are stable.
 - **The operator now bounds qualify-Job recreations for a store that keeps
   failing qualification** (issue #36). A failing `ravel-cli store qualify` Job is
   recreated on a capped exponential backoff (30 s doubling to a 480 s ceiling)

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -452,6 +452,19 @@ once even when the referenced Secrets are unchanged; subsequent reconciles are
 stable. Operators should schedule the operator upgrade in a maintenance window
 that tolerates one rolling restart of each serving tier.
 
+**Amendment (2026-09-08): the credentials `resourceVersion` slot in the
+qualified-input hash distinguishes absent from empty.** The credentials
+`resourceVersion` fed the hash through `unwrap_or("")`, collapsing an unresolved
+Secret (`None`) and one whose `resourceVersion` resolved to the empty string
+(`Some("")`) onto the same `""`, though they are different credential states. It
+now carries the same one-byte presence marker the endpoint slot already uses
+(`0x01` then the value when present, a lone `0x00` when absent), which the field
+separator alone cannot supply. This changes every persisted qualified-input hash
+once more, so the first reconcile after upgrading the operator re-runs store
+qualification once for every existing cluster on otherwise-unchanged inputs. The
+qualify Job is a one-shot that touches no Deployment, so there is no serving
+downtime; subsequent reconciles are stable.
+
 ## Rejected alternatives
 
 1. **Go operator (kubebuilder/controller-runtime).** The larger example

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -8,6 +8,7 @@
 //! references onto the rendered objects, and server-side-applies them.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -1090,6 +1091,32 @@ async fn delete_stale_qualify_job(api: &Api<Job>, name: &str) -> Result<(), Erro
     Ok(())
 }
 
+/// Record the gate's `StoreQualified=False` condition, then run the qualify-Job
+/// mutation the plan chose.
+///
+/// The order is the whole point of this function. `job_action` is an apply or a
+/// delete against the API server, so it can return `Err`, and that `Err` leaves
+/// [`reconcile_inner`] for the degraded status writer, which PATCHes the whole
+/// `conditions` array from `store_qualified_condition` plus the base conditions.
+/// Recording the condition first means a failed mutation still leaves the
+/// degraded object carrying `StoreQualified=False` with the gate's exact
+/// Pending/Failed reason; recording it after would leave the channel `None` and
+/// drop `StoreQualified` from the degraded object entirely, the same hole
+/// [`degraded_extra_conditions`] closes one step later.
+async fn hold_for_qualification(
+    generation: Option<i64>,
+    reason: &str,
+    message: &str,
+    store_qualified_condition: &mut Option<Condition>,
+    extra_conditions: &mut Vec<Condition>,
+    job_action: impl Future<Output = Result<(), Error>>,
+) -> Result<(), Error> {
+    let store_qualified = condition("StoreQualified", false, generation, reason, message);
+    *store_qualified_condition = Some(store_qualified.clone());
+    extra_conditions.push(store_qualified);
+    job_action.await
+}
+
 /// The `StoreQualified=False` message for a Failed qualification hold (finding
 /// 3), naming the consecutive-failure count and, when the plan set one, the next
 /// retry instant, plus the Job's own failure message when it carried one. Kept
@@ -1141,8 +1168,9 @@ fn degraded_store_qualified_hash(
 /// message. Re-adding it keeps the degraded object carrying that condition for
 /// as long as the failing step persists, so a stage-one wait keyed on it fails
 /// on the real qualification state rather than burning its full bound because
-/// the condition went missing. When the pass failed before the gate ran,
-/// `store_qualified` is `None` and the base conditions pass through untouched.
+/// the condition went missing. When the pass failed before the gate built its
+/// condition, `store_qualified` is `None` and the base conditions pass through
+/// untouched.
 fn degraded_extra_conditions(
     mut base: Vec<Condition>,
     store_qualified: Option<Condition>,
@@ -1181,7 +1209,7 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
     // computed at the gate (True on Proceed, False on a Pending/Failed hold), so
     // the degraded error path below carries the real qualification state through
     // instead of reconstructing only the True case (finding 1). A pass that fails
-    // before the gate leaves this None.
+    // before the gate builds its condition leaves this None.
     let mut store_qualified_condition: Option<Condition> = None;
     match reconcile_inner(
         &obj,
@@ -1384,26 +1412,6 @@ async fn reconcile_inner(
                 now_unix_secs(),
                 i64::try_from(BOOTSTRAP_POLL.as_secs()).unwrap_or(10),
             );
-            match plan.action {
-                QualifyJobAction::Create => {
-                    let owner = obj.controller_owner_ref(&()).map(|owner| vec![owner]);
-                    let mut job = desired_qualify_job(&obj.spec, instance, shared_rv);
-                    job.metadata.namespace = Some(namespace.to_string());
-                    job.metadata.owner_references = owner;
-                    apply(&jobs, &qualify_name, &job).await?;
-                }
-                QualifyJobAction::DeleteStale => {
-                    // Delete the stale or Failed Job with FOREGROUND propagation:
-                    // its owned Pod is torn down before the Job object disappears,
-                    // and a later pass observes it fully absent and creates a
-                    // fresh one. Without foreground propagation Kubernetes can
-                    // remove the Job while its Pod still runs the old inputs, and
-                    // the next reconcile would create the replacement alongside
-                    // that live stale Pod.
-                    delete_stale_qualify_job(&jobs, &qualify_name).await?;
-                }
-                QualifyJobAction::None => {}
-            }
             let (reason, message) = match plan.reason {
                 QualifyStoreReason::Pending => (
                     STORE_QUALIFIED_PENDING_REASON,
@@ -1418,19 +1426,41 @@ async fn reconcile_inner(
                     ),
                 ),
             };
-            let store_qualified = condition(
-                "StoreQualified",
-                false,
+            // The condition is recorded BEFORE the plan's Job mutation runs: see
+            // `hold_for_qualification`. Both mutations are API calls that can
+            // return Err, and that Err leaves this function for the degraded
+            // status writer, which needs the gate's condition already carried out.
+            hold_for_qualification(
                 obj.metadata.generation,
                 reason,
                 &message,
-            );
-            // Carry the False condition out so a status-write failure on this
-            // not-qualified path still lands it on the degraded object with its
-            // exact reason and message, rather than dropping StoreQualified
-            // entirely (finding 1).
-            *store_qualified_condition = Some(store_qualified.clone());
-            extra_conditions.push(store_qualified);
+                store_qualified_condition,
+                &mut extra_conditions,
+                async {
+                    match plan.action {
+                        QualifyJobAction::Create => {
+                            let owner = obj.controller_owner_ref(&()).map(|owner| vec![owner]);
+                            let mut job = desired_qualify_job(&obj.spec, instance, shared_rv);
+                            job.metadata.namespace = Some(namespace.to_string());
+                            job.metadata.owner_references = owner;
+                            apply(&jobs, &qualify_name, &job).await.map(|_| ())
+                        }
+                        QualifyJobAction::DeleteStale => {
+                            // Delete the stale or Failed Job with FOREGROUND
+                            // propagation: its owned Pod is torn down before the
+                            // Job object disappears, and a later pass observes it
+                            // fully absent and creates a fresh one. Without
+                            // foreground propagation Kubernetes can remove the Job
+                            // while its Pod still runs the old inputs, and the next
+                            // reconcile would create the replacement alongside that
+                            // live stale Pod.
+                            delete_stale_qualify_job(&jobs, &qualify_name).await
+                        }
+                        QualifyJobAction::None => Ok(()),
+                    }
+                },
+            )
+            .await?;
 
             // Report the readiness a prior pass recorded, so a cluster already
             // serving through a re-qualification keeps `Available=True` instead of
@@ -3203,8 +3233,8 @@ mod tests {
     /// its cloned copy, which never reaches this writer, and the writer PATCHes
     /// the whole conditions array; so without carrying it out the degraded object
     /// drops StoreQualified entirely and a stage-one wait keyed on it burns its
-    /// full bound. When the pass failed before the gate ran (`store_qualified`
-    /// None), the base conditions pass through untouched.
+    /// full bound. When the pass failed before the gate built its condition
+    /// (`store_qualified` None), the base conditions pass through untouched.
     #[test]
     fn degraded_status_keeps_store_qualified_after_a_post_proceed_failure() {
         let base = vec![condition(
@@ -3236,7 +3266,8 @@ mod tests {
         // The base conditions are preserved, not replaced.
         assert!(after.iter().any(|c| c.r#type == "SpecValid"));
 
-        // Failed before the gate: base passes through, StoreQualified absent.
+        // Failed before the gate built its condition: base passes through,
+        // StoreQualified absent.
         let untouched = degraded_extra_conditions(base.clone(), None);
         assert!(!untouched.iter().any(|c| c.r#type == "StoreQualified"));
         assert_eq!(untouched.len(), base.len());
@@ -3285,6 +3316,74 @@ mod tests {
         // Flip: dropping the carried condition leaves StoreQualified absent.
         let dropped = degraded_extra_conditions(base.clone(), None);
         assert!(!dropped.iter().any(|c| c.r#type == "StoreQualified"));
+    }
+
+    /// The not-qualified path records the gate's condition BEFORE it mutates the
+    /// qualify Job, so a failed apply or foreground delete still reaches the
+    /// degraded writer with StoreQualified=False and the gate's exact reason
+    /// rather than a None channel. `hold_for_qualification` is the function
+    /// `reconcile_inner` calls with the real `apply` / `delete_stale_qualify_job`
+    /// future; this passes one that fails the way those calls fail, since the
+    /// crate mocks no `kube::Client`. Move the recording after `job_action.await`
+    /// and the carried condition is None and the assertions below fail.
+    #[tokio::test]
+    async fn a_failed_qualify_job_mutation_still_carries_the_gate_condition() {
+        let mut carried: Option<Condition> = None;
+        let mut extra = vec![condition(
+            "SpecValid",
+            true,
+            Some(11),
+            "Accepted",
+            "spec accepted",
+        )];
+        // A Failed hold's exact reason and message: two consecutive failures with
+        // a next-retry instant, the state the gate holds when it deletes a Failed
+        // Job to recreate it.
+        let message = qualify_failed_message(2, Some(1_700_000_000), Some("probe failed"));
+
+        let err = hold_for_qualification(
+            Some(11),
+            STORE_QUALIFIED_FAILED_REASON,
+            &message,
+            &mut carried,
+            &mut extra,
+            async {
+                Err(Error::SecretNotFound {
+                    name: "ravel-s3".to_string(),
+                    reason: "the qualify Job mutation failed".to_string(),
+                })
+            },
+        )
+        .await
+        .expect_err("the injected Job-mutation failure propagates to the caller");
+        assert!(matches!(err, Error::SecretNotFound { .. }));
+
+        let store_qualified = carried
+            .as_ref()
+            .expect("the gate's condition is recorded before the fallible Job mutation");
+        assert_eq!(store_qualified.r#type, "StoreQualified");
+        assert_eq!(store_qualified.status, "False");
+        assert_eq!(store_qualified.reason, STORE_QUALIFIED_FAILED_REASON);
+        assert_eq!(store_qualified.message, message);
+        assert_eq!(store_qualified.observed_generation, Some(11));
+
+        // The local vector the success-path status writer would use got exactly
+        // one StoreQualified, alongside the one base condition: 2 conditions.
+        assert_eq!(extra.len(), 2);
+        assert_eq!(
+            extra
+                .iter()
+                .filter(|c| c.r#type == "StoreQualified")
+                .count(),
+            1
+        );
+
+        // End to end: that channel is what the degraded writer PATCHes.
+        let degraded = degraded_extra_conditions(Vec::new(), carried);
+        assert_eq!(degraded.len(), 1);
+        assert_eq!(degraded[0].status, "False");
+        assert_eq!(degraded[0].reason, STORE_QUALIFIED_FAILED_REASON);
+        assert_eq!(degraded[0].message, message);
     }
 
     /// Finding 3: credential resourceVersions are resolved before the gate and

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -1131,28 +1131,24 @@ fn degraded_store_qualified_hash(
 }
 
 /// The `extra_conditions` to PATCH onto the degraded status (finding 1).
-/// [`reconcile_inner`] takes `extra_conditions` by clone and pushes
-/// `StoreQualified=True` onto that local copy in the `Proceed` arm, so the
-/// mutation never reaches the outer error path here, and
-/// [`write_degraded_status`] replaces the whole `conditions` array. When a pass
-/// qualified before a later step failed (`qualification_passed`), re-add the
-/// condition so the degraded object still carries `StoreQualified=True` for as
-/// long as that step keeps failing; otherwise a stage-one wait keyed on the
-/// condition burns its full bound instead of failing on the `Degraded` reason.
-/// Reconstructed from the same `proceed_hash` signal the persisted hash reads.
+/// [`reconcile_inner`] takes `extra_conditions` by clone and pushes the
+/// `StoreQualified` condition it computes onto that local copy, so the mutation
+/// never reaches the outer error path here, and [`write_degraded_status`]
+/// replaces the whole `conditions` array. The gate carries the exact condition
+/// it computed out through `store_qualified`, whichever value the pass reached:
+/// `True` when qualification proceeded before a later step failed, or the
+/// `False` the not-qualified path built with its own Pending/Failed reason and
+/// message. Re-adding it keeps the degraded object carrying that condition for
+/// as long as the failing step persists, so a stage-one wait keyed on it fails
+/// on the real qualification state rather than burning its full bound because
+/// the condition went missing. When the pass failed before the gate ran,
+/// `store_qualified` is `None` and the base conditions pass through untouched.
 fn degraded_extra_conditions(
     mut base: Vec<Condition>,
-    qualification_passed: bool,
-    generation: Option<i64>,
+    store_qualified: Option<Condition>,
 ) -> Vec<Condition> {
-    if qualification_passed {
-        base.push(condition(
-            "StoreQualified",
-            true,
-            generation,
-            STORE_QUALIFIED_SUCCEEDED_REASON,
-            STORE_QUALIFIED_MESSAGE,
-        ));
+    if let Some(cond) = store_qualified {
+        base.push(cond);
     }
     base
 }
@@ -1181,6 +1177,12 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
     // reaches `QualificationDecision::Proceed`, so the degraded error path below
     // persists it rather than the stale `obj.status` value (finding 2).
     let mut proceed_hash: Option<String> = None;
+    // Set by `reconcile_inner` to whichever `StoreQualified` condition the pass
+    // computed at the gate (True on Proceed, False on a Pending/Failed hold), so
+    // the degraded error path below carries the real qualification state through
+    // instead of reconstructing only the True case (finding 1). A pass that fails
+    // before the gate leaves this None.
+    let mut store_qualified_condition: Option<Condition> = None;
     match reconcile_inner(
         &obj,
         client,
@@ -1188,6 +1190,7 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
         &instance,
         extra_conditions.clone(),
         &mut proceed_hash,
+        &mut store_qualified_condition,
     )
     .await
     {
@@ -1209,11 +1212,8 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
             // pass's proof and re-run qualification once the Job's TTL collected
             // it; using it when the pass never qualified is correct.
             let qualification_passed = proceed_hash.is_some();
-            let degraded_conditions = degraded_extra_conditions(
-                extra_conditions,
-                qualification_passed,
-                obj.metadata.generation,
-            );
+            let degraded_conditions =
+                degraded_extra_conditions(extra_conditions, store_qualified_condition);
             let store_qualified_hash = degraded_store_qualified_hash(
                 proceed_hash,
                 obj.status
@@ -1280,6 +1280,7 @@ async fn reconcile_inner(
     instance: &str,
     mut extra_conditions: Vec<Condition>,
     proceed_hash: &mut Option<String>,
+    store_qualified_condition: &mut Option<Condition>,
 ) -> Result<Action, Error> {
     // Read the resourceVersion of every credential Secret the spec references
     // BEFORE the qualification gate (finding 3): the shared storage.s3 credential
@@ -1329,13 +1330,17 @@ async fn reconcile_inner(
     // gate that keeps existing Deployments up while the new inputs qualify).
     let store_qualified_hash = match &decision {
         QualificationDecision::Proceed => {
-            extra_conditions.push(condition(
+            let store_qualified = condition(
                 "StoreQualified",
                 true,
                 obj.metadata.generation,
                 STORE_QUALIFIED_SUCCEEDED_REASON,
                 STORE_QUALIFIED_MESSAGE,
-            ));
+            );
+            // Carry the condition out so the degraded error path keeps it if a
+            // later step fails after the gate proceeded (finding 1).
+            *store_qualified_condition = Some(store_qualified.clone());
+            extra_conditions.push(store_qualified);
             // Qualification passed this pass. Carry the fresh hash into the
             // outer error path (finding 2): a later fallible step
             // (resolve_deployment_key, an apply) can still return Err, and
@@ -1413,13 +1418,19 @@ async fn reconcile_inner(
                     ),
                 ),
             };
-            extra_conditions.push(condition(
+            let store_qualified = condition(
                 "StoreQualified",
                 false,
                 obj.metadata.generation,
                 reason,
                 &message,
-            ));
+            );
+            // Carry the False condition out so a status-write failure on this
+            // not-qualified path still lands it on the degraded object with its
+            // exact reason and message, rather than dropping StoreQualified
+            // entirely (finding 1).
+            *store_qualified_condition = Some(store_qualified.clone());
+            extra_conditions.push(store_qualified);
 
             // Report the readiness a prior pass recorded, so a cluster already
             // serving through a re-qualification keeps `Available=True` instead of
@@ -3187,14 +3198,13 @@ mod tests {
         assert_eq!(degraded_store_qualified_hash(None, None), None);
     }
 
-    /// The degraded error path re-adds StoreQualified=True when the pass reached
-    /// Proceed before a later step failed (finding 1), exact condition. The
-    /// Proceed arm pushes it onto reconcile_inner's cloned copy, which never
-    /// reaches this writer, and the writer PATCHes the whole conditions array; so
-    /// without the re-add the degraded object drops StoreQualified entirely and a
-    /// stage-one wait keyed on it burns its full bound. When the pass failed
-    /// before the gate (`qualification_passed` false), the base conditions pass
-    /// through untouched and StoreQualified stays absent.
+    /// The degraded error path carries whichever StoreQualified condition the
+    /// gate computed (finding 1), exact condition. reconcile_inner pushes it onto
+    /// its cloned copy, which never reaches this writer, and the writer PATCHes
+    /// the whole conditions array; so without carrying it out the degraded object
+    /// drops StoreQualified entirely and a stage-one wait keyed on it burns its
+    /// full bound. When the pass failed before the gate ran (`store_qualified`
+    /// None), the base conditions pass through untouched.
     #[test]
     fn degraded_status_keeps_store_qualified_after_a_post_proceed_failure() {
         let base = vec![condition(
@@ -3206,12 +3216,19 @@ mod tests {
         )];
 
         // Reached Proceed, then a later apply failed: StoreQualified=True is
-        // re-added with the exact success reason and message, generation carried.
-        let after = degraded_extra_conditions(base.clone(), true, Some(7));
+        // carried with the exact success reason and message, generation carried.
+        let carried_true = condition(
+            "StoreQualified",
+            true,
+            Some(7),
+            STORE_QUALIFIED_SUCCEEDED_REASON,
+            STORE_QUALIFIED_MESSAGE,
+        );
+        let after = degraded_extra_conditions(base.clone(), Some(carried_true));
         let store_qualified = after
             .iter()
             .find(|c| c.r#type == "StoreQualified")
-            .expect("StoreQualified re-added on the degraded write after Proceed");
+            .expect("StoreQualified carried onto the degraded write after Proceed");
         assert_eq!(store_qualified.status, "True");
         assert_eq!(store_qualified.reason, STORE_QUALIFIED_SUCCEEDED_REASON);
         assert_eq!(store_qualified.message, STORE_QUALIFIED_MESSAGE);
@@ -3220,9 +3237,54 @@ mod tests {
         assert!(after.iter().any(|c| c.r#type == "SpecValid"));
 
         // Failed before the gate: base passes through, StoreQualified absent.
-        let untouched = degraded_extra_conditions(base.clone(), false, Some(7));
+        let untouched = degraded_extra_conditions(base.clone(), None);
         assert!(!untouched.iter().any(|c| c.r#type == "StoreQualified"));
         assert_eq!(untouched.len(), base.len());
+    }
+
+    /// A pass that computes StoreQualified=False at the gate (a Pending/Failed
+    /// hold) and then fails its status write lands that exact False condition on
+    /// the degraded status, not a reconstructed True and not a missing condition
+    /// (finding 1). The gate carries the condition it built, reason and message
+    /// included, out to the degraded writer; dropping the carried condition (the
+    /// flip: pass None) leaves StoreQualified absent and a Failed hold reads as an
+    /// unexplained Degraded instead.
+    #[test]
+    fn degraded_status_keeps_a_false_store_qualified_from_the_gate() {
+        let base = vec![condition(
+            "SpecValid",
+            true,
+            Some(7),
+            "Accepted",
+            "spec accepted",
+        )];
+
+        // The exact Failed-hold condition reconcile_inner's not-qualified arm
+        // builds: StoreQualified=False with the Failed reason and the retry
+        // message qualify_failed_message renders.
+        let message = qualify_failed_message(3, None, Some("backend rejected CAS"));
+        let carried_false = condition(
+            "StoreQualified",
+            false,
+            Some(7),
+            STORE_QUALIFIED_FAILED_REASON,
+            &message,
+        );
+
+        let after = degraded_extra_conditions(base.clone(), Some(carried_false));
+        let store_qualified = after
+            .iter()
+            .find(|c| c.r#type == "StoreQualified")
+            .expect("the gate's StoreQualified=False is carried onto the degraded write");
+        assert_eq!(store_qualified.status, "False");
+        assert_eq!(store_qualified.reason, STORE_QUALIFIED_FAILED_REASON);
+        assert_eq!(store_qualified.message, message);
+        assert_eq!(store_qualified.observed_generation, Some(7));
+        assert!(after.iter().any(|c| c.r#type == "SpecValid"));
+
+        // Flip: dropping the carried condition leaves StoreQualified absent.
+        let dropped = degraded_extra_conditions(base.clone(), None);
+        assert!(!dropped.iter().any(|c| c.r#type == "StoreQualified"));
     }
 
     /// Finding 3: credential resourceVersions are resolved before the gate and

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -6154,6 +6154,74 @@ mod tests {
         );
     }
 
+    /// Does any `verbs:` list in the manifest grant `update`?
+    ///
+    /// Scans the comment-stripped `verbs:` lines and, when a `verbs:` line opens
+    /// a block sequence, its items, for a bare `update` token. Flow style
+    /// (`verbs: ["create", "update"]`) and block style (`- update`, quoted or
+    /// not) both count; a comment or a blank line inside a block sequence does
+    /// not end it. Nothing outside a verbs list is scanned, so a resource named
+    /// `updates` or the word in a comment cannot fail the caller's assertion for
+    /// the wrong reason.
+    fn verbs_grant_update(manifest: &str) -> bool {
+        let has_update = |text: &str| {
+            text.split(|c: char| !c.is_ascii_alphanumeric())
+                .any(|token| token == "update")
+        };
+        let mut in_verbs_block = false;
+        for raw in manifest.lines() {
+            let line = raw.split('#').next().unwrap_or("").trim();
+            if let Some(rest) = line.strip_prefix("verbs:") {
+                if has_update(rest) {
+                    return true;
+                }
+                // A `verbs:` key with nothing after it opens a block sequence
+                // whose items are the verbs.
+                in_verbs_block = rest.trim().is_empty();
+                continue;
+            }
+            if in_verbs_block && !line.is_empty() {
+                match line.strip_prefix("- ") {
+                    Some(item) if has_update(item) => return true,
+                    Some(_) => {}
+                    // The next key ends the sequence.
+                    None => in_verbs_block = false,
+                }
+            }
+        }
+        false
+    }
+
+    /// [`verbs_grant_update`] catches the `update` verb in both YAML spellings a
+    /// rules list can use, and reports nothing for an `update` outside a verbs
+    /// list. The block-style cases are the ones a quoted-substring check missed;
+    /// the negative cases are why the scan is narrowed to verbs lines instead of
+    /// running over every line in the file.
+    #[test]
+    fn the_update_verb_scan_covers_both_yaml_styles_and_nothing_else() {
+        // Flow style, the shape rbac.yaml ships.
+        assert!(verbs_grant_update("    verbs: [\"create\", \"update\"]\n"));
+        // Block style, quoted and unquoted.
+        assert!(verbs_grant_update(
+            "    verbs:\n      - create\n      - update\n      - delete\n"
+        ));
+        assert!(verbs_grant_update("    verbs:\n      - \"update\"\n"));
+        // A comment or a blank line inside the sequence does not end it.
+        assert!(verbs_grant_update(
+            "    verbs:\n      - create\n      # rationale\n\n      - update\n"
+        ));
+
+        // Narrowed: an `update` outside a verbs list is not a grant.
+        assert!(!verbs_grant_update("    resources: [\"updates\"]\n"));
+        assert!(!verbs_grant_update("    verbs: [\"get\"] # never update\n"));
+        assert!(!verbs_grant_update("    # verbs: [\"update\"]\n"));
+        assert!(!verbs_grant_update("    strategy: update\n"));
+        // The next key ends a block sequence, so a later value is out of scope.
+        assert!(!verbs_grant_update(
+            "    verbs:\n      - get\n    resources: [\"update\"]\n"
+        ));
+    }
+
     /// Finding 1 verb sweep. Every operator write is server-side apply (a PATCH,
     /// with `create` for objects that do not yet exist) or a delete, never a
     /// PUT, so no rule grants the `update` verb. Each rule grants exactly the
@@ -6169,21 +6237,13 @@ mod tests {
         let manifest = std::fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
 
-        // No rule anywhere grants `update`. Scan the comment-stripped lines for a
-        // bare `update` token so a reformat of any rule to block sequences
-        // (`- update`, unquoted) cannot make this go quiet: the old check matched
-        // only the quoted "update" substring and saw nothing in block style. The
-        // word "update" in a comment is stripped before the scan, so it does not
-        // count.
-        let grants_update = manifest.lines().any(|line| {
-            line.split('#')
-                .next()
-                .unwrap_or("")
-                .split(|c: char| !c.is_ascii_alphanumeric())
-                .any(|token| token == "update")
-        });
+        // No rule anywhere grants `update`. The scan covers the verbs lines only
+        // (the same lines the count assertion below identifies) and their block
+        // sequence items, so a reformat of any rule to block style (`- update`,
+        // unquoted) cannot make it go quiet while an `update` anywhere else in
+        // the file cannot fail it for the wrong reason.
         assert!(
-            !grants_update,
+            !verbs_grant_update(&manifest),
             "server-side apply is a PATCH, not a PUT: no rule may grant the update verb"
         );
 

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -2155,13 +2155,24 @@ pub fn qualify_job_input_hash(
         Some(value) => format!("\u{1}{value}"),
         None => "\u{0}".to_string(),
     };
+    // The credentials resourceVersion carries the same presence byte as the
+    // endpoint (finding 3, issue #36): an unresolved Secret (None) and a Secret
+    // whose resourceVersion resolved to the empty string are different states,
+    // yet unwrap_or("") fed the hasher the same "" for both and hashed them
+    // identically. 0x01 then the value for Some, a lone 0x00 for None keeps the
+    // two apart, so the field separator's boundary is joined by a presence byte
+    // the separator alone cannot supply.
+    let credentials_rv = match credentials_resource_version {
+        Some(value) => format!("\u{1}{value}"),
+        None => "\u{0}".to_string(),
+    };
     blake3_hex(&[
         spec.storage.s3.bucket.as_str(),
         spec.storage.s3.region.as_str(),
         endpoint.as_str(),
         spec.image.as_str(),
         spec.storage.s3.credentials_secret_ref.name.as_str(),
-        credentials_resource_version.unwrap_or(""),
+        credentials_rv.as_str(),
     ])
 }
 
@@ -6158,76 +6169,127 @@ mod tests {
         let manifest = std::fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
 
-        // No rule anywhere grants `update` (matched with its YAML quotes so the
-        // word "update" in a comment does not count).
+        // No rule anywhere grants `update`. Scan the comment-stripped lines for a
+        // bare `update` token so a reformat of any rule to block sequences
+        // (`- update`, unquoted) cannot make this go quiet: the old check matched
+        // only the quoted "update" substring and saw nothing in block style. The
+        // word "update" in a comment is stripped before the scan, so it does not
+        // count.
+        let grants_update = manifest.lines().any(|line| {
+            line.split('#')
+                .next()
+                .unwrap_or("")
+                .split(|c: char| !c.is_ascii_alphanumeric())
+                .any(|token| token == "update")
+        });
         assert!(
-            !manifest.contains("\"update\""),
+            !grants_update,
             "server-side apply is a PATCH, not a PUT: no rule may grant the update verb"
         );
 
-        // Every rule's resources line paired with the exact verbs line that must
-        // follow it. The `resources:` line uniquely identifies each rule (the two
-        // ClusterRoles never repeat one), and the `verbs:` line is always the next
-        // line, matching rbac.yaml's apiGroups/resources/verbs ordering.
-        let rules: &[(&str, &str)] = &[
+        // Every rule's apiGroups/resources/verbs lines, in rbac.yaml's fixed
+        // ordering: the `resources:` line uniquely identifies each rule, with its
+        // `apiGroups:` line immediately before and its `verbs:` line immediately
+        // after.
+        let rules: &[(&str, &str, &str)] = &[
             (
+                "- apiGroups: [\"apps\"]",
                 "resources: [\"deployments\"]",
                 "verbs: [\"create\", \"patch\", \"get\", \"list\", \"watch\", \"delete\"]",
             ),
             (
+                "- apiGroups: [\"\"]",
                 "resources: [\"services\"]",
                 "verbs: [\"create\", \"patch\", \"get\", \"list\", \"watch\", \"delete\"]",
             ),
             (
+                "- apiGroups: [\"networking.k8s.io\"]",
                 "resources: [\"ingresses\"]",
                 "verbs: [\"create\", \"patch\", \"list\", \"watch\", \"delete\"]",
             ),
             (
+                "- apiGroups: [\"gateway.networking.k8s.io\"]",
                 "resources: [\"httproutes\", \"grpcroutes\"]",
                 "verbs: [\"create\", \"patch\", \"delete\"]",
             ),
             (
+                "- apiGroups: [\"\"]",
                 "resources: [\"serviceaccounts\"]",
                 "verbs: [\"create\", \"patch\", \"delete\"]",
             ),
             (
+                "- apiGroups: [\"rbac.authorization.k8s.io\"]",
                 "resources: [\"roles\", \"rolebindings\"]",
                 "verbs: [\"create\", \"patch\", \"delete\"]",
             ),
             (
+                "- apiGroups: [\"discovery.k8s.io\"]",
                 "resources: [\"endpointslices\"]",
                 "verbs: [\"get\", \"list\", \"watch\"]",
             ),
             (
+                "- apiGroups: [\"ravel.nofire.ai\"]",
                 "resources: [\"ravelclusters\"]",
                 "verbs: [\"list\", \"watch\"]",
             ),
             (
+                "- apiGroups: [\"ravel.nofire.ai\"]",
                 "resources: [\"ravelclusters/status\"]",
                 "verbs: [\"patch\"]",
             ),
             (
+                "- apiGroups: [\"policy\"]",
                 "resources: [\"poddisruptionbudgets\"]",
                 "verbs: [\"create\", \"patch\", \"delete\"]",
             ),
             (
+                "- apiGroups: [\"batch\"]",
                 "resources: [\"jobs\"]",
                 "verbs: [\"create\", \"patch\", \"get\", \"delete\"]",
             ),
-            ("resources: [\"secrets\"]", "verbs: [\"get\"]"),
+            (
+                "- apiGroups: [\"\"]",
+                "resources: [\"secrets\"]",
+                "verbs: [\"get\"]",
+            ),
         ];
 
-        for (resources_line, expected_verbs) in rules {
-            let verbs = manifest
-                .lines()
-                .skip_while(|l| l.trim() != *resources_line)
-                .nth(1)
-                .map(str::trim)
-                .unwrap_or_else(|| {
-                    panic!("rbac.yaml defines a rule for {resources_line} with a verbs line")
-                });
+        let lines: Vec<&str> = manifest.lines().map(str::trim).collect();
+
+        // Exhaustiveness: the table must pin every rule in the manifest. Count the
+        // `verbs:` lines and require the table length to match, so a thirteenth
+        // rule cannot be added without a matching table row.
+        let verbs_lines = lines.iter().filter(|l| l.starts_with("verbs:")).count();
+        assert_eq!(
+            verbs_lines,
+            rules.len(),
+            "the table must pin every rule: rbac.yaml has {verbs_lines} verbs lines, \
+             the table has {} rows",
+            rules.len()
+        );
+
+        for rule in rules {
+            let (apigroups_line, resources_line, expected_verbs) = *rule;
+            // The resources line identifies the rule; assert it occurs exactly
+            // once so a duplicated resources line with wider verbs cannot hide
+            // behind the first match.
+            let occurrences = lines.iter().filter(|l| **l == resources_line).count();
             assert_eq!(
-                verbs, *expected_verbs,
+                occurrences, 1,
+                "the {resources_line} rule must appear exactly once"
+            );
+            let idx = lines
+                .iter()
+                .position(|l| *l == resources_line)
+                .unwrap_or_else(|| panic!("rbac.yaml defines a rule for {resources_line}"));
+            assert_eq!(
+                idx.checked_sub(1).and_then(|i| lines.get(i)).copied(),
+                Some(apigroups_line),
+                "the {resources_line} rule must be under {apigroups_line}"
+            );
+            assert_eq!(
+                lines.get(idx + 1).copied(),
+                Some(expected_verbs),
                 "the {resources_line} rule must grant exactly {expected_verbs}"
             );
         }
@@ -6340,6 +6402,17 @@ mod tests {
             qualify_job_input_hash(&endpoint_none, Some("rv-1")),
             qualify_job_input_hash(&endpoint_empty, Some("rv-1")),
             "endpoint: null and endpoint: \"\" are different stores and must hash differently"
+        );
+
+        // Credentials resourceVersion presence is significant the same way
+        // (finding 3): an unresolved Secret (None) and a resolved empty
+        // resourceVersion (Some("")) are different states, so they must hash
+        // differently. unwrap_or("") fed the hasher "" for both.
+        assert_ne!(
+            qualify_job_input_hash(&spec, None),
+            qualify_job_input_hash(&spec, Some("")),
+            "credentials resourceVersion None and Some(\"\") are different states and \
+             must hash differently"
         );
     }
 
@@ -6546,13 +6619,14 @@ mod tests {
             Some(value) => format!("\u{1}{value}"),
             None => "\u{0}".to_string(),
         };
+        let credentials_rv = format!("\u{1}{}", "rv-1");
         let expected = blake3_hex(&[
             spec.storage.s3.bucket.as_str(),
             spec.storage.s3.region.as_str(),
             endpoint.as_str(),
             spec.image.as_str(),
             spec.storage.s3.credentials_secret_ref.name.as_str(),
-            "rv-1",
+            credentials_rv.as_str(),
         ]);
 
         assert_eq!(
@@ -6605,12 +6679,14 @@ mod tests {
     /// `resourceVersion` hash to a fixed literal, stable by construction across
     /// Rust releases. The literal changed when the endpoint slot gained a
     /// presence byte (0x01 before a Some value) so endpoint: null and
-    /// endpoint: "" no longer collide.
+    /// endpoint: "" no longer collide, and again when the credentials
+    /// `resourceVersion` slot gained the same presence byte so an unresolved
+    /// Secret (None) and a resolved empty version (Some("")) no longer collide.
     #[test]
     fn qualify_job_input_hash_golden_is_stable_by_construction() {
         assert_eq!(
             qualify_job_input_hash(&base_spec(), Some("rv-golden")),
-            "492577362c8a6c9f6057e4281937d8b7a90289116e21e496c0acc7ed55d3784d",
+            "9dbbf674caab21157d312101c70e8d6947f8d86b14d075910a1e02779d7610fd",
         );
     }
 
@@ -6879,13 +6955,14 @@ mod tests {
             Some(value) => format!("\u{1}{value}"),
             None => "\u{0}".to_string(),
         };
+        let credentials_rv = format!("\u{1}{}", "rv");
         let expected = blake3_hex(&[
             spec.storage.s3.bucket.as_str(),
             spec.storage.s3.region.as_str(),
             endpoint.as_str(),
             spec.image.as_str(),
             spec.storage.s3.credentials_secret_ref.name.as_str(),
-            "rv",
+            credentials_rv.as_str(),
         ]);
         assert_eq!(qualify_job_input_hash(&spec, Some("rv")), expected);
     }


### PR DESCRIPTION
Five notes from the local review of the operator store-qualification gate,
none a live defect, all closing a way the gate could go quiet, plus the
round-two review of the first landing attempt.

The rbac test pins the manifest's count of verbs lines to the table length
and asserts each resources line occurs once, so a thirteenth rule or a
duplicated resources line with wider verbs cannot pass, and apiGroups is
pinned. Its no-update scan reads the comment-stripped verbs lines and their
block-sequence items only. qualify_job_input_hash carries a presence byte for
the credentials resourceVersion so None and Some("") hash differently. The
gate's StoreQualified condition is recorded before the qualify Job mutation,
so a failed Job apply or stale-Job delete, as well as a failed status write,
still leaves the degraded object carrying StoreQualified with the gate's
reason; the ordering is unit-tested by injecting the fallible step. The
credentials presence byte and its upgrade note sit under Unreleased, since
v0.15.0 carries only the endpoint byte; the first reconcile after the next
upgrade re-qualifies each existing cluster once with no Deployment touched.

Every guard was shown failing with its flip.

Supersedes #1497.

Local pre-flight was scoped to ravel-operator; the pull request's required
checks run the full workspace gate.

Fixes: #1462
Refs: #36, #1313
