### PR TITLE
fix(mcp): pin a cursor by its resolve inputs, not by its segments

### DIFF
--- a/crates/ravel-mcp/Cargo.toml
+++ b/crates/ravel-mcp/Cargo.toml
@@ -18,7 +18,7 @@ ravel-query = { workspace = true }
 # the `ravel-mcp` member and the `rmcp` workspace dependency to the root
 # manifest, so this follows the same path-dependency convention
 # services/ravel-server and services/ravel-cli already use.
-ravel-sql = { path = "../ravel-sql", version = "0.15.0", features = ["pin-codec"] }
+ravel-sql = { path = "../ravel-sql", version = "0.15.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 schemars = { workspace = true }
@@ -27,9 +27,7 @@ blake3 = { workspace = true }
 base64 = { workspace = true }
 
 [dev-dependencies]
-# Only the cursor round-trip test names this: it builds a `SegmentPin` with
-# every field non-default, which means a non-nil `Uuid`. The pin's
-# `SegmentLevel` comes from `ravel_sql`, which re-exports it beside
-# `SegmentPin`, so no `ravel-catalog` dependency is needed here.
+# Only the cursor tests name this: a `CommitToken`'s `writer_id` is a `Uuid`,
+# and they build tokens with every field non-default.
 uuid = { workspace = true }
 proptest = { workspace = true }

--- a/crates/ravel-mcp/src/compact.rs
+++ b/crates/ravel-mcp/src/compact.rs
@@ -129,7 +129,8 @@ fn cell_display(cell: &Cell) -> String {
     match cell {
         Cell::Null => "null".to_string(),
         Cell::Bool(b) => b.to_string(),
-        Cell::Int(n) | Cell::Timestamp(n) => n.to_string(),
+        Cell::Int(n) => n.to_string(),
+        Cell::Timestamp(n) => n.to_string(),
         Cell::Float(f) if f.is_nan() => "NaN".to_string(),
         Cell::Float(f) if *f == f64::INFINITY => "+Inf".to_string(),
         Cell::Float(f) if *f == f64::NEG_INFINITY => "-Inf".to_string(),
@@ -310,7 +311,7 @@ mod tests {
             r#type: "int64".to_string(),
         }];
         envelope.data.rows = (0..row_count)
-            .map(|i| vec![Cell::Int(i as i64 + 1)])
+            .map(|i| vec![Cell::Int(i as i128 + 1)])
             .collect();
         envelope.data.row_count = row_count as u64;
         envelope

--- a/crates/ravel-mcp/src/cursor.rs
+++ b/crates/ravel-mcp/src/cursor.rs
@@ -24,6 +24,12 @@
 //! cursor did not pin and that reaches its signal and time range. Both live in
 //! [`Cursor::redeem`].
 //!
+//! Those two are what a redemption can detect. A third case exists that it
+//! cannot: an erasure that arrives after the mint and completes before the
+//! redemption is neither pinned nor in force. It stays empty only while a
+//! cursor's lifetime is shorter than an erasure's completion time, which
+//! [`Cursor::redeem`] states as an assumption with both quantities named.
+//!
 //! The watermark is one of those inputs and nothing more. It is what page 2
 //! resolves against, not a test run against whatever watermark the redeeming
 //! call happens to observe: ADR-0010 gives no ordering to run such a test
@@ -220,6 +226,12 @@ pub const MAX_TOKEN_BYTES: usize = 1024 * 1024;
 /// extend how long a token may name that segment. Subtracting it leaves
 /// `max_query_duration + clock_skew_allowance`, which is the part of the
 /// window a redemption starting now may still use.
+///
+/// This constant is also what bounds a cursor's lifetime, and through that
+/// what keeps [`Cursor::redeem`]'s erasure check sound. Raising a
+/// deployment's protection horizon without raising this value lengthens that
+/// lifetime; [`Cursor::redeem`] states the bound the lifetime must stay
+/// under.
 pub const GRACE_NS: i64 = 24 * 3_600 * 1_000_000_000;
 
 /// Typed failure for both [`Cursor`] and [`EvidenceRef`]. The two decode
@@ -572,6 +584,48 @@ impl Cursor {
     /// predicate outside that scope leaves it redeemable (see
     /// [`Cursor::newer_erasure_intersects`]).
     ///
+    /// That erasure check is sound only while the maximum cursor lifetime is
+    /// shorter than the minimum time an erasure takes to complete.
+    /// `erasure_in_force` carries the predicates still pending at redemption.
+    /// An erasure that arrived after the cursor was minted and whose rewrite
+    /// completed before it was redeemed is in neither set: the cursor did not
+    /// pin it and it is no longer in force, so nothing here can observe it,
+    /// and page two is served from a snapshot it changed. The two quantities
+    /// are configured in different crates and nothing asserts the
+    /// relationship between them:
+    ///
+    /// - Maximum cursor lifetime is `protection_horizon_ns` minus
+    ///   [`GRACE_NS`]. The horizon is the deployment's own
+    ///   (`CatalogConfig::protection_horizon_ns` in
+    ///   `crates/ravel-catalog/src/config.rs`, default
+    ///   `DEFAULT_PROTECTION_HORIZON_NS` = 25 h 05 m), set by an operator
+    ///   through `ravel-cli gc-config set --protection-horizon`, which writes
+    ///   durable `sys/gc`. [`GRACE_NS`] is a constant of this crate, 24 h,
+    ///   that no configuration moves. With the default horizon a cursor lives
+    ///   at most 1 h 05 m.
+    /// - Minimum erasure completion is the seal wait,
+    ///   `erasure_seal_wait_bound_ns` in
+    ///   `crates/ravel-maintain/src/erasure_rewrite.rs`: `max_ingest_lag`
+    ///   (2 h by `ravel_catalog::DEFAULT_MAX_INGEST_LAG_NS`, also operator-set)
+    ///   plus one 1 h bucket span plus the seal margin (`max_flush_lifetime`
+    ///   1 h + `clock_skew_allowance` 5 m), 4 h 05 m with defaults. A rewrite
+    ///   cannot acknowledge before the bucket open at the request seals.
+    ///
+    /// 1 h 05 m under 4 h 05 m is what closes the window today. The operator
+    /// action that opens it is raising `--protection-horizon`, because
+    /// [`GRACE_NS`] cannot be raised with it. `gc-config set` accepts any
+    /// horizon at or above `max_query_duration + grace +
+    /// clock_skew_allowance`, so a 30 h horizon is a valid deployment; it
+    /// leaves a 6 h cursor lifetime, above the 4 h 05 m floor, and an erasure
+    /// can then complete inside one cursor's life. Lowering `max_ingest_lag`
+    /// moves the same floor down.
+    ///
+    /// The relationship is not expressible as an assertion in this crate. The
+    /// crate never sees the horizon as a duration: `protection_horizon_ns`
+    /// arrives per call as an absolute instant, the crate has no startup step
+    /// of its own, and it holds no ravel-catalog or ravel-maintain dependency
+    /// to read either configured value from.
+    ///
     // Every parameter is a distinct precondition of a single redemption, and
     // a caller that omits one has skipped a check. Grouping them into a
     // struct would let a call site leave a field at its default.
@@ -627,6 +681,11 @@ impl Cursor {
     /// Predicates that were in force at mint and are not in force now are not
     /// a mismatch either: an erasure that completed took its rows out of the
     /// pinned snapshot before the page was built, and the pin already names it.
+    ///
+    /// An erasure that both arrived and completed between mint and redemption
+    /// is in neither set and is invisible here. What keeps that case empty is
+    /// a timing relationship this method cannot check; [`Cursor::redeem`]
+    /// states it and names both quantities.
     fn newer_erasure_intersects(&self, in_force: &[(Signal, ErasurePredicate)]) -> bool {
         in_force.iter().any(|(signal, predicate)| {
             *signal == self.signal

--- a/crates/ravel-mcp/src/cursor.rs
+++ b/crates/ravel-mcp/src/cursor.rs
@@ -36,8 +36,7 @@
 //! `ravel_sql::SegmentPin` costs about 250 B plus base64, so the 2,000-segment
 //! admission ceiling of D6 mints a token of several hundred KiB: past the
 //! cursor's own 4 KiB bound in the envelope, and past the whole 256 KiB
-//! response floor. Evidence references are unchanged and keep that per-pin
-//! codec, which is why this module still converts a `FlightTicketError`.
+//! response floor.
 //!
 //! # The D5 wrong-tenant rule
 //!
@@ -125,7 +124,7 @@
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ravel_query::erasure::ErasurePredicate;
-use ravel_sql::{DeclaredColumn, DeclaredType, FlightTicketError};
+use ravel_sql::{DeclaredColumn, DeclaredType};
 use ravel_types::{CommitToken, Signal, TenantHash};
 
 /// Length in bytes of the trailing keyed-MAC tag.
@@ -983,20 +982,6 @@ impl<'a> ByteReader<'a> {
 
     fn read_u32(&mut self) -> Result<u32, CursorError> {
         Ok(u32::from_le_bytes(self.read_array::<4>()?))
-    }
-}
-
-impl From<FlightTicketError> for CursorError {
-    /// The pin codec's encode-side length refusal is this codec's own; every
-    /// other variant is a decode failure, which is [`CursorError::Invalid`].
-    fn from(error: FlightTicketError) -> Self {
-        match error {
-            FlightTicketError::FieldTooLong(len) => CursorError::FieldTooLong {
-                len,
-                max: u32::MAX as usize,
-            },
-            _ => CursorError::Invalid,
-        }
     }
 }
 

--- a/crates/ravel-mcp/src/cursor.rs
+++ b/crates/ravel-mcp/src/cursor.rs
@@ -15,8 +15,14 @@
 //! A cursor carries the signal, the half-open time range, the minimum
 //! commit-token watermark the page was resolved against, the pending erasure
 //! predicates in force, and the declared column set (the 2026-09-09 amendment
-//! to ADR-1374 D5). Redemption re-resolves the snapshot from those inputs
-//! deterministically.
+//! to ADR-1374 D5, as corrected by the 2026-09-10 one). Redemption re-resolves
+//! the snapshot from those inputs deterministically, and refuses the cursor as
+//! [`CursorError::Expired`] in the two cases where that re-resolve would no
+//! longer answer with the page's own snapshot: its deadline has fallen outside
+//! the protection horizon less the grace, which is where a compaction becomes
+//! free to take the pin apart, or an erasure predicate is in force that the
+//! cursor did not pin and that reaches its signal and time range. Both live in
+//! [`Cursor::redeem`].
 //!
 //! The watermark is one of those inputs and nothing more. It is what page 2
 //! resolves against, not a test run against whatever watermark the redeeming
@@ -73,8 +79,9 @@
 //!
 //! A cursor whose pin is gone has nothing left to offer: page 2 of a
 //! paginated result means something only against page 1's snapshot, so
-//! [`Cursor::redeem`] reports [`CursorError::Expired`] for a passed deadline
-//! or a foreign nonce. An evidence reference is different. It names one row,
+//! [`Cursor::redeem`] reports [`CursorError::Expired`] for a passed deadline,
+//! a foreign nonce, or a newer erasure over its range. An evidence reference
+//! is different. It names one row,
 //! and every field a fresh re-execution needs (the tenant, the tool, the
 //! argument hash, and the row digest to compare the re-read row against) is
 //! in the token itself. [`EvidenceRef::redeem`] therefore answers
@@ -549,6 +556,23 @@ impl Cursor {
     /// that bounds its own work by the field cannot read past the pin's
     /// protection either.
     ///
+    /// That clamp is also the compaction check of the 2026-09-10 amendment to
+    /// ADR-1374 D5, and the only one. `protection_horizon_ns` minus
+    /// [`GRACE_NS`] is the instant past which a sweep may compact away what
+    /// the pin resolves to, so a cursor whose pin is no longer protected is
+    /// [`CursorError::Expired`] before anything else here runs. Nothing else
+    /// in this codec can observe a compaction, and a second mechanism for it
+    /// would only be a second thing to keep in agreement with this one.
+    ///
+    /// `erasure_in_force` is the pending erasure predicate set at redemption,
+    /// each paired with the signal it applies to. A predicate in force that
+    /// the cursor did not pin, whose signal is the cursor's own and whose
+    /// event-time window overlaps the cursor's half-open range, is the second
+    /// failure the amendment names: the page came from a snapshot that no
+    /// longer reproduces, so the cursor is [`CursorError::Expired`]. A
+    /// predicate outside that scope leaves it redeemable (see
+    /// [`Cursor::newer_erasure_intersects`]).
+    ///
     // Every parameter is a distinct precondition of a single redemption, and
     // a caller that omits one has skipped a check. Grouping them into a
     // struct would let a call site leave a field at its default.
@@ -559,6 +583,7 @@ impl Cursor {
         caller_tenant: TenantHash,
         tool: &str,
         argument_hash: &[u8; 32],
+        erasure_in_force: &[(Signal, ErasurePredicate)],
         now_ns: i64,
         protection_horizon_ns: i64,
     ) -> Result<Cursor, CursorError> {
@@ -576,8 +601,51 @@ impl Cursor {
         if now_ns >= cursor.deadline_ns {
             return Err(CursorError::Expired);
         }
+        if cursor.newer_erasure_intersects(erasure_in_force) {
+            return Err(CursorError::Expired);
+        }
         Ok(cursor)
     }
+
+    /// Whether an erasure predicate is in force at redemption that this
+    /// cursor did not pin and that reaches into what its page read.
+    ///
+    /// Scope is the cursor's signal and its half-open `[range_start_ns,
+    /// range_end_ns)`, and nothing else. A predicate's matchers are tested
+    /// against a record's labels or attributes, and this codec holds no
+    /// records, so no matcher-level analysis is possible here: two predicates
+    /// that name different services are both treated as reaching the cursor's
+    /// rows. Overrefusing that way costs a re-run of the query, where missing
+    /// a predicate would page against a snapshot ADR-0064 requires the erasure
+    /// to have already left.
+    ///
+    /// A predicate for another signal, or one whose window lies entirely
+    /// outside the cursor's range, cannot touch a row this page returned, so
+    /// it leaves the cursor redeemable. A windowless predicate (both bounds
+    /// unset, `ravel_query::erasure`'s zero-as-unset convention) erases
+    /// regardless of event time and so intersects every range.
+    ///
+    /// Predicates that were in force at mint and are not in force now are not
+    /// a mismatch either: an erasure that completed took its rows out of the
+    /// pinned snapshot before the page was built, and the pin already names it.
+    fn newer_erasure_intersects(&self, in_force: &[(Signal, ErasurePredicate)]) -> bool {
+        in_force.iter().any(|(signal, predicate)| {
+            *signal == self.signal
+                && !self.pending_erasure.contains(predicate)
+                && window_intersects(predicate, self.range_start_ns, self.range_end_ns)
+        })
+    }
+}
+
+/// Whether an erasure predicate's half-open event-time window overlaps the
+/// half-open `[start_ns, end_ns)` a cursor was resolved over.
+///
+/// A bound of `0` means unset on that side, the convention
+/// `ravel_query::erasure` reads a predicate's window under, so an unset bound
+/// is unbounded rather than the epoch.
+fn window_intersects(predicate: &ErasurePredicate, start_ns: i64, end_ns: i64) -> bool {
+    (predicate.window_end_ns() == 0 || predicate.window_end_ns() > start_ns)
+        && (predicate.window_start_ns() == 0 || predicate.window_start_ns() < end_ns)
 }
 
 impl EvidenceRef {
@@ -951,6 +1019,10 @@ mod tests {
     /// tests assert the embedded deadline's own behavior.
     const FAR_HORIZON_NS: i64 = NOW_NS + 365 * 24 * 3_600 * 1_000_000_000 + GRACE_NS;
 
+    /// No erasure predicate in force at redemption, so the newer-erasure
+    /// check is inert in every test but the three that exercise it.
+    const NO_ERASURE: &[(Signal, ErasurePredicate)] = &[];
+
     fn test_key() -> CursorKey {
         CursorKey::from_process_secret([0x11u8; CURSOR_KEY_LEN])
     }
@@ -1034,6 +1106,7 @@ mod tests {
             tenant_b,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1060,6 +1133,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1101,6 +1175,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1124,11 +1199,287 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             deadline,
             FAR_HORIZON_NS,
         )
         .expect_err("must be expired at exactly the deadline");
         assert_eq!(err, CursorError::Expired);
+    }
+
+    /// [`sample_cursor`]'s own pinned erasure set, paired with the signal it
+    /// was pinned for, which is what "unchanged" means at redemption.
+    fn pinned_erasure(cursor: &Cursor) -> Vec<(Signal, ErasurePredicate)> {
+        cursor
+            .pending_erasure
+            .iter()
+            .map(|predicate| (cursor.signal, predicate.clone()))
+            .collect()
+    }
+
+    /// An erasure predicate in force at redemption that the cursor did not
+    /// pin, over the cursor's own signal and reaching into its time range,
+    /// is `Expired`: the snapshot the page came from is one ADR-0064 requires
+    /// those rows to have already left, so it cannot be re-resolved.
+    ///
+    /// Five shapes of reaching in, each the pinned set plus exactly one new
+    /// predicate: windowless (no event-time restriction at all), fully inside
+    /// the range, straddling each end of it, and open-ended above from inside.
+    /// A sixth case drops the pinned predicate from the in-force set as well,
+    /// so the refusal is attributable to the predicate that was added rather
+    /// than to set equality.
+    #[test]
+    fn an_intersecting_new_erasure_is_cursor_expired() {
+        let tenant = TenantHash([0x9Du8; 16]);
+        let key = test_key();
+        let cursor = sample_cursor(tenant);
+        let token = cursor.encode(&key).expect("encodes");
+        assert_eq!(cursor.signal, Signal::Logs);
+        assert_eq!(cursor.range_start_ns, 1_699_999_000_000_000_000);
+        assert_eq!(cursor.range_end_ns, 1_700_000_000_000_000_000);
+        assert_eq!(cursor.pending_erasure.len(), 1);
+
+        let user = vec![("user.id".to_owned(), "u-42".to_owned())];
+        let newer = [
+            ErasurePredicate::windowless(user.clone()),
+            ErasurePredicate::new(
+                user.clone(),
+                cursor.range_start_ns + 1,
+                cursor.range_end_ns - 1,
+            ),
+            ErasurePredicate::new(
+                user.clone(),
+                cursor.range_start_ns - 3_600_000_000_000,
+                cursor.range_start_ns + 1,
+            ),
+            ErasurePredicate::new(
+                user.clone(),
+                cursor.range_end_ns - 1,
+                cursor.range_end_ns + 3_600_000_000_000,
+            ),
+            ErasurePredicate::new(user.clone(), cursor.range_start_ns + 1, 0),
+        ];
+        assert_eq!(newer.len(), 5);
+
+        for predicate in &newer {
+            let mut in_force = pinned_erasure(&cursor);
+            in_force.push((cursor.signal, predicate.clone()));
+            assert_eq!(in_force.len(), 2);
+
+            let err = Cursor::redeem(
+                &token,
+                &key,
+                tenant,
+                SAMPLE_TOOL,
+                &SAMPLE_ARGS,
+                &in_force,
+                NOW_NS,
+                FAR_HORIZON_NS,
+            )
+            .expect_err("a newer erasure over the cursor's range must be refused");
+            assert_eq!(err, CursorError::Expired);
+        }
+
+        let only_new = [(cursor.signal, newer[0].clone())];
+        let err = Cursor::redeem(
+            &token,
+            &key,
+            tenant,
+            SAMPLE_TOOL,
+            &SAMPLE_ARGS,
+            &only_new,
+            NOW_NS,
+            FAR_HORIZON_NS,
+        )
+        .expect_err("a newer erasure must be refused whatever else is in force");
+        assert_eq!(err, CursorError::Expired);
+
+        // The bindings still answer first: a newer erasure does not turn a
+        // wrong-tenant token into `Expired`, which would tell its holder the
+        // token itself was well-formed.
+        let err = Cursor::redeem(
+            &token,
+            &key,
+            TenantHash([0x9Cu8; 16]),
+            SAMPLE_TOOL,
+            &SAMPLE_ARGS,
+            &only_new,
+            NOW_NS,
+            FAR_HORIZON_NS,
+        )
+        .expect_err("must be refused");
+        assert_eq!(err, CursorError::Invalid);
+    }
+
+    /// An erasure the cursor did not pin that cannot touch a row the page
+    /// returned leaves the cursor redeemable. Three ways to miss: a window
+    /// that ends exactly where the cursor's half-open range starts, one that
+    /// starts exactly where it ends, and a predicate over another signal
+    /// entirely (windowless, so only the signal keeps it out of scope).
+    ///
+    /// The two boundary cases are then moved one nanosecond into the range,
+    /// which must refuse: that is what pins the comparison as strict overlap
+    /// of half-open intervals rather than as touching endpoints.
+    #[test]
+    fn a_non_intersecting_new_erasure_still_redeems() {
+        let tenant = TenantHash([0x9Eu8; 16]);
+        let key = test_key();
+        let cursor = sample_cursor(tenant);
+        let token = cursor.encode(&key).expect("encodes");
+        assert_ne!(cursor.signal, Signal::Metrics);
+
+        let user = vec![("user.id".to_owned(), "u-42".to_owned())];
+        let outside = [
+            (
+                cursor.signal,
+                ErasurePredicate::new(
+                    user.clone(),
+                    cursor.range_start_ns - 3_600_000_000_000,
+                    cursor.range_start_ns,
+                ),
+            ),
+            (
+                cursor.signal,
+                ErasurePredicate::new(
+                    user.clone(),
+                    cursor.range_end_ns,
+                    cursor.range_end_ns + 3_600_000_000_000,
+                ),
+            ),
+            (Signal::Metrics, ErasurePredicate::windowless(user.clone())),
+        ];
+        assert_eq!(outside.len(), 3);
+
+        for entry in &outside {
+            let mut in_force = pinned_erasure(&cursor);
+            in_force.push(entry.clone());
+            let redeemed = Cursor::redeem(
+                &token,
+                &key,
+                tenant,
+                SAMPLE_TOOL,
+                &SAMPLE_ARGS,
+                &in_force,
+                NOW_NS,
+                FAR_HORIZON_NS,
+            )
+            .expect("an erasure outside the cursor's scope must redeem");
+            assert_eq!(redeemed, cursor);
+        }
+
+        let just_inside = [
+            ErasurePredicate::new(
+                user.clone(),
+                cursor.range_start_ns - 3_600_000_000_000,
+                cursor.range_start_ns + 1,
+            ),
+            ErasurePredicate::new(
+                user.clone(),
+                cursor.range_end_ns - 1,
+                cursor.range_end_ns + 3_600_000_000_000,
+            ),
+        ];
+        assert_eq!(just_inside.len(), 2);
+
+        for predicate in &just_inside {
+            let in_force = [(cursor.signal, predicate.clone())];
+            let err = Cursor::redeem(
+                &token,
+                &key,
+                tenant,
+                SAMPLE_TOOL,
+                &SAMPLE_ARGS,
+                &in_force,
+                NOW_NS,
+                FAR_HORIZON_NS,
+            )
+            .expect_err("one nanosecond inside the range is inside it");
+            assert_eq!(err, CursorError::Expired);
+        }
+    }
+
+    /// The erasure check refuses a predicate the cursor did not pin, not the
+    /// presence of one: the pinned set still in force redeems, and so does an
+    /// in-force set that has lost a predicate the cursor pinned, since an
+    /// erasure that completed already took its rows out of what the page read.
+    /// The cursor comes back whole, carrying the pinned watermark and the
+    /// pinned erasure set unchanged, so page 2 resolves from the pin rather
+    /// than from what the redeeming call happened to observe.
+    #[test]
+    fn an_unchanged_erasure_set_redeems() {
+        let tenant = TenantHash([0x9Fu8; 16]);
+        let key = test_key();
+        let cursor = sample_cursor(tenant);
+        let token = cursor.encode(&key).expect("encodes");
+
+        let mut duplicated = pinned_erasure(&cursor);
+        duplicated.extend(pinned_erasure(&cursor));
+        let in_force_sets = [pinned_erasure(&cursor), Vec::new(), duplicated];
+        assert_eq!(in_force_sets.len(), 3);
+
+        for in_force in &in_force_sets {
+            let redeemed = Cursor::redeem(
+                &token,
+                &key,
+                tenant,
+                SAMPLE_TOOL,
+                &SAMPLE_ARGS,
+                in_force,
+                NOW_NS,
+                FAR_HORIZON_NS,
+            )
+            .expect("an unchanged erasure set must redeem");
+            assert_eq!(redeemed, cursor);
+            assert_eq!(redeemed.min_commit_watermark, cursor.min_commit_watermark);
+            assert_eq!(redeemed.pending_erasure, cursor.pending_erasure);
+        }
+    }
+
+    /// The compaction case of the amendment, through the deadline re-clamp
+    /// that already implements it and not through a second mechanism. A pin
+    /// is protected until `protection_horizon - grace`; past that instant a
+    /// sweep may take apart what the cursor resolves to, so the cursor is
+    /// `Expired` however live its own embedded deadline still is.
+    ///
+    /// The embedded deadline is 29.5 s past `NOW_NS` here and is asserted so,
+    /// which is what makes the horizon the only thing that can produce the
+    /// refusal. One nanosecond of horizon either side of the boundary
+    /// separates the two outcomes.
+    #[test]
+    fn a_cursor_past_the_protection_horizon_is_expired() {
+        let tenant = TenantHash([0xA0u8; 16]);
+        let key = test_key();
+        let cursor = sample_cursor(tenant);
+        let token = cursor.encode(&key).expect("encodes");
+        assert_eq!(cursor.deadline_ns, NOW_NS + 29_500_000_000);
+
+        let horizon = NOW_NS + GRACE_NS;
+        assert_eq!(effective_deadline_ns(cursor.deadline_ns, horizon), NOW_NS);
+        let err = Cursor::redeem(
+            &token,
+            &key,
+            tenant,
+            SAMPLE_TOOL,
+            &SAMPLE_ARGS,
+            NO_ERASURE,
+            NOW_NS,
+            horizon,
+        )
+        .expect_err("a pin no longer inside the protection horizon must be refused");
+        assert_eq!(err, CursorError::Expired);
+
+        let redeemed = Cursor::redeem(
+            &token,
+            &key,
+            tenant,
+            SAMPLE_TOOL,
+            &SAMPLE_ARGS,
+            NO_ERASURE,
+            NOW_NS,
+            horizon + 1,
+        )
+        .expect("one nanosecond of horizon later, the pin is still protected");
+        assert_eq!(redeemed.deadline_ns, NOW_NS + 1);
     }
 
     /// Every resolve input the amendment names survives the round trip, each
@@ -1195,6 +1546,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1214,6 +1566,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1256,6 +1609,7 @@ mod tests {
             tenant,
             "ravel_query_promql",
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1281,6 +1635,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &other,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1310,6 +1665,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1363,6 +1719,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1383,6 +1740,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1418,6 +1776,7 @@ mod tests {
                 tenant,
                 SAMPLE_TOOL,
                 &SAMPLE_ARGS,
+                NO_ERASURE,
                 NOW_NS,
                 FAR_HORIZON_NS,
             )
@@ -1435,6 +1794,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1463,6 +1823,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1507,6 +1868,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1542,6 +1904,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1716,6 +2079,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             NOW_NS,
             horizon,
         )
@@ -1729,6 +2093,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             clamped,
             horizon,
         )
@@ -1741,6 +2106,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            NO_ERASURE,
             clamped,
             FAR_HORIZON_NS,
         )

--- a/crates/ravel-mcp/src/cursor.rs
+++ b/crates/ravel-mcp/src/cursor.rs
@@ -16,9 +16,15 @@
 //! commit-token watermark the page was resolved against, the pending erasure
 //! predicates in force, and the declared column set (the 2026-09-09 amendment
 //! to ADR-1374 D5). Redemption re-resolves the snapshot from those inputs
-//! deterministically; when the re-resolve cannot reproduce the pinned
-//! watermark, the cursor is [`CursorError::Expired`] and the caller re-runs
-//! the query.
+//! deterministically.
+//!
+//! The watermark is one of those inputs and nothing more. It is what page 2
+//! resolves against, not a test run against whatever watermark the redeeming
+//! call happens to observe: ADR-0010 gives no ordering to run such a test
+//! with, since `seq` is monotonic only per (writer_id, epoch, shard) with
+//! gaps carrying no meaning and `epoch` is informational only. The catalog is
+//! what answers whether a commit token can be satisfied, and it answers by
+//! resolving the token's own identity rather than by comparing positions.
 //!
 //! Enumerating the pinned segments instead is what the amendment replaced. One
 //! `ravel_sql::SegmentPin` costs about 250 B plus base64, so the 2,000-segment
@@ -67,9 +73,8 @@
 //!
 //! A cursor whose pin is gone has nothing left to offer: page 2 of a
 //! paginated result means something only against page 1's snapshot, so
-//! [`Cursor::redeem`] reports [`CursorError::Expired`] for a passed deadline,
-//! a foreign nonce, or a pinned watermark the redeeming call's observed
-//! watermark cannot reproduce. An evidence reference is different. It names one row,
+//! [`Cursor::redeem`] reports [`CursorError::Expired`] for a passed deadline
+//! or a foreign nonce. An evidence reference is different. It names one row,
 //! and every field a fresh re-execution needs (the tenant, the tool, the
 //! argument hash, and the row digest to compare the re-read row against) is
 //! in the token itself. [`EvidenceRef::redeem`] therefore answers
@@ -293,10 +298,15 @@ pub struct Cursor {
     /// The minimum commit-token watermark the page was resolved against, one
     /// token per shard the read-your-write lower bound covers.
     ///
-    /// This is what makes the re-resolve deterministic rather than a fresh
-    /// resolution: page 2 resolves against this same watermark, and a
-    /// re-resolve that cannot reproduce it is [`CursorError::Expired`]
-    /// (see [`Cursor::redeem`]).
+    /// This is a resolve input, not a validity test. It is what makes the
+    /// re-resolve deterministic rather than a fresh resolution: page 2
+    /// resolves against this same watermark instead of against whatever the
+    /// redeeming call observes. [`Cursor::redeem`] never compares it with
+    /// anything, because ADR-0010 defines no ordering over commit tokens to
+    /// compare it with: `seq` is monotonic only per (writer_id, epoch,
+    /// shard), gaps in it carry no meaning, and `epoch` is informational
+    /// only. Whether these tokens can still be satisfied is the catalog's
+    /// answer to give at resolve time, not this codec's.
     pub min_commit_watermark: Vec<CommitToken>,
     pub pending_erasure: Vec<ErasurePredicate>,
     pub declared_columns: Vec<DeclaredColumn>,
@@ -539,13 +549,6 @@ impl Cursor {
     /// that bounds its own work by the field cannot read past the pin's
     /// protection either.
     ///
-    /// `current_watermark` is the watermark the redeeming call observes now.
-    /// A cursor whose pinned watermark that one cannot reproduce (see
-    /// [`Cursor::watermark_is_reproducible`]) is [`CursorError::Expired`]: the
-    /// snapshot the page was resolved from is no longer reachable, which is
-    /// the same answer a passed deadline gets and for the same reason.
-    /// Nothing is resolved here; the comparison is against what the caller
-    /// supplies.
     // Every parameter is a distinct precondition of a single redemption, and
     // a caller that omits one has skipped a check. Grouping them into a
     // struct would let a call site leave a field at its default.
@@ -556,7 +559,6 @@ impl Cursor {
         caller_tenant: TenantHash,
         tool: &str,
         argument_hash: &[u8; 32],
-        current_watermark: &[CommitToken],
         now_ns: i64,
         protection_horizon_ns: i64,
     ) -> Result<Cursor, CursorError> {
@@ -574,34 +576,7 @@ impl Cursor {
         if now_ns >= cursor.deadline_ns {
             return Err(CursorError::Expired);
         }
-        if !cursor.watermark_is_reproducible(current_watermark) {
-            return Err(CursorError::Expired);
-        }
         Ok(cursor)
-    }
-
-    /// Whether a re-resolve against `current` can reproduce the pinned
-    /// watermark.
-    ///
-    /// It can when every shard the pin names appears in `current` at a
-    /// position at least as advanced, ordered by `(epoch, seq)`. A commit
-    /// sequence only moves forward within an epoch and an epoch only
-    /// increases, so a pinned position `current` has already passed is a
-    /// point in a history the re-resolve can still cut at. A shard the pin
-    /// names and `current` does not, or one whose position sits behind the
-    /// pin, means the opposite: the observed history never contained the
-    /// pinned point, so no re-resolve can reproduce it.
-    ///
-    /// Extra shards in `current` are not a mismatch. The pin is a lower
-    /// bound on what the page saw, not an assertion about shards it did not
-    /// read from.
-    pub fn watermark_is_reproducible(&self, current: &[CommitToken]) -> bool {
-        self.min_commit_watermark.iter().all(|pinned| {
-            current
-                .iter()
-                .filter(|now| now.shard == pinned.shard)
-                .any(|now| (now.epoch, now.seq) >= (pinned.epoch, pinned.seq))
-        })
     }
 }
 
@@ -1030,13 +1005,6 @@ mod tests {
         }
     }
 
-    /// A current watermark that reproduces [`sample_cursor`]'s pin exactly, so
-    /// the reproducibility check is inert in every test but the two that
-    /// exercise it.
-    fn live_watermark() -> Vec<CommitToken> {
-        vec![sample_token(0)]
-    }
-
     fn sample_token(shard: u32) -> CommitToken {
         CommitToken {
             shard,
@@ -1066,7 +1034,6 @@ mod tests {
             tenant_b,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1093,7 +1060,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1135,7 +1101,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1159,126 +1124,11 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             deadline,
             FAR_HORIZON_NS,
         )
         .expect_err("must be expired at exactly the deadline");
         assert_eq!(err, CursorError::Expired);
-    }
-
-    /// A cursor pins the watermark its page was resolved against, and page 2
-    /// resolves against that same watermark. When the watermark the redeeming
-    /// call observes cannot reproduce the pinned one, the answer is `Expired`
-    /// and not `Invalid`: the token is intact and correctly bound, the
-    /// snapshot behind it is not, and a client can act on the difference.
-    ///
-    /// Both directions of unreproducible are covered: a shard whose observed
-    /// position sits behind the pin, and a shard the pin names that the
-    /// observed watermark does not carry at all.
-    #[test]
-    fn a_watermark_that_cannot_be_reproduced_is_cursor_expired() {
-        let tenant = TenantHash([0x9Du8; 16]);
-        let key = test_key();
-        let cursor = sample_cursor(tenant);
-        let token = cursor.encode(&key).expect("encodes");
-        assert_eq!(cursor.min_commit_watermark.len(), 1);
-        assert_eq!(cursor.min_commit_watermark[0].shard, 0);
-        assert_eq!(cursor.min_commit_watermark[0].seq, 2);
-
-        let mut behind = sample_token(0);
-        behind.seq = 1;
-        let mut other_shard = sample_token(7);
-        other_shard.seq = 900;
-
-        for current in [vec![behind], vec![other_shard], Vec::new()] {
-            let err = Cursor::redeem(
-                &token,
-                &key,
-                tenant,
-                SAMPLE_TOOL,
-                &SAMPLE_ARGS,
-                &current,
-                NOW_NS,
-                FAR_HORIZON_NS,
-            )
-            .expect_err("an unreproducible watermark must be refused");
-            assert_eq!(err, CursorError::Expired);
-        }
-
-        // The bindings still answer first: an unreproducible watermark does
-        // not turn a wrong-tenant or tampered token into `Expired`, which
-        // would tell its holder the token itself was well-formed.
-        let err = Cursor::redeem(
-            &token,
-            &key,
-            TenantHash([0x9Cu8; 16]),
-            SAMPLE_TOOL,
-            &SAMPLE_ARGS,
-            &[],
-            NOW_NS,
-            FAR_HORIZON_NS,
-        )
-        .expect_err("must be refused");
-        assert_eq!(err, CursorError::Invalid);
-
-        let mut bytes = token_bytes(&token);
-        let last = bytes.len() - 1;
-        bytes[last] ^= 0xFF;
-        let tampered = URL_SAFE_NO_PAD.encode(bytes);
-        let err = Cursor::redeem(
-            &tampered,
-            &key,
-            tenant,
-            SAMPLE_TOOL,
-            &SAMPLE_ARGS,
-            &[],
-            NOW_NS,
-            FAR_HORIZON_NS,
-        )
-        .expect_err("must be refused");
-        assert_eq!(err, CursorError::Invalid);
-    }
-
-    /// The other side of the same check: an observed watermark at or past the
-    /// pinned position on every pinned shard redeems, and the cursor comes
-    /// back carrying the pinned watermark unchanged, so page 2 resolves from
-    /// the pin rather than from what the redeeming call happened to see. An
-    /// extra shard the pin does not name is not a mismatch.
-    #[test]
-    fn a_reproducible_watermark_redeems() {
-        let tenant = TenantHash([0x9Eu8; 16]);
-        let key = test_key();
-        let cursor = sample_cursor(tenant);
-        let token = cursor.encode(&key).expect("encodes");
-
-        let mut ahead = sample_token(0);
-        ahead.seq = 3;
-        let mut newer_epoch = sample_token(0);
-        newer_epoch.epoch = 2;
-        newer_epoch.seq = 0;
-        let currents = [
-            live_watermark(),
-            vec![ahead],
-            vec![newer_epoch],
-            vec![sample_token(0), sample_token(7)],
-        ];
-        assert_eq!(currents.len(), 4);
-
-        for current in currents {
-            let redeemed = Cursor::redeem(
-                &token,
-                &key,
-                tenant,
-                SAMPLE_TOOL,
-                &SAMPLE_ARGS,
-                &current,
-                NOW_NS,
-                FAR_HORIZON_NS,
-            )
-            .expect("a reproducible watermark must redeem");
-            assert_eq!(redeemed.min_commit_watermark, cursor.min_commit_watermark);
-        }
     }
 
     /// Every resolve input the amendment names survives the round trip, each
@@ -1345,7 +1195,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &cursor.min_commit_watermark,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1365,7 +1214,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &ranged.min_commit_watermark,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1408,7 +1256,6 @@ mod tests {
             tenant,
             "ravel_query_promql",
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1434,7 +1281,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &other,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1464,7 +1310,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1518,7 +1363,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1539,7 +1383,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1575,7 +1418,6 @@ mod tests {
                 tenant,
                 SAMPLE_TOOL,
                 &SAMPLE_ARGS,
-                &live_watermark(),
                 NOW_NS,
                 FAR_HORIZON_NS,
             )
@@ -1593,7 +1435,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1622,7 +1463,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1667,7 +1507,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1703,7 +1542,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1878,7 +1716,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             NOW_NS,
             horizon,
         )
@@ -1892,7 +1729,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             clamped,
             horizon,
         )
@@ -1905,7 +1741,6 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
-            &live_watermark(),
             clamped,
             FAR_HORIZON_NS,
         )

--- a/crates/ravel-mcp/src/cursor.rs
+++ b/crates/ravel-mcp/src/cursor.rs
@@ -67,8 +67,9 @@
 //!
 //! A cursor whose pin is gone has nothing left to offer: page 2 of a
 //! paginated result means something only against page 1's snapshot, so
-//! [`Cursor::redeem`] reports [`CursorError::Expired`] for a passed deadline
-//! or a foreign nonce. An evidence reference is different. It names one row,
+//! [`Cursor::redeem`] reports [`CursorError::Expired`] for a passed deadline,
+//! a foreign nonce, or a pinned watermark the redeeming call's observed
+//! watermark cannot reproduce. An evidence reference is different. It names one row,
 //! and every field a fresh re-execution needs (the tenant, the tool, the
 //! argument hash, and the row digest to compare the re-read row against) is
 //! in the token itself. [`EvidenceRef::redeem`] therefore answers
@@ -537,12 +538,25 @@ impl Cursor {
     /// returned cursor carries that clamped value in `deadline_ns` so a caller
     /// that bounds its own work by the field cannot read past the pin's
     /// protection either.
+    ///
+    /// `current_watermark` is the watermark the redeeming call observes now.
+    /// A cursor whose pinned watermark that one cannot reproduce (see
+    /// [`Cursor::watermark_is_reproducible`]) is [`CursorError::Expired`]: the
+    /// snapshot the page was resolved from is no longer reachable, which is
+    /// the same answer a passed deadline gets and for the same reason.
+    /// Nothing is resolved here; the comparison is against what the caller
+    /// supplies.
+    // Every parameter is a distinct precondition of a single redemption, and
+    // a caller that omits one has skipped a check. Grouping them into a
+    // struct would let a call site leave a field at its default.
+    #[allow(clippy::too_many_arguments)]
     pub fn redeem(
         token: &str,
         key: &CursorKey,
         caller_tenant: TenantHash,
         tool: &str,
         argument_hash: &[u8; 32],
+        current_watermark: &[CommitToken],
         now_ns: i64,
         protection_horizon_ns: i64,
     ) -> Result<Cursor, CursorError> {
@@ -560,7 +574,34 @@ impl Cursor {
         if now_ns >= cursor.deadline_ns {
             return Err(CursorError::Expired);
         }
+        if !cursor.watermark_is_reproducible(current_watermark) {
+            return Err(CursorError::Expired);
+        }
         Ok(cursor)
+    }
+
+    /// Whether a re-resolve against `current` can reproduce the pinned
+    /// watermark.
+    ///
+    /// It can when every shard the pin names appears in `current` at a
+    /// position at least as advanced, ordered by `(epoch, seq)`. A commit
+    /// sequence only moves forward within an epoch and an epoch only
+    /// increases, so a pinned position `current` has already passed is a
+    /// point in a history the re-resolve can still cut at. A shard the pin
+    /// names and `current` does not, or one whose position sits behind the
+    /// pin, means the opposite: the observed history never contained the
+    /// pinned point, so no re-resolve can reproduce it.
+    ///
+    /// Extra shards in `current` are not a mismatch. The pin is a lower
+    /// bound on what the page saw, not an assertion about shards it did not
+    /// read from.
+    pub fn watermark_is_reproducible(&self, current: &[CommitToken]) -> bool {
+        self.min_commit_watermark.iter().all(|pinned| {
+            current
+                .iter()
+                .filter(|now| now.shard == pinned.shard)
+                .any(|now| (now.epoch, now.seq) >= (pinned.epoch, pinned.seq))
+        })
     }
 }
 
@@ -989,6 +1030,13 @@ mod tests {
         }
     }
 
+    /// A current watermark that reproduces [`sample_cursor`]'s pin exactly, so
+    /// the reproducibility check is inert in every test but the two that
+    /// exercise it.
+    fn live_watermark() -> Vec<CommitToken> {
+        vec![sample_token(0)]
+    }
+
     fn sample_token(shard: u32) -> CommitToken {
         CommitToken {
             shard,
@@ -1018,6 +1066,7 @@ mod tests {
             tenant_b,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1044,6 +1093,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1085,6 +1135,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1108,11 +1159,126 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             deadline,
             FAR_HORIZON_NS,
         )
         .expect_err("must be expired at exactly the deadline");
         assert_eq!(err, CursorError::Expired);
+    }
+
+    /// A cursor pins the watermark its page was resolved against, and page 2
+    /// resolves against that same watermark. When the watermark the redeeming
+    /// call observes cannot reproduce the pinned one, the answer is `Expired`
+    /// and not `Invalid`: the token is intact and correctly bound, the
+    /// snapshot behind it is not, and a client can act on the difference.
+    ///
+    /// Both directions of unreproducible are covered: a shard whose observed
+    /// position sits behind the pin, and a shard the pin names that the
+    /// observed watermark does not carry at all.
+    #[test]
+    fn a_watermark_that_cannot_be_reproduced_is_cursor_expired() {
+        let tenant = TenantHash([0x9Du8; 16]);
+        let key = test_key();
+        let cursor = sample_cursor(tenant);
+        let token = cursor.encode(&key).expect("encodes");
+        assert_eq!(cursor.min_commit_watermark.len(), 1);
+        assert_eq!(cursor.min_commit_watermark[0].shard, 0);
+        assert_eq!(cursor.min_commit_watermark[0].seq, 2);
+
+        let mut behind = sample_token(0);
+        behind.seq = 1;
+        let mut other_shard = sample_token(7);
+        other_shard.seq = 900;
+
+        for current in [vec![behind], vec![other_shard], Vec::new()] {
+            let err = Cursor::redeem(
+                &token,
+                &key,
+                tenant,
+                SAMPLE_TOOL,
+                &SAMPLE_ARGS,
+                &current,
+                NOW_NS,
+                FAR_HORIZON_NS,
+            )
+            .expect_err("an unreproducible watermark must be refused");
+            assert_eq!(err, CursorError::Expired);
+        }
+
+        // The bindings still answer first: an unreproducible watermark does
+        // not turn a wrong-tenant or tampered token into `Expired`, which
+        // would tell its holder the token itself was well-formed.
+        let err = Cursor::redeem(
+            &token,
+            &key,
+            TenantHash([0x9Cu8; 16]),
+            SAMPLE_TOOL,
+            &SAMPLE_ARGS,
+            &[],
+            NOW_NS,
+            FAR_HORIZON_NS,
+        )
+        .expect_err("must be refused");
+        assert_eq!(err, CursorError::Invalid);
+
+        let mut bytes = token_bytes(&token);
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+        let tampered = URL_SAFE_NO_PAD.encode(bytes);
+        let err = Cursor::redeem(
+            &tampered,
+            &key,
+            tenant,
+            SAMPLE_TOOL,
+            &SAMPLE_ARGS,
+            &[],
+            NOW_NS,
+            FAR_HORIZON_NS,
+        )
+        .expect_err("must be refused");
+        assert_eq!(err, CursorError::Invalid);
+    }
+
+    /// The other side of the same check: an observed watermark at or past the
+    /// pinned position on every pinned shard redeems, and the cursor comes
+    /// back carrying the pinned watermark unchanged, so page 2 resolves from
+    /// the pin rather than from what the redeeming call happened to see. An
+    /// extra shard the pin does not name is not a mismatch.
+    #[test]
+    fn a_reproducible_watermark_redeems() {
+        let tenant = TenantHash([0x9Eu8; 16]);
+        let key = test_key();
+        let cursor = sample_cursor(tenant);
+        let token = cursor.encode(&key).expect("encodes");
+
+        let mut ahead = sample_token(0);
+        ahead.seq = 3;
+        let mut newer_epoch = sample_token(0);
+        newer_epoch.epoch = 2;
+        newer_epoch.seq = 0;
+        let currents = [
+            live_watermark(),
+            vec![ahead],
+            vec![newer_epoch],
+            vec![sample_token(0), sample_token(7)],
+        ];
+        assert_eq!(currents.len(), 4);
+
+        for current in currents {
+            let redeemed = Cursor::redeem(
+                &token,
+                &key,
+                tenant,
+                SAMPLE_TOOL,
+                &SAMPLE_ARGS,
+                &current,
+                NOW_NS,
+                FAR_HORIZON_NS,
+            )
+            .expect("a reproducible watermark must redeem");
+            assert_eq!(redeemed.min_commit_watermark, cursor.min_commit_watermark);
+        }
     }
 
     /// Every resolve input the amendment names survives the round trip, each
@@ -1179,6 +1345,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &cursor.min_commit_watermark,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1198,6 +1365,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &ranged.min_commit_watermark,
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1240,6 +1408,7 @@ mod tests {
             tenant,
             "ravel_query_promql",
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1265,6 +1434,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &other,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1294,6 +1464,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1347,6 +1518,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1367,6 +1539,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1402,6 +1575,7 @@ mod tests {
                 tenant,
                 SAMPLE_TOOL,
                 &SAMPLE_ARGS,
+                &live_watermark(),
                 NOW_NS,
                 FAR_HORIZON_NS,
             )
@@ -1419,6 +1593,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1447,6 +1622,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1491,6 +1667,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1526,6 +1703,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             FAR_HORIZON_NS,
         )
@@ -1700,6 +1878,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             NOW_NS,
             horizon,
         )
@@ -1713,6 +1892,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             clamped,
             horizon,
         )
@@ -1725,6 +1905,7 @@ mod tests {
             tenant,
             SAMPLE_TOOL,
             &SAMPLE_ARGS,
+            &live_watermark(),
             clamped,
             FAR_HORIZON_NS,
         )

--- a/crates/ravel-mcp/src/cursor.rs
+++ b/crates/ravel-mcp/src/cursor.rs
@@ -4,22 +4,28 @@
 //! tokens in the same pattern as `ravel_sql::flight_ticket`'s Flight-ticket
 //! codec: magic, version byte, payload, trailing keyed BLAKE3-256 MAC,
 //! base64url on the wire. A cursor pins the snapshot a paginated tool call
-//! must keep reading against (the segment set, any pending erasure
-//! predicates, and the tenant's declared columns at mint time) plus the
-//! caller's position in the result order, so page 2 of a query answers
-//! against exactly the same snapshot page 1 planned against, never a
-//! re-resolution. An evidence reference pins a single row for later
-//! recall by a `ravel_get_trace`-style follow-up.
+//! must keep reading against, as the inputs that resolve it rather than as
+//! its result, plus the caller's position in the result order, so page 2 of
+//! a query answers against the same snapshot page 1 planned against. An
+//! evidence reference pins a single row for later recall by a
+//! `ravel_get_trace`-style follow-up.
 //!
-//! # The pinned snapshot is `ravel_sql::SegmentPin`
+//! # The pinned snapshot is a set of resolve inputs
 //!
-//! A cursor's segment set is a `Vec<ravel_sql::SegmentPin>` encoded through
-//! that crate's own per-pin codec (ADR-1374 decision 9), not a local
-//! projection of the fields the pagination path happens to branch on. The two
-//! tokens pin a snapshot for the same reason and must reconstruct the same
-//! `SegmentRef`, so they share the layout and the field list; a narrower
-//! mirror silently drops the pruning bounds, the routing fields, and each
-//! segment's on-object format version.
+//! A cursor carries the signal, the half-open time range, the minimum
+//! commit-token watermark the page was resolved against, the pending erasure
+//! predicates in force, and the declared column set (the 2026-09-09 amendment
+//! to ADR-1374 D5). Redemption re-resolves the snapshot from those inputs
+//! deterministically; when the re-resolve cannot reproduce the pinned
+//! watermark, the cursor is [`CursorError::Expired`] and the caller re-runs
+//! the query.
+//!
+//! Enumerating the pinned segments instead is what the amendment replaced. One
+//! `ravel_sql::SegmentPin` costs about 250 B plus base64, so the 2,000-segment
+//! admission ceiling of D6 mints a token of several hundred KiB: past the
+//! cursor's own 4 KiB bound in the envelope, and past the whole 256 KiB
+//! response floor. Evidence references are unchanged and keep that per-pin
+//! codec, which is why this module still converts a `FlightTicketError`.
 //!
 //! # The D5 wrong-tenant rule
 //!
@@ -106,8 +112,8 @@
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ravel_query::erasure::ErasurePredicate;
-use ravel_sql::{DeclaredColumn, DeclaredType, FlightTicketError, SegmentPin};
-use ravel_types::TenantHash;
+use ravel_sql::{DeclaredColumn, DeclaredType, FlightTicketError};
+use ravel_types::{CommitToken, Signal, TenantHash};
 
 /// Length in bytes of the trailing keyed-MAC tag.
 const MAC_LEN: usize = 32;
@@ -158,12 +164,15 @@ impl std::fmt::Debug for CursorKey {
 const CURSOR_MAGIC: [u8; 4] = *b"RMC1";
 /// Version 2 pinned each segment as a whole `ravel_sql::SegmentPin` (all 15
 /// fields, through that crate's own codec) instead of the five-field local
-/// projection version 1 carried; version 3 adds the plaintext process nonce
-/// after the version byte. A token of any earlier version decodes as
-/// [`CursorError::Invalid`] like any other unsupported version, which is
-/// correct and costs nothing: these tokens are process-local and
-/// deadline-bounded, so none survives the deploy that changes the number.
-const CURSOR_VERSION: u8 = 3;
+/// projection version 1 carried; version 3 added the plaintext process nonce
+/// after the version byte; version 4 drops the segment enumeration for the
+/// resolve inputs of the 2026-09-09 amendment (signal, time range, commit-token
+/// watermark, pending erasure, declared columns, keyset position). A token of
+/// any earlier version decodes as [`CursorError::Invalid`] like any other
+/// unsupported version, which is correct and costs nothing: these tokens are
+/// process-local and deadline-bounded, so none survives the deploy that
+/// changes the number.
+const CURSOR_VERSION: u8 = 4;
 const EVIDENCE_MAGIC: [u8; 4] = *b"RME1";
 /// Version 2 adds the same plaintext process nonce [`CURSOR_VERSION`] 3 does;
 /// version 3 adds the argument hash, which an unpinned redemption needs to
@@ -183,10 +192,11 @@ const HEADER_LEN: usize = 4 + 1 + NONCE_LEN;
 const NONCE_CONTEXT: &[u8] = b"ravel-mcp cursor process nonce v1";
 
 /// Largest wire token, in base64url characters, either codec will look at.
-/// 1 MiB of base64url decodes to at most 786,432 payload bytes, which at the
-/// ~250 B one segment pin costs is roughly 3,000 pinned segments: far above
-/// any real snapshot, and a bound on what a caller can make this process
-/// allocate from one token.
+/// 1 MiB of base64url decodes to at most 786,432 payload bytes, far above
+/// what any real cursor or evidence reference carries, and a bound on what a
+/// caller can make this process allocate from one token. It is not the bound
+/// a minted cursor is held to: the envelope bounds `presentation.cursor` at
+/// 4 KiB and reports a larger one as an `internal` failure.
 pub const MAX_TOKEN_BYTES: usize = 1024 * 1024;
 
 /// The `grace` component of a deployment's GC protection horizon, 24 h
@@ -237,16 +247,33 @@ pub enum CursorError {
     FieldTooLong { len: usize, max: usize },
 }
 
-/// Where a paginated result left off. A keyset position is an opaque,
-/// tool-defined ordering key (e.g. the last row's sort tuple, encoded by the
-/// tool); a row range is used by tools that page by row index.
+/// Where a paginated result left off.
+///
+/// A keyset position is the last tuple of the page (opaque here, encoded by
+/// the tool that ordered the rows) together with the `ORDER BY` it was taken
+/// under, which the amendment names as part of the position: the same tuple
+/// under a different ordering resumes somewhere else entirely, so the two
+/// travel as one value rather than as a tuple the redeeming call is trusted
+/// to pair correctly. A row range is used by tools that page by row index.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CursorPosition {
-    Keyset(Vec<u8>),
-    RowRange { start: u64, end: u64 },
+    Keyset {
+        /// The last tuple of the page, in the tool's own encoding.
+        tuple: Vec<u8>,
+        /// The `ORDER BY` terms the tuple was taken under, in order.
+        order_by: Vec<String>,
+    },
+    RowRange {
+        start: u64,
+        end: u64,
+    },
 }
 
 /// The D5 cursor: an opaque, snapshot-pinning pagination token.
+///
+/// The pin is the resolve inputs below, not an enumeration of what they
+/// resolved to (the 2026-09-09 amendment to ADR-1374 D5). See this module's
+/// "The pinned snapshot is a set of resolve inputs" docs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cursor {
     pub tenant: TenantHash,
@@ -255,16 +282,21 @@ pub struct Cursor {
     /// so a cursor cannot be redeemed against a call with different
     /// arguments than the one that minted it.
     pub argument_hash: [u8; 32],
-    /// The pinned snapshot, one entry per resolved segment.
+    /// The signal the page was resolved over.
+    pub signal: Signal,
+    /// Start of the half-open time range the page was resolved over,
+    /// inclusive.
+    pub range_start_ns: i64,
+    /// End of that range, exclusive.
+    pub range_end_ns: i64,
+    /// The minimum commit-token watermark the page was resolved against, one
+    /// token per shard the read-your-write lower bound covers.
     ///
-    /// This is `ravel_sql::SegmentPin` itself, not a narrower local mirror
-    /// (ADR-1374 decision 9): a cursor pins a snapshot for exactly the reason
-    /// a Flight ticket does, so it carries the same 15 fields through the
-    /// same codec. A projection of "the fields pagination branches on" drops
-    /// the pruning bounds, the routing fields, and the on-object format
-    /// version, and page 2 then cannot rebuild the `SegmentRef` page 1
-    /// planned against.
-    pub segments: Vec<SegmentPin>,
+    /// This is what makes the re-resolve deterministic rather than a fresh
+    /// resolution: page 2 resolves against this same watermark, and a
+    /// re-resolve that cannot reproduce it is [`CursorError::Expired`]
+    /// (see [`Cursor::redeem`]).
+    pub min_commit_watermark: Vec<CommitToken>,
     pub pending_erasure: Vec<ErasurePredicate>,
     pub declared_columns: Vec<DeclaredColumn>,
     pub position: CursorPosition,
@@ -336,9 +368,16 @@ impl Cursor {
         write_len_prefixed(&mut buf, self.tool.as_bytes())?;
         buf.extend_from_slice(&self.argument_hash);
 
-        write_count(&mut buf, self.segments.len())?;
-        for seg in &self.segments {
-            seg.encode_into(&mut buf)?;
+        buf.push(signal_tag(self.signal));
+        buf.extend_from_slice(&self.range_start_ns.to_le_bytes());
+        buf.extend_from_slice(&self.range_end_ns.to_le_bytes());
+
+        write_count(&mut buf, self.min_commit_watermark.len())?;
+        for token in &self.min_commit_watermark {
+            // The token's own codec, not a local field-by-field mirror: a
+            // commit token is a frozen contract (ADR-0010) and a cursor is
+            // not a second place to define its layout.
+            write_len_prefixed(&mut buf, token.encode().as_bytes())?;
         }
 
         write_count(&mut buf, self.pending_erasure.len())?;
@@ -359,9 +398,13 @@ impl Cursor {
         }
 
         match &self.position {
-            CursorPosition::Keyset(bytes) => {
+            CursorPosition::Keyset { tuple, order_by } => {
                 buf.push(0);
-                write_len_prefixed(&mut buf, bytes)?;
+                write_len_prefixed(&mut buf, tuple)?;
+                write_count(&mut buf, order_by.len())?;
+                for term in order_by {
+                    write_len_prefixed(&mut buf, term.as_bytes())?;
+                }
             }
             CursorPosition::RowRange { start, end } => {
                 buf.push(1);
@@ -397,11 +440,17 @@ impl Cursor {
         let tool = read_string(&mut cur)?;
         let argument_hash = cur.read_array::<32>()?;
 
-        let seg_count = cur.read_u32()?;
+        let signal = signal_from_tag(cur.read_u8()?)?;
+        let range_start_ns = i64::from_le_bytes(cur.read_array::<8>()?);
+        let range_end_ns = i64::from_le_bytes(cur.read_array::<8>()?);
+
+        let watermark_count = cur.read_u32()?;
         // Never pre-allocate from the untrusted count; push and grow.
-        let mut segments = Vec::new();
-        for _ in 0..seg_count {
-            segments.push(cur.read_segment_pin()?);
+        let mut min_commit_watermark = Vec::new();
+        for _ in 0..watermark_count {
+            let encoded = read_string(&mut cur)?;
+            min_commit_watermark
+                .push(CommitToken::decode(&encoded).map_err(|_| CursorError::Invalid)?);
         }
 
         let erasure_count = cur.read_u32()?;
@@ -432,7 +481,15 @@ impl Cursor {
         }
 
         let position = match cur.read_u8()? {
-            0 => CursorPosition::Keyset(read_bytes_vec(&mut cur)?),
+            0 => {
+                let tuple = read_bytes_vec(&mut cur)?;
+                let term_count = cur.read_u32()?;
+                let mut order_by = Vec::new();
+                for _ in 0..term_count {
+                    order_by.push(read_string(&mut cur)?);
+                }
+                CursorPosition::Keyset { tuple, order_by }
+            }
             1 => {
                 let start = u64::from_le_bytes(cur.read_array::<8>()?);
                 let end = u64::from_le_bytes(cur.read_array::<8>()?);
@@ -452,7 +509,10 @@ impl Cursor {
             tenant,
             tool,
             argument_hash,
-            segments,
+            signal,
+            range_start_ns,
+            range_end_ns,
+            min_commit_watermark,
             pending_erasure,
             declared_columns,
             position,
@@ -705,6 +765,33 @@ fn process_nonce(key: &CursorKey) -> [u8; NONCE_LEN] {
     nonce
 }
 
+/// The wire tag for a signal. Written out here rather than taken from the
+/// enum's discriminant: this is a token layout under [`CURSOR_VERSION`], so a
+/// reordering of `ravel_types::Signal` must not silently change what a minted
+/// token means.
+fn signal_tag(signal: Signal) -> u8 {
+    match signal {
+        Signal::Metrics => 1,
+        Signal::Logs => 2,
+        Signal::Spans => 3,
+        Signal::Profiles => 4,
+        Signal::Alerts => 5,
+        Signal::Audit => 6,
+    }
+}
+
+fn signal_from_tag(tag: u8) -> Result<Signal, CursorError> {
+    match tag {
+        1 => Ok(Signal::Metrics),
+        2 => Ok(Signal::Logs),
+        3 => Ok(Signal::Spans),
+        4 => Ok(Signal::Profiles),
+        5 => Ok(Signal::Alerts),
+        6 => Ok(Signal::Audit),
+        _ => Err(CursorError::Invalid),
+    }
+}
+
 fn declared_type_tag(ty: DeclaredType) -> u8 {
     match ty {
         DeclaredType::Str => 1,
@@ -813,19 +900,6 @@ impl<'a> ByteReader<'a> {
     fn read_u32(&mut self) -> Result<u32, CursorError> {
         Ok(u32::from_le_bytes(self.read_array::<4>()?))
     }
-
-    /// Reads one segment pin through `ravel_sql`'s own codec, which owns the
-    /// layout, and advances by however many bytes it consumed. A typed
-    /// `FlightTicketError` from there (truncation, bad UTF-8, an invalid
-    /// level tag) becomes [`CursorError::Invalid`] like any other malformed
-    /// input: a cursor exposes exactly the two D5 decode outcomes and never
-    /// reports which field of which pin was wrong.
-    fn read_segment_pin(&mut self) -> Result<SegmentPin, CursorError> {
-        let rest = self.buf.get(self.pos..).ok_or(CursorError::Invalid)?;
-        let (pin, consumed) = SegmentPin::decode_from(rest).map_err(|_| CursorError::Invalid)?;
-        self.pos = self.pos.checked_add(consumed).ok_or(CursorError::Invalid)?;
-        Ok(pin)
-    }
 }
 
 impl From<FlightTicketError> for CursorError {
@@ -845,7 +919,6 @@ impl From<FlightTicketError> for CursorError {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
-    use ravel_sql::SegmentLevel;
     use uuid::Uuid;
 
     use super::*;
@@ -882,32 +955,6 @@ mod tests {
         URL_SAFE_NO_PAD.decode(token).expect("decode base64")
     }
 
-    /// A pin with every one of its 15 fields set to a distinct non-default
-    /// value, so a field dropped anywhere in the cursor's codec changes the
-    /// decoded struct rather than round-tripping a zero through a zero.
-    fn every_field_pin() -> SegmentPin {
-        SegmentPin {
-            data_object_key: "t/aa/logs/l1/2026090812/w.7.9.deadbeef.rseg".to_owned(),
-            object_size: 4_194_304,
-            min_event_ts_ns: 1_700_000_000_111_111_111,
-            max_event_ts_ns: 1_700_000_003_222_222_222,
-            ingest_hour_bucket: 472_222,
-            sample_count: 123_456,
-            series_count: 789,
-            shard: 5,
-            content_hash: [0xC3u8; 32],
-            writer_id: Uuid::from_bytes([0xD7u8; 16]),
-            writer_epoch: 11,
-            writer_seq: 22,
-            created_unix_ns: 1_700_000_004_333_333_333,
-            level: SegmentLevel::L1 {
-                input_set_hash: [0xE5u8; 32],
-                part_index: 3,
-            },
-            segment_format_version: 4,
-        }
-    }
-
     fn sample_evidence(tenant: TenantHash) -> EvidenceRef {
         EvidenceRef {
             tenant,
@@ -924,31 +971,31 @@ mod tests {
             tenant,
             tool: SAMPLE_TOOL.to_owned(),
             argument_hash: SAMPLE_ARGS,
-            segments: vec![SegmentPin {
-                data_object_key: "t/aa/logs/l0/0000/w.1.2.abc.rseg".to_owned(),
-                object_size: 65_536,
-                min_event_ts_ns: 1_700_000_000_000_000_000,
-                max_event_ts_ns: 1_700_000_001_000_000_000,
-                ingest_hour_bucket: 472_222,
-                sample_count: 10,
-                series_count: 4,
-                shard: 0,
-                content_hash: [3u8; 32],
-                writer_id: Uuid::from_bytes([4u8; 16]),
-                writer_epoch: 1,
-                writer_seq: 2,
-                created_unix_ns: 1_700_000_000_000_000_000,
-                level: SegmentLevel::L0,
-                segment_format_version: 3,
-            }],
+            signal: Signal::Logs,
+            range_start_ns: 1_699_999_000_000_000_000,
+            range_end_ns: 1_700_000_000_000_000_000,
+            min_commit_watermark: vec![sample_token(0)],
             pending_erasure: vec![ErasurePredicate::windowless(vec![(
                 "region".to_owned(),
                 "us-east".to_owned(),
             )])],
             declared_columns: vec![DeclaredColumn::new("http.status_code", DeclaredType::I64)],
-            position: CursorPosition::Keyset(vec![1, 2, 3]),
+            position: CursorPosition::Keyset {
+                tuple: vec![1, 2, 3],
+                order_by: vec!["timestamp desc".to_owned()],
+            },
             mint_ns: 1_700_000_000_000_000_000,
             deadline_ns: 1_700_000_030_000_000_000,
+        }
+    }
+
+    fn sample_token(shard: u32) -> CommitToken {
+        CommitToken {
+            shard,
+            writer_id: Uuid::from_bytes([4u8; 16]),
+            epoch: 1,
+            seq: 2,
+            ingest_hour_bucket: 472_222,
         }
     }
 
@@ -1008,11 +1055,11 @@ mod tests {
     /// MAC'd region is `Invalid` too. Flipping only the tag would pass on a
     /// codec that MAC'd nothing but itself.
     ///
-    /// The byte edited belongs to a pinned segment's object key, which is the
-    /// one thing a forger would actually want to change and which nothing
-    /// downstream re-checks: editing the tenant, tool, or argument hash would
-    /// be refused a second time by the bindings in `redeem`, and the assertion
-    /// would hold even with no MAC at all.
+    /// The byte edited belongs to a pending erasure predicate's matcher value,
+    /// which is the kind of thing a forger would actually want to change and
+    /// which nothing downstream re-checks: editing the tenant, tool, or
+    /// argument hash would be refused a second time by the bindings in
+    /// `redeem`, and the assertion would hold even with no MAC at all.
     #[test]
     fn tampered_payload_byte_is_cursor_invalid() {
         let tenant = TenantHash([0x42u8; 16]);
@@ -1020,11 +1067,11 @@ mod tests {
         let token = sample_cursor(tenant).encode(&key).expect("encodes");
 
         let mut bytes = token_bytes(&token);
-        let needle = b"t/aa/logs/l0/0000/w.1.2.abc.rseg";
+        let needle = b"us-east";
         let at = bytes
             .windows(needle.len())
             .position(|window| window == needle)
-            .expect("the pinned object key is in the payload");
+            .expect("the pending erasure matcher value is in the payload");
         assert!(
             at > HEADER_LEN && at < bytes.len() - MAC_LEN,
             "must edit inside the MAC'd payload"
@@ -1068,17 +1115,62 @@ mod tests {
         assert_eq!(err, CursorError::Expired);
     }
 
-    /// The whole point of pinning `ravel_sql::SegmentPin` itself: every one
-    /// of its 15 fields survives the cursor round trip. Asserted on the whole
-    /// struct, so a field the codec forgets to write fails here whether or
-    /// not this test is updated to name it.
+    /// Every resolve input the amendment names survives the round trip, each
+    /// set to a distinct non-default value so a field the codec forgets to
+    /// write changes the decoded struct rather than round-tripping a zero
+    /// through a zero. Asserted on the whole struct, so a new field fails
+    /// here whether or not this test is updated to name it.
     #[test]
-    fn cursor_round_trips_every_segment_pin_field() {
+    fn cursor_round_trips_every_resolve_input() {
         let tenant = TenantHash([0x5Eu8; 16]);
         let key = test_key();
-        let pin = every_field_pin();
-        let mut cursor = sample_cursor(tenant);
-        cursor.segments = vec![pin.clone(), every_field_pin()];
+        let cursor = Cursor {
+            tenant,
+            tool: SAMPLE_TOOL.to_owned(),
+            argument_hash: SAMPLE_ARGS,
+            signal: Signal::Audit,
+            range_start_ns: 1_700_000_000_111_111_111,
+            range_end_ns: 1_700_000_003_222_222_222,
+            min_commit_watermark: vec![
+                CommitToken {
+                    shard: 5,
+                    writer_id: Uuid::from_bytes([0xD7u8; 16]),
+                    epoch: 11,
+                    seq: 22,
+                    ingest_hour_bucket: 472_222,
+                },
+                CommitToken {
+                    shard: 6,
+                    writer_id: Uuid::from_bytes([0xE5u8; 16]),
+                    epoch: 33,
+                    seq: 44,
+                    ingest_hour_bucket: 472_223,
+                },
+            ],
+            pending_erasure: vec![
+                ErasurePredicate::new(
+                    vec![("region".to_owned(), "us-east".to_owned())],
+                    1_699_000_000_000_000_000,
+                    1_699_500_000_000_000_000,
+                ),
+                ErasurePredicate::windowless(vec![
+                    ("service.name".to_owned(), "checkout".to_owned()),
+                    ("user.id".to_owned(), "u-42".to_owned()),
+                ]),
+            ],
+            declared_columns: vec![
+                DeclaredColumn::new("http.status_code", DeclaredType::I64),
+                DeclaredColumn::new("http.route", DeclaredType::Str),
+                DeclaredColumn::new("error", DeclaredType::Bool),
+                DeclaredColumn::new("trace_id", DeclaredType::Bytes),
+            ],
+            position: CursorPosition::Keyset {
+                tuple: vec![7, 8, 9, 10],
+                order_by: vec!["timestamp desc".to_owned(), "trace_id asc".to_owned()],
+            },
+            mint_ns: 1_700_000_000_000_000_000,
+            deadline_ns: 1_700_000_030_000_000_000,
+        };
 
         let token = cursor.encode(&key).expect("encodes");
         let decoded = Cursor::redeem(
@@ -1091,11 +1183,46 @@ mod tests {
             FAR_HORIZON_NS,
         )
         .expect("round-trips through its own codec");
-
-        assert_eq!(decoded.segments.len(), 2);
-        assert_eq!(decoded.segments[0], pin);
-        assert_eq!(decoded.segments[1], pin);
         assert_eq!(decoded, cursor);
+
+        // The other position arm, through the same codec.
+        let mut ranged = cursor.clone();
+        ranged.position = CursorPosition::RowRange {
+            start: 4_000,
+            end: 4_500,
+        };
+        let token = ranged.encode(&key).expect("encodes");
+        let decoded = Cursor::redeem(
+            &token,
+            &key,
+            tenant,
+            SAMPLE_TOOL,
+            &SAMPLE_ARGS,
+            NOW_NS,
+            FAR_HORIZON_NS,
+        )
+        .expect("round-trips through its own codec");
+        assert_eq!(decoded, ranged);
+    }
+
+    /// The amendment changed what a cursor pins, so a token minted by the
+    /// previous version is not readable under the new layout: its version byte
+    /// is refused at the header, before any field is parsed. Reminted under
+    /// this process's key so the refusal is attributable to the version byte
+    /// rather than to the MAC.
+    #[test]
+    fn a_version_3_token_is_invalid() {
+        let tenant = TenantHash([0x5Fu8; 16]);
+        let key = test_key();
+        let token = sample_cursor(tenant).encode(&key).expect("encodes");
+
+        let mut bytes = token_bytes(&token);
+        assert_eq!(bytes[CURSOR_MAGIC.len()], CURSOR_VERSION);
+        bytes[CURSOR_MAGIC.len()] = 3;
+        let stale = remint(bytes, &key);
+
+        let err = Cursor::decode(&stale, &key).expect_err("must be refused");
+        assert_eq!(err, CursorError::Invalid);
     }
 
     /// A cursor is bound to the tool that minted it: handing a
@@ -1299,10 +1426,11 @@ mod tests {
         assert_eq!(err, CursorError::Invalid);
     }
 
-    /// The version byte is checked, so a token in the version 2 layout (a
-    /// whole-`SegmentPin` cursor without the process nonce) is `Invalid`
-    /// rather than parsed as if the nonce were tenant bytes. Re-MAC'd, so the
-    /// failure is the version check and not the MAC.
+    /// The version byte is checked against this build's own version, not for
+    /// being no newer than it: a token claiming a future layout is `Invalid`
+    /// rather than parsed with the fields this build happens to know.
+    /// Re-MAC'd, so the failure is the version check and not the MAC.
+    /// [`a_version_3_token_is_invalid`] covers the previous layout.
     #[test]
     fn wrong_version_token_is_cursor_invalid() {
         let tenant = TenantHash([0x4Du8; 16]);
@@ -1310,7 +1438,7 @@ mod tests {
         let token = sample_cursor(tenant).encode(&key).expect("encodes");
 
         let mut bytes = token_bytes(&token);
-        bytes[4] = CURSOR_VERSION - 1;
+        bytes[4] = CURSOR_VERSION + 1;
         let reminted = remint(bytes, &key);
 
         let err = Cursor::redeem(
@@ -1543,7 +1671,8 @@ mod tests {
     /// deadline 10 days out, redeemed against a 25h05m protection horizon,
     /// stops being redeemable 1h05m in: the horizon minus the 24 h grace a
     /// redemption may not spend. Without the re-clamp the cursor would still
-    /// be live 10 days later, pinning segments the sweeper is free to delete.
+    /// be live 10 days later, resolving against a watermark whose objects the
+    /// sweeper is free to delete.
     #[test]
     fn redeem_reclamps_the_deadline_to_the_protection_horizon() {
         let tenant = TenantHash([0xB7u8; 16]);

--- a/crates/ravel-mcp/src/envelope.rs
+++ b/crates/ravel-mcp/src/envelope.rs
@@ -92,8 +92,10 @@ const SCALAR_ALLOWANCE: usize = 4096;
 ///
 /// With its own bound nothing else can crowd it out, and the only way to
 /// exceed it is for this process to mint a cursor over its own limit, which
-/// is a server defect and is reported as an `internal` failure rather than
-/// papered over with a warning.
+/// is a server defect. On an otherwise-successful envelope that defect is the
+/// `internal` failure. On one that already carries a failure the class stays
+/// what it was, and the defect is reported as a counted drop plus a warning:
+/// see [`Envelope::fit`].
 ///
 /// Measured the same way the scalar allowance is: the serialized JSON size of
 /// the token string, not its source characters. Distinct from
@@ -445,7 +447,13 @@ pub struct Presentation {
     pub bytes_cap_hit: bool,
     pub rows_omitted: u64,
     pub cells_truncated: u64,
-    /// Metadata entries dropped because their list was over its count bound.
+    /// Metadata entries dropped because their list was over its count bound,
+    /// plus the cursor when it was dropped for being over [`CURSOR_BOUND`] on
+    /// an envelope that already carried a failure. Both are the same fact: a
+    /// field the response bounds would not carry is gone from it. The cursor
+    /// case cannot be reported as a failure class there without displacing the
+    /// one that says why the call failed, so this counter and a warning are
+    /// what make it observable.
     pub metadata_elided: u64,
     /// Metadata entries kept but cut because the entry was over its own
     /// per-entry serialized-size bound. Distinct from `metadata_elided`: a
@@ -1118,6 +1126,14 @@ impl Envelope {
     /// about this process instead of retrying or narrowing. The cursor is
     /// dropped either way, so no unturnable page goes out.
     ///
+    /// On that second path the defect is still reported, through the two
+    /// channels that displace nothing: `presentation.metadata_elided` counts
+    /// the dropped cursor, and a warning names it. A drop that wrote neither
+    /// would leave the one input this method treats as a defect invisible on
+    /// every envelope that already carries a failure, which is the reverse of
+    /// what the bound is for. The warning goes in at the front of `warnings`
+    /// so the bound on that list cannot be what drops it.
+    ///
     /// Scalars are capped after that check because the failure message it
     /// writes is one of the scalars the allowance covers.
     ///
@@ -1142,6 +1158,7 @@ impl Envelope {
     /// having to re-measure or re-cut anything.
     pub fn fit(mut self, requested_max_response_bytes: u64) -> Envelope {
         let cursor_len = self.cursor_serialized_len();
+        let mut cursor_dropped_over_bound = false;
         if cursor_len > CURSOR_BOUND {
             self.presentation.cursor = None;
             self.status = Status::Error;
@@ -1153,12 +1170,21 @@ impl Envelope {
                     ),
                     counter: None,
                 });
+            } else {
+                cursor_dropped_over_bound = true;
+                self.warnings.insert(
+                    0,
+                    format!(
+                        "cursor dropped: it serializes to {cursor_len} B, over its \
+                         {CURSOR_BOUND} B bound; this is a server defect"
+                    ),
+                );
             }
         }
 
         self.presentation.scalars_truncated = self.cap_scalars();
         let caps = self.cap_metadata_lists();
-        self.presentation.metadata_elided = caps.elided;
+        self.presentation.metadata_elided = caps.elided + u64::from(cursor_dropped_over_bound);
         self.presentation.entries_truncated = caps.entries_truncated;
 
         let effective_cap = requested_max_response_bytes.max(MAX_RESPONSE_BYTES_FLOOR);
@@ -2029,8 +2055,14 @@ mod tests {
     /// `internal` would tell the caller to file a bug about this process
     /// instead of narrowing the query that actually tripped, and the counter
     /// naming which budget tripped would be gone with it.
+    ///
+    /// Keeping that class is not licence to drop the cursor quietly. The
+    /// defect is still reported through the two channels that displace nothing:
+    /// `metadata_elided` counts the drop and a warning names it. Without them
+    /// this envelope would be indistinguishable from one that never had a
+    /// cursor, which is the state the bound exists to make visible.
     #[test]
-    fn an_over_bound_cursor_keeps_an_existing_failure_class() {
+    fn an_over_bound_cursor_on_a_failed_envelope_is_still_observable() {
         let cursor = "k".repeat(CURSOR_BOUND - 1);
         let mut envelope = Envelope::default();
         envelope.presentation.cursor = Some(cursor);
@@ -2055,6 +2087,23 @@ mod tests {
         assert_eq!(failure.counter.as_deref(), Some("bytes_scanned"));
         assert_eq!(fitted.status, Status::Error);
         assert_eq!(fitted.presentation.scalars_truncated, 0);
+
+        assert_eq!(
+            fitted.presentation.metadata_elided, 1,
+            "the dropped cursor is the one elided field"
+        );
+        assert_eq!(fitted.warnings.len(), 1);
+        assert_eq!(
+            fitted.warnings[0],
+            "cursor dropped: it serializes to 4097 B, over its 4096 B bound; \
+             this is a server defect"
+        );
+
+        // `finish` returns an error envelope untouched, so both channels are
+        // still there when the caller reads the result.
+        let finished = fitted.finish(true);
+        assert_eq!(finished.presentation.metadata_elided, 1);
+        assert_eq!(finished.warnings.len(), 1);
     }
 
     /// The last byte that is not over: a cursor serializing to exactly

--- a/crates/ravel-mcp/src/envelope.rs
+++ b/crates/ravel-mcp/src/envelope.rs
@@ -75,11 +75,32 @@ const EVIDENCE_ENTRY_BOUND: usize = 512;
 /// It covers every non-list, non-row payload a caller or the engine supplies:
 /// `plan`, `failure.message`, `failure.counter`, the three `budget` values,
 /// `accuracy.approximation`, both `ids` fields, both `visibility` strings,
-/// `scope.signal`, `scope.table`, both `scope.time_range` bounds, and
-/// `presentation.cursor`. The envelope's own bookkeeping (the booleans, the
-/// counters, the status word) is skeleton rather than payload and is covered
-/// by [`SKELETON_SLACK`] instead.
+/// `scope.signal`, `scope.table`, and both `scope.time_range` bounds. The
+/// envelope's own bookkeeping (the booleans, the counters, the status word)
+/// is skeleton rather than payload and is covered by [`SKELETON_SLACK`]
+/// instead. `presentation.cursor` has [`CURSOR_BOUND`] of its own.
 const SCALAR_ALLOWANCE: usize = 4096;
+
+/// The cursor's own bound, separate from [`SCALAR_ALLOWANCE`] (the 2026-09-09
+/// amendment to ADR-1374 D4).
+///
+/// Sharing the scalar allowance made the two compete: a caller's own `plan`
+/// text could push a cursor out of the envelope, and the only way to stay
+/// under the shared bound was to drop the cursor whole, since a MAC'd token
+/// cut to length is a corrupt token. Pagination then ended for a reason that
+/// had nothing to do with pagination.
+///
+/// With its own bound nothing else can crowd it out, and the only way to
+/// exceed it is for this process to mint a cursor over its own limit, which
+/// is a server defect and is reported as an `internal` failure rather than
+/// papered over with a warning.
+///
+/// Measured the same way the scalar allowance is: the serialized JSON size of
+/// the token string, not its source characters. Distinct from
+/// [`crate::cursor::MAX_TOKEN_BYTES`], which is the hostile-input cap the
+/// codec refuses to even look at a longer token past; this is what an
+/// envelope will carry.
+const CURSOR_BOUND: usize = 4096;
 
 /// The per-scalar sub-bounds. Every scalar with a natural size has one, so
 /// no single field can eat the whole allowance and no cut is needed on a
@@ -95,9 +116,8 @@ const APPROXIMATION_BOUND: usize = 256;
 const FAILURE_COUNTER_BOUND: usize = 128;
 
 /// What the sub-bounded scalars can occupy together. `presentation.cursor`
-/// has no entry here: D4 states no per-scalar bound for it, and a MAC'd
-/// token cannot be cut to one without corrupting it (see
-/// [`Envelope::cap_scalars`]).
+/// has no entry here: it is not one of the scalars this allowance covers, and
+/// has [`CURSOR_BOUND`] of its own.
 const FIXED_SCALAR_BOUNDS: usize = SIGNAL_BOUND
     + TABLE_BOUND
     + 2 * TIME_RANGE_BOUND
@@ -110,9 +130,7 @@ const FIXED_SCALAR_BOUNDS: usize = SIGNAL_BOUND
 
 /// The rest of the allowance, for the five scalars with no natural size:
 /// `plan`, `failure.message`, and the three `budget` values.
-/// [`Envelope::cap_scalars`] cuts them in that order. The cursor draws on
-/// this same remaining room too, but is dropped whole rather than cut, so it
-/// has no floor to assert against here the way these five do.
+/// [`Envelope::cap_scalars`] cuts them in that order.
 const VARIABLE_SCALAR_ALLOWANCE: usize = SCALAR_ALLOWANCE - FIXED_SCALAR_BOUNDS;
 
 /// Cutting the five variable scalars to their floor always lands the scalars
@@ -163,6 +181,7 @@ const LIST_ALLOWANCE: usize = MAX_PROJECTION_COLUMNS * (COLUMN_ENTRY_BOUND + 1)
 
 /// The largest fixed part -- the whole envelope but `data.rows` -- that can
 /// survive [`Envelope::cap_metadata_lists`] and [`Envelope::cap_scalars`],
+/// plus the [`CURSOR_BOUND`] the cursor holds outside the scalar allowance,
 /// plus the room [`Envelope::finish`] needs afterward for the
 /// [`IDENTITY_WARNINGS_ALLOWANCE`] it can still add. `finish` runs after
 /// `fit`, so a row-packed envelope that `fit` measured as exactly at its cap
@@ -174,6 +193,7 @@ const MAXIMAL_FIXED_PART: usize = EMPTY_ENVELOPE_SERIALIZED_LEN
     + SKELETON_SLACK
     + LIST_ALLOWANCE
     + SCALAR_ALLOWANCE
+    + CURSOR_BOUND
     + IDENTITY_WARNINGS_ALLOWANCE;
 
 /// What makes [`Envelope::fit`] total. `fit` floors its cap at
@@ -694,21 +714,6 @@ const TRUNCATION_MARKER: &str = "...[truncated]";
 /// value smaller than this.
 const MARKER_SERIALIZED_LEN: usize = TRUNCATION_MARKER.len() + 2;
 
-/// Inserted into `warnings` when [`Envelope::cap_scalars`] drops the cursor.
-/// Serializes to 81 B, far under [`WARNING_ENTRY_BOUND`] (512): it is
-/// inserted before [`Envelope::cap_metadata_lists`] runs, so
-/// [`bound_string_entries`] would still cut it like any other warning if
-/// this text ever grew past that bound.
-const CURSOR_DROPPED_WARNING: &str =
-    "cursor dropped: the pagination token did not fit the response; narrow the query";
-/// Inserted into `next_steps` alongside [`CURSOR_DROPPED_WARNING`]. The whole
-/// entry (both fields, keys, and braces) serializes to 130 B, far under
-/// [`NEXT_STEP_ENTRY_BOUND`] (512): [`bound_next_steps`] runs over it the
-/// same as [`CURSOR_DROPPED_WARNING`] above.
-const CURSOR_DROPPED_NEXT_STEP_ACTION: &str = "narrow the query";
-const CURSOR_DROPPED_NEXT_STEP_DETAIL: &str =
-    "the cursor did not fit the response; request a narrower time_range or fewer rows per page";
-
 /// The four identity fields D4 declares as strings, in the order
 /// [`Envelope::warn_unreported_identity`] warns about them.
 const IDENTITY_FIELDS: [&str; 4] = [
@@ -987,10 +992,16 @@ impl Envelope {
         if let Some(plan) = &self.plan {
             total += serialized_str_len(plan);
         }
-        if let Some(cursor) = &self.presentation.cursor {
-            total += serialized_str_len(cursor);
-        }
         total
+    }
+
+    /// Serialized size of `presentation.cursor`, which [`CURSOR_BOUND`] covers
+    /// on its own rather than through [`SCALAR_ALLOWANCE`].
+    fn cursor_serialized_len(&self) -> usize {
+        self.presentation
+            .cursor
+            .as_ref()
+            .map_or(0, |cursor| serialized_str_len(cursor))
     }
 
     /// Applies the D4 scalar bound, and returns how many scalars it cut.
@@ -1002,26 +1013,16 @@ impl Envelope {
     /// `budget` values -- each by the current overshoot and none below the
     /// truncation marker.
     ///
-    /// The cursor is the exception to cutting: it is a MAC'd token, so a cut
-    /// one is not a shorter cursor but a corrupt one that redeems as invalid.
-    /// It draws on the same allowance as every other scalar, but is never
-    /// itself cut, and D4 states no per-scalar bound for it either. So it is
-    /// left alone through both of the stages above, and only dropped whole,
-    /// as the last resort, if the scalars are still over the allowance once
-    /// those cuts are done. A dropped cursor is announced: the caller sees a
-    /// warning and a `next_steps` entry naming the fix, and `finish` reports
-    /// `ok_bounded` rather than a page it cannot turn. The announcement is
-    /// inserted at index 0 of both lists, not appended, because [`fit`] runs
-    /// this method before [`Envelope::cap_metadata_lists`]: a caller already
-    /// at the D4 count bound for either list still gets the announcement as
-    /// the kept-first entry, and the list's own last entry is what the count
-    /// cap displaces into `metadata_elided` instead.
-    ///
-    /// [`fit`]: Envelope::fit
+    /// `presentation.cursor` is not one of them. It has [`CURSOR_BOUND`] of
+    /// its own, so nothing a caller supplies can crowd it out and nothing
+    /// here touches it: a MAC'd token cut to length is not a shorter cursor
+    /// but a corrupt one, and a token over its own bound is a defect in the
+    /// process that minted it rather than something to negotiate away against
+    /// a caller's `plan` text (see [`Envelope::fit`]).
     ///
     /// The last stage cannot leave the scalars over the allowance: with every
-    /// variable scalar at the marker and the cursor dropped, the total is at
-    /// most `FIXED_SCALAR_BOUNDS + 5 * MARKER_SERIALIZED_LEN`, which the const
+    /// variable scalar at the marker the total is at most
+    /// `FIXED_SCALAR_BOUNDS + 5 * MARKER_SERIALIZED_LEN`, which the const
     /// assertion beside [`VARIABLE_SCALAR_ALLOWANCE`] holds under the bound.
     fn cap_scalars(&mut self) -> u64 {
         let mut cut = 0u64;
@@ -1084,29 +1085,6 @@ impl Envelope {
                 cut += 1;
             }
         }
-
-        // The last resort: the cuts above could not bring the scalars inside
-        // the allowance, so the cursor -- a MAC'd token that cannot be cut --
-        // is dropped whole. Announced, not silent: a caller polling only
-        // `scalars_truncated` would otherwise see a page it cannot turn with
-        // no indication why the cursor it expected is missing.
-        if self.presentation.cursor.is_some() && self.scalar_serialized_len() > SCALAR_ALLOWANCE {
-            self.presentation.cursor = None;
-            // Inserted at index 0, not pushed: see the doc comment above.
-            // `cap_metadata_lists`, which runs after this method returns,
-            // keeps the first `MAX_WARNINGS`/`MAX_NEXT_STEPS` entries of
-            // each list, so index 0 is the one position guaranteed to
-            // survive that cap regardless of how full the list already is.
-            self.warnings.insert(0, CURSOR_DROPPED_WARNING.to_string());
-            self.next_steps.insert(
-                0,
-                NextStep {
-                    action: CURSOR_DROPPED_NEXT_STEP_ACTION.to_string(),
-                    detail: CURSOR_DROPPED_NEXT_STEP_DETAIL.to_string(),
-                },
-            );
-            cut += 1;
-        }
         cut
     }
 
@@ -1118,12 +1096,17 @@ impl Envelope {
     /// of dropping it, so `data.rows` is never empty while `rows_omitted` is
     /// positive and a retained row always fits.
     ///
-    /// Scalars are capped first because [`Envelope::cap_scalars`] can insert
-    /// into `warnings` and `next_steps` (a dropped-cursor announcement), and
-    /// those lists need to go through the count and per-entry bounds
-    /// afterward like any other entry -- capping metadata first would let an
-    /// announcement inserted later push a list that was already at its D4
-    /// count bound over it.
+    /// A cursor over [`CURSOR_BOUND`] is checked before any of that, and is
+    /// the one input this method answers with a failure rather than a cut.
+    /// The bound is the cursor's own, so nothing a caller asked for can push
+    /// a token past it: only this process minting one over its own limit can,
+    /// which is a defect, and an `internal` failure is what says so. Cutting
+    /// a MAC'd token is not an option (a cut cursor redeems as invalid), and
+    /// dropping it silently would return a page the caller cannot turn while
+    /// reporting nothing wrong.
+    ///
+    /// Scalars are capped after that check because the failure message it
+    /// writes is one of the scalars the allowance covers.
     ///
     /// The one case that overrides the first-row guarantee is a row nothing
     /// can shorten enough: a row of cells that are all at their own type's
@@ -1145,6 +1128,19 @@ impl Envelope {
     /// envelope `finish` returns inside the cap it reports, without `finish`
     /// having to re-measure or re-cut anything.
     pub fn fit(mut self, requested_max_response_bytes: u64) -> Envelope {
+        let cursor_len = self.cursor_serialized_len();
+        if cursor_len > CURSOR_BOUND {
+            self.presentation.cursor = None;
+            self.status = Status::Error;
+            self.failure = Some(Failure {
+                class: FailureClass::Internal,
+                message: format!(
+                    "cursor serializes to {cursor_len} B, over its {CURSOR_BOUND} B bound"
+                ),
+                counter: None,
+            });
+        }
+
         self.presentation.scalars_truncated = self.cap_scalars();
         let caps = self.cap_metadata_lists();
         self.presentation.metadata_elided = caps.elided;
@@ -1572,14 +1568,15 @@ mod tests {
     const HEX_ID_PAGE_SERIALIZED_LEN: usize = 14_690;
 
     /// Serialized size of a zero-row envelope with every metadata field at
-    /// both its D4 bounds and every scalar filling the D4 scalar allowance:
-    /// the largest fixed part the bounds permit. The ADR requires this to be
-    /// under 106,496 B, which is what leaves a retained row its 152 KiB under
-    /// the 256 KiB floor.
-    const MAXIMAL_METADATA_ENVELOPE_LEN: usize = 105_806;
+    /// both its D4 bounds, every scalar filling the D4 scalar allowance, and
+    /// the cursor at the [`CURSOR_BOUND`] it now holds on its own: the largest
+    /// fixed part the bounds permit. It must stay under 110,592 B, the earlier
+    /// 106,496 B plus the cursor's own 4 KiB, which is what leaves a retained
+    /// row its 148 KiB under the 256 KiB floor.
+    const MAXIMAL_METADATA_ENVELOPE_LEN: usize = 109_902;
     const _: () = assert!(
-        MAXIMAL_METADATA_ENVELOPE_LEN < 106_496,
-        "ADR-1374 D4 requires the maximal fixed part under 106,496 B"
+        MAXIMAL_METADATA_ENVELOPE_LEN < 110_592,
+        "ADR-1374 D4 requires the maximal fixed part under 110,592 B"
     );
 
     fn cell_len(envelope: &Envelope) -> usize {
@@ -1835,18 +1832,11 @@ mod tests {
     /// The D4 scalar allowance, over the fields that have no natural size.
     ///
     /// Every scalar with a natural size is cut to its own sub-bound first
-    /// (nine of the ten checked). The still-uncut cursor counts its full
-    /// size against the allowance through the rest of this pass, so the
-    /// overshoot the plan and the failure message are each cut by is larger
-    /// than it would be with the cursor already gone: a 1 MiB `plan` is cut
-    /// all the way to the marker, and so -- unlike a plan-only overshoot --
-    /// is the failure message next to it. `budget.effective` is then still
-    /// over and is replaced by the marker too; `budget.actual` (`null`) and
-    /// `budget.estimate` (`7`) are already far under the marker floor and
-    /// are left alone. Only once all of that is done, and the scalars are
-    /// still over the allowance, is the cursor itself dropped -- announced
-    /// with a warning and a `next_steps` entry -- which is why the fitted
-    /// total lands under [`SCALAR_ALLOWANCE`] rather than exactly on it.
+    /// (nine of the ten checked). A 1 MiB `plan` is then cut by the whole
+    /// remaining overshoot, which lands it on the truncation marker, and the
+    /// failure message beside it absorbs what is still over. The cursor takes
+    /// no part in any of it: it has its own bound and is not one of the
+    /// scalars this allowance covers.
     #[test]
     fn oversized_plan_is_cut_to_the_scalar_allowance() {
         let mut envelope = Envelope {
@@ -1869,32 +1859,31 @@ mod tests {
         envelope.visibility.snapshot_id = "v".repeat(4096);
         envelope.visibility.watermark_hour = "2026090800".to_string();
         envelope.accuracy.approximation = Some("x".repeat(4096));
-        envelope.presentation.cursor = Some("k".repeat(4096));
+        envelope.presentation.cursor = Some("k".repeat(3 * 1024));
         envelope.budget.effective = AnyJson(Value::String("b".repeat(1000)));
         envelope.budget.estimate = AnyJson(Value::Number(7.into()));
 
         let fitted = envelope.fit(MAX_RESPONSE_BYTES_FLOOR);
 
-        // Nine scalars cut to their own sub-bound, the plan and the failure
-        // message both cut all the way to the marker, `budget.effective`
-        // replaced by the marker, and the cursor dropped last because the
-        // scalars were still over the allowance once those four were done.
-        assert_eq!(fitted.presentation.scalars_truncated, 13);
-        assert_eq!(fitted.scalar_serialized_len(), 1_089);
-        assert!(fitted.scalar_serialized_len() <= SCALAR_ALLOWANCE);
+        // Nine scalars cut to their own sub-bound, the plan cut to the
+        // marker, and the failure message cut to what is left of the
+        // allowance. The cursor is untouched and uncounted.
+        assert_eq!(fitted.presentation.scalars_truncated, 11);
+        assert_eq!(fitted.scalar_serialized_len(), SCALAR_ALLOWANCE);
 
         assert_eq!(fitted.plan.as_deref(), Some(TRUNCATION_MARKER));
-        assert_eq!(fitted.presentation.cursor, None);
-        assert_eq!(fitted.warnings, vec![CURSOR_DROPPED_WARNING.to_string()]);
-        assert_eq!(fitted.next_steps.len(), 1);
-        assert_eq!(fitted.next_steps[0].action, CURSOR_DROPPED_NEXT_STEP_ACTION);
-        assert_eq!(fitted.next_steps[0].detail, CURSOR_DROPPED_NEXT_STEP_DETAIL);
+        assert_eq!(
+            fitted.presentation.cursor.as_deref(),
+            Some("k".repeat(3 * 1024).as_str())
+        );
+        assert!(fitted.warnings.is_empty());
+        assert!(fitted.next_steps.is_empty());
         let failure = fitted.failure.as_ref().expect("the failure is kept");
-        // Cut all the way to the marker: the overshoot computed while the
-        // cursor still counted its full 4,098 B against the allowance left
-        // nothing of the message's own text to keep.
-        assert_eq!(failure.message, TRUNCATION_MARKER);
-        assert_eq!(serialized_str_len(&failure.message), MARKER_SERIALIZED_LEN);
+        // Cut, but not to the marker: with the cursor no longer counted
+        // against the allowance there is room left for the message's own
+        // text once the plan is at its floor.
+        assert!(failure.message.ends_with(TRUNCATION_MARKER));
+        assert_eq!(serialized_str_len(&failure.message), 2_037);
         assert_eq!(
             serialized_str_len(failure.counter.as_deref().expect("a counter")),
             FAILURE_COUNTER_BOUND
@@ -1922,28 +1911,48 @@ mod tests {
         );
         // Already inside their bounds, so untouched by the cut.
         assert_eq!(fitted.visibility.watermark_hour, "2026090800");
-        // Over the allowance once the cursor's full size is counted in, so
-        // replaced by the marker even though it fit the allowance on its own.
+        // The stage before it brought the scalars inside the allowance, so
+        // the budget values are never reached.
         assert_eq!(
             fitted.budget.effective,
-            AnyJson(Value::String(TRUNCATION_MARKER.to_string()))
+            AnyJson(Value::String("b".repeat(1000)))
         );
         assert_eq!(fitted.budget.estimate, AnyJson(Value::Number(7.into())));
     }
 
-    /// A cursor well under the allowance is left alone by every stage of
-    /// `cap_scalars`, and survives `finish` as a real page token.
+    /// The cursor's bound is its own, so a caller's own scalars cannot crowd
+    /// it out: a 3 KiB cursor next to a `plan` large enough to fill the whole
+    /// scalar allowance survives untouched, the plan absorbs the entire
+    /// overshoot, and the page finishes as `ok_page`.
     #[test]
-    fn cursor_under_the_allowance_survives_fit() {
+    fn a_cursor_within_its_bound_survives_a_full_scalar_allowance() {
         let cursor = "k".repeat(3 * 1024);
-        let mut envelope = Envelope::default();
+        let mut envelope = Envelope {
+            plan: Some("p".repeat(8 * 1024)),
+            ..Default::default()
+        };
         envelope.presentation.cursor = Some(cursor.clone());
         envelope.presentation.row_cap_hit = true;
 
         let fitted = envelope.fit(MAX_RESPONSE_BYTES_FLOOR);
 
-        assert_eq!(fitted.presentation.scalars_truncated, 0);
+        assert_eq!(
+            fitted.presentation.scalars_truncated, 1,
+            "the plan alone was cut"
+        );
+        let plan = fitted.plan.as_deref().expect("the plan is kept");
+        assert!(plan.ends_with(TRUNCATION_MARKER));
+        // The whole allowance less the other scalars of a default envelope.
+        // A cursor counted against the allowance would take 3,074 B off this.
+        assert_eq!(serialized_str_len(plan), 4_072);
+        assert_eq!(
+            fitted.scalar_serialized_len(),
+            SCALAR_ALLOWANCE,
+            "the scalars sit exactly on their allowance"
+        );
         assert_eq!(fitted.presentation.cursor.as_deref(), Some(cursor.as_str()));
+        assert_eq!(fitted.cursor_serialized_len(), 3 * 1024 + 2);
+        assert!(fitted.failure.is_none());
         assert!(fitted.warnings.is_empty());
         assert!(fitted.next_steps.is_empty());
 
@@ -1955,137 +1964,61 @@ mod tests {
         );
     }
 
-    /// The cursor draws on the same allowance `plan` does, but is cut last:
-    /// with a 3 KiB cursor and a 4 KiB plan together over the allowance, the
-    /// plan absorbs the whole overshoot and the cursor -- which alone would
-    /// already fit -- is never touched.
+    /// A cursor over its own bound is not something a caller asked for and
+    /// not something a cut can fix: only this process minting a token past
+    /// its own limit produces one, so it is an `internal` failure. The cursor
+    /// is dropped (a corrupt or over-bound token is worse than none) and the
+    /// envelope finishes as an error rather than as a page.
+    ///
+    /// One byte over is enough: the check is on the bound, not on a margin.
     #[test]
-    fn cursor_is_dropped_only_after_the_other_scalars_are_cut() {
-        let cursor = "k".repeat(3 * 1024);
-        let mut envelope = Envelope {
-            plan: Some("p".repeat(4 * 1024)),
-            ..Default::default()
-        };
-        envelope.presentation.cursor = Some(cursor.clone());
-
-        let fitted = envelope.fit(MAX_RESPONSE_BYTES_FLOOR);
-
-        assert_eq!(
-            fitted.presentation.scalars_truncated, 1,
-            "the plan alone was cut"
-        );
-        assert!(
-            fitted
-                .plan
-                .as_deref()
-                .expect("the plan is kept")
-                .ends_with(TRUNCATION_MARKER)
-        );
-        assert_eq!(fitted.presentation.cursor.as_deref(), Some(cursor.as_str()));
-        assert!(fitted.warnings.is_empty(), "no cursor was dropped");
-        assert!(fitted.next_steps.is_empty());
-        assert_eq!(fitted.scalar_serialized_len(), SCALAR_ALLOWANCE);
-    }
-
-    /// A cursor that still does not fit once every other scalar is at its
-    /// floor is dropped whole, never cut, and the drop is announced: exactly
-    /// one warning and one `next_steps` entry, and the caller sees
-    /// `ok_bounded` rather than a page it cannot turn.
-    #[test]
-    fn dropped_cursor_is_announced() {
+    fn an_over_bound_cursor_is_an_internal_failure() {
+        // Two of the serialized bytes are the JSON quotes, so this is exactly
+        // one byte over CURSOR_BOUND.
+        let cursor = "k".repeat(CURSOR_BOUND - 1);
         let mut envelope = Envelope::default();
-        envelope.presentation.cursor = Some("k".repeat(5 * 1024));
+        envelope.presentation.cursor = Some(cursor);
         envelope.presentation.row_cap_hit = true;
 
         let fitted = envelope.fit(MAX_RESPONSE_BYTES_FLOOR);
 
-        assert_eq!(fitted.presentation.scalars_truncated, 1);
         assert_eq!(fitted.presentation.cursor, None);
-        assert_eq!(fitted.warnings, vec![CURSOR_DROPPED_WARNING.to_string()]);
-        assert_eq!(fitted.next_steps.len(), 1);
-        assert_eq!(fitted.next_steps[0].action, CURSOR_DROPPED_NEXT_STEP_ACTION);
-        assert_eq!(fitted.next_steps[0].detail, CURSOR_DROPPED_NEXT_STEP_DETAIL);
+        assert_eq!(fitted.cursor_serialized_len(), 0);
+        let failure = fitted.failure.as_ref().expect("an internal failure");
+        assert_eq!(failure.class, FailureClass::Internal);
+        assert_eq!(
+            failure.message,
+            "cursor serializes to 4097 B, over its 4096 B bound"
+        );
+        assert_eq!(failure.counter, None);
+        assert!(
+            fitted.warnings.is_empty(),
+            "an over-bound cursor is a failure, not a warning"
+        );
+        assert!(fitted.next_steps.is_empty());
 
         let finished = fitted.finish(true);
-        assert_eq!(finished.status, Status::OkBounded);
+        assert_eq!(finished.status, Status::Error);
+        assert_eq!(finished.presentation.cursor, None);
     }
 
-    /// The announcement text stays comfortably under the D4 per-entry
-    /// bounds today, but is placed in the same `bound_string_entries`/
-    /// `bound_next_steps` path as any other list entry: pinning the exact
-    /// serialized sizes here means growing either string past its bound
-    /// shows up as a change here rather than as a silently-over-bound
-    /// announcement in production.
+    /// The last byte that is not over: a cursor serializing to exactly
+    /// [`CURSOR_BOUND`] is carried, so the refusal above is attributable to
+    /// the bound rather than to being merely large.
     #[test]
-    fn cursor_dropped_announcement_text_is_under_its_entry_bounds() {
-        assert_eq!(serialized_str_len(CURSOR_DROPPED_WARNING), 81);
-        assert!(serialized_str_len(CURSOR_DROPPED_WARNING) <= WARNING_ENTRY_BOUND);
-
-        let step = NextStep {
-            action: CURSOR_DROPPED_NEXT_STEP_ACTION.to_string(),
-            detail: CURSOR_DROPPED_NEXT_STEP_DETAIL.to_string(),
-        };
-        assert_eq!(entry_serialized_len(&step), 130);
-        assert!(entry_serialized_len(&step) <= NEXT_STEP_ENTRY_BOUND);
-    }
-
-    /// `cap_scalars` runs before `cap_metadata_lists` in `fit`, and inserts
-    /// the cursor announcement at index 0 of `warnings` and `next_steps`.
-    /// With both lists already at their D4 count bound, the announcement
-    /// still lands as the kept-first entry: the count cap runs afterward and
-    /// displaces the list's own last entry into `metadata_elided` instead of
-    /// leaving the list one entry over its bound.
-    #[test]
-    fn dropped_cursor_announcement_respects_the_list_bounds() {
-        let full_warnings =
-            || -> Vec<String> { (0..MAX_WARNINGS).map(|i| format!("warning {i}")).collect() };
-        let full_next_steps = || -> Vec<NextStep> {
-            (0..MAX_NEXT_STEPS)
-                .map(|i| NextStep {
-                    action: format!("action {i}"),
-                    detail: format!("detail {i}"),
-                })
-                .collect()
-        };
-
-        let baseline = Envelope {
-            warnings: full_warnings(),
-            next_steps: full_next_steps(),
-            ..Default::default()
-        }
-        .fit(MAX_RESPONSE_BYTES_FLOOR);
-        assert_eq!(
-            baseline.presentation.metadata_elided, 0,
-            "both lists are already exactly at their count bound, not over it"
-        );
-
-        let mut envelope = Envelope {
-            warnings: full_warnings(),
-            next_steps: full_next_steps(),
-            ..Default::default()
-        };
-        envelope.presentation.cursor = Some("k".repeat(5 * 1024));
+    fn a_cursor_exactly_at_its_bound_is_carried() {
+        let cursor = "k".repeat(CURSOR_BOUND - 2);
+        let mut envelope = Envelope::default();
+        envelope.presentation.cursor = Some(cursor.clone());
+        envelope.presentation.row_cap_hit = true;
 
         let fitted = envelope.fit(MAX_RESPONSE_BYTES_FLOOR);
 
-        assert_eq!(fitted.presentation.scalars_truncated, 1);
-        assert_eq!(fitted.presentation.cursor, None);
-        assert_eq!(fitted.warnings.len(), MAX_WARNINGS);
-        assert_eq!(fitted.warnings[0], CURSOR_DROPPED_WARNING);
-        assert_eq!(fitted.next_steps.len(), MAX_NEXT_STEPS);
-        assert_eq!(fitted.next_steps[0].action, CURSOR_DROPPED_NEXT_STEP_ACTION);
-        assert_eq!(fitted.next_steps[0].detail, CURSOR_DROPPED_NEXT_STEP_DETAIL);
-        assert_eq!(
-            fitted.presentation.metadata_elided,
-            baseline.presentation.metadata_elided + 2,
-            "the announcement displaces one warning and one next_step past the count bound"
-        );
-
-        let size = serialized_len(&fitted);
-        assert!(
-            size <= MAX_RESPONSE_BYTES_FLOOR as usize,
-            "serialized size {size} exceeds cap"
-        );
+        assert_eq!(fitted.cursor_serialized_len(), CURSOR_BOUND);
+        assert_eq!(fitted.presentation.cursor.as_deref(), Some(cursor.as_str()));
+        assert!(fitted.failure.is_none());
+        assert_eq!(fitted.presentation.scalars_truncated, 0);
+        assert_eq!(fitted.finish(true).status, Status::OkPage);
     }
 
     /// The last stage of the scalar cut: three budget values that are over
@@ -2112,10 +2045,10 @@ mod tests {
     }
 
     /// Zero rows, every metadata list at its count bound, every entry at its
-    /// per-entry bound, and every scalar filling the D4 scalar allowance
-    /// exactly: the fixed part alone must serialize to exactly
-    /// [`MAXIMAL_METADATA_ENVELOPE_LEN`], which the ADR requires to be under
-    /// 106,496 B.
+    /// per-entry bound, every scalar filling the D4 scalar allowance exactly,
+    /// and the cursor at [`CURSOR_BOUND`]: the fixed part alone must serialize
+    /// to exactly [`MAXIMAL_METADATA_ENVELOPE_LEN`], which must stay under
+    /// 110,592 B.
     ///
     /// Each entry below is sized to land on its bound exactly, so the
     /// envelope this builds is the largest one the D4 bounds permit, and
@@ -2167,12 +2100,9 @@ mod tests {
         envelope.accuracy.exact = true;
         envelope.accuracy.approximation = Some("x".repeat(APPROXIMATION_BOUND - 2));
         envelope.presentation.max_rows = 200;
-        // The cursor has no sub-bound of its own; it is sized here so the
-        // whole scalar block lands on exactly SCALAR_ALLOWANCE (4096) once
-        // the other scalars below (1,056 B of sub-bounded fields plus the
-        // 992 B the plan, failure message, and budget values below occupy)
-        // are added in: 4096 - 1056 - 992 - 2 (quotes) = 2046 source bytes.
-        envelope.presentation.cursor = Some("k".repeat(2046));
+        // The cursor is at CURSOR_BOUND, which it occupies on its own rather
+        // than out of the scalar allowance.
+        envelope.presentation.cursor = Some("k".repeat(CURSOR_BOUND - 2));
         // The longest failure class, so the block's own keys and value are at
         // their widest too.
         envelope.failure = Some(Failure {
@@ -2180,7 +2110,9 @@ mod tests {
             message: "m".repeat(298),
             counter: Some("c".repeat(FAILURE_COUNTER_BOUND - 2)),
         });
-        envelope.plan = Some("p".repeat(498));
+        // The plan takes up the slack the cursor left when it moved out of the
+        // scalar allowance, so the scalars still land on it exactly.
+        envelope.plan = Some("p".repeat(2546));
         envelope.budget.effective = AnyJson(Value::String("b".repeat(62)));
         envelope.budget.actual = AnyJson(Value::String("a".repeat(62)));
         envelope.budget.estimate = AnyJson(Value::String("e".repeat(62)));
@@ -2237,6 +2169,11 @@ mod tests {
             SCALAR_ALLOWANCE,
             "the scalars fill the allowance exactly"
         );
+        assert_eq!(
+            envelope.cursor_serialized_len(),
+            CURSOR_BOUND,
+            "the cursor fills its own bound exactly"
+        );
 
         let caps = envelope.cap_metadata_lists();
         assert_eq!(
@@ -2272,9 +2209,9 @@ mod tests {
         );
         let plan = envelope.plan.as_deref().expect("the plan is kept");
         assert!(plan.ends_with(TRUNCATION_MARKER));
-        assert_eq!(serialized_str_len(plan), 500);
+        assert_eq!(serialized_str_len(plan), 2_548);
         // The plan is cut by exactly the overshoot, so it lands back on the
-        // 500 B it occupied before: neither the 10 MiB warning nor the 1 MiB
+        // 2,548 B it occupied before: neither the 10 MiB warning nor the 1 MiB
         // plan moves the figure at all.
         assert_eq!(serialized_len(&envelope), MAXIMAL_METADATA_ENVELOPE_LEN);
     }

--- a/crates/ravel-mcp/src/envelope.rs
+++ b/crates/ravel-mcp/src/envelope.rs
@@ -1111,7 +1111,12 @@ impl Envelope {
     /// which is a defect, and an `internal` failure is what says so. Cutting
     /// a MAC'd token is not an option (a cut cursor redeems as invalid), and
     /// dropping it silently would return a page the caller cannot turn while
-    /// reporting nothing wrong.
+    /// reporting nothing wrong. It only writes that failure when the envelope
+    /// carries none already: an envelope that arrives here reporting a
+    /// `budget_exceeded` or an `unavailable` is reporting why the call failed,
+    /// and replacing that with `internal` would tell the caller to file a bug
+    /// about this process instead of retrying or narrowing. The cursor is
+    /// dropped either way, so no unturnable page goes out.
     ///
     /// Scalars are capped after that check because the failure message it
     /// writes is one of the scalars the allowance covers.
@@ -1140,13 +1145,15 @@ impl Envelope {
         if cursor_len > CURSOR_BOUND {
             self.presentation.cursor = None;
             self.status = Status::Error;
-            self.failure = Some(Failure {
-                class: FailureClass::Internal,
-                message: format!(
-                    "cursor serializes to {cursor_len} B, over its {CURSOR_BOUND} B bound"
-                ),
-                counter: None,
-            });
+            if self.failure.is_none() {
+                self.failure = Some(Failure {
+                    class: FailureClass::Internal,
+                    message: format!(
+                        "cursor serializes to {cursor_len} B, over its {CURSOR_BOUND} B bound"
+                    ),
+                    counter: None,
+                });
+            }
         }
 
         self.presentation.scalars_truncated = self.cap_scalars();
@@ -2014,6 +2021,40 @@ mod tests {
         let finished = fitted.finish(true);
         assert_eq!(finished.status, Status::Error);
         assert_eq!(finished.presentation.cursor, None);
+    }
+
+    /// The same over-bound cursor on an envelope that is already reporting a
+    /// failure. The cursor is still dropped, but the existing failure's class,
+    /// message, and counter survive: a `budget_exceeded` that turned into an
+    /// `internal` would tell the caller to file a bug about this process
+    /// instead of narrowing the query that actually tripped, and the counter
+    /// naming which budget tripped would be gone with it.
+    #[test]
+    fn an_over_bound_cursor_keeps_an_existing_failure_class() {
+        let cursor = "k".repeat(CURSOR_BOUND - 1);
+        let mut envelope = Envelope::default();
+        envelope.presentation.cursor = Some(cursor);
+        envelope.presentation.row_cap_hit = true;
+        envelope.status = Status::Error;
+        envelope.failure = Some(Failure {
+            class: FailureClass::BudgetExceeded,
+            message: "scanned 4 GiB, over the 1 GiB max_bytes_scanned".to_string(),
+            counter: Some("bytes_scanned".to_string()),
+        });
+
+        let fitted = envelope.fit(MAX_RESPONSE_BYTES_FLOOR);
+
+        assert_eq!(fitted.presentation.cursor, None);
+        assert_eq!(fitted.cursor_serialized_len(), 0);
+        let failure = fitted.failure.as_ref().expect("the original failure");
+        assert_eq!(failure.class, FailureClass::BudgetExceeded);
+        assert_eq!(
+            failure.message,
+            "scanned 4 GiB, over the 1 GiB max_bytes_scanned"
+        );
+        assert_eq!(failure.counter.as_deref(), Some("bytes_scanned"));
+        assert_eq!(fitted.status, Status::Error);
+        assert_eq!(fitted.presentation.scalars_truncated, 0);
     }
 
     /// The last byte that is not over: a cursor serializing to exactly

--- a/crates/ravel-mcp/src/envelope.rs
+++ b/crates/ravel-mcp/src/envelope.rs
@@ -275,7 +275,13 @@ impl HexId {
 pub enum Cell {
     Null,
     Bool(bool),
-    Int(i64),
+    /// A carrier wide enough for the union of the signed and unsigned 64-bit
+    /// ranges, not a general 128-bit integer: every value that reaches it
+    /// came from an `i64` or a `u64`, so it lies in
+    /// `i64::MIN..=u64::MAX`. The width exists so a `u64` above
+    /// `i64::MAX` stays an integer instead of being widened to a float or
+    /// carried as a string.
+    Int(i128),
     Timestamp(i64),
     Float(f64),
     HexId(HexId),
@@ -2224,7 +2230,10 @@ mod tests {
         prop_oneof![
             Just(Cell::Null),
             any::<bool>().prop_map(Cell::Bool),
-            any::<i64>().prop_map(Cell::Int),
+            // Both halves of the carrier's range, since a u64 above i64::MAX
+            // is the case that made it wider than an i64.
+            any::<i64>().prop_map(|n| Cell::Int(i128::from(n))),
+            any::<u64>().prop_map(|n| Cell::Int(i128::from(n))),
             any::<i64>().prop_map(Cell::Timestamp),
             any::<f64>().prop_map(Cell::Float),
             (0usize..=MAX_HEX_ID_LEN)
@@ -2262,7 +2271,7 @@ mod tests {
             requested_cap in 0u64..(400 * 1024),
         ) {
             let mut row: Row = cells;
-            row.extend((0..uncuttable).map(|i| Cell::Int(i as i64 * 1_000_000_009)));
+            row.extend((0..uncuttable).map(|i| Cell::Int(i as i128 * 1_000_000_009)));
             let mut envelope = Envelope::default();
             envelope.data.columns = (0..row.len().min(MAX_PROJECTION_COLUMNS))
                 .map(|i| Column {
@@ -2325,22 +2334,67 @@ mod tests {
     /// 2^53 + 1 does not round-trip through `f64`; the wire form must be a
     /// JSON string so the exact integer survives. A nanosecond timestamp is
     /// the same rule applied to the same representation.
+    ///
+    /// Every digit string is asserted literally. Parsing the cell back into
+    /// an integer and comparing would agree with any serialization the same
+    /// parser accepts, including one that dropped or added a digit the
+    /// parser then re-derived, and it cannot check a value the parser's own
+    /// type has no room for.
     #[test]
     fn integers_and_timestamps_serialize_as_strings() {
-        let big_int: i64 = (1i64 << 53) + 1;
-        let ts_ns: i64 = 1_700_000_000_123_456_789;
-        let row = vec![Cell::Int(big_int), Cell::Timestamp(ts_ns)];
+        let row = vec![
+            Cell::Int(i128::from((1u64 << 53) + 1)),
+            Cell::Timestamp(1_700_000_000_123_456_789),
+            // Both ends of the carrier's range, and the first value above
+            // i64::MAX, which is what a u64 column can reach.
+            Cell::Int(i128::from(u64::MAX)),
+            Cell::Int(i128::from(i64::MAX as u64 + 1)),
+            Cell::Int(i128::from(i64::MIN)),
+            // A small integer travels the identical path, so the string form
+            // is the rule for every magnitude and not a large-value escape.
+            Cell::Int(1),
+        ];
 
         let value = serde_json::to_value(&row).expect("row serializes");
         let cells = value.as_array().expect("row is a JSON array");
+        let text: Vec<&str> = cells
+            .iter()
+            .map(|cell| cell.as_str().expect("every cell must be a JSON string"))
+            .collect();
 
-        let int_cell = cells[0].as_str().expect("int cell must be a JSON string");
-        assert_eq!(int_cell.parse::<i64>().expect("round-trips"), big_int);
+        assert_eq!(
+            text,
+            vec![
+                "9007199254740993",
+                "1700000000123456789",
+                "18446744073709551615",
+                "9223372036854775808",
+                "-9223372036854775808",
+                "1",
+            ]
+        );
+    }
 
-        let ts_cell = cells[1]
-            .as_str()
-            .expect("timestamp cell must be a JSON string");
-        assert_eq!(ts_cell.parse::<i64>().expect("round-trips"), ts_ns);
+    /// The widest integer the carrier holds is still a number, so `fit` never
+    /// cuts it, however small the per-cell budget gets. A string cell of the
+    /// same serialized size under the same budget is cut, which is what makes
+    /// this a claim about the variant rather than about the size.
+    #[test]
+    fn an_oversized_integer_cell_is_never_shortened() {
+        let widest = i128::from(u64::MAX);
+        let equally_long = "1".repeat(u64::MAX.to_string().len());
+        assert_eq!(
+            serialized_str_len(&widest.to_string()),
+            serialized_str_len(&equally_long)
+        );
+        let mut row = vec![Cell::Int(widest), Cell::Str(equally_long)];
+
+        // One byte under the 22 B both cells serialize to.
+        let truncated = shorten_row(&mut row, 21);
+
+        assert_eq!(truncated, 1, "the string alone was cut");
+        assert_eq!(row[0], Cell::Int(widest));
+        assert_eq!(row[1], Cell::Str(format!("11111{TRUNCATION_MARKER}")));
     }
 
     /// JSON has no NaN or infinity, so the three non-finite floats travel
@@ -2394,7 +2448,7 @@ mod tests {
         assert_eq!(finished.status, Status::Ok);
         assert_eq!(finished.presentation.cursor, None);
 
-        let mut envelope = envelope_with_rows(3, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(3, |i| vec![Cell::Int(i as i128)]);
         envelope.presentation.max_rows = 200;
         let finished = envelope.finish(true);
         assert_eq!(finished.status, Status::Ok);
@@ -2406,13 +2460,13 @@ mod tests {
     /// came back and nothing points at them.
     #[test]
     fn finish_is_ok_bounded_when_a_cap_stopped_the_result_without_a_cursor() {
-        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i128)]);
         envelope.presentation.row_cap_hit = true;
         let finished = envelope.finish(false);
         assert_eq!(finished.status, Status::OkBounded);
         assert_eq!(finished.presentation.cursor, None);
 
-        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i128)]);
         envelope.presentation.bytes_cap_hit = true;
         envelope.presentation.rows_omitted = 7;
         let finished = envelope.finish(false);
@@ -2425,7 +2479,7 @@ mod tests {
     /// the cursor survives for the caller to redeem.
     #[test]
     fn finish_is_ok_page_when_a_cap_stopped_the_result_and_a_cursor_exists() {
-        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i128)]);
         envelope.presentation.row_cap_hit = true;
         envelope.presentation.cursor = Some("cursor-token".to_string());
 
@@ -2445,7 +2499,7 @@ mod tests {
     /// disagree.
     #[test]
     fn finish_drops_a_cursor_when_the_ordering_is_not_total() {
-        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i128)]);
         envelope.presentation.row_cap_hit = true;
         envelope.presentation.cursor = Some("cursor-token".to_string());
 
@@ -2459,7 +2513,7 @@ mod tests {
     /// dropped and the result is the plain `ok` it is.
     #[test]
     fn finish_drops_a_cursor_when_no_cap_stopped_the_result() {
-        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i128)]);
         envelope.presentation.cursor = Some("cursor-token".to_string());
 
         let finished = envelope.finish(true);
@@ -2478,7 +2532,7 @@ mod tests {
     /// bounded, which is what keeps the flag from being decoration.
     #[test]
     fn finish_is_ok_when_the_cap_was_hit_but_nothing_was_dropped() {
-        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i128)]);
         envelope.presentation.bytes_cap_hit = true;
         envelope.presentation.cursor = Some("cursor-token".to_string());
 
@@ -2487,12 +2541,12 @@ mod tests {
         assert_eq!(finished.status, Status::Ok);
         assert_eq!(finished.presentation.cursor, None);
 
-        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i128)]);
         envelope.presentation.bytes_cap_hit = true;
         envelope.presentation.rows_omitted = 1;
         assert_eq!(envelope.finish(false).status, Status::OkBounded);
 
-        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(2, |i| vec![Cell::Int(i as i128)]);
         envelope.presentation.bytes_cap_hit = true;
         envelope.presentation.cells_truncated = 1;
         assert_eq!(envelope.finish(false).status, Status::OkBounded);
@@ -2506,7 +2560,7 @@ mod tests {
     /// warning list is exactly the fields still missing.
     #[test]
     fn finish_warns_about_unmeasured_identity_fields() {
-        let envelope = envelope_with_rows(1, |i| vec![Cell::Int(i as i64)]);
+        let envelope = envelope_with_rows(1, |i| vec![Cell::Int(i as i128)]);
 
         let finished = envelope.finish(false);
 
@@ -2520,7 +2574,7 @@ mod tests {
             ]
         );
 
-        let mut measured = envelope_with_rows(1, |i| vec![Cell::Int(i as i64)]);
+        let mut measured = envelope_with_rows(1, |i| vec![Cell::Int(i as i128)]);
         measured.visibility.snapshot_id = "snap-7".to_string();
 
         let finished = measured.finish(false);
@@ -2544,7 +2598,7 @@ mod tests {
     /// `finish` runs.
     #[test]
     fn identity_warnings_are_inside_the_cap_and_the_count_bound() {
-        let mut envelope = envelope_with_rows(1, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(1, |i| vec![Cell::Int(i as i128)]);
         envelope.warnings = (0..MAX_WARNINGS)
             .map(|i| format!("{i:0>2}_{}", "w".repeat(507)))
             .collect();
@@ -2577,7 +2631,7 @@ mod tests {
     /// with both caps set, and loses any cursor on it.
     #[test]
     fn finish_preserves_an_error_status_and_drops_its_cursor() {
-        let mut envelope = envelope_with_rows(1, |i| vec![Cell::Int(i as i64)]);
+        let mut envelope = envelope_with_rows(1, |i| vec![Cell::Int(i as i128)]);
         envelope.status = Status::Error;
         envelope.failure = Some(Failure {
             class: FailureClass::BudgetExceeded,

--- a/crates/ravel-mcp/src/envelope.rs
+++ b/crates/ravel-mcp/src/envelope.rs
@@ -452,9 +452,11 @@ pub struct Presentation {
     /// dropped entry is gone, a cut one is still there and still says so
     /// through its truncation marker.
     pub entries_truncated: u64,
-    /// Scalar fields cut, replaced by the truncation marker, or (for the
-    /// cursor, which is a MAC'd token a cut would corrupt) dropped, because
-    /// the scalars together were over the D4 4 KiB allowance. Counted apart
+    /// Scalar fields cut or replaced by the truncation marker because the
+    /// scalars together were over the D4 4 KiB allowance. The cursor is not
+    /// among them: it holds its own [`CURSOR_BOUND`] outside that allowance,
+    /// and a token over that bound is an internal failure rather than
+    /// something to cut, since a cut would corrupt its MAC. Counted apart
     /// from `entries_truncated` because a scalar is not a list entry: one
     /// oversized `plan` says something different about a result than sixteen
     /// cut warnings do.
@@ -1284,9 +1286,7 @@ impl Envelope {
     /// has already applied the D4 count bound to `warnings`, and re-applies
     /// that same bound afterward (see `finish`'s own doc comment). Putting
     /// the identity warnings first means they are what survives that second
-    /// pass when a caller's own warnings already filled the list, the same
-    /// kept-first reasoning [`Envelope::cap_scalars`] uses for the
-    /// dropped-cursor announcement.
+    /// pass when a caller's own warnings already filled the list.
     fn warn_unreported_identity(&mut self) {
         let reported = [
             !self.visibility.snapshot_id.is_empty(),
@@ -1576,13 +1576,21 @@ mod tests {
     /// Serialized size of a zero-row envelope with every metadata field at
     /// both its D4 bounds, every scalar filling the D4 scalar allowance, and
     /// the cursor at the [`CURSOR_BOUND`] it now holds on its own: the largest
-    /// fixed part the bounds permit. It must stay under 110,592 B, the earlier
-    /// 106,496 B plus the cursor's own 4 KiB, which is what leaves a retained
-    /// row its 148 KiB under the 256 KiB floor.
+    /// fixed part the bounds permit.
+    ///
+    /// The 110,592 B tripwire below is this test's own, not a figure D4
+    /// states: it is 108 KiB, the round number just above what the bounds
+    /// measure to, so a bound that grows shows up as a failure here rather
+    /// than as a quiet climb toward the floor. What D4 constrains is the
+    /// per-list and per-entry bounds and the 4 KiB scalar allowance, whose
+    /// sum with the cursor bound is 106 KiB. What actually guards the 256 KiB
+    /// floor is the [`MAXIMAL_FIXED_PART`] assertion beside that constant,
+    /// which adds the skeleton, its slack, and the identity-warning
+    /// allowance on top of the documented bounds.
     const MAXIMAL_METADATA_ENVELOPE_LEN: usize = 109_902;
     const _: () = assert!(
         MAXIMAL_METADATA_ENVELOPE_LEN < 110_592,
-        "ADR-1374 D4 requires the maximal fixed part under 110,592 B"
+        "the maximal fixed part must stay under this test's 108 KiB tripwire"
     );
 
     fn cell_len(envelope: &Envelope) -> usize {

--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -673,3 +673,35 @@ the identity-warning allowance `finish` may still spend (220 B).
 `MAXIMAL_FIXED_PART` in `crates/ravel-mcp/src/envelope.rs` is the constant
 carrying that real total, and it is the figure the floor guard compares
 against the 256 KiB `max_response_bytes` floor.
+
+**Amendment (2026-09-11).** Three corrections.
+
+1. The 2026-09-09 amendment reports an over-bound cursor as an `internal`
+   failure. That holds only when the envelope carries no other failure. An
+   envelope that already failed keeps its class, message, and counter, which
+   say why the call failed. The cursor is dropped on both paths. On the
+   second, the drop increments `presentation.metadata_elided` and pushes a
+   warning naming the bound. So a dropped cursor is never silent.
+2. D9 says the cursor codec reuses the Flight pin codec, and that
+   `flight-sql` and `mcp` both enable `pin-codec`. Neither is true. The
+   cursor codec follows the Flight ticket pattern but shares no code with
+   it. `ravel-mcp` enables no `ravel-sql` feature and reads nothing from
+   `flight_ticket`. An `mcp` build needs no pin codec. The 2026-09-09
+   amendment kept that reuse for evidence references. They never used it: a
+   reference carries a digest, and redemption re-executes its own call.
+3. The erasure check above sees only predicates in force at redemption. An
+   erasure that arrives after a mint and completes before the redemption is
+   in neither set. The check is sound only while the maximum cursor lifetime
+   is shorter than the minimum time an erasure takes to complete. The
+   maximum cursor lifetime is a deployment's protection horizon minus a 24 h
+   grace. The horizon is operator-set and defaults to 25 h 05 m, so the
+   lifetime is 1 h 05 m. The grace is a constant in
+   `crates/ravel-mcp/src/cursor.rs` that no configuration moves. The minimum
+   erasure completion is the seal wait in
+   `crates/ravel-maintain/src/erasure_rewrite.rs`. It is the ingest lag plus
+   one bucket span plus the seal margin, 4 h 05 m with defaults. Nothing
+   asserts the relationship. `ravel-mcp` cannot assert it either: the horizon
+   reaches the crate per call as an absolute instant. Raising the horizon to
+   30 h leaves a 6 h cursor lifetime and opens the window. The 2026-09-10
+   amendment says a redemption refuses a cursor in exactly two cases. Those
+   are the two a redemption can detect, not every case that breaks a page.

--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -620,3 +620,56 @@ gives it its own bound.
 4. The shipped cursor codec (segment enumeration) is replaced by the
    resolve-input form before the first paging tool ships (#1380); until
    then no tool mints a cursor.
+
+**Amendment (2026-09-10, #1501, #1529).** Corrects the amendment above. Its
+item 1 said redemption "re-resolves the snapshot against that watermark
+deterministically" and fails `cursor_expired` when it "cannot reproduce the
+pinned watermark", without saying what reproducible means. There is no
+reading of it that a redemption can test. ADR-0010 gives no ordering over
+commit tokens to test one with: `seq` is monotonic only per (writer_id,
+epoch, shard) and gaps in it carry no meaning, and `epoch` is informational
+only, so two tokens from different writers have no relative position at
+all. The pinned watermark is a resolve input and only that: it is what page
+2 resolves against, in place of a fresh resolution, which is what makes the
+re-resolve deterministic. Whether a pinned token can still be satisfied is
+the catalog's answer at resolve time, given by resolving the token's own
+identity, and its failure is `UnsatisfiableToken`, not a cursor outcome.
+
+A redemption refuses a structurally valid, correctly bound cursor as
+`cursor_expired` in exactly two cases, which are the two the amendment above
+meant by a compaction and a newer erasure:
+
+1. Its effective deadline, already clamped to `protection_horizon - grace`
+   by the rule D5 states, has passed. Past that instant a sweep is free to
+   compact away what the pin resolves to, so the clamp already is the
+   compaction check and no second mechanism is added for it.
+2. An erasure predicate is in force at redemption that the cursor did not
+   pin, over the cursor's own signal, whose half-open event-time window
+   overlaps the cursor's half-open time range. A windowless predicate has no
+   event-time restriction and so overlaps every range. Intersection is
+   defined on the signal and the range only: a predicate's matchers are
+   tested against a record's labels or attributes, and a cursor holds no
+   records, so no matcher-level analysis is attempted. An erasure that does
+   not intersect that scope leaves the cursor redeemable, and a predicate
+   the cursor pinned that is no longer in force is not a mismatch.
+
+A tampered or wrong-tenant token stays `cursor_invalid`, unchanged. So do
+the dead-process rule, the tenant binding, and the tool and argument-hash
+binding.
+
+Two corrections to the same amendment's own text. Its item 3 said "Evidence
+references are unchanged: each pins one row's segment with a `SegmentPin`".
+That was never true. `EvidenceRef` carries the tenant hash, the tool, the
+argument hash, a `blake3_256` digest of the referenced row, and its mint and
+deadline timestamps; it has never held a `SegmentPin`, and it needs none,
+because redemption re-executes the reference's own call and compares
+digests. Its item 2 gave the maximal fixed part as 106 KiB, which counts
+only the bounds D4 documents: the metadata list bounds (100,824 B) plus the
+4 KiB scalar allowance come to 102 KiB, and the new 4 KiB cursor bound takes
+that to 106 KiB. The implementation reserves 110,600 B, because on top of
+those documented bounds it also counts the empty-envelope skeleton (852 B),
+a bounded skeleton slack for counters and status words widening (512 B), and
+the identity-warning allowance `finish` may still spend (220 B).
+`MAXIMAL_FIXED_PART` in `crates/ravel-mcp/src/envelope.rs` is the constant
+carrying that real total, and it is the figure the floor guard compares
+against the 256 KiB `max_response_bytes` floor.

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -160,7 +160,8 @@ How the result was shaped to fit the response cap: `max_rows`, whether
 `cells_truncated`, how many list entries were `metadata_elided`, the
 `effective_max_response_bytes` actually in force, whether `floor_applied`
 raised a value you sent below the server's minimum, and the paging `cursor`,
-when one exists.
+when one exists. `metadata_elided` also counts a cursor dropped for
+exceeding its own bound.
 
 ### `budget`
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -108,7 +108,7 @@ server minted no cursor. A genuinely empty result is `ok` with
 | `deadline` | The call passed its effective deadline. |
 | `unavailable` | A transient storage or catalog fault. Retryable. |
 | `snapshot_invalidated` | The pinned snapshot was invalidated by concurrent maintenance. Retryable once. |
-| `cursor_expired` | The cursor's minting process, or its deadline, is gone. |
+| `cursor_expired` | The cursor's minting process or its deadline is gone, or an erasure it did not pin now reaches its signal and time range. |
 | `cursor_invalid` | The cursor does not match the tenant, the tool, or the arguments presented with it. |
 | `internal` | An unexpected fault. The message is fixed and carries no storage detail. |
 
@@ -129,13 +129,27 @@ resolve inputs, not by enumerating segments.
 
 A cursor stays valid until the earlier of the call's remaining deadline
 and the protection horizon minus the grace period. Redeeming a cursor
-re-resolves the snapshot deterministically from the pinned watermark and
+resolves the snapshot against the pinned watermark rather than against a
+fresh observation, which is what makes the re-resolve deterministic, and
 re-executes the original statement against it with a keyset predicate; the
-server holds nothing in between calls. Only the process that minted a
-cursor can redeem it, so a load balancer needs sticky routing to a paging
-client. When the re-resolve cannot reproduce the pinned watermark, because
-a compaction or a newer erasure moved past it, redemption fails with
-`cursor_expired` and the caller re-runs the query. A tampered or
+server holds nothing in between calls. The pinned watermark is that resolve
+input and nothing more: redemption never compares it against a watermark
+observed later, because commit tokens from different writers have no
+ordering between them to compare, and whether a pinned token is still
+satisfiable is the catalog's answer at resolve time.
+
+Redemption refuses a structurally valid, correctly bound cursor with
+`cursor_expired` in two cases. The first is that its effective deadline has
+passed: because that deadline is already clamped to the protection horizon
+minus the grace period, this is also the check for a compaction having
+become free to take the pinned data apart. The second is that an erasure
+predicate is in force which the cursor did not pin, over the cursor's own
+signal, whose event-time window overlaps the cursor's time range; a
+windowless predicate overlaps every range. That overlap is judged on the
+signal and the range only, never on the predicate's matchers, since a
+cursor holds no records to match. In both cases the caller re-runs the
+query. Only the process that minted a cursor can redeem it, so a load
+balancer needs sticky routing to a paging client. A tampered or
 wrong-tenant token fails with `cursor_invalid`.
 
 `ravel_query_sql` mints a cursor only when the statement's `ORDER BY`,

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -70,6 +70,9 @@ than dropping it. A number, a timestamp, a boolean, and a hex-encoded
 binary id never shorten; a string or a structured value that exceeds the
 per-cell budget is cut to that budget.
 
+Integers and timestamps travel as JSON strings for every value, whatever
+its magnitude, so parse them as strings.
+
 Three counters say what the fit removed outside `data.rows`.
 `metadata_elided` counts list entries dropped because their list was over
 its count bound. `entries_truncated` counts entries kept but cut because

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -75,14 +75,21 @@ its magnitude, so parse them as strings.
 
 Three counters say what the fit removed outside `data.rows`.
 `metadata_elided` counts list entries dropped because their list was over
-its count bound. `entries_truncated` counts entries kept but cut because
+its count bound, plus the cursor when it was dropped for being over its own
+bound. `entries_truncated` counts entries kept but cut because
 the entry was over its own size bound; a cut entry carries a truncation
 marker. `scalars_truncated` counts scalar cuts. Sub-bounded scalars are
 cut to their own bounds first. The allowance pass then cuts `plan`, the
 failure message, and the budget values. The cursor carries its own 4 KiB
 bound, separate from the scalar allowance. A cursor over its bound is
 never cut, because cutting a token breaks its authentication code; it is
-a server defect reported as an `internal` failure.
+a server defect, and the cursor is dropped. On a result that carries no
+other failure, that defect is the failure and its class is `internal`. On
+a result that already failed, the original class, message, and counter
+stay: they say why the call failed, and an `internal` in their place would
+send you to file a bug instead of retrying or narrowing. The dropped
+cursor is then reported by `metadata_elided` and by a warning naming the
+bound, so the defect is visible either way.
 
 The first-row guarantee applies to the byte cap. It does not apply to
 the row cap. When the equal-group rule leaves no complete group inside
@@ -152,6 +159,17 @@ query. Only the process that minted a cursor can redeem it, so a load
 balancer needs sticky routing to a paging client. A tampered or
 wrong-tenant token fails with `cursor_invalid`.
 
+Those are the two cases a redemption can detect. An erasure that arrives
+after a cursor is minted and finishes before it is redeemed is in neither
+set, so no check sees it. That case stays empty only while a cursor cannot
+outlive an erasure: a cursor lives at most the protection horizon minus a
+24 h grace, 1 h 05 m under the default horizon, and an erasure cannot
+finish before its seal wait, 4 h 05 m under the default ingest lag. An
+operator who raises the protection horizon lengthens the first without
+moving the second, and the grace this server subtracts is a fixed 24 h. A
+30 h horizon leaves a 6 h cursor lifetime, above the 4 h 05 m floor, and
+page two can then come from a snapshot an erasure has changed.
+
 `ravel_query_sql` mints a cursor only when the statement's `ORDER BY`,
 plus a tiebreak the tool appends, is a total order over the projection.
 When the tiebreak is not unique, the equal-group rule applies exactly
@@ -201,7 +219,7 @@ failure.
 | `max_response_bytes` | 512 KiB | floor 256 KiB | yes, raised to the floor if lower |
 | `max_response_bytes` ceiling | 4 MiB | an operator may configure a lower one | no; a larger request clamps to it |
 | cursor or evidence token length | 1 MiB | fixed | no; a longer token is refused unread |
-| `presentation.cursor` in the envelope | 4 KiB | fixed | no; a cursor over its bound is an `internal` failure |
+| `presentation.cursor` in the envelope | 4 KiB | fixed | no; a cursor over its bound is dropped, as an `internal` failure on an otherwise-successful result and as a counted drop with a warning on one that already failed |
 | metric families per `ravel_describe_data` page | 100 | fixed | no |
 | segments admitted for `ravel_find_labels` resolution | 2,000 | fixed | no |
 

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -217,13 +217,10 @@ flight-sql = ["sql", "ravel-sql/flight-sql", "dep:arrow-flight"]
 
 # The native MCP adapter at `POST /mcp` (ADR-1374 decision 9). Implies `sql`:
 # four of the nine tools execute SQL through the query service, so there is no
-# deployment that wants the MCP surface without it. `ravel-sql/pin-codec` is
-# the pinned-snapshot codec the cursor and evidence references share with
-# Flight tickets, without pulling the Flight stack in. Off by default, and
+# deployment that wants the MCP surface without it. Off by default, and
 # `--mcp` is a second, runtime opt-in on top.
 mcp = [
     "sql",
-    "ravel-sql/pin-codec",
     "dep:ravel-mcp",
     "dep:rmcp",
     "rmcp/transport-streamable-http-server",

--- a/services/ravel-server/src/mcp/envelope.rs
+++ b/services/ravel-server/src/mcp/envelope.rs
@@ -522,21 +522,25 @@ fn string_field(value: &Value, field: &str) -> String {
 /// cell variant of its own so it keeps its JSON text.
 ///
 /// `serde_json` parses a JSON integer above `i64::MAX` as a `u64`, and
-/// `Number::as_f64` succeeds on it with precision loss. `Cell` has no
-/// unsigned variant, so a number that fails `as_i64` only becomes a float
-/// when it actually is one (`is_f64`); otherwise its exact digits go out as
-/// `Cell::Str`, matching the string-precision rule integers already get.
+/// `Number::as_f64` succeeds on it with precision loss. `Cell::Int` carries
+/// the union of the two 64-bit ranges, so both `as_i64` and `as_u64` land in
+/// it and an integer stays an integer whichever side it came from. Only a
+/// genuine float becomes `Cell::Float`.
 fn json_to_cell(value: &Value) -> Cell {
     match value {
         Value::Null => Cell::Null,
         Value::Bool(b) => Cell::Bool(*b),
-        Value::Number(number) => match number.as_i64() {
-            Some(n) => Cell::Int(n),
-            None if number.is_f64() => match number.as_f64() {
+        Value::Number(number) => match (number.as_i64(), number.as_u64()) {
+            (Some(n), _) => Cell::Int(i128::from(n)),
+            (None, Some(n)) => Cell::Int(i128::from(n)),
+            (None, None) => match number.as_f64() {
                 Some(f) => Cell::Float(f),
+                // Not an i64, not a u64, and not representable as an f64:
+                // serde_json has no fourth number shape, so this arm is
+                // unreachable. It keeps the digits rather than losing them if
+                // one is ever added.
                 None => Cell::Str(number.to_string()),
             },
-            None => Cell::Str(number.to_string()),
         },
         Value::String(s) => Cell::Str(s.clone()),
         Value::Object(map) => Cell::Map(map.clone()),
@@ -938,24 +942,46 @@ mod tests {
         assert_eq!(data.rows[0][0], Cell::Str("9007199254740993".to_string()));
         assert_eq!(data.rows[0][1], Cell::Null);
         assert_eq!(data.rows[1][0], Cell::Int(9007199254740993));
+        assert_eq!(cell_text(&data.rows[1][0]), "9007199254740993");
         assert_eq!(data.rows[1][1], Cell::Float(1.5));
     }
 
-    /// A JSON integer above `i64::MAX` parses as a `u64`, and `Cell` has no
-    /// unsigned variant. Rendering it through `as_f64` would lose precision
-    /// (D4's exact-semantics-by-default rule), so it must come out as the
-    /// exact digits in `Cell::Str`, the same way an out-of-range `i64` does.
-    /// An ordinary float is unaffected and still becomes `Cell::Float`.
+    /// The digits a cell puts on the wire. Asserting these rather than a
+    /// value parsed back out of them is what catches a digit lost between the
+    /// carrier and the JSON string, which a parse would silently re-derive.
+    fn cell_text(cell: &Cell) -> String {
+        serde_json::to_value(cell)
+            .expect("a cell serializes")
+            .as_str()
+            .expect("an integer cell is a JSON string")
+            .to_string()
+    }
+
+    /// A JSON integer above `i64::MAX` parses as a `u64`. `Cell::Int` carries
+    /// the union of the two 64-bit ranges, so it stays an integer cell with
+    /// every digit intact, instead of going out as a float (which would lose
+    /// precision, against D4's exact-semantics rule) or as a plain string
+    /// (which would give an unsigned column a different wire type from a
+    /// signed one). Both ends of the range and an ordinary small value travel
+    /// the same path, and a genuine float is still `Cell::Float`.
     #[test]
     fn a_large_unsigned_integer_is_not_downgraded_to_a_float() {
-        assert_eq!(
-            json_to_cell(&json!(u64::MAX)),
-            Cell::Str(u64::MAX.to_string())
-        );
-        assert_eq!(
-            json_to_cell(&json!(i64::MAX as u64 + 1)),
-            Cell::Str((i64::MAX as u64 + 1).to_string())
-        );
+        let widest = json_to_cell(&json!(u64::MAX));
+        assert_eq!(widest, Cell::Int(i128::from(u64::MAX)));
+        assert_eq!(cell_text(&widest), "18446744073709551615");
+
+        let first_unsigned = json_to_cell(&json!(i64::MAX as u64 + 1));
+        assert_eq!(first_unsigned, Cell::Int(i128::from(i64::MAX as u64 + 1)));
+        assert_eq!(cell_text(&first_unsigned), "9223372036854775808");
+
+        let smallest = json_to_cell(&json!(i64::MIN));
+        assert_eq!(smallest, Cell::Int(i128::from(i64::MIN)));
+        assert_eq!(cell_text(&smallest), "-9223372036854775808");
+
+        let small = json_to_cell(&json!(1));
+        assert_eq!(small, Cell::Int(1));
+        assert_eq!(cell_text(&small), "1");
+
         assert_eq!(json_to_cell(&json!(1.5f64)), Cell::Float(1.5));
     }
 


### PR DESCRIPTION
A cursor carried the whole pinned segment set. One segment pin costs
about 250 bytes, and a snapshot of the size the budget decision admits
encodes to several hundred kilobytes, larger than the whole response
floor, so a cursor could not both hold what the design asked for and fit
the envelope that carries it.

A cursor now pins its snapshot by the inputs that produced it: the
tenant, the signal, the half-open time range, the commit-token
watermark the page was resolved against, the erasure predicates in
force, the declared columns, and the keyset position. Redemption
re-resolves from those. The watermark is a resolve input and not a
validity test, because commit-token sequence numbers are monotonic only
within one writer and epoch, so there is no ordering to test across
writers.

Two conditions expire a cursor. Its deadline is clamped to the
protection horizon less the grace, which is what catches a compaction
that removed the pinned segments. An erasure predicate in force at
redemption that the cursor did not pin, and that covers its signal and
range, means the snapshot has changed underneath it. A tampered or
wrong-tenant token stays invalid, as before. The check is sound only
while a cursor cannot outlive the shortest time an erasure takes to
complete, and that assumption is now written where an operator changing
the horizon will find it.

The cursor also leaves the shared scalar allowance for a bound of its
own, since it is an opaque token that a cut would corrupt. A cursor
over that bound is a server defect: the envelope reports it, keeping
any failure the query already had and recording the drop so it is never
silent.

Integer cells widen to carry the full unsigned 64-bit range exactly.
The wire form is unchanged, every integer still travels as a JSON
string, and a large value is no longer the only one a byte cap could
truncate. The reference page now states that encoding, which it never
did.

Fixes: #1501
Fixes: #1525
Fixes: #1529
Refs: #1374
