### PR TITLE
feat(ravel-ingest): report bloom construction as its own write-path phase

### DIFF
--- a/crates/ravel-ingest/Cargo.toml
+++ b/crates/ravel-ingest/Cargo.toml
@@ -11,7 +11,12 @@ rust-version.workspace = true
 # links the seam. On, it compiles in the `Instant`-based accumulator and wires
 # the logs pipeline's admit/route/merge/encode boundaries through it, read only
 # by the bench reporter. A CI lane must build and run this feature.
-stage-timing = []
+#
+# Also turns on `ravel-logseg/stage-timing`, which is what makes the RLOG
+# block-write loop report per-block bloom-construction nanoseconds through
+# `WriteStats::bloom_block_ns` for the `LogStage::Bloom` boundary below to
+# fold in (issue #1516).
+stage-timing = ["ravel-logseg/stage-timing"]
 
 [dependencies]
 ravel-types = { workspace = true }

--- a/crates/ravel-ingest/src/log_metrics.rs
+++ b/crates/ravel-ingest/src/log_metrics.rs
@@ -677,6 +677,8 @@ mod tests {
                     postings_distinct_max: 25,
                     dynamic_columns_used: 7,
                     dynamic_columns_overflowed: 2,
+                    #[cfg(feature = "stage-timing")]
+                    bloom_block_ns: Vec::new(),
                 })
             },
             LogIngestMetricsSnapshot {

--- a/crates/ravel-ingest/src/log_shard.rs
+++ b/crates/ravel-ingest/src/log_shard.rs
@@ -552,6 +552,14 @@ impl LogFlushCtx {
         }
         let bytes = match writer.finish_with_stats() {
             Ok((bytes, stats)) => {
+                // Per-block bloom-construction time (issue #1516), nested inside
+                // the `Encode` window this whole match arm sits in: one sample
+                // per block, read before `record_postings` moves `stats`.
+                #[cfg(feature = "stage-timing")]
+                for bloom_ns in &stats.bloom_block_ns {
+                    self.stage_timings
+                        .record(LogStage::Bloom, Duration::from_nanos(*bloom_ns));
+                }
                 // Write-side POSTINGS metrics: section bytes, per-field distinct
                 // counts, and the cap-exceeded counter.
                 self.metrics.record_postings(stats);

--- a/crates/ravel-ingest/src/stage_timing.rs
+++ b/crates/ravel-ingest/src/stage_timing.rs
@@ -59,7 +59,28 @@ mod imp {
         /// `finish_with_stats` in the spawned flush. `RlogWriter`, not
         /// `SegmentWriter`; it excludes the object-store PUT, which decision 5
         /// measures separately.
+        ///
+        /// [`LogStage::Bloom`] construction happens inside this window: it is
+        /// a nested sub-phase, not a slice cut out of it, so `Encode`'s total
+        /// is unchanged by `Bloom` existing. Summing every [`LogStage`]
+        /// variant's `total_ns` double-counts bloom time for exactly that
+        /// reason.
         Encode,
+        /// Per-block bloom construction inside the RLOG block-write loop
+        /// (issue #1516): each block's `BloomBuilder::new`-through-`finish`
+        /// window in `ravel_logseg::RlogWriter`'s `build_object` /
+        /// `build_object_columnar`, one sample per block. It covers the bloom
+        /// build only, excluding `write_block` / `write_block_columnar`
+        /// (block assembly) and everything else those functions do.
+        ///
+        /// This window is INSIDE [`LogStage::Encode`], not subtracted from
+        /// it: `Encode` still times the whole `RlogWriter::push` +
+        /// `finish_with_stats` call, bloom construction included. `Bloom` is
+        /// reported anyway, nested, because a profile (#1511) found bloom
+        /// construction is 61% of `Encode` and the only way to see that
+        /// number before this stage existed was hand-instrumenting two crates
+        /// and reverting the patch afterward.
+        Bloom,
     }
 
     impl LogStage {
@@ -70,6 +91,7 @@ mod imp {
                 LogStage::Route => "route",
                 LogStage::Merge => "merge",
                 LogStage::Encode => "encode",
+                LogStage::Bloom => "bloom",
             }
         }
     }
@@ -101,6 +123,7 @@ mod imp {
         route: StageCell,
         merge: StageCell,
         encode: StageCell,
+        bloom: StageCell,
     }
 
     impl LogStageTimings {
@@ -114,6 +137,7 @@ mod imp {
                 LogStage::Route => &self.route,
                 LogStage::Merge => &self.merge,
                 LogStage::Encode => &self.encode,
+                LogStage::Bloom => &self.bloom,
             }
         }
 
@@ -137,6 +161,7 @@ mod imp {
                 LogStage::Route,
                 LogStage::Merge,
                 LogStage::Encode,
+                LogStage::Bloom,
             ] {
                 let cell = self.cell(stage);
                 let samples = cell.samples.load(Ordering::Relaxed);
@@ -409,13 +434,15 @@ mod tests {
     }
 
     /// Drives a real logs write through the router to a flush and asserts the
-    /// wired stage set is EXACTLY {admit, route, merge, encode} -- no missing
-    /// stage, no extra one -- and every stage recorded a nonzero duration.
+    /// wired stage set is EXACTLY {admit, route, merge, encode, bloom} -- no
+    /// missing stage, no extra one -- and every stage recorded a nonzero
+    /// duration.
     ///
     /// The set is pinned exactly on purpose: a "the map is non-empty" assertion
-    /// would still pass with three of the four stages silently unwired, which is
-    /// the failure this test exists to catch (ADR-0104 decision 2 wires four
-    /// logs stages).
+    /// would still pass with several of the five stages silently unwired,
+    /// which is the failure this test exists to catch (ADR-0104 decision 2
+    /// wires the original four logs stages; issue #1516 adds `bloom` as a
+    /// fifth, nested inside `encode`).
     #[cfg(feature = "stage-timing")]
     #[tokio::test]
     async fn logs_pipeline_records_every_wired_stage() {
@@ -451,12 +478,13 @@ mod tests {
             LogStage::Route,
             LogStage::Merge,
             LogStage::Encode,
+            LogStage::Bloom,
         ];
         let recorded: Vec<LogStage> = snap.stages().collect();
         assert_eq!(
             recorded,
             wired.to_vec(),
-            "recorded stage set must be exactly the four wired logs stages, got {:?}",
+            "recorded stage set must be exactly the five wired logs stages, got {:?}",
             recorded.iter().map(|s| s.name()).collect::<Vec<_>>(),
         );
 

--- a/crates/ravel-logseg/Cargo.toml
+++ b/crates/ravel-logseg/Cargo.toml
@@ -5,6 +5,16 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+# Per-block bloom-construction timing (issue #1516, ADR-0104 decision 2c). Off
+# by default: with it off, `WriteStats` carries no bloom timing field and no
+# `Instant` is read in the block-write loop, so the crate compiles and behaves
+# exactly as today. On, `RlogWriter` measures each block's `BloomBuilder`
+# insert-plus-`finish` window and reports it through `WriteStats::bloom_block_ns`
+# for `ravel-ingest` to fold into its `LogStage::Bloom` accumulator. Enabled
+# transitively by `ravel-ingest/stage-timing`.
+stage-timing = []
+
 [dependencies]
 ravel-codec = { workspace = true }
 ravel-proto = { workspace = true }

--- a/crates/ravel-logseg/src/writer.rs
+++ b/crates/ravel-logseg/src/writer.rs
@@ -110,7 +110,8 @@ pub struct RlogWriter {
 /// allowlist forbids: `postings_distinct_total` over `postings_indexed_fields`
 /// yields a mean distinct-per-field, and `postings_distinct_max` the tail,
 /// with no field name ever leaving this struct.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(not(feature = "stage-timing"), derive(Copy))]
 pub struct WriteStats {
     /// Indexed fields dropped from POSTINGS in this object for exceeding
     /// `RlogConfig::postings_max_distinct`
@@ -142,6 +143,17 @@ pub struct WriteStats {
     /// budget, which is otherwise silent (ADR-0100 decision 1). Same
     /// aggregate-only, no-per-field-label shaping as the fields above.
     pub dynamic_columns_overflowed: u32,
+    /// Nanoseconds spent building each block's bloom filter: the
+    /// `BloomBuilder::new` through `finish` window in the block-write loop,
+    /// one entry per block in block order. Excludes `write_block` /
+    /// `write_block_columnar` (block assembly) and everything else
+    /// `build_object` / `build_object_columnar` does. Only present with the
+    /// `stage-timing` feature; the caller (`ravel_ingest::log_shard`) folds
+    /// each entry in as its own `LogStage::Bloom` sample, nested inside (not
+    /// subtracted from) the `LogStage::Encode` window that already times the
+    /// whole `finish_with_stats` call (issue #1516).
+    #[cfg(feature = "stage-timing")]
+    pub bloom_block_ns: Vec<u64>,
 }
 
 /// The maximum byte length of a string value inserted into the bloom by exact
@@ -520,6 +532,8 @@ impl RlogWriter {
 
         let mut blocks = BlocksBuilder::new(layout);
         let mut bloom_entries: Vec<Vec<u8>> = Vec::new();
+        #[cfg(feature = "stage-timing")]
+        let mut bloom_block_ns: Vec<u64> = Vec::new();
 
         // POSTINGS accumulation: per indexed column, term -> sorted block
         // indices. `BTreeMap`/`BTreeSet` throughout, never `HashMap`, so
@@ -581,6 +595,8 @@ impl RlogWriter {
             let out = write_block(block_rows, &plans, self.cfg.zstd_level)?;
 
             // Bloom over body, severity_text, and string columns.
+            #[cfg(feature = "stage-timing")]
+            let bloom_start = std::time::Instant::now();
             let mut builder = BloomBuilder::new(self.cfg.bloom_seed);
             for row in block_rows {
                 insert_text(&mut builder, COL_BODY, row.body.as_bytes());
@@ -619,6 +635,9 @@ impl RlogWriter {
                 }
             }
             bloom_entries.push(builder.finish());
+            #[cfg(feature = "stage-timing")]
+            bloom_block_ns
+                .push(u64::try_from(bloom_start.elapsed().as_nanos()).unwrap_or(u64::MAX));
 
             // Accounting.
             for row in block_rows {
@@ -801,6 +820,8 @@ impl RlogWriter {
                 postings_distinct_max,
                 dynamic_columns_used,
                 dynamic_columns_overflowed,
+                #[cfg(feature = "stage-timing")]
+                bloom_block_ns,
             },
         ))
     }
@@ -1177,6 +1198,8 @@ impl RlogWriter {
         let mut last_blk: HashMap<u32, u32> = HashMap::new();
         let mut blocks = BlocksBuilder::new(layout);
         let mut bloom_entries: Vec<Vec<u8>> = Vec::new();
+        #[cfg(feature = "stage-timing")]
+        let mut bloom_block_ns: Vec<u64> = Vec::new();
         let mut postings_terms: BTreeMap<u32, BTreeMap<Vec<u8>, BTreeSet<u32>>> = BTreeMap::new();
         let mut postings_capped: BTreeSet<u32> = BTreeSet::new();
         let mut min_ts = i64::MAX;
@@ -1395,6 +1418,8 @@ impl RlogWriter {
 
             // Bloom over body, severity_text, and string columns; POSTINGS over
             // each row's merged-view indexed terms.
+            #[cfg(feature = "stage-timing")]
+            let bloom_start = std::time::Instant::now();
             let mut builder = BloomBuilder::new(self.cfg.bloom_seed);
             let mut terms_start = 0usize;
             for (li, &g) in block_rows.iter().enumerate() {
@@ -1456,6 +1481,9 @@ impl RlogWriter {
                 }
             }
             bloom_entries.push(builder.finish());
+            #[cfg(feature = "stage-timing")]
+            bloom_block_ns
+                .push(u64::try_from(bloom_start.elapsed().as_nanos()).unwrap_or(u64::MAX));
 
             for &g in block_rows {
                 min_ts = min_ts.min(g_ts[g]);
@@ -1617,6 +1645,8 @@ impl RlogWriter {
                 postings_distinct_max,
                 dynamic_columns_used,
                 dynamic_columns_overflowed,
+                #[cfg(feature = "stage-timing")]
+                bloom_block_ns,
             },
         ))
     }
@@ -3504,13 +3534,48 @@ mod tests {
         let mut w = RlogWriter::new(RlogConfig::default(), identity());
         w.push(base_record(0, 0)).expect("push");
         let (_obj, stats) = w.finish_with_stats().expect("finish");
+        // Field-by-field, not a full-struct `assert_eq!` against
+        // `WriteStats::default()`: with `stage-timing` on, this single-record
+        // write still builds one block's bloom, so `bloom_block_ns` is
+        // genuinely non-empty here and a full-struct comparison against the
+        // all-default value would fail for a reason this test isn't about.
+        assert_eq!(stats.postings_capped_fields, 0);
+        assert_eq!(stats.postings_bytes, 0);
+        assert_eq!(stats.postings_indexed_fields, 0);
+        assert_eq!(stats.postings_distinct_total, 0);
+        assert_eq!(stats.postings_distinct_max, 0);
+        assert_eq!(stats.dynamic_columns_used, 1);
+        assert_eq!(stats.dynamic_columns_overflowed, 0);
+    }
+
+    /// One `bloom_block_ns` sample per block, no more, no fewer (issue #1516).
+    /// `block_target_records: 3` chunks 30 pushed records into exactly 10
+    /// blocks (`chunk_blocks` splits by record count alone here;
+    /// `block_max_bytes`'s default 8MB is nowhere near reached at this
+    /// scale), so the sample count is pinned to 10, not merely asserted
+    /// non-empty: a build that recorded one sample for the whole write
+    /// instead of one per block would still pass a `> 0` check but fails
+    /// this one.
+    #[cfg(feature = "stage-timing")]
+    #[test]
+    fn bloom_block_ns_reports_exactly_one_sample_per_block() {
+        let cfg = RlogConfig {
+            block_target_records: 3,
+            ..RlogConfig::default()
+        };
+        let mut w = RlogWriter::new(cfg, identity());
+        for i in 0..30i64 {
+            w.push(base_record(0, i)).expect("push");
+        }
+        let (_obj, stats) = w.finish_with_stats().expect("finish");
         assert_eq!(
-            stats,
-            WriteStats {
-                dynamic_columns_used: 1,
-                ..WriteStats::default()
-            }
+            stats.bloom_block_ns.len(),
+            10,
+            "30 records at block_target_records=3 must chunk into exactly 10 blocks, one bloom sample each"
         );
+        for (i, ns) in stats.bloom_block_ns.iter().enumerate() {
+            assert!(*ns > 0, "block {i}'s bloom build reported a zero duration");
+        }
     }
 
     #[test]

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -4211,9 +4211,10 @@ type = "i64"
     }
 
     /// A real `load --parquet` run wires and records every stage of the logs
-    /// pipeline, not a subset: admit, route, merge, and encode all recorded at
-    /// least one sample. Drop `#[cfg(feature = "stage-timing")]` from
-    /// `LogIngestRouter::stage_timings` (or from any one stage boundary) and
+    /// pipeline, not a subset: admit, route, merge, encode, and bloom all
+    /// recorded at least one sample. Drop `#[cfg(feature = "stage-timing")]`
+    /// from `LogIngestRouter::stage_timings` (or from any one stage boundary,
+    /// including the `LogStage::Bloom` recording added for issue #1516) and
     /// this fails, either at compile time or on an empty/partial stage set.
     #[cfg(feature = "stage-timing")]
     #[tokio::test]
@@ -4227,6 +4228,7 @@ type = "i64"
                 ravel_ingest::LogStage::Route,
                 ravel_ingest::LogStage::Merge,
                 ravel_ingest::LogStage::Encode,
+                ravel_ingest::LogStage::Bloom,
             ],
             "a real load must wire and record every stage, not a subset"
         );


### PR DESCRIPTION
A profile of the RLOG write path (#1514) found bloom construction is about
61 percent of the serialize stage and roughly half of ingest-to-durable
acknowledgement. Finding that required hand-instrumenting two crates and
then reverting it, because the stage-timing seam bucketed the whole of
RlogWriter::push plus finish_with_stats as one Encode figure. The largest
cost on the write path reported nothing.

LogStage::Bloom now records per block. RlogWriter returns per-block bloom
nanoseconds in WriteStats, and the log shard folds them into the existing
accumulator.

The new stage is nested inside Encode rather than subtracted from it, so
summing every LogStage double-counts bloom. Both doc comments say so,
Encode's included, because a reader adding up the stages is exactly who
that would mislead.

The seam stays free when the feature is off: the module is gated at
module level, so with stage-timing disabled the types and the Instant
reads do not exist rather than sitting unused.

A test pins the sample count to the block count exactly, ten blocks from
thirty records at a block target of three, and was demonstrated failing by
skipping one block. Another asserts the recorded stage set, demonstrated
failing by removing the recording call.

The expected stage list in ravel-cli's load test gains Bloom, which is
outside the two crates this change targets but would otherwise break the
moment Bloom starts recording. That test is separately broken on main and
run by no gate; see #1522.

Refs: #1516
