### PR TITLE
fix(maintain): count rewrite records in age-based retention

### DIFF
--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -365,13 +365,17 @@ impl SpanErasureMatcher {
 /// correctly hide the matching samples while this prefilter skipped the
 /// bucket that should have erased them (a GDPR gap, ADR-0064).
 ///
-/// A windowless request (`has_window() == false`) can match a series
-/// regardless of when its samples were recorded, so it overlaps every
-/// bucket that has any live record at all. A bucket whose live record set
-/// carries no samples (`min_event_ts_ns > max_event_ts_ns`, the empty-parts
-/// sentinel [`live_input_event_bounds`] returns) has nothing left to
-/// physically erase, so this always returns `false` for a windowed
-/// request in that case regardless of the window.
+/// A windowless request (`window_start_ns == 0 && window_end_ns == 0`) can
+/// match a series regardless of when its samples were recorded, so it returns
+/// `true` unconditionally, BEFORE the empty-range sentinel below: it overlaps
+/// every bucket, including one whose live record set carries no samples at all.
+/// That is why the empty-RawL0 case needs the separate caller-side
+/// [`is_empty_raw_l0`] guard rather than relying on this prefilter to skip it.
+/// The sentinel applies to windowed requests only: a bucket whose live record
+/// set carries no samples (`min_event_ts_ns > max_event_ts_ns`, the
+/// empty-parts sentinel [`live_input_event_bounds`] returns) has nothing left
+/// to physically erase, so a windowed request always returns `false` in that
+/// case regardless of the window.
 pub fn bucket_may_overlap(
     min_event_ts_ns: i64,
     max_event_ts_ns: i64,
@@ -1569,6 +1573,25 @@ pub async fn publish_rewrite_record(
         RewriteSupersession::Existing(key) => (Vec::new(), key.clone()),
     };
 
+    // An empty input set with no superseded record key names nothing at all:
+    // `erasure::compute_rewrite_input_set_hash` treats that as a caller
+    // contract violation and panics, and `erasure::validate_rewrite` would
+    // reject the record anyway. The in-crate driver cannot reach this
+    // (`is_empty_raw_l0` skips the bucket before any part is built), but this
+    // function is public, so an external caller passing
+    // `RewriteSupersession::RawL0(vec![])` gets a typed error instead of a
+    // panic in a library.
+    if inputs.is_empty() && superseded_record_key.is_empty() {
+        return Err(MaintainError::Invariant(format!(
+            "erasure rewrite supersession names nothing: empty RawL0 input set with no \
+             superseded record key for tenant {} signal {} shard {} hour {}",
+            hex::encode(bucket.tenant_hash.0),
+            bucket.signal.key_prefix(),
+            bucket.shard,
+            bucket.ingest_hour_bucket
+        )));
+    }
+
     let mut applied_request_ids: Vec<String> =
         build.drops.iter().map(|d| d.request_id.clone()).collect();
     applied_request_ids.sort();
@@ -2740,6 +2763,59 @@ mod tests {
         );
     }
 
+    /// A conserving build whose supersession names nothing -- an empty
+    /// `RawL0` input set with no superseded record key -- must return a typed
+    /// invariant error, not panic inside
+    /// `erasure::compute_rewrite_input_set_hash`. The in-crate driver cannot
+    /// reach this shape (`is_empty_raw_l0` skips the bucket first), so this
+    /// pins the public function's own contract for an external caller.
+    /// Flip-line proof: disabling the `if inputs.is_empty() &&
+    /// superseded_record_key.is_empty()` guard in `publish_rewrite_record`
+    /// makes this panic with `compute_rewrite_input_set_hash: exactly one of
+    /// `inputs` (non-empty) or `superseded_record_key` (non-empty) must be set
+    /// (inputs_present=false, superseded_present=false)`.
+    #[tokio::test]
+    async fn empty_supersession_returns_invariant_error_not_panic() {
+        let store = MemoryStore::new();
+        let clock = FixedClock::new(0);
+        let config = CompactorConfig::default();
+        // Conserving on purpose: 0 + 0 == 0, so the conservation and encode
+        // reconciliation gates both pass and the supersession guard is the
+        // only thing that can reject this build.
+        let build = RewriteBuild {
+            parts: Vec::new(),
+            input_sample_count: 0,
+            output_sample_count: 0,
+            drops: Vec::new(),
+        };
+
+        let err = publish_rewrite_record(
+            &store,
+            &config,
+            &clock,
+            &bucket(),
+            RewriteSupersession::RawL0(Vec::new()),
+            build,
+            0,
+        )
+        .await
+        .expect_err("a supersession that names nothing must abort");
+
+        match err {
+            MaintainError::Invariant(message) => {
+                assert!(
+                    message.contains("erasure rewrite supersession names nothing"),
+                    "unexpected invariant message: {message}"
+                );
+            }
+            other => panic!("expected MaintainError::Invariant, got {other:?}"),
+        }
+        assert!(
+            list_all(&store, "").await.expect("list").is_empty(),
+            "the rejected publish must write nothing"
+        );
+    }
+
     /// A `LeaseCheck` that protects any key under one prefix -- `NoLeases`
     /// alone can never produce a `Held` outcome, so this local double
     /// simulates a legal hold on the fixture bucket.
@@ -3274,8 +3350,14 @@ mod tests {
     }
 
     /// A metrics bucket on a tenant distinct from [`bucket`]'s `acme`, for the
-    /// empty-bucket tests (which never seed, so they must not collide with any
-    /// other test's tenant).
+    /// tests that need a bucket holding no objects at all.
+    ///
+    /// The distinct tenant is not about cross-test isolation: every test here
+    /// builds its own `MemoryStore`, so two tests could share a tenant safely.
+    /// It is about the seeding helpers in this module, which all write into
+    /// [`bucket`]'s tenant. A bucket on any other tenant cannot be reached by
+    /// them, so an empty-bucket test cannot be seeded by accident, and the
+    /// tenant name says which test the bucket belongs to.
     fn empty_bucket(tenant: &str) -> Bucket {
         Bucket::new(TenantId::new(tenant).hash(), Signal::Metrics, SHARD, HOUR)
     }

--- a/crates/ravel-maintain/src/retention.rs
+++ b/crates/ravel-maintain/src/retention.rs
@@ -7,21 +7,31 @@
 //! new snapshots (the resolver's job, ravel-catalog), then a horizon-gated
 //! physical sweep here.
 //!
-//! 1. **Expiry evaluation** decodes the bucket's already-listed commit and
-//!    compaction records and takes `max(max_event_ts_ns)` across all of them
-//!    (no footer reads). A bucket is expired when it is sealed and that
-//!    maximum is `< now - R`, so no sample younger than `R` is ever excluded
-//!    (ADR-0019 decision 1; the impossibility floor).
+//! 1. **Expiry evaluation** decodes the bucket's already-listed commit,
+//!    compaction, and selective-erasure rewrite records and takes
+//!    `max(max_event_ts_ns)` across all of them (no footer reads). A bucket is
+//!    expired when it is sealed and that maximum is `< now - R`, so no sample
+//!    younger than `R` is ever excluded (ADR-0019 decision 1; the
+//!    impossibility floor). ADR-0019 decision 1 names only L0 commit records
+//!    and compaction records because selective erasure (ADR-0064) postdates
+//!    it; a rewrite record is a live record set exactly as a compaction record
+//!    is, and rewrite-record-only is the durable steady state of an erased
+//!    bucket once the superseded-input sweep has removed its inputs, so
+//!    omitting it retained erased-and-rewritten data past `R` forever
+//!    (issue #1321).
 //! 2. **Tombstone** is written `CreateIfAbsent` at the fixed per-bucket key
 //!    with an injected `retired_at_ns`. It is durable and irreversible:
 //!    raising `R` later never resurrects a tombstoned bucket (ADR-0019
 //!    decision 2).
 //! 3. **Physical sweep** runs once `now >= retired_at_ns + protection_horizon`,
-//!    deleting in the fixed order L0 commit records, compaction records, L0
-//!    data objects, L1 parts, then the tombstone last, and only after a
-//!    verifying LIST shows the bucket's commit prefix holds only the tombstone
-//!    and its `l1/` prefix is empty. Any residue leaves the tombstone in place
-//!    for the next pass (ADR-0019 decision 4).
+//!    deleting in the fixed order L0 commit records, compaction records,
+//!    rewrite records, L0 data objects, L1 parts, then the tombstone last, and
+//!    only after a verifying LIST shows the bucket's commit prefix holds only
+//!    the tombstone and its `l1/` prefix is empty. Any residue leaves the
+//!    tombstone in place for the next pass (ADR-0019 decision 4). The rewrite
+//!    record is deleted with the other records for the same reason it is read
+//!    during expiry evaluation: without it the verifying LIST always found
+//!    residue and the sweep never got past `SweptPartial` (issue #1321).
 //!
 //! Retention runs before compaction ([`maintain_bucket`], ADR-0019 decision
 //! 6): an expired bucket is tombstoned, never compacted first. That ordering
@@ -34,12 +44,13 @@
 //! measure only": its absence would only waste work, never corrupt data.
 
 use prost::Message;
+use ravel_commit::erasure;
 use ravel_commit::keys;
 use ravel_commit::record;
 use ravel_object_store::{
     GetRange, ObjectStoreBackend, PutOptions, StoreError, UploadChecksum, list_all,
 };
-use ravel_proto::commit::v1::{CommitRecord, CompactionRecord, RetentionTombstone};
+use ravel_proto::commit::v1::{CommitRecord, CompactionRecord, RetentionTombstone, RewriteRecord};
 use ravel_types::TenantHash;
 
 use crate::bucket::Bucket;
@@ -216,7 +227,11 @@ pub async fn retention_sweep_bucket_with_reach(
     for key in &listing.compaction_record_keys {
         compaction_records.push(get_compaction_record(store, key).await?);
     }
-    let max_event = max_event_ts(&commit_records, &compaction_records);
+    let mut rewrite_records = Vec::with_capacity(listing.rewrite_record_keys.len());
+    for key in &listing.rewrite_record_keys {
+        rewrite_records.push(get_rewrite_record(store, key).await?);
+    }
+    let max_event = max_event_ts(&commit_records, &compaction_records, &rewrite_records);
     if !is_expired(max_event, now, window_ns) {
         return Ok(RetentionOutcome::NotExpired);
     }
@@ -279,11 +294,27 @@ pub async fn maintain_bucket_with_reach(
     Ok((outcome, compaction))
 }
 
-/// The maximum `max_event_ts_ns` across a bucket's L0 commit records and
-/// compaction-record parts. `None` when the bucket holds no records.
+/// The maximum `max_event_ts_ns` across a bucket's L0 commit records,
+/// compaction-record parts, and rewrite-record parts. `None` when the bucket
+/// holds no records.
+///
+/// Every record kind `keys::partition_bucket_entry` can classify inside a
+/// bucket's commit prefix contributes here except the tombstone (whose own
+/// presence short-circuits expiry evaluation entirely). A rewrite record left
+/// out of this maximum is a bucket that can never expire: once the
+/// protection-horizon sweep has removed a rewrite's superseded inputs, the
+/// rewrite record is the bucket's whole live record set (issue #1321).
+///
+/// A rewrite record with no parts (an erasure that dropped every record in the
+/// bucket, which `RewriteRecord.parts` explicitly permits) carries no event
+/// timestamp at all, so it contributes its own `created_unix_ns` instead. It
+/// holds no sample, so no sample younger than `R` can hide behind it, and
+/// anchoring on the instant the record was published is what keeps such a
+/// bucket expirable rather than permanently retained metadata.
 pub fn max_event_ts(
     commit_records: &[CommitRecord],
     compaction_records: &[CompactionRecord],
+    rewrite_records: &[RewriteRecord],
 ) -> Option<i64> {
     let mut max: Option<i64> = None;
     let mut bump = |v: i64| max = Some(max.map_or(v, |m: i64| m.max(v)));
@@ -291,6 +322,15 @@ pub fn max_event_ts(
         bump(rec.max_event_ts_ns);
     }
     for rec in compaction_records {
+        for part in &rec.parts {
+            bump(part.max_event_ts_ns);
+        }
+    }
+    for rec in rewrite_records {
+        if rec.parts.is_empty() {
+            bump(rec.created_unix_ns);
+            continue;
+        }
         for part in &rec.parts {
             bump(part.max_event_ts_ns);
         }
@@ -322,7 +362,13 @@ async fn write_tombstone(
     listing: &BucketListing,
     dry_run: bool,
 ) -> Result<()> {
-    let record_count = (listing.commit_keys.len() + listing.compaction_record_keys.len()) as u64;
+    // Every record kind the bucket can hold counts, rewrite records included:
+    // `record_count_observed` is the audit evidence for what was in the bucket
+    // when it was retired, and a rewrite-record-only bucket reporting zero
+    // records observed reads as an empty bucket that was never written to.
+    let record_count = (listing.commit_keys.len()
+        + listing.compaction_record_keys.len()
+        + listing.rewrite_record_keys.len()) as u64;
     let tombstone = RetentionTombstone {
         format_version: 1,
         tenant_hash: bucket.tenant_hash.0.to_vec(),
@@ -350,10 +396,15 @@ async fn write_tombstone(
 }
 
 /// Horizon-gated physical sweep (ADR-0019 decision 4). Deletes in the
-/// fixed order L0 commit records, compaction records, L0 data objects, L1
-/// parts, then the tombstone last, and only after a verifying LIST shows the
-/// bucket's commit prefix holds only the tombstone and its `l1/` prefix is
-/// empty. Any residue leaves the tombstone in place.
+/// fixed order L0 commit records, compaction records, rewrite records, L0 data
+/// objects, L1 parts, then the tombstone last, and only after a verifying LIST
+/// shows the bucket's commit prefix holds only the tombstone and its `l1/`
+/// prefix is empty. Any residue leaves the tombstone in place.
+///
+/// The record deletes cover every non-tombstone shape
+/// `keys::partition_bucket_entry` classifies in the commit prefix, which is
+/// the same set [`bucket_is_empty_but_tombstone`] refuses to call empty: a
+/// shape deleted by neither is residue forever (issue #1321).
 async fn physical_sweep(
     reach: &mut SnapshotReachability,
     store: &dyn ObjectStoreBackend,
@@ -398,6 +449,10 @@ async fn physical_sweep(
             Err(e) => return Err(MaintainError::Store(e)),
         }
     }
+    // Rewrite output parts need no separate resolution step: ADR-0064 decision
+    // 3 point 2 PUTs them under the same `l1/` part-key shape a compaction
+    // record's parts use, so the fresh LIST below already covers them.
+    //
     // Discover L1 parts by a fresh LIST of the bucket's own l1/ prefix (the
     // same LIST bucket_is_empty_but_tombstone uses), not by reconstructing
     // keys from compaction records. This makes the L1 delete independent of
@@ -418,6 +473,7 @@ async fn physical_sweep(
     // decision 4): records, then data objects, then L1 parts, tombstone last.
     delete_all(store, lease, &listing.commit_keys, dry_run).await?;
     delete_all(store, lease, &listing.compaction_record_keys, dry_run).await?;
+    delete_all(store, lease, &listing.rewrite_record_keys, dry_run).await?;
     delete_all(store, lease, &l0_data_keys, dry_run).await?;
     delete_all(store, lease, &l1_part_keys, dry_run).await?;
 
@@ -466,6 +522,14 @@ async fn delete_all(
 /// tombstone: the commit prefix contains only the tombstone entry, and the
 /// `l1/` prefix for this bucket is empty (ADR-0019 decision 4's verifying
 /// LIST).
+///
+/// This enumerates by exclusion rather than by listing the shapes it expects,
+/// so it needs no change when a new record kind appears: anything
+/// `keys::partition_bucket_entry` classifies as other than the tombstone is
+/// residue, and an unclassifiable key is layout drift. What that costs is
+/// silence about which shape the sweeper forgot to delete -- a rewrite record
+/// held this check false on every pass forever until the delete list above
+/// learned about it (issue #1321).
 async fn bucket_is_empty_but_tombstone(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,
@@ -522,6 +586,20 @@ async fn get_compaction_record(
     let record = record::decode_compaction(got.data.as_ref())
         .map_err(|e| MaintainError::Invariant(format!("compaction record decode failed: {e}")))?;
     keys::verify_compaction_record_key(&record, key)?;
+    Ok(record)
+}
+
+/// GET, decode, and key-verify one selective-erasure rewrite record (ADR-0064
+/// decision 3, ADR-0010 §7). Decoded through
+/// [`ravel_commit::erasure::decode_rewrite`], never a raw `prost` decode: that
+/// is the reader with the `format_version` gate (ADR-0066 decision 2), and it
+/// also re-verifies the record's own `input_set_hash` and the bucket its
+/// `superseded_record_key` names.
+async fn get_rewrite_record(store: &dyn ObjectStoreBackend, key: &str) -> Result<RewriteRecord> {
+    let got = store.get(key, GetRange::Full).await?;
+    let record = erasure::decode_rewrite(got.data.as_ref())
+        .map_err(|e| MaintainError::Invariant(format!("rewrite record decode failed: {e}")))?;
+    keys::verify_rewrite_record_key(&record, key)?;
     Ok(record)
 }
 

--- a/crates/ravel-maintain/tests/retention.rs
+++ b/crates/ravel-maintain/tests/retention.rs
@@ -24,7 +24,11 @@ use ravel_object_store::fault::{
 };
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions, list_all};
-use ravel_proto::commit::v1::{CommitRecord, Signal as ProtoSignal};
+use ravel_proto::commit::v1::{
+    CommitRecord, CompactionInputIdentity, CompactionPart, RewriteDrop, RewriteRecord,
+    Signal as ProtoSignal,
+};
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -234,7 +238,7 @@ proptest! {
     ) {
         let commits: Vec<CommitRecord> =
             events.iter().map(|&ts| commit_with_max_event(ts)).collect();
-        let max = max_event_ts(&commits, &[]);
+        let max = max_event_ts(&commits, &[], &[]);
         let expired = is_expired(max, now, r);
         let threshold = now.saturating_sub(r);
 
@@ -1806,4 +1810,414 @@ async fn tombstoned_bucket_token_query_reports_tombstoned() {
         snapshot.segments.is_empty(),
         "the tombstoned flush is satisfied with zero segments, not served stale data"
     );
+}
+
+// --- Rewrite records are records for retention (issue #1321) ---------------
+//
+// A selective-erasure rewrite record (ADR-0064 decision 3) is a bucket's whole
+// live record set once the superseded-input sweep has removed its inputs, and
+// compaction refuses a bucket holding one, so rewrite-record-only is the
+// durable steady state of an erased bucket. Retention must read it when
+// computing expiry and delete it when sweeping.
+
+/// The synthetic raw-L0 input identity the seeded rewrite records supersede,
+/// and the erasure request they record as applied. Neither has to exist as an
+/// object: retention reads the rewrite record's own fields, and
+/// `erasure::decode_rewrite` validates them against the record's key.
+const REWRITE_INPUT_WRITER: u128 = 0x51;
+const REWRITE_REQUEST: u128 = 0x77;
+
+/// The bytes seeded at each rewrite output part key. Content is irrelevant to
+/// retention (it reads records, never parts), only the object's presence is.
+const REWRITE_PART_BYTES: &[u8] = b"rewrite-output-part";
+
+/// Build one rewrite record for `bucket`: `parts` gives each output part's
+/// `(min_event_ts_ns, max_event_ts_ns)`, empty for a rewrite that dropped
+/// every record in the bucket (which `RewriteRecord.parts` permits).
+fn rewrite_record_for(
+    bucket: &Bucket,
+    created_unix_ns: i64,
+    parts: &[(i64, i64)],
+) -> RewriteRecord {
+    let inputs = vec![CompactionInputIdentity {
+        writer_id: Uuid::from_u128(REWRITE_INPUT_WRITER).to_string(),
+        writer_epoch: 1,
+        writer_seq: 1,
+    }];
+    let request_id = Uuid::from_u128(REWRITE_REQUEST).to_string();
+    let input_set_hash = ravel_commit::erasure::compute_rewrite_input_set_hash(
+        &inputs,
+        None,
+        std::slice::from_ref(&request_id),
+    );
+    RewriteRecord {
+        format_version: 1,
+        tenant_hash: bucket.tenant_hash.0.to_vec(),
+        signal: ravel_commit::signal::to_proto(bucket.signal) as i32,
+        shard: bucket.shard,
+        ingest_hour_bucket: bucket.ingest_hour_bucket,
+        inputs,
+        input_set_hash: input_set_hash.to_vec(),
+        parts: parts
+            .iter()
+            .enumerate()
+            .map(
+                |(index, (min_event_ts_ns, max_event_ts_ns))| CompactionPart {
+                    part_index: index as u32,
+                    first_series_id: vec![0x00; 16],
+                    last_series_id: vec![0xff; 16],
+                    content_hash: vec![0xab; 32],
+                    object_size: REWRITE_PART_BYTES.len() as u64,
+                    sample_count: 1,
+                    series_count: 1,
+                    run_count: 1,
+                    min_event_ts_ns: *min_event_ts_ns,
+                    max_event_ts_ns: *max_event_ts_ns,
+                    segment_format_version: 3,
+                    declared_column_stats: Vec::new(),
+                },
+            )
+            .collect(),
+        drops: vec![RewriteDrop {
+            request_id,
+            dropped_count: 1,
+        }],
+        created_unix_ns,
+        superseded_record_key: String::new(),
+    }
+}
+
+/// Seed [`rewrite_record_for`] plus the L1 part object each of its parts
+/// names, exactly as `publish_rewrite_record` would (ADR-0064 decision 3
+/// point 2: rewrite outputs are PUT under the L1 part-key shape). Returns the
+/// record key and the part keys.
+async fn seed_rewrite_record(
+    store: &dyn ObjectStoreBackend,
+    bucket: &Bucket,
+    created_unix_ns: i64,
+    parts: &[(i64, i64)],
+) -> (String, Vec<String>) {
+    let record = rewrite_record_for(bucket, created_unix_ns, parts);
+    let record_key = keys::rewrite_record_key_for(&record).expect("rewrite record key");
+    store
+        .put(
+            &record_key,
+            ravel_commit::erasure::encode_rewrite(&record),
+            PutOptions::default(),
+        )
+        .await
+        .expect("put rewrite record");
+    let mut part_keys = Vec::new();
+    for part in &record.parts {
+        let key = keys::reconstruct_rewrite_part_key(&record, part).expect("rewrite part key");
+        store
+            .put(
+                &key,
+                Bytes::from_static(REWRITE_PART_BYTES),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put rewrite part");
+        part_keys.push(key);
+    }
+    (record_key, part_keys)
+}
+
+/// The exact set of keys in the store, so a sweep assertion pins which objects
+/// are gone rather than how many.
+async fn key_set(store: &dyn ObjectStoreBackend) -> BTreeSet<String> {
+    list_all(store, "")
+        .await
+        .expect("list")
+        .into_iter()
+        .map(|meta| meta.key)
+        .collect()
+}
+
+fn tombstone_key_of(bucket: &Bucket) -> String {
+    keys::retention_tombstone_key(
+        &bucket.tenant_hash,
+        bucket.signal,
+        bucket.shard,
+        bucket.ingest_hour_bucket,
+    )
+    .expect("tombstone key")
+}
+
+/// `now`, and the tenant's window, for a bucket whose expiry threshold
+/// (`now - R`) is a workable number: sealed well past the seal margin, with
+/// `R` at the config floor.
+fn window_and_now(config: &CompactorConfig) -> (i64, i64) {
+    let window = config.retention_floor_ns(DEFAULT_MAX_INGEST_LAG_NS);
+    (window, sealed_now_ns() + window)
+}
+
+/// The expiry maximum takes the later of an L0 commit record's
+/// `max_event_ts_ns` and a rewrite record's part bounds, in both directions,
+/// and falls back to a part-less rewrite record's own `created_unix_ns`.
+///
+/// Exact values, not bands: dropping the rewrite arm of `max_event_ts` makes
+/// the first assertion return `Some(1_000)` instead of `Some(5_000)` and the
+/// third `None` instead of `Some(7_777)`.
+#[test]
+fn max_event_ts_takes_the_later_of_l0_and_rewrite() {
+    let b = bucket();
+    let rewrite = rewrite_record_for(&b, 42, &[(2_000, 5_000)]);
+
+    assert_eq!(
+        max_event_ts(
+            &[commit_with_max_event(1_000)],
+            &[],
+            std::slice::from_ref(&rewrite)
+        ),
+        Some(5_000),
+        "the rewrite record's part is the newest record in the bucket"
+    );
+    assert_eq!(
+        max_event_ts(&[commit_with_max_event(9_000)], &[], &[rewrite]),
+        Some(9_000),
+        "the L0 commit record is the newest record in the bucket"
+    );
+    assert_eq!(
+        max_event_ts(&[], &[], &[rewrite_record_for(&b, 7_777, &[])]),
+        Some(7_777),
+        "a rewrite with no surviving part contributes its own created_unix_ns"
+    );
+    assert_eq!(
+        max_event_ts(&[], &[], &[]),
+        None,
+        "a bucket with no records at all still yields no maximum"
+    );
+}
+
+/// A bucket whose only record is a rewrite record is tombstoned once the clock
+/// passes the tenant's retention window, and the horizon-gated sweep then
+/// deletes the rewrite record, its output part, and the tombstone, leaving the
+/// bucket empty.
+///
+/// Exact key sets at both steps, so a sweep that leaves the rewrite record
+/// behind (the pre-fix `SweptPartial` forever) cannot pass.
+#[tokio::test]
+async fn rewrite_record_only_bucket_is_tombstoned_then_fully_swept() {
+    let store = MemoryStore::new();
+    let config = cfg();
+    let retention = retention_at_floor(&config);
+    let (window, now) = window_and_now(&config);
+    let b = bucket();
+
+    // One nanosecond older than the expiry threshold `now - R`: expired.
+    let max_event = now - window - 1;
+    let (record_key, part_keys) =
+        seed_rewrite_record(&store, &b, max_event, &[(max_event - 1_000, max_event)]).await;
+    assert_eq!(part_keys.len(), 1, "one output part seeded");
+    let seeded: BTreeSet<String> = [record_key.clone(), part_keys[0].clone()]
+        .into_iter()
+        .collect();
+    assert_eq!(key_set(&store).await, seeded, "exactly what was seeded");
+
+    let clock = FixedClock::new(now);
+    let outcome = retention_sweep_bucket(&store, &clock, &config, &retention, &NoLeases, &b)
+        .await
+        .expect("retention pass");
+    assert_eq!(outcome, RetentionOutcome::Tombstoned);
+
+    let tombstone_key = tombstone_key_of(&b);
+    let mut tombstoned = seeded.clone();
+    tombstoned.insert(tombstone_key.clone());
+    assert_eq!(
+        key_set(&store).await,
+        tombstoned,
+        "the tombstone is the only new object; nothing is deleted yet"
+    );
+
+    // The tombstone counts the rewrite record as a record observed.
+    let bytes = store
+        .get(&tombstone_key, ravel_object_store::GetRange::Full)
+        .await
+        .expect("get tombstone")
+        .data;
+    let tombstone = ravel_commit::record::decode_tombstone(bytes.as_ref()).expect("decode");
+    assert_eq!(
+        tombstone.record_count_observed, 1,
+        "the rewrite record is the one record the bucket held"
+    );
+    assert_eq!(tombstone.retired_at_ns, now);
+    assert_eq!(tombstone.retention_window_ns, window as u64);
+
+    // Horizon elapsed: the physical sweep finishes the bucket.
+    let after_horizon = FixedClock::new(now + config.protection_horizon_ns);
+    let outcome =
+        retention_sweep_bucket(&store, &after_horizon, &config, &retention, &NoLeases, &b)
+            .await
+            .expect("sweep pass");
+    assert_eq!(outcome, RetentionOutcome::Swept);
+    assert_eq!(
+        key_set(&store).await,
+        BTreeSet::new(),
+        "rewrite record, its part, and the tombstone are all gone"
+    );
+}
+
+/// A rewrite-record-only bucket still inside its retention window is not
+/// tombstoned, at the threshold (`max_event_ts == now - R`, which
+/// [`is_expired`] treats as live) and strictly inside it.
+#[tokio::test]
+async fn rewrite_record_only_bucket_inside_its_window_is_not_tombstoned() {
+    for past_threshold in [0i64, 1] {
+        let store = MemoryStore::new();
+        let config = cfg();
+        let retention = retention_at_floor(&config);
+        let (window, now) = window_and_now(&config);
+        let b = bucket();
+
+        let max_event = now - window + past_threshold;
+        let (record_key, part_keys) =
+            seed_rewrite_record(&store, &b, max_event, &[(max_event - 1_000, max_event)]).await;
+        let seeded: BTreeSet<String> = [record_key, part_keys[0].clone()].into_iter().collect();
+
+        let clock = FixedClock::new(now);
+        let outcome = retention_sweep_bucket(&store, &clock, &config, &retention, &NoLeases, &b)
+            .await
+            .expect("retention pass");
+        assert_eq!(
+            outcome,
+            RetentionOutcome::NotExpired,
+            "max_event_ts {max_event} is not older than the threshold {}",
+            now - window
+        );
+        assert!(!has_tombstone(&store, &b).await, "no tombstone was written");
+        assert_eq!(
+            key_set(&store).await,
+            seeded,
+            "an unexpired bucket is untouched: exact key set unchanged"
+        );
+    }
+}
+
+/// A bucket holding a rewrite record plus a live L0 commit record expires on
+/// the later of the two timestamps, whichever record carries it. The
+/// rewrite-is-younger direction is what fails when `max_event_ts` ignores
+/// rewrite records: the bucket then looks expired and is tombstoned while a
+/// surviving rewrite output part is still inside the window.
+#[tokio::test]
+async fn rewrite_record_plus_live_l0_expires_on_the_later_timestamp() {
+    // (label, rewrite part max_event offset from the threshold, L0 offset)
+    let cases = [
+        ("rewrite is younger", 1i64, -1i64),
+        ("l0 is younger", -1, 1),
+    ];
+    for (label, rewrite_offset, l0_offset) in cases {
+        let store = MemoryStore::new();
+        let config = cfg();
+        let retention = retention_at_floor(&config);
+        let (window, now) = window_and_now(&config);
+        let threshold = now - window;
+        let b = bucket();
+
+        let l0_max = threshold + l0_offset;
+        let commit_key = seed_input(
+            &store,
+            &InputSpec::new(
+                Uuid::from_u128(0x71),
+                4,
+                1,
+                vec![raw_series(
+                    "m",
+                    &[("k", "a")],
+                    &[(l0_max - 1_000, 1.0), (l0_max, 2.0)],
+                )],
+            ),
+        )
+        .await;
+        let rewrite_max = threshold + rewrite_offset;
+        let (record_key, part_keys) = seed_rewrite_record(
+            &store,
+            &b,
+            rewrite_max,
+            &[(rewrite_max - 1_000, rewrite_max)],
+        )
+        .await;
+
+        let clock = FixedClock::new(now);
+        let outcome = retention_sweep_bucket(&store, &clock, &config, &retention, &NoLeases, &b)
+            .await
+            .expect("retention pass");
+        assert_eq!(
+            outcome,
+            RetentionOutcome::NotExpired,
+            "{label}: the later of {rewrite_max} (rewrite) and {l0_max} (L0) is not \
+             older than the threshold {threshold}"
+        );
+        assert!(
+            !has_tombstone(&store, &b).await,
+            "{label}: no tombstone was written"
+        );
+        let expected: BTreeSet<String> = [commit_key, record_key, part_keys[0].clone()]
+            .into_iter()
+            .chain(
+                list_all(
+                    &store,
+                    &format!("t/{}/{}/l0/", b.tenant_hash.to_hex(), b.signal.key_prefix()),
+                )
+                .await
+                .expect("list l0")
+                .into_iter()
+                .map(|meta| meta.key),
+            )
+            .collect();
+        assert_eq!(
+            key_set(&store).await,
+            expected,
+            "{label}: an unexpired bucket is untouched"
+        );
+    }
+}
+
+/// A rewrite that dropped every record in its bucket leaves a part-less
+/// rewrite record: no event timestamp anywhere in the bucket. It expires on
+/// the record's own `created_unix_ns`, so the metadata is not retained
+/// forever, and it is swept the same way.
+#[tokio::test]
+async fn part_less_rewrite_record_expires_on_its_created_ts() {
+    let config = cfg();
+    let (window, now) = window_and_now(&config);
+    let b = bucket();
+
+    // Inside the window: the record's creation instant is the threshold
+    // itself, which is not strictly older than it.
+    let store = MemoryStore::new();
+    let retention = retention_at_floor(&config);
+    let (record_key, part_keys) = seed_rewrite_record(&store, &b, now - window, &[]).await;
+    assert!(part_keys.is_empty(), "a part-less rewrite seeds no part");
+    let clock = FixedClock::new(now);
+    let outcome = retention_sweep_bucket(&store, &clock, &config, &retention, &NoLeases, &b)
+        .await
+        .expect("retention pass");
+    assert_eq!(outcome, RetentionOutcome::NotExpired);
+    assert_eq!(
+        key_set(&store).await,
+        BTreeSet::from([record_key.clone()]),
+        "the rewrite record is untouched"
+    );
+
+    // One nanosecond older: expired, then swept away entirely.
+    let store = MemoryStore::new();
+    let (record_key, _) = seed_rewrite_record(&store, &b, now - window - 1, &[]).await;
+    let outcome = retention_sweep_bucket(&store, &clock, &config, &retention, &NoLeases, &b)
+        .await
+        .expect("retention pass");
+    assert_eq!(outcome, RetentionOutcome::Tombstoned);
+    assert_eq!(
+        key_set(&store).await,
+        BTreeSet::from([record_key, tombstone_key_of(&b)]),
+        "the tombstone joins the rewrite record"
+    );
+
+    let after_horizon = FixedClock::new(now + config.protection_horizon_ns);
+    let outcome =
+        retention_sweep_bucket(&store, &after_horizon, &config, &retention, &NoLeases, &b)
+            .await
+            .expect("sweep pass");
+    assert_eq!(outcome, RetentionOutcome::Swept);
+    assert_eq!(key_set(&store).await, BTreeSet::new());
 }

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -377,6 +377,22 @@ and the CAS read/write helpers.
   unclassified `rw.` key would have had its supersession of the erased inputs
   ignored by the index fold, letting erased records reappear in a folded
   snapshot.
+- Age-based retention (ADR-0019) reads and deletes all three record shapes.
+  ADR-0019 decision 1 names only L0 commit records and compaction records as
+  the inputs to a bucket's expiry maximum, and decision 4 names only those two
+  in the physical sweep's delete list, because selective erasure (ADR-0064)
+  postdates it. Both include rewrite records: a bucket's expiry maximum is
+  `max(max_event_ts_ns)` over L0 commit records, compaction-record parts, and
+  rewrite-record parts, and the sweep deletes the rewrite record with the other
+  records, before the data objects and parts and before the tombstone last. A
+  rewrite record with no parts (an erasure that dropped every record in the
+  bucket) carries no event timestamp and contributes its own `created_unix_ns`
+  to that maximum instead. Rewrite-record-only is the durable steady state of
+  an erased bucket -- the superseded-input sweep removes the rewrite's inputs
+  once their protection horizon elapses, and compaction refuses a bucket
+  holding a live rewrite record -- so a retention pass blind to that shape
+  retains erased-and-rewritten data past `R` with no path to deletion, and a
+  sweep blind to it can never see the bucket empty.
 - Format-version gate on read (ADR-0066 decision 2). A compaction record and a
   retention tombstone each carry a `format_version` (= 1), and every production
   reader decodes them through `ravel_commit::record::decode_compaction` and


### PR DESCRIPTION
Retention computed a bucket's expiry from L0 commit records and compaction
parts only, so a bucket whose sole remaining record is a rewrite record
yielded no maximum event timestamp, was never judged expired, and was retained
past the tenant's window indefinitely. The second half was worse: had it been
tombstoned, the physical sweep deleted every other object class and never the
rewrite record, so the emptiness check that follows could never succeed and the
outcome stayed partial forever. Rewrite-record-only is the normal durable
steady state for an erased bucket once the protection-horizon sweep has removed
its superseded inputs.

max_event_ts now spans commit records, compaction parts and rewrite parts, and
a parts-less rewrite record contributes its own creation timestamp rather than
nothing. Rewrite records are read through the version-gated decoder and their
keys verified before any field is trusted. The physical sweep deletes them
between the compaction records and the L0 data, leaving the ordering
guarantees intact: nothing before the horizon, the tombstone last.

The sweep behind this covers every enumeration of bucket record kinds in the
crate. Retention was the only listing consumer that omitted this one, and the
emptiness predicate was already generic because it enumerates by exclusion,
which is exactly why the bug presented as a permanent partial sweep rather than
a wrong answer.

Fixes: #1321
Refs: #1289, #1313
