### PR TITLE
test(commit): fail closed on unhandled IAM statement shapes

### DIFF
--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -171,6 +171,21 @@ struct Policy {
 /// rather than be silently skipped (issue #1346).
 const HANDLED_STATEMENT_KEYS: &[&str] = &["Sid", "Effect", "Action", "Resource", "Condition"];
 
+/// The complete set of `Condition` operators any guard in this file reads.
+/// Only `list_prefix_patterns` reads a Condition at all, and only its
+/// `StringLike` block. A statement whose Condition names any other operator --
+/// a different comparison such as `StringNotLike`, or a set-qualified form such
+/// as `ForAnyValue:StringLike` -- carries a constraint no guard reasons about,
+/// so it must fail closed at `validate_statement` rather than pass with its
+/// Condition unexamined (issue #1346).
+const HANDLED_CONDITION_OPERATORS: &[&str] = &["StringLike"];
+
+/// The complete set of `Condition` keys any guard in this file reads, under a
+/// handled operator. Only `s3:prefix` is inspected (by `list_prefix_patterns`);
+/// any other condition key (`s3:delimiter`, `aws:SourceIp`, ...) is a constraint
+/// no guard reads and must fail closed rather than sit unexamined.
+const HANDLED_CONDITION_KEYS: &[&str] = &["s3:prefix"];
+
 /// Keys that describe a statement shape these guards deliberately cannot
 /// reason about: `NotAction`/`NotResource` invert the set the Action/Resource
 /// guards inspect (so a statement carrying them is permissive in exactly the
@@ -193,11 +208,19 @@ const NEGATED_OR_PRINCIPAL_KEYS: &[&str] =
 ///   principal-scoped: the guard cannot reason about them);
 /// - any other key outside `HANDLED_STATEMENT_KEYS` (e.g. a `Resources` typo);
 /// - an `Effect` that is neither `Allow` nor `Deny`;
-/// - an `Action` or `Resource` that is neither a string nor an array of
-///   strings;
+/// - an `Action` or `Resource` that is neither a string nor a non-empty array
+///   of strings (an empty array is vacuously "all strings", so it slipped past
+///   as a valid set the guards then derived nothing from);
 /// - a missing `Resource` key (the exact shape #1346 records being skipped:
 ///   the resource guards read `stmt["Resource"]`, find `Null`, and drop the
-///   statement as having nothing to check).
+///   statement as having nothing to check);
+/// - a `Condition` whose sub-shape is anything other than the one block a guard
+///   reads: it must be a JSON object of handled operators
+///   (`HANDLED_CONDITION_OPERATORS`, today `StringLike`), each mapping handled
+///   condition keys (`HANDLED_CONDITION_KEYS`, today `s3:prefix`) to a string or
+///   non-empty array of strings. A different operator, a set-qualified operator,
+///   or an unhandled key is a constraint `list_prefix_patterns` never reads, so
+///   it fails closed here rather than contributing nothing silently.
 fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Result<(), String> {
     let obj = stmt
         .as_object()
@@ -251,23 +274,107 @@ fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Res
         }
         resource if !is_string_or_string_array(resource) => {
             return Err(format!(
-                "{role}/{sid}: Resource is neither a string nor an array of \
-                 strings: {resource:?}"
+                "{role}/{sid}: Resource is neither a string nor a non-empty array \
+                 of strings: {resource:?}"
             ));
         }
         _ => {}
     }
 
+    if let Some(condition) = obj.get("Condition") {
+        validate_condition(role, sid, condition)?;
+    }
+
     Ok(())
 }
 
-/// True only for a JSON string or an array whose every element is a string.
+/// Validate a statement's `Condition` sub-shape against the exact operators and
+/// keys the guards read (`HANDLED_CONDITION_OPERATORS` / `HANDLED_CONDITION_KEYS`).
+/// The Condition must be a JSON object; every operator in it must be handled;
+/// every key under a handled operator must be handled and map to a string or
+/// non-empty array of strings (the shape `list_prefix_patterns` reads). Anything
+/// else -- an unhandled operator such as `StringNotLike` or a set-qualified
+/// `ForAnyValue:StringLike`, an unhandled key such as `s3:delimiter`, or a
+/// non-object Condition -- is a constraint no guard reasons about and is rejected
+/// by name (issue #1346). Without this, a ListBucket statement carrying such a
+/// Condition passes validation and `list_prefix_patterns` then finds no
+/// `["StringLike"]["s3:prefix"]` array and silently contributes nothing.
+fn validate_condition(role: &str, sid: &str, condition: &serde_json::Value) -> Result<(), String> {
+    let cond_obj = condition
+        .as_object()
+        .ok_or_else(|| format!("{role}/{sid}: Condition is not a JSON object: {condition:?}"))?;
+    for (operator, keys) in cond_obj {
+        if !HANDLED_CONDITION_OPERATORS.contains(&operator.as_str()) {
+            return Err(format!(
+                "{role}/{sid}: Condition uses operator {operator:?}, which no guard \
+                 in this file reads (handled operators: {HANDLED_CONDITION_OPERATORS:?}); \
+                 a different or set-qualified operator such as StringNotLike or \
+                 ForAnyValue:StringLike must fail closed rather than sit unexamined"
+            ));
+        }
+        let key_obj = keys.as_object().ok_or_else(|| {
+            format!("{role}/{sid}: Condition operator {operator:?} is not a JSON object: {keys:?}")
+        })?;
+        for (cond_key, value) in key_obj {
+            if !HANDLED_CONDITION_KEYS.contains(&cond_key.as_str()) {
+                return Err(format!(
+                    "{role}/{sid}: Condition operator {operator:?} names key {cond_key:?}, \
+                     which no guard in this file reads (handled keys: {HANDLED_CONDITION_KEYS:?}); \
+                     it must fail closed rather than sit unexamined"
+                ));
+            }
+            if !is_string_or_string_array(Some(value)) {
+                return Err(format!(
+                    "{role}/{sid}: Condition {operator:?}.{cond_key:?} is neither a string \
+                     nor a non-empty array of strings: {value:?}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// True only for a JSON string or a non-empty array whose every element is a
+/// string. An empty array is rejected: `iter().all(..)` is vacuously true on it,
+/// so `"Action": []` / `"Resource": []` used to pass and every downstream guard
+/// then derived an empty set and skipped the statement (issue #1346).
 fn is_string_or_string_array(value: Option<&serde_json::Value>) -> bool {
     match value {
         Some(serde_json::Value::String(_)) => true,
-        Some(serde_json::Value::Array(a)) => a.iter().all(serde_json::Value::is_string),
+        Some(serde_json::Value::Array(a)) => {
+            !a.is_empty() && a.iter().all(serde_json::Value::is_string)
+        }
         _ => false,
     }
+}
+
+/// Run `validate_statement` over every statement in a policy's `Statement`
+/// array, returning the first rejection. This is the real per-statement
+/// validation loop `load_policy` runs on every shipped template; extracting it
+/// lets the regression tests call THIS function (and drive it through
+/// `build_policy`, load_policy's own body) rather than a re-typed copy of the
+/// loop that would keep passing if the call in `load_policy` were deleted.
+fn validate_policy_statements(role: &str, statements: &serde_json::Value) -> Result<(), String> {
+    let array = statements
+        .as_array()
+        .ok_or_else(|| format!("{role}: Statement is not an array"))?;
+    for (index, stmt) in array.iter().enumerate() {
+        validate_statement(role, index, stmt)?;
+    }
+    Ok(())
+}
+
+/// The parse-and-validate body shared by `load_policy` and the regression tests
+/// that need to drive the real validation call site with a synthetic policy
+/// (`load_policy` itself only reads the fixed `deploy/iam/*.json` paths). Panics,
+/// naming `source`, if `Statement` is not an array or any statement is rejected.
+fn build_policy(role: &'static str, source: &str, json: &serde_json::Value) -> Policy {
+    let statements = json["Statement"].clone();
+    assert!(statements.is_array(), "{source}: Statement is not an array");
+    if let Err(msg) = validate_policy_statements(role, &statements) {
+        panic!("{source}: {msg}");
+    }
+    Policy { role, statements }
 }
 
 fn load_policy(role: &'static str) -> Policy {
@@ -278,14 +385,7 @@ fn load_policy(role: &'static str) -> Policy {
     let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
     let json: serde_json::Value =
         serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
-    let statements = json["Statement"].clone();
-    assert!(statements.is_array(), "{path}: Statement is not an array");
-    for (index, stmt) in statements.as_array().unwrap().iter().enumerate() {
-        if let Err(msg) = validate_statement(role, index, stmt) {
-            panic!("{path}: {msg}");
-        }
-    }
-    Policy { role, statements }
+    build_policy(role, &path, &json)
 }
 
 /// IAM action names are case-insensitive: a statement granting
@@ -333,10 +433,18 @@ fn list_prefix_patterns(policy: &Policy) -> Vec<String> {
         if !is_list {
             continue;
         }
-        if let Some(patterns) = stmt["Condition"]["StringLike"]["s3:prefix"].as_array() {
-            for p in patterns {
-                out.push(p.as_str().expect("s3:prefix entry is a string").to_string());
+        // IAM allows a single `s3:prefix` value as a bare string or an array;
+        // read both so a bare-string prefix is not silently skipped (its shape
+        // is checked by validate_condition, which accepts both). Any other JSON
+        // shape here was already rejected at load_policy.
+        match &stmt["Condition"]["StringLike"]["s3:prefix"] {
+            serde_json::Value::String(s) => out.push(s.clone()),
+            serde_json::Value::Array(patterns) => {
+                for p in patterns {
+                    out.push(p.as_str().expect("s3:prefix entry is a string").to_string());
+                }
             }
+            _ => {}
         }
     }
     out
@@ -1421,17 +1529,14 @@ fn statement_using_an_unhandled_key_fails_closed() {
             "fixture {sid}: rejection must name the Sid; got {err:?}"
         );
 
-        // ...and so does load_policy's per-statement loop, the real call site.
-        let loaded = std::panic::catch_unwind(|| {
-            for (i, s) in policy.statements.as_array().unwrap().iter().enumerate() {
-                if let Err(msg) = validate_statement(policy.role, i, s) {
-                    panic!("{msg}");
-                }
-            }
-        });
+        // ...and so does the extracted loop `load_policy` actually runs
+        // (`validate_policy_statements`), called directly here rather than
+        // re-typed into a closure. `load_policy_rejects_an_unhandled_statement`
+        // separately pins that `load_policy`/`build_policy` still call it.
         assert!(
-            loaded.is_err(),
-            "fixture {sid}: the load_policy validation loop must reject it"
+            validate_policy_statements(policy.role, &policy.statements).is_err(),
+            "fixture {sid}: validate_policy_statements (load_policy's real loop) \
+             must reject it"
         );
     }
 
@@ -1512,6 +1617,212 @@ fn malformed_effect_action_or_resource_fails_closed() {
             "fixture {sid}: rejection must name the Sid; got {err:?}"
         );
     }
+}
+
+/// F2 regression: an empty `Action`/`Resource` array must fail closed. Pre-fix,
+/// `is_string_or_string_array` returned true for `[]` (`iter().all(..)` is
+/// vacuously true on an empty array), so `"Action": []` / `"Resource": []`
+/// passed validation and every downstream guard derived an empty set and
+/// skipped the statement -- the skip class #1346 tracks, one level inside a
+/// handled key. Synthetic, not `deploy/iam/*.json`: the shipped templates carry
+/// no empty arrays.
+#[test]
+fn empty_action_or_resource_array_fails_closed() {
+    let cases = [
+        (
+            "EmptyAction",
+            serde_json::json!({
+                "Sid": "EmptyAction",
+                "Effect": "Allow",
+                "Action": [],
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Action",
+        ),
+        (
+            "EmptyResource",
+            serde_json::json!({
+                "Sid": "EmptyResource",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": []
+            }),
+            "Resource",
+        ),
+    ];
+
+    for (sid, stmt, must_name) in &cases {
+        // The fixed predicate rejects the empty array. (An `iter().all` over the
+        // empty array is vacuously true, which is exactly the pre-fix bug.)
+        assert!(
+            !is_string_or_string_array(stmt.get(must_name)),
+            "fixture {sid}: an empty {must_name} array must not count as a string array"
+        );
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+    }
+}
+
+/// F1 regression: a `Condition` whose sub-shape is anything other than the one
+/// `StringLike`/`s3:prefix` block a guard reads must fail closed. Pre-fix,
+/// `validate_statement` accepted any `Condition` value, so a statement carrying
+/// `StringNotLike`, a set-qualified `ForAnyValue:StringLike`, an unhandled key
+/// such as `s3:delimiter`, or a non-object Condition passed validation and
+/// `list_prefix_patterns` then found no `["StringLike"]["s3:prefix"]` array and
+/// silently contributed nothing -- the skip class moved one level down into a
+/// handled key. Synthetic, not `deploy/iam/*.json`: every shipped Condition is
+/// exactly `StringLike`/`s3:prefix`.
+#[test]
+fn unhandled_condition_shape_fails_closed() {
+    let cases = [
+        (
+            "StringNotLikeOperator",
+            serde_json::json!({
+                "Sid": "StringNotLikeOperator",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"StringNotLike": {"s3:prefix": ["t/*"]}}
+            }),
+            "StringNotLike",
+        ),
+        (
+            "SetQualifiedOperator",
+            serde_json::json!({
+                "Sid": "SetQualifiedOperator",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"ForAnyValue:StringLike": {"s3:prefix": ["t/*"]}}
+            }),
+            "ForAnyValue:StringLike",
+        ),
+        (
+            "UnhandledConditionKey",
+            serde_json::json!({
+                "Sid": "UnhandledConditionKey",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"StringLike": {"s3:delimiter": ["/"]}}
+            }),
+            "s3:delimiter",
+        ),
+        (
+            "ConditionNotObject",
+            serde_json::json!({
+                "Sid": "ConditionNotObject",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": "StringLike"
+            }),
+            "Condition",
+        ),
+    ];
+
+    for (sid, stmt, must_name) in &cases {
+        // Load-bearing: the guard that would read this Condition finds nothing,
+        // so the constraint sits unexamined. Prove the pre-fix skip on the two
+        // operator cases (both are s3:ListBucket, so list_prefix_patterns is the
+        // guard that skips them).
+        if *sid == "StringNotLikeOperator" || *sid == "SetQualifiedOperator" {
+            let policy = Policy {
+                role: "fixture",
+                statements: serde_json::json!([stmt.clone()]),
+            };
+            assert!(
+                list_prefix_patterns(&policy).is_empty(),
+                "fixture {sid}: list_prefix_patterns was expected to skip the \
+                 statement (finding no StringLike/s3:prefix); it did not"
+            );
+        }
+
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+    }
+
+    // Positive control: the shipped StringLike/s3:prefix shape passes.
+    let ok = serde_json::json!({
+        "Sid": "GoodCondition",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": "arn:aws:s3:::my-ravel-bucket",
+        "Condition": {"StringLike": {"s3:prefix": ["t/*", "sys/*"]}}
+    });
+    assert!(
+        validate_statement("fixture", 0, &ok).is_ok(),
+        "the shipped StringLike/s3:prefix Condition shape must pass"
+    );
+}
+
+/// F3 wiring guard: `load_policy` (through its shared body `build_policy`) must
+/// actually call `validate_policy_statements`. Driving a synthetic invalid
+/// policy through `build_policy` -- the real validation call site -- is what
+/// makes this test fail if that call is deleted; a test that only calls
+/// `validate_policy_statements` directly would keep passing. Proven by removing
+/// the call from `build_policy`: this test then reports no panic and fails.
+#[test]
+fn load_policy_rejects_an_unhandled_statement() {
+    let json = serde_json::json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Sid": "NegatedResource",
+            "Effect": "Allow",
+            "Action": "s3:DeleteObject",
+            "NotResource": "arn:aws:s3:::my-ravel-bucket/t/*"
+        }]
+    });
+    let built = std::panic::catch_unwind(|| build_policy("fixture", "synthetic", &json));
+    assert!(
+        built.is_err(),
+        "build_policy (load_policy's real body) must reject a statement whose \
+         permission lives in NotResource, a field no guard reads"
+    );
+}
+
+/// Sweep proof: `list_prefix_patterns` reads a bare-string `s3:prefix`, not only
+/// an array. IAM allows either shape; before this fix the `.as_array()` read
+/// skipped a bare string, so a ListBucket discovery prefix expressed as a string
+/// contributed nothing.
+#[test]
+fn list_prefix_patterns_reads_a_bare_string_prefix() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "BareStringPrefix",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+            "Condition": {"StringLike": {"s3:prefix": "t/"}}
+        }]),
+    };
+    assert_eq!(
+        list_prefix_patterns(&policy),
+        vec!["t/".to_string()],
+        "a bare-string s3:prefix must be read, not skipped"
+    );
+    // ...and the shipped array shape still validates and is read.
+    assert!(
+        validate_statement("fixture", 0, &policy.statements.as_array().unwrap()[0]).is_ok(),
+        "a bare-string s3:prefix is a valid IAM shape and must pass validation"
+    );
 }
 
 #[test]

--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -160,6 +160,116 @@ struct Policy {
     statements: serde_json::Value,
 }
 
+/// The complete set of statement keys any guard in this file reads. Sid,
+/// Effect, Action, and Resource are read directly (see `statement_actions`,
+/// `resource_key_patterns`, `delete_key_patterns`, `kms_statement_resources`,
+/// ...); Condition is read for the `s3:prefix` ListBucket block
+/// (`list_prefix_patterns`). Nothing else is examined by any guard.
+///
+/// This list is the guard's contract: a statement carrying any key outside it
+/// is one no guard reasons about, so it must fail closed at `load_policy`
+/// rather than be silently skipped (issue #1346).
+const HANDLED_STATEMENT_KEYS: &[&str] = &["Sid", "Effect", "Action", "Resource", "Condition"];
+
+/// Keys that describe a statement shape these guards deliberately cannot
+/// reason about: `NotAction`/`NotResource` invert the set the Action/Resource
+/// guards inspect (so a statement carrying them is permissive in exactly the
+/// direction the guard reads, while the guard sees an empty positive set and
+/// passes it), and `Principal`/`NotPrincipal` scope a statement to identities
+/// this file models nothing about. Each is rejected with a message saying so,
+/// rather than lumped in with an unrecognized-typo key.
+const NEGATED_OR_PRINCIPAL_KEYS: &[&str] =
+    &["NotAction", "NotResource", "NotPrincipal", "Principal"];
+
+/// Fail closed on any statement shape the guards in this file do not fully
+/// understand. This is the single choke point every shipped-template guard
+/// passes through (`load_policy` calls it for each statement), so a new
+/// unhandled shape is rejected once here instead of slipping past a guard that
+/// only reads the fields it happens to know.
+///
+/// Rejects, naming the `Sid` and the offending key or field:
+/// - a statement that is not a JSON object;
+/// - `NotAction`/`NotResource`/`NotPrincipal`/`Principal` (negated or
+///   principal-scoped: the guard cannot reason about them);
+/// - any other key outside `HANDLED_STATEMENT_KEYS` (e.g. a `Resources` typo);
+/// - an `Effect` that is neither `Allow` nor `Deny`;
+/// - an `Action` or `Resource` that is neither a string nor an array of
+///   strings;
+/// - a missing `Resource` key (the exact shape #1346 records being skipped:
+///   the resource guards read `stmt["Resource"]`, find `Null`, and drop the
+///   statement as having nothing to check).
+fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Result<(), String> {
+    let obj = stmt
+        .as_object()
+        .ok_or_else(|| format!("{role}: statement #{index} is not a JSON object: {stmt:?}"))?;
+    let sid = obj
+        .get("Sid")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<no Sid>");
+
+    for key in obj.keys() {
+        if NEGATED_OR_PRINCIPAL_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "{role}/{sid}: statement uses {key:?}; the guards in this file \
+                 cannot reason about negated or principal-scoped statements \
+                 (they read only the positive Action/Resource sets), so a policy \
+                 carrying it must be rejected rather than silently passed"
+            ));
+        }
+        if !HANDLED_STATEMENT_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "{role}/{sid}: statement uses key {key:?}, which no guard in this \
+                 file handles (handled keys: {HANDLED_STATEMENT_KEYS:?}); it must \
+                 fail closed rather than sit unexamined"
+            ));
+        }
+    }
+
+    match obj.get("Effect").and_then(|v| v.as_str()) {
+        Some(e) if e.eq_ignore_ascii_case("Allow") || e.eq_ignore_ascii_case("Deny") => {}
+        other => {
+            return Err(format!(
+                "{role}/{sid}: Effect is neither \"Allow\" nor \"Deny\": {other:?}"
+            ));
+        }
+    }
+
+    if !is_string_or_string_array(obj.get("Action")) {
+        return Err(format!(
+            "{role}/{sid}: Action is neither a string nor an array of strings: {:?}",
+            obj.get("Action")
+        ));
+    }
+
+    match obj.get("Resource") {
+        None => {
+            return Err(format!(
+                "{role}/{sid}: statement has no Resource key -- a statement with no \
+                 Resource is the exact shape the resource guards skip (they read \
+                 stmt[\"Resource\"], find Null, and treat it as nothing to check)"
+            ));
+        }
+        resource if !is_string_or_string_array(resource) => {
+            return Err(format!(
+                "{role}/{sid}: Resource is neither a string nor an array of \
+                 strings: {resource:?}"
+            ));
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+/// True only for a JSON string or an array whose every element is a string.
+fn is_string_or_string_array(value: Option<&serde_json::Value>) -> bool {
+    match value {
+        Some(serde_json::Value::String(_)) => true,
+        Some(serde_json::Value::Array(a)) => a.iter().all(serde_json::Value::is_string),
+        _ => false,
+    }
+}
+
 fn load_policy(role: &'static str) -> Policy {
     let path = format!(
         "{}/../../deploy/iam/{role}.json",
@@ -170,6 +280,11 @@ fn load_policy(role: &'static str) -> Policy {
         serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
     let statements = json["Statement"].clone();
     assert!(statements.is_array(), "{path}: Statement is not an array");
+    for (index, stmt) in statements.as_array().unwrap().iter().enumerate() {
+        if let Err(msg) = validate_statement(role, index, stmt) {
+            panic!("{path}: {msg}");
+        }
+    }
     Policy { role, statements }
 }
 
@@ -1196,6 +1311,205 @@ fn single_character_wildcard_in_kms_resource_is_not_a_bypass() {
             key_id_guard.is_err(),
             "every_kms_statement_names_a_key_id's assertion must fire on \
              {resource:?}"
+        );
+    }
+}
+
+/// Regression fixtures for the fail-closed choke point (issue #1346, the fourth
+/// instance of the skip-what-you-do-not-understand class this guard keeps
+/// repeating: could not read `Resource`; matched the action prefix
+/// case-sensitively; accepted `?` in ARN segments; and now ignores
+/// `NotResource`/`NotAction`). Before this fix, `load_policy` performed no
+/// per-statement validation, so a statement whose permission lived in a field
+/// no guard reads -- `NotResource`, `NotAction`, an unrecognized key such as a
+/// `Resources` typo, or a statement with no `Resource` at all -- was loaded and
+/// then silently skipped by whichever guard went looking for a field it did not
+/// find. The guard ran, reported the templates safe, and the statement sat
+/// unexamined.
+///
+/// Synthetic statements, not `deploy/iam/*.json`: the shipped templates carry
+/// only handled, well-formed statements, so a fixture over them proves nothing
+/// about the choke point and goes green the day someone edits the config. Each
+/// negative case asserts in both directions -- that the pre-fix guards found
+/// nothing to object to (Observation 1, the hole) and that `validate_statement`
+/// now rejects it naming both the `Sid` and the offending key (Observation 2).
+#[test]
+fn statement_using_an_unhandled_key_fails_closed() {
+    // (Sid, statement, substring the rejection must name, which field hid the
+    // permission pre-fix: "resource" => resource_key_patterns skipped it,
+    // "action" => statement_actions saw no action).
+    let negative_cases = [
+        (
+            "NegatedResource",
+            serde_json::json!({
+                "Sid": "NegatedResource",
+                "Effect": "Allow",
+                "Action": "s3:DeleteObject",
+                "NotResource": "arn:aws:s3:::my-ravel-bucket/t/*/*/prov"
+            }),
+            "NotResource",
+            "resource",
+        ),
+        (
+            "NegatedAction",
+            serde_json::json!({
+                "Sid": "NegatedAction",
+                "Effect": "Allow",
+                "NotAction": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "NotAction",
+            "action",
+        ),
+        (
+            "TypoResources",
+            serde_json::json!({
+                "Sid": "TypoResources",
+                "Effect": "Allow",
+                "Action": "s3:PutObject",
+                "Resources": "arn:aws:s3:::my-ravel-bucket/t/*/*/l0/*"
+            }),
+            "Resources",
+            "resource",
+        ),
+        (
+            "MissingResource",
+            serde_json::json!({
+                "Sid": "MissingResource",
+                "Effect": "Allow",
+                "Action": "s3:GetObject"
+            }),
+            "no Resource",
+            "resource",
+        ),
+    ];
+
+    for (sid, stmt, must_name, hidden_side) in &negative_cases {
+        let policy = Policy {
+            role: "fixture",
+            statements: serde_json::json!([stmt.clone()]),
+        };
+
+        // Observation 1 (load-bearing): the pre-fix guard that would have read
+        // the permission found nothing. A resource-hidden statement produces no
+        // resource pattern to check; an action-hidden statement produces no
+        // action. If the relevant set stops being empty, the fixture no longer
+        // proves the statement was skipped and must be rewritten, not deleted.
+        match *hidden_side {
+            "resource" => assert!(
+                resource_key_patterns(&policy).is_empty(),
+                "fixture {sid} invalid: resource_key_patterns was expected to \
+                 skip the statement (returning nothing); it did not"
+            ),
+            "action" => assert!(
+                statement_actions(stmt).is_empty(),
+                "fixture {sid} invalid: statement_actions was expected to see no \
+                 action (returning nothing); it did not"
+            ),
+            other => panic!("fixture {sid}: unknown hidden_side {other:?}"),
+        }
+
+        // Observation 2: the choke point rejects it, naming the Sid and the key.
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+
+        // ...and so does load_policy's per-statement loop, the real call site.
+        let loaded = std::panic::catch_unwind(|| {
+            for (i, s) in policy.statements.as_array().unwrap().iter().enumerate() {
+                if let Err(msg) = validate_statement(policy.role, i, s) {
+                    panic!("{msg}");
+                }
+            }
+        });
+        assert!(
+            loaded.is_err(),
+            "fixture {sid}: the load_policy validation loop must reject it"
+        );
+    }
+
+    // Positive control: a well-formed Allow whose keys are all handled passes.
+    let ok = serde_json::json!({
+        "Sid": "WellFormedAllow",
+        "Effect": "Allow",
+        "Action": ["s3:GetObject", "s3:PutObject"],
+        "Resource": ["arn:aws:s3:::my-ravel-bucket/t/*"]
+    });
+    assert!(
+        validate_statement("fixture", 0, &ok).is_ok(),
+        "a well-formed Allow with only handled keys must pass"
+    );
+}
+
+/// Companion to the choke point's key check: a statement whose keys are all
+/// handled but whose values are malformed must also fail closed rather than be
+/// skipped. Pre-fix, an `Effect` that is neither Allow nor Deny was skipped by
+/// every effect-filtered guard (they compare case-insensitively against exactly
+/// those two), and an `Action` or `Resource` that is neither a string nor an
+/// array of strings was read as an empty set and dropped. Synthetic for the
+/// same reason as above.
+#[test]
+fn malformed_effect_action_or_resource_fails_closed() {
+    let cases = [
+        (
+            "BadEffect",
+            serde_json::json!({
+                "Sid": "BadEffect",
+                "Effect": "Permit",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Effect",
+        ),
+        (
+            "ActionIsNumber",
+            serde_json::json!({
+                "Sid": "ActionIsNumber",
+                "Effect": "Allow",
+                "Action": 7,
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Action",
+        ),
+        (
+            "ActionArrayHasNonString",
+            serde_json::json!({
+                "Sid": "ActionArrayHasNonString",
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", 7],
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Action",
+        ),
+        (
+            "ResourceIsNumber",
+            serde_json::json!({
+                "Sid": "ResourceIsNumber",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": 7
+            }),
+            "Resource",
+        ),
+    ];
+
+    for (sid, stmt, must_name) in &cases {
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
         );
     }
 }


### PR DESCRIPTION
The IAM template guards read only a statement's Action and Resource, so a
statement carrying NotResource or NotAction, or lacking Resource entirely, was
skipped rather than rejected. This is the fifth time this guard has passed
while a permissive statement sat unexamined, so the fix is structural rather
than another targeted patch: load_policy, the one function every guard obtains
its policy through, validates each statement and rejects any key outside the
handled set, naming the Sid and the key.

The review of the first round found the same skip class twice more inside the
new validation, and both are closed here. The Condition sub-shape is validated
at the same choke point, since the only Condition any guard reads is
StringLike with s3:prefix: any other operator, including a set-qualified one,
and any other condition key are rejected by name. An empty Action or Resource
array no longer passes, where the all-elements-are-strings test was vacuously
true. The per-statement loop is extracted into a named function that
load_policy calls and the test calls, so the assertion covers the real call
site instead of a copy of it that would keep passing if the loop were deleted.

Synthetic fixtures pin each rejection and the pre-fix hole, so the tests
cannot become tautologies, and the shipped templates under deploy/iam pass
unchanged.

Supersedes #1530.

Fixes: #1346
Refs: #1303, #1313
