### PR TITLE
feat(guards): add a disk watchdog scoped to one worktree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,12 @@ jobs:
       # without anything noticing.
       - name: pr-review-status.sh cases
         run: bash scripts/pr-review-status.test.sh
+      # Requires lsof, which is what reads a process cwd and is the entire
+      # scoping property; the guard refuses to run without it. If this step
+      # fails on the runner for that reason, that is worth knowing, because
+      # CLAUDE.md tells sessions to arm the guard and it would be inert.
+      - name: Disk-watchdog guard cases
+        run: bash scripts/guards/disk-watchdog.test.sh
       - name: Python script unit tests
         run: make test-python
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ graft/
 
 # Local, per-checkout state for .claude/guards/epic-status-nudge.mjs.
 .claude/.epic-status-nudge-state.json
+
+# The disk watchdog drops this in the scope directory when it fires; the
+# harness commit-on-death sweeps an unignored file into a wip commit.
+.disk-watchdog-fired

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,10 +351,26 @@ there before changing a rule.
   build. A session that read 82 GB free, started a cold gate, and took
   the volume to 886 MiB still passed this guard: another session was
   building at the same time. For anything longer than a few minutes,
-  also arm a watchdog that samples free space every 45 s or so and kills
-  its OWN `cargo`/`rustc` below a floor of about 8 GB. Killing your build
-  costs a retry; letting the volume reach zero stops every Bash command
-  in every session on the host, including the ones that would clean up.
+  also arm `scripts/guards/disk-watchdog.sh <your-worktree>` alongside it.
+  Killing your build costs a retry; letting the volume reach zero stops
+  every Bash command in every session on the host, including the ones
+  that would clean up.
+- `scripts/guards/disk-watchdog.sh <scope-dir> [floor_gb] [warn_gb]
+  [sample_s]`: samples free space and kills the `cargo`/`rustc`
+  processes whose cwd is inside `scope-dir` once it drops below the floor
+  (default 9 GB, warning at 15). The scope is REQUIRED and it is what
+  makes the thing safe here: a watchdog that matches by command name
+  kills every session's build on this box and reports it as killing
+  yours. Two sessions wrote that version independently within one hour on
+  2026-09-09 and one killed the other's compile with it, which is why
+  this exists as a script rather than as the paragraph above.
+  `WATCHDOG_DRY_RUN=1` names the pids and kills nothing; use it rather
+  than testing the kill path against live processes. On firing it writes
+  `<scope-dir>/.disk-watchdog-fired` BEFORE killing anything: a gate whose
+  run overlaps that marker is INVALID rather than red, because a runner
+  reports a SIGTERM'd test as a failure and the next reader cannot tell
+  the two apart. It never touches the gate's own exit code. Cases in
+  `scripts/guards/disk-watchdog.test.sh`.
 - This host is itself a fleet executor. `~/.fleet/executor` holds the
   cargo target of whatever task it has claimed from the queue, which no
   session here chose and which grows without warning; it has been observed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,20 +356,32 @@ there before changing a rule.
   every Bash command in every session on the host, including the ones
   that would clean up.
 - `scripts/guards/disk-watchdog.sh <scope-dir> [floor_gb] [warn_gb]
-  [sample_s]`: samples free space and kills the `cargo`/`rustc`
-  processes whose cwd is inside `scope-dir` once it drops below the floor
+  [sample_s]`: samples free space and kills the build processes whose cwd
+  is inside `scope-dir` once it drops below the floor
   (default 9 GB, warning at 15). The scope is REQUIRED and it is what
   makes the thing safe here: a watchdog that matches by command name
   kills every session's build on this box and reports it as killing
   yours. Two sessions wrote that version independently within one hour on
   2026-09-09 and one killed the other's compile with it, which is why
   this exists as a script rather than as the paragraph above.
+  The matched set is `cargo` and `rustc` plus the linker children they
+  spawn (`cc`, `ld`, `collect2`, `rust-lld`, `clang`, `clang++`): SIGKILL
+  to rustc leaves its linker running, and linking is the phase writing
+  the largest artifacts, so a matcher of the first two reports success
+  while the volume keeps draining. After the kill it re-scans and kills
+  again until the scoped set is empty, since a child can outlive the
+  parent that was matched, and gives up with exit 1 after five rounds
+  rather than claiming a volume it did not free.
   `WATCHDOG_DRY_RUN=1` names the pids and kills nothing; use it rather
   than testing the kill path against live processes. On firing it writes
   `<scope-dir>/.disk-watchdog-fired` BEFORE killing anything: a gate whose
   run overlaps that marker is INVALID rather than red, because a runner
   reports a SIGTERM'd test as a failure and the next reader cannot tell
-  the two apart. It never touches the gate's own exit code. Cases in
+  the two apart. Arming clears a marker from an earlier run so its
+  presence always refers to the current one; a dry run arms nothing and
+  leaves it alone, because the reason to run one is usually a gate that
+  just came back red and the marker is the answer. It never touches the
+  gate's own exit code. Cases in
   `scripts/guards/disk-watchdog.test.sh`.
 - This host is itself a fleet executor. `~/.fleet/executor` holds the
   cargo target of whatever task it has claimed from the queue, which no

--- a/scripts/guards/disk-watchdog.sh
+++ b/scripts/guards/disk-watchdog.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+# disk-watchdog.sh <scope-dir> [floor_gb] [warn_gb] [sample_seconds]
+#
+# Samples free space on the data volume and kills the cargo/rustc processes
+# running under <scope-dir> when it falls below the floor. Killing one build
+# costs a retry; letting the volume reach zero stops every Bash command in
+# every session on this host, including the ones that would clean up
+# (docs/guides/operations.md's disk section, and issue #1526's executor
+# variant of the same failure).
+#
+# <scope-dir> is REQUIRED, and is the only thing that makes this safe on a
+# machine several sessions share. A process is killed only when its own cwd,
+# read from `lsof -a -d cwd`, lies inside that directory. Matching by command
+# name instead kills every session's build and reports it as killing yours:
+# two sessions independently wrote that version of this watchdog within an
+# hour on 2026-09-09, and one of them killed the other's compile with it. On
+# a shared box a cleanup action needs the same scoping care as any other
+# destructive one, because it is one.
+#
+# WATCHDOG_DRY_RUN=1 names the pids it would kill and kills nothing. Use it to
+# check the matcher: testing the kill path for real is how you learn it works
+# by losing a build to it.
+#
+# On firing it writes a marker at <scope-dir>/.disk-watchdog-fired. A gate
+# whose run overlaps that marker is INVALID, not red: nextest reports a
+# SIGTERM'd test as "1 failed", which the next reader cannot tell from a
+# genuine failure. The marker is written BEFORE the kills, because the moment
+# this fires is the moment a write is least likely to succeed, and a
+# zero-byte marker still says the watchdog was in play. Any marker from an
+# earlier firing is removed when this arms, so a stale one can never label a
+# later, valid gate as invalid.
+#
+# It does not touch the gate's exit code. That belongs to the tool that
+# produced it, and a wrapper that edits it is the same "nothing ran, reported
+# as a result" failure wearing different clothes.
+set -u
+
+SCOPE_ARG=${1:?usage: disk-watchdog.sh <scope-dir> [floor_gb] [warn_gb] [sample_s]}
+# Resolve the scope to a physical path. `lsof` reports a process's cwd with
+# every symlink already resolved, so a caller-supplied `/tmp/...` or
+# `/var/...` would never prefix-match its `/private/tmp/...` answer on macOS,
+# and the watchdog would silently match nothing and kill nothing. Session
+# scratchpads live under exactly those paths, so this is the common case, not
+# a corner.
+SCOPE=$(cd "${SCOPE_ARG}" 2>/dev/null && pwd -P) || SCOPE=""
+if [ -z "${SCOPE}" ]; then
+  echo "watchdog: scope directory does not exist: ${SCOPE_ARG}" >&2
+  exit 2
+fi
+floor_gb=${2:-9}
+warn_gb=${3:-15}
+sample=${4:-45}
+marker="${SCOPE}/.disk-watchdog-fired"
+warned=0
+
+# Arm: clear any marker from a previous firing, so its presence always refers
+# to this run.
+rm -f "${marker}" 2>/dev/null || true
+
+free_gb() {
+    # BSD df -g reports whole gibibytes; field 4 is available.
+    df -g /System/Volumes/Data | awk 'NR==2 {print $4}'
+}
+
+# The cargo/rustc processes whose cwd is inside SCOPE. Two stages on purpose:
+# `ps comm` is the full toolchain path on macOS, so the basename decides what
+# is a build, and lsof decides whose it is.
+scoped_pids() {
+    for pid in $(ps -eo pid,comm= | awk '{ n = split($2, p, "/"); if (p[n] == "cargo" || p[n] == "rustc") print $1 }'); do
+        cwd=$(lsof -a -d cwd -p "${pid}" -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
+        case "${cwd}" in
+            "${SCOPE}"*) printf '%s ' "${pid}" ;;
+        esac
+    done
+}
+
+while :; do
+    avail=$(free_gb)
+    case "${avail}" in
+        ''|*[!0-9]*)
+            echo "watchdog: could not read free space, sample skipped" >&2
+            sleep "${sample}"
+            continue
+            ;;
+    esac
+
+    if [ "${avail}" -lt "${floor_gb}" ]; then
+        pids=$(scoped_pids | sed 's/ *$//')
+        if [ -z "${pids}" ]; then
+            echo "watchdog: ${avail} GB left, below the floor, but no cargo/rustc under ${SCOPE} is running"
+            exit 0
+        fi
+        if [ "${WATCHDOG_DRY_RUN:-0}" = "1" ]; then
+            echo "watchdog: DRY RUN, ${avail} GB left, would kill: ${pids}"
+            exit 0
+        fi
+        # Marker first: see the header.
+        {
+            echo "fired_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "free_gb=${avail}"
+            echo "floor_gb=${floor_gb}"
+            echo "killed_pids=${pids}"
+            echo "note=any gate run overlapping this window is INVALID, not red;"
+            echo "note=a SIGTERM'd test is reported as a failure by the runner."
+        } > "${marker}" 2>/dev/null || true
+        echo "watchdog: ${avail} GB left, below the ${floor_gb} GB floor; killing cargo/rustc under ${SCOPE}: ${pids}"
+        # shellcheck disable=SC2086
+        kill -TERM ${pids} 2>/dev/null || true
+        sleep 5
+        # shellcheck disable=SC2086
+        kill -KILL ${pids} 2>/dev/null || true
+        echo "watchdog: killed; marker at ${marker}; free space now $(free_gb) GB."
+        exit 0
+    fi
+
+    if [ "${avail}" -lt "${warn_gb}" ] && [ "${warned}" -eq 0 ]; then
+        echo "watchdog: ${avail} GB left, under the ${warn_gb} GB warning line, floor is ${floor_gb}"
+        warned=1
+    fi
+
+    sleep "${sample}"
+done

--- a/scripts/guards/disk-watchdog.sh
+++ b/scripts/guards/disk-watchdog.sh
@@ -55,8 +55,14 @@ warned=0
 starved=0
 
 # Arm: clear any marker from a previous firing, so its presence always refers
-# to this run.
-rm -f "${marker}" 2>/dev/null || true
+# to this run. A dry run arms nothing and must not clear it. The marker is the
+# only record that a gate's result is invalid rather than red, and the dry run
+# is what a session is told to reach for instead of testing the kill path,
+# including while working out why a gate just came back red: the check for
+# whether the watchdog fired would have destroyed the answer.
+if [ "${WATCHDOG_DRY_RUN:-0}" != "1" ]; then
+    rm -f "${marker}" 2>/dev/null || true
+fi
 
 free_gb() {
     # The volume backing the SCOPE, not a hardcoded one: what fills is the

--- a/scripts/guards/disk-watchdog.sh
+++ b/scripts/guards/disk-watchdog.sh
@@ -69,11 +69,16 @@ free_gb() {
     df -Pk "${SCOPE}" 2>/dev/null | awk 'NR==2 {print int($4/1048576)}'
 }
 
-# The cargo/rustc processes whose cwd is inside SCOPE. Two stages on purpose:
-# `ps comm` is the full toolchain path on macOS, so the basename decides what
-# is a build, and lsof decides whose it is.
+# The build processes whose cwd is inside SCOPE. Two stages on purpose: `ps
+# comm` is the full toolchain path on macOS, so the basename decides what is a
+# build, and lsof decides whose it is.
+#
+# The linker children are in the set deliberately. SIGKILL to rustc does not
+# kill the cc/ld/collect2/rust-lld it spawned, and the link is the phase that
+# writes the largest artifacts, so a matcher of cargo and rustc alone reports
+# success while the volume keeps draining.
 scoped_pids() {
-    for pid in $(ps -eo pid,comm= | awk '{ n = split($2, p, "/"); if (p[n] == "cargo" || p[n] == "rustc") print $1 }'); do
+    for pid in $(ps -eo pid,comm= | awk '{ n = split($2, p, "/"); if (p[n] == "cargo" || p[n] == "rustc" || p[n] == "cc" || p[n] == "ld" || p[n] == "collect2" || p[n] == "rust-lld" || p[n] == "clang" || p[n] == "clang++") print $1 }'); do
         cwd=$(lsof -a -d cwd -p "${pid}" -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
         # The scope root itself, or a path UNDER it. A bare "${SCOPE}"*
         # prefix also matches a sibling whose name merely starts with the
@@ -97,20 +102,23 @@ while :; do
             ;;
     esac
 
+    if [ "${WATCHDOG_DRY_RUN:-0}" = "1" ]; then
+        # Before the floor comparison on purpose. This is the check CLAUDE.md
+        # tells every session to run instead of testing the kill path against
+        # live processes, and it is run on a healthy volume, which is exactly
+        # when the floor branch is not taken. Inside it, the dry run produced
+        # no output and never returned.
+        dry_pids=$(scoped_pids | sed 's/ *$//')
+        if [ -n "${dry_pids}" ]; then
+            echo "watchdog: DRY RUN, ${avail} GB left (floor ${floor_gb}), would kill: ${dry_pids}"
+        else
+            echo "watchdog: DRY RUN, ${avail} GB left (floor ${floor_gb}), no build under ${SCOPE}"
+        fi
+        exit 0
+    fi
+
     if [ "${avail}" -lt "${floor_gb}" ]; then
         pids=$(scoped_pids | sed 's/ *$//')
-        if [ "${WATCHDOG_DRY_RUN:-0}" = "1" ]; then
-            # A dry run is a diagnostic: it answers "what would you kill right
-            # now" and returns. It must terminate whether or not anything
-            # matched, or the very invocation meant for checking the matcher
-            # hangs on the answer "nothing", which is the answer being checked.
-            if [ -n "${pids}" ]; then
-                echo "watchdog: DRY RUN, ${avail} GB left, would kill: ${pids}"
-            else
-                echo "watchdog: DRY RUN, ${avail} GB left, no cargo/rustc under ${SCOPE}"
-            fi
-            exit 0
-        fi
         if [ -z "${pids}" ]; then
             # Nothing of ours to kill YET. Do not exit: the common way to
             # arm this is alongside a gate that has not spawned cargo yet,
@@ -142,6 +150,26 @@ while :; do
         sleep 5
         # shellcheck disable=SC2086
         kill -KILL ${pids} 2>/dev/null || true
+        # Confirm rather than assume. A process can be spawned between the
+        # scan and the kill, and a child can outlive the parent that was
+        # matched, so re-scan and kill again until the scoped set is empty.
+        # Reporting a free-space figure straight after the first SIGKILL reads
+        # it while an in-flight link is still writing.
+        round=0
+        while [ "${round}" -lt 5 ]; do
+            sleep 2
+            remaining=$(scoped_pids | sed 's/ *$//')
+            [ -z "${remaining}" ] && break
+            echo "watchdog: still running under ${SCOPE} after the kill: ${remaining}"
+            # shellcheck disable=SC2086
+            kill -KILL ${remaining} 2>/dev/null || true
+            round=$((round + 1))
+        done
+        if [ -n "${remaining:-}" ]; then
+            echo "watchdog: gave up with these still running under ${SCOPE}: ${remaining}" >&2
+            echo "watchdog: free space now $(free_gb) GB."
+            exit 1
+        fi
         echo "watchdog: killed; marker at ${marker}; free space now $(free_gb) GB."
         exit 0
     fi

--- a/scripts/guards/disk-watchdog.sh
+++ b/scripts/guards/disk-watchdog.sh
@@ -47,6 +47,29 @@ if [ -z "${SCOPE}" ]; then
   echo "watchdog: scope directory does not exist: ${SCOPE_ARG}" >&2
   exit 2
 fi
+# Scoping every kill by cwd is the whole safety property, and lsof is what
+# reads the cwd. Without it every candidate is skipped, so the watchdog runs
+# forever, matches nothing, and never fires while the volume drains: the same
+# silent no-fire this file rejects for `df -g` a few lines down. Refuse
+# instead.
+if ! command -v lsof >/dev/null 2>&1; then
+    echo "watchdog: lsof is required to scope kills by cwd, and is not installed" >&2
+    exit 2
+fi
+
+# An unrecognised spelling must not silently mean "not a dry run". `=true`
+# took the arming path, DELETED the marker a session had come to read, then
+# looped above the floor printing nothing: one character from the documented
+# spelling, landing on the exact property the dry run exists to protect.
+case "${WATCHDOG_DRY_RUN:-0}" in
+    ''|0|false|no|FALSE|NO) dry_run=0 ;;
+    1|true|yes|TRUE|YES) dry_run=1 ;;
+    *)
+        echo "watchdog: unrecognised WATCHDOG_DRY_RUN='${WATCHDOG_DRY_RUN}'; use 1 or 0" >&2
+        exit 2
+        ;;
+esac
+
 floor_gb=${2:-9}
 warn_gb=${3:-15}
 sample=${4:-45}
@@ -60,7 +83,7 @@ starved=0
 # is what a session is told to reach for instead of testing the kill path,
 # including while working out why a gate just came back red: the check for
 # whether the watchdog fired would have destroyed the answer.
-if [ "${WATCHDOG_DRY_RUN:-0}" != "1" ]; then
+if [ "${dry_run}" -eq 0 ]; then
     rm -f "${marker}" 2>/dev/null || true
 fi
 
@@ -108,7 +131,7 @@ while :; do
             ;;
     esac
 
-    if [ "${WATCHDOG_DRY_RUN:-0}" = "1" ]; then
+    if [ "${dry_run}" -eq 1 ]; then
         # Before the floor comparison on purpose. This is the check CLAUDE.md
         # tells every session to run instead of testing the kill path against
         # live processes, and it is run on a healthy volume, which is exactly
@@ -171,6 +194,15 @@ while :; do
             kill -KILL ${remaining} 2>/dev/null || true
             round=$((round + 1))
         done
+        # The loop kills on its last iteration and then exits without looking
+        # again, so `remaining` still holds the pre-kill snapshot: a kill that
+        # worked was reported as "gave up". One more scan. This can only ever
+        # have produced a false alarm, never a false success, but a guard that
+        # cries wolf on its own success stops being read.
+        if [ -n "${remaining:-}" ]; then
+            sleep 2
+            remaining=$(scoped_pids | sed 's/ *$//')
+        fi
         if [ -n "${remaining:-}" ]; then
             echo "watchdog: gave up with these still running under ${SCOPE}: ${remaining}" >&2
             echo "watchdog: free space now $(free_gb) GB."

--- a/scripts/guards/disk-watchdog.sh
+++ b/scripts/guards/disk-watchdog.sh
@@ -61,11 +61,26 @@ fi
 # took the arming path, DELETED the marker a session had come to read, then
 # looped above the floor printing nothing: one character from the documented
 # spelling, landing on the exact property the dry run exists to protect.
-case "${WATCHDOG_DRY_RUN:-0}" in
-    ''|0|false|no|FALSE|NO) dry_run=0 ;;
+#
+# `${VAR-0}` without the colon, so a variable that is SET AND EMPTY reaches
+# the case as the empty string instead of being substituted to `0`. With the
+# colon the empty arm below was unreachable and an empty value armed for
+# real, deleting the marker. Empty is refused rather than treated as off,
+# because here "off" is the DESTRUCTIVE branch: it clears the marker and
+# kills. The usual "empty means off" idiom is safe only when off is the
+# passive choice, and the realistic way to produce an empty value is a
+# wrapper forwarding `"${DRY:-}"`, which is the same near-miss shape as
+# `=true`.
+case "${WATCHDOG_DRY_RUN-0}" in
+    0|false|no|FALSE|NO) dry_run=0 ;;
     1|true|yes|TRUE|YES) dry_run=1 ;;
+    '')
+        echo "watchdog: WATCHDOG_DRY_RUN is set but empty; use 1 or 0" >&2
+        exit 2
+        ;;
     *)
-        echo "watchdog: unrecognised WATCHDOG_DRY_RUN='${WATCHDOG_DRY_RUN}'; use 1 or 0" >&2
+        printf 'watchdog: unrecognised WATCHDOG_DRY_RUN=%s; use 1 or 0\n' \
+            "${WATCHDOG_DRY_RUN}" >&2
         exit 2
         ;;
 esac
@@ -196,9 +211,21 @@ while :; do
         done
         # The loop kills on its last iteration and then exits without looking
         # again, so `remaining` still holds the pre-kill snapshot: a kill that
-        # worked was reported as "gave up". One more scan. This can only ever
-        # have produced a false alarm, never a false success, but a guard that
-        # cries wolf on its own success stops being read.
+        # worked was reported as "gave up".
+        #
+        # A full re-scan, not `kill -0` on the pids just signalled. `kill -0`
+        # was tried and is wrong here: it answers "did THOSE pids die", and
+        # the thing this loop exists to catch is a build that keeps putting
+        # new processes into the scope, where the old pids are indeed gone
+        # and the volume is still draining. It turned three give-up cases
+        # green by reporting success against a live respawning fixture.
+        #
+        # The cost of re-scanning is one more chance for a spurious empty
+        # answer to override five correct observations of survivors. That is
+        # the dangerous direction, and it is accepted deliberately: missing a
+        # respawn means the watchdog reports success while the volume fills,
+        # which is the failure it exists to prevent, and a spurious empty
+        # needs lsof to fail exactly once at exactly that moment.
         if [ -n "${remaining:-}" ]; then
             sleep 2
             remaining=$(scoped_pids | sed 's/ *$//')

--- a/scripts/guards/disk-watchdog.sh
+++ b/scripts/guards/disk-watchdog.sh
@@ -52,14 +52,21 @@ warn_gb=${3:-15}
 sample=${4:-45}
 marker="${SCOPE}/.disk-watchdog-fired"
 warned=0
+starved=0
 
 # Arm: clear any marker from a previous firing, so its presence always refers
 # to this run.
 rm -f "${marker}" 2>/dev/null || true
 
 free_gb() {
-    # BSD df -g reports whole gibibytes; field 4 is available.
-    df -g /System/Volumes/Data | awk 'NR==2 {print $4}'
+    # The volume backing the SCOPE, not a hardcoded one: what fills is the
+    # target dir, and CARGO_TARGET_DIR need not sit on the same mount as the
+    # system volume. `df -Pk` is POSIX and gives KiB, matching
+    # check-disk-headroom.sh; `df -g` is a BSD spelling that errors on Linux,
+    # where every sample would then read empty and the watchdog would loop
+    # forever looking armed. Integer division floors, so the effective floor
+    # is never higher than the documented one.
+    df -Pk "${SCOPE}" 2>/dev/null | awk 'NR==2 {print int($4/1048576)}'
 }
 
 # The cargo/rustc processes whose cwd is inside SCOPE. Two stages on purpose:
@@ -68,8 +75,14 @@ free_gb() {
 scoped_pids() {
     for pid in $(ps -eo pid,comm= | awk '{ n = split($2, p, "/"); if (p[n] == "cargo" || p[n] == "rustc") print $1 }'); do
         cwd=$(lsof -a -d cwd -p "${pid}" -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
+        # The scope root itself, or a path UNDER it. A bare "${SCOPE}"*
+        # prefix also matches a sibling whose name merely starts with the
+        # same string, so a scope of .../wt matches a build in .../wt2 and
+        # kills another session's work: the exact thing this script exists
+        # to prevent. Subdirectories must still match, since a build's cwd
+        # is normally a crate directory rather than the worktree root.
         case "${cwd}" in
-            "${SCOPE}"*) printf '%s ' "${pid}" ;;
+            "${SCOPE}"|"${SCOPE}"/*) printf '%s ' "${pid}" ;;
         esac
     done
 }
@@ -86,14 +99,34 @@ while :; do
 
     if [ "${avail}" -lt "${floor_gb}" ]; then
         pids=$(scoped_pids | sed 's/ *$//')
-        if [ -z "${pids}" ]; then
-            echo "watchdog: ${avail} GB left, below the floor, but no cargo/rustc under ${SCOPE} is running"
-            exit 0
-        fi
         if [ "${WATCHDOG_DRY_RUN:-0}" = "1" ]; then
-            echo "watchdog: DRY RUN, ${avail} GB left, would kill: ${pids}"
+            # A dry run is a diagnostic: it answers "what would you kill right
+            # now" and returns. It must terminate whether or not anything
+            # matched, or the very invocation meant for checking the matcher
+            # hangs on the answer "nothing", which is the answer being checked.
+            if [ -n "${pids}" ]; then
+                echo "watchdog: DRY RUN, ${avail} GB left, would kill: ${pids}"
+            else
+                echo "watchdog: DRY RUN, ${avail} GB left, no cargo/rustc under ${SCOPE}"
+            fi
             exit 0
         fi
+        if [ -z "${pids}" ]; then
+            # Nothing of ours to kill YET. Do not exit: the common way to
+            # arm this is alongside a gate that has not spawned cargo yet,
+            # or during a gap between two of gates.sh's sequential lanes,
+            # which is exactly when free space is lowest. Exiting here
+            # disarms the watchdog at the moment it is most needed, and with
+            # the same status a successful firing returns, so no caller can
+            # tell the two apart. Say it once, then keep sampling.
+            if [ "${starved}" -eq 0 ]; then
+                echo "watchdog: ${avail} GB left, below the ${floor_gb} GB floor, but no cargo/rustc under ${SCOPE} yet; still watching"
+                starved=1
+            fi
+            sleep "${sample}"
+            continue
+        fi
+        starved=0
         # Marker first: see the header.
         {
             echo "fired_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/scripts/guards/disk-watchdog.test.sh
+++ b/scripts/guards/disk-watchdog.test.sh
@@ -385,12 +385,29 @@ check_eq "giving up does not print the success line" "absent" \
 # earlier case above only ever passed `1`, so it could not see this.
 SPELL="${TMP}/spelling"
 mkdir -p "${SPELL}"
-for word in true yes TRUE 1; do
+# Marker survival alone cannot tell ACCEPTED from REFUSED: a refused value
+# leaves the marker present too, so `bogus` would satisfy it. Assert the run
+# actually performed a dry run as well, or a future edit moving `true` into
+# the refuse arm keeps these green.
+for word in true yes TRUE; do
   echo "fired_at=1999-01-01T00:00:00Z" > "${SPELL}/.disk-watchdog-fired"
-  WATCHDOG_DRY_RUN="${word}" timeout 10 "${WATCHDOG}" "${SPELL}" 999999 1000000 1 >/dev/null 2>&1
+  out="$(WATCHDOG_DRY_RUN="${word}" timeout 10 "${WATCHDOG}" "${SPELL}" 999999 1000000 1 2>&1)"; rc=$?
+  check_eq "a dry run spelled '${word}' is accepted" "0" "${rc}"
+  check_contains "'${word}' really ran as a dry run" "DRY RUN" "${out}"
   check_eq "a dry run spelled '${word}' keeps the marker" "present" \
     "$([[ -e "${SPELL}/.disk-watchdog-fired" ]] && echo present || echo absent)"
 done
+
+# Set but EMPTY is refused, not treated as off. `${VAR:-0}` used to substitute
+# the default here, so the empty arm was unreachable and an empty value armed
+# for real and deleted the marker. Off is the destructive branch, so an
+# ambiguous value must not select it.
+echo "fired_at=1999-01-01T00:00:00Z" > "${SPELL}/.disk-watchdog-fired"
+out="$(WATCHDOG_DRY_RUN= timeout 10 "${WATCHDOG}" "${SPELL}" 999999 1000000 1 2>&1)"; rc=$?
+check_eq "an empty dry-run value is refused" "2" "${rc}"
+check_contains "it says the value was empty" "set but empty" "${out}"
+check_eq "an empty value touches no marker" "present" \
+  "$([[ -e "${SPELL}/.disk-watchdog-fired" ]] && echo present || echo absent)"
 # An unrecognised value is refused rather than silently meaning "not a dry
 # run", which is what let `=true` through as a real arming run.
 echo "fired_at=1999-01-01T00:00:00Z" > "${SPELL}/.disk-watchdog-fired"
@@ -413,8 +430,20 @@ rm -f "${SPELL}/.disk-watchdog-fired"
 # not one.
 NOLSOF="${TMP}/nolsof-bin"
 mkdir -p "${NOLSOF}"
-for tool in df awk ps sed head kill sleep printf date rm timeout; do
-  src="$(command -v "${tool}" 2>/dev/null)" || continue
+for tool in df awk ps sed head sleep date rm timeout; do
+  src="$(command -v "${tool}" 2>/dev/null)"
+  # An external binary that is missing means the fixture cannot pose the
+  # question. `|| continue` degraded silently: without GNU timeout the lsof
+  # case failed at 127 rather than 2, and nothing said the fixture was
+  # incomplete. `kill` and `printf` are deliberately absent from this list:
+  # they are shell builtins, so `command -v` returns the bare name and the
+  # symlink would dangle.
+  if [ -z "${src}" ] || [ ! -x "${src}" ]; then
+    printf 'FAIL  %-52s fixture needs %s and it is not on PATH\n' \
+      "no-lsof fixture" "${tool}"
+    fails=$((fails + 1))
+    continue
+  fi
   ln -sf "${src}" "${NOLSOF}/${tool}"
 done
 check_eq "fixture PATH really has no lsof" "absent" \

--- a/scripts/guards/disk-watchdog.test.sh
+++ b/scripts/guards/disk-watchdog.test.sh
@@ -77,9 +77,16 @@ check_contains "no scope argument: says what it wanted" "usage" "${out}"
 pid_a="$(start_fake_build)"
 sleep 1
 mkdir -p "${TMP}/no-builds-here"
-out="$(WATCHDOG_DRY_RUN=1 "${WATCHDOG}" "${TMP}/no-builds-here" 999999 1000000 1 2>&1)"
-check_contains "out of scope: reports no build under that path" "no cargo/rustc under" "${out}"
-check_eq "out of scope: the process is still alive" "alive" \
+# Backgrounded, because below the floor with nothing of ours running the
+# watchdog keeps sampling rather than exiting; see the no-disarm case below
+# for why. A foreground run here would hang the suite.
+"${WATCHDOG}" "${TMP}/no-builds-here" 999999 1000000 1 >"${TMP}/oos.out" 2>&1 &
+pid_oos=$!
+sleep 3
+kill -KILL "${pid_oos}" 2>/dev/null || true
+check_contains "out of scope: reports no build under that path" "no cargo/rustc under" \
+  "$(cat "${TMP}/oos.out" 2>/dev/null)"
+check_eq "out of scope: the build outside it is untouched" "alive" \
   "$(kill -0 "${pid_a}" 2>/dev/null && echo alive || echo dead)"
 
 # --- a scope that does not exist is refused -------------------------------
@@ -133,6 +140,60 @@ check_contains "marker: carries the free-space figure" "free_gb=" "${marker}"
 # The reason the marker exists at all: a runner reports a SIGTERM'd test as a
 # failure, and the next reader cannot tell that from a real one.
 check_contains "marker: says an overlapping gate is invalid, not red" "INVALID" "${marker}"
+
+# --- a sibling whose name starts with the scope is NOT in scope -----------
+#
+# The defect this pins, reproduced on the first version of this script: a
+# bare "${SCOPE}"* prefix match also matches a sibling directory whose name
+# merely begins with the same string, so a scope of .../wt named a build
+# running in .../wt2 for killing. That is another session's work, and it is
+# precisely what the scoping exists to prevent. Every other case here puts
+# its build at the scope root or under it, so none of them can see this.
+SIB="${TMP}/scope2"
+mkdir -p "${SIB}/bin"
+ln -s /bin/sh "${SIB}/bin/cargo"
+( cd "${SIB}" && exec "${SIB}/bin/cargo" -c 'while :; do sleep 1; done' ) \
+  >/dev/null 2>&1 &
+pid_sibling=$!
+sleep 1
+out="$(WATCHDOG_DRY_RUN=1 "${WATCHDOG}" "${SCOPE}" 999999 1000000 1 2>&1)"
+check_eq "a name-prefix sibling of the scope is not matched" "0" \
+  "$(printf '%s' "${out}" | grep -c "${pid_sibling}")"
+kill -KILL "${pid_sibling}" 2>/dev/null || true
+
+# --- a build in a SUBDIRECTORY of the scope IS in scope --------------------
+#
+# The obvious over-correction to the case above is an exact match, which
+# passes every other case here while silently narrowing the watchdog to
+# processes sitting at the worktree root. A real build's cwd is a crate
+# directory, so this is the normal case, not the exotic one.
+SUB="${SCOPE}/crates/ravel-sql"
+mkdir -p "${SUB}"
+( cd "${SUB}" && exec "${SCOPE}/bin/cargo" -c 'while :; do sleep 1; done' ) \
+  >/dev/null 2>&1 &
+pid_sub=$!
+sleep 1
+out="$(WATCHDOG_DRY_RUN=1 "${WATCHDOG}" "${SCOPE}" 999999 1000000 1 2>&1)"
+check_eq "a build in a subdirectory of the scope is matched" "1" \
+  "$(printf '%s' "${out}" | grep -c "${pid_sub}")"
+kill -KILL "${pid_sub}" 2>/dev/null || true
+
+# --- below the floor with no build yet: keep watching, do not disarm -------
+#
+# Arming happens alongside a gate that has not spawned cargo yet, and
+# gates.sh runs its lanes as separate processes, so a sample can legitimately
+# find nothing of ours while the volume is already low. Exiting there would
+# disarm the watchdog at the moment it is most needed, returning the same
+# status a successful firing returns.
+mkdir -p "${TMP}/empty-scope"
+"${WATCHDOG}" "${TMP}/empty-scope" 999999 1000000 1 >"${TMP}/starve.out" 2>&1 &
+pid_wd=$!
+sleep 3
+check_eq "below the floor with nothing of ours: still running" "alive" \
+  "$(kill -0 "${pid_wd}" 2>/dev/null && echo alive || echo dead)"
+check_contains "below the floor with nothing of ours: says it is still watching" \
+  "still watching" "$(cat "${TMP}/starve.out" 2>/dev/null)"
+kill -KILL "${pid_wd}" 2>/dev/null || true
 
 # --- a build outside the scope survives a real firing ---------------------
 #

--- a/scripts/guards/disk-watchdog.test.sh
+++ b/scripts/guards/disk-watchdog.test.sh
@@ -120,10 +120,29 @@ check_eq "dry run: writes no marker" "absent" \
 #
 # A marker left by an earlier firing would label a later, valid gate as
 # invalid. Ignored markers are worse than no markers, so arming truncates.
+# Armed for real, with a floor of 0 so it watches without ever firing: an
+# earlier version of this proved the clearing with a DRY RUN, which asserted
+# the behaviour the dry run must not have.
 echo "fired_at=1999-01-01T00:00:00Z" > "${SCOPE}/.disk-watchdog-fired"
-WATCHDOG_DRY_RUN=1 "${WATCHDOG}" "${SCOPE}" 999999 1000000 1 >/dev/null 2>&1
+"${WATCHDOG}" "${SCOPE}" 0 0 1 >/dev/null 2>&1 &
+arm_pid=$!
+sleep 1
 check_eq "arming clears a marker from an earlier firing" "absent" \
   "$([[ -e "${SCOPE}/.disk-watchdog-fired" ]] && echo present || echo absent)"
+kill "${arm_pid}" 2>/dev/null || true
+wait "${arm_pid}" 2>/dev/null || true
+
+# --- a DRY RUN preserves a marker it did not write ------------------------
+#
+# The dry run is the documented way to check the matcher, and the situation
+# that prompts it is a gate that has just come back red. Clearing the marker
+# there answers the question by destroying the evidence: the run that fired is
+# gone, and the gate reads as a genuine failure.
+echo "fired_at=1999-01-01T00:00:00Z" > "${SCOPE}/.disk-watchdog-fired"
+WATCHDOG_DRY_RUN=1 "${WATCHDOG}" "${SCOPE}" 999999 1000000 1 >/dev/null 2>&1
+check_eq "a dry run leaves an existing marker in place" "present" \
+  "$([[ -e "${SCOPE}/.disk-watchdog-fired" ]] && echo present || echo absent)"
+rm -f "${SCOPE}/.disk-watchdog-fired"
 
 # --- firing kills the scoped build and leaves the marker ------------------
 out="$("${WATCHDOG}" "${SCOPE}" 999999 1000000 1 2>&1)"
@@ -264,6 +283,67 @@ sleep 1
 check_eq "the marker exists while the build is still alive" "yes" \
   "$(head -1 "${ORD_SEEN}" 2>/dev/null)"
 kill -KILL "${pid_ord}" 2>/dev/null || true
+
+# --- the linker children are really in the match set -----------------------
+#
+# The matcher names cc, ld, collect2, rust-lld, clang and clang++ alongside
+# cargo and rustc, because SIGKILL to rustc leaves the linker it spawned
+# running and the link is the phase writing the largest artifacts. Every case
+# above builds its fixture as `cargo`, so deleting all six linker names from
+# the matcher left the whole suite green and the shipped watchdog reporting
+# success while the volume kept draining. One fixture per name.
+LINKERS="${TMP}/linkers"
+mkdir -p "${LINKERS}/bin"
+for tool in cc ld collect2 rust-lld clang clang++; do
+  ln -s /bin/sh "${LINKERS}/bin/${tool}"
+  ( cd "${LINKERS}" && exec "${LINKERS}/bin/${tool}" -c 'while :; do sleep 1; done' ) \
+    >/dev/null 2>&1 &
+  eval "pid_${tool//[!a-z0-9]/_}=$!"
+done
+sleep 1
+link_out="$(WATCHDOG_DRY_RUN=1 timeout 10 "${WATCHDOG}" "${LINKERS}" 2>&1)"
+for tool in cc ld collect2 rust-lld clang clang++; do
+  eval "tool_pid=\${pid_${tool//[!a-z0-9]/_}}"
+  check_contains "a ${tool} under the scope is in the match set" "${tool_pid}" "${link_out}"
+  kill -KILL "${tool_pid}" 2>/dev/null || true
+done
+
+# --- the post-kill re-scan catches a child the kill left behind ------------
+#
+# A process can be spawned between the scan and the kill, and a linker child
+# outlives the rustc that was matched, so the watchdog re-scans and kills
+# again until the scoped set is empty. Nothing asserted that: deleting the
+# whole re-scan loop left every case green, because in all of them the single
+# fixture dies to the first SIGKILL. Here the victim spawns a cc child from
+# its TERM handler and then exits, so the child exists only AFTER the first
+# scan and only the re-scan can find it.
+RESCAN="${TMP}/rescan"
+mkdir -p "${RESCAN}/bin"
+ln -s /bin/sh "${RESCAN}/bin/cargo"
+ln -s /bin/sh "${RESCAN}/bin/cc"
+cat > "${RESCAN}/spawn-on-term.sh" <<'EOF'
+on_term() {
+  "${RESCAN_BIN}/cc" -c 'while :; do sleep 1; done' >/dev/null 2>&1 &
+  echo "$!" > "${RESCAN_CHILD}"
+  exit 0
+}
+trap on_term TERM
+while :; do sleep 1; done
+EOF
+RESCAN_CHILD="${RESCAN}/child.pid"
+: > "${RESCAN_CHILD}"
+( cd "${RESCAN}" && RESCAN_BIN="${RESCAN}/bin" RESCAN_CHILD="${RESCAN_CHILD}" \
+    exec "${RESCAN}/bin/cargo" "${RESCAN}/spawn-on-term.sh" ) >/dev/null 2>&1 &
+pid_rescan=$!
+sleep 1
+rescan_out="$(timeout 60 "${WATCHDOG}" "${RESCAN}" 999999 1000000 1 2>&1)"; rescan_rc=$?
+child_pid="$(cat "${RESCAN_CHILD}" 2>/dev/null)"
+check_contains "the re-scan reports the child left behind" "still running under" "${rescan_out}"
+check_contains "the re-scan names the child's pid" "${child_pid}" "${rescan_out}"
+check_eq "the orphaned linker child is dead" "dead" \
+  "$(kill -0 "${child_pid}" 2>/dev/null && echo alive || echo dead)"
+check_eq "the watchdog still succeeds once the set is empty" "0" "${rescan_rc}"
+kill -KILL "${pid_rescan}" "${child_pid}" 2>/dev/null || true
 
 printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
 [[ "${fails}" -eq 0 ]]

--- a/scripts/guards/disk-watchdog.test.sh
+++ b/scripts/guards/disk-watchdog.test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Cases for scripts/guards/disk-watchdog.sh.
+#
+# Every case that involves killing runs against a process this file started
+# itself, never against whatever happens to be building on the box: testing
+# the kill path for real against live processes is the mistake that produced
+# this script's scoping rules in the first place.
+#
+# Exit 0 all pass, 1 on a failure.
+set -uo pipefail
+
+WATCHDOG="$(cd "$(dirname "$0")" && pwd)/disk-watchdog.sh"
+[[ -x "${WATCHDOG}" ]] || { echo "missing or not executable: ${WATCHDOG}" >&2; exit 64; }
+
+passes=0
+fails=0
+
+check_eq() {
+  local name="$1" want="$2" got="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    printf 'ok    %s\n' "${name}"
+    passes=$((passes + 1))
+  else
+    printf 'FAIL  %s:\n  want: %s\n  got:  %s\n' "${name}" "${want}" "${got}"
+    fails=$((fails + 1))
+  fi
+}
+
+check_contains() {
+  local name="$1" needle="$2" hay="$3"
+  if [[ "${hay}" == *"${needle}"* ]]; then
+    printf 'ok    %s\n' "${name}"
+    passes=$((passes + 1))
+  else
+    printf 'FAIL  %s:\n  expected to contain: %s\n  got: %s\n' "${name}" "${needle}" "${hay}"
+    fails=$((fails + 1))
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# A stand-in for a build: a process named `cargo` whose cwd is inside the
+# scope directory. The name has to be the basename of an executable, since
+# the watchdog reads `ps comm`, and the cwd has to be real, since it reads
+# lsof. A SYMLINK to /bin/sh named cargo satisfies both: `ps comm` reports
+# the symlink's own path, so the basename is `cargo`. A COPY of /bin/sh does
+# not work on macOS, where the copy fails code-signing checks and dies
+# silently the moment it is executed.
+SCOPE="${TMP}/scope"
+mkdir -p "${SCOPE}/bin"
+ln -s /bin/sh "${SCOPE}/bin/cargo"
+# stdout and stderr are redirected, not inherited. A background process that
+# keeps the command substitution's pipe open makes `$(start_fake_build)` block
+# until that process exits, which turns every call into a hang rather than a
+# pid.
+start_fake_build() {
+  ( cd "${SCOPE}" && exec "${SCOPE}/bin/cargo" -c 'while :; do sleep 1; done' ) \
+    >/dev/null 2>&1 &
+  echo $!
+}
+
+# --- the scope argument is mandatory -------------------------------------
+#
+# A watchdog invoked with no scope must refuse rather than default to "every
+# build on this machine", which is the unscoped version this script exists to
+# replace.
+out="$("${WATCHDOG}" 2>&1)"; rc=$?
+check_eq "no scope argument: refuses" "1" "$((rc == 0 ? 0 : 1))"
+check_contains "no scope argument: says what it wanted" "usage" "${out}"
+
+# --- out of scope is left alone ------------------------------------------
+#
+# The floor is impossible, so the watchdog is firing; the scope names a
+# directory with no builds under it. It must report finding nothing rather
+# than fall back to matching by name.
+pid_a="$(start_fake_build)"
+sleep 1
+mkdir -p "${TMP}/no-builds-here"
+out="$(WATCHDOG_DRY_RUN=1 "${WATCHDOG}" "${TMP}/no-builds-here" 999999 1000000 1 2>&1)"
+check_contains "out of scope: reports no build under that path" "no cargo/rustc under" "${out}"
+check_eq "out of scope: the process is still alive" "alive" \
+  "$(kill -0 "${pid_a}" 2>/dev/null && echo alive || echo dead)"
+
+# --- a scope that does not exist is refused -------------------------------
+#
+# Not cosmetic. `lsof` reports a cwd with symlinks resolved, so a scope that
+# cannot be resolved to a physical path would prefix-match nothing and the
+# watchdog would sample forever, killing nothing, while looking armed.
+out="$("${WATCHDOG}" "${TMP}/never-created" 999999 1000000 1 2>&1)"; rc=$?
+check_eq "missing scope: refuses rather than matching nothing" "2" "${rc}"
+check_contains "missing scope: names the path it could not resolve" "does not exist" "${out}"
+
+# --- a scope given through a symlinked path still matches -----------------
+#
+# The defect this pins: on macOS /tmp and /var are symlinks, `mktemp -d`
+# hands back the symlinked form, and lsof answers with the physical one. A
+# watchdog comparing those two directly matches nothing, which is silent and
+# looks exactly like a healthy idle watchdog.
+sym_out="$(WATCHDOG_DRY_RUN=1 "${WATCHDOG}" "${SCOPE}" 999999 1000000 1 2>&1)"
+check_contains "symlinked scope path: still finds the build under it" "would kill" "${sym_out}"
+
+# --- dry run names the pid and kills nothing ------------------------------
+out="$(WATCHDOG_DRY_RUN=1 "${WATCHDOG}" "${SCOPE}" 999999 1000000 1 2>&1)"
+check_contains "dry run: names the scoped pid" "${pid_a}" "${out}"
+check_contains "dry run: says it is a dry run" "DRY RUN" "${out}"
+check_eq "dry run: the process is still alive" "alive" \
+  "$(kill -0 "${pid_a}" 2>/dev/null && echo alive || echo dead)"
+check_eq "dry run: writes no marker" "absent" \
+  "$([[ -e "${SCOPE}/.disk-watchdog-fired" ]] && echo present || echo absent)"
+
+# --- a stale marker is cleared when the watchdog arms ---------------------
+#
+# A marker left by an earlier firing would label a later, valid gate as
+# invalid. Ignored markers are worse than no markers, so arming truncates.
+echo "fired_at=1999-01-01T00:00:00Z" > "${SCOPE}/.disk-watchdog-fired"
+WATCHDOG_DRY_RUN=1 "${WATCHDOG}" "${SCOPE}" 999999 1000000 1 >/dev/null 2>&1
+check_eq "arming clears a marker from an earlier firing" "absent" \
+  "$([[ -e "${SCOPE}/.disk-watchdog-fired" ]] && echo present || echo absent)"
+
+# --- firing kills the scoped build and leaves the marker ------------------
+out="$("${WATCHDOG}" "${SCOPE}" 999999 1000000 1 2>&1)"
+sleep 1
+check_eq "firing: the scoped process is dead" "dead" \
+  "$(kill -0 "${pid_a}" 2>/dev/null && echo alive || echo dead)"
+check_eq "firing: writes the marker" "present" \
+  "$([[ -e "${SCOPE}/.disk-watchdog-fired" ]] && echo present || echo absent)"
+
+marker="$(cat "${SCOPE}/.disk-watchdog-fired" 2>/dev/null)"
+check_contains "marker: names the pid it killed" "${pid_a}" "${marker}"
+check_contains "marker: carries the firing time" "fired_at=" "${marker}"
+check_contains "marker: carries the free-space figure" "free_gb=" "${marker}"
+# The reason the marker exists at all: a runner reports a SIGTERM'd test as a
+# failure, and the next reader cannot tell that from a real one.
+check_contains "marker: says an overlapping gate is invalid, not red" "INVALID" "${marker}"
+
+# --- a build outside the scope survives a real firing ---------------------
+#
+# The case the scoping exists for: another session's build, running while
+# this watchdog fires on its own scope, must be untouched.
+OTHER="${TMP}/other-session"
+mkdir -p "${OTHER}/bin"
+ln -s /bin/sh "${OTHER}/bin/cargo"
+( cd "${OTHER}" && exec "${OTHER}/bin/cargo" -c 'while :; do sleep 1; done' ) \
+  >/dev/null 2>&1 &
+pid_other=$!
+pid_b="$(start_fake_build)"
+sleep 1
+"${WATCHDOG}" "${SCOPE}" 999999 1000000 1 >/dev/null 2>&1
+sleep 1
+check_eq "firing: kills the build inside the scope" "dead" \
+  "$(kill -0 "${pid_b}" 2>/dev/null && echo alive || echo dead)"
+check_eq "firing: leaves another session's build alone" "alive" \
+  "$(kill -0 "${pid_other}" 2>/dev/null && echo alive || echo dead)"
+kill -KILL "${pid_other}" 2>/dev/null || true
+
+printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
+[[ "${fails}" -eq 0 ]]

--- a/scripts/guards/disk-watchdog.test.sh
+++ b/scripts/guards/disk-watchdog.test.sh
@@ -345,5 +345,36 @@ check_eq "the orphaned linker child is dead" "dead" \
 check_eq "the watchdog still succeeds once the set is empty" "0" "${rescan_rc}"
 kill -KILL "${pid_rescan}" "${child_pid}" 2>/dev/null || true
 
+# --- giving up is reported, not reported as success ------------------------
+#
+# After five rounds the watchdog stops and exits 1 rather than claiming a
+# volume it did not free. CLAUDE.md states that; nothing reached it, so
+# deleting the give-up branch and letting the loop fall through to the success
+# message left every case green. A keeper OUTSIDE the scope respawns a `cc`
+# inside it whenever one dies, so the scoped set is never empty. The keeper is
+# named `sh`, which the matcher ignores, and it is bounded to 20 spawns so a
+# failing test cannot leave a respawn loop running on a shared box.
+GIVEUP="${TMP}/giveup"
+mkdir -p "${GIVEUP}/bin"
+ln -s /bin/sh "${GIVEUP}/bin/cc"
+cat > "${TMP}/keeper.sh" <<'EOF'
+n=0
+while [ "${n}" -lt 20 ]; do
+  ( cd "${KEEP_DIR}" && exec "${KEEP_DIR}/bin/cc" -c 'while :; do sleep 1; done' ) \
+    >/dev/null 2>&1
+  n=$((n + 1))
+done
+EOF
+KEEP_DIR="${GIVEUP}" sh "${TMP}/keeper.sh" >/dev/null 2>&1 &
+keeper_pid=$!
+sleep 1
+giveup_out="$(timeout 90 "${WATCHDOG}" "${GIVEUP}" 999999 1000000 1 2>&1)"; giveup_rc=$?
+kill -KILL "${keeper_pid}" 2>/dev/null || true
+pkill -KILL -f "${GIVEUP}/bin/cc" 2>/dev/null || true
+check_eq "giving up exits non-zero" "1" "${giveup_rc}"
+check_contains "giving up says what is still running" "gave up" "${giveup_out}"
+check_eq "giving up does not print the success line" "absent" \
+  "$([[ "${giveup_out}" == *"killed; marker at"* ]] && echo present || echo absent)"
+
 printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
 [[ "${fails}" -eq 0 ]]

--- a/scripts/guards/disk-watchdog.test.sh
+++ b/scripts/guards/disk-watchdog.test.sh
@@ -215,5 +215,55 @@ check_eq "firing: leaves another session's build alone" "alive" \
   "$(kill -0 "${pid_other}" 2>/dev/null && echo alive || echo dead)"
 kill -KILL "${pid_other}" 2>/dev/null || true
 
+# --- the dry run works ABOVE the floor, which is the only time it is used ---
+#
+# The dry run is the safe check CLAUDE.md tells sessions to use instead of
+# testing the kill path against live processes, so it is run on a healthy
+# volume. Shipped inside the floor branch it produced no output and never
+# returned, and no case saw it because every dry-run case above passes an
+# impossible floor. Default floor here, real free space.
+pid_dry="$(start_fake_build)"
+sleep 1
+dry_out=""
+if dry_out="$(WATCHDOG_DRY_RUN=1 timeout 10 "${WATCHDOG}" "${SCOPE}" 2>&1)"; then dry_rc=0; else dry_rc=$?; fi
+check_eq "dry run above the floor returns instead of looping" "0" "${dry_rc}"
+check_contains "dry run above the floor names the build it would kill" "${pid_dry}" "${dry_out}"
+check_eq "dry run above the floor kills nothing" "alive" \
+  "$(kill -0 "${pid_dry}" 2>/dev/null && echo alive || echo dead)"
+kill -KILL "${pid_dry}" 2>/dev/null || true
+
+# --- the free-space reader is real, not a constant ------------------------
+#
+# Nothing asserted on the parsed figure, so replacing free_gb's body with a
+# constant left every case green while turning the shipped watchdog into an
+# unconditional killer at the default floor. Pin the number against df.
+want_gb="$(df -Pk "${SCOPE}" | awk 'NR==2 {print int($4/1048576)}')"
+got_line="$(WATCHDOG_DRY_RUN=1 timeout 10 "${WATCHDOG}" "${SCOPE}" 2>&1)"
+check_contains "the reported free space matches df on the scope" "${want_gb} GB left" "${got_line}"
+
+# --- the marker is written BEFORE the kill --------------------------------
+#
+# Both the commit message and CLAUDE.md assert this ordering, and every other
+# case observes the marker only after the target is already dead, so moving
+# the marker below the SIGKILL left them all green. Here the victim ignores
+# SIGTERM, so it survives into the five-second window between the TERM and the
+# KILL, and records whether the marker exists while it is still alive. With
+# the marker written first it sees it; with the marker written after the kill
+# it is dead before the marker exists and never can.
+ORD="${TMP}/ordering"
+mkdir -p "${ORD}/bin"
+ln -s /bin/sh "${ORD}/bin/cargo"
+ORD_MARKER="${ORD}/.disk-watchdog-fired"
+ORD_SEEN="${ORD}/seen"
+: > "${ORD_SEEN}"
+( cd "${ORD}" && exec "${ORD}/bin/cargo" -c "trap '' TERM; while :; do if [ -e '${ORD_MARKER}' ]; then echo yes >> '${ORD_SEEN}'; fi; sleep 1; done" ) \
+  >/dev/null 2>&1 &
+pid_ord=$!
+sleep 1
+"${WATCHDOG}" "${ORD}" 999999 1000000 1 >/dev/null 2>&1
+check_eq "the marker exists while the build is still alive" "yes" \
+  "$(head -1 "${ORD_SEEN}" 2>/dev/null)"
+kill -KILL "${pid_ord}" 2>/dev/null || true
+
 printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
 [[ "${fails}" -eq 0 ]]

--- a/scripts/guards/disk-watchdog.test.sh
+++ b/scripts/guards/disk-watchdog.test.sh
@@ -376,5 +376,58 @@ check_contains "giving up says what is still running" "gave up" "${giveup_out}"
 check_eq "giving up does not print the success line" "absent" \
   "$([[ "${giveup_out}" == *"killed; marker at"* ]] && echo present || echo absent)"
 
+# --- the dry-run flag must not fail open on a near-miss spelling ----------
+#
+# `WATCHDOG_DRY_RUN=true` took the ARMING path, deleted the marker, and then
+# looped above the floor printing nothing. One character from the documented
+# spelling, and it lands on the one property the dry run exists to protect:
+# the record that a red gate was invalid rather than genuinely failing. The
+# earlier case above only ever passed `1`, so it could not see this.
+SPELL="${TMP}/spelling"
+mkdir -p "${SPELL}"
+for word in true yes TRUE 1; do
+  echo "fired_at=1999-01-01T00:00:00Z" > "${SPELL}/.disk-watchdog-fired"
+  WATCHDOG_DRY_RUN="${word}" timeout 10 "${WATCHDOG}" "${SPELL}" 999999 1000000 1 >/dev/null 2>&1
+  check_eq "a dry run spelled '${word}' keeps the marker" "present" \
+    "$([[ -e "${SPELL}/.disk-watchdog-fired" ]] && echo present || echo absent)"
+done
+# An unrecognised value is refused rather than silently meaning "not a dry
+# run", which is what let `=true` through as a real arming run.
+echo "fired_at=1999-01-01T00:00:00Z" > "${SPELL}/.disk-watchdog-fired"
+out="$(WATCHDOG_DRY_RUN=bogus timeout 10 "${WATCHDOG}" "${SPELL}" 999999 1000000 1 2>&1)"; rc=$?
+check_eq "an unrecognised dry-run value is refused" "2" "${rc}"
+check_contains "it names the value it could not use" "bogus" "${out}"
+check_eq "a refused value touches no marker" "present" \
+  "$([[ -e "${SPELL}/.disk-watchdog-fired" ]] && echo present || echo absent)"
+rm -f "${SPELL}/.disk-watchdog-fired"
+
+# --- without lsof the scoping cannot work, so refuse rather than no-op ----
+#
+# lsof is what reads a process's cwd, and the cwd is the entire safety
+# property. Absent, every candidate is skipped: the watchdog runs forever,
+# matches nothing and never fires while the volume drains. That is the same
+# silent no-fire the header rejects for `df -g`, one function later.
+# A PATH carrying everything the script needs EXCEPT lsof. Blanking PATH
+# entirely does not test this: `timeout` is then not found either and the
+# run dies at 127 before the script starts, which reads as a refusal and is
+# not one.
+NOLSOF="${TMP}/nolsof-bin"
+mkdir -p "${NOLSOF}"
+for tool in df awk ps sed head kill sleep printf date rm timeout; do
+  src="$(command -v "${tool}" 2>/dev/null)" || continue
+  ln -sf "${src}" "${NOLSOF}/${tool}"
+done
+check_eq "fixture PATH really has no lsof" "absent" \
+  "$(PATH="${NOLSOF}" command -v lsof >/dev/null 2>&1 && echo present || echo absent)"
+check_eq "fixture PATH really does have df" "present" \
+  "$(PATH="${NOLSOF}" command -v df >/dev/null 2>&1 && echo present || echo absent)"
+# Wrapped in `timeout` on purpose. Without the availability check the script
+# does not fail, it LOOPS FOREVER matching nothing, which is the defect. An
+# unwrapped call turns that mutant into a hung suite rather than a red one,
+# and a test that hangs instead of failing reports nothing to anybody.
+out="$(PATH="${NOLSOF}" timeout 10 "${WATCHDOG}" "${SPELL}" 999999 1000000 1 2>&1)"; rc=$?
+check_eq "no lsof on PATH is refused, not ignored" "2" "${rc}"
+check_contains "it says lsof is what is missing" "lsof" "${out}"
+
 printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
 [[ "${fails}" -eq 0 ]]


### PR DESCRIPTION
feat(guards): add a disk watchdog scoped to one worktree

CLAUDE.md tells sessions to arm a watchdog that kills "its OWN" cargo and rustc when the volume runs low, and does not say how to tell whose is whose. On 2026-09-09 two sessions on this box wrote that watchdog independently within an hour, both matched processes by command name, and one killed the other session's compile while reporting that it had killed its own. A rule that two people implement wrongly the same way inside an hour wants to be a script.

**Scoping.** The scope directory is required, and a process is killed only when its own cwd, read from `lsof -a -d cwd`, lies inside it. The command name decides what is a build; the cwd decides whose it is.

**Path resolution, which is the subtle half.** `lsof` reports a cwd with symlinks already resolved. On macOS `/tmp` and `/var` are symlinks, so a scope passed in either form prefix-matches nothing, and every session scratchpad on this host lives under exactly those paths. Without resolving the scope to a physical path first, the watchdog looks armed and kills nothing, silently. The first version had that bug and the cases caught it.

**The marker, and why it exists.** On firing it writes `<scope>/.disk-watchdog-fired` naming the time, the free-space figure and the pids, *before* killing anything, because the moment it fires is the moment a write is least likely to succeed and a zero-byte marker still says the watchdog was in play. A gate run overlapping that marker is INVALID, not red: a runner reports a SIGTERM'd test as "1 failed", indistinguishable to the next reader from a real failure. A peer hit exactly that and only discounted the result because they happened to know their own watchdog had just fired. The marker is cleared when the watchdog arms, so a stale one can never condemn a later valid run.

It deliberately does not touch the gate's exit code. That belongs to the tool that produced it, and a wrapper that rewrites it is the same "nothing ran, reported as a result" failure in different clothes.

**Cases.** Twenty, including both directions of the scoping: a build inside the scope dies, another session's build running beside it survives. Shown failing against the defects they exist for — reverting the path resolution fails twelve, matching by command name fails the two that matter. Every process the cases kill is one they started themselves; testing the kill path against whatever happens to be building is the mistake that produced these rules, and it cost me a compile.

`shellcheck` clean, docs gate clean.

Refs: #1199
