### PR TITLE
test(commit): make IAM template guards fail closed in every direction

### DIFF
--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -155,47 +155,813 @@ fn glob_matches(pattern: &str, candidate: &str) -> bool {
     glob_to_regex(pattern).is_match(candidate)
 }
 
+/// True when an IAM glob admits EVERYTHING: it excludes no candidate at all, so
+/// it constrains exactly as little as naming no pattern would. The test is
+/// whether the pattern matches the empty string: `*` (and any all-`*` run such
+/// as `**`) matches it, while a `?` -- which IAM resolves as exactly one
+/// character -- does not, and any literal segment (`t/`, `sys/`) forces that
+/// literal and so cannot match the empty candidate. Matching the empty string is
+/// the precise, minimal reading of "admits everything": a `Resource` object-key
+/// pattern the empty key matches covers every key in the bucket, and an
+/// `s3:prefix` the empty prefix matches lets a caller pass the empty prefix and
+/// list the whole bucket -- each the vacuous-value sibling of the empty-map and
+/// empty-array holes this file already closes (issue #1346, F1). A narrower glob
+/// (`t/*`, `sys/*`, `?`, `*x`) still excludes some candidate and is left alone;
+/// rejecting a merely OVER-broad-but-non-vacuous pattern is a different guard.
+fn glob_admits_everything(pattern: &str) -> bool {
+    glob_matches(pattern, "")
+}
+
+// ---------------------------------------------------------------------------
+// The action vocabulary. One predicate (`action_grants`) and one operation list
+// per axis; every axis in this file routes through them.
+// ---------------------------------------------------------------------------
+
+/// The S3 operations these guards reason about that act on an OBJECT, so a
+/// statement granting one must name bucket-relative object ARNs.
+const S3_OBJECT_OPERATIONS: [&str; 4] = [
+    "s3:GetObject",
+    "s3:PutObject",
+    "s3:DeleteObject",
+    "s3:DeleteObjectVersion",
+];
+
+/// The S3 operations these guards reason about that act on the BUCKET, so a
+/// statement granting one must name the bare bucket ARN. `s3:ListBucket` is the
+/// only one: it is what `list_prefix_patterns` reads an `s3:prefix` Condition
+/// for, and what the Condition-presence rule keys on.
+const S3_BUCKET_OPERATIONS: [&str; 1] = ["s3:ListBucket"];
+
+/// The S3 operations that destroy a stored object. A subset of
+/// `S3_OBJECT_OPERATIONS` (pinned by `operation_vocabulary_is_consistent`), kept
+/// separate because the delete axis selects on exactly these.
+const S3_DELETE_OPERATIONS: [&str; 2] = ["s3:DeleteObject", "s3:DeleteObjectVersion"];
+
+/// The KMS operations that mint a data key, i.e. that let the holder produce new
+/// ciphertext under a tenant key. `write_roles_have_kms_generate_data_key` and
+/// `roles_writing_routed_objects_have_kms_grant` require one; ADR-0055 forbids
+/// admin any of them (`admin_has_no_kms_generate_data_key`). All four spellings
+/// are listed so the negative assertion cannot be evaded by granting a variant.
+const KMS_DATA_KEY_OPERATIONS: [&str; 4] = [
+    "kms:GenerateDataKey",
+    "kms:GenerateDataKeyWithoutPlaintext",
+    "kms:GenerateDataKeyPair",
+    "kms:GenerateDataKeyPairWithoutPlaintext",
+];
+
+/// The remaining KMS operations these guards reason about.
+const KMS_OTHER_OPERATIONS: [&str; 2] = ["kms:Decrypt", "kms:Encrypt"];
+
+/// The single action predicate every axis in this file goes through: does the
+/// policy string `action` (possibly an IAM wildcard pattern, in whatever case
+/// the template spells it) grant `operation` (a literal IAM operation name)?
+///
+/// IAM action names are case-insensitive and resolve two wildcards, `*` (any
+/// sequence) and `?` (exactly one character), so `"*"`, `"s3:*"`, `"s3:Delete*"`
+/// and `"S3:DELETEOBJECT"` all grant `s3:DeleteObject`. Before this predicate
+/// existed each axis carried its own matcher and only the delete axis resolved
+/// wildcards, so `"Action": "s3:*"` granted PutObject and ListBucket while being
+/// selected by neither -- and the Condition-presence rule, which keys on the
+/// list grant, never fired either (issue #1346, H3). There is now one place that
+/// decides, so no axis can be wildcard-aware while another is not.
+///
+/// The asymmetry is deliberate and asserted: the wildcard lives on the policy
+/// side. An `operation` carrying `*` or `?` is a caller bug, not a pattern to
+/// resolve, because a wildcarded operation would make the predicate answer a
+/// question no axis asked.
+fn action_grants(action: &str, operation: &str) -> bool {
+    assert!(
+        !operation.contains(IAM_WILDCARDS),
+        "action_grants takes a literal IAM operation name, not a pattern: {operation:?}"
+    );
+    let action = action.to_ascii_lowercase();
+    let operation = operation.to_ascii_lowercase();
+    if action == operation {
+        return true;
+    }
+    // Only a wildcard pattern grants beyond its own name: an unrelated literal
+    // action (`s3:DeleteObjectTagging`, `s3:DeleteBucket`) grants nothing else.
+    action.contains(IAM_WILDCARDS) && glob_matches(&action, &operation)
+}
+
+/// True when `action` grants at least one of `operations`.
+fn action_grants_any(action: &str, operations: &[&str]) -> bool {
+    operations.iter().any(|op| action_grants(action, op))
+}
+
+/// True when at least one of a statement's `actions` grants at least one of
+/// `operations`. Every axis's statement selection is this call.
+fn any_action_grants_any(actions: &[String], operations: &[&str]) -> bool {
+    actions.iter().any(|a| action_grants_any(a, operations))
+}
+
+/// True when `action` grants any KMS operation these guards reason about, so the
+/// statement carrying it is a KMS statement whose `Resource` the KMS resource
+/// guards own. This replaces the old case-folded `kms:` prefix test, which a
+/// wildcard action (`"*"`, `"kms:*"`) slipped past.
+fn action_selects_kms(action: &str) -> bool {
+    action_grants_any(action, &KMS_OTHER_OPERATIONS)
+        || action_grants_any(action, &KMS_DATA_KEY_OPERATIONS)
+}
+
+// ---------------------------------------------------------------------------
+// The resource vocabulary. `classify_resource` is the only place a `Resource`
+// string is interpreted; the choke point and every helper share it, so a shape
+// cannot be understood in one and dropped in the other.
+// ---------------------------------------------------------------------------
+
+/// The ARN service prefix of a KMS key resource.
+const KMS_ARN_PREFIX: &str = "arn:aws:kms:";
+
+/// What a `Resource` string names, as far as the guards in this file are
+/// concerned. `Unclassified` is not a fourth kind of resource: it is the shape
+/// `validate_statement` rejects, so no helper downstream ever has to decide what
+/// to do with one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResourceShape<'a> {
+    /// An object ARN under the configured bucket; carries the bucket-relative
+    /// key pattern (always non-empty).
+    ObjectKey(&'a str),
+    /// Exactly the bare bucket ARN: what an `s3:ListBucket` grant names.
+    Bucket,
+    /// A KMS key ARN.
+    KmsKey,
+    /// Anything else, including every shape issue #1346 H1 lists: an S3
+    /// access-point ARN (`arn:aws:s3:<region>:<account>:accesspoint/...`), an
+    /// Object Lambda ARN (`arn:aws:s3-object-lambda:...`), a multi-region access
+    /// point (`arn:aws:s3::<account>:accesspoint/...`), the everything-grant
+    /// `arn:*`, the bare `"*"`, another bucket's ARN, and a malformed non-ARN
+    /// such as `my-ravel-bucket/*`.
+    Unclassified,
+}
+
+/// Classify one `Resource` string. Total: every string lands in exactly one
+/// shape, and everything the guards cannot reason about lands in `Unclassified`
+/// rather than being returned as "nothing to check".
+///
+/// The bucket-relative arm requires a NON-EMPTY key pattern:
+/// `arn:aws:s3:::my-ravel-bucket/` names the object with the empty key, which no
+/// key constructor produces and no guard has a pattern for, so it is
+/// unclassified rather than an `ObjectKey("")` that matches nothing.
+fn classify_resource(resource: &str) -> ResourceShape<'_> {
+    match resource.strip_prefix(BUCKET_KEY_PREFIX) {
+        Some(key) if !key.is_empty() => return ResourceShape::ObjectKey(key),
+        _ => {}
+    }
+    if resource == BUCKET_ARN {
+        return ResourceShape::Bucket;
+    }
+    if resource.starts_with(KMS_ARN_PREFIX) {
+        return ResourceShape::KmsKey;
+    }
+    ResourceShape::Unclassified
+}
+
+#[derive(Debug)]
 struct Policy {
     role: &'static str,
     statements: serde_json::Value,
 }
 
-fn load_policy(role: &'static str) -> Policy {
-    let path = format!(
-        "{}/../../deploy/iam/{role}.json",
-        env!("CARGO_MANIFEST_DIR")
-    );
-    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
-    let json: serde_json::Value =
-        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+/// The complete set of statement keys any guard in this file reads. Sid,
+/// Effect, Action, and Resource are read directly (see `statement_actions`,
+/// `statement_resources`, `key_patterns_for`, `kms_statement_resources`, ...);
+/// Condition is read for the `s3:prefix` ListBucket block
+/// (`list_prefix_patterns`). Nothing else is examined by any guard.
+///
+/// This list is the guard's contract: a statement carrying any key outside it
+/// is one no guard reasons about, so it must fail closed at `load_policy`
+/// rather than be silently skipped (issue #1346).
+const HANDLED_STATEMENT_KEYS: &[&str] = &["Sid", "Effect", "Action", "Resource", "Condition"];
+
+/// The complete set of `Condition` operators any guard in this file reads.
+/// Only `list_prefix_patterns` reads a Condition at all, and only its
+/// `StringLike` block. A statement whose Condition names any other operator --
+/// a different comparison such as `StringNotLike`, or a set-qualified form such
+/// as `ForAnyValue:StringLike` -- carries a constraint no guard reasons about,
+/// so it must fail closed at `validate_statement` rather than pass with its
+/// Condition unexamined (issue #1346).
+const HANDLED_CONDITION_OPERATORS: &[&str] = &["StringLike"];
+
+/// The complete set of `Condition` keys any guard in this file reads, under a
+/// handled operator. Only `s3:prefix` is inspected (by `list_prefix_patterns`);
+/// any other condition key (`s3:delimiter`, `aws:SourceIp`, ...) is a constraint
+/// no guard reads and must fail closed rather than sit unexamined.
+const HANDLED_CONDITION_KEYS: &[&str] = &["s3:prefix"];
+
+/// Keys that describe a statement shape these guards deliberately cannot
+/// reason about: `NotAction`/`NotResource` invert the set the Action/Resource
+/// guards inspect (so a statement carrying them is permissive in exactly the
+/// direction the guard reads, while the guard sees an empty positive set and
+/// passes it), and `Principal`/`NotPrincipal` scope a statement to identities
+/// this file models nothing about. Each is rejected with a message saying so,
+/// rather than lumped in with an unrecognized-typo key.
+const NEGATED_OR_PRINCIPAL_KEYS: &[&str] =
+    &["NotAction", "NotResource", "NotPrincipal", "Principal"];
+
+/// Fail closed on any statement shape the guards in this file do not fully
+/// understand. This is the single choke point every shipped-template guard
+/// passes through (`load_policy` calls it for each statement), so a new
+/// unhandled shape is rejected once here instead of slipping past a guard that
+/// only reads the fields it happens to know.
+///
+/// # The closure argument
+///
+/// Every earlier round of this guard fixed one hole and left another, because
+/// each helper decided for itself which shapes it understood and answered "no
+/// resources to check" for the rest. The fix is structural: ALL shape decisions
+/// happen here, and the helpers are total functions over the shapes that got
+/// through. Concretely, a statement reaching any guard has:
+///
+/// - a present string `Sid`, so every message can name it;
+/// - only keys in `HANDLED_STATEMENT_KEYS`, so no permission lives in a field no
+///   guard reads (`NotAction`/`NotResource`/`Principal` are rejected by name);
+/// - an `Effect` of `Allow` or `Deny`, so the effect-filtered axes partition it;
+/// - an `Action` that is a string or non-empty array of strings, EVERY element of
+///   which grants at least one operation in the vocabulary
+///   (`S3_OBJECT_OPERATIONS`, `S3_BUCKET_OPERATIONS`, `KMS_OTHER_OPERATIONS`,
+///   `KMS_DATA_KEY_OPERATIONS`), decided by the one predicate `action_grants`;
+/// - a `Resource` that is a string or non-empty array of strings, EVERY element
+///   of which `classify_resource` places in `ObjectKey`, `Bucket`, or `KmsKey`
+///   -- never `Unclassified`;
+/// - for each granted operation class, at least one resource of the matching
+///   shape, and no resource of a shape whose class the statement does not grant.
+///   So an object grant carries only bucket-relative object ARNs, a list grant
+///   carries the bare bucket ARN, a KMS grant carries only `arn:aws:kms:` ARNs,
+///   and the normal mixed idiom (ListBucket + GetObject over the bucket ARN plus
+///   an object prefix) is accepted because both classes are granted;
+/// - a `Condition` exactly when the Action grants a list operation, whose
+///   sub-shape is the one `StringLike`/`s3:prefix` block
+///   `list_prefix_patterns` reads.
+///
+/// A helper downstream can therefore no longer meet a shape it does not
+/// understand. `object_key_patterns` matches all four `ResourceShape` variants:
+/// it strips `ObjectKey`, skips `Bucket` and `KmsKey` because this function
+/// proved the same statement grants the list or KMS operation whose own guard
+/// reads that exact string, and panics on `Unclassified` because this function
+/// rejects it. Each remaining `continue` in a helper is axis selection ("this
+/// statement grants no operation on my axis", or "this statement is the other
+/// Effect"), never a shape skip.
+///
+/// The coverage rule holds PER EFFECT-SELECTED AXIS: every ALLOW statement is
+/// selected by at least one axis (the axis of a granted operation class), and
+/// that axis sees every resource it carries. It does NOT say every statement is
+/// read by some axis. One shape is deliberately read by none: a `Deny` whose
+/// Action grants ONLY KMS operations. Both KMS helpers (`kms_actions`,
+/// `kms_statement_resources`) filter to `Allow`, and every S3 axis skips it on
+/// actions, so no helper reads it. That is safe: a `Deny` grants nothing, so
+/// there is no grant left unchecked, and the KMS grant it would withdraw is
+/// itself an `Allow` the KMS axes DO read. `deny_kms_statement_is_not_scope_checked`
+/// pins this shape reaching no scope-check guard on purpose. (A `Deny` that
+/// grants S3 object/list/delete operations is still read by its S3 axis under
+/// `None`, e.g. `delete_key_patterns(.., "Deny")`, so KMS-only is the sole
+/// no-axis shape.)
+///
+/// Effect is a third axis, orthogonal to Action and Resource, and this guard
+/// does NOT partition on it: a `Deny` statement is validated for shape exactly
+/// like an `Allow`, so a well-formed `Deny` reaches every helper its Action and
+/// Resource select. IAM resolves an explicit `Deny` as an overriding
+/// prohibition, so any helper whose result a caller reads as a held permission
+/// ("this role MAY do X", "X is scoped") or a prohibition ("this role MAY NOT
+/// do X") MUST filter by Effect itself; the guard cannot do it for them without
+/// rejecting legitimate `Deny` blocks. The contract is per helper, stated in
+/// its own doc: a helper that reads as a grant takes an effect argument and its
+/// permission-reading callers pass `Some("Allow")` (`key_patterns_for`,
+/// `list_prefix_patterns`, `put_resource_key_patterns`, `delete_key_patterns`),
+/// or the helper filters to `Allow` internally when every caller reads it as a
+/// grant (`kms_actions`, `kms_statement_resources`). A pure shape check that
+/// reads the result as neither a grant nor a prohibition (the pattern-vs-key
+/// coverage guard) passes `None` and sees both effects on purpose.
+///
+/// The `Allow` filter closes ONE direction, and the claim is narrowed to it: it
+/// stops a `Deny` being READ AS a grant -- a Deny-derived output read as an
+/// Allow-derived permission, asserting the inverse of the fact (issue #1346,
+/// F1/F2). It does NOT stop a `Deny` WITHDRAWING a grant that a positive guard
+/// then asserts is held: a Deny added alongside a retained Allow, withdrawing
+/// (say) `kms:GenerateDataKey`/`kms:Encrypt` from the only key, leaves
+/// `write_roles_have_kms_generate_data_key` and
+/// `roles_writing_routed_objects_have_kms_grant` green, because those guards read
+/// the retained `Allow` and never subtract the `Deny`. That case is knowingly
+/// left unhandled here. It is availability drift, not permissiveness: the
+/// templates would fail CLOSED in production (the write is denied) while the
+/// guard stayed green, so it is strictly safer than the direction the filter
+/// closes, and no shipped template carries a `Deny` that withdraws a granted
+/// KMS/Put capability (the only shipped `Deny` is `DenyDeleteProtected`, a
+/// delete-only prohibition disjoint from every Allow). Closing it would require
+/// each positive-capability guard to subtract the matching `Deny` before
+/// asserting; that is a deliberate non-goal of this round. This is the axis the
+/// next reviewer checks the next finding against.
+///
+/// Rejects, naming the `Sid` (and the statement index) and the offending key or
+/// field:
+/// - a statement that is not a JSON object;
+/// - a missing or non-string `Sid` (`"Sid": 123`): Sid is in the handled set,
+///   but its type went unchecked pre-fix and the `<no Sid>` fallback then named
+///   nothing (issue #1346, F3);
+/// - `NotAction`/`NotResource`/`NotPrincipal`/`Principal` (negated or
+///   principal-scoped: the guard cannot reason about them);
+/// - any other key outside `HANDLED_STATEMENT_KEYS` (e.g. a `Resources` typo);
+/// - an `Effect` that is neither `Allow` nor `Deny`;
+/// - an `Action` or `Resource` that is neither a string nor a non-empty array
+///   of strings (an empty array is vacuously "all strings", so it slipped past
+///   as a valid set the guards then derived nothing from);
+/// - a missing `Resource` key (the exact shape #1346 records being skipped:
+///   the resource guards read `stmt["Resource"]`, find `Null`, and drop the
+///   statement as having nothing to check);
+/// - an `Action` element that grants no operation in the vocabulary, so no axis
+///   would select the statement (H3);
+/// - a `Resource` element `classify_resource` cannot place, quoting the value:
+///   an S3 access-point or Object Lambda or multi-region-access-point ARN, the
+///   everything-grant `arn:*`, the bare `"*"`, another bucket's ARN, or a
+///   malformed non-ARN such as `my-ravel-bucket/*` (H1);
+/// - a `Resource` whose shape belongs to an operation class the statement does
+///   not grant (an `s3:ListBucket` on an object ARN, an `s3:GetObject` on the
+///   bare bucket ARN, a KMS ARN on a statement granting no KMS operation), and
+///   conversely a granted class with no resource of its shape (an
+///   `s3:ListBucket` that names no bucket ARN -- the H2 hole, where round
+///   three's list-only exemption left a list statement's Resource read by
+///   nothing at all);
+/// - a `Resource` object-key pattern that admits every key (a bucket-relative
+///   `arn:aws:s3:::my-ravel-bucket/*`, which strips to `"*"`): shape-valid but
+///   vacuous, scoping the object grant no more than naming no key would, the
+///   resource-axis sibling of F1's `"*"` s3:prefix (issue #1346, F1 sweep);
+/// - a Condition whose presence does not track the ListBucket action: a
+///   ListBucket statement with no Condition (an unconstrained bucket-wide list),
+///   or a Condition on any non-ListBucket statement (read by no guard) (F2);
+/// - a `Condition` whose sub-shape is anything other than the one block a guard
+///   reads: it must be a non-empty JSON object of handled operators
+///   (`HANDLED_CONDITION_OPERATORS`, today `StringLike`), each a non-empty map of
+///   handled condition keys (`HANDLED_CONDITION_KEYS`, today `s3:prefix`) to a
+///   string or non-empty array of strings. A different operator, a set-qualified
+///   operator, an unhandled key, or an empty `{}`/`{"StringLike":{}}` (which
+///   constrains nothing) is a shape `list_prefix_patterns` cannot read, so it
+///   fails closed here rather than contributing nothing silently;
+/// - an `s3:prefix` VALUE that admits every key (a bare `"*"`, any all-`"*"`
+///   run): shape-valid but vacuous, letting a caller list the whole bucket
+///   exactly as an absent Condition would (issue #1346, F1).
+fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Result<(), String> {
+    let obj = stmt
+        .as_object()
+        .ok_or_else(|| format!("{role}: statement #{index} is not a JSON object: {stmt:?}"))?;
+
+    // Sid must be a present string. Every rejection below quotes it, and every
+    // guard's own failure message names it; a missing Sid, or a non-string
+    // `"Sid": 123`, was accepted pre-fix through the `<no Sid>` fallback (Sid is
+    // in the handled set but its type was never checked), leaving a statement
+    // whose rejections could name nothing (issue #1346, F3).
+    let sid = match obj.get("Sid") {
+        Some(serde_json::Value::String(s)) => s.as_str(),
+        Some(other) => {
+            return Err(format!(
+                "{role}: statement #{index} has a non-string Sid: {other:?} -- Sid is a \
+                 handled key and must be a string so every rejection can name it"
+            ));
+        }
+        None => {
+            return Err(format!(
+                "{role}: statement #{index} has no Sid -- Sid is required so every \
+                 rejection names the statement it rejects"
+            ));
+        }
+    };
+
+    for key in obj.keys() {
+        if NEGATED_OR_PRINCIPAL_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): statement uses {key:?}; the guards \
+                 in this file cannot reason about negated or principal-scoped \
+                 statements (they read only the positive Action/Resource sets), so a \
+                 policy carrying it must be rejected rather than silently passed"
+            ));
+        }
+        if !HANDLED_STATEMENT_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): statement uses key {key:?}, which no \
+                 guard in this file handles (handled keys: {HANDLED_STATEMENT_KEYS:?}); it \
+                 must fail closed rather than sit unexamined"
+            ));
+        }
+    }
+
+    match obj.get("Effect").and_then(|v| v.as_str()) {
+        Some(e) if e.eq_ignore_ascii_case("Allow") || e.eq_ignore_ascii_case("Deny") => {}
+        other => {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): Effect is neither \"Allow\" nor \
+                 \"Deny\": {other:?}"
+            ));
+        }
+    }
+
+    if !is_string_or_string_array(obj.get("Action")) {
+        return Err(format!(
+            "{role}/{sid} (statement #{index}): Action is neither a string nor a \
+             non-empty array of strings: {:?}",
+            obj.get("Action")
+        ));
+    }
+
+    match obj.get("Resource") {
+        None => {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): statement has no Resource key -- a \
+                 statement with no Resource is the exact shape the resource guards skip \
+                 (they read stmt[\"Resource\"], find Null, and treat it as nothing to \
+                 check)"
+            ));
+        }
+        resource if !is_string_or_string_array(resource) => {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): Resource is neither a string nor a \
+                 non-empty array of strings: {resource:?}"
+            ));
+        }
+        _ => {}
+    }
+
+    // Both shape checks above have passed, so `statement_actions` and
+    // `statement_resources` now return exactly what the policy declares.
+    let actions = statement_actions(stmt);
+    let resources = statement_resources(stmt);
+    validate_actions_and_resources(role, sid, index, &actions, &resources)?;
+
+    // Condition presence must track the list action. `list_prefix_patterns`
+    // is the only Condition reader and only reads one when the Action grants
+    // s3:ListBucket, so:
+    //  - a list statement MUST carry a Condition (an unconstrained bucket-wide
+    //    list is rejected, exactly like a missing Resource), and
+    //  - a non-list statement must carry NONE (a Condition there is read by no
+    //    guard: a StringLike/s3:prefix on the protected-delete Deny would pass
+    //    validation while, in AWS, a DeleteObject request carries no s3:prefix
+    //    context key, so the Deny never fires and protects nothing).
+    // (issue #1346, F2)
+    //
+    // The list grant is decided by `action_grants`, the same predicate every
+    // other axis uses, so `"Action": "s3:*"` -- which grants ListBucket -- is
+    // required to carry a Condition here too. Under round three's exact-name
+    // detection it was not, and `list_prefix_patterns` then read nothing from it
+    // (issue #1346, H3).
+    let grants_list = any_action_grants_any(&actions, &S3_BUCKET_OPERATIONS);
+    match obj.get("Condition") {
+        Some(condition) => {
+            if !grants_list {
+                return Err(format!(
+                    "{role}/{sid} (statement #{index}): statement carries a Condition but \
+                     its Action does not include s3:ListBucket -- only the ListBucket \
+                     s3:prefix Condition is read by any guard, so a Condition on any other \
+                     statement sits unexamined and must fail closed"
+                ));
+            }
+            validate_condition(role, sid, index, condition)?;
+        }
+        None => {
+            if grants_list {
+                return Err(format!(
+                    "{role}/{sid} (statement #{index}): s3:ListBucket statement carries no \
+                     Condition -- an unconstrained bucket-wide list must be rejected, the \
+                     same as a missing Resource; it must carry a non-empty \
+                     StringLike/s3:prefix Condition"
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// The Action/Resource half of the choke point: every action must grant an
+/// operation in the vocabulary, and every resource must have a shape that some
+/// granted operation class asks for, with no granted class left without one.
+///
+/// This is what makes the resource helpers total. Round three put the same
+/// question inside `bucket_relative_s3_pattern`, which meant each helper decided
+/// on its own which resources it understood, and everything else came back as
+/// "nothing to check": an access-point ARN, an Object Lambda ARN, `arn:*` and a
+/// malformed `my-ravel-bucket/*` were all real S3 object grants reaching outside
+/// the bucket and all silently dropped (H1), and the list-only exemption added to
+/// keep the bare bucket ARN from tripping the strip left list statements'
+/// Resource examined by nothing at all (H2). Asking it here instead answers it
+/// once, for every axis, before any helper runs.
+///
+/// The three classes are independent, so a statement granting several carries the
+/// resources of each. That is what makes the normal IAM idiom -- one statement
+/// granting `s3:ListBucket` and `s3:GetObject` over the bucket ARN plus an object
+/// prefix -- valid rather than a rejection with a misleading reason.
+fn validate_actions_and_resources(
+    role: &str,
+    sid: &str,
+    index: usize,
+    actions: &[String],
+    resources: &[&str],
+) -> Result<(), String> {
+    for action in actions {
+        let known = action_grants_any(action, &S3_OBJECT_OPERATIONS)
+            || action_grants_any(action, &S3_BUCKET_OPERATIONS)
+            || action_selects_kms(action);
+        if !known {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): Action {action:?} grants no operation \
+                 any guard in this file reasons about (S3 object {S3_OBJECT_OPERATIONS:?}, \
+                 S3 bucket {S3_BUCKET_OPERATIONS:?}, KMS {KMS_OTHER_OPERATIONS:?} + \
+                 {KMS_DATA_KEY_OPERATIONS:?}) -- no axis would select this statement, so \
+                 its Resource would sit unexamined"
+            ));
+        }
+    }
+
+    let grants_object = any_action_grants_any(actions, &S3_OBJECT_OPERATIONS);
+    let grants_list = any_action_grants_any(actions, &S3_BUCKET_OPERATIONS);
+    let grants_kms = actions.iter().any(|a| action_selects_kms(a));
+
+    let mut saw_object = false;
+    let mut saw_bucket = false;
+    let mut saw_kms = false;
+    for resource in resources {
+        match classify_resource(resource) {
+            ResourceShape::ObjectKey(key) => {
+                if !grants_object {
+                    return Err(format!(
+                        "{role}/{sid} (statement #{index}): Resource {resource:?} names an \
+                         object under {BUCKET_ARN:?}, but the statement's Action \
+                         {actions:?} grants no S3 object operation \
+                         ({S3_OBJECT_OPERATIONS:?}) -- an object ARN on a statement that \
+                         cannot act on an object is a shape no axis reads"
+                    ));
+                }
+                // The object-key VALUE must constrain, not merely have the object
+                // shape: `arn:aws:s3:::my-ravel-bucket/*` strips to `*`, which
+                // matches every key in the bucket, so it scopes the object grant
+                // no more than naming no key prefix at all -- the same vacuity F1
+                // closes for an s3:prefix, on the resource axis (issue #1346, F1
+                // sweep). A bounded prefix (`t/*`, `sys/*`) excludes keys outside
+                // it and is unaffected.
+                if glob_admits_everything(key) {
+                    return Err(format!(
+                        "{role}/{sid} (statement #{index}): Resource {resource:?} strips to the \
+                         object-key pattern {key:?}, which matches every key under {BUCKET_ARN:?} \
+                         (the empty key matches it) -- a full-bucket object grant constrains no \
+                         more than naming no key scope at all; it must name a bounded key prefix \
+                         (issue #1346, F1 sweep)"
+                    ));
+                }
+                saw_object = true;
+            }
+            ResourceShape::Bucket => {
+                if !grants_list {
+                    return Err(format!(
+                        "{role}/{sid} (statement #{index}): Resource {resource:?} is the \
+                         bare bucket ARN, but the statement's Action {actions:?} grants no \
+                         S3 bucket operation ({S3_BUCKET_OPERATIONS:?}) -- an S3 object \
+                         operation must name a bucket-relative object ARN, not the bucket"
+                    ));
+                }
+                saw_bucket = true;
+            }
+            ResourceShape::KmsKey => {
+                if !grants_kms {
+                    return Err(format!(
+                        "{role}/{sid} (statement #{index}): Resource {resource:?} is a KMS \
+                         key ARN, but the statement's Action {actions:?} grants no KMS \
+                         operation -- the KMS resource guards select on the action, so this \
+                         ARN would be checked by nothing"
+                    ));
+                }
+                saw_kms = true;
+            }
+            ResourceShape::Unclassified => {
+                return Err(format!(
+                    "{role}/{sid} (statement #{index}): Resource {resource:?} is neither \
+                     bucket-relative to {BUCKET_ARN:?}, nor exactly that bucket ARN, nor \
+                     an {KMS_ARN_PREFIX:?} key ARN -- an access-point or Object Lambda or \
+                     multi-region-access-point ARN, \"*\", \"arn:*\", another bucket, or a \
+                     malformed non-ARN grants access no guard in this file can check, so \
+                     it must fail closed rather than be dropped as nothing to check \
+                     (issue #1346, H1)"
+                ));
+            }
+        }
+    }
+
+    if grants_object && !saw_object {
+        return Err(format!(
+            "{role}/{sid} (statement #{index}): Action {actions:?} grants an S3 object \
+             operation but Resource {resources:?} names no object under {BUCKET_ARN:?} -- \
+             the object axis would derive an empty pattern set and skip the statement"
+        ));
+    }
+    if grants_list && !saw_bucket {
+        return Err(format!(
+            "{role}/{sid} (statement #{index}): Action {actions:?} grants an S3 bucket \
+             operation but Resource {resources:?} is not the bare bucket ARN \
+             {BUCKET_ARN:?} -- a list grant on any other resource enumerates a bucket this \
+             file models nothing about, and round three's list-only exemption left exactly \
+             this shape read by no guard (issue #1346, H2)"
+        ));
+    }
+    if grants_kms && !saw_kms {
+        return Err(format!(
+            "{role}/{sid} (statement #{index}): Action {actions:?} grants a KMS operation \
+             but Resource {resources:?} names no {KMS_ARN_PREFIX:?} key ARN -- \
+             kms_statement_resources would return an empty resource list and both KMS \
+             resource guards would examine nothing"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a statement's `Condition` sub-shape against the exact operators and
+/// keys the guards read (`HANDLED_CONDITION_OPERATORS` / `HANDLED_CONDITION_KEYS`).
+/// The Condition must be a NON-EMPTY JSON object; every operator in it must be
+/// handled and map to a NON-EMPTY object; every key under a handled operator must
+/// be handled and map to a string or non-empty array of strings (the shape
+/// `list_prefix_patterns` reads). Anything else -- an unhandled operator such as
+/// `StringNotLike` or a set-qualified `ForAnyValue:StringLike`, an unhandled key
+/// such as `s3:delimiter`, a non-object Condition, or an empty `{}` /
+/// `{"StringLike": {}}` (a `for` over an empty map iterates zero times, so it used
+/// to return Ok and constrain nothing) -- is a shape no guard reasons about and is
+/// rejected by name (issue #1346, F2). Without this, a ListBucket statement
+/// carrying such a Condition passes validation and `list_prefix_patterns` then
+/// finds no `["StringLike"]["s3:prefix"]` array and silently contributes nothing.
+///
+/// A non-empty `StringLike` map whose every key is handled forces `s3:prefix` to
+/// be present (it is the only handled key), so no separate presence check is
+/// needed.
+///
+/// Shape is necessary but not sufficient: each `s3:prefix` VALUE must also
+/// constrain. A value that `glob_admits_everything` accepts -- a bare `"*"`, any
+/// all-`"*"` run -- passes every shape check yet lets a caller list the whole
+/// bucket, constraining no more than an absent Condition. It is rejected for the
+/// same reason the empty block is, one level down in the value (issue #1346, F1).
+fn validate_condition(
+    role: &str,
+    sid: &str,
+    index: usize,
+    condition: &serde_json::Value,
+) -> Result<(), String> {
+    let cond_obj = condition.as_object().ok_or_else(|| {
+        format!("{role}/{sid} (statement #{index}): Condition is not a JSON object: {condition:?}")
+    })?;
+    if cond_obj.is_empty() {
+        return Err(format!(
+            "{role}/{sid} (statement #{index}): Condition is an empty object -- an empty \
+             Condition constrains nothing, so a ListBucket statement carrying it is an \
+             unconstrained bucket-wide list; it must be a non-empty StringLike/s3:prefix \
+             block (issue #1346, F2)"
+        ));
+    }
+    for (operator, keys) in cond_obj {
+        if !HANDLED_CONDITION_OPERATORS.contains(&operator.as_str()) {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): Condition uses operator {operator:?}, \
+                 which no guard in this file reads (handled operators: \
+                 {HANDLED_CONDITION_OPERATORS:?}); a different or set-qualified operator \
+                 such as StringNotLike or ForAnyValue:StringLike must fail closed rather \
+                 than sit unexamined"
+            ));
+        }
+        let key_obj = keys.as_object().ok_or_else(|| {
+            format!(
+                "{role}/{sid} (statement #{index}): Condition operator {operator:?} is not a \
+                 JSON object: {keys:?}"
+            )
+        })?;
+        if key_obj.is_empty() {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): Condition operator {operator:?} is an \
+                 empty object -- it must map s3:prefix to a non-empty value; an empty \
+                 operator map constrains nothing (issue #1346, F2)"
+            ));
+        }
+        for (cond_key, value) in key_obj {
+            if !HANDLED_CONDITION_KEYS.contains(&cond_key.as_str()) {
+                return Err(format!(
+                    "{role}/{sid} (statement #{index}): Condition operator {operator:?} names \
+                     key {cond_key:?}, which no guard in this file reads (handled keys: \
+                     {HANDLED_CONDITION_KEYS:?}); it must fail closed rather than sit \
+                     unexamined"
+                ));
+            }
+            if !is_string_or_string_array(Some(value)) {
+                return Err(format!(
+                    "{role}/{sid} (statement #{index}): Condition {operator:?}.{cond_key:?} is \
+                     neither a string nor a non-empty array of strings: {value:?}"
+                ));
+            }
+            // Shape is not enough: the VALUE must constrain. A shape-valid
+            // s3:prefix that admits everything (a bare "*", any all-"*" run) lets
+            // a caller pass the empty prefix and list the whole bucket, exactly as
+            // an absent Condition would -- the same emptiness the empty-map arms
+            // above reject, one level down in the value (issue #1346, F1). The
+            // empty-block rejection says an empty block "constrains nothing"; that
+            // is equally true of a "*" value, so it fails here too. Gated on
+            // s3:prefix because "admits everything" is a glob-prefix reading; a
+            // future handled key with different value semantics would need its own.
+            if cond_key == "s3:prefix" {
+                for prefix in condition_value_strings(value) {
+                    if glob_admits_everything(prefix) {
+                        return Err(format!(
+                            "{role}/{sid} (statement #{index}): Condition {operator:?}.{cond_key:?} \
+                             value {prefix:?} admits every key (the empty prefix matches it), so it \
+                             constrains no more than an absent Condition -- an s3:prefix must \
+                             exclude some key outside its listed prefixes (issue #1346, F1)"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The string values in a Condition-key value that is a string or an array of
+/// strings (`validate_condition` has already proved it is one of those shapes).
+fn condition_value_strings(value: &serde_json::Value) -> Vec<&str> {
+    match value {
+        serde_json::Value::String(s) => vec![s.as_str()],
+        serde_json::Value::Array(a) => a.iter().filter_map(|v| v.as_str()).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// True only for a JSON string or a non-empty array whose every element is a
+/// string. An empty array is rejected: `iter().all(..)` is vacuously true on it,
+/// so `"Action": []` / `"Resource": []` used to pass and every downstream guard
+/// then derived an empty set and skipped the statement (issue #1346).
+fn is_string_or_string_array(value: Option<&serde_json::Value>) -> bool {
+    match value {
+        Some(serde_json::Value::String(_)) => true,
+        Some(serde_json::Value::Array(a)) => {
+            !a.is_empty() && a.iter().all(serde_json::Value::is_string)
+        }
+        _ => false,
+    }
+}
+
+/// Run `validate_statement` over every statement in a policy's `Statement`
+/// array, returning the first rejection. This is the real per-statement
+/// validation loop `load_policy` runs on every shipped template; extracting it
+/// lets the regression tests call THIS function (and drive it through
+/// `build_policy`, load_policy's own body) rather than a re-typed copy of the
+/// loop that would keep passing if the call in `load_policy` were deleted.
+fn validate_policy_statements(role: &str, statements: &serde_json::Value) -> Result<(), String> {
+    let array = statements
+        .as_array()
+        .ok_or_else(|| format!("{role}: Statement is not an array"))?;
+    for (index, stmt) in array.iter().enumerate() {
+        validate_statement(role, index, stmt)?;
+    }
+    Ok(())
+}
+
+/// The parse-and-validate body shared by `load_policy` and the regression tests
+/// that need to drive the real validation call site with a synthetic policy
+/// (`load_policy` itself only reads the fixed `deploy/iam/*.json` paths). Panics,
+/// naming `source`, if `Statement` is not an array or any statement is rejected.
+fn build_policy(role: &'static str, source: &str, json: &serde_json::Value) -> Policy {
     let statements = json["Statement"].clone();
-    assert!(statements.is_array(), "{path}: Statement is not an array");
+    assert!(statements.is_array(), "{source}: Statement is not an array");
+    if let Err(msg) = validate_policy_statements(role, &statements) {
+        panic!("{source}: {msg}");
+    }
     Policy { role, statements }
 }
 
-/// IAM action names are case-insensitive: a statement granting
-/// `KMS:GenerateDataKey*` grants exactly what `kms:GenerateDataKey*` grants.
-/// Every action comparison in this file goes through this helper (or
-/// `action_has_prefix`), in both directions. A case-sensitive positive check
-/// only fails loudly, but a case-sensitive negative check reports a role
-/// unprivileged while it holds the grant.
-fn action_eq(action: &str, expected: &str) -> bool {
-    action.eq_ignore_ascii_case(expected)
+/// The on-disk path of a shipped template.
+fn policy_json_path(role: &str) -> String {
+    format!(
+        "{}/../../deploy/iam/{role}.json",
+        env!("CARGO_MANIFEST_DIR")
+    )
 }
 
-/// Case-insensitive prefix match for action names, so `kms:GenerateDataKey`
-/// selects `KMS:GenerateDataKey*` too. Indexed with `get` rather than a slice
-/// so an action name whose bytes do not split on a char boundary at
-/// `prefix.len()` returns false instead of panicking.
-fn action_has_prefix(action: &str, prefix: &str) -> bool {
-    action
-        .get(..prefix.len())
-        .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+fn load_policy(role: &'static str) -> Policy {
+    load_policy_from(role, &policy_json_path(role))
+}
+
+/// The real file-reading entry point: read the policy at `path`, parse it, and
+/// run the full per-statement validation through `build_policy`. `load_policy`
+/// is exactly this against the fixed `deploy/iam/{role}.json` paths; a
+/// regression test drives it with a synthetic invalid file so the validation is
+/// exercised through the entry point production uses, not only through
+/// `build_policy` (issue #1346, F4).
+fn load_policy_from(role: &'static str, path: &str) -> Policy {
+    let text = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let json: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+    build_policy(role, path, &json)
 }
 
 /// Every action name in a statement's `Action` (a bare string or an array),
 /// with the policy's own capitalization preserved so a failure message quotes
 /// what the template actually says.
+///
+/// The `_ => Vec::new()` arm and the `filter_map` are unreachable for any
+/// statement that passed the choke point: `validate_statement` runs
+/// `is_string_or_string_array` on `Action` BEFORE calling this, so a non-string,
+/// a non-array, an empty array, and an array holding a non-string are all
+/// already rejected. The empty return survives only for the pre-fix fixtures,
+/// which call this on a raw `NotAction` statement precisely to pin that the
+/// action used to be invisible.
 fn statement_actions(stmt: &serde_json::Value) -> Vec<String> {
     match &stmt["Action"] {
         serde_json::Value::String(s) => vec![s.clone()],
@@ -207,180 +973,227 @@ fn statement_actions(stmt: &serde_json::Value) -> Vec<String> {
     }
 }
 
-/// `s3:prefix` patterns from every `s3:ListBucket` statement's
-/// `Condition.StringLike` block.
-fn list_prefix_patterns(policy: &Policy) -> Vec<String> {
-    let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
-        let is_list = statement_actions(stmt)
-            .iter()
-            .any(|a| action_eq(a, "s3:ListBucket"));
-        if !is_list {
-            continue;
-        }
-        if let Some(patterns) = stmt["Condition"]["StringLike"]["s3:prefix"].as_array() {
-            for p in patterns {
-                out.push(p.as_str().expect("s3:prefix entry is a string").to_string());
-            }
-        }
+/// Every resource string in a statement's `Resource` (a bare string or an
+/// array). Unreachable-arm justification is the same as `statement_actions`:
+/// `validate_statement` checks `Resource` with `is_string_or_string_array`
+/// before anything reads it.
+fn statement_resources(stmt: &serde_json::Value) -> Vec<&str> {
+    match &stmt["Resource"] {
+        serde_json::Value::String(s) => vec![s.as_str()],
+        serde_json::Value::Array(a) => a.iter().filter_map(|v| v.as_str()).collect(),
+        _ => Vec::new(),
     }
-    out
 }
 
-/// Resource-ARN key patterns (bucket prefix stripped) from every
-/// non-ListBucket statement (`GetObject`, `PutObject`, `DeleteObject`, ...).
-fn resource_key_patterns(policy: &Policy) -> Vec<String> {
-    let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
-        let is_list_only = stmt["Action"]
-            .as_str()
-            .is_some_and(|a| action_eq(a, "s3:ListBucket"));
-        if is_list_only {
-            continue;
-        }
-        let resources = match &stmt["Resource"] {
-            serde_json::Value::Array(a) => a.clone(),
-            v @ serde_json::Value::String(_) => vec![v.clone()],
-            _ => continue,
-        };
-        for r in resources {
-            let r = r.as_str().expect("Resource entry is a string");
-            if let Some(key_pattern) = r.strip_prefix("arn:aws:s3:::my-ravel-bucket/") {
-                out.push(key_pattern.to_string());
-            }
-        }
-    }
-    out
+/// A statement's `Sid`. Total for anything that passed the choke point, which
+/// requires a present string Sid so every message can name the statement it is
+/// about; the old `unwrap_or("<no Sid>")` fallback named nothing.
+fn statement_sid(stmt: &serde_json::Value) -> &str {
+    stmt["Sid"].as_str().expect(
+        "the choke point (validate_statement) requires a present string Sid, so any \
+         statement reaching a guard has one",
+    )
 }
 
-/// Resource-ARN key patterns (bucket prefix stripped) from every statement
-/// whose `Action` grants `s3:PutObject` --- the writes that go through
-/// `KmsRoutingStore` and can select a per-tenant key. Delete/Get/Deny
-/// statements are excluded: they never route (reads and deletes delegate to
-/// the default store unconditionally, see `kms_routing.rs`).
-fn put_resource_key_patterns(policy: &Policy) -> Vec<String> {
-    let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
-        let grants_put = statement_actions(stmt)
-            .iter()
-            .any(|a| action_eq(a, "s3:PutObject"));
-        if !grants_put {
-            continue;
-        }
-        let resources = match &stmt["Resource"] {
-            serde_json::Value::Array(a) => a.clone(),
-            v @ serde_json::Value::String(_) => vec![v.clone()],
-            _ => continue,
-        };
-        for r in resources {
-            let r = r.as_str().expect("Resource entry is a string");
-            if let Some(key_pattern) = r.strip_prefix("arn:aws:s3:::my-ravel-bucket/") {
-                out.push(key_pattern.to_string());
-            }
-        }
-    }
-    out
-}
-
-/// The literal S3 actions that delete a stored object, ASCII-folded. IAM action
-/// names are case-insensitive, so every comparison folds both sides.
-const DELETE_ACTION_NAMES: [&str; 2] = ["s3:deleteobject", "s3:deleteobjectversion"];
-
-/// True when an IAM `Action` grants (in an Allow) or withdraws (in a Deny) the
-/// capability to delete a stored object: one of the literal delete actions, or
-/// ANY IAM wildcard pattern (`*`/`?`) that matches one of them. This is the
-/// predicate the delete guard must use instead of an exact `s3:DeleteObject`
-/// match. `"*"`, `"s3:*"`, `"s3:Delete*"`, `"s3:DeleteObject*"`, and a
-/// mis-cased `"S3:DELETEOBJECT"` all grant the delete a bare-literal check
-/// misses, and missing one lets a delete-everywhere statement sit unexamined
-/// while the guard reports Admin scoped to the scratch prefix (issue #1372, the
-/// seventh instance of the skip-what-you-don't-recognize class #1346 tracks).
-fn action_is_delete_capable(action: &str) -> bool {
-    let folded = action.to_ascii_lowercase();
-    if DELETE_ACTION_NAMES.contains(&folded.as_str()) {
-        return true;
-    }
-    // Only a wildcard pattern can match beyond an exact name; a plain unrelated
-    // action (`s3:DeleteObjectTagging`, `s3:DeleteBucket`) is correctly not
-    // delete-capable. Fold before globbing so `S3:Delete*` is resolved too.
-    if folded.contains(IAM_WILDCARDS) {
-        return DELETE_ACTION_NAMES
-            .iter()
-            .any(|name| glob_matches(&folded, name));
-    }
-    false
-}
-
-/// Strip the configured bucket's object-ARN prefix from a delete statement's
-/// `Resource`, or fail the test naming the role, `Sid`, and resource. A
-/// delete-capable statement whose resource is `"*"`, names a different bucket,
-/// or is otherwise not bucket-relative grants (or denies) delete outside the
-/// configured bucket, and dropping it silently is the same mistake #1346
-/// records for `NotResource`: the entry you do not understand is exactly the
-/// one that must not vanish.
-fn require_bucket_relative_delete_resource(role: &str, sid: &str, resource: &str) -> String {
-    resource
-        .strip_prefix(BUCKET_KEY_PREFIX)
-        .map(str::to_string)
-        .unwrap_or_else(|| {
-            panic!(
-                "{role}/{sid}: delete-capable statement names resource {resource:?}, \
-                 which is not bucket-relative to {BUCKET_ARN:?} -- a delete grant or \
-                 deny on \"*\" or on another bucket reaches outside the configured \
-                 bucket and must not be silently dropped"
-            )
-        })
-}
-
-/// Resource key patterns (bucket prefix stripped) from every statement whose
-/// `Effect` is `effect` and whose `Action` is delete-capable (see
-/// `action_is_delete_capable`).
+/// `s3:prefix` patterns from the `Condition.StringLike` block of every statement
+/// whose `Effect` matches `effect` (`None` matches any) and whose `Action` grants
+/// a list operation.
 ///
-/// One function for both effects, because the two sides differ only in which
-/// `Effect` they select. The Resource-shape panic, the `Sid` fallback, and the
-/// bucket-relative requirement have to be identical on both, and a rule
-/// tightened on one copy and not the other is the failure this file keeps
-/// repeating.
+/// The `effect` argument is the same one `key_patterns_for` takes, and it exists
+/// for the same reason: a prefix is read as a permission or a prohibition
+/// depending on which caller reads it, and an explicit IAM `Deny` wins over an
+/// `Allow`. `discovery_prefix_admitted_for_every_discovering_role` reads the
+/// result as the prefixes a role is ALLOWED to list, so it must pass
+/// `Some("Allow")`: pooling a `Deny` block's `s3:prefix` into that vector would
+/// assert the inverse of the fact, admitting a discovery prefix that an explicit
+/// Deny withdraws (issue #1346, F1). A caller that only checks each prefix names a
+/// real key shape (`every_in_scope_policy_pattern_matches_a_real_key_shape`) is
+/// effect-agnostic and passes `None`.
+///
+/// Selection goes through `action_grants`, so `"Action": "s3:*"` is read here
+/// too. Under round three's exact-name detection it was not, which is half of
+/// H3: an `s3:*` statement granted an unconstrained ListBucket while this
+/// function read nothing from it.
+fn list_prefix_patterns(policy: &Policy, effect: Option<&str>) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        if let Some(effect) = effect {
+            let has_effect = stmt["Effect"]
+                .as_str()
+                .is_some_and(|e| e.eq_ignore_ascii_case(effect));
+            if !has_effect {
+                continue;
+            }
+        }
+        if !any_action_grants_any(&statement_actions(stmt), &S3_BUCKET_OPERATIONS) {
+            continue;
+        }
+        // IAM allows a single `s3:prefix` value as a bare string or an array;
+        // read both so a bare-string prefix is not silently skipped. Any other
+        // shape is unreachable: the choke point requires a list statement to
+        // carry a non-empty StringLike/s3:prefix Condition whose value is a
+        // string or non-empty array of strings, so the panic arm fires only for
+        // a statement that never passed validation.
+        match &stmt["Condition"]["StringLike"]["s3:prefix"] {
+            serde_json::Value::String(s) => out.push(s.clone()),
+            serde_json::Value::Array(patterns) => {
+                for p in patterns {
+                    out.push(p.as_str().expect("s3:prefix entry is a string").to_string());
+                }
+            }
+            other => panic!(
+                "{}/{}: list statement's Condition.StringLike.s3:prefix is {other:?} -- the \
+                 choke point requires a string or non-empty array of strings here, so \
+                 reaching this means a guard ran on an unvalidated statement",
+                policy.role,
+                statement_sid(stmt)
+            ),
+        }
+    }
+    out
+}
+
+/// A policy's statement array. `Statement`-is-an-array is asserted by
+/// `build_policy` and `validate_policy_statements` before a `Policy` exists.
+fn policy_statements(policy: &Policy) -> &Vec<serde_json::Value> {
+    policy
+        .statements
+        .as_array()
+        .expect("a Policy's Statement is an array (checked by build_policy)")
+}
+
+/// The bucket-relative key patterns among one statement's `resources`.
+///
+/// Total over `ResourceShape`, which is the point of the redesign: every arm is
+/// named and justified by a choke-point rule, so there is no catch-all that can
+/// quietly absorb a shape nobody thought about.
+///
+/// - `ObjectKey` is the pattern to check, returned.
+/// - `Bucket` contributes nothing to strip. Skipping it is safe because
+///   `validate_actions_and_resources` proved the same statement grants a list
+///   operation, and a list grant is checked on both counts: its Resource must be
+///   exactly this ARN, and its Condition must be the `s3:prefix` block
+///   `list_prefix_patterns` reads. This is the arm that makes the normal mixed
+///   ListBucket+GetObject idiom work without a misleading rejection, and round
+///   three's alternative -- exempting whole list statements at the caller --
+///   is what left list Resources read by nothing (H2).
+/// - `KmsKey` likewise: the choke point proved the statement grants a KMS
+///   operation, so `kms_statement_resources` selects it and both KMS resource
+///   guards run over this exact string.
+/// - `Unclassified` panics. The choke point rejects it, so reaching here means a
+///   guard ran on a statement that never passed validation (a synthetic fixture
+///   built straight from `Policy`), and the loud failure is the belt-and-braces
+///   half of the H1 fix.
+///
+/// A bucket-relative FULL-bucket object grant `arn:aws:s3:::my-ravel-bucket/*`
+/// (which strips to `"*"` and matches every key) is now rejected at the choke
+/// point by `validate_actions_and_resources`: it is the vacuous-value sibling of
+/// F1's `"*"` s3:prefix, on the resource axis, so a shape-valid object ARN that
+/// constrains nothing fails there rather than reaching
+/// `every_in_scope_policy_pattern_matches_a_real_key_shape` -- which asserts a
+/// pattern matches AT LEAST ONE real key and so, being a coverage check, cannot
+/// reject an over-broad pattern (issue #1346, F1 sweep). Rejecting an in-bucket
+/// grant that is merely too wide but still bounded (`t/*`) remains a separate
+/// guard, out of scope here.
+fn object_key_patterns(role: &str, sid: &str, resources: &[&str]) -> Vec<String> {
+    let mut out = Vec::new();
+    for resource in resources {
+        match classify_resource(resource) {
+            ResourceShape::ObjectKey(key_pattern) => out.push(key_pattern.to_string()),
+            ResourceShape::Bucket | ResourceShape::KmsKey => {}
+            ResourceShape::Unclassified => panic!(
+                "{role}/{sid}: statement names resource {resource:?}, which is neither \
+                 bucket-relative to {BUCKET_ARN:?}, nor exactly that bucket ARN, nor an \
+                 {KMS_ARN_PREFIX:?} key ARN -- validate_statement rejects this shape, so \
+                 reaching here means a guard ran on an unvalidated statement (issue \
+                 #1346, H1)"
+            ),
+        }
+    }
+    out
+}
+
+/// Bucket-relative key patterns from every statement whose `Effect` matches
+/// `effect` (`None` matches any) and whose `Action` grants at least one of
+/// `operations`.
+///
+/// The single resource-collection loop every S3 axis uses. Round three had four
+/// near-copies of it (read, put, delete-Allow, delete-Deny) that differed in
+/// which actions they selected, whether the selection resolved wildcards, and
+/// what they did with a resource they could not strip; the read copy and the
+/// delete copy then disagreed about the bare bucket ARN, which is how the
+/// list-only exemption got added to one of them. There is now one loop, one
+/// action predicate, and one resource classifier.
+///
+/// The `continue`s are axis selection, not shape skips: "this statement grants
+/// no operation on my axis" and "this statement is the other Effect". The choke
+/// point's coverage rule guarantees every statement is selected by at least one
+/// axis, and whichever axis selects it sees every resource it carries.
+fn key_patterns_for(policy: &Policy, operations: &[&str], effect: Option<&str>) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        if let Some(effect) = effect {
+            let has_effect = stmt["Effect"]
+                .as_str()
+                .is_some_and(|e| e.eq_ignore_ascii_case(effect));
+            if !has_effect {
+                continue;
+            }
+        }
+        if !any_action_grants_any(&statement_actions(stmt), operations) {
+            continue;
+        }
+        out.extend(object_key_patterns(
+            policy.role,
+            statement_sid(stmt),
+            &statement_resources(stmt),
+        ));
+    }
+    out
+}
+
+/// Bucket-relative key patterns from every statement granting an S3 object
+/// operation (`GetObject`, `PutObject`, `DeleteObject`, ...), either Effect.
+///
+/// Selection is by grant, not by "not ListBucket": a list-only statement grants
+/// no object operation and is not selected, and a mixed ListBucket+GetObject
+/// statement IS selected and contributes its object patterns.
+fn resource_key_patterns(policy: &Policy) -> Vec<String> {
+    key_patterns_for(policy, &S3_OBJECT_OPERATIONS, None)
+}
+
+/// Bucket-relative key patterns from every statement whose `Action` grants
+/// `s3:PutObject` --- the writes that go through `KmsRoutingStore` and can
+/// select a per-tenant key. Delete/Get/Deny statements are excluded: they never
+/// route (reads and deletes delegate to the default store unconditionally, see
+/// `kms_routing.rs`).
+///
+/// Delete and Get are excluded by action selection; `Deny` is excluded by the
+/// `Some("Allow")` effect argument. Its consumer,
+/// `roles_writing_routed_objects_have_kms_grant`, reads the result as the routed
+/// writes a role performs and then demands a KMS grant for them, so a `Deny`
+/// PutObject read as a routed write would demand a KMS grant for a write the role
+/// cannot perform --- the inverse of the fact, since an explicit Deny withdraws
+/// the write (issue #1346, F1/F2). Passing `None` here left `Deny` matching, so
+/// the sentence above was true of Delete/Get and false of Deny; `Some("Allow")`
+/// makes it true.
+///
+/// `"Action": "s3:*"` grants PutObject and so is selected here, which round
+/// three's exact-name match missed (H3).
+fn put_resource_key_patterns(policy: &Policy) -> Vec<String> {
+    key_patterns_for(policy, &["s3:PutObject"], Some("Allow"))
+}
+
+/// Bucket-relative key patterns from every statement whose `Effect` is `effect`
+/// and whose `Action` grants an S3 delete operation.
 ///
 /// `"Allow"` returns the delete capability a role actually holds. The
 /// `DenyDeleteProtected` block names delete actions too, but it withdraws
 /// capability rather than granting it (and an explicit IAM `Deny` always wins),
 /// so it is selected separately by `"Deny"`, which returns the keys that block
-/// protects (ADR-0055 §3). Either way a delete-capable statement whose Resource
-/// is not bucket-relative fails the test rather than being dropped: a Deny
-/// naming a delete on `"*"` would deny the qualification probe's own delete and
-/// one on another bucket protects nothing here.
+/// protects (ADR-0055 §3).
 fn delete_key_patterns(policy: &Policy, effect: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
-        let has_effect = stmt["Effect"]
-            .as_str()
-            .is_some_and(|e| e.eq_ignore_ascii_case(effect));
-        if !has_effect {
-            continue;
-        }
-        let touches_delete = statement_actions(stmt)
-            .iter()
-            .any(|a| action_is_delete_capable(a));
-        if !touches_delete {
-            continue;
-        }
-        let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
-        let resources = match &stmt["Resource"] {
-            serde_json::Value::Array(a) => a.clone(),
-            v @ serde_json::Value::String(_) => vec![v.clone()],
-            other => panic!(
-                "{}/{sid}: delete-capable {effect} has a Resource that is neither a \
-                 string nor an array: {other:?}",
-                policy.role
-            ),
-        };
-        for r in resources {
-            let r = r.as_str().expect("Resource entry is a string");
-            out.push(require_bucket_relative_delete_resource(policy.role, sid, r));
-        }
-    }
-    out
+    key_patterns_for(policy, &S3_DELETE_OPERATIONS, Some(effect))
 }
 
 const ROLES_WITH_DISCOVERY: [&str; 3] = ["gateway", "query", "maintain"];
@@ -412,55 +1225,85 @@ const ROUTED_WRITE_EXEMPT_ROLES: [&str; 1] = ["admin"];
 /// own PUT patterns and `KmsRoutingStore`'s real routing predicate.
 const WRITE_ROLES: [&str; 3] = ["gateway", "maintain", "query"];
 
-/// `kms:*` action strings appearing anywhere in `policy`'s statements
+/// `kms:*` action strings granted by an `Allow` statement anywhere in `policy`
 /// (`Action` as a bare string or an array), regardless of statement Sid.
 ///
-/// Selection is case-insensitive, so `KMS:GenerateDataKey*` is returned; the
-/// strings themselves keep the template's capitalization, so a caller's
-/// failure message shows what the policy said rather than a normalized form
-/// the operator would then grep for in vain. Callers compare with `action_eq`
-/// or `action_has_prefix` rather than against these strings directly.
+/// Allow-only, for the F1 reason applied to actions rather than resources: every
+/// caller reads the result as a grant the role HOLDS
+/// (`write_roles_have_kms_generate_data_key`,
+/// `roles_writing_routed_objects_have_kms_grant`, `every_role_has_kms_decrypt`) or
+/// as the absence of one (`admin_has_no_kms_generate_data_key`), and an explicit
+/// IAM `Deny` grants nothing. Pooling a `Deny kms:GenerateDataKey` into this
+/// vector would report a role able to mint ciphertext when the Deny withdraws
+/// exactly that, and would make the negative admin assertion fail on a policy that
+/// safely denies the operation --- the inverse of the fact in both directions
+/// (issue #1346, F1 sweep). A `Deny` KMS statement passes the choke point, so this
+/// case is reachable, not hypothetical.
+///
+/// Selection goes through `action_selects_kms`, so `KMS:GenerateDataKey*` is
+/// returned and so is a wildcard action (`"*"`, `"kms:*"`) that grants a KMS
+/// operation without naming the service literally --- which the old case-folded
+/// `kms:` prefix test missed. The strings themselves keep the template's
+/// capitalization, so a caller's failure message shows what the policy said
+/// rather than a normalized form the operator would then grep for in vain.
+/// Callers ask `action_grants` what a returned string grants; none compares it
+/// literally.
 fn kms_actions(policy: &Policy) -> Vec<String> {
     let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
+    for stmt in policy_statements(policy) {
+        let is_allow = stmt["Effect"]
+            .as_str()
+            .is_some_and(|e| e.eq_ignore_ascii_case("Allow"));
+        if !is_allow {
+            continue;
+        }
         out.extend(
             statement_actions(stmt)
                 .into_iter()
-                .filter(|a| action_has_prefix(a, "kms:")),
+                .filter(|a| action_selects_kms(a)),
         );
     }
     out
 }
 
-/// Sid and parsed `Resource` list for every statement carrying a `kms:`
-/// action. Both resource guards below go through this one selection rule, so
-/// a change to it cannot reach one guard and miss the other.
+/// Sid and KMS key ARNs for every `Allow` statement granting a KMS operation.
+/// Both KMS resource guards below go through this one selection rule, so a change
+/// to it cannot reach one guard and miss the other.
 ///
-/// Panics on a `Resource` that is neither a string nor an array, as the
-/// guards did inline: a malformed template must fail the test rather than be
-/// skipped as "no resources to check".
+/// Allow-only, for the F1 reason: both guards read the result as a GRANT that must
+/// be narrowly scoped (`no_allow_kms_statement_grants_every_key_in_the_region`,
+/// `every_allow_kms_statement_names_a_key_id`). An explicit `Deny` grants nothing, so a
+/// `Deny` naming `key/*` is a broad prohibition (safe), yet these guards would
+/// flag it as an account-wide grant --- the inverse of the fact. A `Deny` KMS
+/// statement passes the choke point, so this is reachable; scoping is asked only
+/// of the grants (issue #1346, F1 sweep).
+///
+/// The returned resources are filtered to `ResourceShape::KmsKey`, so a mixed
+/// statement's S3 object ARNs are not handed to the KMS ARN-shape assertions
+/// (which would reject them for the wrong reason). Nothing is lost: the choke
+/// point proved a KMS-granting statement carries at least one KMS ARN, and any
+/// object ARN it also carries is read by the object axis.
 fn kms_statement_resources(policy: &Policy) -> Vec<(String, Vec<String>)> {
-    let role = policy.role;
     let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
+    for stmt in policy_statements(policy) {
+        let is_allow = stmt["Effect"]
+            .as_str()
+            .is_some_and(|e| e.eq_ignore_ascii_case("Allow"));
+        if !is_allow {
+            continue;
+        }
         if !statement_actions(stmt)
             .iter()
-            .any(|a| action_has_prefix(a, "kms:"))
+            .any(|a| action_selects_kms(a))
         {
             continue;
         }
-        let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>").to_string();
-        let resources: Vec<String> = match &stmt["Resource"] {
-            serde_json::Value::String(s) => vec![s.clone()],
-            serde_json::Value::Array(a) => a
-                .iter()
-                .map(|v| v.as_str().expect("Resource entry is a string").to_string())
-                .collect(),
-            other => {
-                panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
-            }
-        };
-        out.push((sid, resources));
+        let resources: Vec<String> = statement_resources(stmt)
+            .into_iter()
+            .filter(|r| matches!(classify_resource(r), ResourceShape::KmsKey))
+            .map(str::to_string)
+            .collect();
+        out.push((statement_sid(stmt).to_string(), resources));
     }
     out
 }
@@ -481,7 +1324,7 @@ fn write_roles_have_kms_generate_data_key() {
         assert!(
             actions
                 .iter()
-                .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
+                .any(|a| action_grants_any(a, &KMS_DATA_KEY_OPERATIONS)),
             "{role}: policy is missing kms:GenerateDataKey* -- its ingest/compaction/\
              catalog-fold PUTs under t/<hash>/... will fail closed against a \
              --tenant-kms-config tenant. Found kms actions: {actions:?}"
@@ -534,13 +1377,13 @@ fn roles_writing_routed_objects_have_kms_grant() {
         assert!(
             actions
                 .iter()
-                .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
+                .any(|a| action_grants_any(a, &KMS_DATA_KEY_OPERATIONS)),
             "{role}: PUTs routed object class(es) {routed:?} but policy lacks \
              kms:GenerateDataKey* -- those writes fail closed under \
              --tenant-kms-config. Found kms actions: {actions:?}"
         );
         assert!(
-            actions.iter().any(|a| action_eq(a, "kms:Encrypt")),
+            actions.iter().any(|a| action_grants(a, "kms:Encrypt")),
             "{role}: PUTs routed object class(es) {routed:?} but policy lacks \
              kms:Encrypt -- those writes fail closed under --tenant-kms-config. \
              Found kms actions: {actions:?}"
@@ -561,7 +1404,7 @@ fn admin_has_no_kms_generate_data_key() {
     assert!(
         !actions
             .iter()
-            .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
+            .any(|a| action_grants_any(a, &KMS_DATA_KEY_OPERATIONS)),
         "admin: policy must not carry kms:GenerateDataKey* (Decrypt-only per ADR-0055). \
          Found kms actions: {actions:?}"
     );
@@ -640,9 +1483,15 @@ fn admin_delete_grant_is_qualify_scratch_only() {
 /// pins the two holes existed independent of the fixed code: delete capability
 /// recognized only by an exact `s3:DeleteObject` match, and any resource not
 /// under the bucket prefix silently dropped (`if let Some(..)` with no `else`).
+///
+/// Every pre-fix body in this file spells its own comparisons out (here
+/// `eq_ignore_ascii_case`, below `strip_prefix` against a literal ARN) rather
+/// than calling a live helper: a pre-fix copy that reuses today's predicates
+/// stops proving the hole the moment those predicates change, which is how a
+/// fixture becomes a tautology.
 fn pre_fix_allow_delete_key_patterns(policy: &Policy) -> Vec<String> {
     let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
+    for stmt in policy_statements(policy) {
         let is_allow = stmt["Effect"]
             .as_str()
             .is_some_and(|e| e.eq_ignore_ascii_case("Allow"));
@@ -651,7 +1500,7 @@ fn pre_fix_allow_delete_key_patterns(policy: &Policy) -> Vec<String> {
         }
         let grants_delete = statement_actions(stmt)
             .iter()
-            .any(|a| action_eq(a, "s3:DeleteObject"));
+            .any(|a| a.eq_ignore_ascii_case("s3:DeleteObject"));
         if !grants_delete {
             continue;
         }
@@ -740,7 +1589,7 @@ fn wildcard_or_out_of_bucket_delete_grant_is_not_a_bypass() {
                 "Resource": resource,
             }]),
         };
-        let stmt = &policy.statements.as_array().unwrap()[0];
+        let stmt = &policy_statements(&policy)[0];
         let actions = statement_actions(stmt);
 
         // Observation 1 (load-bearing): the pre-fix helper returned no delete
@@ -758,16 +1607,18 @@ fn wildcard_or_out_of_bucket_delete_grant_is_not_a_bypass() {
         // ...pin WHY it was empty so the two holes stay distinguishable: either
         // the pre-fix exact match did not see a wildcard action, or it saw the
         // action but the silent drop discarded a non-bucket-relative resource.
-        let pre_fix_action_hit = actions.iter().any(|a| action_eq(a, "s3:DeleteObject"));
+        let pre_fix_action_hit = actions
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("s3:DeleteObject"));
         assert_eq!(
             pre_fix_action_hit, pre_fix_exact_recognizes,
             "fixture {sid} invalid: expected pre-fix exact action recognition = \
              {pre_fix_exact_recognizes} for {actions:?}"
         );
         assert!(
-            actions.iter().any(|a| action_is_delete_capable(a)),
-            "fixture {sid} invalid: post-fix action_is_delete_capable must \
-             recognize {actions:?} as a delete grant"
+            any_action_grants_any(&actions, &S3_DELETE_OPERATIONS),
+            "fixture {sid} invalid: the post-fix action predicate must recognize \
+             {actions:?} as a delete grant"
         );
 
         // Observation 2: the real guard fires on the synthetic policy --- either
@@ -799,7 +1650,7 @@ fn every_role_has_kms_decrypt() {
         let policy = load_policy(role);
         let actions = kms_actions(&policy);
         assert!(
-            actions.iter().any(|a| action_eq(a, "kms:Decrypt")),
+            actions.iter().any(|a| action_grants(a, "kms:Decrypt")),
             "{role}: policy is missing kms:Decrypt -- its reads of SSE-KMS objects \
              under a --tenant-kms-config tenant will fail closed. \
              Found kms actions: {actions:?}"
@@ -850,16 +1701,18 @@ fn assert_kms_resource_names_a_key_id(role: &str, sid: &str, resource: &str) {
     );
 }
 
-/// Every statement whose `Action` grants any `kms:` action must not name a
+/// Every ALLOW statement whose `Action` grants any `kms:` action must not name a
 /// `Resource` that covers every key in the account/region: not the bare
 /// wildcard `"*"`, not an ARN ending `:key/*`, and not an ARN carrying an IAM
-/// wildcard character anywhere else either. Pinned as a negation (not an
+/// wildcard character anywhere else either. Only `Allow` statements are checked
+/// (`kms_statement_resources` filters to them): a `Deny` naming `key/*` is a
+/// broad prohibition, not an over-broad grant. Pinned as a negation (not an
 /// exact tenant-key ARN) so it survives an operator's post-substitution
 /// value. Widen any of the four templates' KMS `Resource` back to
 /// `arn:aws:kms:us-east-1:111122223333:key/*` and this test fails, naming
 /// the role and the statement `Sid`.
 #[test]
-fn no_kms_statement_grants_every_key_in_the_region() {
+fn no_allow_kms_statement_grants_every_key_in_the_region() {
     for role in ALL_ROLES {
         let policy = load_policy(role);
         let statements = kms_statement_resources(&policy);
@@ -869,6 +1722,13 @@ fn no_kms_statement_grants_every_key_in_the_region() {
              would pass having examined nothing"
         );
         for (sid, resources) in statements {
+            assert!(
+                !resources.is_empty(),
+                "{role}/{sid}: statement grants a KMS operation but names no \
+                 {KMS_ARN_PREFIX:?} key ARN -- this guard would examine nothing \
+                 (validate_statement rejects the shape, so a shipped template reaching \
+                 here means the choke point was bypassed)"
+            );
             for resource in &resources {
                 assert_kms_resource_is_not_account_wide(role, &sid, resource);
             }
@@ -876,13 +1736,15 @@ fn no_kms_statement_grants_every_key_in_the_region() {
     }
 }
 
-/// Every statement whose `Action` grants any `kms:` action must name a
+/// Every ALLOW statement whose `Action` grants any `kms:` action must name a
 /// `Resource` that pins a specific key id, so an operator cannot re-widen
 /// the grant to every key by substituting `arn:aws:kms:<region>:<account>:key/*`
 /// (or any other wildcard variant, in the key id or in the region or account
-/// segment) in place of the placeholder.
+/// segment) in place of the placeholder. Only `Allow` statements are checked
+/// (`kms_statement_resources` filters to them): a `Deny` names a prohibition,
+/// which need not pin a single key.
 #[test]
-fn every_kms_statement_names_a_key_id() {
+fn every_allow_kms_statement_names_a_key_id() {
     for role in ALL_ROLES {
         let policy = load_policy(role);
         let statements = kms_statement_resources(&policy);
@@ -892,6 +1754,13 @@ fn every_kms_statement_names_a_key_id() {
              would pass having examined nothing"
         );
         for (sid, resources) in statements {
+            assert!(
+                !resources.is_empty(),
+                "{role}/{sid}: statement grants a KMS operation but names no \
+                 {KMS_ARN_PREFIX:?} key ARN -- this guard would examine nothing \
+                 (validate_statement rejects the shape, so a shipped template reaching \
+                 here means the choke point was bypassed)"
+            );
             for resource in &resources {
                 assert_kms_resource_names_a_key_id(role, &sid, resource);
             }
@@ -930,7 +1799,7 @@ fn mixed_case_kms_action_is_not_a_bypass() {
 
     // Observation 2: the post-fix selection catches it, through the same
     // helper the guards use.
-    let selected_after_fix = actions.iter().any(|a| action_has_prefix(a, "kms:"));
+    let selected_after_fix = actions.iter().any(|a| action_selects_kms(a));
     assert!(
         selected_after_fix,
         "fixture invalid: the post-fix matcher should select \"KMS:Decrypt\""
@@ -1021,12 +1890,12 @@ fn mixed_case_generate_data_key_is_not_missed_by_the_negative_assertion() {
     assert!(
         actions
             .iter()
-            .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
+            .any(|a| action_grants_any(a, &KMS_DATA_KEY_OPERATIONS)),
         "the post-fix matcher must see KMS:GenerateDataKey* as the \
          kms:GenerateDataKey* grant it is. Found kms actions: {actions:?}"
     );
     assert!(
-        actions.iter().any(|a| action_eq(a, "kms:Decrypt")),
+        actions.iter().any(|a| action_grants(a, "kms:Decrypt")),
         "the post-fix matcher must see KMS:Decrypt as kms:Decrypt. \
          Found kms actions: {actions:?}"
     );
@@ -1186,7 +2055,7 @@ fn single_character_wildcard_in_kms_resource_is_not_a_bypass() {
         });
         assert!(
             account_wide_guard.is_err(),
-            "no_kms_statement_grants_every_key_in_the_region's assertion must \
+            "no_allow_kms_statement_grants_every_key_in_the_region's assertion must \
              fire on {resource:?}"
         );
         let key_id_guard = std::panic::catch_unwind(|| {
@@ -1194,17 +2063,422 @@ fn single_character_wildcard_in_kms_resource_is_not_a_bypass() {
         });
         assert!(
             key_id_guard.is_err(),
-            "every_kms_statement_names_a_key_id's assertion must fire on \
+            "every_allow_kms_statement_names_a_key_id's assertion must fire on \
              {resource:?}"
         );
     }
+}
+
+/// Regression fixtures for the fail-closed choke point (issue #1346, the fourth
+/// instance of the skip-what-you-do-not-understand class this guard keeps
+/// repeating: could not read `Resource`; matched the action prefix
+/// case-sensitively; accepted `?` in ARN segments; and now ignores
+/// `NotResource`/`NotAction`). Before this fix, `load_policy` performed no
+/// per-statement validation, so a statement whose permission lived in a field
+/// no guard reads -- `NotResource`, `NotAction`, an unrecognized key such as a
+/// `Resources` typo, or a statement with no `Resource` at all -- was loaded and
+/// then silently skipped by whichever guard went looking for a field it did not
+/// find. The guard ran, reported the templates safe, and the statement sat
+/// unexamined.
+///
+/// Synthetic statements, not `deploy/iam/*.json`: the shipped templates carry
+/// only handled, well-formed statements, so a fixture over them proves nothing
+/// about the choke point and goes green the day someone edits the config. Each
+/// negative case asserts in both directions -- that the pre-fix guards found
+/// nothing to object to (Observation 1, the hole) and that `validate_statement`
+/// now rejects it naming both the `Sid` and the offending key (Observation 2).
+#[test]
+fn statement_using_an_unhandled_key_fails_closed() {
+    // (Sid, statement, substring the rejection must name, which field hid the
+    // permission pre-fix: "resource" => resource_key_patterns skipped it,
+    // "action" => statement_actions saw no action).
+    let negative_cases = [
+        (
+            "NegatedResource",
+            serde_json::json!({
+                "Sid": "NegatedResource",
+                "Effect": "Allow",
+                "Action": "s3:DeleteObject",
+                "NotResource": "arn:aws:s3:::my-ravel-bucket/t/*/*/prov"
+            }),
+            "NotResource",
+            "resource",
+        ),
+        (
+            "NegatedAction",
+            serde_json::json!({
+                "Sid": "NegatedAction",
+                "Effect": "Allow",
+                "NotAction": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "NotAction",
+            "action",
+        ),
+        (
+            "TypoResources",
+            serde_json::json!({
+                "Sid": "TypoResources",
+                "Effect": "Allow",
+                "Action": "s3:PutObject",
+                "Resources": "arn:aws:s3:::my-ravel-bucket/t/*/*/l0/*"
+            }),
+            "Resources",
+            "resource",
+        ),
+        (
+            "MissingResource",
+            serde_json::json!({
+                "Sid": "MissingResource",
+                "Effect": "Allow",
+                "Action": "s3:GetObject"
+            }),
+            "no Resource",
+            "resource",
+        ),
+    ];
+
+    for (sid, stmt, must_name, hidden_side) in &negative_cases {
+        let policy = Policy {
+            role: "fixture",
+            statements: serde_json::json!([stmt.clone()]),
+        };
+
+        // Observation 1 (load-bearing): the pre-fix guard that would have read
+        // the permission found nothing. A resource-hidden statement produces no
+        // resource pattern to check; an action-hidden statement produces no
+        // action. If the relevant set stops being empty, the fixture no longer
+        // proves the statement was skipped and must be rewritten, not deleted.
+        match *hidden_side {
+            "resource" => assert!(
+                resource_key_patterns(&policy).is_empty(),
+                "fixture {sid} invalid: resource_key_patterns was expected to \
+                 skip the statement (returning nothing); it did not"
+            ),
+            "action" => assert!(
+                statement_actions(stmt).is_empty(),
+                "fixture {sid} invalid: statement_actions was expected to see no \
+                 action (returning nothing); it did not"
+            ),
+            other => panic!("fixture {sid}: unknown hidden_side {other:?}"),
+        }
+
+        // Observation 2: the choke point rejects it, naming the Sid and the key.
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+
+        // ...and so does the extracted loop `load_policy` actually runs
+        // (`validate_policy_statements`), called directly here rather than
+        // re-typed into a closure. `load_policy_rejects_an_unhandled_statement`
+        // separately pins that `load_policy`/`build_policy` still call it.
+        assert!(
+            validate_policy_statements(policy.role, &policy.statements).is_err(),
+            "fixture {sid}: validate_policy_statements (load_policy's real loop) \
+             must reject it"
+        );
+    }
+
+    // Positive control: a well-formed Allow whose keys are all handled passes.
+    let ok = serde_json::json!({
+        "Sid": "WellFormedAllow",
+        "Effect": "Allow",
+        "Action": ["s3:GetObject", "s3:PutObject"],
+        "Resource": ["arn:aws:s3:::my-ravel-bucket/t/*"]
+    });
+    assert!(
+        validate_statement("fixture", 0, &ok).is_ok(),
+        "a well-formed Allow with only handled keys must pass"
+    );
+}
+
+/// Companion to the choke point's key check: a statement whose keys are all
+/// handled but whose values are malformed must also fail closed rather than be
+/// skipped. Pre-fix, an `Effect` that is neither Allow nor Deny was skipped by
+/// every effect-filtered guard (they compare case-insensitively against exactly
+/// those two), and an `Action` or `Resource` that is neither a string nor an
+/// array of strings was read as an empty set and dropped. Synthetic for the
+/// same reason as above.
+#[test]
+fn malformed_effect_action_or_resource_fails_closed() {
+    let cases = [
+        (
+            "BadEffect",
+            serde_json::json!({
+                "Sid": "BadEffect",
+                "Effect": "Permit",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Effect",
+        ),
+        (
+            "ActionIsNumber",
+            serde_json::json!({
+                "Sid": "ActionIsNumber",
+                "Effect": "Allow",
+                "Action": 7,
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Action",
+        ),
+        (
+            "ActionArrayHasNonString",
+            serde_json::json!({
+                "Sid": "ActionArrayHasNonString",
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", 7],
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Action",
+        ),
+        (
+            "ResourceIsNumber",
+            serde_json::json!({
+                "Sid": "ResourceIsNumber",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": 7
+            }),
+            "Resource",
+        ),
+    ];
+
+    for (sid, stmt, must_name) in &cases {
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+    }
+}
+
+/// F2 regression: an empty `Action`/`Resource` array must fail closed. Pre-fix,
+/// `is_string_or_string_array` returned true for `[]` (`iter().all(..)` is
+/// vacuously true on an empty array), so `"Action": []` / `"Resource": []`
+/// passed validation and every downstream guard derived an empty set and
+/// skipped the statement -- the skip class #1346 tracks, one level inside a
+/// handled key. Synthetic, not `deploy/iam/*.json`: the shipped templates carry
+/// no empty arrays.
+#[test]
+fn empty_action_or_resource_array_fails_closed() {
+    let cases = [
+        (
+            "EmptyAction",
+            serde_json::json!({
+                "Sid": "EmptyAction",
+                "Effect": "Allow",
+                "Action": [],
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Action",
+        ),
+        (
+            "EmptyResource",
+            serde_json::json!({
+                "Sid": "EmptyResource",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": []
+            }),
+            "Resource",
+        ),
+    ];
+
+    for (sid, stmt, must_name) in &cases {
+        // The fixed predicate rejects the empty array. (An `iter().all` over the
+        // empty array is vacuously true, which is exactly the pre-fix bug.)
+        assert!(
+            !is_string_or_string_array(stmt.get(must_name)),
+            "fixture {sid}: an empty {must_name} array must not count as a string array"
+        );
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+    }
+}
+
+/// F1 regression: a `Condition` whose sub-shape is anything other than the one
+/// `StringLike`/`s3:prefix` block a guard reads must fail closed. Pre-fix,
+/// `validate_statement` accepted any `Condition` value, so a statement carrying
+/// `StringNotLike`, a set-qualified `ForAnyValue:StringLike`, an unhandled key
+/// such as `s3:delimiter`, or a non-object Condition passed validation and
+/// `list_prefix_patterns` then found no `["StringLike"]["s3:prefix"]` array and
+/// silently contributed nothing -- the skip class moved one level down into a
+/// handled key. Synthetic, not `deploy/iam/*.json`: every shipped Condition is
+/// exactly `StringLike`/`s3:prefix`.
+#[test]
+fn unhandled_condition_shape_fails_closed() {
+    let cases = [
+        (
+            "StringNotLikeOperator",
+            serde_json::json!({
+                "Sid": "StringNotLikeOperator",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"StringNotLike": {"s3:prefix": ["t/*"]}}
+            }),
+            "StringNotLike",
+        ),
+        (
+            "SetQualifiedOperator",
+            serde_json::json!({
+                "Sid": "SetQualifiedOperator",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"ForAnyValue:StringLike": {"s3:prefix": ["t/*"]}}
+            }),
+            "ForAnyValue:StringLike",
+        ),
+        (
+            "UnhandledConditionKey",
+            serde_json::json!({
+                "Sid": "UnhandledConditionKey",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"StringLike": {"s3:delimiter": ["/"]}}
+            }),
+            "s3:delimiter",
+        ),
+        (
+            "ConditionNotObject",
+            serde_json::json!({
+                "Sid": "ConditionNotObject",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": "StringLike"
+            }),
+            "Condition",
+        ),
+    ];
+
+    for (sid, stmt, must_name) in &cases {
+        // Load-bearing: the guard that would read this Condition finds nothing,
+        // so the constraint sits unexamined. Prove the pre-fix skip on the two
+        // operator cases (both are s3:ListBucket, so list_prefix_patterns is the
+        // guard that skips them).
+        if *sid == "StringNotLikeOperator" || *sid == "SetQualifiedOperator" {
+            let policy = Policy {
+                role: "fixture",
+                statements: serde_json::json!([stmt.clone()]),
+            };
+            assert!(
+                pre_fix_list_prefix_patterns(&policy).is_empty(),
+                "fixture {sid}: the pre-fix list_prefix_patterns was expected to \
+                 skip the statement (finding no StringLike/s3:prefix); it did not"
+            );
+        }
+
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+    }
+
+    // Positive control: the shipped StringLike/s3:prefix shape passes.
+    let ok = serde_json::json!({
+        "Sid": "GoodCondition",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": "arn:aws:s3:::my-ravel-bucket",
+        "Condition": {"StringLike": {"s3:prefix": ["t/*", "sys/*"]}}
+    });
+    assert!(
+        validate_statement("fixture", 0, &ok).is_ok(),
+        "the shipped StringLike/s3:prefix Condition shape must pass"
+    );
+}
+
+/// F3 wiring guard: `load_policy` (through its shared body `build_policy`) must
+/// actually call `validate_policy_statements`. Driving a synthetic invalid
+/// policy through `build_policy` -- the real validation call site -- is what
+/// makes this test fail if that call is deleted; a test that only calls
+/// `validate_policy_statements` directly would keep passing. Proven by removing
+/// the call from `build_policy`: this test then reports no panic and fails.
+#[test]
+fn load_policy_rejects_an_unhandled_statement() {
+    let json = serde_json::json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Sid": "NegatedResource",
+            "Effect": "Allow",
+            "Action": "s3:DeleteObject",
+            "NotResource": "arn:aws:s3:::my-ravel-bucket/t/*"
+        }]
+    });
+    let built = std::panic::catch_unwind(|| build_policy("fixture", "synthetic", &json));
+    assert!(
+        built.is_err(),
+        "build_policy (load_policy's real body) must reject a statement whose \
+         permission lives in NotResource, a field no guard reads"
+    );
+}
+
+/// Sweep proof: `list_prefix_patterns` reads a bare-string `s3:prefix`, not only
+/// an array. IAM allows either shape; before this fix the `.as_array()` read
+/// skipped a bare string, so a ListBucket discovery prefix expressed as a string
+/// contributed nothing.
+#[test]
+fn list_prefix_patterns_reads_a_bare_string_prefix() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "BareStringPrefix",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+            "Condition": {"StringLike": {"s3:prefix": "t/"}}
+        }]),
+    };
+    assert_eq!(
+        list_prefix_patterns(&policy, None),
+        vec!["t/".to_string()],
+        "a bare-string s3:prefix must be read, not skipped"
+    );
+    // ...and the shipped array shape still validates and is read.
+    assert!(
+        validate_statement("fixture", 0, &policy_statements(&policy)[0]).is_ok(),
+        "a bare-string s3:prefix is a valid IAM shape and must pass validation"
+    );
 }
 
 #[test]
 fn discovery_prefix_admitted_for_every_discovering_role() {
     for role in ROLES_WITH_DISCOVERY {
         let policy = load_policy(role);
-        let patterns = list_prefix_patterns(&policy);
+        // Allow-only: an explicit Deny ListBucket withdraws listing, so its
+        // s3:prefix is not a prefix the role is ALLOWED to discover. Reading it
+        // here would assert the inverse of the fact (issue #1346, F1).
+        let patterns = list_prefix_patterns(&policy, Some("Allow"));
         assert!(
             patterns.iter().any(|p| glob_matches(p, "t/")),
             "{role}: ListBucket s3:prefix condition {patterns:?} does not admit \
@@ -1219,7 +2493,9 @@ fn every_in_scope_policy_pattern_matches_a_real_key_shape() {
     let keys = representative_keys();
     for role in ALL_ROLES {
         let policy = load_policy(role);
-        let mut patterns = list_prefix_patterns(&policy);
+        // None: this is a shape check (does every pattern name a real key?), not
+        // a permission read, so a Deny list prefix must still name a real key.
+        let mut patterns = list_prefix_patterns(&policy, None);
         patterns.extend(resource_key_patterns(&policy));
         for pattern in patterns {
             if is_out_of_scope(&pattern) {
@@ -1238,5 +2514,1433 @@ fn every_in_scope_policy_pattern_matches_a_real_key_shape() {
                 policy.role
             );
         }
+    }
+}
+
+/// The pre-fix `list_prefix_patterns` body, verbatim: an exact-name list
+/// detection and a `_ => {}` arm that contributed nothing for any Condition
+/// sub-shape it did not recognize. Kept so the Condition fixtures can pin that
+/// the constraint used to sit unread; the live helper now panics on that arm,
+/// because the choke point rejects every shape that could reach it.
+fn pre_fix_list_prefix_patterns(policy: &Policy) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        let is_list = statement_actions(stmt)
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("s3:ListBucket"));
+        if !is_list {
+            continue;
+        }
+        match &stmt["Condition"]["StringLike"]["s3:prefix"] {
+            serde_json::Value::String(s) => out.push(s.clone()),
+            serde_json::Value::Array(patterns) => {
+                for p in patterns {
+                    out.push(p.as_str().expect("s3:prefix entry is a string").to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// The pre-fix `resource_key_patterns` body, verbatim: `is_list_only` read from
+/// `stmt["Action"].as_str()` only, and a resource that did not strip the bucket
+/// prefix silently dropped (`if let Some(..)` with no `else`). Kept so the F1
+/// fixture pins the two holes existed rather than restating the fix.
+fn pre_fix_resource_key_patterns(policy: &Policy) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        let is_list_only = stmt["Action"]
+            .as_str()
+            .is_some_and(|a| a.eq_ignore_ascii_case("s3:ListBucket"));
+        if is_list_only {
+            continue;
+        }
+        let resources = match &stmt["Resource"] {
+            serde_json::Value::Array(a) => a.clone(),
+            v @ serde_json::Value::String(_) => vec![v.clone()],
+            _ => continue,
+        };
+        for r in resources {
+            let r = r.as_str().expect("Resource entry is a string");
+            if let Some(key_pattern) = r.strip_prefix("arn:aws:s3:::my-ravel-bucket/") {
+                out.push(key_pattern.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// The pre-fix `put_resource_key_patterns` body, verbatim (same silent drop).
+fn pre_fix_put_resource_key_patterns(policy: &Policy) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        let grants_put = statement_actions(stmt)
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("s3:PutObject"));
+        if !grants_put {
+            continue;
+        }
+        let resources = match &stmt["Resource"] {
+            serde_json::Value::Array(a) => a.clone(),
+            v @ serde_json::Value::String(_) => vec![v.clone()],
+            _ => continue,
+        };
+        for r in resources {
+            let r = r.as_str().expect("Resource entry is a string");
+            if let Some(key_pattern) = r.strip_prefix("arn:aws:s3:::my-ravel-bucket/") {
+                out.push(key_pattern.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// F1 regression: a Resource that grants S3 object access but is not
+/// bucket-relative (`"*"`, `s3:*` on `"*"`, another bucket's ARN) must surface as
+/// a test failure naming the role and Sid, in BOTH the read and write resource
+/// helpers, not be silently dropped. Synthetic statements, not `deploy/iam/*.json`:
+/// a fixture over the (correct) shipped templates passes whichever way the strip
+/// behaves and proves nothing. Each case asserts in both directions -- that the
+/// pre-fix helper dropped it (returning an empty set, hiding the grant) and that
+/// the post-fix helper panics on it.
+#[test]
+fn out_of_bucket_resource_grant_is_not_a_bypass() {
+    // Read side (resource_key_patterns): (Sid, Action, Resource).
+    let read_cases = [
+        ("GetOnStar", serde_json::json!("s3:GetObject"), "*"),
+        (
+            "GetOnOtherBucket",
+            serde_json::json!("s3:GetObject"),
+            "arn:aws:s3:::other-bucket/t/*",
+        ),
+        ("StarActionStarResource", serde_json::json!("s3:*"), "*"),
+    ];
+    for (sid, action, resource) in &read_cases {
+        let policy = Policy {
+            role: "fixture",
+            statements: serde_json::json!([{
+                "Sid": sid,
+                "Effect": "Allow",
+                "Action": action,
+                "Resource": resource,
+            }]),
+        };
+        // Observation 1 (load-bearing): the pre-fix helper dropped the
+        // out-of-bucket resource, so the derived set was empty and every resource
+        // guard skipped the statement. If it stops being empty the fixture no
+        // longer proves the hole and must be rewritten, not deleted.
+        let pre = pre_fix_resource_key_patterns(&policy);
+        assert!(
+            pre.is_empty(),
+            "fixture {sid} invalid: pre-fix resource_key_patterns was expected to \
+             drop the out-of-bucket resource (returning nothing); returned {pre:?}"
+        );
+        // Observation 2: the post-fix helper panics naming the role and Sid.
+        let guard = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            resource_key_patterns(&policy)
+        }));
+        assert!(
+            guard.is_err(),
+            "resource_key_patterns must reject fixture {sid}: an S3 grant on \
+             {resource:?} must surface, not be silently dropped"
+        );
+    }
+
+    // Write side (put_resource_key_patterns): PutObject on "*". Dropping it left
+    // roles_writing_routed_objects_have_kms_grant an empty routed set, so it
+    // skipped the role's KMS-grant check entirely.
+    let put_policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "PutOnStar",
+            "Effect": "Allow",
+            "Action": "s3:PutObject",
+            "Resource": "*",
+        }]),
+    };
+    let pre_put = pre_fix_put_resource_key_patterns(&put_policy);
+    assert!(
+        pre_put.is_empty(),
+        "fixture PutOnStar invalid: pre-fix put_resource_key_patterns was expected \
+         to drop the \"*\" resource; returned {pre_put:?}"
+    );
+    let put_guard = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        put_resource_key_patterns(&put_policy)
+    }));
+    assert!(
+        put_guard.is_err(),
+        "put_resource_key_patterns must reject PutObject on \"*\": dropping it \
+         makes roles_writing_routed_objects_have_kms_grant skip the role on an \
+         empty routed set"
+    );
+
+    // Trap (must not trip the new guard): an array-form ListBucket statement's
+    // bare bucket ARN must be SKIPPED, not panicked. The pre-fix `.as_str()`
+    // is_list_only returned None for the array form, so the bare bucket ARN would
+    // reach the now-fatal strip; the post-fix statement_actions-based detection
+    // recognizes it as list-only and skips it.
+    let list_policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "ArrayFormList",
+            "Effect": "Allow",
+            "Action": ["s3:ListBucket"],
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+        }]),
+    };
+    let pre_fix_is_list_only = policy_statements(&list_policy)[0]["Action"]
+        .as_str()
+        .is_some_and(|a| a.eq_ignore_ascii_case("s3:ListBucket"));
+    assert!(
+        !pre_fix_is_list_only,
+        "fixture ArrayFormList invalid: the pre-fix as_str() detection was \
+         expected to miss the array-form ListBucket (proving the trap is real)"
+    );
+    let list_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        resource_key_patterns(&list_policy)
+    }));
+    assert_eq!(
+        list_result.ok(),
+        Some(Vec::<String>::new()),
+        "resource_key_patterns must skip an array-form ListBucket statement, not \
+         panic on its bare bucket ARN"
+    );
+
+    // A kms: ARN on a non-list statement is skipped (None), not panicked: the KMS
+    // resource guards own it. This is why the read-path strip cannot blindly
+    // panic on every non-bucket-relative resource -- every role carries a
+    // *TenantKms statement whose Resource is a kms: ARN.
+    let kms_policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "KmsResource",
+            "Effect": "Allow",
+            "Action": "kms:Decrypt",
+            "Resource": "arn:aws:kms:us-east-1:111122223333:key/abcd1234-5678-90ab-cdef-1234567890ab",
+        }]),
+    };
+    let kms_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        resource_key_patterns(&kms_policy)
+    }));
+    assert_eq!(
+        kms_result.ok(),
+        Some(Vec::<String>::new()),
+        "resource_key_patterns must skip a kms: ARN (checked by the KMS guards), \
+         not panic"
+    );
+}
+
+/// The pre-fix `validate_condition` body, verbatim (round two's version, no
+/// empty-object checks): a `for` over an empty map iterates zero times, so `{}`
+/// and `{"StringLike": {}}` both returned Ok. Kept so the F2 fixture pins the
+/// hole existed rather than restating the fix.
+fn pre_fix_validate_condition(condition: &serde_json::Value) -> Result<(), String> {
+    let cond_obj = condition
+        .as_object()
+        .ok_or_else(|| "Condition is not an object".to_string())?;
+    for (operator, keys) in cond_obj {
+        if !HANDLED_CONDITION_OPERATORS.contains(&operator.as_str()) {
+            return Err(format!("operator {operator:?}"));
+        }
+        let key_obj = keys
+            .as_object()
+            .ok_or_else(|| "operator is not an object".to_string())?;
+        for (cond_key, value) in key_obj {
+            if !HANDLED_CONDITION_KEYS.contains(&cond_key.as_str()) {
+                return Err(format!("key {cond_key:?}"));
+            }
+            if !is_string_or_string_array(Some(value)) {
+                return Err(format!("value {value:?}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// F2 regression (empty maps): `"Condition": {}` and `"Condition": {"StringLike":
+/// {}}` must fail closed. Pre-fix, a `for` over an empty map iterated zero times,
+/// so both returned Ok -- the vacuous-set bug round two fixed for arrays,
+/// re-created in the code that fixed it. Synthetic, not `deploy/iam/*.json`: the
+/// shipped Conditions are all non-empty StringLike/s3:prefix blocks.
+#[test]
+fn empty_condition_or_stringlike_map_fails_closed() {
+    let cases = [
+        ("EmptyCondition", serde_json::json!({})),
+        ("EmptyStringLike", serde_json::json!({"StringLike": {}})),
+    ];
+    for (sid, condition) in &cases {
+        // Observation 1 (load-bearing): the pre-fix validator accepted the empty
+        // map (zero loop iterations), so the constraint sat unexamined.
+        assert!(
+            pre_fix_validate_condition(condition).is_ok(),
+            "fixture {sid} invalid: pre-fix validate_condition was expected to \
+             accept {condition:?} (vacuous empty-map loop); it did not"
+        );
+        // Observation 2: the full statement validator rejects a ListBucket
+        // statement carrying it, naming the empty shape and the Sid.
+        let stmt = serde_json::json!({
+            "Sid": sid,
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+            "Condition": condition,
+        });
+        let err = validate_statement("fixture", 0, &stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains("empty"),
+            "fixture {sid}: rejection must name the empty shape; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+    }
+}
+
+/// F1 regression (the blocking finding): an `s3:prefix` value that admits every
+/// key must fail closed. Pre-fix, `validate_condition` checked the value's SHAPE
+/// (a non-empty string or non-empty array of strings) but never whether the value
+/// constrained anything, so `{"StringLike": {"s3:prefix": ["*"]}}` -- non-empty,
+/// and constraining exactly as little as no Condition at all -- passed. The
+/// discovery guard's glob on "*" succeeds and every representative key matches the
+/// "*" shape, so narrowing a shipped template's list Condition to it left the
+/// whole suite green. This is the vacuous-value sibling of the empty-map holes
+/// `empty_condition_or_stringlike_map_fails_closed` covers, one level down in the
+/// value. Synthetic: every shipped s3:prefix is a bounded prefix.
+#[test]
+fn vacuous_s3_prefix_value_fails_closed() {
+    // Observation 1 (load-bearing): the pre-fix value check accepted the star.
+    // Written as the exact pre-fix expression -- SHAPE only -- so this pins the
+    // hole rather than restating the fix.
+    let star_value = serde_json::json!(["*"]);
+    assert!(
+        is_string_or_string_array(Some(&star_value)),
+        "fixture invalid: the pre-fix s3:prefix value check (shape only) was \
+         expected to accept [\"*\"]"
+    );
+    // ...and the pre-fix Condition validator (round two's body, kept verbatim)
+    // blessed the whole StringLike/s3:prefix block, so the constraint sat
+    // unexamined.
+    let star_condition = serde_json::json!({"StringLike": {"s3:prefix": ["*"]}});
+    assert!(
+        pre_fix_validate_condition(&star_condition).is_ok(),
+        "fixture invalid: pre-fix validate_condition was expected to accept the \
+         \"*\" s3:prefix value (shape only); it did not"
+    );
+
+    // The star value fails: the ListBucket statement carrying it is rejected,
+    // naming the Sid, the value, and why.
+    let star_stmt = serde_json::json!({
+        "Sid": "ListEverything",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": BUCKET_ARN,
+        "Condition": {"StringLike": {"s3:prefix": ["*"]}},
+    });
+    let err = validate_statement("fixture", 0, &star_stmt)
+        .expect_err("validate_statement must reject a \"*\" s3:prefix");
+    for expected in ["\"*\"", "ListEverything", "admits every key"] {
+        assert!(
+            err.contains(expected),
+            "rejection must name {expected:?}; got {err:?}"
+        );
+    }
+    // A bare-string "*" (not only the array form) fails the same way.
+    let star_string_stmt = serde_json::json!({
+        "Sid": "ListEverythingBareString",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": BUCKET_ARN,
+        "Condition": {"StringLike": {"s3:prefix": "*"}},
+    });
+    assert!(
+        validate_statement("fixture", 0, &star_string_stmt).is_err(),
+        "a bare-string \"*\" s3:prefix must also fail closed"
+    );
+
+    // A real tenant-scoped list of prefixes passes: each one excludes some key
+    // outside it, so none is vacuous.
+    let tenant_scoped = serde_json::json!({
+        "Sid": "ListTenantScoped",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": BUCKET_ARN,
+        "Condition": {"StringLike": {"s3:prefix": ["t/", "t/*/*/c/*", "sys/query/workers/*"]}},
+    });
+    assert!(
+        validate_statement("fixture", 0, &tenant_scoped).is_ok(),
+        "a tenant-scoped s3:prefix list must pass: {:?}",
+        validate_statement("fixture", 0, &tenant_scoped)
+    );
+
+    // On a shipped template: narrowing QueryList's s3:prefix to ["*"] makes the
+    // whole list vacuous and must fail the choke point, while the unmutated
+    // template still loads. In-memory; the file on disk is untouched.
+    let path = policy_json_path("query");
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let mut json: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build_policy(
+            "query", &path, &json
+        )))
+        .is_ok(),
+        "the shipped query template must load unchanged"
+    );
+    let statements = json["Statement"]
+        .as_array_mut()
+        .expect("query.json Statement is an array");
+    let target = statements
+        .iter_mut()
+        .find(|stmt| stmt["Sid"] == serde_json::json!("QueryList"))
+        .expect("query.json carries a QueryList statement");
+    target["Condition"]["StringLike"]["s3:prefix"] = serde_json::json!(["*"]);
+    let built = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build_policy("query", &path, &json)
+    }));
+    let message = panic_message(built.expect_err(
+        "build_policy must reject QueryList once its s3:prefix is narrowed to [\"*\"]",
+    ));
+    assert!(
+        message.contains("QueryList") && message.contains("admits every key"),
+        "the rejection must name the mutated statement and the vacuity; got {message:?}"
+    );
+}
+
+/// F1 sweep regression (resource axis): a bucket-relative object grant that admits
+/// every key -- `arn:aws:s3:::my-ravel-bucket/*`, which strips to "*" -- must fail
+/// closed. It is shape-valid (bucket-relative, non-empty key) yet scopes the object
+/// grant no more than naming no key prefix would: the resource-axis sibling of F1's
+/// "*" s3:prefix. Round four's `object_key_patterns` doc recorded this as
+/// deliberately NOT closed ("a coverage check cannot reject an over-broad
+/// pattern"); the sweep for this round closes it at the choke point. Synthetic: no
+/// shipped template names a bucket-relative "*" object resource.
+#[test]
+fn full_bucket_object_resource_fails_closed() {
+    // Observation 1 (load-bearing): the coverage guard cannot catch this -- "*"
+    // matches every representative key, so it matches AT LEAST ONE, which is all
+    // `every_in_scope_policy_pattern_matches_a_real_key_shape` asks. Written as
+    // that guard's own predicate over the real keys.
+    let keys = representative_keys();
+    assert!(
+        keys.iter().any(|k| glob_matches("*", k)),
+        "fixture invalid: the coverage check (matches at least one real key) must \
+         accept \"*\", which is why it cannot reject this vacuous grant"
+    );
+
+    for action in ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"] {
+        let stmt = serde_json::json!({
+            "Sid": "FullBucketObject",
+            "Effect": "Allow",
+            "Action": action,
+            "Resource": "arn:aws:s3:::my-ravel-bucket/*",
+        });
+        let err = validate_statement("fixture", 0, &stmt).expect_err(&format!(
+            "validate_statement must reject a full-bucket {action} grant"
+        ));
+        for expected in ["\"*\"", "FullBucketObject", "matches every key"] {
+            assert!(
+                err.contains(expected),
+                "{action}: rejection must name {expected:?}; got {err:?}"
+            );
+        }
+    }
+
+    // A bounded object prefix (the shipped shape) still passes: it excludes keys
+    // outside `t/`.
+    let bounded = serde_json::json!({
+        "Sid": "BoundedObject",
+        "Effect": "Allow",
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::my-ravel-bucket/t/*",
+    });
+    assert!(
+        validate_statement("fixture", 0, &bounded).is_ok(),
+        "a bounded object prefix must pass: {:?}",
+        validate_statement("fixture", 0, &bounded)
+    );
+}
+
+/// F2 regression (Condition presence): a ListBucket statement must carry a
+/// Condition, and a non-ListBucket statement must not. Pre-fix, `validate_statement`
+/// only validated a Condition when present and never checked the Action, so a
+/// ListBucket with no Condition (an unconstrained bucket-wide list) and a
+/// StringLike/s3:prefix on the protected-delete Deny (read by no guard, and never
+/// fired in AWS since a DeleteObject request carries no s3:prefix) both passed.
+/// Synthetic for the same reason as above.
+#[test]
+fn condition_presence_must_track_list_bucket_action() {
+    // Hole: a ListBucket statement with NO Condition. list_prefix_patterns
+    // contributes nothing for it, and pre-fix validation accepted it.
+    let no_condition = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "ListNoCondition",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+        }]),
+    };
+    assert!(
+        pre_fix_list_prefix_patterns(&no_condition).is_empty(),
+        "fixture invalid: a ListBucket statement with no Condition must contribute \
+         no s3:prefix pattern (the unconstrained-list shape)"
+    );
+    let err = validate_statement("fixture", 0, &policy_statements(&no_condition)[0])
+        .expect_err("validate_statement must reject a ListBucket statement with no Condition");
+    assert!(
+        err.contains("no Condition"),
+        "rejection must name the missing Condition; got {err:?}"
+    );
+    assert!(
+        err.contains("ListNoCondition"),
+        "rejection must name the Sid; got {err:?}"
+    );
+
+    // Hole: a StringLike/s3:prefix Condition on a NON-ListBucket statement (a
+    // protected-delete Deny). list_prefix_patterns never reads it (not
+    // ListBucket), so the Condition sits unexamined while pre-fix validation
+    // blessed it.
+    let deny_with_prefix = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "DenyWithPrefix",
+            "Effect": "Deny",
+            "Action": ["s3:DeleteObject", "s3:DeleteObjectVersion"],
+            "Resource": "arn:aws:s3:::my-ravel-bucket/t/*/*/prov",
+            "Condition": {"StringLike": {"s3:prefix": ["t/*"]}},
+        }]),
+    };
+    assert!(
+        list_prefix_patterns(&deny_with_prefix, None).is_empty(),
+        "fixture invalid: list_prefix_patterns must skip a non-ListBucket \
+         statement, so its Condition sits unread"
+    );
+    let err = validate_statement("fixture", 0, &policy_statements(&deny_with_prefix)[0])
+        .expect_err("validate_statement must reject a Condition on a non-ListBucket statement");
+    assert!(
+        err.contains("does not include s3:ListBucket"),
+        "rejection must explain the non-ListBucket Condition; got {err:?}"
+    );
+    assert!(
+        err.contains("DenyWithPrefix"),
+        "rejection must name the Sid; got {err:?}"
+    );
+}
+
+/// F1 regression (Effect axis, list discovery): a `Deny` ListBucket carrying an
+/// s3:prefix must not be read as a prefix the role is ALLOWED to discover. This
+/// round's Condition-presence rule forces a deny-listing block to carry an
+/// s3:prefix, and `list_prefix_patterns`' only permission-reading caller,
+/// `discovery_prefix_admitted_for_every_discovering_role`, pools every
+/// statement's prefixes into one vector it reads as allowed listing. Reading a
+/// Deny's prefix there asserts the inverse of the fact, since an explicit IAM
+/// Deny withdraws listing. The fix gives `list_prefix_patterns` the same effect
+/// argument `key_patterns_for` takes and calls it with `Some("Allow")` from the
+/// discovery guard. Synthetic, not `deploy/iam/*.json`: no shipped template
+/// carries a Deny ListBucket, so a fixture over them proves nothing.
+#[test]
+fn deny_list_prefix_does_not_admit_a_discovery_prefix() {
+    // Arm A: Allow lists only "sys/*"; no statement mentions "t/".
+    let arm_a = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "AllowListSys",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+            "Condition": {"StringLike": {"s3:prefix": ["sys/*"]}},
+        }]),
+    };
+    // Arm B: same Allow, plus a Deny ListBucket carrying the discovery prefix.
+    let arm_b = Policy {
+        role: "fixture",
+        statements: serde_json::json!([
+            {
+                "Sid": "AllowListSys",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"StringLike": {"s3:prefix": ["sys/*"]}},
+            },
+            {
+                "Sid": "DenyListOutsideTenant",
+                "Effect": "Deny",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"StringLike": {"s3:prefix": ["t/"]}},
+            },
+        ]),
+    };
+
+    // Observation 1 (load-bearing): the effect-blind read (`None`, the mode the
+    // discovery guard used before the fix) pools the Deny's "t/" into the set in
+    // arm B. If this stops admitting "t/" the effect-blindness is gone and the
+    // fixture no longer pins the hole.
+    assert!(
+        list_prefix_patterns(&arm_b, None)
+            .iter()
+            .any(|p| glob_matches(p, "t/")),
+        "fixture invalid: an effect-blind read must pool the Deny ListBucket's \
+         s3:prefix \"t/\" into the discovery set (the hole this fixes)"
+    );
+
+    // Observation 2: the Allow-only read the discovery guard now performs admits
+    // "t/" in NEITHER arm -- arm A never allows it, and arm B only DENIES it.
+    for (label, policy) in [("arm A", &arm_a), ("arm B", &arm_b)] {
+        let admitted = list_prefix_patterns(policy, Some("Allow"));
+        assert!(
+            !admitted.iter().any(|p| glob_matches(p, "t/")),
+            "{label}: Allow-only list_prefix_patterns must not admit \"t/\" as a \
+             discovery prefix (arm A never allows it; arm B only denies it); got \
+             {admitted:?}"
+        );
+    }
+
+    // Both statements are well-formed IAM the choke point accepts, so the Deny
+    // really does reach the helper: the fix is the effect filter, not a rejection.
+    for (idx, stmt) in policy_statements(&arm_b).iter().enumerate() {
+        assert!(
+            validate_statement("fixture", idx, stmt).is_ok(),
+            "fixture invalid: statement #{idx} must pass the choke point so the \
+             Deny reaches list_prefix_patterns"
+        );
+    }
+}
+
+/// F1/F2 regression (Effect axis, routed write): a `Deny` PutObject must not be
+/// read as a routed write. `put_resource_key_patterns`' caller
+/// `roles_writing_routed_objects_have_kms_grant` reads its result as object
+/// classes the role WRITES and then demands a KMS grant for them; a Deny put is
+/// a prohibition, so reading it there would demand a KMS grant to satisfy a write
+/// the policy forbids. The fix passes `Some("Allow")` to the effect-aware base
+/// helper (F2), the consistent choice given F1. Synthetic: no shipped template
+/// carries a Deny PutObject.
+#[test]
+fn deny_put_object_is_not_a_routed_write() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "DenyPutRouted",
+            "Effect": "Deny",
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::my-ravel-bucket/t/*/catalog/*/HEAD",
+        }]),
+    };
+    // Observation 1 (load-bearing): the effect-blind base helper reads the Deny
+    // put as a routed write. If it stops returning the pattern the fixture no
+    // longer pins the hole.
+    let blind = key_patterns_for(&policy, &["s3:PutObject"], None);
+    assert!(
+        blind.iter().any(|p| p == "t/*/catalog/*/HEAD"),
+        "fixture invalid: an effect-blind read must return the Deny PutObject \
+         resource as a routed write (the hole this fixes); got {blind:?}"
+    );
+    // Observation 2: the Allow-only put helper the caller uses returns nothing.
+    let routed = put_resource_key_patterns(&policy);
+    assert!(
+        routed.is_empty(),
+        "put_resource_key_patterns must not read a Deny PutObject as a routed \
+         write; got {routed:?}"
+    );
+    // The Deny reaches the helper: it passes the choke point.
+    assert!(
+        validate_statement("fixture", 0, &policy_statements(&policy)[0]).is_ok(),
+        "fixture invalid: the Deny PutObject must pass the choke point so it \
+         reaches put_resource_key_patterns"
+    );
+}
+
+/// F1 regression (Effect axis, KMS actions): a `Deny kms:GenerateDataKey` must
+/// not be read as a held grant. Every `kms_actions` caller reads its result as a
+/// KMS operation the role HOLDS (or, for admin, the absence of one); an explicit
+/// Deny grants nothing, so pooling it would report a role able to mint ciphertext
+/// the Deny withdraws, and would flip the negative admin assertion. The fix
+/// filters `kms_actions` to `Allow` internally, since every caller reads a grant.
+/// Synthetic: no shipped template carries a Deny KMS statement.
+#[test]
+fn deny_kms_action_is_not_read_as_a_grant() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "DenyGenerateDataKey",
+            "Effect": "Deny",
+            "Action": "kms:GenerateDataKey",
+            "Resource": "arn:aws:kms:us-east-1:111122223333:key/abcd1234-5678-90ab-cdef-1234567890ab",
+        }]),
+    };
+    // Observation 1 (load-bearing): the pre-fix effect-blind scan (the live body
+    // minus its `Allow` filter) pooled the Deny action into the grant set.
+    let mut blind: Vec<String> = Vec::new();
+    for stmt in policy_statements(&policy) {
+        blind.extend(
+            statement_actions(stmt)
+                .into_iter()
+                .filter(|a| action_selects_kms(a)),
+        );
+    }
+    assert!(
+        blind
+            .iter()
+            .any(|a| action_grants_any(a, &KMS_DATA_KEY_OPERATIONS)),
+        "fixture invalid: an effect-blind scan must pool the Deny \
+         kms:GenerateDataKey into the grant set (the hole this fixes); got {blind:?}"
+    );
+    // Observation 2: the Allow-only kms_actions returns nothing.
+    let actions = kms_actions(&policy);
+    assert!(
+        actions.is_empty(),
+        "kms_actions must not read a Deny KMS statement as a held grant; got \
+         {actions:?}"
+    );
+    // The Deny reaches the helper: it passes the choke point.
+    assert!(
+        validate_statement("fixture", 0, &policy_statements(&policy)[0]).is_ok(),
+        "fixture invalid: the Deny KMS statement must pass the choke point so it \
+         reaches kms_actions"
+    );
+}
+
+/// F1 regression (Effect axis, KMS resources): a `Deny` naming `key/*` is a broad
+/// prohibition (safe), but both KMS resource guards read `kms_statement_resources`
+/// as a grant that must be narrowly scoped, so reading a Deny there would flag a
+/// safe account-wide prohibition as an over-broad grant -- the inverse of the
+/// fact. The fix filters `kms_statement_resources` to `Allow`; scoping is asked
+/// only of the grants. Synthetic: no shipped template carries a Deny KMS
+/// statement.
+#[test]
+fn deny_kms_statement_is_not_scope_checked() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "DenyBroadKms",
+            "Effect": "Deny",
+            "Action": "kms:Decrypt",
+            "Resource": "arn:aws:kms:us-east-1:111122223333:key/*",
+        }]),
+    };
+    // Observation 1 (load-bearing): the pre-fix effect-blind scan (the live body
+    // minus its `Allow` filter) returned the Deny's broad key/* ARN.
+    let mut blind: Vec<(String, Vec<String>)> = Vec::new();
+    for stmt in policy_statements(&policy) {
+        if !statement_actions(stmt)
+            .iter()
+            .any(|a| action_selects_kms(a))
+        {
+            continue;
+        }
+        let resources: Vec<String> = statement_resources(stmt)
+            .into_iter()
+            .filter(|r| matches!(classify_resource(r), ResourceShape::KmsKey))
+            .map(str::to_string)
+            .collect();
+        blind.push((statement_sid(stmt).to_string(), resources));
+    }
+    assert!(
+        blind
+            .iter()
+            .any(|(_, rs)| rs.iter().any(|r| r.ends_with("key/*"))),
+        "fixture invalid: an effect-blind scan must return the Deny's broad key/* \
+         ARN (the hole this fixes); got {blind:?}"
+    );
+    // Observation 2: the Allow-only helper returns nothing.
+    let statements = kms_statement_resources(&policy);
+    assert!(
+        statements.is_empty(),
+        "kms_statement_resources must not hand a Deny KMS statement to the \
+         scope-check guards; got {statements:?}"
+    );
+    // The Deny reaches the helper: it passes the choke point.
+    assert!(
+        validate_statement("fixture", 0, &policy_statements(&policy)[0]).is_ok(),
+        "fixture invalid: the Deny KMS statement must pass the choke point so it \
+         reaches kms_statement_resources"
+    );
+}
+
+/// F3 regression (Sid): a missing or non-string Sid must fail closed. Pre-fix,
+/// `obj.get("Sid").and_then(as_str).unwrap_or("<no Sid>")` swallowed a
+/// `"Sid": 123` and an absent Sid, and the otherwise-valid statement passed while
+/// every rejection could name only `<no Sid>`. Synthetic, not `deploy/iam/*.json`:
+/// every shipped statement carries a string Sid.
+#[test]
+fn sid_must_be_a_present_string() {
+    // Non-string Sid.
+    let non_string = serde_json::json!({
+        "Sid": 123,
+        "Effect": "Allow",
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::my-ravel-bucket/t/*",
+    });
+    // Observation 1 (load-bearing): the pre-fix extraction saw no string Sid, so
+    // it fell back to "<no Sid>" and validated the rest as if well-formed.
+    assert!(
+        non_string["Sid"].as_str().is_none(),
+        "fixture invalid: the pre-fix as_str() extraction was expected to see no \
+         string Sid for 123"
+    );
+    let err = validate_statement("fixture", 0, &non_string)
+        .expect_err("validate_statement must reject a non-string Sid");
+    assert!(
+        err.contains("non-string Sid"),
+        "rejection must name the non-string Sid; got {err:?}"
+    );
+
+    // Missing Sid entirely.
+    let missing = serde_json::json!({
+        "Effect": "Allow",
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::my-ravel-bucket/t/*",
+    });
+    let err = validate_statement("fixture", 0, &missing)
+        .expect_err("validate_statement must reject a missing Sid");
+    assert!(
+        err.contains("no Sid"),
+        "rejection must name the missing Sid; got {err:?}"
+    );
+}
+
+/// F3 regression (index): every rejection names the statement index, so an
+/// operator can locate the offending statement in a Sid-less or duplicate-Sid
+/// array. Pre-fix, messages carried only `role/Sid`.
+#[test]
+fn rejection_message_names_the_statement_index() {
+    let statements = serde_json::json!([
+        {"Sid": "Good", "Effect": "Allow", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"},
+        {"Sid": "Bad", "Effect": "Permit", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"},
+    ]);
+    let err = validate_policy_statements("fixture", &statements)
+        .expect_err("the invalid second statement must be rejected");
+    assert!(
+        err.contains("#1"),
+        "rejection must name the statement index #1; got {err:?}"
+    );
+    assert!(
+        err.contains("Bad"),
+        "rejection must name the Sid; got {err:?}"
+    );
+}
+
+/// F4 wiring guard: `load_policy_from` -- `load_policy`'s real file-reading body --
+/// must reject an invalid policy. Driving a synthetic invalid file through it is
+/// what fails if the validation call is deleted from `build_policy`, or if
+/// `load_policy_from` stops calling `build_policy`; a test that only calls
+/// `validate_policy_statements` directly would keep passing. This closes the F4
+/// gap: the shipped entry point, not only the extracted body, is exercised.
+#[test]
+fn load_policy_from_rejects_a_synthetic_invalid_file() {
+    let path = std::env::temp_dir().join(format!(
+        "ravel-iam-fixture-{}-invalid.json",
+        std::process::id()
+    ));
+    let json = r#"{"Version":"2012-10-17","Statement":[{"Sid":"NegatedResource","Effect":"Allow","Action":"s3:DeleteObject","NotResource":"arn:aws:s3:::my-ravel-bucket/t/*"}]}"#;
+    std::fs::write(&path, json).expect("write synthetic policy fixture");
+    let path_str = path.to_str().expect("temp path is valid UTF-8").to_string();
+    let built = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        load_policy_from("fixture", &path_str)
+    }));
+    std::fs::remove_file(&path).ok();
+    assert!(
+        built.is_err(),
+        "load_policy_from (load_policy's real file-reading body) must reject a \
+         statement whose permission lives in NotResource, a field no guard reads"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Round four (issue #1346, holes H1/H2/H3): the redesign's own fixtures.
+//
+// Round three's `bucket_relative_s3_pattern` and the list-only exemption its
+// callers carried, kept verbatim, so each fixture below pins the hole it closes
+// instead of restating today's rule.
+// ---------------------------------------------------------------------------
+
+/// Round three's resource classifier, verbatim: it panicked for exactly two
+/// shapes (`"*"` and an `arn:aws:s3:::` prefix) and returned `None` for
+/// everything else. Its doc claimed `None` meant "names a different service such
+/// as a KMS ARN", but nothing checked that, so every S3 grant shape outside those
+/// two -- access point, Object Lambda, multi-region access point, `arn:*`, a
+/// malformed non-ARN -- came back as "nothing to check" (H1).
+fn round_three_bucket_relative_s3_pattern(resource: &str) -> Option<String> {
+    if let Some(key_pattern) = resource.strip_prefix("arn:aws:s3:::my-ravel-bucket/") {
+        return Some(key_pattern.to_string());
+    }
+    if resource == "*" || resource.starts_with("arn:aws:s3:::") {
+        panic!("round three panicked for {resource:?}");
+    }
+    None
+}
+
+/// Round three's `resource_key_patterns`, verbatim: the list-only exemption that
+/// skipped a list statement before its Resource was looked at by anything (H2),
+/// plus the silent-drop classifier above.
+fn round_three_resource_key_patterns(policy: &Policy) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        let actions = statement_actions(stmt);
+        let is_list_only = !actions.is_empty()
+            && actions
+                .iter()
+                .all(|a| a.eq_ignore_ascii_case("s3:ListBucket"));
+        if is_list_only {
+            continue;
+        }
+        let resources = match &stmt["Resource"] {
+            serde_json::Value::Array(a) => a.clone(),
+            v @ serde_json::Value::String(_) => vec![v.clone()],
+            _ => continue,
+        };
+        for r in resources {
+            let r = r.as_str().expect("Resource entry is a string");
+            if let Some(key_pattern) = round_three_bucket_relative_s3_pattern(r) {
+                out.push(key_pattern);
+            }
+        }
+    }
+    out
+}
+
+/// The message a `catch_unwind` payload carries, so a fixture can assert the
+/// rejection names the offending statement rather than only that something
+/// panicked.
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        return (*s).to_string();
+    }
+    "<non-string panic payload>".to_string()
+}
+
+/// A single-statement synthetic policy.
+fn fixture_policy(stmt: serde_json::Value) -> Policy {
+    Policy {
+        role: "fixture",
+        statements: serde_json::json!([stmt]),
+    }
+}
+
+/// H1 regression: every S3 object grant whose `Resource` is not bucket-relative
+/// must be rejected by name. Round three's classifier panicked only for `"*"` and
+/// for an `arn:aws:s3:::` prefix and returned `None` for everything else, so each
+/// of these five shapes -- all real S3 object grants reaching outside the
+/// configured bucket -- was silently dropped and every resource guard derived an
+/// empty set.
+///
+/// All five shapes are covered, not one: the access-point and multi-region
+/// access-point forms carry a region and/or account and so miss the `:::` form,
+/// Object Lambda is a different service name entirely, `arn:*` is the
+/// everything-grant, and `my-ravel-bucket/*` is not an ARN at all.
+///
+/// Synthetic statements, not `deploy/iam/*.json`: the shipped templates name only
+/// bucket-relative object ARNs, so a fixture over them passes whichever way the
+/// classifier behaves. Each case asserts in both directions.
+#[test]
+fn non_bucket_relative_s3_object_resource_fails_closed() {
+    let cases = [
+        (
+            "AccessPointArn",
+            "arn:aws:s3:us-east-1:111122223333:accesspoint/ap/object/*",
+        ),
+        (
+            "ObjectLambdaArn",
+            "arn:aws:s3-object-lambda:us-east-1:111122223333:accesspoint/olap/object/*",
+        ),
+        (
+            "MultiRegionAccessPointArn",
+            "arn:aws:s3::111122223333:accesspoint/mrap/object/*",
+        ),
+        ("EverythingArn", "arn:*"),
+        ("MalformedNonArn", "my-ravel-bucket/*"),
+    ];
+
+    for (sid, resource) in cases {
+        let stmt = serde_json::json!({
+            "Sid": sid,
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": resource,
+        });
+        let policy = fixture_policy(stmt.clone());
+
+        // Observation 1 (load-bearing): the resource is not bucket-relative, yet
+        // round three's classifier fell through to None instead of panicking, so
+        // its callers dropped it. Written as round three's own two literal
+        // conditions, so this pins the hole rather than restating the fix.
+        assert!(
+            resource.strip_prefix(BUCKET_KEY_PREFIX).is_none(),
+            "fixture {sid} invalid: {resource:?} must NOT be bucket-relative, or it \
+             is not an out-of-bucket grant at all"
+        );
+        let round_three_panicked = resource == "*" || resource.starts_with("arn:aws:s3:::");
+        assert!(
+            !round_three_panicked,
+            "fixture {sid} invalid: round three's two panic conditions were expected \
+             to miss {resource:?} -- if one catches it, this fixture no longer proves \
+             the catch-all None hole existed"
+        );
+        assert_eq!(
+            round_three_bucket_relative_s3_pattern(resource),
+            None,
+            "fixture {sid} invalid: round three's classifier was expected to return \
+             None (silently dropping the grant) for {resource:?}"
+        );
+        assert!(
+            round_three_resource_key_patterns(&policy).is_empty(),
+            "fixture {sid} invalid: round three's resource helper was expected to \
+             derive an empty pattern set for {resource:?}, hiding the grant"
+        );
+
+        // Observation 2: the choke point rejects it, naming the role, the
+        // statement index, the Sid and the offending value.
+        let err = validate_statement("gateway", 3, &stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        for expected in [resource, sid, "#3", "gateway"] {
+            assert!(
+                err.contains(expected),
+                "fixture {sid}: rejection must name {expected:?}; got {err:?}"
+            );
+        }
+
+        // Observation 3 (belt and braces): the helper itself panics if a guard is
+        // ever run on a statement that never passed the choke point.
+        let guard = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            resource_key_patterns(&policy)
+        }));
+        let message = panic_message(guard.expect_err(&format!(
+            "resource_key_patterns must panic on fixture {sid}, not drop the resource"
+        )));
+        assert!(
+            message.contains(resource) && message.contains(sid),
+            "fixture {sid}: the helper's panic must name the Sid and the resource; \
+             got {message:?}"
+        );
+    }
+}
+
+/// H2 regression: a list statement's `Resource` must be examined. Round three
+/// made a non-bucket-relative Resource fatal and then, to stop that tripping the
+/// bare bucket ARN that `s3:ListBucket` legitimately names, exempted whole
+/// list-only statements from the resource helpers. The result was a list
+/// statement whose Resource was read by NO guard in the file: `s3:ListBucket` on
+/// `"*"` -- which enumerates every bucket in the account -- passed validation,
+/// was skipped by the resource helpers, and `list_prefix_patterns` read only its
+/// Condition. This hole did not exist before round three.
+///
+/// The fix is the choke point's resource-class rule: a list grant must name the
+/// bare bucket ARN and nothing else, so the exemption is no longer needed and the
+/// helper never has to guess.
+#[test]
+fn list_statement_resource_is_examined() {
+    let cases = [
+        // The account-wide list: no class at all, rejected as unclassified.
+        ("ListOnStar", "*", "nor exactly that bucket ARN"),
+        // A list grant naming an object ARN: legal JSON, and in AWS a ListBucket
+        // on an object ARN matches nothing, so it is a template bug either way.
+        // The resource classifies, and the mismatch with the granted class is
+        // what rejects it.
+        (
+            "ListOnObjectArn",
+            "arn:aws:s3:::my-ravel-bucket/t/*",
+            "grants no S3 object operation",
+        ),
+    ];
+
+    for (sid, resource, must_explain) in cases {
+        let stmt = serde_json::json!({
+            "Sid": sid,
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": resource,
+            "Condition": {"StringLike": {"s3:prefix": ["t/*"]}},
+        });
+        let policy = fixture_policy(stmt.clone());
+
+        // Observation 1 (load-bearing): round three's list-only exemption skipped
+        // the statement before its Resource was classified at all, so the
+        // resource helper derived nothing.
+        assert!(
+            round_three_resource_key_patterns(&policy).is_empty(),
+            "fixture {sid} invalid: round three's list-only exemption was expected \
+             to skip the statement entirely; it did not"
+        );
+
+        // ...and the only guard that DID look at this statement looked solely at
+        // its Condition, which is the shape of the hole: the prefix was read, the
+        // Resource was not.
+        assert_eq!(
+            pre_fix_list_prefix_patterns(&policy),
+            vec!["t/*".to_string()],
+            "fixture {sid} invalid: list_prefix_patterns was expected to read the \
+             Condition (and nothing else) for this statement"
+        );
+
+        // Observation 2: the choke point now rejects the Resource by name.
+        let err = validate_statement("admin", 0, &stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        for expected in [resource, sid, must_explain] {
+            assert!(
+                err.contains(expected),
+                "fixture {sid}: rejection must name {expected:?}; got {err:?}"
+            );
+        }
+    }
+
+    // The same hole with the list grant hidden beside an object grant, which is
+    // what makes the class-mismatch arms above insufficient on their own: the
+    // object ARN is legitimate for the GetObject half, so only the coverage rule
+    // ("grants a bucket operation, names no bucket ARN") catches the ListBucket
+    // half reaching every key in the bucket with no Resource a guard reads.
+    let hidden = serde_json::json!({
+        "Sid": "ListHiddenBesideRead",
+        "Effect": "Allow",
+        "Action": ["s3:ListBucket", "s3:GetObject"],
+        "Resource": "arn:aws:s3:::my-ravel-bucket/t/*",
+        "Condition": {"StringLike": {"s3:prefix": ["t/*"]}},
+    });
+    let hidden_policy = fixture_policy(hidden.clone());
+
+    // Observation 1 (load-bearing): round three read this statement twice and
+    // never once asked what its list half was scoped to. The resource helper saw
+    // it (is_list_only was false, so the exemption did not apply) and derived only
+    // the object pattern; the list guard saw it and read only the Condition.
+    assert_eq!(
+        round_three_resource_key_patterns(&hidden_policy),
+        vec!["t/*".to_string()],
+        "fixture invalid: round three's resource helper was expected to derive only \
+         the object pattern here, saying nothing about the list grant"
+    );
+    assert_eq!(
+        pre_fix_list_prefix_patterns(&hidden_policy),
+        vec!["t/*".to_string()],
+        "fixture invalid: round three's list guard was expected to read only the \
+         Condition here"
+    );
+
+    // Observation 2: the coverage rule rejects it, tagged H2.
+    let err = validate_statement("query", 2, &hidden)
+        .expect_err("validate_statement must reject a list grant that names no bucket ARN");
+    for expected in ["ListHiddenBesideRead", "#2", "issue #1346, H2"] {
+        assert!(
+            err.contains(expected),
+            "the rejection must name {expected:?}; got {err:?}"
+        );
+    }
+
+    // Trap (must not trip): the shipped list shape -- exactly the bare bucket ARN
+    // with an s3:prefix Condition -- still passes, and still contributes its
+    // prefixes.
+    let shipped = serde_json::json!({
+        "Sid": "ShippedListShape",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": BUCKET_ARN,
+        "Condition": {"StringLike": {"s3:prefix": ["t/", "sys/*"]}},
+    });
+    assert!(
+        validate_statement("fixture", 0, &shipped).is_ok(),
+        "the shipped list statement shape (bare bucket ARN + s3:prefix Condition) \
+         must still pass"
+    );
+    assert_eq!(
+        list_prefix_patterns(&fixture_policy(shipped), None),
+        vec!["t/".to_string(), "sys/*".to_string()],
+        "the shipped list shape must still contribute its s3:prefix patterns"
+    );
+}
+
+/// H3 regression, the predicate: `"s3:*"` and `"*"` grant PutObject, ListBucket
+/// and the delete actions, and `"*"` grants the KMS operations too. Round three
+/// resolved IAM wildcards on the delete axis only; put, list and KMS selection
+/// all compared exact names, so an `s3:*` statement was selected by none of them
+/// and the Condition-presence rule (which keys on the list grant) never fired.
+///
+/// This test is over the predicate rather than a policy because the predicate is
+/// now the only place any axis decides: if it answers all of these, no axis can
+/// be wildcard-blind.
+#[test]
+fn wildcard_action_is_selected_by_every_axis() {
+    // (action, does it grant an S3 object op, a bucket op, a KMS op)
+    let cases = [
+        ("s3:*", true, true, false),
+        ("S3:*", true, true, false),
+        ("*", true, true, true),
+        ("s3:?utObject", true, false, false),
+        ("kms:*", false, false, true),
+        // Control: a literal action grants only itself.
+        ("s3:GetObject", true, false, false),
+        // Control: an unrelated literal grants nothing in the vocabulary.
+        ("s3:DeleteObjectTagging", false, false, false),
+    ];
+
+    for (action, grants_object, grants_list, grants_kms) in cases {
+        assert_eq!(
+            action_grants_any(action, &S3_OBJECT_OPERATIONS),
+            grants_object,
+            "action_grants: {action:?} vs {S3_OBJECT_OPERATIONS:?}"
+        );
+        assert_eq!(
+            action_grants_any(action, &S3_BUCKET_OPERATIONS),
+            grants_list,
+            "action_grants: {action:?} vs {S3_BUCKET_OPERATIONS:?}"
+        );
+        assert_eq!(
+            action_selects_kms(action),
+            grants_kms,
+            "action_selects_kms: {action:?}"
+        );
+    }
+
+    // Observation 1 (load-bearing): round three's per-axis matchers -- exact
+    // case-folded equality for put and list, a case-folded `kms:` prefix for KMS
+    // -- each missed the wildcard action that grants their operation. Written as
+    // those literal expressions, so this pins the hole rather than restating the
+    // fix.
+    assert!(
+        !"s3:*".eq_ignore_ascii_case("s3:PutObject"),
+        "fixture invalid: round three's put selection was expected to miss \"s3:*\""
+    );
+    assert!(
+        !"s3:*".eq_ignore_ascii_case("s3:ListBucket"),
+        "fixture invalid: round three's list selection was expected to miss \"s3:*\""
+    );
+    assert!(
+        !"*".starts_with("kms:"),
+        "fixture invalid: round three's KMS selection was expected to miss \"*\""
+    );
+
+    // ...while the delete axis, the one round three made wildcard-aware, saw it.
+    // That asymmetry is what the single predicate removes.
+    assert!(
+        action_grants_any("s3:*", &S3_DELETE_OPERATIONS),
+        "the delete axis was already wildcard-aware and must stay so"
+    );
+}
+
+/// H3 regression, the shipped-template mutation the reviewer used: changing
+/// `GatewayWrite`'s Action from `s3:PutObject` to `s3:*` passed all 26 tests
+/// under round three. `s3:*` grants PutObject (so the routed-write KMS check
+/// should select the statement) and ListBucket (so the Condition-presence rule
+/// should demand an `s3:prefix` Condition and the resource rule should demand the
+/// bucket ARN), and round three's exact-name matchers saw neither.
+///
+/// The mutation is applied to an in-memory copy of `deploy/iam/gateway.json`; the
+/// file on disk is not touched, and the unmutated policy is asserted to still
+/// load.
+#[test]
+fn shipped_gateway_write_mutated_to_wildcard_action_fails_closed() {
+    let path = policy_json_path("gateway");
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let mut json: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+
+    // The unmutated template still loads: this test's failure is about the
+    // mutation, not about the shipped file.
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build_policy(
+            "gateway", &path, &json
+        )))
+        .is_ok(),
+        "the shipped gateway template must load unchanged"
+    );
+
+    let statements = json["Statement"]
+        .as_array_mut()
+        .expect("gateway.json Statement is an array");
+    let target = statements
+        .iter_mut()
+        .find(|stmt| stmt["Sid"] == serde_json::json!("GatewayWrite"))
+        .expect("gateway.json carries a GatewayWrite statement");
+    let original = target["Action"].clone();
+    assert_eq!(
+        original,
+        serde_json::json!("s3:PutObject"),
+        "fixture invalid: GatewayWrite's Action is no longer the s3:PutObject this \
+         mutation replaces"
+    );
+    target["Action"] = serde_json::json!("s3:*");
+
+    let mutated = Policy {
+        role: "gateway",
+        statements: json["Statement"].clone(),
+    };
+
+    // Observation 1 (load-bearing): under round three's exact-name matchers the
+    // mutated policy hid the grant in two independent places.
+    assert!(
+        pre_fix_put_resource_key_patterns(&mutated).is_empty(),
+        "fixture invalid: round three's PutObject selection was expected to derive \
+         an EMPTY routed-write set from the mutated policy (so \
+         roles_writing_routed_objects_have_kms_grant skipped the role)"
+    );
+    let round_three_list_prefixes = pre_fix_list_prefix_patterns(&mutated);
+    assert!(
+        !round_three_list_prefixes.contains(&"*".to_string()),
+        "fixture invalid: round three's list detection was expected to read nothing \
+         from the s3:* statement; got {round_three_list_prefixes:?}"
+    );
+    assert!(
+        round_three_bucket_relative_s3_pattern("arn:aws:s3:::my-ravel-bucket/t/*/*/l0/*").is_some(),
+        "fixture invalid: the mutated statement's resources still strip cleanly, so \
+         nothing but the Action matcher could have caught this"
+    );
+
+    // Observation 2: the choke point rejects the mutated template, naming the
+    // statement, and `load_policy`'s real body is what does it.
+    let built = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build_policy("gateway", &path, &json)
+    }));
+    let message = panic_message(built.expect_err(
+        "build_policy must reject GatewayWrite mutated to \"s3:*\": the action grants \
+         ListBucket and PutObject, and its resources are object ARNs with no Condition",
+    ));
+    assert!(
+        message.contains("GatewayWrite") && message.contains("s3:*"),
+        "the rejection must name the mutated statement and its Action; got {message:?}"
+    );
+
+    // Observation 3: the post-fix put axis DOES select the mutated statement, so
+    // the routed-write KMS check would run on it rather than skip the role.
+    let routed: Vec<String> = put_resource_key_patterns(&mutated)
+        .into_iter()
+        .filter(|p| ravel_object_store::routes_through_tenant_key(p))
+        .collect();
+    assert!(
+        !routed.is_empty(),
+        "the post-fix put axis must select the s3:* statement's routed PUT patterns"
+    );
+}
+
+/// H3 companion: the normal IAM idiom round three's list-only exemption would
+/// have mishandled -- one statement granting both `s3:ListBucket` and
+/// `s3:GetObject`, naming both the bare bucket ARN and an object prefix -- must be
+/// ACCEPTED, and both axes must read it. Rejecting it (or rejecting it with a
+/// misleading "not bucket-relative" reason) would be a new failure of the same
+/// class, in the opposite direction.
+#[test]
+fn mixed_list_and_object_statement_is_accepted() {
+    let stmt = serde_json::json!({
+        "Sid": "MixedListAndRead",
+        "Effect": "Allow",
+        "Action": ["s3:ListBucket", "s3:GetObject"],
+        "Resource": [BUCKET_ARN, "arn:aws:s3:::my-ravel-bucket/t/*"],
+        "Condition": {"StringLike": {"s3:prefix": ["t/*"]}},
+    });
+    assert!(
+        validate_statement("fixture", 0, &stmt).is_ok(),
+        "a statement granting both ListBucket and GetObject over the bucket ARN plus \
+         an object prefix is a normal IAM idiom and must be accepted: {:?}",
+        validate_statement("fixture", 0, &stmt)
+    );
+
+    let policy = fixture_policy(stmt);
+
+    // The object axis reads the object prefix and skips the bucket ARN rather
+    // than panicking on it (round three's classifier panicked for the bare bucket
+    // ARN, which is why the exemption was added at the caller).
+    assert!(
+        std::panic::catch_unwind(|| round_three_bucket_relative_s3_pattern(BUCKET_ARN)).is_err(),
+        "fixture invalid: round three's classifier was expected to panic on the bare \
+         bucket ARN (the reason the list-only exemption existed)"
+    );
+    assert_eq!(
+        resource_key_patterns(&policy),
+        vec!["t/*".to_string()],
+        "the object axis must read the object prefix and skip the bucket ARN"
+    );
+
+    // ...and the list axis reads the Condition, so neither half sits unexamined.
+    assert_eq!(
+        list_prefix_patterns(&policy, None),
+        vec!["t/*".to_string()],
+        "the list axis must read the mixed statement's s3:prefix Condition"
+    );
+}
+
+/// The vocabulary's own invariants, so a later edit cannot silently narrow it:
+/// every operation is a literal name (`action_grants` asserts this, and an
+/// operation carrying a wildcard would make it answer a different question), the
+/// delete axis selects a subset of the object axis (a delete that is not an
+/// object operation would be selected by the delete guard while the choke point
+/// demanded a resource shape for a class it does not grant), and the three
+/// classes are disjoint (a shape rule keyed on class would otherwise be
+/// ambiguous).
+#[test]
+fn operation_vocabulary_is_consistent() {
+    let all: Vec<&str> = S3_OBJECT_OPERATIONS
+        .iter()
+        .chain(S3_BUCKET_OPERATIONS.iter())
+        .chain(KMS_OTHER_OPERATIONS.iter())
+        .chain(KMS_DATA_KEY_OPERATIONS.iter())
+        .copied()
+        .collect();
+    for op in &all {
+        assert!(
+            !op.contains(IAM_WILDCARDS),
+            "operation {op:?} carries an IAM wildcard; operations must be literal names"
+        );
+    }
+    for op in S3_DELETE_OPERATIONS {
+        assert!(
+            S3_OBJECT_OPERATIONS.contains(&op),
+            "delete operation {op:?} is not in S3_OBJECT_OPERATIONS, so a statement \
+             granting it would be selected by the delete axis while the choke point \
+             required no object resource for it"
+        );
+    }
+    for op in &all {
+        let object = S3_OBJECT_OPERATIONS.contains(op);
+        let bucket = S3_BUCKET_OPERATIONS.contains(op);
+        let kms = action_selects_kms(op);
+        assert_eq!(
+            u8::from(object) + u8::from(bucket) + u8::from(kms),
+            1,
+            "operation {op:?} belongs to more than one resource class (object \
+             {object}, bucket {bucket}, kms {kms}), so the choke point's shape rules \
+             would be ambiguous"
+        );
+    }
+}
+
+/// Every shipped template under `deploy/iam` passes the choke point, and the set
+/// this file guards is exactly the set on disk. `ALL_ROLES` is hand-written, so
+/// without this a new template would ship unguarded.
+#[test]
+fn every_shipped_template_passes_the_choke_point() {
+    let dir = format!("{}/../../deploy/iam", env!("CARGO_MANIFEST_DIR"));
+    let mut on_disk: Vec<String> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read dir {dir}: {e}"))
+        .map(|entry| entry.expect("dir entry").file_name())
+        .filter_map(|name| {
+            name.to_str()
+                .and_then(|n| n.strip_suffix(".json"))
+                .map(str::to_string)
+        })
+        .collect();
+    on_disk.sort();
+    let mut guarded: Vec<String> = ALL_ROLES.iter().map(|r| (*r).to_string()).collect();
+    guarded.sort();
+    assert_eq!(
+        on_disk, guarded,
+        "the templates under deploy/iam and the roles ALL_ROLES guards must be the \
+         same set"
+    );
+    assert_eq!(
+        on_disk.len(),
+        4,
+        "expected 4 shipped templates: {on_disk:?}"
+    );
+
+    for role in ALL_ROLES {
+        // load_policy panics on any rejection, naming role, index, Sid and field.
+        let policy = load_policy(role);
+        assert!(
+            !policy_statements(&policy).is_empty(),
+            "{role}: policy has no statements"
+        );
     }
 }


### PR DESCRIPTION
The IAM template guard suite in `crates/ravel-commit/tests/iam_templates.rs`
has been patched several times, and each round left or introduced another
helper that met a policy shape it did not understand and returned an empty
or partial result instead of failing. This round makes the fix structural
rather than another patch.

Every shape decision moves to the choke point. `validate_statement` now
classifies each resource and rejects, by role, statement index, Sid and
offending value: an action granting no modelled operation, a resource of no
known shape, a resource whose class the statement's actions do not grant,
and a granted class with no resource covering it. That makes the pattern
helpers total functions, so an unhandled shape panics instead of being
skipped.

Every action question routes through one predicate. `action_grants` folds
case and resolves IAM wildcards for all axes, so an `s3:*` statement can no
longer grant PutObject and ListBucket while being selected by no put guard,
no list guard and no Condition rule.

Effect is an explicit axis. A Deny pooled into a grant set asserts the
inverse of the fact, so every helper whose caller reads its result as a
permission the role holds now filters to Allow. The one direction left open
is named in the commit body with the reason: a Deny that withdraws a grant a
positive guard asserts is held is availability drift, not permissiveness,
and no shipped template carries one.

Shape is not constraint. A value that is present and well-formed can still
constrain nothing. An `s3:prefix` of `*` and a bucket-relative object grant
of `arn:aws:s3:::my-ravel-bucket/*` both passed the shape checks while
granting exactly what no constraint would grant; narrowing a shipped
template to the former left the whole suite green. Both are now rejected at
the choke point.

Each hole carries a fixture that pins the pre-fix behaviour with the earlier
bodies kept verbatim, so a fixture cannot quietly become a tautology when
the live predicates change. The four shipped templates under `deploy/iam`
pass unchanged.

Supersedes #1566.

Fixes: #1346
Refs: #1313
