### PR TITLE
fix(object-store): name the entry point in listing drain failures

### DIFF
--- a/crates/ravel-object-store/src/conformance.rs
+++ b/crates/ravel-object-store/src/conformance.rs
@@ -784,8 +784,8 @@ async fn probe_consistent_list_after_write(
                     );
                 }
             }
-            // Already a reportable detail naming the prefix and the backend's
-            // own error, like the sibling drains below.
+            // Already a reportable detail naming the entry point, the prefix,
+            // and the backend's own error, like the sibling drains below.
             Err(detail) => return ProbeResult::fail(property, detail),
         }
     }
@@ -1056,6 +1056,20 @@ enum ProbeListing<'a> {
     After(Option<&'a str>),
 }
 
+impl ProbeListing<'_> {
+    /// The backend method this drain issues. Threaded into every failure
+    /// detail so a listing probe names which of the two separately implemented
+    /// entry points is broken, not merely the prefix -- a backend whose `list`
+    /// fails or never terminates while `list_after` is fine must not yield a
+    /// report that cannot say which call broke.
+    fn method(&self) -> &'static str {
+        match self {
+            ProbeListing::List => "list",
+            ProbeListing::After(_) => "list_after",
+        }
+    }
+}
+
 /// Drain every page of `prefix` through `listing` and return the keys in
 /// delivery order together with the number of pages served.
 ///
@@ -1069,6 +1083,7 @@ async fn drain_probe_pages(
     prefix: &str,
     listing: ProbeListing<'_>,
 ) -> Result<(Vec<String>, usize), String> {
+    let method = listing.method();
     let mut delivered: Vec<String> = Vec::new();
     let mut pages = 0usize;
     let mut token = None;
@@ -1077,7 +1092,7 @@ async fn drain_probe_pages(
             ProbeListing::List => store.list(prefix, token).await,
             ProbeListing::After(start_after) => store.list_after(prefix, start_after, token).await,
         };
-        let page = result.map_err(|err| format!("listing {prefix} failed: {err}"))?;
+        let page = result.map_err(|err| format!("{method}({prefix}) failed: {err}"))?;
         pages += 1;
         delivered.extend(page.objects.into_iter().map(|meta| meta.key));
         match page.next {
@@ -1086,7 +1101,7 @@ async fn drain_probe_pages(
         }
         if pages >= MAX_PROBE_PAGES {
             return Err(format!(
-                "listing {prefix} still returned a continuation token after {pages} pages over \
+                "{method}({prefix}) still returned a continuation token after {pages} pages over \
                  far fewer keys; this backend's pagination does not terminate"
             ));
         }
@@ -1325,7 +1340,10 @@ async fn probe_cross_page_listing(store: &dyn ObjectStoreBackend, prefix: &str) 
 }
 
 /// Delete visibility: after a delete the key is gone from both access paths a
-/// caller has, and deleting it again changes nothing.
+/// caller has, and deleting it again changes nothing. The listing side is
+/// checked through both `list` and `list_after`, since they are separately
+/// implemented methods and a delete visible through one but not the other is a
+/// real defect the property must catch itself.
 ///
 /// Nothing probed delete at all, so a backend that acknowledged a delete
 /// without performing it, or performed it lazily, could qualify. Ravel's
@@ -1375,25 +1393,32 @@ async fn probe_delete_visibility(store: &dyn ObjectStoreBackend, prefix: &str) -
     }
 
     let expected = vec![kept.clone()];
-    // Drain `list`: retention sweeps and GC enumerate survivors through `list`,
-    // so a delete that `get` reports gone but `list` still re-delivers (a stale
-    // index on the list path) is exactly what a sweep would re-process. The
-    // path the enumeration production runs uses is the one to judge here.
-    let (delivered, _pages) = match drain_probe_pages(store, &list_prefix, ProbeListing::List).await
-    {
-        Ok(result) => result,
-        Err(detail) => return ProbeResult::fail(property, detail),
-    };
-    let distinct = distinct_in_delivery_order(&delivered);
-    if distinct != expected {
-        return ProbeResult::fail(
-            property,
-            format!(
-                "listing {list_prefix} after deleting {gone} returned {} keys, expected exactly \
-                 1 ({kept}): got {distinct:?}",
-                distinct.len()
-            ),
-        );
+    // Drain BOTH entry points and require the deleted key absent from each.
+    // Retention sweeps and GC enumerate survivors through `list`, so a delete
+    // that `get` reports gone but `list` still re-delivers (a stale index on
+    // the list path) is exactly what a sweep would re-process; `list_after` is
+    // a separately implemented method (`S3Store` overrides each natively), so a
+    // delete visible through one path and not the other is a real defect the
+    // property must catch on its own rather than lean on there being no
+    // `list_after` caller outside this crate. Naming the entry point tells an
+    // operator which path still re-delivers the deleted key.
+    for listing in [ProbeListing::List, ProbeListing::After(None)] {
+        let (delivered, _pages) = match drain_probe_pages(store, &list_prefix, listing).await {
+            Ok(result) => result,
+            Err(detail) => return ProbeResult::fail(property, detail),
+        };
+        let distinct = distinct_in_delivery_order(&delivered);
+        if distinct != expected {
+            return ProbeResult::fail(
+                property,
+                format!(
+                    "{}({list_prefix}) after deleting {gone} returned {} keys, expected exactly \
+                     1 ({kept}): got {distinct:?}",
+                    listing.method(),
+                    distinct.len()
+                ),
+            );
+        }
     }
 
     // Idempotence: a second delete of an absent key succeeds and changes no
@@ -1406,27 +1431,30 @@ async fn probe_delete_visibility(store: &dyn ObjectStoreBackend, prefix: &str) -
             ),
         );
     }
-    let (delivered, _pages) = match drain_probe_pages(store, &list_prefix, ProbeListing::List).await
-    {
-        Ok(result) => result,
-        Err(detail) => return ProbeResult::fail(property, detail),
-    };
-    let distinct = distinct_in_delivery_order(&delivered);
-    if distinct != expected {
-        return ProbeResult::fail(
-            property,
-            format!(
-                "a second delete of the absent {gone} changed the listing of {list_prefix} to \
-                 {distinct:?}, expected it to still hold exactly 1 key ({kept})"
-            ),
-        );
+    for listing in [ProbeListing::List, ProbeListing::After(None)] {
+        let (delivered, _pages) = match drain_probe_pages(store, &list_prefix, listing).await {
+            Ok(result) => result,
+            Err(detail) => return ProbeResult::fail(property, detail),
+        };
+        let distinct = distinct_in_delivery_order(&delivered);
+        if distinct != expected {
+            return ProbeResult::fail(
+                property,
+                format!(
+                    "a second delete of the absent {gone} changed the {}({list_prefix}) listing \
+                     to {distinct:?}, expected it to still hold exactly 1 key ({kept})",
+                    listing.method()
+                ),
+            );
+        }
     }
 
     ProbeResult::pass(
         property,
         format!(
-            "after deleting {gone}, a get returned NotFound and the listing held exactly 1 key \
-             ({kept}); a second delete of the absent key succeeded and changed nothing"
+            "after deleting {gone}, a get returned NotFound and both list and list_after held \
+             exactly 1 key ({kept}); a second delete of the absent key succeeded and changed \
+             nothing"
         ),
     )
 }
@@ -1865,14 +1893,15 @@ mod tests {
         );
         let verbatim = |subprefix: &str| {
             format!(
-                "listing {prefix}{subprefix} still returned a continuation token after \
+                "list({prefix}{subprefix}) still returned a continuation token after \
                  {MAX_PROBE_PAGES} pages over far fewer keys; this backend's pagination does \
                  not terminate"
             )
         };
         // The membership probe reports the drain's own detail verbatim under
         // its `law/` subprefix, and the ordering probe under `order/`: the
-        // detail is not re-wrapped, and it names the subprefix that drained.
+        // detail is not re-wrapped, it names the `list` entry point that
+        // drained, and it names the subprefix.
         let membership = report
             .results
             .iter()
@@ -2920,6 +2949,64 @@ mod tests {
         .expect("a drain over a permitted repeat must succeed");
         assert_eq!(
             keys,
+            vec![
+                format!("{list_prefix}a"),
+                format!("{list_prefix}b"),
+                format!("{list_prefix}c"),
+                format!("{list_prefix}d"),
+                format!("{list_prefix}e"),
+            ]
+        );
+    }
+
+    /// The `list` twin of
+    /// [`listing_order_probe_accepts_a_repeat_of_the_last_delivered_key`]: a
+    /// backend that re-delivers its own last key across a page boundary on
+    /// `list` (the path every catalog scan drains) keeps the raw sequence
+    /// non-decreasing, so it is the repeat the contract permits and must
+    /// qualify. The reject case has a `list` twin, but nothing pinned that the
+    /// `list` pass still TOLERATES the permitted repeat, only that it rejects
+    /// the earlier-key one.
+    #[tokio::test]
+    async fn listing_order_probe_accepts_a_repeat_of_the_last_delivered_key_on_list() {
+        let store = PageBoundaryStore::new_on_list(PageBoundary::RepeatLastKey);
+        let prefix = "sys/qualify/order-repeat-last-on-list/";
+        let report = run_conformance_suite(&store, prefix).await;
+        assert!(
+            report.passed(),
+            "a repeat of the last delivered key on list is a permitted delivery, so every probe \
+             must pass, got: {:?}",
+            report.failures().collect::<Vec<_>>()
+        );
+        let list_prefix = format!("{prefix}order/");
+        assert_eq!(
+            order_probe_result(&report).detail,
+            expected_order_pass_detail(&list_prefix)
+        );
+
+        // The repeat fired on the list pass: seven deliveries of five keys
+        // across three pages, never decreasing, with each repeat adjacent to
+        // the key it repeats.
+        let (delivered, pages) = drain_probe_pages(&store, &list_prefix, ProbeListing::List)
+            .await
+            .expect("draining the probe's own prefix through list");
+        assert_eq!(
+            delivered,
+            vec![
+                format!("{list_prefix}a"),
+                format!("{list_prefix}b"),
+                format!("{list_prefix}b"),
+                format!("{list_prefix}c"),
+                format!("{list_prefix}d"),
+                format!("{list_prefix}d"),
+                format!("{list_prefix}e"),
+            ]
+        );
+        assert_eq!(pages, 3, "5 keys at page size 2 is exactly 3 pages");
+        assert_eq!(first_order_violation(&delivered), None);
+        // And the verdict a caller gets: the same five keys, once each.
+        assert_eq!(
+            distinct_in_delivery_order(&delivered),
             vec![
                 format!("{list_prefix}a"),
                 format!("{list_prefix}b"),

--- a/crates/ravel-object-store/src/conformance.rs
+++ b/crates/ravel-object-store/src/conformance.rs
@@ -1084,6 +1084,15 @@ async fn drain_probe_pages(
     listing: ProbeListing<'_>,
 ) -> Result<(Vec<String>, usize), String> {
     let method = listing.method();
+    // The call the failure detail names, carrying the `start_after` marker for a
+    // tail drain so a `list_after` tail failure reads distinctly from a full
+    // `list_after` drain failure over the same prefix.
+    let call = match listing {
+        ProbeListing::After(Some(start_after)) => {
+            format!("{method}({prefix}, start_after={start_after})")
+        }
+        _ => format!("{method}({prefix})"),
+    };
     let mut delivered: Vec<String> = Vec::new();
     let mut pages = 0usize;
     let mut token = None;
@@ -1092,7 +1101,7 @@ async fn drain_probe_pages(
             ProbeListing::List => store.list(prefix, token).await,
             ProbeListing::After(start_after) => store.list_after(prefix, start_after, token).await,
         };
-        let page = result.map_err(|err| format!("{method}({prefix}) failed: {err}"))?;
+        let page = result.map_err(|err| format!("{call} failed: {err}"))?;
         pages += 1;
         delivered.extend(page.objects.into_iter().map(|meta| meta.key));
         match page.next {
@@ -1101,8 +1110,8 @@ async fn drain_probe_pages(
         }
         if pages >= MAX_PROBE_PAGES {
             return Err(format!(
-                "{method}({prefix}) still returned a continuation token after {pages} pages over \
-                 far fewer keys; this backend's pagination does not terminate"
+                "{call} still returned a continuation token after {pages} pages over far fewer \
+                 keys; this backend's pagination does not terminate"
             ));
         }
     }
@@ -1184,11 +1193,11 @@ async fn probe_lexicographic_listing_order(
     // the other. Draining only one qualified a backend no caller can list:
     // `drain_pages` hard-fails with `ListOrderViolation` on the very sequence
     // the un-judged entry point would have waved through. The detail names the
-    // offending entry point so a qualification report says which call is broken.
-    for (entry_point, listing) in [
-        ("list", ProbeListing::List),
-        ("list_after", ProbeListing::After(None)),
-    ] {
+    // offending entry point via `listing.method()`, so the label a report shows
+    // is owned by the one function every drain already routes through, not a
+    // second literal restated beside the value it must agree with.
+    for listing in [ProbeListing::List, ProbeListing::After(None)] {
+        let entry_point = listing.method();
         let (delivered, _pages) = match drain_probe_pages(store, &list_prefix, listing).await {
             Ok(result) => result,
             Err(detail) => return ProbeResult::fail(property, detail),
@@ -1225,16 +1234,21 @@ async fn probe_lexicographic_listing_order(
     // exactly the last three, still in order.
     let marker = expected[1].clone();
     let expected_tail: Vec<String> = expected[2..].to_vec();
-    let (tail_delivered, _pages) =
-        match drain_probe_pages(store, &list_prefix, ProbeListing::After(Some(&marker))).await {
-            Ok(result) => result,
-            Err(detail) => return ProbeResult::fail(property, detail),
-        };
+    // The tail names its entry point through the same `method()` the full drain
+    // uses, so the ordering probe never hardcodes `list_after`: one function
+    // owns the label on every path.
+    let tail_listing = ProbeListing::After(Some(&marker));
+    let tail_method = tail_listing.method();
+    let (tail_delivered, _pages) = match drain_probe_pages(store, &list_prefix, tail_listing).await
+    {
+        Ok(result) => result,
+        Err(detail) => return ProbeResult::fail(property, detail),
+    };
     if let Some(key) = tail_delivered.iter().find(|key| *key <= &marker) {
         return ProbeResult::fail(
             property,
             format!(
-                "list_after({list_prefix}, start_after={marker}) returned {key}, which does not \
+                "{tail_method}({list_prefix}, start_after={marker}) returned {key}, which does not \
                  compare strictly greater than the marker (docs/object-store-contract.md: \
                  start_after is exclusive)"
             ),
@@ -1246,7 +1260,7 @@ async fn probe_lexicographic_listing_order(
         return ProbeResult::fail(
             property,
             format!(
-                "list_after({list_prefix}, start_after={marker}) delivered {after} after \
+                "{tail_method}({list_prefix}, start_after={marker}) delivered {after} after \
                  {before}, which sorts before it"
             ),
         );
@@ -1256,7 +1270,7 @@ async fn probe_lexicographic_listing_order(
         return ProbeResult::fail(
             property,
             format!(
-                "list_after({list_prefix}, start_after={marker}) returned {} distinct keys, \
+                "{tail_method}({list_prefix}, start_after={marker}) returned {} distinct keys, \
                  expected exactly {}: got {distinct_tail:?}, expected {expected_tail:?}",
                 distinct_tail.len(),
                 expected_tail.len()
@@ -2213,6 +2227,173 @@ mod tests {
                 .contains("acknowledges deletes it has not applied"),
             "the failure must say what is wrong: {}",
             failure.detail
+        );
+    }
+
+    /// Wraps `MemoryStore` and really applies every delete -- so `get` and
+    /// `list` see the key gone -- but re-injects the deleted key into every
+    /// `list_after` page. Models a backend with a stale index on the
+    /// separately implemented `list_after` path alone: a delete is visible
+    /// through `get` and `list`, invisible through `list_after`. The mirror of
+    /// [`WeakOnlyOnListStore`] (defect confined to `list`) and of
+    /// `ReversedOrderStore(ReversedEntryPoint::ListAfter)` (ordering defect
+    /// confined to `list_after`), aimed at the delete probe's `list_after`
+    /// drain, which nothing else reaches.
+    ///
+    /// Violated invariant: `DeleteIdempotent`
+    /// (formal/tla/common/traceability.md `Delete / DeleteIdempotent`) as
+    /// observed through `list_after`: the key must be absent from every access
+    /// path after a delete.
+    struct WeakDeleteOnListAfterStore {
+        inner: MemoryStore,
+        /// Deleted keys, with the metadata they had at delete time, re-injected
+        /// into `list_after` pages under their prefix.
+        resurrected_on_list_after: Mutex<HashMap<String, ObjectMeta>>,
+    }
+
+    impl WeakDeleteOnListAfterStore {
+        fn new() -> Self {
+            WeakDeleteOnListAfterStore {
+                inner: MemoryStore::new(),
+                resurrected_on_list_after: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStoreBackend for WeakDeleteOnListAfterStore {
+        async fn put(
+            &self,
+            key: &str,
+            data: Bytes,
+            opts: PutOptions,
+        ) -> Result<crate::PutOutcome, StoreError> {
+            self.inner.put(key, data, opts).await
+        }
+
+        async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn list(
+            &self,
+            prefix: &str,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            self.inner.list(prefix, page).await
+        }
+
+        async fn list_after(
+            &self,
+            prefix: &str,
+            start_after: Option<&str>,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            let mut page_result = self.inner.list_after(prefix, start_after, page).await?;
+            let resurrected = self.resurrected_on_list_after.lock();
+            for (key, meta) in resurrected.iter() {
+                let after_marker = start_after.is_none_or(|marker| key.as_str() > marker);
+                if key.starts_with(prefix)
+                    && after_marker
+                    && !page_result
+                        .objects
+                        .iter()
+                        .any(|existing| &existing.key == key)
+                {
+                    page_result.objects.push(meta.clone());
+                }
+            }
+            page_result.objects.sort_by(|a, b| a.key.cmp(&b.key));
+            Ok(page_result)
+        }
+
+        async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+            self.inner.list_delimited(prefix).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), StoreError> {
+            if let Ok(meta) = self.inner.head(key).await {
+                self.resurrected_on_list_after
+                    .lock()
+                    .insert(key.to_string(), meta);
+            }
+            self.inner.delete(key).await
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            self.inner.capabilities()
+        }
+    }
+
+    /// The delete probe drains BOTH `list` and `list_after` and requires the
+    /// deleted key absent from each, so a delete visible through `list` but not
+    /// through the separately implemented `list_after` fails qualification,
+    /// named against `list_after`. Without the `list_after` drain the delete
+    /// probe passed `list` and never looked, and the tightening rested on there
+    /// being no `list_after` caller outside this crate.
+    #[tokio::test]
+    async fn a_backend_with_a_delete_stale_on_list_after_fails_qualification() {
+        let store = WeakDeleteOnListAfterStore::new();
+        let report = run_conformance_suite(&store, "sys/qualify/delete-stale-list-after/").await;
+        assert!(
+            !report.passed(),
+            "a delete invisible through list_after must not qualify even when list is correct"
+        );
+        let failed: Vec<Property> = report.failures().map(|r| r.property).collect();
+        assert_eq!(
+            failed,
+            vec![Property::DeleteVisibility],
+            "only delete visibility should be named: get, list, and every non-delete probe are \
+             untouched"
+        );
+        let failure = report
+            .results
+            .iter()
+            .find(|r| r.property == Property::DeleteVisibility)
+            .expect("the delete probe ran");
+        assert!(
+            failure.detail.starts_with("list_after(")
+                && failure
+                    .detail
+                    .contains("returned 2 keys, expected exactly 1"),
+            "the failure must name the list_after entry point that still re-delivers the deleted \
+             key: {}",
+            failure.detail
+        );
+    }
+
+    /// The delete probe's PASS detail wording is pinned verbatim, so the claim
+    /// it makes -- that BOTH `list` and `list_after` held exactly one key after
+    /// the delete -- is asserted somewhere and cannot drift silently.
+    #[tokio::test]
+    async fn delete_probe_pass_detail_is_pinned() {
+        let store = MemoryStore::new();
+        let prefix = "sys/qualify/delete-pass-detail/";
+        let report = run_conformance_suite(&store, prefix).await;
+        assert!(
+            report.passed(),
+            "the oracle must pass every probe, got: {:?}",
+            report.failures().collect::<Vec<_>>()
+        );
+        let list_prefix = format!("{prefix}delete/");
+        let kept = format!("{list_prefix}kept");
+        let gone = format!("{list_prefix}gone");
+        let delete = report
+            .results
+            .iter()
+            .find(|r| r.property == Property::DeleteVisibility)
+            .expect("the delete probe ran");
+        assert_eq!(
+            delete.detail,
+            format!(
+                "after deleting {gone}, a get returned NotFound and both list and list_after held \
+                 exactly 1 key ({kept}); a second delete of the absent key succeeded and changed \
+                 nothing"
+            )
         );
     }
 
@@ -3250,6 +3431,98 @@ mod tests {
             ]
         );
         assert_eq!(distinct_in_delivery_order(&tail_delivered), tail_delivered);
+    }
+
+    /// Wraps `MemoryStore` and errors every `list_after` call that carries a
+    /// `start_after` marker, delegating every other operation (including the
+    /// marker-free full drains) to the oracle. Reaches the ordering probe's
+    /// `start_after` tail drain alone, so its failure detail is the one the
+    /// drain builds for a tail call.
+    struct TailErrorStore {
+        inner: MemoryStore,
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStoreBackend for TailErrorStore {
+        async fn put(
+            &self,
+            key: &str,
+            data: Bytes,
+            opts: PutOptions,
+        ) -> Result<crate::PutOutcome, StoreError> {
+            self.inner.put(key, data, opts).await
+        }
+
+        async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn list(
+            &self,
+            prefix: &str,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            self.inner.list(prefix, page).await
+        }
+
+        async fn list_after(
+            &self,
+            prefix: &str,
+            start_after: Option<&str>,
+            page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            if start_after.is_some() {
+                return Err(StoreError::Timeout);
+            }
+            self.inner.list_after(prefix, start_after, page).await
+        }
+
+        async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+            self.inner.list_delimited(prefix).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), StoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            self.inner.capabilities()
+        }
+    }
+
+    /// A `list_after` tail drain failure names the `start_after` marker, so it
+    /// reads distinctly from a full `list_after` drain failure over the same
+    /// prefix (both once said only `list_after({prefix}) failed`). Reaches the
+    /// tail-labeling arm of the drain's failure detail, which the marker-free
+    /// full and `list` drains never take.
+    #[tokio::test]
+    async fn list_after_tail_drain_failure_names_the_start_after_marker() {
+        let store = TailErrorStore {
+            inner: MemoryStore::new(),
+        };
+        let prefix = "sys/qualify/tail-error/";
+        let report = run_conformance_suite(&store, prefix).await;
+        assert!(!report.passed());
+        let failed: Vec<Property> = report.failures().map(|r| r.property).collect();
+        assert_eq!(
+            failed,
+            vec![Property::LexicographicListingOrder],
+            "only the ordering probe drains list_after with a start_after marker; every other \
+             probe uses list or a marker-free list_after and is untouched"
+        );
+        let list_prefix = format!("{prefix}order/");
+        // The ordering probe resumes strictly after the second sorted key.
+        let marker = format!("{list_prefix}b");
+        assert_eq!(
+            order_probe_result(&report).detail,
+            format!("list_after({list_prefix}, start_after={marker}) failed: timeout"),
+            "the tail drain failure must name the start_after marker, not read like a full drain \
+             failure over the same prefix"
+        );
     }
 
     /// The `list` twin of

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -569,7 +569,9 @@ throwaway key prefix:
   `S3Store` implements `list` and `list_after` separately (the default
   `list_after` is `list` plus a client-side filter), so a backend can be
   ordered on one entry point and reversed on the other; the probe drains a
-  full pass through each and names the offending entry point in its failure.
+  full pass through each and names the offending entry point in its failure,
+  including when the failure is the drain itself (a `list`/`list_after` error,
+  or pagination that never terminates), not only an out-of-order delivery.
   Every pass judges the raw delivery sequence, repeats included, on the rule
   the listing bullet above states: a repeat of the last delivered key passes,
   a repeat of an earlier one fails. Judging a deduplicated sequence instead,
@@ -582,8 +584,11 @@ throwaway key prefix:
 - `DeleteVisibility`: after a successful delete, a `get` of the key returns
   `NotFound` and a listing of its prefix omits it while still holding the
   sibling key that was not deleted; a second delete of the now-absent key
-  succeeds and changes nothing. Retention sweep, GC, and ADR-0064 erasure
-  all read a delete's acknowledgement as the object being gone.
+  succeeds and changes nothing. The listing side is drained through both
+  `list` and `list_after`, so a delete visible through one entry point but not
+  the other is caught here rather than depending on which path a caller
+  happens to use. Retention sweep, GC, and ADR-0064 erasure all read a
+  delete's acknowledgement as the object being gone.
 
 Each probe returns a `ProbeResult` naming which `Property` it checked, so a
 failure reads "this backend cannot do conditional writes" or "this backend's


### PR DESCRIPTION
The conformance suite judges listing order on both list and list_after, but
the failure details the shared page drain built named only the prefix, so a
backend whose list fails or spins while list_after is fine produced a
qualification report that could not say which call was broken. The entry point
is now threaded through one helper that owns the name, which the ordering probe
and the tail pass both use, and a tail drain failure names its start_after
marker so it reads distinctly from a full drain over the same prefix.

The delete-visibility probe drains both entry points and asserts the deleted
key is absent from each, so that property no longer rests on there happening to
be no production list_after caller.

Each of those claims is witnessed. Reverting the delete probe's second entry
point fails a named test, mislabelling the entry point fails six, and the
marker in the tail detail fails one. The round that introduced the label had
none of those witnesses: the suite stayed byte-identical under both mutations,
which is how the gap was found.

Supersedes #1537.

Fixes: #1498
Refs: #1448, #1313
