### PR TITLE
test(commit): measure IAM grant sets and pin Deny action coverage

### DIFF
--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -155,19 +155,34 @@ const NON_TENANT_WITNESS_KEYS: [&str; 7] = [
 /// anti-vacuity guard was an ANY over the whole protected set that `sys/tenancy`
 /// alone satisfied, so the two zero-witness keyspaces went unnoticed (#1346).
 ///
-/// These are kept out of `representative_keys` for the same reason the non-tenant
-/// witnesses are: they are hand-written literals, not evidence that a constructor
-/// produces the shape, and the delete-scope/coverage guards that read
-/// `representative_keys` alone must keep seeing only constructor output.
-const CONSTRUCTOR_FREE_TENANT_WITNESS_KEYS: [&str; 7] = [
-    "t/0123456789abcdef/catalog/u/HEAD",
-    "t/0123456789abcdef/catalog/m/HEAD",
-    "t/0123456789abcdef/catalog/u/snap/0000000000000000.csnap",
-    "t/0123456789abcdef/catalog/u/idx/name-postings",
-    "t/0123456789abcdef/m/prov",
-    "t/0123456789abcdef/m/idem/0123456789abcdef",
-    "t/0123456789abcdef/m/admission/writer-0",
-];
+/// These are kept out of `representative_keys` because no constructor produces
+/// them, for the same reason the non-tenant witnesses are: they are not evidence
+/// that a constructor builds the shape, and the delete-scope/coverage guards that
+/// read `representative_keys` alone must keep seeing only constructor output.
+///
+/// The SIGNAL segment is derived from `ALL_SIGNALS` rather than typed, so every
+/// signal gets a witness in each of these keyspaces. Typing two of the six is
+/// what a delete pattern with a literal signal segment escapes: `t/*/*/c/*`
+/// matches `t/<hash>/catalog/c/HEAD`, so today's green rests on no
+/// `Signal::key_prefix()` being `c`, which nothing states. Adding a signal, or
+/// changing a prefix to a letter some delete grant names, now moves this set
+/// instead of leaving the scan silently narrow.
+fn constructor_free_tenant_witness_keys() -> Vec<String> {
+    let hash = hash16();
+    let mut keys = Vec::new();
+    for signal in ALL_SIGNALS {
+        let prefix = signal.key_prefix();
+        keys.push(format!("t/{hash}/catalog/{prefix}/HEAD"));
+        keys.push(format!(
+            "t/{hash}/catalog/{prefix}/snap/0000000000000000.csnap"
+        ));
+        keys.push(format!("t/{hash}/catalog/{prefix}/idx/name-postings"));
+        keys.push(format!("t/{hash}/{prefix}/prov"));
+        keys.push(format!("t/{hash}/{prefix}/idem/{hash}"));
+        keys.push(format!("t/{hash}/{prefix}/admission/writer-0"));
+    }
+    keys
+}
 
 /// The key domain the value-level checks in this file evaluate a pattern
 /// against: every key `ravel-commit`'s constructors can produce, plus one
@@ -178,11 +193,7 @@ fn key_domain() -> &'static [String] {
     DOMAIN.get_or_init(|| {
         let mut keys = representative_keys();
         keys.extend(NON_TENANT_WITNESS_KEYS.iter().map(|k| (*k).to_string()));
-        keys.extend(
-            CONSTRUCTOR_FREE_TENANT_WITNESS_KEYS
-                .iter()
-                .map(|k| (*k).to_string()),
-        );
+        keys.extend(constructor_free_tenant_witness_keys());
         keys
     })
 }
@@ -200,8 +211,8 @@ fn assert_pattern_is_witnessed(role: &str, class: &str, pattern: &str) {
         "{role}: {class} pattern {pattern:?} matches no key in key_domain(), so \
          the overlap enumeration models no key for its keyspace and would report \
          an empty overlap having examined nothing. Add a witness key for this \
-         keyspace to CONSTRUCTOR_FREE_TENANT_WITNESS_KEYS or NON_TENANT_WITNESS_KEYS \
-         (#1346)"
+         keyspace to constructor_free_tenant_witness_keys() or \
+         NON_TENANT_WITNESS_KEYS (#1346)"
     );
 }
 
@@ -2260,13 +2271,68 @@ fn every_overlap_pattern_has_a_domain_witness() {
     }
 }
 
+/// `ALL_SIGNALS` is every `Signal`, and each one's `key_prefix()` is the letter
+/// this file's key shapes are written against. The `match` is the mechanism: a
+/// new variant makes this fail to compile, so `ALL_SIGNALS` -- and with it
+/// `representative_keys` and the derived constructor-free witness set -- cannot
+/// go silently short one signal.
+///
+/// The letters matter, not only the count. A delete grant can name the signal
+/// segment literally: maintain's `t/*/*/c/*` does. So whether a catalog witness
+/// `t/<hash>/catalog/<prefix>/HEAD` is reached by a delete `Allow` depends on
+/// which letters exist, and `no_delete_allow_reaches_the_disjoint_protected_keyspaces`
+/// is green partly because no prefix is `c`. Pinning the six letters here makes
+/// that a checked fact instead of an unstated one; if a prefix ever becomes `c`,
+/// that test starts reporting a delete grant reaching a protected keyspace,
+/// which is a template and ADR finding, not an assertion to weaken.
+#[test]
+fn all_signals_is_exhaustive_and_witnessed() {
+    for signal in ALL_SIGNALS {
+        let expected_prefix = match signal {
+            Signal::Metrics => "m",
+            Signal::Logs => "l",
+            Signal::Spans => "s",
+            Signal::Profiles => "p",
+            Signal::Alerts => "a",
+            Signal::Audit => "u",
+        };
+        assert_eq!(
+            signal.key_prefix(),
+            expected_prefix,
+            "{signal:?}: key_prefix() changed. The physical key prefixes are part \
+             of the frozen object-layout contract (docs/catalog-and-mvcc.md), and \
+             both the witness keys and the signal-segment delete patterns in this \
+             file are written against these letters"
+        );
+    }
+
+    let witnesses = constructor_free_tenant_witness_keys();
+    let hash = hash16();
+    for signal in ALL_SIGNALS {
+        let prefix = signal.key_prefix();
+        for shape in [
+            format!("t/{hash}/catalog/{prefix}/HEAD"),
+            format!("t/{hash}/{prefix}/prov"),
+            format!("t/{hash}/{prefix}/idem/{hash}"),
+            format!("t/{hash}/{prefix}/admission/writer-0"),
+        ] {
+            assert!(
+                witnesses.contains(&shape),
+                "{signal:?}: the constructor-free witness set carries no {shape:?}, \
+                 so a delete grant naming the {prefix:?} signal segment literally \
+                 would be measured against no key in that keyspace"
+            );
+        }
+    }
+}
+
 /// ADR-0055 section 2 says the protected keyspaces `sys/`, `prov` and `catalog/`
 /// "hold for a different reason than" the legal-hold shard: they are disjoint
 /// from every delete grant, so their `Deny` is belt-and-suspenders, while the
 /// legal-hold shard `t/*/u/*/0000/*` IS reached by maintain's level-based delete
 /// grants and holds only because the explicit `Deny` overrides them. Round eight
 /// added that sentence by inspection; this backs it now that the domain carries
-/// catalog and prov witnesses (`CONSTRUCTOR_FREE_TENANT_WITNESS_KEYS`): no delete
+/// catalog and prov witnesses (`constructor_free_tenant_witness_keys`): no delete
 /// `Allow` pattern in any template matches a witness key of those three
 /// keyspaces.
 ///
@@ -2681,8 +2747,12 @@ fn admin_has_no_kms_generate_data_key() {
 /// (the same pattern the KMS `assert_kms_resource_*` helpers use). The delete
 /// set is derived first, so a delete-capable Allow that is out-of-bucket or
 /// wildcard-actioned fails inside `delete_key_patterns` before any
-/// protected-block check, and a synthetic fixture need not carry a Deny block
-/// to make the guard fire for the right reason.
+/// protected-block check.
+///
+/// A synthetic fixture still has to carry the whole shape --- the scratch Allow
+/// and a Deny block as well as the statement under test --- or it fails the
+/// first `assert_eq` for an unrelated reason and cannot tell a guard that
+/// rejects from one that does not.
 fn assert_admin_delete_grant_is_scratch_only(policy: &Policy) {
     let deletes = delete_key_patterns(policy, "Allow");
     assert_eq!(
@@ -2750,11 +2820,22 @@ fn admin_delete_grant_is_qualify_scratch_only() {
 /// recognized only by an exact `s3:DeleteObject` match, and any resource not
 /// under the bucket prefix silently dropped (`if let Some(..)` with no `else`).
 ///
-/// Every pre-fix body in this file spells its own comparisons out (here
-/// `eq_ignore_ascii_case`, below `strip_prefix` against a literal ARN) rather
-/// than calling a live helper: a pre-fix copy that reuses today's predicates
-/// stops proving the hole the moment those predicates change, which is how a
-/// fixture becomes a tautology.
+/// A pre-fix body spells out the comparison whose HOLE it pins, and only that
+/// one: here `eq_ignore_ascii_case` on the action and `strip_prefix` against a
+/// literal ARN on the resource, because those two are the holes. A pre-fix copy
+/// that reused today's predicate for the axis it is proving would stop proving
+/// the hole the moment that predicate changed, which is how a fixture becomes a
+/// tautology.
+///
+/// Everything that is NOT the hole still goes through live code, and that is
+/// deliberate: this body reads `statement_actions`, and
+/// `pre_fix_validate_condition` calls the live `is_string_or_string_array` and
+/// the live handled-operator and handled-key constants. So an assertion whose
+/// whole content is "a pre-fix body came back empty" can be satisfied by a
+/// regression in that live code instead of by the historical hole, and it has
+/// to pin WHY the result was empty from the raw JSON alongside. The fixture
+/// below is the pattern: it asserts the pre-fix delete set exactly, then
+/// asserts separately which of the two holes swallowed the statement.
 fn pre_fix_allow_delete_key_patterns(policy: &Policy) -> Vec<String> {
     let mut out = Vec::new();
     for stmt in policy_statements(policy) {
@@ -2801,29 +2882,58 @@ fn pre_fix_allow_delete_key_patterns(policy: &Policy) -> Vec<String> {
 ///
 /// Synthetic statements, not `deploy/iam/*.json`: a fixture over the shipped
 /// (correct) admin policy passes whichever way the matcher behaves and proves
-/// nothing about the matcher. Each case asserts in both directions --- that the
-/// pre-fix helper accepted the input (returned no delete entry, hiding the
-/// grant, with a message flagging the fixture invalid if it ever stops) and
-/// that the post-fix guard rejects it.
+/// nothing about the matcher.
+///
+/// Each fixture carries the WHOLE bypass shape, not just the permissive
+/// statement: admin's shipped `s3:DeleteObject` Allow on `sys/qualify/*`, which
+/// the pre-fix exact match does see; the permissive statement, which it does
+/// not; and a `DenyDeleteProtected` block. That combination is what makes the
+/// fixture reach the same PASSING state under the pre-fix derivation that
+/// admin's real policy reaches, so only the post-fix derivation rejects. A
+/// fixture holding the permissive statement alone panics on the scratch-only
+/// `assert_eq` either way (its delete set can never be `["sys/qualify/*"]`),
+/// which makes a bare `is_err()` unfalsifiable: measured, the suite stayed
+/// 50/0 with both historical holes reintroduced.
+///
+/// So each case asserts in both directions, and names WHICH direction: the
+/// pre-fix derivation returns exactly the scratch prefix (hiding the grant, so
+/// the scratch-only assertion passes over it) and the post-fix guard rejects
+/// with that case's expected message.
 #[test]
 fn wildcard_or_out_of_bucket_delete_grant_is_not_a_bypass() {
-    // (Sid, Action, Resource, does the pre-fix EXACT action match recognize it)
+    // The two post-fix rejection paths, as a substring of the panic each
+    // produces. Asserting the message rather than `is_err()` is what keeps them
+    // distinguishable: a fixture rejected by some third guard, or by a missing
+    // Deny block, would otherwise read as a pass for the wrong reason.
+    const UNCLASSIFIED_RESOURCE: &str =
+        "reaching here means a guard ran on an unvalidated statement";
+    const NOT_SCRATCH_ONLY: &str =
+        "the only delete-capable Allow must be the qualification scratch";
+
+    // (Sid, Action, Resource, does the pre-fix EXACT action match recognize it,
+    //  which post-fix rejection the case must produce)
     let cases = [
         // Wildcard action the exact match misses, on the bare "*" resource: the
-        // action hole and the resource hole at once.
+        // action hole and the resource hole at once. Post-fix the action is
+        // selected and the resource classifies as nothing, so the rejection
+        // comes from inside delete_key_patterns.
         (
             "StarActionStarResource",
             serde_json::json!("s3:*"),
             "*",
             false,
+            UNCLASSIFIED_RESOURCE,
         ),
         // Wildcard action, bucket-relative resource OUTSIDE sys/qualify: the
-        // action hole alone; post-fix this surfaces as a non-scratch pattern.
+        // action hole ALONE. The resource is classifiable either way, so this
+        // case reddens only if the action predicate resolves wildcards, and it
+        // surfaces as a second, non-scratch pattern in the delete set.
         (
             "DeleteStarOutsidePrefix",
             serde_json::json!("s3:Delete*"),
             "arn:aws:s3:::my-ravel-bucket/t/tenant/data",
             false,
+            NOT_SCRATCH_ONLY,
         ),
         // The all-actions wildcard on a DIFFERENT bucket's ARN: the action hole
         // plus a resource that names another bucket entirely.
@@ -2832,47 +2942,79 @@ fn wildcard_or_out_of_bucket_delete_grant_is_not_a_bypass() {
             serde_json::json!("*"),
             "arn:aws:s3:::other-bucket/t/*",
             false,
+            UNCLASSIFIED_RESOURCE,
         ),
         // Mis-cased literal delete on "*": here the pre-fix EXACT match already
         // recognized the action (it folds case), so this isolates the resource
-        // hole --- the statement was seen as a delete yet its "*" resource was
-        // silently dropped, leaving an empty delete set.
+        // hole ALONE --- the statement was seen as a delete yet its "*" resource
+        // was silently dropped, leaving the scratch prefix as the whole set.
         (
             "WrongCaseDeleteObjectStarResource",
             serde_json::json!("S3:DELETEOBJECT"),
             "*",
             true,
+            UNCLASSIFIED_RESOURCE,
         ),
     ];
 
-    for (sid, action, resource, pre_fix_exact_recognizes) in cases {
+    let protected_resources: Vec<String> = PROTECTED_DELETE_KEYS
+        .iter()
+        .map(|key| format!("{BUCKET_KEY_PREFIX}{key}"))
+        .collect();
+
+    for (sid, action, resource, pre_fix_exact_recognizes, expected_rejection) in cases {
         let policy = Policy {
             role: "fixture",
-            statements: serde_json::json!([{
-                "Sid": sid,
-                "Effect": "Allow",
-                "Action": action,
-                "Resource": resource,
-            }]),
+            statements: serde_json::json!([
+                // The shipped scratch delete. The pre-fix exact action match
+                // sees this one, so the pre-fix delete set is non-empty and
+                // equal to what the guard demands.
+                {
+                    "Sid": "AdminQualifyScratchDelete",
+                    "Effect": "Allow",
+                    "Action": "s3:DeleteObject",
+                    "Resource": format!("{BUCKET_KEY_PREFIX}sys/qualify/*"),
+                },
+                // The permissive statement the pre-fix match misses.
+                {
+                    "Sid": sid,
+                    "Effect": "Allow",
+                    "Action": action,
+                    "Resource": resource,
+                },
+                // ...and the protected block, so the guard's "DenyDeleteProtected
+                // names no keys" check cannot be what rejects and mask which
+                // assertion actually fired.
+                {
+                    "Sid": "DenyDeleteProtected",
+                    "Effect": "Deny",
+                    "Action": PROTECTED_DELETE_ACTIONS,
+                    "Resource": protected_resources,
+                },
+            ]),
         };
-        let stmt = &policy_statements(&policy)[0];
-        let actions = statement_actions(stmt);
+        let permissive = &policy_statements(&policy)[1];
+        let actions = statement_actions(permissive);
 
-        // Observation 1 (load-bearing): the pre-fix helper returned no delete
-        // entry, so the permissive grant was invisible and the scratch-only
-        // assertion passed over it. If this stops being empty, the fixture no
-        // longer proves the hole existed and must be rewritten, not deleted.
+        // Observation 1 (load-bearing): under the pre-fix derivation the delete
+        // set is EXACTLY the shipped scratch prefix --- the permissive statement
+        // contributes nothing --- so the scratch-only assert_eq passes on a
+        // policy that grants delete outside sys/qualify. That is the hole. If
+        // this stops holding, the fixture no longer reaches the state admin's
+        // real policy reaches and must be rewritten, not deleted.
         let pre_fix = pre_fix_allow_delete_key_patterns(&policy);
-        assert!(
-            pre_fix.is_empty(),
-            "fixture {sid} invalid: pre_fix_allow_delete_key_patterns was \
-             expected to return no delete entry (hiding the grant); returned \
-             {pre_fix:?}"
+        assert_eq!(
+            pre_fix,
+            vec!["sys/qualify/*".to_string()],
+            "fixture {sid} invalid: the pre-fix derivation must return exactly \
+             the shipped scratch prefix, hiding the permissive grant so the \
+             scratch-only assertion passes over it; returned {pre_fix:?}"
         );
 
-        // ...pin WHY it was empty so the two holes stay distinguishable: either
-        // the pre-fix exact match did not see a wildcard action, or it saw the
-        // action but the silent drop discarded a non-bucket-relative resource.
+        // ...pin WHY the permissive statement was invisible so the two holes
+        // stay distinguishable: either the pre-fix exact match did not see a
+        // wildcard action, or it saw the action but the silent drop discarded a
+        // non-bucket-relative resource.
         let pre_fix_action_hit = actions
             .iter()
             .any(|a| a.eq_ignore_ascii_case("s3:DeleteObject"));
@@ -2887,18 +3029,24 @@ fn wildcard_or_out_of_bucket_delete_grant_is_not_a_bypass() {
              {actions:?} as a delete grant"
         );
 
-        // Observation 2: the real guard fires on the synthetic policy --- either
-        // panicking inside delete_key_patterns on an out-of-bucket
-        // resource, or failing the scratch-only assert_eq on a non-scratch key.
+        // Observation 2: the real guard fires on the synthetic policy, and the
+        // message says which path did it --- panicking inside
+        // delete_key_patterns on a resource that classifies as nothing, or
+        // failing the scratch-only assert_eq on a second, non-scratch key.
         // catch_unwind so the panic is reported as a result here.
         let guard = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             assert_admin_delete_grant_is_scratch_only(&policy)
         }));
-        assert!(
-            guard.is_err(),
+        let message = panic_message(guard.expect_err(&format!(
             "the delete guard must reject fixture {sid}: a delete-capable \
              statement on {resource:?} must surface as a permissive grant, not \
-             be silently dropped"
+             sit unexamined beside the scratch prefix"
+        )));
+        assert!(
+            message.contains(expected_rejection),
+            "fixture {sid}: the delete guard rejected, but not for the reason \
+             this case is written for. Expected a message containing \
+             {expected_rejection:?}; got {message:?}"
         );
     }
 }
@@ -3133,13 +3281,6 @@ fn mixed_case_generate_data_key_is_not_missed_by_the_negative_assertion() {
          \"KMS:GenerateDataKey*\" -- if it saw it, this fixture no longer \
          proves the hole existed"
     );
-    assert!(
-        !selected_before_fix
-            .iter()
-            .any(|a| a.starts_with("kms:GenerateDataKey")),
-        "fixture invalid: the pre-fix negative assertion was expected to hold \
-         (reporting the role unprivileged) on a policy that grants the key"
-    );
     // The second half of the hole, independent of the first: even handed the
     // action directly, the pre-fix comparison did not recognize it.
     assert!(
@@ -3355,9 +3496,17 @@ fn single_character_wildcard_in_kms_resource_is_not_a_bypass() {
 /// now rejects it naming both the `Sid` and the offending key (Observation 2).
 #[test]
 fn statement_using_an_unhandled_key_fails_closed() {
-    // (Sid, statement, substring the rejection must name, which field hid the
-    // permission pre-fix: "resource" => resource_key_patterns skipped it,
-    // "action" => statement_actions saw no action).
+    // (Sid, statement, substring the rejection must name, phrase identifying
+    // WHICH rule rejected, which field hid the permission pre-fix:
+    // "resource" => resource_key_patterns skipped it, "action" =>
+    // statement_actions saw no action).
+    //
+    // The name and the rule are separate columns because a Sid can contain the
+    // name (`TypoResources` contains `Resources`), and then "the rejection
+    // names the offending key" is implied by "the rejection names the Sid" and
+    // asserts nothing. The rule phrase is the independent claim: it fires when
+    // the choke point rejects for some other reason than the one this case is
+    // written for.
     let negative_cases = [
         (
             "NegatedResource",
@@ -3368,6 +3517,7 @@ fn statement_using_an_unhandled_key_fails_closed() {
                 "NotResource": "arn:aws:s3:::my-ravel-bucket/t/*/*/prov"
             }),
             "NotResource",
+            "cannot reason about negated or principal-scoped",
             "resource",
         ),
         (
@@ -3379,6 +3529,7 @@ fn statement_using_an_unhandled_key_fails_closed() {
                 "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
             }),
             "NotAction",
+            "cannot reason about negated or principal-scoped",
             "action",
         ),
         (
@@ -3390,6 +3541,7 @@ fn statement_using_an_unhandled_key_fails_closed() {
                 "Resources": "arn:aws:s3:::my-ravel-bucket/t/*/*/l0/*"
             }),
             "Resources",
+            "which no guard in this file handles",
             "resource",
         ),
         (
@@ -3400,11 +3552,12 @@ fn statement_using_an_unhandled_key_fails_closed() {
                 "Action": "s3:GetObject"
             }),
             "no Resource",
+            "the exact shape the resource guards skip",
             "resource",
         ),
     ];
 
-    for (sid, stmt, must_name, hidden_side) in &negative_cases {
+    for (sid, stmt, must_name, must_explain, hidden_side) in &negative_cases {
         let policy = Policy {
             role: "fixture",
             statements: serde_json::json!([stmt.clone()]),
@@ -3429,7 +3582,8 @@ fn statement_using_an_unhandled_key_fails_closed() {
             other => panic!("fixture {sid}: unknown hidden_side {other:?}"),
         }
 
-        // Observation 2: the choke point rejects it, naming the Sid and the key.
+        // Observation 2: the choke point rejects it, naming the Sid and the key,
+        // and the rejection is the one this case is written for.
         let err = validate_statement("fixture", 0, stmt)
             .expect_err(&format!("validate_statement must reject fixture {sid}"));
         assert!(
@@ -3439,6 +3593,11 @@ fn statement_using_an_unhandled_key_fails_closed() {
         assert!(
             err.contains(sid),
             "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+        assert!(
+            err.contains(must_explain),
+            "fixture {sid}: rejection must come from the rule this case is \
+             written for, whose message contains {must_explain:?}; got {err:?}"
         );
 
         // ...and so does the extracted loop `load_policy` actually runs
@@ -3484,6 +3643,7 @@ fn malformed_effect_action_or_resource_fails_closed() {
                 "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
             }),
             "Effect",
+            "Effect is neither \"Allow\" nor \"Deny\"",
         ),
         (
             "ActionIsNumber",
@@ -3494,6 +3654,7 @@ fn malformed_effect_action_or_resource_fails_closed() {
                 "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
             }),
             "Action",
+            "Action is neither a string nor a non-empty array of strings",
         ),
         (
             "ActionArrayHasNonString",
@@ -3504,6 +3665,7 @@ fn malformed_effect_action_or_resource_fails_closed() {
                 "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
             }),
             "Action",
+            "Action is neither a string nor a non-empty array of strings",
         ),
         (
             "ResourceIsNumber",
@@ -3514,10 +3676,11 @@ fn malformed_effect_action_or_resource_fails_closed() {
                 "Resource": 7
             }),
             "Resource",
+            "Resource is neither a string nor a non-empty array of strings",
         ),
     ];
 
-    for (sid, stmt, must_name) in &cases {
+    for (sid, stmt, must_name, must_explain) in &cases {
         let err = validate_statement("fixture", 0, stmt)
             .expect_err(&format!("validate_statement must reject fixture {sid}"));
         assert!(
@@ -3527,6 +3690,15 @@ fn malformed_effect_action_or_resource_fails_closed() {
         assert!(
             err.contains(sid),
             "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+        // Independent of both above: every Sid here contains its own
+        // `must_name`, so "the rejection names the key" follows from "the
+        // rejection names the Sid" and asserts nothing on its own. This is the
+        // claim that fires when some other rule rejected the statement first.
+        assert!(
+            err.contains(must_explain),
+            "fixture {sid}: rejection must come from the rule this case is \
+             written for, whose message contains {must_explain:?}; got {err:?}"
         );
     }
 }
@@ -3550,6 +3722,7 @@ fn empty_action_or_resource_array_fails_closed() {
                 "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
             }),
             "Action",
+            "Action is neither a string nor a non-empty array of strings",
         ),
         (
             "EmptyResource",
@@ -3560,10 +3733,11 @@ fn empty_action_or_resource_array_fails_closed() {
                 "Resource": []
             }),
             "Resource",
+            "Resource is neither a string nor a non-empty array of strings",
         ),
     ];
 
-    for (sid, stmt, must_name) in &cases {
+    for (sid, stmt, must_name, must_explain) in &cases {
         // The fixed predicate rejects the empty array. (An `iter().all` over the
         // empty array is vacuously true, which is exactly the pre-fix bug.)
         assert!(
@@ -3579,6 +3753,14 @@ fn empty_action_or_resource_array_fails_closed() {
         assert!(
             err.contains(sid),
             "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+        // Both Sids here contain their own `must_name`, so the key-naming
+        // assertion above follows from the Sid-naming one. This is the
+        // independent claim: the empty array is what rejected the statement.
+        assert!(
+            err.contains(must_explain),
+            "fixture {sid}: rejection must come from the string-array shape \
+             rule, whose message contains {must_explain:?}; got {err:?}"
         );
     }
 }
@@ -3605,6 +3787,7 @@ fn unhandled_condition_shape_fails_closed() {
                 "Condition": {"StringNotLike": {"s3:prefix": ["t/*"]}}
             }),
             "StringNotLike",
+            "which no guard in this file reads (handled operators:",
         ),
         (
             "SetQualifiedOperator",
@@ -3616,6 +3799,7 @@ fn unhandled_condition_shape_fails_closed() {
                 "Condition": {"ForAnyValue:StringLike": {"s3:prefix": ["t/*"]}}
             }),
             "ForAnyValue:StringLike",
+            "which no guard in this file reads (handled operators:",
         ),
         (
             "UnhandledConditionKey",
@@ -3627,6 +3811,7 @@ fn unhandled_condition_shape_fails_closed() {
                 "Condition": {"StringLike": {"s3:delimiter": ["/"]}}
             }),
             "s3:delimiter",
+            "which no guard in this file reads (handled keys:",
         ),
         (
             "ConditionNotObject",
@@ -3638,10 +3823,11 @@ fn unhandled_condition_shape_fails_closed() {
                 "Condition": "StringLike"
             }),
             "Condition",
+            "Condition is not a JSON object",
         ),
     ];
 
-    for (sid, stmt, must_name) in &cases {
+    for (sid, stmt, must_name, must_explain) in &cases {
         // Load-bearing: the guard that would read this Condition finds nothing,
         // so the constraint sits unexamined. Prove the pre-fix skip on the two
         // operator cases (both are s3:ListBucket, so list_prefix_patterns is the
@@ -3651,6 +3837,17 @@ fn unhandled_condition_shape_fails_closed() {
                 role: "fixture",
                 statements: serde_json::json!([stmt.clone()]),
             };
+            // The pre-fix body decides list membership through the live
+            // `statement_actions`, so an empty result on its own is also what a
+            // regression there would produce. Pin the raw Action first: the
+            // emptiness has to come from the unread Condition sub-shape.
+            assert_eq!(
+                stmt["Action"],
+                serde_json::json!("s3:ListBucket"),
+                "fixture {sid} invalid: this case is a list statement, and the \
+                 emptiness below must come from the unread Condition rather \
+                 than from action selection returning nothing"
+            );
             assert!(
                 pre_fix_list_prefix_patterns(&policy).is_empty(),
                 "fixture {sid}: the pre-fix list_prefix_patterns was expected to \
@@ -3667,6 +3864,15 @@ fn unhandled_condition_shape_fails_closed() {
         assert!(
             err.contains(sid),
             "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+        // Two of these Sids contain their own `must_name`, so for them the
+        // key-naming assertion follows from the Sid-naming one. This names the
+        // Condition rule that had to be the one to reject.
+        assert!(
+            err.contains(must_explain),
+            "fixture {sid}: rejection must come from the Condition rule this \
+             case is written for, whose message contains {must_explain:?}; got \
+             {err:?}"
         );
     }
 
@@ -4610,6 +4816,22 @@ fn condition_presence_must_track_list_bucket_action() {
             "Resource": "arn:aws:s3:::my-ravel-bucket",
         }]),
     };
+    // The pre-fix body decides list membership through the live
+    // `statement_actions`, so an empty result on its own is also what a
+    // regression there would produce. Pin the raw JSON first: this statement IS
+    // a list statement and it carries no Condition, so the emptiness below can
+    // only be the absent Condition.
+    let no_condition_stmt = &policy_statements(&no_condition)[0];
+    assert_eq!(
+        no_condition_stmt["Action"],
+        serde_json::json!("s3:ListBucket"),
+        "fixture invalid: this statement must be a list statement"
+    );
+    assert_eq!(
+        no_condition_stmt["Condition"],
+        serde_json::Value::Null,
+        "fixture invalid: this statement must carry no Condition at all"
+    );
     assert!(
         pre_fix_list_prefix_patterns(&no_condition).is_empty(),
         "fixture invalid: a ListBucket statement with no Condition must contribute \
@@ -5290,20 +5512,28 @@ fn list_statement_resource_is_examined() {
 /// be wildcard-blind.
 #[test]
 fn wildcard_action_is_selected_by_every_axis() {
-    // (action, does it grant an S3 object op, a bucket op, a KMS op)
+    // (action, does it grant an S3 object op / a bucket op / a KMS op,
+    //  and what did round three's put / list / KMS matcher answer for it)
     let cases = [
-        ("s3:*", true, true, false),
-        ("S3:*", true, true, false),
-        ("*", true, true, true),
-        ("s3:?utObject", true, false, false),
-        ("kms:*", false, false, true),
+        ("s3:*", (true, true, false), (false, false, false)),
+        ("S3:*", (true, true, false), (false, false, false)),
+        ("*", (true, true, true), (false, false, false)),
+        ("s3:?utObject", (true, false, false), (false, false, false)),
+        // The one wildcard round three's KMS prefix matcher did catch: `kms:*`
+        // starts with `kms:`. It is `"*"` that slipped past that axis.
+        ("kms:*", (false, false, true), (false, false, true)),
         // Control: a literal action grants only itself.
-        ("s3:GetObject", true, false, false),
+        ("s3:GetObject", (true, false, false), (false, false, false)),
         // Control: an unrelated literal grants nothing in the vocabulary.
-        ("s3:DeleteObjectTagging", false, false, false),
+        (
+            "s3:DeleteObjectTagging",
+            (false, false, false),
+            (false, false, false),
+        ),
     ];
 
-    for (action, grants_object, grants_list, grants_kms) in cases {
+    for (action, post_fix, pre_fix) in cases {
+        let (grants_object, grants_list, grants_kms) = post_fix;
         assert_eq!(
             action_grants_any(action, &S3_OBJECT_OPERATIONS),
             grants_object,
@@ -5319,25 +5549,24 @@ fn wildcard_action_is_selected_by_every_axis() {
             grants_kms,
             "action_selects_kms: {action:?}"
         );
-    }
 
-    // Observation 1 (load-bearing): round three's per-axis matchers -- exact
-    // case-folded equality for put and list, a case-folded `kms:` prefix for KMS
-    // -- each missed the wildcard action that grants their operation. Written as
-    // those literal expressions, so this pins the hole rather than restating the
-    // fix.
-    assert!(
-        !"s3:*".eq_ignore_ascii_case("s3:PutObject"),
-        "fixture invalid: round three's put selection was expected to miss \"s3:*\""
-    );
-    assert!(
-        !"s3:*".eq_ignore_ascii_case("s3:ListBucket"),
-        "fixture invalid: round three's list selection was expected to miss \"s3:*\""
-    );
-    assert!(
-        !"*".starts_with("kms:"),
-        "fixture invalid: round three's KMS selection was expected to miss \"*\""
-    );
+        // Observation 1 (load-bearing): round three's per-axis matchers --
+        // exact case-folded equality for put and list, a case-folded `kms:`
+        // prefix for KMS -- asked about THIS case's action, so a row added to
+        // the table has to state what they answered for it. Spelled against
+        // two literals instead, the comparison is a compile-time constant that
+        // no edit to this file, to a template, or to the predicate could make
+        // fire, which is decoration rather than an assertion.
+        assert_eq!(
+            (
+                action.eq_ignore_ascii_case("s3:PutObject"),
+                action.eq_ignore_ascii_case("s3:ListBucket"),
+                action.starts_with("kms:"),
+            ),
+            pre_fix,
+            "round three's (put, list, KMS) selection for {action:?}"
+        );
+    }
 
     // ...while the delete axis, the one round three made wildcard-aware, saw it.
     // That asymmetry is what the single predicate removes.
@@ -5397,6 +5626,30 @@ fn shipped_gateway_write_mutated_to_wildcard_action_fails_closed() {
 
     // Observation 1 (load-bearing): under round three's exact-name matchers the
     // mutated policy hid the grant in two independent places.
+    //
+    // The pre-fix put body decides membership through the live
+    // `statement_actions`, so an empty result on its own is also what a
+    // regression there would produce. Pin the raw mutated Action and round
+    // three's own comparison over it, so the emptiness is the exact-name
+    // matcher missing a wildcard and nothing else.
+    let mutated_action = json["Statement"]
+        .as_array()
+        .and_then(|s| {
+            s.iter()
+                .find(|stmt| stmt["Sid"] == serde_json::json!("GatewayWrite"))
+        })
+        .and_then(|stmt| stmt["Action"].as_str())
+        .expect("the mutated GatewayWrite statement carries a string Action")
+        .to_string();
+    assert_eq!(
+        mutated_action, "s3:*",
+        "fixture invalid: the mutation must have taken effect on GatewayWrite"
+    );
+    assert!(
+        !mutated_action.eq_ignore_ascii_case("s3:PutObject"),
+        "fixture invalid: round three selected put statements by exact name, so \
+         the mutated action {mutated_action:?} must not match it"
+    );
     assert!(
         pre_fix_put_resource_key_patterns(&mutated).is_empty(),
         "fixture invalid: round three's PutObject selection was expected to derive \

--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -113,6 +113,98 @@ fn representative_keys() -> Vec<String> {
     keys
 }
 
+/// One literal key per non-tenant keyspace the shipped templates name, for the
+/// keyspaces `ravel-commit` has no constructor for (`sys/`, `admission/`). They
+/// exist only as EXCLUSION WITNESSES for `glob_admits_everything`: a pattern
+/// that matches every key in `key_domain()` excludes nothing, and without a
+/// non-`t/` key in that domain the bounded prefix `t/*` -- which every
+/// `ravel-commit` key matches -- would be misread as excluding nothing and the
+/// shipped `admin` template would be rejected.
+///
+/// These are hand-written literals, which `representative_keys` deliberately is
+/// not, so they are kept out of that function: they are not evidence that any
+/// key constructor produces this shape, and no coverage or delete-scope guard
+/// reads them (`assert_admin_delete_grant_is_scratch_only` asks specifically
+/// about `t/**` tenant data and must keep reading `representative_keys` alone).
+/// Every one carries a `/`, so a pattern such as `*/*` still matches all of
+/// them and is still vacuous.
+const NON_TENANT_WITNESS_KEYS: [&str; 7] = [
+    "sys/tenancy",
+    "sys/qualification",
+    "sys/gc",
+    "sys/qualify/run-0/probe",
+    "sys/maintain/workers/worker-0",
+    "sys/query/workers/worker-0",
+    "admission/query/query-0",
+];
+
+/// One literal key per TENANT-ROUTED keyspace the templates name that
+/// `ravel-commit` has no key constructor for, so `representative_keys` produces
+/// no witness for it: `catalog/`, `prov`, tenant `idem/`, and tenant
+/// `admission/`. Every one is a real `t/<hash>/...` object key the templates
+/// grant an action on, written here as a literal because no crate constructor
+/// builds it (fold writes catalog objects, the log-segment writer writes prov,
+/// ingest writes idem and admission markers).
+///
+/// Without these, the two overlap mechanisms
+/// (`delete_deny_and_allow_overlap_exactly_where_expected` and
+/// `every_allow_deny_key_overlap_is_named_by_the_deny`) enumerate a domain that
+/// models NO key for `t/*/*/prov` or `t/*/catalog/*/*`: both protected patterns,
+/// and the live `t/*/*/idem/*` MaintainDelete grant, then matched zero keys and
+/// the measurement reported an empty overlap having examined nothing there. The
+/// anti-vacuity guard was an ANY over the whole protected set that `sys/tenancy`
+/// alone satisfied, so the two zero-witness keyspaces went unnoticed (#1346).
+///
+/// These are kept out of `representative_keys` for the same reason the non-tenant
+/// witnesses are: they are hand-written literals, not evidence that a constructor
+/// produces the shape, and the delete-scope/coverage guards that read
+/// `representative_keys` alone must keep seeing only constructor output.
+const CONSTRUCTOR_FREE_TENANT_WITNESS_KEYS: [&str; 7] = [
+    "t/0123456789abcdef/catalog/u/HEAD",
+    "t/0123456789abcdef/catalog/m/HEAD",
+    "t/0123456789abcdef/catalog/u/snap/0000000000000000.csnap",
+    "t/0123456789abcdef/catalog/u/idx/name-postings",
+    "t/0123456789abcdef/m/prov",
+    "t/0123456789abcdef/m/idem/0123456789abcdef",
+    "t/0123456789abcdef/m/admission/writer-0",
+];
+
+/// The key domain the value-level checks in this file evaluate a pattern
+/// against: every key `ravel-commit`'s constructors can produce, plus one
+/// witness per non-tenant keyspace the templates name, plus one per
+/// tenant-routed keyspace no constructor builds. Built once.
+fn key_domain() -> &'static [String] {
+    static DOMAIN: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
+    DOMAIN.get_or_init(|| {
+        let mut keys = representative_keys();
+        keys.extend(NON_TENANT_WITNESS_KEYS.iter().map(|k| (*k).to_string()));
+        keys.extend(
+            CONSTRUCTOR_FREE_TENANT_WITNESS_KEYS
+                .iter()
+                .map(|k| (*k).to_string()),
+        );
+        keys
+    })
+}
+
+/// Assert `pattern` (a shipped Allow or Deny object-key pattern) matches at least
+/// one key in `key_domain()`. If it matches none, the overlap mechanisms that
+/// enumerate the domain are BLIND to its keyspace: they report an empty overlap
+/// for it having examined nothing, which reads as "no overlap" when the truth is
+/// "not measured". Refuse by name rather than measure vacuously, mirroring how
+/// the list and KMS axes are refused as unmodelled in
+/// `assert_allow_deny_overlaps_are_named`.
+fn assert_pattern_is_witnessed(role: &str, class: &str, pattern: &str) {
+    assert!(
+        key_domain().iter().any(|k| glob_matches(pattern, k)),
+        "{role}: {class} pattern {pattern:?} matches no key in key_domain(), so \
+         the overlap enumeration models no key for its keyspace and would report \
+         an empty overlap having examined nothing. Add a witness key for this \
+         keyspace to CONSTRUCTOR_FREE_TENANT_WITNESS_KEYS or NON_TENANT_WITNESS_KEYS \
+         (#1346)"
+    );
+}
+
 /// Policy prefixes naming keyspaces `ravel-commit` has no key constructor
 /// for. Matched as plain substrings against the raw pattern text.
 const OUT_OF_SCOPE_PATTERNS: &[&str] = &["idem/", "/prov", "catalog/", "admission/", "sys/"];
@@ -134,8 +226,9 @@ const BUCKET_KEY_PREFIX: &str = "arn:aws:s3:::my-ravel-bucket/";
 /// Translate an IAM policy glob into an anchored regex. IAM resolves two
 /// wildcard characters inside both `Action` and `Resource` strings: `*` matches
 /// any sequence and `?` matches exactly one character; every other character is
-/// literal. This once handled only `*`; the shipped templates carry no `?`, so
-/// widening it changes no existing match, but a `?` smuggled into an action or
+/// literal. This once handled only `*`; the shipped templates carry no `?`
+/// (asserted by `every_shipped_template_passes_the_choke_point`, not assumed),
+/// so widening it changes no existing match, but a `?` smuggled into an action or
 /// resource pattern is now resolved as the wildcard IAM treats it as instead of
 /// being escaped to a literal `\?` that quietly matches nothing.
 fn glob_to_regex(pattern: &str) -> regex::Regex {
@@ -155,47 +248,854 @@ fn glob_matches(pattern: &str, candidate: &str) -> bool {
     glob_to_regex(pattern).is_match(candidate)
 }
 
+/// True when an IAM glob EXCLUDES NO KEY THIS SYSTEM CAN PRODUCE, so it
+/// constrains exactly as little as naming no pattern would.
+///
+/// # What the claim is relative to
+///
+/// The check is relative to `key_domain()`: every key `ravel-commit`'s own
+/// constructors emit, plus one literal witness per non-tenant keyspace the
+/// shipped templates name. It claims no more than that. A pattern this
+/// predicate accepts is not proved to exclude some arbitrary string; it is
+/// proved to exclude at least one key shape the templates are written to scope.
+/// That is the property the callers need, because a `Resource` key pattern or
+/// an `s3:prefix` only ever confronts keys the system actually stores.
+///
+/// # Why not the empty string
+///
+/// The first version of this predicate asked one question: does the pattern
+/// match the empty string? That domain is wrong in a way that let real
+/// spellings through, because `classify_resource` rejects the empty key outright
+/// -- so the predicate decided vacuity by asking about the one value the code
+/// downstream can never see. `*` and `**` match the empty string, but `?*`,
+/// `*?*` and `*/*` do not, while each of those matches all 67 representative
+/// keys; `*/*` is the plausible operator spelling of "any tenant, any signal"
+/// and, put in a shipped template's delete `Resource`, left the whole suite
+/// green (issue #1346, hole ten).
+///
+/// The empty-string test is kept as a disjunct, so the new definition is a
+/// SUPERSET of the old one rather than a trade of one blind spot for another:
+/// the empty pattern `""` matches no key in the domain yet still constrains
+/// nothing (a bucket-relative `arn:aws:s3:::my-ravel-bucket/` strips to it), and
+/// the bare star, an all-star run, and every other pattern the old test caught
+/// are still caught.
+///
+/// A pattern that is merely OVER-broad remains accepted, which is deliberate and
+/// asserted: `t/*` matches every tenant key but excludes every `sys/` and
+/// `admission/` key, so it is not vacuous, and the shipped `admin` template
+/// names it. Rejecting a bounded-but-too-wide grant is a separate guard, out of
+/// scope here.
+fn glob_admits_everything(pattern: &str) -> bool {
+    let regex = glob_to_regex(pattern);
+    regex.is_match("") || key_domain().iter().all(|key| regex.is_match(key))
+}
+
+// ---------------------------------------------------------------------------
+// The action vocabulary. One predicate (`action_grants`) and one operation list
+// per axis; every axis in this file routes through them.
+// ---------------------------------------------------------------------------
+
+/// The S3 operations these guards reason about that act on an OBJECT, so a
+/// statement granting one must name bucket-relative object ARNs.
+const S3_OBJECT_OPERATIONS: [&str; 4] = [
+    "s3:GetObject",
+    "s3:PutObject",
+    "s3:DeleteObject",
+    "s3:DeleteObjectVersion",
+];
+
+/// The S3 operations these guards reason about that act on the BUCKET, so a
+/// statement granting one must name the bare bucket ARN. `s3:ListBucket` is the
+/// only one: it is what `list_prefix_patterns` reads an `s3:prefix` Condition
+/// for, and what the Condition-presence rule keys on.
+const S3_BUCKET_OPERATIONS: [&str; 1] = ["s3:ListBucket"];
+
+/// The S3 operations that destroy a stored object. A subset of
+/// `S3_OBJECT_OPERATIONS` (pinned by `operation_vocabulary_is_consistent`), kept
+/// separate because the delete axis selects on exactly these.
+const S3_DELETE_OPERATIONS: [&str; 2] = ["s3:DeleteObject", "s3:DeleteObjectVersion"];
+
+/// The KMS operations that mint a data key, i.e. that let the holder produce new
+/// ciphertext under a tenant key. `write_roles_have_kms_generate_data_key` and
+/// `roles_writing_routed_objects_have_kms_grant` require one; ADR-0055 forbids
+/// admin any of them (`admin_has_no_kms_generate_data_key`). All four spellings
+/// are listed so the negative assertion cannot be evaded by granting a variant.
+const KMS_DATA_KEY_OPERATIONS: [&str; 4] = [
+    "kms:GenerateDataKey",
+    "kms:GenerateDataKeyWithoutPlaintext",
+    "kms:GenerateDataKeyPair",
+    "kms:GenerateDataKeyPairWithoutPlaintext",
+];
+
+/// The remaining KMS operations these guards reason about.
+const KMS_OTHER_OPERATIONS: [&str; 2] = ["kms:Decrypt", "kms:Encrypt"];
+
+/// The single action predicate every axis in this file goes through: does the
+/// policy string `action` (possibly an IAM wildcard pattern, in whatever case
+/// the template spells it) grant `operation` (a literal IAM operation name)?
+///
+/// IAM action names are case-insensitive and resolve two wildcards, `*` (any
+/// sequence) and `?` (exactly one character), so `"*"`, `"s3:*"`, `"s3:Delete*"`
+/// and `"S3:DELETEOBJECT"` all grant `s3:DeleteObject`. Before this predicate
+/// existed each axis carried its own matcher and only the delete axis resolved
+/// wildcards, so `"Action": "s3:*"` granted PutObject and ListBucket while being
+/// selected by neither -- and the Condition-presence rule, which keys on the
+/// list grant, never fired either (issue #1346, H3). There is now one place that
+/// decides, so no axis can be wildcard-aware while another is not.
+///
+/// The asymmetry is deliberate and asserted: the wildcard lives on the policy
+/// side. An `operation` carrying `*` or `?` is a caller bug, not a pattern to
+/// resolve, because a wildcarded operation would make the predicate answer a
+/// question no axis asked.
+fn action_grants(action: &str, operation: &str) -> bool {
+    assert!(
+        !operation.contains(IAM_WILDCARDS),
+        "action_grants takes a literal IAM operation name, not a pattern: {operation:?}"
+    );
+    let action = action.to_ascii_lowercase();
+    let operation = operation.to_ascii_lowercase();
+    if action == operation {
+        return true;
+    }
+    // Only a wildcard pattern grants beyond its own name: an unrelated literal
+    // action (`s3:DeleteObjectTagging`, `s3:DeleteBucket`) grants nothing else.
+    action.contains(IAM_WILDCARDS) && glob_matches(&action, &operation)
+}
+
+/// True when `action` grants at least one of `operations`.
+fn action_grants_any(action: &str, operations: &[&str]) -> bool {
+    operations.iter().any(|op| action_grants(action, op))
+}
+
+/// True when at least one of a statement's `actions` grants at least one of
+/// `operations`. Every axis's statement selection is this call.
+fn any_action_grants_any(actions: &[String], operations: &[&str]) -> bool {
+    actions.iter().any(|a| action_grants_any(a, operations))
+}
+
+/// True when `action` grants any KMS operation these guards reason about, so the
+/// statement carrying it is a KMS statement whose `Resource` the KMS resource
+/// guards own. This replaces the old case-folded `kms:` prefix test, which a
+/// wildcard action (`"*"`, `"kms:*"`) slipped past.
+fn action_selects_kms(action: &str) -> bool {
+    action_grants_any(action, &KMS_OTHER_OPERATIONS)
+        || action_grants_any(action, &KMS_DATA_KEY_OPERATIONS)
+}
+
+// ---------------------------------------------------------------------------
+// The resource vocabulary. `classify_resource` is the only place a `Resource`
+// string is interpreted; the choke point and every helper share it, so a shape
+// cannot be understood in one and dropped in the other.
+// ---------------------------------------------------------------------------
+
+/// The ARN service prefix of a KMS key resource.
+const KMS_ARN_PREFIX: &str = "arn:aws:kms:";
+
+/// What a `Resource` string names, as far as the guards in this file are
+/// concerned. `Unclassified` is not a fourth kind of resource: it is the shape
+/// `validate_statement` rejects, so no helper downstream ever has to decide what
+/// to do with one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResourceShape<'a> {
+    /// An object ARN under the configured bucket; carries the bucket-relative
+    /// key pattern (always non-empty).
+    ObjectKey(&'a str),
+    /// Exactly the bare bucket ARN: what an `s3:ListBucket` grant names.
+    Bucket,
+    /// A KMS key ARN.
+    KmsKey,
+    /// Anything else, including every shape issue #1346 H1 lists: an S3
+    /// access-point ARN (`arn:aws:s3:<region>:<account>:accesspoint/...`), an
+    /// Object Lambda ARN (`arn:aws:s3-object-lambda:...`), a multi-region access
+    /// point (`arn:aws:s3::<account>:accesspoint/...`), the everything-grant
+    /// `arn:*`, the bare `"*"`, another bucket's ARN, and a malformed non-ARN
+    /// such as `my-ravel-bucket/*`.
+    Unclassified,
+}
+
+/// Classify one `Resource` string. Total: every string lands in exactly one
+/// shape, and everything the guards cannot reason about lands in `Unclassified`
+/// rather than being returned as "nothing to check".
+///
+/// The bucket-relative arm requires a NON-EMPTY key pattern:
+/// `arn:aws:s3:::my-ravel-bucket/` names the object with the empty key, which no
+/// key constructor produces and no guard has a pattern for, so it is
+/// unclassified rather than an `ObjectKey("")` that matches nothing.
+fn classify_resource(resource: &str) -> ResourceShape<'_> {
+    match resource.strip_prefix(BUCKET_KEY_PREFIX) {
+        Some(key) if !key.is_empty() => return ResourceShape::ObjectKey(key),
+        _ => {}
+    }
+    if resource == BUCKET_ARN {
+        return ResourceShape::Bucket;
+    }
+    if resource.starts_with(KMS_ARN_PREFIX) {
+        return ResourceShape::KmsKey;
+    }
+    ResourceShape::Unclassified
+}
+
+#[derive(Debug)]
 struct Policy {
     role: &'static str,
     statements: serde_json::Value,
 }
 
-fn load_policy(role: &'static str) -> Policy {
-    let path = format!(
-        "{}/../../deploy/iam/{role}.json",
-        env!("CARGO_MANIFEST_DIR")
-    );
-    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
-    let json: serde_json::Value =
-        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+/// The complete set of statement keys any guard in this file reads. Sid,
+/// Effect, Action, and Resource are read directly (see `statement_actions`,
+/// `statement_resources`, `key_patterns_for`, `kms_statement_resources`, ...);
+/// Condition is read for the `s3:prefix` ListBucket block
+/// (`list_prefix_patterns`). Nothing else is examined by any guard.
+///
+/// This list is the guard's contract: a statement carrying any key outside it
+/// is one no guard reasons about, so it must fail closed at `load_policy`
+/// rather than be silently skipped (issue #1346).
+const HANDLED_STATEMENT_KEYS: &[&str] = &["Sid", "Effect", "Action", "Resource", "Condition"];
+
+/// The complete set of `Condition` operators any guard in this file reads.
+/// Only `list_prefix_patterns` reads a Condition at all, and only its
+/// `StringLike` block. A statement whose Condition names any other operator --
+/// a different comparison such as `StringNotLike`, or a set-qualified form such
+/// as `ForAnyValue:StringLike` -- carries a constraint no guard reasons about,
+/// so it must fail closed at `validate_statement` rather than pass with its
+/// Condition unexamined (issue #1346).
+const HANDLED_CONDITION_OPERATORS: &[&str] = &["StringLike"];
+
+/// The complete set of `Condition` keys any guard in this file reads, under a
+/// handled operator. Only `s3:prefix` is inspected (by `list_prefix_patterns`);
+/// any other condition key (`s3:delimiter`, `aws:SourceIp`, ...) is a constraint
+/// no guard reads and must fail closed rather than sit unexamined.
+const HANDLED_CONDITION_KEYS: &[&str] = &["s3:prefix"];
+
+/// Keys that describe a statement shape these guards deliberately cannot
+/// reason about: `NotAction`/`NotResource` invert the set the Action/Resource
+/// guards inspect (so a statement carrying them is permissive in exactly the
+/// direction the guard reads, while the guard sees an empty positive set and
+/// passes it), and `Principal`/`NotPrincipal` scope a statement to identities
+/// this file models nothing about. Each is rejected with a message saying so,
+/// rather than lumped in with an unrecognized-typo key.
+const NEGATED_OR_PRINCIPAL_KEYS: &[&str] =
+    &["NotAction", "NotResource", "NotPrincipal", "Principal"];
+
+/// Fail closed on any statement shape the guards in this file do not fully
+/// understand. This is the single choke point every shipped-template guard
+/// passes through (`load_policy` calls it for each statement), so a new
+/// unhandled shape is rejected once here instead of slipping past a guard that
+/// only reads the fields it happens to know.
+///
+/// # The closure argument
+///
+/// Every earlier round of this guard fixed one hole and left another, because
+/// each helper decided for itself which shapes it understood and answered "no
+/// resources to check" for the rest. The fix is structural: ALL shape decisions
+/// happen here, and the helpers are total functions over the shapes that got
+/// through. Concretely, a statement reaching any guard has:
+///
+/// - a present string `Sid`, so every message can name it;
+/// - only keys in `HANDLED_STATEMENT_KEYS`, so no permission lives in a field no
+///   guard reads (`NotAction`/`NotResource`/`Principal` are rejected by name);
+/// - an `Effect` of `Allow` or `Deny`, so the effect-filtered axes partition it;
+/// - an `Action` that is a string or non-empty array of strings, EVERY element of
+///   which grants at least one operation in the vocabulary
+///   (`S3_OBJECT_OPERATIONS`, `S3_BUCKET_OPERATIONS`, `KMS_OTHER_OPERATIONS`,
+///   `KMS_DATA_KEY_OPERATIONS`), decided by the one predicate `action_grants`;
+/// - a `Resource` that is a string or non-empty array of strings, EVERY element
+///   of which `classify_resource` places in `ObjectKey`, `Bucket`, or `KmsKey`
+///   -- never `Unclassified`;
+/// - for each granted operation class, at least one resource of the matching
+///   shape, and no resource of a shape whose class the statement does not grant.
+///   So an object grant carries only bucket-relative object ARNs, a list grant
+///   carries the bare bucket ARN, a KMS grant carries only `arn:aws:kms:` ARNs,
+///   and the normal mixed idiom (ListBucket + GetObject over the bucket ARN plus
+///   an object prefix) is accepted because both classes are granted;
+/// - a `Condition` exactly when the Action grants a list operation, whose
+///   sub-shape is the one `StringLike`/`s3:prefix` block
+///   `list_prefix_patterns` reads.
+///
+/// A helper downstream can therefore no longer meet a shape it does not
+/// understand. `object_key_patterns` matches all four `ResourceShape` variants:
+/// it strips `ObjectKey`, skips `Bucket` and `KmsKey` because this function
+/// proved the same statement grants the list or KMS operation whose own guard
+/// reads that exact string, and panics on `Unclassified` because this function
+/// rejects it. Each remaining `continue` in a helper is axis selection ("this
+/// statement grants no operation on my axis", or "this statement is the other
+/// Effect"), never a shape skip.
+///
+/// The coverage rule holds PER EFFECT-SELECTED AXIS: every ALLOW statement is
+/// selected by at least one axis (the axis of a granted operation class), and
+/// that axis sees every resource it carries. It does NOT say every statement is
+/// read by some axis. One shape is deliberately read by none: a `Deny` whose
+/// Action grants ONLY KMS operations. Both KMS helpers (`kms_actions`,
+/// `kms_statement_resources`) filter to `Allow`, and every S3 axis skips it on
+/// actions, so no helper reads it. That is safe: a `Deny` grants nothing, so
+/// there is no grant left unchecked, and the KMS grant it would withdraw is
+/// itself an `Allow` the KMS axes DO read. `deny_kms_statement_is_not_scope_checked`
+/// pins this shape reaching no scope-check guard on purpose. (A `Deny` that
+/// grants S3 object/list/delete operations is still read by its S3 axis under
+/// `None`, e.g. `delete_key_patterns(.., "Deny")`, so KMS-only is the sole
+/// no-axis shape.)
+///
+/// Effect is a third axis, orthogonal to Action and Resource, and this guard
+/// does NOT partition on it: a `Deny` statement is validated for shape exactly
+/// like an `Allow`, so a well-formed `Deny` reaches every helper its Action and
+/// Resource select. IAM resolves an explicit `Deny` as an overriding
+/// prohibition, so any helper whose result a caller reads as a held permission
+/// ("this role MAY do X", "X is scoped") or a prohibition ("this role MAY NOT
+/// do X") MUST filter by Effect itself; the guard cannot do it for them without
+/// rejecting legitimate `Deny` blocks. The contract is per helper, stated in
+/// its own doc: a helper that reads as a grant takes an effect argument and its
+/// permission-reading callers pass `Some("Allow")` (`key_patterns_for`,
+/// `list_prefix_patterns`, `put_resource_key_patterns`, `delete_key_patterns`),
+/// or the helper filters to `Allow` internally when every caller reads it as a
+/// grant (`kms_actions`, `kms_statement_resources`). A pure shape check that
+/// reads the result as neither a grant nor a prohibition (the pattern-vs-key
+/// coverage guard) passes `None` and sees both effects on purpose.
+///
+/// The `Allow` filter closes ONE direction, and the claim is narrowed to it: it
+/// stops a `Deny` being READ AS a grant -- a Deny-derived output read as an
+/// Allow-derived permission, asserting the inverse of the fact (issue #1346,
+/// F1/F2). It does NOT stop a `Deny` WITHDRAWING a grant that a positive guard
+/// then asserts is held: a Deny added alongside a retained Allow, withdrawing
+/// (say) `kms:GenerateDataKey`/`kms:Encrypt` from the only key, leaves
+/// `write_roles_have_kms_generate_data_key` and
+/// `roles_writing_routed_objects_have_kms_grant` green, because those guards read
+/// the retained `Allow` and never subtract the `Deny`. That case is knowingly
+/// left unhandled here. It is availability drift, not permissiveness: the
+/// templates would fail CLOSED in production (the write is denied) while the
+/// guard stayed green, so it is strictly safer than the direction the filter
+/// closes. Its precondition is that no shipped template carries a `Deny` that
+/// withdraws a granted KMS/Put capability, which is a property of the four JSON
+/// files rather than of this code and is therefore asserted rather than assumed:
+/// `every_shipped_deny_is_a_delete_only_prohibition` pins that the only shipped
+/// `Deny` is `DenyDeleteProtected` and that every action it names grants a delete
+/// operation and nothing else. Round six stated that premise with a second
+/// clause, "disjoint from every Allow", which is FALSE and was never asserted:
+/// maintain's level-based delete grants and the legal-hold audit-shard
+/// protection cover the same keys (`t/<hash>/u/{l0,c,l1}/0000/...`), so the
+/// delete `Allow` set overstates the capability by exactly the three pattern
+/// pairs `delete_deny_and_allow_overlap_exactly_where_expected` now pins.
+/// Closing the drift would require each positive-capability guard to subtract
+/// the matching `Deny` before asserting; that is a deliberate non-goal. This is
+/// the axis the next reviewer checks the next finding against.
+///
+/// Rejects, naming the `Sid` (and the statement index) and the offending key or
+/// field:
+/// - a statement that is not a JSON object;
+/// - a missing or non-string `Sid` (`"Sid": 123`): Sid is in the handled set,
+///   but its type went unchecked pre-fix and the `<no Sid>` fallback then named
+///   nothing (issue #1346, F3);
+/// - `NotAction`/`NotResource`/`NotPrincipal`/`Principal` (negated or
+///   principal-scoped: the guard cannot reason about them);
+/// - any other key outside `HANDLED_STATEMENT_KEYS` (e.g. a `Resources` typo);
+/// - an `Effect` that is neither `Allow` nor `Deny`;
+/// - an `Action` or `Resource` that is neither a string nor a non-empty array
+///   of strings (an empty array is vacuously "all strings", so it slipped past
+///   as a valid set the guards then derived nothing from);
+/// - a missing `Resource` key (the exact shape #1346 records being skipped:
+///   the resource guards read `stmt["Resource"]`, find `Null`, and drop the
+///   statement as having nothing to check);
+/// - an `Action` element that grants no operation in the vocabulary, so no axis
+///   would select the statement (H3);
+/// - a `Resource` element `classify_resource` cannot place, quoting the value:
+///   an S3 access-point or Object Lambda or multi-region-access-point ARN, the
+///   everything-grant `arn:*`, the bare `"*"`, another bucket's ARN, or a
+///   malformed non-ARN such as `my-ravel-bucket/*` (H1);
+/// - a `Resource` whose shape belongs to an operation class the statement does
+///   not grant (an `s3:ListBucket` on an object ARN, an `s3:GetObject` on the
+///   bare bucket ARN, a KMS ARN on a statement granting no KMS operation), and
+///   conversely a granted class with no resource of its shape (an
+///   `s3:ListBucket` that names no bucket ARN -- the H2 hole, where round
+///   three's list-only exemption left a list statement's Resource read by
+///   nothing at all);
+/// - a `Resource` object-key pattern that admits every key in `key_domain()` (a
+///   bucket-relative `arn:aws:s3:::my-ravel-bucket/*`, which strips to `"*"`, or
+///   any other spelling that excludes nothing, such as `"*/*"`): shape-valid but
+///   vacuous, scoping the object grant no more than naming no key would, the
+///   resource-axis sibling of F1's `"*"` s3:prefix (issue #1346, F1 sweep and
+///   hole ten);
+/// - a Condition whose presence does not track the ListBucket action: a
+///   ListBucket statement with no Condition (an unconstrained bucket-wide list),
+///   or a Condition on any non-ListBucket statement (read by no guard) (F2);
+/// - a `Condition` whose sub-shape is anything other than the one block a guard
+///   reads: it must be a non-empty JSON object of handled operators
+///   (`HANDLED_CONDITION_OPERATORS`, today `StringLike`), each a non-empty map of
+///   handled condition keys (`HANDLED_CONDITION_KEYS`, today `s3:prefix`) to a
+///   string or non-empty array of strings. A different operator, a set-qualified
+///   operator, an unhandled key, or an empty `{}`/`{"StringLike":{}}` (which
+///   constrains nothing) is a shape `list_prefix_patterns` cannot read, so it
+///   fails closed here rather than contributing nothing silently;
+/// - an `s3:prefix` VALUE that admits every key in `key_domain()` (a bare `"*"`,
+///   any all-`"*"` run, `"?*"`, `"*/*"`): shape-valid but vacuous, letting a
+///   caller list the whole bucket exactly as an absent Condition would (issue
+///   #1346, F1 and hole ten).
+fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Result<(), String> {
+    let obj = stmt
+        .as_object()
+        .ok_or_else(|| format!("{role}: statement #{index} is not a JSON object: {stmt:?}"))?;
+
+    // Sid must be a present string. Every rejection below quotes it, and every
+    // guard's own failure message names it; a missing Sid, or a non-string
+    // `"Sid": 123`, was accepted pre-fix through the `<no Sid>` fallback (Sid is
+    // in the handled set but its type was never checked), leaving a statement
+    // whose rejections could name nothing (issue #1346, F3).
+    let sid = match obj.get("Sid") {
+        Some(serde_json::Value::String(s)) => s.as_str(),
+        Some(other) => {
+            return Err(format!(
+                "{role}: statement #{index} has a non-string Sid: {other:?} -- Sid is a \
+                 handled key and must be a string so every rejection can name it"
+            ));
+        }
+        None => {
+            return Err(format!(
+                "{role}: statement #{index} has no Sid -- Sid is required so every \
+                 rejection names the statement it rejects"
+            ));
+        }
+    };
+
+    for key in obj.keys() {
+        if NEGATED_OR_PRINCIPAL_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): statement uses {key:?}; the guards \
+                 in this file cannot reason about negated or principal-scoped \
+                 statements (they read only the positive Action/Resource sets), so a \
+                 policy carrying it must be rejected rather than silently passed"
+            ));
+        }
+        if !HANDLED_STATEMENT_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): statement uses key {key:?}, which no \
+                 guard in this file handles (handled keys: {HANDLED_STATEMENT_KEYS:?}); it \
+                 must fail closed rather than sit unexamined"
+            ));
+        }
+    }
+
+    match obj.get("Effect").and_then(|v| v.as_str()) {
+        Some(e) if e.eq_ignore_ascii_case("Allow") || e.eq_ignore_ascii_case("Deny") => {}
+        other => {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): Effect is neither \"Allow\" nor \
+                 \"Deny\": {other:?}"
+            ));
+        }
+    }
+
+    if !is_string_or_string_array(obj.get("Action")) {
+        return Err(format!(
+            "{role}/{sid} (statement #{index}): Action is neither a string nor a \
+             non-empty array of strings: {:?}",
+            obj.get("Action")
+        ));
+    }
+
+    match obj.get("Resource") {
+        None => {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): statement has no Resource key -- a \
+                 statement with no Resource is the exact shape the resource guards skip \
+                 (they read stmt[\"Resource\"], find Null, and treat it as nothing to \
+                 check)"
+            ));
+        }
+        resource if !is_string_or_string_array(resource) => {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): Resource is neither a string nor a \
+                 non-empty array of strings: {resource:?}"
+            ));
+        }
+        _ => {}
+    }
+
+    // Both shape checks above have passed, so `statement_actions` and
+    // `statement_resources` now return exactly what the policy declares.
+    let actions = statement_actions(stmt);
+    let resources = statement_resources(stmt);
+    validate_actions_and_resources(role, sid, index, &actions, &resources)?;
+
+    // Condition presence must track the list action. `list_prefix_patterns`
+    // is the only Condition reader and only reads one when the Action grants
+    // s3:ListBucket, so:
+    //  - a list statement MUST carry a Condition (an unconstrained bucket-wide
+    //    list is rejected, exactly like a missing Resource), and
+    //  - a non-list statement must carry NONE (a Condition there is read by no
+    //    guard: a StringLike/s3:prefix on the protected-delete Deny would pass
+    //    validation while, in AWS, a DeleteObject request carries no s3:prefix
+    //    context key, so the Deny never fires and protects nothing).
+    // (issue #1346, F2)
+    //
+    // The list grant is decided by `action_grants`, the same predicate every
+    // other axis uses, so `"Action": "s3:*"` -- which grants ListBucket -- is
+    // required to carry a Condition here too. Under round three's exact-name
+    // detection it was not, and `list_prefix_patterns` then read nothing from it
+    // (issue #1346, H3).
+    let grants_list = any_action_grants_any(&actions, &S3_BUCKET_OPERATIONS);
+    match obj.get("Condition") {
+        Some(condition) => {
+            if !grants_list {
+                return Err(format!(
+                    "{role}/{sid} (statement #{index}): statement carries a Condition but \
+                     its Action does not include s3:ListBucket -- only the ListBucket \
+                     s3:prefix Condition is read by any guard, so a Condition on any other \
+                     statement sits unexamined and must fail closed"
+                ));
+            }
+            validate_condition(role, sid, index, condition)?;
+        }
+        None => {
+            if grants_list {
+                return Err(format!(
+                    "{role}/{sid} (statement #{index}): s3:ListBucket statement carries no \
+                     Condition -- an unconstrained bucket-wide list must be rejected, the \
+                     same as a missing Resource; it must carry a non-empty \
+                     StringLike/s3:prefix Condition"
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// The Action/Resource half of the choke point: every action must grant an
+/// operation in the vocabulary, and every resource must have a shape that some
+/// granted operation class asks for, with no granted class left without one.
+///
+/// This is what makes the resource helpers total. Round three put the same
+/// question inside `bucket_relative_s3_pattern`, which meant each helper decided
+/// on its own which resources it understood, and everything else came back as
+/// "nothing to check": an access-point ARN, an Object Lambda ARN, `arn:*` and a
+/// malformed `my-ravel-bucket/*` were all real S3 object grants reaching outside
+/// the bucket and all silently dropped (H1), and the list-only exemption added to
+/// keep the bare bucket ARN from tripping the strip left list statements'
+/// Resource examined by nothing at all (H2). Asking it here instead answers it
+/// once, for every axis, before any helper runs.
+///
+/// The three classes are independent, so a statement granting several carries the
+/// resources of each. That is what makes the normal IAM idiom -- one statement
+/// granting `s3:ListBucket` and `s3:GetObject` over the bucket ARN plus an object
+/// prefix -- valid rather than a rejection with a misleading reason.
+fn validate_actions_and_resources(
+    role: &str,
+    sid: &str,
+    index: usize,
+    actions: &[String],
+    resources: &[&str],
+) -> Result<(), String> {
+    for action in actions {
+        let known = action_grants_any(action, &S3_OBJECT_OPERATIONS)
+            || action_grants_any(action, &S3_BUCKET_OPERATIONS)
+            || action_selects_kms(action);
+        if !known {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): Action {action:?} grants no operation \
+                 any guard in this file reasons about (S3 object {S3_OBJECT_OPERATIONS:?}, \
+                 S3 bucket {S3_BUCKET_OPERATIONS:?}, KMS {KMS_OTHER_OPERATIONS:?} + \
+                 {KMS_DATA_KEY_OPERATIONS:?}) -- no axis would select this statement, so \
+                 its Resource would sit unexamined"
+            ));
+        }
+    }
+
+    let grants_object = any_action_grants_any(actions, &S3_OBJECT_OPERATIONS);
+    let grants_list = any_action_grants_any(actions, &S3_BUCKET_OPERATIONS);
+    let grants_kms = actions.iter().any(|a| action_selects_kms(a));
+
+    let mut saw_object = false;
+    let mut saw_bucket = false;
+    let mut saw_kms = false;
+    for resource in resources {
+        match classify_resource(resource) {
+            ResourceShape::ObjectKey(key) => {
+                if !grants_object {
+                    return Err(format!(
+                        "{role}/{sid} (statement #{index}): Resource {resource:?} names an \
+                         object under {BUCKET_ARN:?}, but the statement's Action \
+                         {actions:?} grants no S3 object operation \
+                         ({S3_OBJECT_OPERATIONS:?}) -- an object ARN on a statement that \
+                         cannot act on an object is a shape no axis reads"
+                    ));
+                }
+                // The object-key VALUE must constrain, not merely have the object
+                // shape: `arn:aws:s3:::my-ravel-bucket/*` strips to `*`, which
+                // matches every key in the bucket, so it scopes the object grant
+                // no more than naming no key prefix at all -- the same vacuity F1
+                // closes for an s3:prefix, on the resource axis (issue #1346, F1
+                // sweep). Vacuity is decided against `key_domain()`, so the
+                // spellings that dodge the empty-string reading (`*/*`, `?*`) are
+                // caught too (issue #1346, hole ten). A bounded prefix (`t/*`,
+                // `sys/*`) excludes keys outside it and is unaffected.
+                if glob_admits_everything(key) {
+                    return Err(format!(
+                        "{role}/{sid} (statement #{index}): Resource {resource:?} strips to the \
+                         object-key pattern {key:?}, which matches every key shape this file \
+                         knows about under {BUCKET_ARN:?} -- a full-bucket object grant constrains \
+                         no more than naming no key scope at all; it must name a bounded key \
+                         prefix that excludes some key the system can produce (issue #1346, F1 \
+                         sweep and hole ten)"
+                    ));
+                }
+                saw_object = true;
+            }
+            ResourceShape::Bucket => {
+                if !grants_list {
+                    return Err(format!(
+                        "{role}/{sid} (statement #{index}): Resource {resource:?} is the \
+                         bare bucket ARN, but the statement's Action {actions:?} grants no \
+                         S3 bucket operation ({S3_BUCKET_OPERATIONS:?}) -- an S3 object \
+                         operation must name a bucket-relative object ARN, not the bucket"
+                    ));
+                }
+                saw_bucket = true;
+            }
+            ResourceShape::KmsKey => {
+                if !grants_kms {
+                    return Err(format!(
+                        "{role}/{sid} (statement #{index}): Resource {resource:?} is a KMS \
+                         key ARN, but the statement's Action {actions:?} grants no KMS \
+                         operation -- the KMS resource guards select on the action, so this \
+                         ARN would be checked by nothing"
+                    ));
+                }
+                saw_kms = true;
+            }
+            ResourceShape::Unclassified => {
+                return Err(format!(
+                    "{role}/{sid} (statement #{index}): Resource {resource:?} is neither \
+                     bucket-relative to {BUCKET_ARN:?}, nor exactly that bucket ARN, nor \
+                     an {KMS_ARN_PREFIX:?} key ARN -- an access-point or Object Lambda or \
+                     multi-region-access-point ARN, \"*\", \"arn:*\", another bucket, or a \
+                     malformed non-ARN grants access no guard in this file can check, so \
+                     it must fail closed rather than be dropped as nothing to check \
+                     (issue #1346, H1)"
+                ));
+            }
+        }
+    }
+
+    if grants_object && !saw_object {
+        return Err(format!(
+            "{role}/{sid} (statement #{index}): Action {actions:?} grants an S3 object \
+             operation but Resource {resources:?} names no object under {BUCKET_ARN:?} -- \
+             the object axis would derive an empty pattern set and skip the statement"
+        ));
+    }
+    if grants_list && !saw_bucket {
+        return Err(format!(
+            "{role}/{sid} (statement #{index}): Action {actions:?} grants an S3 bucket \
+             operation but Resource {resources:?} is not the bare bucket ARN \
+             {BUCKET_ARN:?} -- a list grant on any other resource enumerates a bucket this \
+             file models nothing about, and round three's list-only exemption left exactly \
+             this shape read by no guard (issue #1346, H2)"
+        ));
+    }
+    if grants_kms && !saw_kms {
+        return Err(format!(
+            "{role}/{sid} (statement #{index}): Action {actions:?} grants a KMS operation \
+             but Resource {resources:?} names no {KMS_ARN_PREFIX:?} key ARN -- \
+             kms_statement_resources would return an empty resource list and both KMS \
+             resource guards would examine nothing"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a statement's `Condition` sub-shape against the exact operators and
+/// keys the guards read (`HANDLED_CONDITION_OPERATORS` / `HANDLED_CONDITION_KEYS`).
+/// The Condition must be a NON-EMPTY JSON object; every operator in it must be
+/// handled and map to a NON-EMPTY object; every key under a handled operator must
+/// be handled and map to a string or non-empty array of strings (the shape
+/// `list_prefix_patterns` reads). Anything else -- an unhandled operator such as
+/// `StringNotLike` or a set-qualified `ForAnyValue:StringLike`, an unhandled key
+/// such as `s3:delimiter`, a non-object Condition, or an empty `{}` /
+/// `{"StringLike": {}}` (a `for` over an empty map iterates zero times, so it used
+/// to return Ok and constrain nothing) -- is a shape no guard reasons about and is
+/// rejected by name (issue #1346, F2). Without this, a ListBucket statement
+/// carrying such a Condition passes validation and `list_prefix_patterns` then
+/// finds no `["StringLike"]["s3:prefix"]` array and silently contributes nothing.
+///
+/// A non-empty `StringLike` map whose every key is handled forces `s3:prefix` to
+/// be present (it is the only handled key), so no separate presence check is
+/// needed.
+///
+/// Shape is necessary but not sufficient: each `s3:prefix` VALUE must also
+/// constrain. A value `glob_admits_everything` reports as vacuous -- a bare
+/// `"*"`, any all-`"*"` run, and every spelling that excludes no key in
+/// `key_domain()` such as `"?*"` or `"*/*"` -- passes every shape check yet lets
+/// a caller list the whole bucket, constraining no more than an absent
+/// Condition. It is rejected for the same reason the empty block is, one level
+/// down in the value (issue #1346, F1 and hole ten).
+fn validate_condition(
+    role: &str,
+    sid: &str,
+    index: usize,
+    condition: &serde_json::Value,
+) -> Result<(), String> {
+    let cond_obj = condition.as_object().ok_or_else(|| {
+        format!("{role}/{sid} (statement #{index}): Condition is not a JSON object: {condition:?}")
+    })?;
+    if cond_obj.is_empty() {
+        return Err(format!(
+            "{role}/{sid} (statement #{index}): Condition is an empty object -- an empty \
+             Condition constrains nothing, so a ListBucket statement carrying it is an \
+             unconstrained bucket-wide list; it must be a non-empty StringLike/s3:prefix \
+             block (issue #1346, F2)"
+        ));
+    }
+    for (operator, keys) in cond_obj {
+        if !HANDLED_CONDITION_OPERATORS.contains(&operator.as_str()) {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): Condition uses operator {operator:?}, \
+                 which no guard in this file reads (handled operators: \
+                 {HANDLED_CONDITION_OPERATORS:?}); a different or set-qualified operator \
+                 such as StringNotLike or ForAnyValue:StringLike must fail closed rather \
+                 than sit unexamined"
+            ));
+        }
+        let key_obj = keys.as_object().ok_or_else(|| {
+            format!(
+                "{role}/{sid} (statement #{index}): Condition operator {operator:?} is not a \
+                 JSON object: {keys:?}"
+            )
+        })?;
+        if key_obj.is_empty() {
+            return Err(format!(
+                "{role}/{sid} (statement #{index}): Condition operator {operator:?} is an \
+                 empty object -- it must map s3:prefix to a non-empty value; an empty \
+                 operator map constrains nothing (issue #1346, F2)"
+            ));
+        }
+        for (cond_key, value) in key_obj {
+            if !HANDLED_CONDITION_KEYS.contains(&cond_key.as_str()) {
+                return Err(format!(
+                    "{role}/{sid} (statement #{index}): Condition operator {operator:?} names \
+                     key {cond_key:?}, which no guard in this file reads (handled keys: \
+                     {HANDLED_CONDITION_KEYS:?}); it must fail closed rather than sit \
+                     unexamined"
+                ));
+            }
+            if !is_string_or_string_array(Some(value)) {
+                return Err(format!(
+                    "{role}/{sid} (statement #{index}): Condition {operator:?}.{cond_key:?} is \
+                     neither a string nor a non-empty array of strings: {value:?}"
+                ));
+            }
+            // Shape is not enough: the VALUE must constrain. A shape-valid
+            // s3:prefix that admits everything (a bare "*", any all-"*" run) lets
+            // a caller pass the empty prefix and list the whole bucket, exactly as
+            // an absent Condition would -- the same emptiness the empty-map arms
+            // above reject, one level down in the value (issue #1346, F1). The
+            // empty-block rejection says an empty block "constrains nothing"; that
+            // is equally true of a "*" value, so it fails here too. Gated on
+            // s3:prefix because "admits everything" is a glob-prefix reading; a
+            // future handled key with different value semantics would need its own.
+            if cond_key == "s3:prefix" {
+                for prefix in condition_value_strings(value) {
+                    if glob_admits_everything(prefix) {
+                        return Err(format!(
+                            "{role}/{sid} (statement #{index}): Condition {operator:?}.{cond_key:?} \
+                             value {prefix:?} admits every key shape this file knows about, so it \
+                             constrains no more than an absent Condition -- an s3:prefix must \
+                             exclude some key the system can produce (issue #1346, F1 and hole ten)"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The string values in a Condition-key value that is a string or an array of
+/// strings (`validate_condition` has already proved it is one of those shapes).
+fn condition_value_strings(value: &serde_json::Value) -> Vec<&str> {
+    match value {
+        serde_json::Value::String(s) => vec![s.as_str()],
+        serde_json::Value::Array(a) => a.iter().filter_map(|v| v.as_str()).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// True only for a JSON string or a non-empty array whose every element is a
+/// string. An empty array is rejected: `iter().all(..)` is vacuously true on it,
+/// so `"Action": []` / `"Resource": []` used to pass and every downstream guard
+/// then derived an empty set and skipped the statement (issue #1346).
+fn is_string_or_string_array(value: Option<&serde_json::Value>) -> bool {
+    match value {
+        Some(serde_json::Value::String(_)) => true,
+        Some(serde_json::Value::Array(a)) => {
+            !a.is_empty() && a.iter().all(serde_json::Value::is_string)
+        }
+        _ => false,
+    }
+}
+
+/// Run `validate_statement` over every statement in a policy's `Statement`
+/// array, returning the first rejection. This is the real per-statement
+/// validation loop `load_policy` runs on every shipped template; extracting it
+/// lets the regression tests call THIS function (and drive it through
+/// `build_policy`, load_policy's own body) rather than a re-typed copy of the
+/// loop that would keep passing if the call in `load_policy` were deleted.
+fn validate_policy_statements(role: &str, statements: &serde_json::Value) -> Result<(), String> {
+    let array = statements
+        .as_array()
+        .ok_or_else(|| format!("{role}: Statement is not an array"))?;
+    for (index, stmt) in array.iter().enumerate() {
+        validate_statement(role, index, stmt)?;
+    }
+    Ok(())
+}
+
+/// The parse-and-validate body shared by `load_policy` and the regression tests
+/// that need to drive the real validation call site with a synthetic policy
+/// (`load_policy` itself only reads the fixed `deploy/iam/*.json` paths). Panics,
+/// naming `source`, if `Statement` is not an array or any statement is rejected.
+fn build_policy(role: &'static str, source: &str, json: &serde_json::Value) -> Policy {
     let statements = json["Statement"].clone();
-    assert!(statements.is_array(), "{path}: Statement is not an array");
+    assert!(statements.is_array(), "{source}: Statement is not an array");
+    if let Err(msg) = validate_policy_statements(role, &statements) {
+        panic!("{source}: {msg}");
+    }
     Policy { role, statements }
 }
 
-/// IAM action names are case-insensitive: a statement granting
-/// `KMS:GenerateDataKey*` grants exactly what `kms:GenerateDataKey*` grants.
-/// Every action comparison in this file goes through this helper (or
-/// `action_has_prefix`), in both directions. A case-sensitive positive check
-/// only fails loudly, but a case-sensitive negative check reports a role
-/// unprivileged while it holds the grant.
-fn action_eq(action: &str, expected: &str) -> bool {
-    action.eq_ignore_ascii_case(expected)
+/// The on-disk path of a shipped template.
+fn policy_json_path(role: &str) -> String {
+    format!(
+        "{}/../../deploy/iam/{role}.json",
+        env!("CARGO_MANIFEST_DIR")
+    )
 }
 
-/// Case-insensitive prefix match for action names, so `kms:GenerateDataKey`
-/// selects `KMS:GenerateDataKey*` too. Indexed with `get` rather than a slice
-/// so an action name whose bytes do not split on a char boundary at
-/// `prefix.len()` returns false instead of panicking.
-fn action_has_prefix(action: &str, prefix: &str) -> bool {
-    action
-        .get(..prefix.len())
-        .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+fn load_policy(role: &'static str) -> Policy {
+    load_policy_from(role, &policy_json_path(role))
+}
+
+/// The real file-reading entry point: read the policy at `path`, parse it, and
+/// run the full per-statement validation through `build_policy`. `load_policy`
+/// is exactly this against the fixed `deploy/iam/{role}.json` paths; a
+/// regression test drives it with a synthetic invalid file so the validation is
+/// exercised through the entry point production uses, not only through
+/// `build_policy` (issue #1346, F4).
+fn load_policy_from(role: &'static str, path: &str) -> Policy {
+    let text = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let json: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+    build_policy(role, path, &json)
 }
 
 /// Every action name in a statement's `Action` (a bare string or an array),
 /// with the policy's own capitalization preserved so a failure message quotes
 /// what the template actually says.
+///
+/// The `_ => Vec::new()` arm and the `filter_map` are unreachable for any
+/// statement that passed the choke point: `validate_statement` runs
+/// `is_string_or_string_array` on `Action` BEFORE calling this, so a non-string,
+/// a non-array, an empty array, and an array holding a non-string are all
+/// already rejected. The empty return survives only for the pre-fix fixtures,
+/// which call this on a raw `NotAction` statement precisely to pin that the
+/// action used to be invisible.
 fn statement_actions(stmt: &serde_json::Value) -> Vec<String> {
     match &stmt["Action"] {
         serde_json::Value::String(s) => vec![s.clone()],
@@ -207,180 +1107,264 @@ fn statement_actions(stmt: &serde_json::Value) -> Vec<String> {
     }
 }
 
-/// `s3:prefix` patterns from every `s3:ListBucket` statement's
-/// `Condition.StringLike` block.
-fn list_prefix_patterns(policy: &Policy) -> Vec<String> {
-    let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
-        let is_list = statement_actions(stmt)
-            .iter()
-            .any(|a| action_eq(a, "s3:ListBucket"));
-        if !is_list {
-            continue;
-        }
-        if let Some(patterns) = stmt["Condition"]["StringLike"]["s3:prefix"].as_array() {
-            for p in patterns {
-                out.push(p.as_str().expect("s3:prefix entry is a string").to_string());
-            }
-        }
+/// Every resource string in a statement's `Resource` (a bare string or an
+/// array). Unreachable-arm justification is the same as `statement_actions`:
+/// `validate_statement` checks `Resource` with `is_string_or_string_array`
+/// before anything reads it.
+fn statement_resources(stmt: &serde_json::Value) -> Vec<&str> {
+    match &stmt["Resource"] {
+        serde_json::Value::String(s) => vec![s.as_str()],
+        serde_json::Value::Array(a) => a.iter().filter_map(|v| v.as_str()).collect(),
+        _ => Vec::new(),
     }
-    out
 }
 
-/// Resource-ARN key patterns (bucket prefix stripped) from every
-/// non-ListBucket statement (`GetObject`, `PutObject`, `DeleteObject`, ...).
-fn resource_key_patterns(policy: &Policy) -> Vec<String> {
-    let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
-        let is_list_only = stmt["Action"]
-            .as_str()
-            .is_some_and(|a| action_eq(a, "s3:ListBucket"));
-        if is_list_only {
-            continue;
-        }
-        let resources = match &stmt["Resource"] {
-            serde_json::Value::Array(a) => a.clone(),
-            v @ serde_json::Value::String(_) => vec![v.clone()],
-            _ => continue,
-        };
-        for r in resources {
-            let r = r.as_str().expect("Resource entry is a string");
-            if let Some(key_pattern) = r.strip_prefix("arn:aws:s3:::my-ravel-bucket/") {
-                out.push(key_pattern.to_string());
-            }
-        }
-    }
-    out
+/// A statement's `Sid`. Total for anything that passed the choke point, which
+/// requires a present string Sid so every message can name the statement it is
+/// about; the old `unwrap_or("<no Sid>")` fallback named nothing.
+fn statement_sid(stmt: &serde_json::Value) -> &str {
+    stmt["Sid"].as_str().expect(
+        "the choke point (validate_statement) requires a present string Sid, so any \
+         statement reaching a guard has one",
+    )
 }
 
-/// Resource-ARN key patterns (bucket prefix stripped) from every statement
-/// whose `Action` grants `s3:PutObject` --- the writes that go through
-/// `KmsRoutingStore` and can select a per-tenant key. Delete/Get/Deny
-/// statements are excluded: they never route (reads and deletes delegate to
-/// the default store unconditionally, see `kms_routing.rs`).
-fn put_resource_key_patterns(policy: &Policy) -> Vec<String> {
-    let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
-        let grants_put = statement_actions(stmt)
-            .iter()
-            .any(|a| action_eq(a, "s3:PutObject"));
-        if !grants_put {
-            continue;
-        }
-        let resources = match &stmt["Resource"] {
-            serde_json::Value::Array(a) => a.clone(),
-            v @ serde_json::Value::String(_) => vec![v.clone()],
-            _ => continue,
-        };
-        for r in resources {
-            let r = r.as_str().expect("Resource entry is a string");
-            if let Some(key_pattern) = r.strip_prefix("arn:aws:s3:::my-ravel-bucket/") {
-                out.push(key_pattern.to_string());
-            }
-        }
-    }
-    out
-}
-
-/// The literal S3 actions that delete a stored object, ASCII-folded. IAM action
-/// names are case-insensitive, so every comparison folds both sides.
-const DELETE_ACTION_NAMES: [&str; 2] = ["s3:deleteobject", "s3:deleteobjectversion"];
-
-/// True when an IAM `Action` grants (in an Allow) or withdraws (in a Deny) the
-/// capability to delete a stored object: one of the literal delete actions, or
-/// ANY IAM wildcard pattern (`*`/`?`) that matches one of them. This is the
-/// predicate the delete guard must use instead of an exact `s3:DeleteObject`
-/// match. `"*"`, `"s3:*"`, `"s3:Delete*"`, `"s3:DeleteObject*"`, and a
-/// mis-cased `"S3:DELETEOBJECT"` all grant the delete a bare-literal check
-/// misses, and missing one lets a delete-everywhere statement sit unexamined
-/// while the guard reports Admin scoped to the scratch prefix (issue #1372, the
-/// seventh instance of the skip-what-you-don't-recognize class #1346 tracks).
-fn action_is_delete_capable(action: &str) -> bool {
-    let folded = action.to_ascii_lowercase();
-    if DELETE_ACTION_NAMES.contains(&folded.as_str()) {
-        return true;
-    }
-    // Only a wildcard pattern can match beyond an exact name; a plain unrelated
-    // action (`s3:DeleteObjectTagging`, `s3:DeleteBucket`) is correctly not
-    // delete-capable. Fold before globbing so `S3:Delete*` is resolved too.
-    if folded.contains(IAM_WILDCARDS) {
-        return DELETE_ACTION_NAMES
-            .iter()
-            .any(|name| glob_matches(&folded, name));
-    }
-    false
-}
-
-/// Strip the configured bucket's object-ARN prefix from a delete statement's
-/// `Resource`, or fail the test naming the role, `Sid`, and resource. A
-/// delete-capable statement whose resource is `"*"`, names a different bucket,
-/// or is otherwise not bucket-relative grants (or denies) delete outside the
-/// configured bucket, and dropping it silently is the same mistake #1346
-/// records for `NotResource`: the entry you do not understand is exactly the
-/// one that must not vanish.
-fn require_bucket_relative_delete_resource(role: &str, sid: &str, resource: &str) -> String {
-    resource
-        .strip_prefix(BUCKET_KEY_PREFIX)
-        .map(str::to_string)
-        .unwrap_or_else(|| {
-            panic!(
-                "{role}/{sid}: delete-capable statement names resource {resource:?}, \
-                 which is not bucket-relative to {BUCKET_ARN:?} -- a delete grant or \
-                 deny on \"*\" or on another bucket reaches outside the configured \
-                 bucket and must not be silently dropped"
-            )
-        })
-}
-
-/// Resource key patterns (bucket prefix stripped) from every statement whose
-/// `Effect` is `effect` and whose `Action` is delete-capable (see
-/// `action_is_delete_capable`).
+/// `s3:prefix` patterns from the `Condition.StringLike` block of every statement
+/// whose `Effect` matches `effect` (`None` matches any) and whose `Action` grants
+/// a list operation.
 ///
-/// One function for both effects, because the two sides differ only in which
-/// `Effect` they select. The Resource-shape panic, the `Sid` fallback, and the
-/// bucket-relative requirement have to be identical on both, and a rule
-/// tightened on one copy and not the other is the failure this file keeps
-/// repeating.
+/// The `effect` argument is the same one `key_patterns_for` takes, and it exists
+/// for the same reason: a prefix is read as a permission or a prohibition
+/// depending on which caller reads it, and an explicit IAM `Deny` wins over an
+/// `Allow`. `discovery_prefix_admitted_for_every_discovering_role` reads the
+/// result as the prefixes a role is ALLOWED to list, so it must pass
+/// `Some("Allow")`: pooling a `Deny` block's `s3:prefix` into that vector would
+/// assert the inverse of the fact, admitting a discovery prefix that an explicit
+/// Deny withdraws (issue #1346, F1). A caller that only checks each prefix names a
+/// real key shape (`every_in_scope_policy_pattern_matches_a_real_key_shape`) is
+/// effect-agnostic and passes `None`.
+///
+/// Selection goes through `action_grants`, so `"Action": "s3:*"` is read here
+/// too. Under round three's exact-name detection it was not, which is half of
+/// H3: an `s3:*` statement granted an unconstrained ListBucket while this
+/// function read nothing from it.
+fn list_prefix_patterns(policy: &Policy, effect: Option<&str>) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        if let Some(effect) = effect {
+            let has_effect = stmt["Effect"]
+                .as_str()
+                .is_some_and(|e| e.eq_ignore_ascii_case(effect));
+            if !has_effect {
+                continue;
+            }
+        }
+        if !any_action_grants_any(&statement_actions(stmt), &S3_BUCKET_OPERATIONS) {
+            continue;
+        }
+        // IAM allows a single `s3:prefix` value as a bare string or an array;
+        // read both so a bare-string prefix is not silently skipped. Any other
+        // shape is unreachable: the choke point requires a list statement to
+        // carry a non-empty StringLike/s3:prefix Condition whose value is a
+        // string or non-empty array of strings, so the panic arm fires only for
+        // a statement that never passed validation.
+        match &stmt["Condition"]["StringLike"]["s3:prefix"] {
+            serde_json::Value::String(s) => out.push(s.clone()),
+            serde_json::Value::Array(patterns) => {
+                for p in patterns {
+                    out.push(p.as_str().expect("s3:prefix entry is a string").to_string());
+                }
+            }
+            other => panic!(
+                "{}/{}: list statement's Condition.StringLike.s3:prefix is {other:?} -- the \
+                 choke point requires a string or non-empty array of strings here, so \
+                 reaching this means a guard ran on an unvalidated statement",
+                policy.role,
+                statement_sid(stmt)
+            ),
+        }
+    }
+    out
+}
+
+/// A policy's statement array. `Statement`-is-an-array is asserted by
+/// `build_policy` and `validate_policy_statements` before a `Policy` exists.
+fn policy_statements(policy: &Policy) -> &Vec<serde_json::Value> {
+    policy
+        .statements
+        .as_array()
+        .expect("a Policy's Statement is an array (checked by build_policy)")
+}
+
+/// The bucket-relative key patterns among one statement's `resources`.
+///
+/// Total over `ResourceShape`, which is the point of the redesign: every arm is
+/// named and justified by a choke-point rule, so there is no catch-all that can
+/// quietly absorb a shape nobody thought about.
+///
+/// - `ObjectKey` is the pattern to check, returned.
+/// - `Bucket` contributes nothing to strip. Skipping it is safe because
+///   `validate_actions_and_resources` proved the same statement grants a list
+///   operation, and a list grant is checked on both counts: its Resource must be
+///   exactly this ARN, and its Condition must be the `s3:prefix` block
+///   `list_prefix_patterns` reads. This is the arm that makes the normal mixed
+///   ListBucket+GetObject idiom work without a misleading rejection, and round
+///   three's alternative -- exempting whole list statements at the caller --
+///   is what left list Resources read by nothing (H2).
+/// - `KmsKey` likewise: the choke point proved the statement grants a KMS
+///   operation, so `kms_statement_resources` selects it and both KMS resource
+///   guards run over this exact string.
+/// - `Unclassified` panics. The choke point rejects it, so reaching here means a
+///   guard ran on a statement that never passed validation (a synthetic fixture
+///   built straight from `Policy`), and the loud failure is the belt-and-braces
+///   half of the H1 fix.
+///
+/// A bucket-relative FULL-bucket object grant `arn:aws:s3:::my-ravel-bucket/*`
+/// (which strips to `"*"` and matches every key) is now rejected at the choke
+/// point by `validate_actions_and_resources`: it is the vacuous-value sibling of
+/// F1's `"*"` s3:prefix, on the resource axis, so a shape-valid object ARN that
+/// constrains nothing fails there rather than reaching
+/// `every_in_scope_policy_pattern_matches_a_real_key_shape` -- which asserts a
+/// pattern matches AT LEAST ONE real key and so, being a coverage check, cannot
+/// reject an over-broad pattern (issue #1346, F1 sweep). Rejecting an in-bucket
+/// grant that is merely too wide but still bounded (`t/*`) remains a separate
+/// guard, out of scope here.
+fn object_key_patterns(role: &str, sid: &str, resources: &[&str]) -> Vec<String> {
+    let mut out = Vec::new();
+    for resource in resources {
+        match classify_resource(resource) {
+            ResourceShape::ObjectKey(key_pattern) => out.push(key_pattern.to_string()),
+            ResourceShape::Bucket | ResourceShape::KmsKey => {}
+            ResourceShape::Unclassified => panic!(
+                "{role}/{sid}: statement names resource {resource:?}, which is neither \
+                 bucket-relative to {BUCKET_ARN:?}, nor exactly that bucket ARN, nor an \
+                 {KMS_ARN_PREFIX:?} key ARN -- validate_statement rejects this shape, so \
+                 reaching here means a guard ran on an unvalidated statement (issue \
+                 #1346, H1)"
+            ),
+        }
+    }
+    out
+}
+
+/// Bucket-relative key patterns from every statement whose `Effect` matches
+/// `effect` (`None` matches any) and whose `Action` grants at least one of
+/// `operations`.
+///
+/// The single resource-collection loop every S3 axis uses. Round three had four
+/// near-copies of it (read, put, delete-Allow, delete-Deny) that differed in
+/// which actions they selected, whether the selection resolved wildcards, and
+/// what they did with a resource they could not strip; the read copy and the
+/// delete copy then disagreed about the bare bucket ARN, which is how the
+/// list-only exemption got added to one of them. There is now one loop, one
+/// action predicate, and one resource classifier.
+///
+/// The `continue`s are axis selection, not shape skips: "this statement grants
+/// no operation on my axis" and "this statement is the other Effect". The choke
+/// point's coverage rule guarantees every statement is selected by at least one
+/// axis, and whichever axis selects it sees every resource it carries.
+fn key_patterns_for(policy: &Policy, operations: &[&str], effect: Option<&str>) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        if let Some(effect) = effect {
+            let has_effect = stmt["Effect"]
+                .as_str()
+                .is_some_and(|e| e.eq_ignore_ascii_case(effect));
+            if !has_effect {
+                continue;
+            }
+        }
+        if !any_action_grants_any(&statement_actions(stmt), operations) {
+            continue;
+        }
+        out.extend(object_key_patterns(
+            policy.role,
+            statement_sid(stmt),
+            &statement_resources(stmt),
+        ));
+    }
+    out
+}
+
+/// The action strings, in template order, that select `policy` on the axis
+/// `operations` under `effect`. The action-side mirror of `key_patterns_for`,
+/// and the S3 counterpart of `kms_actions`.
+///
+/// Only the actions that grant an axis operation are returned, for the reason
+/// `kms_actions` filters the same way: a mixed ListBucket+GetObject statement
+/// must contribute `s3:ListBucket` to the list axis and `s3:GetObject` to the
+/// get axis rather than both to each, or an axis would report an action it does
+/// not select on. A wildcard action that grants an axis operation without naming
+/// it (`"s3:*"`) is returned, because `action_grants` decides membership.
+///
+/// The strings keep the template's own capitalization and spelling, so an
+/// expectation over them pins WHAT THE POLICY SAYS, not what it resolves to.
+/// That is the point: an action edit that leaves the resolved capability
+/// unchanged for the operations this file has a vocabulary for (`s3:Delete*` for
+/// the two delete operations) still widens the real grant, and must be read by a
+/// human rather than absorbed.
+fn actions_for(policy: &Policy, operations: &[&str], effect: Option<&str>) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        if let Some(effect) = effect {
+            let has_effect = stmt["Effect"]
+                .as_str()
+                .is_some_and(|e| e.eq_ignore_ascii_case(effect));
+            if !has_effect {
+                continue;
+            }
+        }
+        out.extend(
+            statement_actions(stmt)
+                .into_iter()
+                .filter(|a| action_grants_any(a, operations)),
+        );
+    }
+    out
+}
+
+/// Bucket-relative key patterns from every statement granting an S3 object
+/// operation (`GetObject`, `PutObject`, `DeleteObject`, ...), either Effect.
+///
+/// Selection is by grant, not by "not ListBucket": a list-only statement grants
+/// no object operation and is not selected, and a mixed ListBucket+GetObject
+/// statement IS selected and contributes its object patterns.
+fn resource_key_patterns(policy: &Policy) -> Vec<String> {
+    key_patterns_for(policy, &S3_OBJECT_OPERATIONS, None)
+}
+
+/// Bucket-relative key patterns from every statement whose `Action` grants
+/// `s3:PutObject` --- the writes that go through `KmsRoutingStore` and can
+/// select a per-tenant key. Delete/Get/Deny statements are excluded: they never
+/// route (reads and deletes delegate to the default store unconditionally, see
+/// `kms_routing.rs`).
+///
+/// Delete and Get are excluded by action selection; `Deny` is excluded by the
+/// `Some("Allow")` effect argument. Its consumer,
+/// `roles_writing_routed_objects_have_kms_grant`, reads the result as the routed
+/// writes a role performs and then demands a KMS grant for them, so a `Deny`
+/// PutObject read as a routed write would demand a KMS grant for a write the role
+/// cannot perform --- the inverse of the fact, since an explicit Deny withdraws
+/// the write (issue #1346, F1/F2). Passing `None` here left `Deny` matching, so
+/// the sentence above was true of Delete/Get and false of Deny; `Some("Allow")`
+/// makes it true.
+///
+/// `"Action": "s3:*"` grants PutObject and so is selected here, which round
+/// three's exact-name match missed (H3).
+fn put_resource_key_patterns(policy: &Policy) -> Vec<String> {
+    key_patterns_for(policy, &["s3:PutObject"], Some("Allow"))
+}
+
+/// Bucket-relative key patterns from every statement whose `Effect` is `effect`
+/// and whose `Action` grants an S3 delete operation.
 ///
 /// `"Allow"` returns the delete capability a role actually holds. The
 /// `DenyDeleteProtected` block names delete actions too, but it withdraws
 /// capability rather than granting it (and an explicit IAM `Deny` always wins),
 /// so it is selected separately by `"Deny"`, which returns the keys that block
-/// protects (ADR-0055 §3). Either way a delete-capable statement whose Resource
-/// is not bucket-relative fails the test rather than being dropped: a Deny
-/// naming a delete on `"*"` would deny the qualification probe's own delete and
-/// one on another bucket protects nothing here.
+/// protects (ADR-0055 §3).
 fn delete_key_patterns(policy: &Policy, effect: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
-        let has_effect = stmt["Effect"]
-            .as_str()
-            .is_some_and(|e| e.eq_ignore_ascii_case(effect));
-        if !has_effect {
-            continue;
-        }
-        let touches_delete = statement_actions(stmt)
-            .iter()
-            .any(|a| action_is_delete_capable(a));
-        if !touches_delete {
-            continue;
-        }
-        let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>");
-        let resources = match &stmt["Resource"] {
-            serde_json::Value::Array(a) => a.clone(),
-            v @ serde_json::Value::String(_) => vec![v.clone()],
-            other => panic!(
-                "{}/{sid}: delete-capable {effect} has a Resource that is neither a \
-                 string nor an array: {other:?}",
-                policy.role
-            ),
-        };
-        for r in resources {
-            let r = r.as_str().expect("Resource entry is a string");
-            out.push(require_bucket_relative_delete_resource(policy.role, sid, r));
-        }
-    }
-    out
+    key_patterns_for(policy, &S3_DELETE_OPERATIONS, Some(effect))
 }
 
 const ROLES_WITH_DISCOVERY: [&str; 3] = ["gateway", "query", "maintain"];
@@ -412,55 +1396,85 @@ const ROUTED_WRITE_EXEMPT_ROLES: [&str; 1] = ["admin"];
 /// own PUT patterns and `KmsRoutingStore`'s real routing predicate.
 const WRITE_ROLES: [&str; 3] = ["gateway", "maintain", "query"];
 
-/// `kms:*` action strings appearing anywhere in `policy`'s statements
+/// `kms:*` action strings granted by an `Allow` statement anywhere in `policy`
 /// (`Action` as a bare string or an array), regardless of statement Sid.
 ///
-/// Selection is case-insensitive, so `KMS:GenerateDataKey*` is returned; the
-/// strings themselves keep the template's capitalization, so a caller's
-/// failure message shows what the policy said rather than a normalized form
-/// the operator would then grep for in vain. Callers compare with `action_eq`
-/// or `action_has_prefix` rather than against these strings directly.
+/// Allow-only, for the F1 reason applied to actions rather than resources: every
+/// caller reads the result as a grant the role HOLDS
+/// (`write_roles_have_kms_generate_data_key`,
+/// `roles_writing_routed_objects_have_kms_grant`, `every_role_has_kms_decrypt`) or
+/// as the absence of one (`admin_has_no_kms_generate_data_key`), and an explicit
+/// IAM `Deny` grants nothing. Pooling a `Deny kms:GenerateDataKey` into this
+/// vector would report a role able to mint ciphertext when the Deny withdraws
+/// exactly that, and would make the negative admin assertion fail on a policy that
+/// safely denies the operation --- the inverse of the fact in both directions
+/// (issue #1346, F1 sweep). A `Deny` KMS statement passes the choke point, so this
+/// case is reachable, not hypothetical.
+///
+/// Selection goes through `action_selects_kms`, so `KMS:GenerateDataKey*` is
+/// returned and so is a wildcard action (`"*"`, `"kms:*"`) that grants a KMS
+/// operation without naming the service literally --- which the old case-folded
+/// `kms:` prefix test missed. The strings themselves keep the template's
+/// capitalization, so a caller's failure message shows what the policy said
+/// rather than a normalized form the operator would then grep for in vain.
+/// Callers ask `action_grants` what a returned string grants; none compares it
+/// literally.
 fn kms_actions(policy: &Policy) -> Vec<String> {
     let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
+    for stmt in policy_statements(policy) {
+        let is_allow = stmt["Effect"]
+            .as_str()
+            .is_some_and(|e| e.eq_ignore_ascii_case("Allow"));
+        if !is_allow {
+            continue;
+        }
         out.extend(
             statement_actions(stmt)
                 .into_iter()
-                .filter(|a| action_has_prefix(a, "kms:")),
+                .filter(|a| action_selects_kms(a)),
         );
     }
     out
 }
 
-/// Sid and parsed `Resource` list for every statement carrying a `kms:`
-/// action. Both resource guards below go through this one selection rule, so
-/// a change to it cannot reach one guard and miss the other.
+/// Sid and KMS key ARNs for every `Allow` statement granting a KMS operation.
+/// Both KMS resource guards below go through this one selection rule, so a change
+/// to it cannot reach one guard and miss the other.
 ///
-/// Panics on a `Resource` that is neither a string nor an array, as the
-/// guards did inline: a malformed template must fail the test rather than be
-/// skipped as "no resources to check".
+/// Allow-only, for the F1 reason: both guards read the result as a GRANT that must
+/// be narrowly scoped (`no_allow_kms_statement_grants_every_key_in_the_region`,
+/// `every_allow_kms_statement_names_a_key_id`). An explicit `Deny` grants nothing, so a
+/// `Deny` naming `key/*` is a broad prohibition (safe), yet these guards would
+/// flag it as an account-wide grant --- the inverse of the fact. A `Deny` KMS
+/// statement passes the choke point, so this is reachable; scoping is asked only
+/// of the grants (issue #1346, F1 sweep).
+///
+/// The returned resources are filtered to `ResourceShape::KmsKey`, so a mixed
+/// statement's S3 object ARNs are not handed to the KMS ARN-shape assertions
+/// (which would reject them for the wrong reason). Nothing is lost: the choke
+/// point proved a KMS-granting statement carries at least one KMS ARN, and any
+/// object ARN it also carries is read by the object axis.
 fn kms_statement_resources(policy: &Policy) -> Vec<(String, Vec<String>)> {
-    let role = policy.role;
     let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
+    for stmt in policy_statements(policy) {
+        let is_allow = stmt["Effect"]
+            .as_str()
+            .is_some_and(|e| e.eq_ignore_ascii_case("Allow"));
+        if !is_allow {
+            continue;
+        }
         if !statement_actions(stmt)
             .iter()
-            .any(|a| action_has_prefix(a, "kms:"))
+            .any(|a| action_selects_kms(a))
         {
             continue;
         }
-        let sid = stmt["Sid"].as_str().unwrap_or("<no Sid>").to_string();
-        let resources: Vec<String> = match &stmt["Resource"] {
-            serde_json::Value::String(s) => vec![s.clone()],
-            serde_json::Value::Array(a) => a
-                .iter()
-                .map(|v| v.as_str().expect("Resource entry is a string").to_string())
-                .collect(),
-            other => {
-                panic!("{role}/{sid}: Resource is neither a string nor an array: {other:?}")
-            }
-        };
-        out.push((sid, resources));
+        let resources: Vec<String> = statement_resources(stmt)
+            .into_iter()
+            .filter(|r| matches!(classify_resource(r), ResourceShape::KmsKey))
+            .map(str::to_string)
+            .collect();
+        out.push((statement_sid(stmt).to_string(), resources));
     }
     out
 }
@@ -481,7 +1495,7 @@ fn write_roles_have_kms_generate_data_key() {
         assert!(
             actions
                 .iter()
-                .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
+                .any(|a| action_grants_any(a, &KMS_DATA_KEY_OPERATIONS)),
             "{role}: policy is missing kms:GenerateDataKey* -- its ingest/compaction/\
              catalog-fold PUTs under t/<hash>/... will fail closed against a \
              --tenant-kms-config tenant. Found kms actions: {actions:?}"
@@ -510,42 +1524,1137 @@ fn write_roles_have_kms_generate_data_key() {
 #[test]
 fn roles_writing_routed_objects_have_kms_grant() {
     for role in ALL_ROLES {
-        let policy = load_policy(role);
-        let routed: Vec<String> = put_resource_key_patterns(&policy)
-            .into_iter()
-            .filter(|p| ravel_object_store::routes_through_tenant_key(p))
+        assert_role_routed_writes_have_kms_grant(&load_policy(role));
+    }
+}
+
+/// The routed-write guard's body, factored out so a fixture can drive the real
+/// assertions on a synthetic policy rather than a re-typed copy of them (the
+/// same pattern `assert_admin_delete_grant_is_scratch_only` uses).
+///
+/// An EMPTY routed set is a failure here, not a skip. Pre-fix the body read
+/// `if routed.is_empty() { continue; }`, so widening a non-exempt write role's
+/// PutObject `Resource` to a pattern the routing predicate does not recognize
+/// emptied the set and silently retired the KMS requirement for that role: the
+/// guard reported nothing while the role kept its PUT grant (issue #1346, hole
+/// twelve). Every shipped role PUTs at least one `t/<hash>/...` object, so the
+/// only way to reach an empty set is a widening or a deletion, and both must be
+/// loud. The exemption-honesty check reads off the same assertion.
+fn assert_role_routed_writes_have_kms_grant(policy: &Policy) {
+    let role = policy.role;
+    let puts = put_resource_key_patterns(policy);
+    assert!(
+        !puts.is_empty(),
+        "{role}: policy grants s3:PutObject on nothing -- every shipped role \
+         writes objects, so an empty PUT set means the write grant was dropped \
+         or moved somewhere no axis reads"
+    );
+
+    let routed: Vec<String> = puts
+        .iter()
+        .filter(|p| ravel_object_store::routes_through_tenant_key(p.as_str()))
+        .cloned()
+        .collect();
+    assert!(
+        !routed.is_empty(),
+        "{role}: grants s3:PutObject on {puts:?}, none of which routes through a \
+         per-tenant key. An empty routed set is not a role with nothing to check: \
+         pre-fix it SKIPPED the kms:GenerateDataKey*/kms:Encrypt requirement below \
+         (and, for a role in ROUTED_WRITE_EXEMPT_ROLES, voided the exemption-honesty \
+         check that the exemption still covers a real routed write). Either the PUT \
+         resource was widened past the tenant keyspace, or the role should be dropped \
+         from ROUTED_WRITE_EXEMPT_ROLES (issue #1346, hole twelve)"
+    );
+
+    // `routes_through_tenant_key` answers about a KEY; every caller above asks it
+    // about a PATTERN, which is a value no key constructor produces. That is the
+    // hole-ten property on the routing axis: a pattern whose own text does not
+    // parse as a tenant key can still ADMIT tenant keys (`*/*` admits every key in
+    // `key_domain()`), and the difference decides whether the KMS requirement
+    // applies. Asked here against real keys, so it cannot be dodged by spelling.
+    for pattern in &puts {
+        if ravel_object_store::routes_through_tenant_key(pattern) {
+            continue;
+        }
+        let admitted: Vec<&String> = key_domain()
+            .iter()
+            .filter(|key| {
+                glob_matches(pattern, key.as_str())
+                    && ravel_object_store::routes_through_tenant_key(key.as_str())
+            })
             .collect();
-        if ROUTED_WRITE_EXEMPT_ROLES.contains(&role) {
-            // Keep the exemption honest: an exempt role that no longer writes
-            // any routed object should be dropped from the list, not left to
-            // silently mask a later regression. `admin_has_no_kms_generate_data_key`
-            // separately pins that this exempt role stays Decrypt-only.
-            assert!(
-                !routed.is_empty(),
-                "{role}: listed in ROUTED_WRITE_EXEMPT_ROLES but PUTs no routed \
-                 object -- remove it from the exemption list"
-            );
-            continue;
-        }
-        if routed.is_empty() {
-            continue;
-        }
-        let actions = kms_actions(&policy);
         assert!(
-            actions
-                .iter()
-                .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
-            "{role}: PUTs routed object class(es) {routed:?} but policy lacks \
-             kms:GenerateDataKey* -- those writes fail closed under \
-             --tenant-kms-config. Found kms actions: {actions:?}"
-        );
-        assert!(
-            actions.iter().any(|a| action_eq(a, "kms:Encrypt")),
-            "{role}: PUTs routed object class(es) {routed:?} but policy lacks \
-             kms:Encrypt -- those writes fail closed under --tenant-kms-config. \
-             Found kms actions: {actions:?}"
+            admitted.is_empty(),
+            "{role}: PUT pattern {pattern:?} does not itself parse as a routed \
+             tenant key, yet it admits routed keys {admitted:?} -- the KMS \
+             requirement would be decided on the pattern's own text instead of on \
+             the keys it grants (issue #1346, hole ten sweep)"
         );
     }
+
+    if ROUTED_WRITE_EXEMPT_ROLES.contains(&role) {
+        // `admin_has_no_kms_generate_data_key` pins that this exempt role stays
+        // Decrypt-only; the assertion above pins that the exemption still covers
+        // a real routed write rather than masking a later regression.
+        return;
+    }
+
+    let actions = kms_actions(policy);
+    assert!(
+        actions
+            .iter()
+            .any(|a| action_grants_any(a, &KMS_DATA_KEY_OPERATIONS)),
+        "{role}: PUTs routed object class(es) {routed:?} but policy lacks \
+         kms:GenerateDataKey* -- those writes fail closed under \
+         --tenant-kms-config. Found kms actions: {actions:?}"
+    );
+    assert!(
+        actions.iter().any(|a| action_grants(a, "kms:Encrypt")),
+        "{role}: PUTs routed object class(es) {routed:?} but policy lacks \
+         kms:Encrypt -- those writes fail closed under --tenant-kms-config. \
+         Found kms actions: {actions:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The effective pattern set every role grants, per axis, by exact equality.
+//
+// Before this table, nothing asserted that a Deny is a Deny. Flipping
+// `DenyDeleteProtected`'s Effect to `Allow` in gateway.json, query.json or
+// maintain.json left the suite green, and so did deleting the statement
+// outright: only admin.json went red, and only because
+// `assert_admin_delete_grant_is_scratch_only` happens to assert exact equality
+// on admin's delete grant. Every other guard asks a one-sided question ("does
+// SOME pattern do X?"), which a Deny turning into an Allow, or vanishing,
+// cannot make false (issue #1346, hole eleven). Generalising that exact-equality
+// shape to every role and every axis is what makes the Effect load-bearing.
+//
+// The form is deliberate: an Allow set and a Deny set per axis, each by exact
+// equality, plus the overlap properties asserted separately over real keys
+// (`delete_deny_and_allow_overlap_exactly_where_expected` measures where the two
+// sides cover the same key, and `every_allow_deny_key_overlap_is_named_by_the_deny`
+// asserts the Deny's actions cover the Allow's wherever they do). The alternative
+// -- one "effective" set per axis, with the Deny globs subtracted from the Allow
+// globs -- is not exactly computable: glob difference is not a glob, so any
+// single-set form would have to approximate, and an approximation asserted by
+// exact equality is a fake. Two exact sets and a checked disjointness property
+// state the same fact without pretending to compute the subtraction.
+// ---------------------------------------------------------------------------
+
+/// The placeholder tenant-key ARN every shipped template carries.
+const TENANT_KMS_KEY_ARN: &str =
+    "arn:aws:kms:us-east-1:111122223333:key/REPLACE-WITH-TENANT-KEY-ID";
+
+/// The `DenyDeleteProtected` resource set, identical in all four templates:
+/// the three singleton control objects, the per-tenant provenance record, the
+/// whole catalog keyspace, and the legal-hold audit shard (ADR-0055 section 3).
+/// Shared by every row below, so a template that drifts out of step with the
+/// others fails on this axis rather than passing with its own variant.
+const PROTECTED_DELETE_KEYS: &[&str] = &[
+    "sys/tenancy",
+    "sys/qualification",
+    "sys/gc",
+    "t/*/*/prov",
+    "t/*/catalog/*/*",
+    "t/*/u/*/0000/*",
+];
+
+/// The `DenyDeleteProtected` action set, identical in all four templates: both
+/// delete operations S3 distinguishes.
+///
+/// This is the axis the protection actually turns on. A `Deny` overrides an
+/// `Allow` only for the operations it NAMES, and three of maintain's delete
+/// grants cover the legal-hold shard (`EXPECTED_DELETE_OVERLAPS`), so dropping
+/// `s3:DeleteObjectVersion` from here would leave Maintain able to destroy
+/// versions of legal-hold audit objects while every pattern-set expectation and
+/// the overlap measurement stayed green. `every_allow_deny_key_overlap_is_named_by_the_deny`
+/// asserts the property directly; this row makes the edit itself visible.
+const PROTECTED_DELETE_ACTIONS: &[&str] = &["s3:DeleteObject", "s3:DeleteObjectVersion"];
+
+/// One role's complete grant surface, as the guards in this file derive it.
+/// Written as intent: each field is the exact list, in template order, that the
+/// axis returns. The Deny side of every axis except delete is empty, which is
+/// the claim `every_shipped_deny_is_a_delete_only_prohibition` restates
+/// structurally.
+///
+/// Every S3 axis carries a pattern list AND an action list, because a statement
+/// is two independent halves and the pattern half alone leaves one of them
+/// unpinned. Resources decide WHICH keys a statement reaches; actions decide
+/// WHAT it may do to them and, on a `Deny`, exactly how much of an overlapping
+/// `Allow` it overrides. Before the action rows, a resource edit reddened this
+/// table and an action edit prompted nobody.
+struct ExpectedRolePatterns {
+    role: &'static str,
+    list_prefixes: &'static [&'static str],
+    list_actions: &'static [&'static str],
+    gets: &'static [&'static str],
+    get_actions: &'static [&'static str],
+    puts: &'static [&'static str],
+    put_actions: &'static [&'static str],
+    deletes: &'static [&'static str],
+    delete_actions: &'static [&'static str],
+    protected_deletes: &'static [&'static str],
+    protected_delete_actions: &'static [&'static str],
+    kms_actions: &'static [&'static str],
+    /// `(Sid, KMS key ARNs)` per `Allow` statement granting a KMS operation.
+    kms_resources: &'static [(&'static str, &'static [&'static str])],
+}
+
+const EXPECTED_PATTERNS: [ExpectedRolePatterns; 4] = [
+    // Gateway: ingest. Writes L0 data, commit records, idempotency and
+    // admission records, provenance, and the catalog objects a commit
+    // publishes; deletes nothing.
+    ExpectedRolePatterns {
+        role: "gateway",
+        list_prefixes: &[
+            "t/",
+            "t/*/*/l0/*",
+            "t/*/*/c/*",
+            "t/*/*/admission/*",
+            "t/*/catalog/*/*",
+        ],
+        list_actions: &["s3:ListBucket"],
+        gets: &[
+            "t/*/*/l0/*",
+            "t/*/*/c/*",
+            "t/*/*/prov",
+            "t/*/*/idem/*",
+            "t/*/*/admission/*",
+            "t/*/catalog/*/*",
+            "sys/tenancy",
+            "sys/qualification",
+            "sys/gc",
+        ],
+        get_actions: &["s3:GetObject"],
+        puts: &[
+            "t/*/*/l0/*",
+            "t/*/*/c/*",
+            "t/*/*/idem/*",
+            "t/*/*/admission/*",
+            "t/*/*/prov",
+            "t/*/catalog/*/snap/*",
+            "t/*/catalog/*/HEAD",
+            "t/*/catalog/*/idx/*",
+            "sys/tenancy",
+        ],
+        put_actions: &["s3:PutObject"],
+        deletes: &[],
+        delete_actions: &[],
+        protected_deletes: PROTECTED_DELETE_KEYS,
+        protected_delete_actions: PROTECTED_DELETE_ACTIONS,
+        kms_actions: &["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
+        kms_resources: &[("GatewayTenantKms", &[TENANT_KMS_KEY_ARN])],
+    },
+    // Query: reads every level, writes catalog-fold output, the query-audit
+    // prefix and its worker registration; deletes nothing.
+    ExpectedRolePatterns {
+        role: "query",
+        list_prefixes: &[
+            "t/",
+            "t/*/*/c/*",
+            "t/*/catalog/*/*",
+            "admission/query/*",
+            "sys/query/workers/*",
+        ],
+        list_actions: &["s3:ListBucket"],
+        gets: &[
+            "t/*/*/c/*",
+            "t/*/*/l0/*",
+            "t/*/*/l1/*",
+            "t/*/catalog/*/*",
+            "t/*/*/prov",
+            "admission/query/*",
+            "sys/tenancy",
+            "sys/qualification",
+            "sys/gc",
+            "sys/query/workers/*",
+        ],
+        get_actions: &["s3:GetObject"],
+        puts: &[
+            "t/*/catalog/*/snap/*",
+            "t/*/catalog/*/HEAD",
+            "t/*/catalog/*/idx/*",
+            "t/*/u/*",
+            "admission/query/*",
+            "sys/tenancy",
+            "sys/query/workers/*",
+        ],
+        put_actions: &["s3:PutObject"],
+        deletes: &[],
+        delete_actions: &[],
+        protected_deletes: PROTECTED_DELETE_KEYS,
+        protected_delete_actions: PROTECTED_DELETE_ACTIONS,
+        kms_actions: &["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
+        kms_resources: &[("QueryTenantKms", &[TENANT_KMS_KEY_ARN])],
+    },
+    // Maintain: the only role that deletes. Compaction and rewrite outputs,
+    // maintenance cursors, and the GC/tenancy control objects; its deletes
+    // cover the inputs compaction supersedes plus the non-hold audit shard.
+    ExpectedRolePatterns {
+        role: "maintain",
+        list_prefixes: &[
+            "t/",
+            "t/*/*/l0/*",
+            "t/*/*/c/*",
+            "t/*/*/l1/*",
+            "t/*/*/idem/*",
+            "sys/maintain/workers/*",
+        ],
+        list_actions: &["s3:ListBucket"],
+        gets: &[
+            "t/*/*/l0/*",
+            "t/*/*/c/*",
+            "t/*/*/l1/*",
+            "t/*/*/maint/*",
+            "t/*/u/*",
+            "t/*/*/prov",
+            "sys/tenancy",
+            "sys/qualification",
+            "sys/gc",
+            "sys/maintain/*",
+        ],
+        get_actions: &["s3:GetObject"],
+        puts: &[
+            "t/*/*/l1/*",
+            "t/*/*/c/*",
+            "t/*/*/maint/*",
+            "sys/gc",
+            "sys/tenancy",
+            "sys/maintain/*",
+        ],
+        put_actions: &["s3:PutObject"],
+        deletes: &[
+            "t/*/*/l0/*",
+            "t/*/*/c/*",
+            "t/*/*/l1/*",
+            "t/*/*/idem/*",
+            "t/*/u/*/0001/*",
+        ],
+        // Both delete operations, and the same two the Deny names. Maintain is
+        // the only role where that identity is load-bearing rather than
+        // incidental: its level-based grants cover the legal-hold shard, so the
+        // shard is protected only as far as this list is covered by
+        // PROTECTED_DELETE_ACTIONS.
+        delete_actions: &["s3:DeleteObject", "s3:DeleteObjectVersion"],
+        protected_deletes: PROTECTED_DELETE_KEYS,
+        protected_delete_actions: PROTECTED_DELETE_ACTIONS,
+        kms_actions: &["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
+        kms_resources: &[("MaintainTenantKms", &[TENANT_KMS_KEY_ARN])],
+    },
+    // Admin: broad read, narrow create-only writes, and the one delete grant
+    // ADR-0050's qualification probe needs. Decrypt-only on KMS.
+    ExpectedRolePatterns {
+        role: "admin",
+        list_prefixes: &["t/*", "sys/*"],
+        list_actions: &["s3:ListBucket"],
+        gets: &["t/*", "sys/*"],
+        get_actions: &["s3:GetObject"],
+        puts: &[
+            "sys/tenancy",
+            "sys/qualification",
+            "sys/qualify/*",
+            "sys/gc",
+            "t/*/*/prov",
+            "t/*/*/c/*",
+            "t/*/u/*",
+        ],
+        put_actions: &["s3:PutObject"],
+        deletes: &["sys/qualify/*"],
+        // Narrower than the Deny, which names both operations. Legitimate, and
+        // the reason the overlap property is asserted as containment rather than
+        // equality: admin's delete grant and its Deny cover no key in common, and
+        // where they did, a Deny naming MORE than the Allow grants is safe.
+        delete_actions: &["s3:DeleteObject"],
+        protected_deletes: PROTECTED_DELETE_KEYS,
+        protected_delete_actions: PROTECTED_DELETE_ACTIONS,
+        kms_actions: &["kms:Decrypt"],
+        kms_resources: &[("AdminTenantKms", &[TENANT_KMS_KEY_ARN])],
+    },
+];
+
+/// Compare one axis's derived set (key patterns, `s3:prefix` values or action
+/// strings) against the expected set, by exact equality and in order.
+fn assert_axis_eq(role: &str, axis: &str, actual: &[String], expected: &[&str]) {
+    let expected: Vec<String> = expected.iter().map(|p| (*p).to_string()).collect();
+    assert_eq!(
+        actual,
+        expected.as_slice(),
+        "{role}: the effective {axis} set is not the set this test \
+         expects. Every axis is pinned by exact equality, so a widened, dropped, \
+         reordered or Effect-flipped statement fails here rather than passing a \
+         one-sided \"does some pattern do X?\" check. If the template change is \
+         intended, update EXPECTED_PATTERNS in the same commit (issue #1346, \
+         hole eleven)"
+    );
+}
+
+/// Every role's grant surface, per axis, by exact equality against
+/// `EXPECTED_PATTERNS`: the key patterns and the action strings, both sides of
+/// every statement. The Allow and Deny sides are asserted separately: glob
+/// difference is not a glob, so a single "effective" set would have to
+/// approximate the subtraction, and the overlap that makes the two sides unsafe
+/// to read as independent is measured and covered by its own properties below.
+#[test]
+fn every_role_grants_exactly_the_expected_pattern_set() {
+    let mut covered: Vec<&str> = EXPECTED_PATTERNS.iter().map(|e| e.role).collect();
+    covered.sort_unstable();
+    let mut all_roles: Vec<&str> = ALL_ROLES.to_vec();
+    all_roles.sort_unstable();
+    assert_eq!(
+        covered, all_roles,
+        "EXPECTED_PATTERNS must carry exactly one row per guarded role, or a \
+         template would ship with no exact-equality assertion over it"
+    );
+
+    for expected in &EXPECTED_PATTERNS {
+        let role = expected.role;
+        let policy = load_policy(role);
+
+        assert_axis_eq(
+            role,
+            "s3:prefix Allow",
+            &list_prefix_patterns(&policy, Some("Allow")),
+            expected.list_prefixes,
+        );
+        assert_axis_eq(
+            role,
+            "s3:prefix Deny",
+            &list_prefix_patterns(&policy, Some("Deny")),
+            &[],
+        );
+        assert_axis_eq(
+            role,
+            "list action Allow",
+            &actions_for(&policy, &S3_BUCKET_OPERATIONS, Some("Allow")),
+            expected.list_actions,
+        );
+        assert_axis_eq(
+            role,
+            "list action Deny",
+            &actions_for(&policy, &S3_BUCKET_OPERATIONS, Some("Deny")),
+            &[],
+        );
+        assert_axis_eq(
+            role,
+            "s3:GetObject Allow",
+            &key_patterns_for(&policy, &["s3:GetObject"], Some("Allow")),
+            expected.gets,
+        );
+        assert_axis_eq(
+            role,
+            "s3:GetObject Deny",
+            &key_patterns_for(&policy, &["s3:GetObject"], Some("Deny")),
+            &[],
+        );
+        assert_axis_eq(
+            role,
+            "get action Allow",
+            &actions_for(&policy, &["s3:GetObject"], Some("Allow")),
+            expected.get_actions,
+        );
+        assert_axis_eq(
+            role,
+            "get action Deny",
+            &actions_for(&policy, &["s3:GetObject"], Some("Deny")),
+            &[],
+        );
+        assert_axis_eq(
+            role,
+            "s3:PutObject Allow",
+            &put_resource_key_patterns(&policy),
+            expected.puts,
+        );
+        assert_axis_eq(
+            role,
+            "s3:PutObject Deny",
+            &key_patterns_for(&policy, &["s3:PutObject"], Some("Deny")),
+            &[],
+        );
+        assert_axis_eq(
+            role,
+            "put action Allow",
+            &actions_for(&policy, &["s3:PutObject"], Some("Allow")),
+            expected.put_actions,
+        );
+        assert_axis_eq(
+            role,
+            "put action Deny",
+            &actions_for(&policy, &["s3:PutObject"], Some("Deny")),
+            &[],
+        );
+        assert_axis_eq(
+            role,
+            "delete Allow",
+            &delete_key_patterns(&policy, "Allow"),
+            expected.deletes,
+        );
+        assert_axis_eq(
+            role,
+            "delete Deny",
+            &delete_key_patterns(&policy, "Deny"),
+            expected.protected_deletes,
+        );
+        assert_axis_eq(
+            role,
+            "delete action Allow",
+            &actions_for(&policy, &S3_DELETE_OPERATIONS, Some("Allow")),
+            expected.delete_actions,
+        );
+        assert_axis_eq(
+            role,
+            "delete action Deny",
+            &actions_for(&policy, &S3_DELETE_OPERATIONS, Some("Deny")),
+            expected.protected_delete_actions,
+        );
+        assert_axis_eq(
+            role,
+            "KMS action",
+            &kms_actions(&policy),
+            expected.kms_actions,
+        );
+
+        let expected_kms: Vec<(String, Vec<String>)> = expected
+            .kms_resources
+            .iter()
+            .map(|(sid, resources)| {
+                (
+                    (*sid).to_string(),
+                    resources.iter().map(|r| (*r).to_string()).collect(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            kms_statement_resources(&policy),
+            expected_kms,
+            "{role}: the Allow KMS statements (Sid and key ARNs) are not the set \
+             this test expects (issue #1346, hole eleven)"
+        );
+    }
+}
+
+/// A Deny must be a Deny. Every `Deny` statement in every shipped template is
+/// the single `DenyDeleteProtected` block, and every action it names grants a
+/// delete operation and NOTHING else: no read, no write, no list, no KMS.
+///
+/// This is what makes the round-six availability-drift argument checkable
+/// instead of a claim about templates nobody asserted on. That argument says a
+/// `Deny` withdrawing a granted capability while a positive guard stays green is
+/// acceptable BECAUSE no shipped `Deny` withdraws a KMS or Put capability. The
+/// premise is a property of the four JSON files, so it belongs in an assertion:
+/// a `Deny kms:GenerateDataKey` or a `Deny s3:PutObject` added to any template
+/// fails here, and the argument's precondition is re-checked on every run rather
+/// than remembered from a commit message.
+#[test]
+fn every_shipped_deny_is_a_delete_only_prohibition() {
+    for role in ALL_ROLES {
+        let policy = load_policy(role);
+        let denies: Vec<&serde_json::Value> = policy_statements(&policy)
+            .iter()
+            .filter(|stmt| {
+                stmt["Effect"]
+                    .as_str()
+                    .is_some_and(|e| e.eq_ignore_ascii_case("Deny"))
+            })
+            .collect();
+        assert_eq!(
+            denies.len(),
+            1,
+            "{role}: expected exactly one Deny statement (DenyDeleteProtected). \
+             Zero means the protected-delete block was deleted or its Effect \
+             flipped to Allow; more than one means a prohibition this file's \
+             guards have not been reasoned about was added (issue #1346, hole \
+             eleven)"
+        );
+        for stmt in denies {
+            let sid = statement_sid(stmt);
+            assert_eq!(
+                sid, "DenyDeleteProtected",
+                "{role}: the only Deny statement must be DenyDeleteProtected"
+            );
+            for action in statement_actions(stmt) {
+                assert!(
+                    action_grants_any(&action, &S3_DELETE_OPERATIONS),
+                    "{role}/{sid}: Deny action {action:?} grants no delete \
+                     operation, so this block prohibits something other than \
+                     deletion"
+                );
+                for operation in ["s3:GetObject", "s3:PutObject"] {
+                    assert!(
+                        !action_grants(&action, operation),
+                        "{role}/{sid}: Deny action {action:?} also withdraws \
+                         {operation} -- a Deny that withdraws a capability a \
+                         positive guard asserts is HELD is the availability-drift \
+                         case those guards do not subtract, so it must not ship"
+                    );
+                }
+                assert!(
+                    !action_grants_any(&action, &S3_BUCKET_OPERATIONS),
+                    "{role}/{sid}: Deny action {action:?} also withdraws \
+                     s3:ListBucket, which the discovery guard reads as held"
+                );
+                assert!(
+                    !action_selects_kms(&action),
+                    "{role}/{sid}: Deny action {action:?} also withdraws a KMS \
+                     operation, which write_roles_have_kms_generate_data_key and \
+                     roles_writing_routed_objects_have_kms_grant read as held"
+                );
+            }
+        }
+    }
+}
+
+/// Where a delete `Deny` and a delete `Allow` in the same policy cover the same
+/// key, exactly. `(Deny pattern, Allow pattern)` pairs, per role, sorted and
+/// deduplicated, witnessed by at least one key in `key_domain()`.
+///
+/// Round six asserted nothing here and claimed "the only shipped `Deny` is
+/// `DenyDeleteProtected`, a delete-only prohibition DISJOINT FROM EVERY ALLOW".
+/// The delete-only half is true (`every_shipped_deny_is_a_delete_only_prohibition`
+/// pins it); the disjointness half is FALSE, and measuring it is what found that
+/// out. Maintain's level-based delete grants cover the legal-hold audit shard:
+/// an `Signal::Audit` shard-0 key is spelled `t/<hash>/u/{l0,c,l1}/0000/...`, so
+/// `t/*/*/l0/*` and `t/*/u/*/0000/*` both match it. That is the protection
+/// working as ADR-0055 section 3 designs it, not a template bug: an explicit IAM
+/// `Deny` overrides the `Allow`, so the effective capability is correct. What is
+/// wrong is reading the `Allow` set alone as the delete capability the role
+/// HOLDS -- for these three pattern pairs it overstates.
+///
+/// Pinning the overlap rather than asserting it away fails in both directions: a
+/// new overlap (a widened delete grant reaching a protected keyspace) and a
+/// vanished one (the audit-hold protection dropped, or a level grant narrowed)
+/// each change this table.
+const EXPECTED_DELETE_OVERLAPS: &[(&str, &[(&str, &str)])] = &[
+    ("gateway", &[]),
+    ("query", &[]),
+    // The ADR-0055 section 3 legal-hold shard, protected out of the three
+    // level-based grants compaction otherwise deletes.
+    (
+        "maintain",
+        &[
+            ("t/*/u/*/0000/*", "t/*/*/c/*"),
+            ("t/*/u/*/0000/*", "t/*/*/l0/*"),
+            ("t/*/u/*/0000/*", "t/*/*/l1/*"),
+        ],
+    ),
+    ("admin", &[]),
+];
+
+/// The other half of the round-six premise, corrected: measure where the shipped
+/// delete `Deny` and delete `Allow` sets cover the same key and pin the result
+/// against `EXPECTED_DELETE_OVERLAPS`, instead of claiming a disjointness that
+/// does not hold.
+///
+/// The measurement is OVER `key_domain()`, not over all strings, and the
+/// narrowing is necessary rather than convenient: as globs, maintain's delete
+/// grant `t/*/*/c/*` and its protected pattern `t/*/catalog/*/*` intersect,
+/// because IAM's `*` spans `/` (witness `t/a/catalog/b/c/d`, asserted below), yet
+/// no key any constructor emits lies in that intersection. An all-strings
+/// comparison would report an overlap that cannot occur while saying nothing
+/// about the one that does.
+#[test]
+fn delete_deny_and_allow_overlap_exactly_where_expected() {
+    // Observation 0: the narrowing to real keys is load-bearing, not cosmetic.
+    let glob_witness = "t/a/catalog/b/c/d";
+    assert!(
+        glob_matches("t/*/*/c/*", glob_witness) && glob_matches("t/*/catalog/*/*", glob_witness),
+        "fixture invalid: these two shipped maintain patterns were expected to \
+         intersect as globs, which is why disjointness is asserted over real keys"
+    );
+    assert!(
+        !key_domain().iter().any(|k| k.as_str() == glob_witness),
+        "fixture invalid: the glob-intersection witness must not be a key any \
+         constructor produces, or the templates really would be wrong"
+    );
+
+    let mut covered: Vec<&str> = EXPECTED_DELETE_OVERLAPS.iter().map(|(r, _)| *r).collect();
+    covered.sort_unstable();
+    let mut all_roles: Vec<&str> = ALL_ROLES.to_vec();
+    all_roles.sort_unstable();
+    assert_eq!(
+        covered, all_roles,
+        "EXPECTED_DELETE_OVERLAPS must carry exactly one row per guarded role"
+    );
+
+    for (role, expected) in EXPECTED_DELETE_OVERLAPS.iter().copied() {
+        let policy = load_policy(role);
+        let granted = delete_key_patterns(&policy, "Allow");
+        let protected = delete_key_patterns(&policy, "Deny");
+        assert!(
+            !protected.is_empty(),
+            "{role}: no delete-protected patterns -- this measurement would report \
+             an empty overlap having examined nothing"
+        );
+
+        // Anti-vacuity, per pattern rather than ANY. The guard this replaces was
+        // `protected_keys > 0` -- an ANY over the whole protected set that
+        // `sys/tenancy` alone satisfied, while its message claimed the stronger
+        // per-keyspace thing. Under it two of maintain's six protected patterns
+        // (`t/*/*/prov`, `t/*/catalog/*/*`) matched ZERO keys in the domain, so
+        // the overlap below examined nothing for those keyspaces and still
+        // reported the pinned overlap set as complete. Refusing each pattern by
+        // name fails closed on any protected or granted keyspace the domain does
+        // not model (#1346).
+        for pattern in &protected {
+            assert_pattern_is_witnessed(role, "delete Deny (protected)", pattern);
+        }
+        for pattern in &granted {
+            assert_pattern_is_witnessed(role, "delete Allow", pattern);
+        }
+
+        let mut overlaps: Vec<(&str, &str)> = Vec::new();
+        for key in key_domain() {
+            let denied: Vec<&String> = protected
+                .iter()
+                .filter(|p| glob_matches(p.as_str(), key))
+                .collect();
+            if denied.is_empty() {
+                continue;
+            }
+            for deny in denied {
+                for allow in granted.iter().filter(|p| glob_matches(p.as_str(), key)) {
+                    overlaps.push((deny.as_str(), allow.as_str()));
+                }
+            }
+        }
+        overlaps.sort_unstable();
+        overlaps.dedup();
+        assert_eq!(
+            overlaps.as_slice(),
+            expected,
+            "{role}: the delete Deny/Allow overlap is not the one \
+             EXPECTED_DELETE_OVERLAPS records. A new pair means a delete grant \
+             now reaches a protected keyspace (safe in AWS, since the explicit \
+             Deny wins, but the Allow set overstates the capability by that much \
+             and every guard reading it must account for the difference); a \
+             missing pair means a protection or a grant was narrowed"
+        );
+    }
+}
+
+/// Every object-key pattern the two overlap mechanisms read -- the delete
+/// protected `Deny` set, and every get/put/delete `Allow` set (the
+/// `OBJECT_OVERLAP_AXES` the containment/pin test enumerates) -- must be
+/// witnessed by at least one key in `key_domain()`. A pattern with no witness is
+/// invisible to both enumerations: they report no overlap for its keyspace having
+/// examined nothing.
+///
+/// This is the standalone form of the per-pattern refusal the delete-overlap and
+/// containment tests apply inline, and it fails closed on a keyspace the domain
+/// stops modelling: delete the `t/.../m/prov` witness, or add a template grant
+/// over a keyspace no constructor and no witness produces, and this test names
+/// the pattern rather than letting the measurement pass vacuously.
+#[test]
+fn every_overlap_pattern_has_a_domain_witness() {
+    for role in ALL_ROLES {
+        let policy = load_policy(role);
+        for pattern in &delete_key_patterns(&policy, "Deny") {
+            assert_pattern_is_witnessed(role, "delete Deny (protected)", pattern);
+        }
+        for (axis, operations) in OBJECT_OVERLAP_AXES {
+            for stmt in axis_statements(&policy, operations, "Allow") {
+                for pattern in &stmt.patterns {
+                    assert_pattern_is_witnessed(role, &format!("{axis} Allow"), pattern);
+                }
+            }
+        }
+    }
+}
+
+/// ADR-0055 section 2 says the protected keyspaces `sys/`, `prov` and `catalog/`
+/// "hold for a different reason than" the legal-hold shard: they are disjoint
+/// from every delete grant, so their `Deny` is belt-and-suspenders, while the
+/// legal-hold shard `t/*/u/*/0000/*` IS reached by maintain's level-based delete
+/// grants and holds only because the explicit `Deny` overrides them. Round eight
+/// added that sentence by inspection; this backs it now that the domain carries
+/// catalog and prov witnesses (`CONSTRUCTOR_FREE_TENANT_WITNESS_KEYS`): no delete
+/// `Allow` pattern in any template matches a witness key of those three
+/// keyspaces.
+///
+/// Scoped to DELETE on purpose. The ADR sentence is about delete capability;
+/// get and put legitimately reach catalog and prov (fold reads and writes catalog
+/// objects, the log-segment writer writes prov), so an all-axes version would be
+/// false and would say nothing about the delete protection the sentence
+/// describes. `sys/qualify/*` (admin's delete scratch) is a DIFFERENT sys key
+/// than the three protected ones, so the disjoint set is defined from the
+/// protected patterns, not from the `sys/` prefix.
+///
+/// If this fails, a delete grant reaches one of the three disjoint keyspaces:
+/// that is a template finding to report, not an assertion to weaken.
+#[test]
+fn no_delete_allow_reaches_the_disjoint_protected_keyspaces() {
+    // The protected keyspaces that hold by pattern disjointness: every
+    // PROTECTED_DELETE_KEYS entry EXCEPT the legal-hold shard, which instead
+    // holds by the Deny overriding the level-based grants that do reach it.
+    const DISJOINT_PROTECTED: &[&str] = &[
+        "sys/tenancy",
+        "sys/qualification",
+        "sys/gc",
+        "t/*/*/prov",
+        "t/*/catalog/*/*",
+    ];
+    // Pin DISJOINT_PROTECTED to its own definition so it cannot drift from the
+    // protected list it is carved out of. It must be exactly
+    // PROTECTED_DELETE_KEYS minus the one entry that does NOT hold by
+    // disjointness: the legal-hold shard, reached by maintain's level-based
+    // delete grants and held only by the Deny. The expected value is derived
+    // from PROTECTED_DELETE_KEYS, so a keyspace added there forces a matching
+    // entry here (or this fails loudly and names it), emptying this list fails,
+    // and dropping an entry fails. Nothing else asserts this relationship, so a
+    // new protected keyspace could otherwise be added with every other assertion
+    // green and its disjointness from delete grants never checked (#1346).
+    const LEGAL_HOLD_SHARD: &str = "t/*/u/*/0000/*";
+    assert!(
+        PROTECTED_DELETE_KEYS.contains(&LEGAL_HOLD_SHARD),
+        "legal-hold shard {LEGAL_HOLD_SHARD:?} is not in PROTECTED_DELETE_KEYS; \
+         the disjoint set is defined as PROTECTED_DELETE_KEYS minus that shard \
+         and must track a rename (#1346)"
+    );
+    let expected_disjoint: Vec<&str> = PROTECTED_DELETE_KEYS
+        .iter()
+        .copied()
+        .filter(|p| *p != LEGAL_HOLD_SHARD)
+        .collect();
+    assert_eq!(
+        DISJOINT_PROTECTED,
+        expected_disjoint.as_slice(),
+        "DISJOINT_PROTECTED must equal PROTECTED_DELETE_KEYS minus the legal-hold \
+         shard {LEGAL_HOLD_SHARD:?}. If a protected keyspace was added to \
+         PROTECTED_DELETE_KEYS, add it here so its disjointness from delete \
+         grants is checked; if one must be excluded for a reason other than the \
+         legal-hold shard, exclude it explicitly and justify it (#1346)"
+    );
+    let disjoint_witnesses: Vec<&String> = key_domain()
+        .iter()
+        .filter(|k| {
+            DISJOINT_PROTECTED
+                .iter()
+                .any(|p| glob_matches(p, k.as_str()))
+        })
+        .collect();
+    // Each disjoint keyspace must be witnessed, or its disjointness is asserted
+    // over a keyspace the domain models no key for -- the gap this round fixes:
+    // prov and catalog had zero witnesses.
+    for pattern in DISJOINT_PROTECTED {
+        assert!(
+            disjoint_witnesses
+                .iter()
+                .any(|k| glob_matches(pattern, k.as_str())),
+            "domain models no key for protected keyspace {pattern:?}, so its \
+             disjointness from delete grants cannot be checked"
+        );
+    }
+
+    for role in ALL_ROLES {
+        let policy = load_policy(role);
+        for allow in &delete_key_patterns(&policy, "Allow") {
+            for witness in &disjoint_witnesses {
+                assert!(
+                    !glob_matches(allow, witness.as_str()),
+                    "{role}: delete Allow {allow:?} reaches {witness:?}, a key of \
+                     the sys/, prov or catalog/ keyspaces ADR-0055 section 2 calls \
+                     disjoint from every delete grant (they hold WITHOUT relying on \
+                     the Deny, unlike the legal-hold shard). Either that ADR \
+                     sentence is wrong or a template grants a delete it must not -- \
+                     report it, do not weaken this assertion (#1346)"
+                );
+            }
+        }
+    }
+}
+
+/// One statement reduced to what an Allow/Deny overlap check needs: which
+/// operations ON ONE AXIS it names, and which object keys it names them over.
+///
+/// The operations are the resolved literal names, not the policy's action
+/// strings, so `"s3:Delete*"` on one side and
+/// `["s3:DeleteObject", "s3:DeleteObjectVersion"]` on the other compare as the
+/// same coverage. Pinning the spellings is the separate job of
+/// `EXPECTED_PATTERNS`.
+struct AxisStatement {
+    sid: String,
+    operations: Vec<&'static str>,
+    patterns: Vec<String>,
+}
+
+/// Every statement of `effect` that names at least one operation in
+/// `operations`, reduced to an `AxisStatement`.
+fn axis_statements(
+    policy: &Policy,
+    operations: &[&'static str],
+    effect: &str,
+) -> Vec<AxisStatement> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        let has_effect = stmt["Effect"]
+            .as_str()
+            .is_some_and(|e| e.eq_ignore_ascii_case(effect));
+        if !has_effect {
+            continue;
+        }
+        let actions = statement_actions(stmt);
+        let named: Vec<&'static str> = operations
+            .iter()
+            .copied()
+            .filter(|operation| actions.iter().any(|a| action_grants(a, operation)))
+            .collect();
+        if named.is_empty() {
+            continue;
+        }
+        let sid = statement_sid(stmt).to_string();
+        let patterns = object_key_patterns(policy.role, &sid, &statement_resources(stmt));
+        out.push(AxisStatement {
+            sid,
+            operations: named,
+            patterns,
+        });
+    }
+    out
+}
+
+/// The operation classes on which an `Allow` and a `Deny` in the same policy can
+/// select the same OBJECT KEY. Swept as a set rather than written for delete
+/// alone, but what the sweep buys differs by axis, and the earlier claim that
+/// get and put "carry a live overlap check" was only half right:
+///
+/// - `delete` is a TWO-operation axis (`s3:DeleteObject`,
+///   `s3:DeleteObjectVersion`), so its containment assertion can actually fire:
+///   an `Allow` may name a delete operation the overlapping `Deny` does not,
+///   leaving a non-empty uncovered set. That is the maintain legal-hold finding.
+/// - `get` and `put` are SINGLE-operation axes. A `Deny` that selects one of
+///   them necessarily names its only operation, so the uncovered set is always
+///   empty and the containment assertion structurally CANNOT fire on them. What
+///   the get/put sweep buys is not the containment property but the PIN: a `Deny`
+///   added to get or put makes a new `(role, axis)` pair that fails the
+///   `EXPECTED_OVERLAP_AXES` equality in
+///   `every_allow_deny_key_overlap_is_named_by_the_deny`. The sweep stays because
+///   that pin is worth having; it just does not establish containment on get/put.
+///
+/// The two axes NOT here have a domain that is not an object key, and the test
+/// fails closed on them instead: the list axis compares `s3:prefix` values
+/// (request parameters, not stored keys) and the KMS axis compares key ARNs.
+/// Neither can overlap today because no shipped `Deny` selects either -- the
+/// test asserts that emptiness directly, so a `Deny` added to one of them fails
+/// here rather than passing an axis this file does not model.
+const OBJECT_OVERLAP_AXES: [(&str, &[&str]); 3] = [
+    ("get", &["s3:GetObject"]),
+    ("put", &["s3:PutObject"]),
+    ("delete", &S3_DELETE_OPERATIONS),
+];
+
+/// The `(role, axis)` pairs where an `Allow` and a `Deny` statement cover a
+/// common key today. Exactly one: maintain's delete axis, over the legal-hold
+/// shard (`EXPECTED_DELETE_OVERLAPS` records the pattern pairs).
+///
+/// This is the anti-vacuity half of the containment test. Containment over an
+/// empty overlap set is vacuously true, so a test that only asserted the
+/// property would go green if the measurement stopped finding the overlap it
+/// exists for.
+const EXPECTED_OVERLAP_AXES: &[(&str, &str)] = &[("maintain", "delete")];
+
+/// Sid pairs of every `Deny` statement that selects a KMS operation.
+fn deny_kms_statement_sids(policy: &Policy) -> Vec<String> {
+    policy_statements(policy)
+        .iter()
+        .filter(|stmt| {
+            stmt["Effect"]
+                .as_str()
+                .is_some_and(|e| e.eq_ignore_ascii_case("Deny"))
+        })
+        .filter(|stmt| {
+            statement_actions(stmt)
+                .iter()
+                .any(|a| action_selects_kms(a))
+        })
+        .map(|stmt| statement_sid(stmt).to_string())
+        .collect()
+}
+
+/// The containment property, for one policy. Returns the `(role, axis)` pairs
+/// where an overlap was found and checked, so a caller can pin that the
+/// measurement examined what it claims to.
+fn assert_allow_deny_overlaps_are_named(policy: &Policy) -> Vec<(&'static str, &'static str)> {
+    let role = policy.role;
+
+    // The two axes whose domain is not an object key. Neither is modelled here,
+    // so neither may carry a Deny: with an empty Deny side no Allow/Deny pair
+    // can select the same value, which is what makes the omission safe.
+    assert!(
+        list_prefix_patterns(policy, Some("Deny")).is_empty(),
+        "{role}: a Deny statement grants s3:ListBucket. The list axis compares \
+         s3:prefix request parameters rather than stored keys, so this file does \
+         not model an Allow/Deny overlap on it: whether the Deny covers every \
+         list the Allow permits is unchecked"
+    );
+    let deny_kms = deny_kms_statement_sids(policy);
+    assert!(
+        deny_kms.is_empty(),
+        "{role}: Deny statement(s) {deny_kms:?} select a KMS operation. The KMS \
+         axis compares key ARNs rather than stored keys, so this file does not \
+         model an Allow/Deny overlap on it: whether the Deny covers every KMS \
+         operation the Allow grants on the same key is unchecked"
+    );
+
+    let mut observed = Vec::new();
+    for (axis, operations) in OBJECT_OVERLAP_AXES {
+        let allows = axis_statements(policy, operations, "Allow");
+        let denies = axis_statements(policy, operations, "Deny");
+        for deny in &denies {
+            for allow in &allows {
+                let witnesses: Vec<&String> = key_domain()
+                    .iter()
+                    .filter(|key| {
+                        deny.patterns
+                            .iter()
+                            .any(|p| glob_matches(p.as_str(), key.as_str()))
+                            && allow
+                                .patterns
+                                .iter()
+                                .any(|p| glob_matches(p.as_str(), key.as_str()))
+                    })
+                    .collect();
+                if witnesses.is_empty() {
+                    continue;
+                }
+                observed.push((role, axis));
+                let uncovered: Vec<&str> = allow
+                    .operations
+                    .iter()
+                    .copied()
+                    .filter(|operation| !deny.operations.contains(operation))
+                    .collect();
+                assert!(
+                    uncovered.is_empty(),
+                    "{role}: on the {axis} axis, Allow statement {} and Deny \
+                     statement {} both cover key(s) {witnesses:?}, and the Allow \
+                     grants {uncovered:?} there, which the Deny does not name. An \
+                     IAM Deny overrides an Allow only for the operations it \
+                     names, so the effective capability on those keys includes \
+                     {uncovered:?}: the overlap is NOT neutralized. Either name \
+                     those operations in the Deny, or narrow the Allow off these \
+                     keys",
+                    allow.sid,
+                    deny.sid
+                );
+            }
+        }
+    }
+    observed.sort_unstable();
+    observed.dedup();
+    observed
+}
+
+/// A Deny overrides only the operations it NAMES.
+///
+/// `delete_deny_and_allow_overlap_exactly_where_expected` measures WHERE the
+/// shipped delete Allow and Deny sets cover the same key, and its
+/// justification for the three recorded maintain pairs is that an explicit IAM
+/// Deny wins, so the effective capability is still correct. That justification
+/// holds only for the actions the Deny names, and nothing asserted it: drop
+/// `s3:DeleteObjectVersion` from `DenyDeleteProtected` and Maintain can
+/// permanently destroy versions of legal-hold audit objects
+/// (`t/<hash>/u/{l0,c,l1}/0000/...`, reached through `t/*/*/l0/*` and its two
+/// siblings) while the overlap measurement reports the same three pairs and
+/// every pattern expectation stays green. ADR-0055 section 2 and its section 3
+/// amendment call that shard deny-delete-forever, so this is a documented
+/// invariant with no check under it.
+///
+/// The assertion is CONTAINMENT, not equality: the Allow's operations on the
+/// overlapping keys must be a subset of the Deny's. A Deny broader than the
+/// Allow is legitimate (admin's Deny names both delete operations while its
+/// `sys/qualify/*` grant names one), and equality would reject it.
+///
+/// Swept over every axis where an Allow and a Deny can select the same key, not
+/// written for delete: see `OBJECT_OVERLAP_AXES` for the two axes whose domain
+/// is not a key and how the sweep fails closed on them instead.
+#[test]
+fn every_allow_deny_key_overlap_is_named_by_the_deny() {
+    let mut observed = Vec::new();
+    for role in ALL_ROLES {
+        observed.extend(assert_allow_deny_overlaps_are_named(&load_policy(role)));
+    }
+    observed.sort_unstable();
+    observed.dedup();
+    assert_eq!(
+        observed.as_slice(),
+        EXPECTED_OVERLAP_AXES,
+        "the set of (role, axis) pairs carrying an Allow/Deny key overlap is not \
+         the one EXPECTED_OVERLAP_AXES records. A missing pair means the \
+         containment above now checks nothing where it used to check the \
+         legal-hold shard; a new pair means an Allow and a Deny began covering a \
+         common key on an axis where they did not"
+    );
+}
+
+/// The containment assertion in both directions, on synthetic policies, so
+/// neither direction rests on the shipped templates happening to be correct.
+///
+/// Case 1 is the shape that must stay accepted: a Deny naming MORE operations
+/// than the overlapping Allow grants. Asserting the two action sets are EQUAL
+/// would reject it, and equality is a stronger condition than the property
+/// needs.
+///
+/// Case 2 is the finding itself, reproduced in miniature: an Allow granting a
+/// delete operation the overlapping Deny does not name.
+#[test]
+fn deny_broader_than_the_allow_is_accepted_and_narrower_is_not() {
+    let hold_shard = format!("{BUCKET_KEY_PREFIX}t/*/u/*/0000/*");
+    let level_zero = format!("{BUCKET_KEY_PREFIX}t/*/*/l0/*");
+
+    let policy = |allow_actions: serde_json::Value, deny_actions: serde_json::Value| {
+        build_policy(
+            "fixture",
+            "<synthetic>",
+            &serde_json::json!({
+                "Statement": [
+                    {
+                        "Sid": "LevelDelete",
+                        "Effect": "Allow",
+                        "Action": allow_actions,
+                        "Resource": [level_zero],
+                    },
+                    {
+                        "Sid": "DenyDeleteProtected",
+                        "Effect": "Deny",
+                        "Action": deny_actions,
+                        "Resource": [hold_shard],
+                    },
+                ]
+            }),
+        )
+    };
+
+    // Case 1: Deny names both operations, the Allow grants one. Accepted, and
+    // the overlap is real -- the returned axis proves the check ran rather than
+    // finding nothing to check.
+    let broader = policy(
+        serde_json::json!("s3:DeleteObject"),
+        serde_json::json!(["s3:DeleteObject", "s3:DeleteObjectVersion"]),
+    );
+    assert_eq!(
+        assert_allow_deny_overlaps_are_named(&broader),
+        vec![("fixture", "delete")],
+        "fixture invalid: the Allow and the Deny were expected to cover a common \
+         legal-hold key, or case 1 proves nothing about a Deny broader than the \
+         Allow"
+    );
+
+    // Case 2: the same overlap with the operations swapped. Rejected, naming the
+    // operation the Deny leaves granted.
+    let narrower = policy(
+        serde_json::json!(["s3:DeleteObject", "s3:DeleteObjectVersion"]),
+        serde_json::json!("s3:DeleteObject"),
+    );
+    let failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_allow_deny_overlaps_are_named(&narrower)
+    }));
+    let message = panic_message(
+        failure.expect_err("a Deny that names less than the overlapping Allow must fail"),
+    );
+    assert!(
+        message.contains("s3:DeleteObjectVersion"),
+        "the failure must name the operation the Deny does not cover; got \
+         {message:?}"
+    );
 }
 
 /// Admin is GetObject-only per ADR-0055 (its only tenant-scoped writes are
@@ -561,7 +2670,7 @@ fn admin_has_no_kms_generate_data_key() {
     assert!(
         !actions
             .iter()
-            .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
+            .any(|a| action_grants_any(a, &KMS_DATA_KEY_OPERATIONS)),
         "admin: policy must not carry kms:GenerateDataKey* (Decrypt-only per ADR-0055). \
          Found kms actions: {actions:?}"
     );
@@ -640,9 +2749,15 @@ fn admin_delete_grant_is_qualify_scratch_only() {
 /// pins the two holes existed independent of the fixed code: delete capability
 /// recognized only by an exact `s3:DeleteObject` match, and any resource not
 /// under the bucket prefix silently dropped (`if let Some(..)` with no `else`).
+///
+/// Every pre-fix body in this file spells its own comparisons out (here
+/// `eq_ignore_ascii_case`, below `strip_prefix` against a literal ARN) rather
+/// than calling a live helper: a pre-fix copy that reuses today's predicates
+/// stops proving the hole the moment those predicates change, which is how a
+/// fixture becomes a tautology.
 fn pre_fix_allow_delete_key_patterns(policy: &Policy) -> Vec<String> {
     let mut out = Vec::new();
-    for stmt in policy.statements.as_array().unwrap() {
+    for stmt in policy_statements(policy) {
         let is_allow = stmt["Effect"]
             .as_str()
             .is_some_and(|e| e.eq_ignore_ascii_case("Allow"));
@@ -651,7 +2766,7 @@ fn pre_fix_allow_delete_key_patterns(policy: &Policy) -> Vec<String> {
         }
         let grants_delete = statement_actions(stmt)
             .iter()
-            .any(|a| action_eq(a, "s3:DeleteObject"));
+            .any(|a| a.eq_ignore_ascii_case("s3:DeleteObject"));
         if !grants_delete {
             continue;
         }
@@ -740,7 +2855,7 @@ fn wildcard_or_out_of_bucket_delete_grant_is_not_a_bypass() {
                 "Resource": resource,
             }]),
         };
-        let stmt = &policy.statements.as_array().unwrap()[0];
+        let stmt = &policy_statements(&policy)[0];
         let actions = statement_actions(stmt);
 
         // Observation 1 (load-bearing): the pre-fix helper returned no delete
@@ -758,16 +2873,18 @@ fn wildcard_or_out_of_bucket_delete_grant_is_not_a_bypass() {
         // ...pin WHY it was empty so the two holes stay distinguishable: either
         // the pre-fix exact match did not see a wildcard action, or it saw the
         // action but the silent drop discarded a non-bucket-relative resource.
-        let pre_fix_action_hit = actions.iter().any(|a| action_eq(a, "s3:DeleteObject"));
+        let pre_fix_action_hit = actions
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("s3:DeleteObject"));
         assert_eq!(
             pre_fix_action_hit, pre_fix_exact_recognizes,
             "fixture {sid} invalid: expected pre-fix exact action recognition = \
              {pre_fix_exact_recognizes} for {actions:?}"
         );
         assert!(
-            actions.iter().any(|a| action_is_delete_capable(a)),
-            "fixture {sid} invalid: post-fix action_is_delete_capable must \
-             recognize {actions:?} as a delete grant"
+            any_action_grants_any(&actions, &S3_DELETE_OPERATIONS),
+            "fixture {sid} invalid: the post-fix action predicate must recognize \
+             {actions:?} as a delete grant"
         );
 
         // Observation 2: the real guard fires on the synthetic policy --- either
@@ -799,7 +2916,7 @@ fn every_role_has_kms_decrypt() {
         let policy = load_policy(role);
         let actions = kms_actions(&policy);
         assert!(
-            actions.iter().any(|a| action_eq(a, "kms:Decrypt")),
+            actions.iter().any(|a| action_grants(a, "kms:Decrypt")),
             "{role}: policy is missing kms:Decrypt -- its reads of SSE-KMS objects \
              under a --tenant-kms-config tenant will fail closed. \
              Found kms actions: {actions:?}"
@@ -850,16 +2967,18 @@ fn assert_kms_resource_names_a_key_id(role: &str, sid: &str, resource: &str) {
     );
 }
 
-/// Every statement whose `Action` grants any `kms:` action must not name a
+/// Every ALLOW statement whose `Action` grants any `kms:` action must not name a
 /// `Resource` that covers every key in the account/region: not the bare
 /// wildcard `"*"`, not an ARN ending `:key/*`, and not an ARN carrying an IAM
-/// wildcard character anywhere else either. Pinned as a negation (not an
+/// wildcard character anywhere else either. Only `Allow` statements are checked
+/// (`kms_statement_resources` filters to them): a `Deny` naming `key/*` is a
+/// broad prohibition, not an over-broad grant. Pinned as a negation (not an
 /// exact tenant-key ARN) so it survives an operator's post-substitution
 /// value. Widen any of the four templates' KMS `Resource` back to
 /// `arn:aws:kms:us-east-1:111122223333:key/*` and this test fails, naming
 /// the role and the statement `Sid`.
 #[test]
-fn no_kms_statement_grants_every_key_in_the_region() {
+fn no_allow_kms_statement_grants_every_key_in_the_region() {
     for role in ALL_ROLES {
         let policy = load_policy(role);
         let statements = kms_statement_resources(&policy);
@@ -869,6 +2988,13 @@ fn no_kms_statement_grants_every_key_in_the_region() {
              would pass having examined nothing"
         );
         for (sid, resources) in statements {
+            assert!(
+                !resources.is_empty(),
+                "{role}/{sid}: statement grants a KMS operation but names no \
+                 {KMS_ARN_PREFIX:?} key ARN -- this guard would examine nothing \
+                 (validate_statement rejects the shape, so a shipped template reaching \
+                 here means the choke point was bypassed)"
+            );
             for resource in &resources {
                 assert_kms_resource_is_not_account_wide(role, &sid, resource);
             }
@@ -876,13 +3002,15 @@ fn no_kms_statement_grants_every_key_in_the_region() {
     }
 }
 
-/// Every statement whose `Action` grants any `kms:` action must name a
+/// Every ALLOW statement whose `Action` grants any `kms:` action must name a
 /// `Resource` that pins a specific key id, so an operator cannot re-widen
 /// the grant to every key by substituting `arn:aws:kms:<region>:<account>:key/*`
 /// (or any other wildcard variant, in the key id or in the region or account
-/// segment) in place of the placeholder.
+/// segment) in place of the placeholder. Only `Allow` statements are checked
+/// (`kms_statement_resources` filters to them): a `Deny` names a prohibition,
+/// which need not pin a single key.
 #[test]
-fn every_kms_statement_names_a_key_id() {
+fn every_allow_kms_statement_names_a_key_id() {
     for role in ALL_ROLES {
         let policy = load_policy(role);
         let statements = kms_statement_resources(&policy);
@@ -892,6 +3020,13 @@ fn every_kms_statement_names_a_key_id() {
              would pass having examined nothing"
         );
         for (sid, resources) in statements {
+            assert!(
+                !resources.is_empty(),
+                "{role}/{sid}: statement grants a KMS operation but names no \
+                 {KMS_ARN_PREFIX:?} key ARN -- this guard would examine nothing \
+                 (validate_statement rejects the shape, so a shipped template reaching \
+                 here means the choke point was bypassed)"
+            );
             for resource in &resources {
                 assert_kms_resource_names_a_key_id(role, &sid, resource);
             }
@@ -930,7 +3065,7 @@ fn mixed_case_kms_action_is_not_a_bypass() {
 
     // Observation 2: the post-fix selection catches it, through the same
     // helper the guards use.
-    let selected_after_fix = actions.iter().any(|a| action_has_prefix(a, "kms:"));
+    let selected_after_fix = actions.iter().any(|a| action_selects_kms(a));
     assert!(
         selected_after_fix,
         "fixture invalid: the post-fix matcher should select \"KMS:Decrypt\""
@@ -1021,12 +3156,12 @@ fn mixed_case_generate_data_key_is_not_missed_by_the_negative_assertion() {
     assert!(
         actions
             .iter()
-            .any(|a| action_has_prefix(a, "kms:GenerateDataKey")),
+            .any(|a| action_grants_any(a, &KMS_DATA_KEY_OPERATIONS)),
         "the post-fix matcher must see KMS:GenerateDataKey* as the \
          kms:GenerateDataKey* grant it is. Found kms actions: {actions:?}"
     );
     assert!(
-        actions.iter().any(|a| action_eq(a, "kms:Decrypt")),
+        actions.iter().any(|a| action_grants(a, "kms:Decrypt")),
         "the post-fix matcher must see KMS:Decrypt as kms:Decrypt. \
          Found kms actions: {actions:?}"
     );
@@ -1186,7 +3321,7 @@ fn single_character_wildcard_in_kms_resource_is_not_a_bypass() {
         });
         assert!(
             account_wide_guard.is_err(),
-            "no_kms_statement_grants_every_key_in_the_region's assertion must \
+            "no_allow_kms_statement_grants_every_key_in_the_region's assertion must \
              fire on {resource:?}"
         );
         let key_id_guard = std::panic::catch_unwind(|| {
@@ -1194,17 +3329,422 @@ fn single_character_wildcard_in_kms_resource_is_not_a_bypass() {
         });
         assert!(
             key_id_guard.is_err(),
-            "every_kms_statement_names_a_key_id's assertion must fire on \
+            "every_allow_kms_statement_names_a_key_id's assertion must fire on \
              {resource:?}"
         );
     }
+}
+
+/// Regression fixtures for the fail-closed choke point (issue #1346, the fourth
+/// instance of the skip-what-you-do-not-understand class this guard keeps
+/// repeating: could not read `Resource`; matched the action prefix
+/// case-sensitively; accepted `?` in ARN segments; and now ignores
+/// `NotResource`/`NotAction`). Before this fix, `load_policy` performed no
+/// per-statement validation, so a statement whose permission lived in a field
+/// no guard reads -- `NotResource`, `NotAction`, an unrecognized key such as a
+/// `Resources` typo, or a statement with no `Resource` at all -- was loaded and
+/// then silently skipped by whichever guard went looking for a field it did not
+/// find. The guard ran, reported the templates safe, and the statement sat
+/// unexamined.
+///
+/// Synthetic statements, not `deploy/iam/*.json`: the shipped templates carry
+/// only handled, well-formed statements, so a fixture over them proves nothing
+/// about the choke point and goes green the day someone edits the config. Each
+/// negative case asserts in both directions -- that the pre-fix guards found
+/// nothing to object to (Observation 1, the hole) and that `validate_statement`
+/// now rejects it naming both the `Sid` and the offending key (Observation 2).
+#[test]
+fn statement_using_an_unhandled_key_fails_closed() {
+    // (Sid, statement, substring the rejection must name, which field hid the
+    // permission pre-fix: "resource" => resource_key_patterns skipped it,
+    // "action" => statement_actions saw no action).
+    let negative_cases = [
+        (
+            "NegatedResource",
+            serde_json::json!({
+                "Sid": "NegatedResource",
+                "Effect": "Allow",
+                "Action": "s3:DeleteObject",
+                "NotResource": "arn:aws:s3:::my-ravel-bucket/t/*/*/prov"
+            }),
+            "NotResource",
+            "resource",
+        ),
+        (
+            "NegatedAction",
+            serde_json::json!({
+                "Sid": "NegatedAction",
+                "Effect": "Allow",
+                "NotAction": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "NotAction",
+            "action",
+        ),
+        (
+            "TypoResources",
+            serde_json::json!({
+                "Sid": "TypoResources",
+                "Effect": "Allow",
+                "Action": "s3:PutObject",
+                "Resources": "arn:aws:s3:::my-ravel-bucket/t/*/*/l0/*"
+            }),
+            "Resources",
+            "resource",
+        ),
+        (
+            "MissingResource",
+            serde_json::json!({
+                "Sid": "MissingResource",
+                "Effect": "Allow",
+                "Action": "s3:GetObject"
+            }),
+            "no Resource",
+            "resource",
+        ),
+    ];
+
+    for (sid, stmt, must_name, hidden_side) in &negative_cases {
+        let policy = Policy {
+            role: "fixture",
+            statements: serde_json::json!([stmt.clone()]),
+        };
+
+        // Observation 1 (load-bearing): the pre-fix guard that would have read
+        // the permission found nothing. A resource-hidden statement produces no
+        // resource pattern to check; an action-hidden statement produces no
+        // action. If the relevant set stops being empty, the fixture no longer
+        // proves the statement was skipped and must be rewritten, not deleted.
+        match *hidden_side {
+            "resource" => assert!(
+                resource_key_patterns(&policy).is_empty(),
+                "fixture {sid} invalid: resource_key_patterns was expected to \
+                 skip the statement (returning nothing); it did not"
+            ),
+            "action" => assert!(
+                statement_actions(stmt).is_empty(),
+                "fixture {sid} invalid: statement_actions was expected to see no \
+                 action (returning nothing); it did not"
+            ),
+            other => panic!("fixture {sid}: unknown hidden_side {other:?}"),
+        }
+
+        // Observation 2: the choke point rejects it, naming the Sid and the key.
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+
+        // ...and so does the extracted loop `load_policy` actually runs
+        // (`validate_policy_statements`), called directly here rather than
+        // re-typed into a closure. `load_policy_rejects_an_unhandled_statement`
+        // separately pins that `load_policy`/`build_policy` still call it.
+        assert!(
+            validate_policy_statements(policy.role, &policy.statements).is_err(),
+            "fixture {sid}: validate_policy_statements (load_policy's real loop) \
+             must reject it"
+        );
+    }
+
+    // Positive control: a well-formed Allow whose keys are all handled passes.
+    let ok = serde_json::json!({
+        "Sid": "WellFormedAllow",
+        "Effect": "Allow",
+        "Action": ["s3:GetObject", "s3:PutObject"],
+        "Resource": ["arn:aws:s3:::my-ravel-bucket/t/*"]
+    });
+    assert!(
+        validate_statement("fixture", 0, &ok).is_ok(),
+        "a well-formed Allow with only handled keys must pass"
+    );
+}
+
+/// Companion to the choke point's key check: a statement whose keys are all
+/// handled but whose values are malformed must also fail closed rather than be
+/// skipped. Pre-fix, an `Effect` that is neither Allow nor Deny was skipped by
+/// every effect-filtered guard (they compare case-insensitively against exactly
+/// those two), and an `Action` or `Resource` that is neither a string nor an
+/// array of strings was read as an empty set and dropped. Synthetic for the
+/// same reason as above.
+#[test]
+fn malformed_effect_action_or_resource_fails_closed() {
+    let cases = [
+        (
+            "BadEffect",
+            serde_json::json!({
+                "Sid": "BadEffect",
+                "Effect": "Permit",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Effect",
+        ),
+        (
+            "ActionIsNumber",
+            serde_json::json!({
+                "Sid": "ActionIsNumber",
+                "Effect": "Allow",
+                "Action": 7,
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Action",
+        ),
+        (
+            "ActionArrayHasNonString",
+            serde_json::json!({
+                "Sid": "ActionArrayHasNonString",
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", 7],
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Action",
+        ),
+        (
+            "ResourceIsNumber",
+            serde_json::json!({
+                "Sid": "ResourceIsNumber",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": 7
+            }),
+            "Resource",
+        ),
+    ];
+
+    for (sid, stmt, must_name) in &cases {
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+    }
+}
+
+/// F2 regression: an empty `Action`/`Resource` array must fail closed. Pre-fix,
+/// `is_string_or_string_array` returned true for `[]` (`iter().all(..)` is
+/// vacuously true on an empty array), so `"Action": []` / `"Resource": []`
+/// passed validation and every downstream guard derived an empty set and
+/// skipped the statement -- the skip class #1346 tracks, one level inside a
+/// handled key. Synthetic, not `deploy/iam/*.json`: the shipped templates carry
+/// no empty arrays.
+#[test]
+fn empty_action_or_resource_array_fails_closed() {
+    let cases = [
+        (
+            "EmptyAction",
+            serde_json::json!({
+                "Sid": "EmptyAction",
+                "Effect": "Allow",
+                "Action": [],
+                "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"
+            }),
+            "Action",
+        ),
+        (
+            "EmptyResource",
+            serde_json::json!({
+                "Sid": "EmptyResource",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": []
+            }),
+            "Resource",
+        ),
+    ];
+
+    for (sid, stmt, must_name) in &cases {
+        // The fixed predicate rejects the empty array. (An `iter().all` over the
+        // empty array is vacuously true, which is exactly the pre-fix bug.)
+        assert!(
+            !is_string_or_string_array(stmt.get(must_name)),
+            "fixture {sid}: an empty {must_name} array must not count as a string array"
+        );
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+    }
+}
+
+/// F1 regression: a `Condition` whose sub-shape is anything other than the one
+/// `StringLike`/`s3:prefix` block a guard reads must fail closed. Pre-fix,
+/// `validate_statement` accepted any `Condition` value, so a statement carrying
+/// `StringNotLike`, a set-qualified `ForAnyValue:StringLike`, an unhandled key
+/// such as `s3:delimiter`, or a non-object Condition passed validation and
+/// `list_prefix_patterns` then found no `["StringLike"]["s3:prefix"]` array and
+/// silently contributed nothing -- the skip class moved one level down into a
+/// handled key. Synthetic, not `deploy/iam/*.json`: every shipped Condition is
+/// exactly `StringLike`/`s3:prefix`.
+#[test]
+fn unhandled_condition_shape_fails_closed() {
+    let cases = [
+        (
+            "StringNotLikeOperator",
+            serde_json::json!({
+                "Sid": "StringNotLikeOperator",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"StringNotLike": {"s3:prefix": ["t/*"]}}
+            }),
+            "StringNotLike",
+        ),
+        (
+            "SetQualifiedOperator",
+            serde_json::json!({
+                "Sid": "SetQualifiedOperator",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"ForAnyValue:StringLike": {"s3:prefix": ["t/*"]}}
+            }),
+            "ForAnyValue:StringLike",
+        ),
+        (
+            "UnhandledConditionKey",
+            serde_json::json!({
+                "Sid": "UnhandledConditionKey",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"StringLike": {"s3:delimiter": ["/"]}}
+            }),
+            "s3:delimiter",
+        ),
+        (
+            "ConditionNotObject",
+            serde_json::json!({
+                "Sid": "ConditionNotObject",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": "StringLike"
+            }),
+            "Condition",
+        ),
+    ];
+
+    for (sid, stmt, must_name) in &cases {
+        // Load-bearing: the guard that would read this Condition finds nothing,
+        // so the constraint sits unexamined. Prove the pre-fix skip on the two
+        // operator cases (both are s3:ListBucket, so list_prefix_patterns is the
+        // guard that skips them).
+        if *sid == "StringNotLikeOperator" || *sid == "SetQualifiedOperator" {
+            let policy = Policy {
+                role: "fixture",
+                statements: serde_json::json!([stmt.clone()]),
+            };
+            assert!(
+                pre_fix_list_prefix_patterns(&policy).is_empty(),
+                "fixture {sid}: the pre-fix list_prefix_patterns was expected to \
+                 skip the statement (finding no StringLike/s3:prefix); it did not"
+            );
+        }
+
+        let err = validate_statement("fixture", 0, stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains(must_name),
+            "fixture {sid}: rejection must name {must_name:?}; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+    }
+
+    // Positive control: the shipped StringLike/s3:prefix shape passes.
+    let ok = serde_json::json!({
+        "Sid": "GoodCondition",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": "arn:aws:s3:::my-ravel-bucket",
+        "Condition": {"StringLike": {"s3:prefix": ["t/*", "sys/*"]}}
+    });
+    assert!(
+        validate_statement("fixture", 0, &ok).is_ok(),
+        "the shipped StringLike/s3:prefix Condition shape must pass"
+    );
+}
+
+/// F3 wiring guard: `load_policy` (through its shared body `build_policy`) must
+/// actually call `validate_policy_statements`. Driving a synthetic invalid
+/// policy through `build_policy` -- the real validation call site -- is what
+/// makes this test fail if that call is deleted; a test that only calls
+/// `validate_policy_statements` directly would keep passing. Proven by removing
+/// the call from `build_policy`: this test then reports no panic and fails.
+#[test]
+fn load_policy_rejects_an_unhandled_statement() {
+    let json = serde_json::json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Sid": "NegatedResource",
+            "Effect": "Allow",
+            "Action": "s3:DeleteObject",
+            "NotResource": "arn:aws:s3:::my-ravel-bucket/t/*"
+        }]
+    });
+    let built = std::panic::catch_unwind(|| build_policy("fixture", "synthetic", &json));
+    assert!(
+        built.is_err(),
+        "build_policy (load_policy's real body) must reject a statement whose \
+         permission lives in NotResource, a field no guard reads"
+    );
+}
+
+/// Sweep proof: `list_prefix_patterns` reads a bare-string `s3:prefix`, not only
+/// an array. IAM allows either shape; before this fix the `.as_array()` read
+/// skipped a bare string, so a ListBucket discovery prefix expressed as a string
+/// contributed nothing.
+#[test]
+fn list_prefix_patterns_reads_a_bare_string_prefix() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "BareStringPrefix",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+            "Condition": {"StringLike": {"s3:prefix": "t/"}}
+        }]),
+    };
+    assert_eq!(
+        list_prefix_patterns(&policy, None),
+        vec!["t/".to_string()],
+        "a bare-string s3:prefix must be read, not skipped"
+    );
+    // ...and the shipped array shape still validates and is read.
+    assert!(
+        validate_statement("fixture", 0, &policy_statements(&policy)[0]).is_ok(),
+        "a bare-string s3:prefix is a valid IAM shape and must pass validation"
+    );
 }
 
 #[test]
 fn discovery_prefix_admitted_for_every_discovering_role() {
     for role in ROLES_WITH_DISCOVERY {
         let policy = load_policy(role);
-        let patterns = list_prefix_patterns(&policy);
+        // Allow-only: an explicit Deny ListBucket withdraws listing, so its
+        // s3:prefix is not a prefix the role is ALLOWED to discover. Reading it
+        // here would assert the inverse of the fact (issue #1346, F1).
+        let patterns = list_prefix_patterns(&policy, Some("Allow"));
         assert!(
             patterns.iter().any(|p| glob_matches(p, "t/")),
             "{role}: ListBucket s3:prefix condition {patterns:?} does not admit \
@@ -1219,7 +3759,9 @@ fn every_in_scope_policy_pattern_matches_a_real_key_shape() {
     let keys = representative_keys();
     for role in ALL_ROLES {
         let policy = load_policy(role);
-        let mut patterns = list_prefix_patterns(&policy);
+        // None: this is a shape check (does every pattern name a real key?), not
+        // a permission read, so a Deny list prefix must still name a real key.
+        let mut patterns = list_prefix_patterns(&policy, None);
         patterns.extend(resource_key_patterns(&policy));
         for pattern in patterns {
             if is_out_of_scope(&pattern) {
@@ -1237,6 +3779,1819 @@ fn every_in_scope_policy_pattern_matches_a_real_key_shape() {
                  ravel-commit's key constructors",
                 policy.role
             );
+        }
+    }
+}
+
+/// The pre-fix `list_prefix_patterns` body, verbatim: an exact-name list
+/// detection and a `_ => {}` arm that contributed nothing for any Condition
+/// sub-shape it did not recognize. Kept so the Condition fixtures can pin that
+/// the constraint used to sit unread; the live helper now panics on that arm,
+/// because the choke point rejects every shape that could reach it.
+fn pre_fix_list_prefix_patterns(policy: &Policy) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        let is_list = statement_actions(stmt)
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("s3:ListBucket"));
+        if !is_list {
+            continue;
+        }
+        match &stmt["Condition"]["StringLike"]["s3:prefix"] {
+            serde_json::Value::String(s) => out.push(s.clone()),
+            serde_json::Value::Array(patterns) => {
+                for p in patterns {
+                    out.push(p.as_str().expect("s3:prefix entry is a string").to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// The pre-fix `resource_key_patterns` body, verbatim: `is_list_only` read from
+/// `stmt["Action"].as_str()` only, and a resource that did not strip the bucket
+/// prefix silently dropped (`if let Some(..)` with no `else`). Kept so the F1
+/// fixture pins the two holes existed rather than restating the fix.
+fn pre_fix_resource_key_patterns(policy: &Policy) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        let is_list_only = stmt["Action"]
+            .as_str()
+            .is_some_and(|a| a.eq_ignore_ascii_case("s3:ListBucket"));
+        if is_list_only {
+            continue;
+        }
+        let resources = match &stmt["Resource"] {
+            serde_json::Value::Array(a) => a.clone(),
+            v @ serde_json::Value::String(_) => vec![v.clone()],
+            _ => continue,
+        };
+        for r in resources {
+            let r = r.as_str().expect("Resource entry is a string");
+            if let Some(key_pattern) = r.strip_prefix("arn:aws:s3:::my-ravel-bucket/") {
+                out.push(key_pattern.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// The pre-fix `put_resource_key_patterns` body, verbatim (same silent drop).
+fn pre_fix_put_resource_key_patterns(policy: &Policy) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        let grants_put = statement_actions(stmt)
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("s3:PutObject"));
+        if !grants_put {
+            continue;
+        }
+        let resources = match &stmt["Resource"] {
+            serde_json::Value::Array(a) => a.clone(),
+            v @ serde_json::Value::String(_) => vec![v.clone()],
+            _ => continue,
+        };
+        for r in resources {
+            let r = r.as_str().expect("Resource entry is a string");
+            if let Some(key_pattern) = r.strip_prefix("arn:aws:s3:::my-ravel-bucket/") {
+                out.push(key_pattern.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// F1 regression: a Resource that grants S3 object access but is not
+/// bucket-relative (`"*"`, `s3:*` on `"*"`, another bucket's ARN) must surface as
+/// a test failure naming the role and Sid, in BOTH the read and write resource
+/// helpers, not be silently dropped. Synthetic statements, not `deploy/iam/*.json`:
+/// a fixture over the (correct) shipped templates passes whichever way the strip
+/// behaves and proves nothing. Each case asserts in both directions -- that the
+/// pre-fix helper dropped it (returning an empty set, hiding the grant) and that
+/// the post-fix helper panics on it.
+#[test]
+fn out_of_bucket_resource_grant_is_not_a_bypass() {
+    // Read side (resource_key_patterns): (Sid, Action, Resource).
+    let read_cases = [
+        ("GetOnStar", serde_json::json!("s3:GetObject"), "*"),
+        (
+            "GetOnOtherBucket",
+            serde_json::json!("s3:GetObject"),
+            "arn:aws:s3:::other-bucket/t/*",
+        ),
+        ("StarActionStarResource", serde_json::json!("s3:*"), "*"),
+    ];
+    for (sid, action, resource) in &read_cases {
+        let policy = Policy {
+            role: "fixture",
+            statements: serde_json::json!([{
+                "Sid": sid,
+                "Effect": "Allow",
+                "Action": action,
+                "Resource": resource,
+            }]),
+        };
+        // Observation 1 (load-bearing): the pre-fix helper dropped the
+        // out-of-bucket resource, so the derived set was empty and every resource
+        // guard skipped the statement. If it stops being empty the fixture no
+        // longer proves the hole and must be rewritten, not deleted.
+        let pre = pre_fix_resource_key_patterns(&policy);
+        assert!(
+            pre.is_empty(),
+            "fixture {sid} invalid: pre-fix resource_key_patterns was expected to \
+             drop the out-of-bucket resource (returning nothing); returned {pre:?}"
+        );
+        // Observation 2: the post-fix helper panics naming the role and Sid.
+        let guard = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            resource_key_patterns(&policy)
+        }));
+        assert!(
+            guard.is_err(),
+            "resource_key_patterns must reject fixture {sid}: an S3 grant on \
+             {resource:?} must surface, not be silently dropped"
+        );
+    }
+
+    // Write side (put_resource_key_patterns): PutObject on "*". Dropping it left
+    // roles_writing_routed_objects_have_kms_grant an empty routed set, so it
+    // skipped the role's KMS-grant check entirely.
+    let put_policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "PutOnStar",
+            "Effect": "Allow",
+            "Action": "s3:PutObject",
+            "Resource": "*",
+        }]),
+    };
+    let pre_put = pre_fix_put_resource_key_patterns(&put_policy);
+    assert!(
+        pre_put.is_empty(),
+        "fixture PutOnStar invalid: pre-fix put_resource_key_patterns was expected \
+         to drop the \"*\" resource; returned {pre_put:?}"
+    );
+    let put_guard = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        put_resource_key_patterns(&put_policy)
+    }));
+    assert!(
+        put_guard.is_err(),
+        "put_resource_key_patterns must reject PutObject on \"*\": dropping it \
+         makes roles_writing_routed_objects_have_kms_grant skip the role on an \
+         empty routed set"
+    );
+
+    // Trap (must not trip the new guard): an array-form ListBucket statement's
+    // bare bucket ARN must be SKIPPED, not panicked. The pre-fix `.as_str()`
+    // is_list_only returned None for the array form, so the bare bucket ARN would
+    // reach the now-fatal strip; the post-fix statement_actions-based detection
+    // recognizes it as list-only and skips it.
+    let list_policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "ArrayFormList",
+            "Effect": "Allow",
+            "Action": ["s3:ListBucket"],
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+        }]),
+    };
+    let pre_fix_is_list_only = policy_statements(&list_policy)[0]["Action"]
+        .as_str()
+        .is_some_and(|a| a.eq_ignore_ascii_case("s3:ListBucket"));
+    assert!(
+        !pre_fix_is_list_only,
+        "fixture ArrayFormList invalid: the pre-fix as_str() detection was \
+         expected to miss the array-form ListBucket (proving the trap is real)"
+    );
+    let list_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        resource_key_patterns(&list_policy)
+    }));
+    assert_eq!(
+        list_result.ok(),
+        Some(Vec::<String>::new()),
+        "resource_key_patterns must skip an array-form ListBucket statement, not \
+         panic on its bare bucket ARN"
+    );
+
+    // A kms: ARN on a non-list statement is skipped (None), not panicked: the KMS
+    // resource guards own it. This is why the read-path strip cannot blindly
+    // panic on every non-bucket-relative resource -- every role carries a
+    // *TenantKms statement whose Resource is a kms: ARN.
+    let kms_policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "KmsResource",
+            "Effect": "Allow",
+            "Action": "kms:Decrypt",
+            "Resource": "arn:aws:kms:us-east-1:111122223333:key/abcd1234-5678-90ab-cdef-1234567890ab",
+        }]),
+    };
+    let kms_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        resource_key_patterns(&kms_policy)
+    }));
+    assert_eq!(
+        kms_result.ok(),
+        Some(Vec::<String>::new()),
+        "resource_key_patterns must skip a kms: ARN (checked by the KMS guards), \
+         not panic"
+    );
+}
+
+/// The pre-fix `validate_condition` body, verbatim (round two's version, no
+/// empty-object checks): a `for` over an empty map iterates zero times, so `{}`
+/// and `{"StringLike": {}}` both returned Ok. Kept so the F2 fixture pins the
+/// hole existed rather than restating the fix.
+fn pre_fix_validate_condition(condition: &serde_json::Value) -> Result<(), String> {
+    let cond_obj = condition
+        .as_object()
+        .ok_or_else(|| "Condition is not an object".to_string())?;
+    for (operator, keys) in cond_obj {
+        if !HANDLED_CONDITION_OPERATORS.contains(&operator.as_str()) {
+            return Err(format!("operator {operator:?}"));
+        }
+        let key_obj = keys
+            .as_object()
+            .ok_or_else(|| "operator is not an object".to_string())?;
+        for (cond_key, value) in key_obj {
+            if !HANDLED_CONDITION_KEYS.contains(&cond_key.as_str()) {
+                return Err(format!("key {cond_key:?}"));
+            }
+            if !is_string_or_string_array(Some(value)) {
+                return Err(format!("value {value:?}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// F2 regression (empty maps): `"Condition": {}` and `"Condition": {"StringLike":
+/// {}}` must fail closed. Pre-fix, a `for` over an empty map iterated zero times,
+/// so both returned Ok -- the vacuous-set bug round two fixed for arrays,
+/// re-created in the code that fixed it. Synthetic, not `deploy/iam/*.json`: the
+/// shipped Conditions are all non-empty StringLike/s3:prefix blocks.
+#[test]
+fn empty_condition_or_stringlike_map_fails_closed() {
+    let cases = [
+        ("EmptyCondition", serde_json::json!({})),
+        ("EmptyStringLike", serde_json::json!({"StringLike": {}})),
+    ];
+    for (sid, condition) in &cases {
+        // Observation 1 (load-bearing): the pre-fix validator accepted the empty
+        // map (zero loop iterations), so the constraint sat unexamined.
+        assert!(
+            pre_fix_validate_condition(condition).is_ok(),
+            "fixture {sid} invalid: pre-fix validate_condition was expected to \
+             accept {condition:?} (vacuous empty-map loop); it did not"
+        );
+        // Observation 2: the full statement validator rejects a ListBucket
+        // statement carrying it, naming the empty shape and the Sid.
+        let stmt = serde_json::json!({
+            "Sid": sid,
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+            "Condition": condition,
+        });
+        let err = validate_statement("fixture", 0, &stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        assert!(
+            err.contains("empty"),
+            "fixture {sid}: rejection must name the empty shape; got {err:?}"
+        );
+        assert!(
+            err.contains(sid),
+            "fixture {sid}: rejection must name the Sid; got {err:?}"
+        );
+    }
+}
+
+/// F1 regression (the blocking finding): an `s3:prefix` value that admits every
+/// key must fail closed. Pre-fix, `validate_condition` checked the value's SHAPE
+/// (a non-empty string or non-empty array of strings) but never whether the value
+/// constrained anything, so `{"StringLike": {"s3:prefix": ["*"]}}` -- non-empty,
+/// and constraining exactly as little as no Condition at all -- passed. The
+/// discovery guard's glob on "*" succeeds and every representative key matches the
+/// "*" shape, so narrowing a shipped template's list Condition to it left the
+/// whole suite green. This is the vacuous-value sibling of the empty-map holes
+/// `empty_condition_or_stringlike_map_fails_closed` covers, one level down in the
+/// value. Synthetic: every shipped s3:prefix is a bounded prefix.
+#[test]
+fn vacuous_s3_prefix_value_fails_closed() {
+    // Observation 1 (load-bearing): the pre-fix value check accepted the star.
+    // Written as the exact pre-fix expression -- SHAPE only -- so this pins the
+    // hole rather than restating the fix.
+    let star_value = serde_json::json!(["*"]);
+    assert!(
+        is_string_or_string_array(Some(&star_value)),
+        "fixture invalid: the pre-fix s3:prefix value check (shape only) was \
+         expected to accept [\"*\"]"
+    );
+    // ...and the pre-fix Condition validator (round two's body, kept verbatim)
+    // blessed the whole StringLike/s3:prefix block, so the constraint sat
+    // unexamined.
+    let star_condition = serde_json::json!({"StringLike": {"s3:prefix": ["*"]}});
+    assert!(
+        pre_fix_validate_condition(&star_condition).is_ok(),
+        "fixture invalid: pre-fix validate_condition was expected to accept the \
+         \"*\" s3:prefix value (shape only); it did not"
+    );
+
+    // The star value fails: the ListBucket statement carrying it is rejected,
+    // naming the Sid, the value, and why.
+    let star_stmt = serde_json::json!({
+        "Sid": "ListEverything",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": BUCKET_ARN,
+        "Condition": {"StringLike": {"s3:prefix": ["*"]}},
+    });
+    let err = validate_statement("fixture", 0, &star_stmt)
+        .expect_err("validate_statement must reject a \"*\" s3:prefix");
+    for expected in ["\"*\"", "ListEverything", "admits every key"] {
+        assert!(
+            err.contains(expected),
+            "rejection must name {expected:?}; got {err:?}"
+        );
+    }
+    // A bare-string "*" (not only the array form) fails the same way.
+    let star_string_stmt = serde_json::json!({
+        "Sid": "ListEverythingBareString",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": BUCKET_ARN,
+        "Condition": {"StringLike": {"s3:prefix": "*"}},
+    });
+    assert!(
+        validate_statement("fixture", 0, &star_string_stmt).is_err(),
+        "a bare-string \"*\" s3:prefix must also fail closed"
+    );
+
+    // A real tenant-scoped list of prefixes passes: each one excludes some key
+    // outside it, so none is vacuous.
+    let tenant_scoped = serde_json::json!({
+        "Sid": "ListTenantScoped",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": BUCKET_ARN,
+        "Condition": {"StringLike": {"s3:prefix": ["t/", "t/*/*/c/*", "sys/query/workers/*"]}},
+    });
+    assert!(
+        validate_statement("fixture", 0, &tenant_scoped).is_ok(),
+        "a tenant-scoped s3:prefix list must pass: {:?}",
+        validate_statement("fixture", 0, &tenant_scoped)
+    );
+
+    // On a shipped template: narrowing QueryList's s3:prefix to ["*"] makes the
+    // whole list vacuous and must fail the choke point, while the unmutated
+    // template still loads. In-memory; the file on disk is untouched.
+    let path = policy_json_path("query");
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let mut json: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build_policy(
+            "query", &path, &json
+        )))
+        .is_ok(),
+        "the shipped query template must load unchanged"
+    );
+    let statements = json["Statement"]
+        .as_array_mut()
+        .expect("query.json Statement is an array");
+    let target = statements
+        .iter_mut()
+        .find(|stmt| stmt["Sid"] == serde_json::json!("QueryList"))
+        .expect("query.json carries a QueryList statement");
+    target["Condition"]["StringLike"]["s3:prefix"] = serde_json::json!(["*"]);
+    let built = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build_policy("query", &path, &json)
+    }));
+    let message = panic_message(built.expect_err(
+        "build_policy must reject QueryList once its s3:prefix is narrowed to [\"*\"]",
+    ));
+    assert!(
+        message.contains("QueryList") && message.contains("admits every key"),
+        "the rejection must name the mutated statement and the vacuity; got {message:?}"
+    );
+}
+
+/// F1 sweep regression (resource axis): a bucket-relative object grant that admits
+/// every key -- `arn:aws:s3:::my-ravel-bucket/*`, which strips to "*" -- must fail
+/// closed. It is shape-valid (bucket-relative, non-empty key) yet scopes the object
+/// grant no more than naming no key prefix would: the resource-axis sibling of F1's
+/// "*" s3:prefix. Round four's `object_key_patterns` doc recorded this as
+/// deliberately NOT closed ("a coverage check cannot reject an over-broad
+/// pattern"); the sweep for this round closes it at the choke point. Synthetic: no
+/// shipped template names a bucket-relative "*" object resource.
+#[test]
+fn full_bucket_object_resource_fails_closed() {
+    // Observation 1 (load-bearing): the coverage guard cannot catch this -- "*"
+    // matches every representative key, so it matches AT LEAST ONE, which is all
+    // `every_in_scope_policy_pattern_matches_a_real_key_shape` asks. Written as
+    // that guard's own predicate over the real keys.
+    let keys = representative_keys();
+    assert!(
+        keys.iter().any(|k| glob_matches("*", k)),
+        "fixture invalid: the coverage check (matches at least one real key) must \
+         accept \"*\", which is why it cannot reject this vacuous grant"
+    );
+
+    for action in ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"] {
+        let stmt = serde_json::json!({
+            "Sid": "FullBucketObject",
+            "Effect": "Allow",
+            "Action": action,
+            "Resource": "arn:aws:s3:::my-ravel-bucket/*",
+        });
+        let err = validate_statement("fixture", 0, &stmt).expect_err(&format!(
+            "validate_statement must reject a full-bucket {action} grant"
+        ));
+        for expected in ["\"*\"", "FullBucketObject", "matches every key"] {
+            assert!(
+                err.contains(expected),
+                "{action}: rejection must name {expected:?}; got {err:?}"
+            );
+        }
+    }
+
+    // A bounded object prefix (the shipped shape) still passes: it excludes keys
+    // outside `t/`.
+    let bounded = serde_json::json!({
+        "Sid": "BoundedObject",
+        "Effect": "Allow",
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::my-ravel-bucket/t/*",
+    });
+    assert!(
+        validate_statement("fixture", 0, &bounded).is_ok(),
+        "a bounded object prefix must pass: {:?}",
+        validate_statement("fixture", 0, &bounded)
+    );
+}
+
+/// Hole ten regression: the vacuity predicate used to ask whether a pattern
+/// matched the EMPTY STRING, a value `classify_resource` rejects outright, so it
+/// decided vacuity against a key the code downstream can never see. Three
+/// spellings match every real key while matching no empty string -- `?*`, `*?*`
+/// and `*/*` -- and `*/*` is the plausible operator spelling of "any tenant, any
+/// signal". Put in a shipped template's delete `Resource`, it left the suite
+/// green at 39/0.
+///
+/// Both directions per spelling: the pre-fix predicate (written verbatim, so
+/// this fixture cannot become a tautology when the live one changes) accepted
+/// it while it matched every representative key, and the corpus-relative
+/// predicate rejects it. The superset property is asserted too: everything the
+/// old test caught is still caught, and a bounded-but-broad `t/*` is still
+/// accepted, since rejecting over-broad-but-bounded grants is a separate guard.
+#[test]
+fn vacuous_pattern_spellings_that_dodge_the_empty_string_fail_closed() {
+    let keys = representative_keys();
+    assert_eq!(
+        keys.len(),
+        67,
+        "fixture invalid: the measured table below is stated over 67 \
+         representative keys"
+    );
+
+    // Observation 1 (load-bearing): each spelling dodged the pre-fix predicate
+    // (`glob_matches(pattern, "")`, spelled out here) while matching every
+    // single representative key.
+    for spelling in ["?*", "*?*", "*/*"] {
+        assert!(
+            !glob_matches(spelling, ""),
+            "fixture invalid: the pre-fix predicate was expected to call \
+             {spelling:?} non-vacuous; it did not"
+        );
+        assert!(
+            keys.iter().all(|k| glob_matches(spelling, k)),
+            "fixture invalid: {spelling:?} was expected to match all 67 \
+             representative keys"
+        );
+    }
+
+    // Observation 2: the corpus-relative predicate rejects every vacuous
+    // spelling, including the two the old one already caught (superset).
+    for spelling in ["", "*", "**", "***", "?*", "*?*", "*/*"] {
+        assert!(
+            glob_admits_everything(spelling),
+            "{spelling:?} excludes no key the system can produce and must be \
+             rejected as vacuous"
+        );
+    }
+
+    // ...and still accepts every pattern that excludes something, including the
+    // over-broad-but-bounded `t/*` the shipped admin template names.
+    for bounded in [
+        "t/*",
+        "sys/*",
+        "t/",
+        "t/*/*/l0/*",
+        "t/*/catalog/*/*",
+        "admission/query/*",
+        "sys/tenancy",
+        "?",
+        "*x",
+        "*/*/*",
+    ] {
+        assert!(
+            !glob_admits_everything(bounded),
+            "{bounded:?} excludes some key in the domain, so it is over-broad at \
+             worst, not vacuous; rejecting it is a different guard"
+        );
+    }
+
+    // On a shipped template: MaintainDelete's five scoped resources replaced by
+    // the single `*/*` must fail the choke point, naming the statement. Every
+    // sample key DenyDeleteProtected covers is inside `*/*`, so the delete-scope
+    // guards saw nothing wrong. In-memory; the file on disk is untouched.
+    for spelling in ["*/*", "?*", "*?*"] {
+        let message = panic_message(
+            mutate_maintain_delete_resource(spelling)
+                .expect_err("build_policy must reject a vacuous MaintainDelete resource"),
+        );
+        assert!(
+            message.contains("MaintainDelete") && message.contains("matches every key"),
+            "the rejection must name the mutated statement and the vacuity; got \
+             {message:?}"
+        );
+    }
+    // A bounded replacement in the same position still builds: this fixture pins
+    // vacuity, not breadth.
+    assert!(
+        mutate_maintain_delete_resource("t/*").is_ok(),
+        "a bounded delete resource must still be accepted in that position"
+    );
+}
+
+/// Rebuild the shipped `maintain` template with `MaintainDelete`'s `Resource`
+/// replaced by the single bucket-relative pattern `key_pattern`, in memory.
+fn mutate_maintain_delete_resource(
+    key_pattern: &str,
+) -> Result<Policy, Box<dyn std::any::Any + Send>> {
+    let path = policy_json_path("maintain");
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let mut json: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+    let statements = json["Statement"]
+        .as_array_mut()
+        .expect("maintain.json Statement is an array");
+    let target = statements
+        .iter_mut()
+        .find(|stmt| stmt["Sid"] == serde_json::json!("MaintainDelete"))
+        .expect("maintain.json carries a MaintainDelete statement");
+    target["Resource"] = serde_json::json!([format!("{BUCKET_KEY_PREFIX}{key_pattern}")]);
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build_policy("maintain", &path, &json)
+    }))
+}
+
+/// The pre-fix routed-write guard body, verbatim in the derivation and in the
+/// skip: an empty routed set fell through to `continue`, so neither KMS
+/// assertion ran. Returns true when the pre-fix guard SKIPPED the role.
+fn pre_fix_routed_write_guard_skipped(policy: &Policy) -> bool {
+    let mut routed = Vec::new();
+    for stmt in policy_statements(policy) {
+        let is_allow = stmt["Effect"]
+            .as_str()
+            .is_some_and(|e| e.eq_ignore_ascii_case("Allow"));
+        if !is_allow {
+            continue;
+        }
+        let grants_put = statement_actions(stmt)
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("s3:PutObject"));
+        if !grants_put {
+            continue;
+        }
+        for resource in statement_resources(stmt) {
+            if let Some(key) = resource.strip_prefix("arn:aws:s3:::my-ravel-bucket/")
+                && ravel_object_store::routes_through_tenant_key(key)
+            {
+                routed.push(key.to_string());
+            }
+        }
+    }
+    routed.is_empty()
+}
+
+/// Hole twelve regression: an empty routed-write set is a failure, not a skip.
+/// The guard derived the routed PUT patterns and then read
+/// `if routed.is_empty() { continue; }`, so widening a write role's PutObject
+/// `Resource` off the tenant keyspace emptied the set and silently retired the
+/// `kms:GenerateDataKey*`/`kms:Encrypt` requirement for that role: the policy
+/// kept its write grant, and the guard reported nothing.
+///
+/// Both directions: the pre-fix body skipped the synthetic role, and the live
+/// guard fails on it. Driven through `assert_role_routed_writes_have_kms_grant`,
+/// the function the real test calls, not a re-typed copy.
+#[test]
+fn empty_routed_write_set_is_not_a_skip() {
+    // A role that PUTs only outside the tenant keyspace and holds no KMS grant
+    // at all: exactly the shape the KMS requirement exists for, if it applied.
+    let widened = fixture_policy(serde_json::json!({
+        "Sid": "WidenedWrite",
+        "Effect": "Allow",
+        "Action": "s3:PutObject",
+        "Resource": ["arn:aws:s3:::my-ravel-bucket/sys/maintain/*"],
+    }));
+
+    // Observation 1 (load-bearing): the pre-fix body skipped it.
+    assert!(
+        pre_fix_routed_write_guard_skipped(&widened),
+        "fixture invalid: the pre-fix guard was expected to skip a role whose PUT \
+         patterns route nowhere"
+    );
+
+    // Observation 2: the live guard fails on it, naming the role and the reason.
+    let failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_role_routed_writes_have_kms_grant(&widened)
+    }));
+    let message = panic_message(
+        failure.expect_err("an empty routed set must fail, not skip the KMS requirement"),
+    );
+    assert!(
+        message.contains("none of which routes through a per-tenant key"),
+        "the failure must say the routed set was empty; got {message:?}"
+    );
+
+    // A role that PUTs a routed object and carries the KMS grants still passes,
+    // so this fixture pins the skip, not the requirement.
+    let routed_with_kms = Policy {
+        role: "fixture",
+        statements: serde_json::json!([
+            {
+                "Sid": "RoutedWrite",
+                "Effect": "Allow",
+                "Action": "s3:PutObject",
+                "Resource": ["arn:aws:s3:::my-ravel-bucket/t/*/*/l0/*"],
+            },
+            {
+                "Sid": "FixtureTenantKms",
+                "Effect": "Allow",
+                "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
+                "Resource": [TENANT_KMS_KEY_ARN],
+            },
+        ]),
+    };
+    assert_role_routed_writes_have_kms_grant(&routed_with_kms);
+
+    // On a shipped template: MaintainWrite narrowed to its one non-routing
+    // resource empties the routed set. Pre-fix that skipped maintain entirely;
+    // now it fails. In-memory; the file on disk is untouched.
+    let path = policy_json_path("maintain");
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let mut json: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+    let statements = json["Statement"]
+        .as_array_mut()
+        .expect("maintain.json Statement is an array");
+    let target = statements
+        .iter_mut()
+        .find(|stmt| stmt["Sid"] == serde_json::json!("MaintainWrite"))
+        .expect("maintain.json carries a MaintainWrite statement");
+    target["Resource"] = serde_json::json!(["arn:aws:s3:::my-ravel-bucket/sys/maintain/*"]);
+    let mutated = build_policy("maintain", &path, &json);
+    assert!(
+        pre_fix_routed_write_guard_skipped(&mutated),
+        "fixture invalid: the pre-fix guard was expected to skip the narrowed \
+         maintain template"
+    );
+    let failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_role_routed_writes_have_kms_grant(&mutated)
+    }));
+    assert!(
+        failure.is_err(),
+        "narrowing MaintainWrite to a non-routing resource must fail the routed \
+         write guard, not silently skip maintain"
+    );
+}
+
+/// The routed-write guard's first failure branch: no PUT grant at all.
+///
+/// `assert_role_routed_writes_have_kms_grant` has three failure branches, and
+/// each is a distinct claim about a distinct policy shape. Only the empty-routed-set
+/// branch had a fixture; this one and the pattern-admits-routed-keys branch below
+/// existed only at their definition sites, so a rewrite that turned either back
+/// into a skip would have gone unnoticed.
+///
+/// The shape is a role whose PutObject grant was dropped or moved to a field no
+/// axis reads. Pre-empty-set-fix that emptied `routed` too and skipped the role;
+/// the dedicated assertion distinguishes it, so the message says the write grant
+/// is gone rather than that it routes nowhere.
+#[test]
+fn empty_put_set_fails_the_routed_write_guard() {
+    let read_only = build_policy(
+        "fixture",
+        "<synthetic>",
+        &serde_json::json!({
+            "Statement": [{
+                "Sid": "ReadOnly",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": [format!("{BUCKET_KEY_PREFIX}t/*/*/l0/*")],
+            }]
+        }),
+    );
+    assert!(
+        put_resource_key_patterns(&read_only).is_empty(),
+        "fixture invalid: this policy was expected to grant s3:PutObject on \
+         nothing"
+    );
+
+    let failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_role_routed_writes_have_kms_grant(&read_only)
+    }));
+    let message =
+        panic_message(failure.expect_err("a policy with no PUT grant must fail, not pass"));
+    assert!(
+        message.contains("grants s3:PutObject on nothing"),
+        "the failure must say the PUT set was empty, not that it routes nowhere; \
+         got {message:?}"
+    );
+}
+
+/// The routed-write guard's third failure branch: a PUT pattern that does not
+/// itself parse as a routed tenant key yet admits routed keys.
+///
+/// This is the hole-ten property on the routing axis. `t/*` is not a routed key
+/// (`routes_through_tenant_key` needs a non-empty hash segment FOLLOWED BY a
+/// slash, and `t/*` has no second slash), but as a glob it matches every tenant
+/// key, so a role holding it can PUT routed objects while the KMS requirement is
+/// decided on the pattern's own text and comes out false.
+///
+/// Reaching the branch takes a two-element resource list: the guard asserts a
+/// non-empty routed set first, so a policy whose only PUT pattern is `t/*` fails
+/// at the branch above instead. The routing element makes the routed set
+/// non-empty, and `t/*` then trips this branch.
+#[test]
+fn non_routing_put_pattern_admitting_routed_keys_fails_the_routed_write_guard() {
+    let kms_statement = serde_json::json!({
+        "Sid": "FixtureTenantKms",
+        "Effect": "Allow",
+        "Action": ["kms:Encrypt", "kms:GenerateDataKey*", "kms:Decrypt"],
+        "Resource": [TENANT_KMS_KEY_ARN],
+    });
+    let write_statement = |resources: serde_json::Value| {
+        serde_json::json!({
+            "Sid": "FixtureWrite",
+            "Effect": "Allow",
+            "Action": "s3:PutObject",
+            "Resource": resources,
+        })
+    };
+
+    // The same policy without the `t/*` element passes, so the branch below is
+    // fired by that element and not by anything else in the fixture.
+    let routing_only = build_policy(
+        "fixture",
+        "<synthetic>",
+        &serde_json::json!({
+            "Statement": [
+                write_statement(serde_json::json!([format!("{BUCKET_KEY_PREFIX}t/*/*/l1/*")])),
+                kms_statement.clone(),
+            ]
+        }),
+    );
+    assert_role_routed_writes_have_kms_grant(&routing_only);
+
+    let admits_routed = build_policy(
+        "fixture",
+        "<synthetic>",
+        &serde_json::json!({
+            "Statement": [
+                write_statement(serde_json::json!([
+                    format!("{BUCKET_KEY_PREFIX}t/*/*/l1/*"),
+                    format!("{BUCKET_KEY_PREFIX}t/*"),
+                ])),
+                kms_statement,
+            ]
+        }),
+    );
+    assert!(
+        !ravel_object_store::routes_through_tenant_key("t/*")
+            && key_domain()
+                .iter()
+                .any(|key| glob_matches("t/*", key.as_str())
+                    && ravel_object_store::routes_through_tenant_key(key.as_str())),
+        "fixture invalid: `t/*` must not parse as a routed key while still \
+         admitting one, or this case does not reach the branch it is written for"
+    );
+
+    let failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_role_routed_writes_have_kms_grant(&admits_routed)
+    }));
+    let message = panic_message(
+        failure.expect_err("a PUT pattern admitting routed keys it does not parse as must fail"),
+    );
+    assert!(
+        message.contains("yet it admits routed keys"),
+        "the failure must name the pattern-versus-key gap; got {message:?}"
+    );
+}
+
+/// F2 regression (Condition presence): a ListBucket statement must carry a
+/// Condition, and a non-ListBucket statement must not. Pre-fix, `validate_statement`
+/// only validated a Condition when present and never checked the Action, so a
+/// ListBucket with no Condition (an unconstrained bucket-wide list) and a
+/// StringLike/s3:prefix on the protected-delete Deny (read by no guard, and never
+/// fired in AWS since a DeleteObject request carries no s3:prefix) both passed.
+/// Synthetic for the same reason as above.
+#[test]
+fn condition_presence_must_track_list_bucket_action() {
+    // Hole: a ListBucket statement with NO Condition. list_prefix_patterns
+    // contributes nothing for it, and pre-fix validation accepted it.
+    let no_condition = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "ListNoCondition",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+        }]),
+    };
+    assert!(
+        pre_fix_list_prefix_patterns(&no_condition).is_empty(),
+        "fixture invalid: a ListBucket statement with no Condition must contribute \
+         no s3:prefix pattern (the unconstrained-list shape)"
+    );
+    let err = validate_statement("fixture", 0, &policy_statements(&no_condition)[0])
+        .expect_err("validate_statement must reject a ListBucket statement with no Condition");
+    assert!(
+        err.contains("no Condition"),
+        "rejection must name the missing Condition; got {err:?}"
+    );
+    assert!(
+        err.contains("ListNoCondition"),
+        "rejection must name the Sid; got {err:?}"
+    );
+
+    // Hole: a StringLike/s3:prefix Condition on a NON-ListBucket statement (a
+    // protected-delete Deny). list_prefix_patterns never reads it (not
+    // ListBucket), so the Condition sits unexamined while pre-fix validation
+    // blessed it.
+    let deny_with_prefix = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "DenyWithPrefix",
+            "Effect": "Deny",
+            "Action": ["s3:DeleteObject", "s3:DeleteObjectVersion"],
+            "Resource": "arn:aws:s3:::my-ravel-bucket/t/*/*/prov",
+            "Condition": {"StringLike": {"s3:prefix": ["t/*"]}},
+        }]),
+    };
+    assert!(
+        list_prefix_patterns(&deny_with_prefix, None).is_empty(),
+        "fixture invalid: list_prefix_patterns must skip a non-ListBucket \
+         statement, so its Condition sits unread"
+    );
+    let err = validate_statement("fixture", 0, &policy_statements(&deny_with_prefix)[0])
+        .expect_err("validate_statement must reject a Condition on a non-ListBucket statement");
+    assert!(
+        err.contains("does not include s3:ListBucket"),
+        "rejection must explain the non-ListBucket Condition; got {err:?}"
+    );
+    assert!(
+        err.contains("DenyWithPrefix"),
+        "rejection must name the Sid; got {err:?}"
+    );
+}
+
+/// F1 regression (Effect axis, list discovery): a `Deny` ListBucket carrying an
+/// s3:prefix must not be read as a prefix the role is ALLOWED to discover. This
+/// round's Condition-presence rule forces a deny-listing block to carry an
+/// s3:prefix, and `list_prefix_patterns`' only permission-reading caller,
+/// `discovery_prefix_admitted_for_every_discovering_role`, pools every
+/// statement's prefixes into one vector it reads as allowed listing. Reading a
+/// Deny's prefix there asserts the inverse of the fact, since an explicit IAM
+/// Deny withdraws listing. The fix gives `list_prefix_patterns` the same effect
+/// argument `key_patterns_for` takes and calls it with `Some("Allow")` from the
+/// discovery guard. Synthetic, not `deploy/iam/*.json`: no shipped template
+/// carries a Deny ListBucket, so a fixture over them proves nothing.
+#[test]
+fn deny_list_prefix_does_not_admit_a_discovery_prefix() {
+    // Arm A: Allow lists only "sys/*"; no statement mentions "t/".
+    let arm_a = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "AllowListSys",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-ravel-bucket",
+            "Condition": {"StringLike": {"s3:prefix": ["sys/*"]}},
+        }]),
+    };
+    // Arm B: same Allow, plus a Deny ListBucket carrying the discovery prefix.
+    let arm_b = Policy {
+        role: "fixture",
+        statements: serde_json::json!([
+            {
+                "Sid": "AllowListSys",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"StringLike": {"s3:prefix": ["sys/*"]}},
+            },
+            {
+                "Sid": "DenyListOutsideTenant",
+                "Effect": "Deny",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::my-ravel-bucket",
+                "Condition": {"StringLike": {"s3:prefix": ["t/"]}},
+            },
+        ]),
+    };
+
+    // Observation 1 (load-bearing): the effect-blind read (`None`, the mode the
+    // discovery guard used before the fix) pools the Deny's "t/" into the set in
+    // arm B. If this stops admitting "t/" the effect-blindness is gone and the
+    // fixture no longer pins the hole.
+    assert!(
+        list_prefix_patterns(&arm_b, None)
+            .iter()
+            .any(|p| glob_matches(p, "t/")),
+        "fixture invalid: an effect-blind read must pool the Deny ListBucket's \
+         s3:prefix \"t/\" into the discovery set (the hole this fixes)"
+    );
+
+    // Observation 2: the Allow-only read the discovery guard now performs admits
+    // "t/" in NEITHER arm -- arm A never allows it, and arm B only DENIES it.
+    for (label, policy) in [("arm A", &arm_a), ("arm B", &arm_b)] {
+        let admitted = list_prefix_patterns(policy, Some("Allow"));
+        assert!(
+            !admitted.iter().any(|p| glob_matches(p, "t/")),
+            "{label}: Allow-only list_prefix_patterns must not admit \"t/\" as a \
+             discovery prefix (arm A never allows it; arm B only denies it); got \
+             {admitted:?}"
+        );
+    }
+
+    // Both statements are well-formed IAM the choke point accepts, so the Deny
+    // really does reach the helper: the fix is the effect filter, not a rejection.
+    for (idx, stmt) in policy_statements(&arm_b).iter().enumerate() {
+        assert!(
+            validate_statement("fixture", idx, stmt).is_ok(),
+            "fixture invalid: statement #{idx} must pass the choke point so the \
+             Deny reaches list_prefix_patterns"
+        );
+    }
+}
+
+/// F1/F2 regression (Effect axis, routed write): a `Deny` PutObject must not be
+/// read as a routed write. `put_resource_key_patterns`' caller
+/// `roles_writing_routed_objects_have_kms_grant` reads its result as object
+/// classes the role WRITES and then demands a KMS grant for them; a Deny put is
+/// a prohibition, so reading it there would demand a KMS grant to satisfy a write
+/// the policy forbids. The fix passes `Some("Allow")` to the effect-aware base
+/// helper (F2), the consistent choice given F1. Synthetic: no shipped template
+/// carries a Deny PutObject.
+#[test]
+fn deny_put_object_is_not_a_routed_write() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "DenyPutRouted",
+            "Effect": "Deny",
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::my-ravel-bucket/t/*/catalog/*/HEAD",
+        }]),
+    };
+    // Observation 1 (load-bearing): the effect-blind base helper reads the Deny
+    // put as a routed write. If it stops returning the pattern the fixture no
+    // longer pins the hole.
+    let blind = key_patterns_for(&policy, &["s3:PutObject"], None);
+    assert!(
+        blind.iter().any(|p| p == "t/*/catalog/*/HEAD"),
+        "fixture invalid: an effect-blind read must return the Deny PutObject \
+         resource as a routed write (the hole this fixes); got {blind:?}"
+    );
+    // Observation 2: the Allow-only put helper the caller uses returns nothing.
+    let routed = put_resource_key_patterns(&policy);
+    assert!(
+        routed.is_empty(),
+        "put_resource_key_patterns must not read a Deny PutObject as a routed \
+         write; got {routed:?}"
+    );
+    // The Deny reaches the helper: it passes the choke point.
+    assert!(
+        validate_statement("fixture", 0, &policy_statements(&policy)[0]).is_ok(),
+        "fixture invalid: the Deny PutObject must pass the choke point so it \
+         reaches put_resource_key_patterns"
+    );
+}
+
+/// F1 regression (Effect axis, KMS actions): a `Deny kms:GenerateDataKey` must
+/// not be read as a held grant. Every `kms_actions` caller reads its result as a
+/// KMS operation the role HOLDS (or, for admin, the absence of one); an explicit
+/// Deny grants nothing, so pooling it would report a role able to mint ciphertext
+/// the Deny withdraws, and would flip the negative admin assertion. The fix
+/// filters `kms_actions` to `Allow` internally, since every caller reads a grant.
+/// Synthetic: no shipped template carries a Deny KMS statement.
+#[test]
+fn deny_kms_action_is_not_read_as_a_grant() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "DenyGenerateDataKey",
+            "Effect": "Deny",
+            "Action": "kms:GenerateDataKey",
+            "Resource": "arn:aws:kms:us-east-1:111122223333:key/abcd1234-5678-90ab-cdef-1234567890ab",
+        }]),
+    };
+    // Observation 1 (load-bearing): the pre-fix effect-blind scan (the live body
+    // minus its `Allow` filter) pooled the Deny action into the grant set.
+    let mut blind: Vec<String> = Vec::new();
+    for stmt in policy_statements(&policy) {
+        blind.extend(
+            statement_actions(stmt)
+                .into_iter()
+                .filter(|a| action_selects_kms(a)),
+        );
+    }
+    assert!(
+        blind
+            .iter()
+            .any(|a| action_grants_any(a, &KMS_DATA_KEY_OPERATIONS)),
+        "fixture invalid: an effect-blind scan must pool the Deny \
+         kms:GenerateDataKey into the grant set (the hole this fixes); got {blind:?}"
+    );
+    // Observation 2: the Allow-only kms_actions returns nothing.
+    let actions = kms_actions(&policy);
+    assert!(
+        actions.is_empty(),
+        "kms_actions must not read a Deny KMS statement as a held grant; got \
+         {actions:?}"
+    );
+    // The Deny reaches the helper: it passes the choke point.
+    assert!(
+        validate_statement("fixture", 0, &policy_statements(&policy)[0]).is_ok(),
+        "fixture invalid: the Deny KMS statement must pass the choke point so it \
+         reaches kms_actions"
+    );
+}
+
+/// F1 regression (Effect axis, KMS resources): a `Deny` naming `key/*` is a broad
+/// prohibition (safe), but both KMS resource guards read `kms_statement_resources`
+/// as a grant that must be narrowly scoped, so reading a Deny there would flag a
+/// safe account-wide prohibition as an over-broad grant -- the inverse of the
+/// fact. The fix filters `kms_statement_resources` to `Allow`; scoping is asked
+/// only of the grants. Synthetic: no shipped template carries a Deny KMS
+/// statement.
+#[test]
+fn deny_kms_statement_is_not_scope_checked() {
+    let policy = Policy {
+        role: "fixture",
+        statements: serde_json::json!([{
+            "Sid": "DenyBroadKms",
+            "Effect": "Deny",
+            "Action": "kms:Decrypt",
+            "Resource": "arn:aws:kms:us-east-1:111122223333:key/*",
+        }]),
+    };
+    // Observation 1 (load-bearing): the pre-fix effect-blind scan (the live body
+    // minus its `Allow` filter) returned the Deny's broad key/* ARN.
+    let mut blind: Vec<(String, Vec<String>)> = Vec::new();
+    for stmt in policy_statements(&policy) {
+        if !statement_actions(stmt)
+            .iter()
+            .any(|a| action_selects_kms(a))
+        {
+            continue;
+        }
+        let resources: Vec<String> = statement_resources(stmt)
+            .into_iter()
+            .filter(|r| matches!(classify_resource(r), ResourceShape::KmsKey))
+            .map(str::to_string)
+            .collect();
+        blind.push((statement_sid(stmt).to_string(), resources));
+    }
+    assert!(
+        blind
+            .iter()
+            .any(|(_, rs)| rs.iter().any(|r| r.ends_with("key/*"))),
+        "fixture invalid: an effect-blind scan must return the Deny's broad key/* \
+         ARN (the hole this fixes); got {blind:?}"
+    );
+    // Observation 2: the Allow-only helper returns nothing.
+    let statements = kms_statement_resources(&policy);
+    assert!(
+        statements.is_empty(),
+        "kms_statement_resources must not hand a Deny KMS statement to the \
+         scope-check guards; got {statements:?}"
+    );
+    // The Deny reaches the helper: it passes the choke point.
+    assert!(
+        validate_statement("fixture", 0, &policy_statements(&policy)[0]).is_ok(),
+        "fixture invalid: the Deny KMS statement must pass the choke point so it \
+         reaches kms_statement_resources"
+    );
+}
+
+/// F3 regression (Sid): a missing or non-string Sid must fail closed. Pre-fix,
+/// `obj.get("Sid").and_then(as_str).unwrap_or("<no Sid>")` swallowed a
+/// `"Sid": 123` and an absent Sid, and the otherwise-valid statement passed while
+/// every rejection could name only `<no Sid>`. Synthetic, not `deploy/iam/*.json`:
+/// every shipped statement carries a string Sid.
+#[test]
+fn sid_must_be_a_present_string() {
+    // Non-string Sid.
+    let non_string = serde_json::json!({
+        "Sid": 123,
+        "Effect": "Allow",
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::my-ravel-bucket/t/*",
+    });
+    // Observation 1 (load-bearing): the pre-fix extraction saw no string Sid, so
+    // it fell back to "<no Sid>" and validated the rest as if well-formed.
+    assert!(
+        non_string["Sid"].as_str().is_none(),
+        "fixture invalid: the pre-fix as_str() extraction was expected to see no \
+         string Sid for 123"
+    );
+    let err = validate_statement("fixture", 0, &non_string)
+        .expect_err("validate_statement must reject a non-string Sid");
+    assert!(
+        err.contains("non-string Sid"),
+        "rejection must name the non-string Sid; got {err:?}"
+    );
+
+    // Missing Sid entirely.
+    let missing = serde_json::json!({
+        "Effect": "Allow",
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::my-ravel-bucket/t/*",
+    });
+    let err = validate_statement("fixture", 0, &missing)
+        .expect_err("validate_statement must reject a missing Sid");
+    assert!(
+        err.contains("no Sid"),
+        "rejection must name the missing Sid; got {err:?}"
+    );
+}
+
+/// F3 regression (index): every rejection names the statement index, so an
+/// operator can locate the offending statement in a Sid-less or duplicate-Sid
+/// array. Pre-fix, messages carried only `role/Sid`.
+#[test]
+fn rejection_message_names_the_statement_index() {
+    let statements = serde_json::json!([
+        {"Sid": "Good", "Effect": "Allow", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"},
+        {"Sid": "Bad", "Effect": "Permit", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::my-ravel-bucket/t/*"},
+    ]);
+    let err = validate_policy_statements("fixture", &statements)
+        .expect_err("the invalid second statement must be rejected");
+    assert!(
+        err.contains("#1"),
+        "rejection must name the statement index #1; got {err:?}"
+    );
+    assert!(
+        err.contains("Bad"),
+        "rejection must name the Sid; got {err:?}"
+    );
+}
+
+/// F4 wiring guard: `load_policy_from` -- `load_policy`'s real file-reading body --
+/// must reject an invalid policy. Driving a synthetic invalid file through it is
+/// what fails if the validation call is deleted from `build_policy`, or if
+/// `load_policy_from` stops calling `build_policy`; a test that only calls
+/// `validate_policy_statements` directly would keep passing. This closes the F4
+/// gap: the shipped entry point, not only the extracted body, is exercised.
+#[test]
+fn load_policy_from_rejects_a_synthetic_invalid_file() {
+    let path = std::env::temp_dir().join(format!(
+        "ravel-iam-fixture-{}-invalid.json",
+        std::process::id()
+    ));
+    let json = r#"{"Version":"2012-10-17","Statement":[{"Sid":"NegatedResource","Effect":"Allow","Action":"s3:DeleteObject","NotResource":"arn:aws:s3:::my-ravel-bucket/t/*"}]}"#;
+    std::fs::write(&path, json).expect("write synthetic policy fixture");
+    let path_str = path.to_str().expect("temp path is valid UTF-8").to_string();
+    let built = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        load_policy_from("fixture", &path_str)
+    }));
+    std::fs::remove_file(&path).ok();
+    assert!(
+        built.is_err(),
+        "load_policy_from (load_policy's real file-reading body) must reject a \
+         statement whose permission lives in NotResource, a field no guard reads"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Round four (issue #1346, holes H1/H2/H3): the redesign's own fixtures.
+//
+// Round three's `bucket_relative_s3_pattern` and the list-only exemption its
+// callers carried, kept verbatim, so each fixture below pins the hole it closes
+// instead of restating today's rule.
+// ---------------------------------------------------------------------------
+
+/// Round three's resource classifier, verbatim: it panicked for exactly two
+/// shapes (`"*"` and an `arn:aws:s3:::` prefix) and returned `None` for
+/// everything else. Its doc claimed `None` meant "names a different service such
+/// as a KMS ARN", but nothing checked that, so every S3 grant shape outside those
+/// two -- access point, Object Lambda, multi-region access point, `arn:*`, a
+/// malformed non-ARN -- came back as "nothing to check" (H1).
+fn round_three_bucket_relative_s3_pattern(resource: &str) -> Option<String> {
+    if let Some(key_pattern) = resource.strip_prefix("arn:aws:s3:::my-ravel-bucket/") {
+        return Some(key_pattern.to_string());
+    }
+    if resource == "*" || resource.starts_with("arn:aws:s3:::") {
+        panic!("round three panicked for {resource:?}");
+    }
+    None
+}
+
+/// Round three's `resource_key_patterns`, verbatim: the list-only exemption that
+/// skipped a list statement before its Resource was looked at by anything (H2),
+/// plus the silent-drop classifier above.
+fn round_three_resource_key_patterns(policy: &Policy) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in policy_statements(policy) {
+        let actions = statement_actions(stmt);
+        let is_list_only = !actions.is_empty()
+            && actions
+                .iter()
+                .all(|a| a.eq_ignore_ascii_case("s3:ListBucket"));
+        if is_list_only {
+            continue;
+        }
+        let resources = match &stmt["Resource"] {
+            serde_json::Value::Array(a) => a.clone(),
+            v @ serde_json::Value::String(_) => vec![v.clone()],
+            _ => continue,
+        };
+        for r in resources {
+            let r = r.as_str().expect("Resource entry is a string");
+            if let Some(key_pattern) = round_three_bucket_relative_s3_pattern(r) {
+                out.push(key_pattern);
+            }
+        }
+    }
+    out
+}
+
+/// The message a `catch_unwind` payload carries, so a fixture can assert the
+/// rejection names the offending statement rather than only that something
+/// panicked.
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        return (*s).to_string();
+    }
+    "<non-string panic payload>".to_string()
+}
+
+/// A single-statement synthetic policy.
+fn fixture_policy(stmt: serde_json::Value) -> Policy {
+    Policy {
+        role: "fixture",
+        statements: serde_json::json!([stmt]),
+    }
+}
+
+/// H1 regression: every S3 object grant whose `Resource` is not bucket-relative
+/// must be rejected by name. Round three's classifier panicked only for `"*"` and
+/// for an `arn:aws:s3:::` prefix and returned `None` for everything else, so each
+/// of these five shapes -- all real S3 object grants reaching outside the
+/// configured bucket -- was silently dropped and every resource guard derived an
+/// empty set.
+///
+/// All five shapes are covered, not one: the access-point and multi-region
+/// access-point forms carry a region and/or account and so miss the `:::` form,
+/// Object Lambda is a different service name entirely, `arn:*` is the
+/// everything-grant, and `my-ravel-bucket/*` is not an ARN at all.
+///
+/// Synthetic statements, not `deploy/iam/*.json`: the shipped templates name only
+/// bucket-relative object ARNs, so a fixture over them passes whichever way the
+/// classifier behaves. Each case asserts in both directions.
+#[test]
+fn non_bucket_relative_s3_object_resource_fails_closed() {
+    let cases = [
+        (
+            "AccessPointArn",
+            "arn:aws:s3:us-east-1:111122223333:accesspoint/ap/object/*",
+        ),
+        (
+            "ObjectLambdaArn",
+            "arn:aws:s3-object-lambda:us-east-1:111122223333:accesspoint/olap/object/*",
+        ),
+        (
+            "MultiRegionAccessPointArn",
+            "arn:aws:s3::111122223333:accesspoint/mrap/object/*",
+        ),
+        ("EverythingArn", "arn:*"),
+        ("MalformedNonArn", "my-ravel-bucket/*"),
+    ];
+
+    for (sid, resource) in cases {
+        let stmt = serde_json::json!({
+            "Sid": sid,
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": resource,
+        });
+        let policy = fixture_policy(stmt.clone());
+
+        // Observation 1 (load-bearing): the resource is not bucket-relative, yet
+        // round three's classifier fell through to None instead of panicking, so
+        // its callers dropped it. Written as round three's own two literal
+        // conditions, so this pins the hole rather than restating the fix.
+        assert!(
+            resource.strip_prefix(BUCKET_KEY_PREFIX).is_none(),
+            "fixture {sid} invalid: {resource:?} must NOT be bucket-relative, or it \
+             is not an out-of-bucket grant at all"
+        );
+        let round_three_panicked = resource == "*" || resource.starts_with("arn:aws:s3:::");
+        assert!(
+            !round_three_panicked,
+            "fixture {sid} invalid: round three's two panic conditions were expected \
+             to miss {resource:?} -- if one catches it, this fixture no longer proves \
+             the catch-all None hole existed"
+        );
+        assert_eq!(
+            round_three_bucket_relative_s3_pattern(resource),
+            None,
+            "fixture {sid} invalid: round three's classifier was expected to return \
+             None (silently dropping the grant) for {resource:?}"
+        );
+        assert!(
+            round_three_resource_key_patterns(&policy).is_empty(),
+            "fixture {sid} invalid: round three's resource helper was expected to \
+             derive an empty pattern set for {resource:?}, hiding the grant"
+        );
+
+        // Observation 2: the choke point rejects it, naming the role, the
+        // statement index, the Sid and the offending value.
+        let err = validate_statement("gateway", 3, &stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        for expected in [resource, sid, "#3", "gateway"] {
+            assert!(
+                err.contains(expected),
+                "fixture {sid}: rejection must name {expected:?}; got {err:?}"
+            );
+        }
+
+        // Observation 3 (belt and braces): the helper itself panics if a guard is
+        // ever run on a statement that never passed the choke point.
+        let guard = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            resource_key_patterns(&policy)
+        }));
+        let message = panic_message(guard.expect_err(&format!(
+            "resource_key_patterns must panic on fixture {sid}, not drop the resource"
+        )));
+        assert!(
+            message.contains(resource) && message.contains(sid),
+            "fixture {sid}: the helper's panic must name the Sid and the resource; \
+             got {message:?}"
+        );
+    }
+}
+
+/// H2 regression: a list statement's `Resource` must be examined. Round three
+/// made a non-bucket-relative Resource fatal and then, to stop that tripping the
+/// bare bucket ARN that `s3:ListBucket` legitimately names, exempted whole
+/// list-only statements from the resource helpers. The result was a list
+/// statement whose Resource was read by NO guard in the file: `s3:ListBucket` on
+/// `"*"` -- which enumerates every bucket in the account -- passed validation,
+/// was skipped by the resource helpers, and `list_prefix_patterns` read only its
+/// Condition. This hole did not exist before round three.
+///
+/// The fix is the choke point's resource-class rule: a list grant must name the
+/// bare bucket ARN and nothing else, so the exemption is no longer needed and the
+/// helper never has to guess.
+#[test]
+fn list_statement_resource_is_examined() {
+    let cases = [
+        // The account-wide list: no class at all, rejected as unclassified.
+        ("ListOnStar", "*", "nor exactly that bucket ARN"),
+        // A list grant naming an object ARN: legal JSON, and in AWS a ListBucket
+        // on an object ARN matches nothing, so it is a template bug either way.
+        // The resource classifies, and the mismatch with the granted class is
+        // what rejects it.
+        (
+            "ListOnObjectArn",
+            "arn:aws:s3:::my-ravel-bucket/t/*",
+            "grants no S3 object operation",
+        ),
+    ];
+
+    for (sid, resource, must_explain) in cases {
+        let stmt = serde_json::json!({
+            "Sid": sid,
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": resource,
+            "Condition": {"StringLike": {"s3:prefix": ["t/*"]}},
+        });
+        let policy = fixture_policy(stmt.clone());
+
+        // Observation 1 (load-bearing): round three's list-only exemption skipped
+        // the statement before its Resource was classified at all, so the
+        // resource helper derived nothing.
+        assert!(
+            round_three_resource_key_patterns(&policy).is_empty(),
+            "fixture {sid} invalid: round three's list-only exemption was expected \
+             to skip the statement entirely; it did not"
+        );
+
+        // ...and the only guard that DID look at this statement looked solely at
+        // its Condition, which is the shape of the hole: the prefix was read, the
+        // Resource was not.
+        assert_eq!(
+            pre_fix_list_prefix_patterns(&policy),
+            vec!["t/*".to_string()],
+            "fixture {sid} invalid: list_prefix_patterns was expected to read the \
+             Condition (and nothing else) for this statement"
+        );
+
+        // Observation 2: the choke point now rejects the Resource by name.
+        let err = validate_statement("admin", 0, &stmt)
+            .expect_err(&format!("validate_statement must reject fixture {sid}"));
+        for expected in [resource, sid, must_explain] {
+            assert!(
+                err.contains(expected),
+                "fixture {sid}: rejection must name {expected:?}; got {err:?}"
+            );
+        }
+    }
+
+    // The same hole with the list grant hidden beside an object grant, which is
+    // what makes the class-mismatch arms above insufficient on their own: the
+    // object ARN is legitimate for the GetObject half, so only the coverage rule
+    // ("grants a bucket operation, names no bucket ARN") catches the ListBucket
+    // half reaching every key in the bucket with no Resource a guard reads.
+    let hidden = serde_json::json!({
+        "Sid": "ListHiddenBesideRead",
+        "Effect": "Allow",
+        "Action": ["s3:ListBucket", "s3:GetObject"],
+        "Resource": "arn:aws:s3:::my-ravel-bucket/t/*",
+        "Condition": {"StringLike": {"s3:prefix": ["t/*"]}},
+    });
+    let hidden_policy = fixture_policy(hidden.clone());
+
+    // Observation 1 (load-bearing): round three read this statement twice and
+    // never once asked what its list half was scoped to. The resource helper saw
+    // it (is_list_only was false, so the exemption did not apply) and derived only
+    // the object pattern; the list guard saw it and read only the Condition.
+    assert_eq!(
+        round_three_resource_key_patterns(&hidden_policy),
+        vec!["t/*".to_string()],
+        "fixture invalid: round three's resource helper was expected to derive only \
+         the object pattern here, saying nothing about the list grant"
+    );
+    assert_eq!(
+        pre_fix_list_prefix_patterns(&hidden_policy),
+        vec!["t/*".to_string()],
+        "fixture invalid: round three's list guard was expected to read only the \
+         Condition here"
+    );
+
+    // Observation 2: the coverage rule rejects it, tagged H2.
+    let err = validate_statement("query", 2, &hidden)
+        .expect_err("validate_statement must reject a list grant that names no bucket ARN");
+    for expected in ["ListHiddenBesideRead", "#2", "issue #1346, H2"] {
+        assert!(
+            err.contains(expected),
+            "the rejection must name {expected:?}; got {err:?}"
+        );
+    }
+
+    // Trap (must not trip): the shipped list shape -- exactly the bare bucket ARN
+    // with an s3:prefix Condition -- still passes, and still contributes its
+    // prefixes.
+    let shipped = serde_json::json!({
+        "Sid": "ShippedListShape",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": BUCKET_ARN,
+        "Condition": {"StringLike": {"s3:prefix": ["t/", "sys/*"]}},
+    });
+    assert!(
+        validate_statement("fixture", 0, &shipped).is_ok(),
+        "the shipped list statement shape (bare bucket ARN + s3:prefix Condition) \
+         must still pass"
+    );
+    assert_eq!(
+        list_prefix_patterns(&fixture_policy(shipped), None),
+        vec!["t/".to_string(), "sys/*".to_string()],
+        "the shipped list shape must still contribute its s3:prefix patterns"
+    );
+}
+
+/// H3 regression, the predicate: `"s3:*"` and `"*"` grant PutObject, ListBucket
+/// and the delete actions, and `"*"` grants the KMS operations too. Round three
+/// resolved IAM wildcards on the delete axis only; put, list and KMS selection
+/// all compared exact names, so an `s3:*` statement was selected by none of them
+/// and the Condition-presence rule (which keys on the list grant) never fired.
+///
+/// This test is over the predicate rather than a policy because the predicate is
+/// now the only place any axis decides: if it answers all of these, no axis can
+/// be wildcard-blind.
+#[test]
+fn wildcard_action_is_selected_by_every_axis() {
+    // (action, does it grant an S3 object op, a bucket op, a KMS op)
+    let cases = [
+        ("s3:*", true, true, false),
+        ("S3:*", true, true, false),
+        ("*", true, true, true),
+        ("s3:?utObject", true, false, false),
+        ("kms:*", false, false, true),
+        // Control: a literal action grants only itself.
+        ("s3:GetObject", true, false, false),
+        // Control: an unrelated literal grants nothing in the vocabulary.
+        ("s3:DeleteObjectTagging", false, false, false),
+    ];
+
+    for (action, grants_object, grants_list, grants_kms) in cases {
+        assert_eq!(
+            action_grants_any(action, &S3_OBJECT_OPERATIONS),
+            grants_object,
+            "action_grants: {action:?} vs {S3_OBJECT_OPERATIONS:?}"
+        );
+        assert_eq!(
+            action_grants_any(action, &S3_BUCKET_OPERATIONS),
+            grants_list,
+            "action_grants: {action:?} vs {S3_BUCKET_OPERATIONS:?}"
+        );
+        assert_eq!(
+            action_selects_kms(action),
+            grants_kms,
+            "action_selects_kms: {action:?}"
+        );
+    }
+
+    // Observation 1 (load-bearing): round three's per-axis matchers -- exact
+    // case-folded equality for put and list, a case-folded `kms:` prefix for KMS
+    // -- each missed the wildcard action that grants their operation. Written as
+    // those literal expressions, so this pins the hole rather than restating the
+    // fix.
+    assert!(
+        !"s3:*".eq_ignore_ascii_case("s3:PutObject"),
+        "fixture invalid: round three's put selection was expected to miss \"s3:*\""
+    );
+    assert!(
+        !"s3:*".eq_ignore_ascii_case("s3:ListBucket"),
+        "fixture invalid: round three's list selection was expected to miss \"s3:*\""
+    );
+    assert!(
+        !"*".starts_with("kms:"),
+        "fixture invalid: round three's KMS selection was expected to miss \"*\""
+    );
+
+    // ...while the delete axis, the one round three made wildcard-aware, saw it.
+    // That asymmetry is what the single predicate removes.
+    assert!(
+        action_grants_any("s3:*", &S3_DELETE_OPERATIONS),
+        "the delete axis was already wildcard-aware and must stay so"
+    );
+}
+
+/// H3 regression, the shipped-template mutation the reviewer used: changing
+/// `GatewayWrite`'s Action from `s3:PutObject` to `s3:*` passed all 26 tests
+/// under round three. `s3:*` grants PutObject (so the routed-write KMS check
+/// should select the statement) and ListBucket (so the Condition-presence rule
+/// should demand an `s3:prefix` Condition and the resource rule should demand the
+/// bucket ARN), and round three's exact-name matchers saw neither.
+///
+/// The mutation is applied to an in-memory copy of `deploy/iam/gateway.json`; the
+/// file on disk is not touched, and the unmutated policy is asserted to still
+/// load.
+#[test]
+fn shipped_gateway_write_mutated_to_wildcard_action_fails_closed() {
+    let path = policy_json_path("gateway");
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let mut json: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+
+    // The unmutated template still loads: this test's failure is about the
+    // mutation, not about the shipped file.
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build_policy(
+            "gateway", &path, &json
+        )))
+        .is_ok(),
+        "the shipped gateway template must load unchanged"
+    );
+
+    let statements = json["Statement"]
+        .as_array_mut()
+        .expect("gateway.json Statement is an array");
+    let target = statements
+        .iter_mut()
+        .find(|stmt| stmt["Sid"] == serde_json::json!("GatewayWrite"))
+        .expect("gateway.json carries a GatewayWrite statement");
+    let original = target["Action"].clone();
+    assert_eq!(
+        original,
+        serde_json::json!("s3:PutObject"),
+        "fixture invalid: GatewayWrite's Action is no longer the s3:PutObject this \
+         mutation replaces"
+    );
+    target["Action"] = serde_json::json!("s3:*");
+
+    let mutated = Policy {
+        role: "gateway",
+        statements: json["Statement"].clone(),
+    };
+
+    // Observation 1 (load-bearing): under round three's exact-name matchers the
+    // mutated policy hid the grant in two independent places.
+    assert!(
+        pre_fix_put_resource_key_patterns(&mutated).is_empty(),
+        "fixture invalid: round three's PutObject selection was expected to derive \
+         an EMPTY routed-write set from the mutated policy (so \
+         roles_writing_routed_objects_have_kms_grant skipped the role)"
+    );
+    let round_three_list_prefixes = pre_fix_list_prefix_patterns(&mutated);
+    assert!(
+        !round_three_list_prefixes.contains(&"*".to_string()),
+        "fixture invalid: round three's list detection was expected to read nothing \
+         from the s3:* statement; got {round_three_list_prefixes:?}"
+    );
+    assert!(
+        round_three_bucket_relative_s3_pattern("arn:aws:s3:::my-ravel-bucket/t/*/*/l0/*").is_some(),
+        "fixture invalid: the mutated statement's resources still strip cleanly, so \
+         nothing but the Action matcher could have caught this"
+    );
+
+    // Observation 2: the choke point rejects the mutated template, naming the
+    // statement, and `load_policy`'s real body is what does it.
+    let built = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build_policy("gateway", &path, &json)
+    }));
+    let message = panic_message(built.expect_err(
+        "build_policy must reject GatewayWrite mutated to \"s3:*\": the action grants \
+         ListBucket and PutObject, and its resources are object ARNs with no Condition",
+    ));
+    assert!(
+        message.contains("GatewayWrite") && message.contains("s3:*"),
+        "the rejection must name the mutated statement and its Action; got {message:?}"
+    );
+
+    // Observation 3: the post-fix put axis DOES select the mutated statement, so
+    // the routed-write KMS check would run on it rather than skip the role.
+    let routed: Vec<String> = put_resource_key_patterns(&mutated)
+        .into_iter()
+        .filter(|p| ravel_object_store::routes_through_tenant_key(p))
+        .collect();
+    assert!(
+        !routed.is_empty(),
+        "the post-fix put axis must select the s3:* statement's routed PUT patterns"
+    );
+}
+
+/// H3 companion: the normal IAM idiom round three's list-only exemption would
+/// have mishandled -- one statement granting both `s3:ListBucket` and
+/// `s3:GetObject`, naming both the bare bucket ARN and an object prefix -- must be
+/// ACCEPTED, and both axes must read it. Rejecting it (or rejecting it with a
+/// misleading "not bucket-relative" reason) would be a new failure of the same
+/// class, in the opposite direction.
+#[test]
+fn mixed_list_and_object_statement_is_accepted() {
+    let stmt = serde_json::json!({
+        "Sid": "MixedListAndRead",
+        "Effect": "Allow",
+        "Action": ["s3:ListBucket", "s3:GetObject"],
+        "Resource": [BUCKET_ARN, "arn:aws:s3:::my-ravel-bucket/t/*"],
+        "Condition": {"StringLike": {"s3:prefix": ["t/*"]}},
+    });
+    assert!(
+        validate_statement("fixture", 0, &stmt).is_ok(),
+        "a statement granting both ListBucket and GetObject over the bucket ARN plus \
+         an object prefix is a normal IAM idiom and must be accepted: {:?}",
+        validate_statement("fixture", 0, &stmt)
+    );
+
+    let policy = fixture_policy(stmt);
+
+    // The object axis reads the object prefix and skips the bucket ARN rather
+    // than panicking on it (round three's classifier panicked for the bare bucket
+    // ARN, which is why the exemption was added at the caller).
+    assert!(
+        std::panic::catch_unwind(|| round_three_bucket_relative_s3_pattern(BUCKET_ARN)).is_err(),
+        "fixture invalid: round three's classifier was expected to panic on the bare \
+         bucket ARN (the reason the list-only exemption existed)"
+    );
+    assert_eq!(
+        resource_key_patterns(&policy),
+        vec!["t/*".to_string()],
+        "the object axis must read the object prefix and skip the bucket ARN"
+    );
+
+    // ...and the list axis reads the Condition, so neither half sits unexamined.
+    assert_eq!(
+        list_prefix_patterns(&policy, None),
+        vec!["t/*".to_string()],
+        "the list axis must read the mixed statement's s3:prefix Condition"
+    );
+}
+
+/// The vocabulary's own invariants, so a later edit cannot silently narrow it:
+/// every operation is a literal name (`action_grants` asserts this, and an
+/// operation carrying a wildcard would make it answer a different question), the
+/// delete axis selects a subset of the object axis (a delete that is not an
+/// object operation would be selected by the delete guard while the choke point
+/// demanded a resource shape for a class it does not grant), and the three
+/// classes are disjoint (a shape rule keyed on class would otherwise be
+/// ambiguous).
+#[test]
+fn operation_vocabulary_is_consistent() {
+    let all: Vec<&str> = S3_OBJECT_OPERATIONS
+        .iter()
+        .chain(S3_BUCKET_OPERATIONS.iter())
+        .chain(KMS_OTHER_OPERATIONS.iter())
+        .chain(KMS_DATA_KEY_OPERATIONS.iter())
+        .copied()
+        .collect();
+    for op in &all {
+        assert!(
+            !op.contains(IAM_WILDCARDS),
+            "operation {op:?} carries an IAM wildcard; operations must be literal names"
+        );
+    }
+    for op in S3_DELETE_OPERATIONS {
+        assert!(
+            S3_OBJECT_OPERATIONS.contains(&op),
+            "delete operation {op:?} is not in S3_OBJECT_OPERATIONS, so a statement \
+             granting it would be selected by the delete axis while the choke point \
+             required no object resource for it"
+        );
+    }
+    for op in &all {
+        let object = S3_OBJECT_OPERATIONS.contains(op);
+        let bucket = S3_BUCKET_OPERATIONS.contains(op);
+        let kms = action_selects_kms(op);
+        assert_eq!(
+            u8::from(object) + u8::from(bucket) + u8::from(kms),
+            1,
+            "operation {op:?} belongs to more than one resource class (object \
+             {object}, bucket {bucket}, kms {kms}), so the choke point's shape rules \
+             would be ambiguous"
+        );
+    }
+}
+
+/// Every shipped template under `deploy/iam` passes the choke point, and the set
+/// this file guards is exactly the set on disk. `ALL_ROLES` is hand-written, so
+/// without this a new template would ship unguarded.
+#[test]
+fn every_shipped_template_passes_the_choke_point() {
+    let dir = format!("{}/../../deploy/iam", env!("CARGO_MANIFEST_DIR"));
+    let mut on_disk: Vec<String> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read dir {dir}: {e}"))
+        .map(|entry| entry.expect("dir entry").file_name())
+        .filter_map(|name| {
+            name.to_str()
+                .and_then(|n| n.strip_suffix(".json"))
+                .map(str::to_string)
+        })
+        .collect();
+    on_disk.sort();
+    let mut guarded: Vec<String> = ALL_ROLES.iter().map(|r| (*r).to_string()).collect();
+    guarded.sort();
+    assert_eq!(
+        on_disk, guarded,
+        "the templates under deploy/iam and the roles ALL_ROLES guards must be the \
+         same set"
+    );
+    assert_eq!(
+        on_disk.len(),
+        4,
+        "expected 4 shipped templates: {on_disk:?}"
+    );
+
+    for role in ALL_ROLES {
+        // load_policy panics on any rejection, naming role, index, Sid and field.
+        let policy = load_policy(role);
+        assert!(
+            !policy_statements(&policy).is_empty(),
+            "{role}: policy has no statements"
+        );
+
+        // `glob_to_regex` resolves `?` as IAM's single-character wildcard and
+        // documents that widening it changed no existing match because no
+        // shipped Action or Resource carries a `?`. That is a property of the
+        // four JSON files, so it is asserted here rather than assumed: a `?`
+        // added to a template silently changes what every pattern axis reads.
+        for stmt in policy_statements(&policy) {
+            let sid = statement_sid(stmt);
+            for action in statement_actions(stmt) {
+                assert!(
+                    !action.contains('?'),
+                    "{role}/{sid}: Action {action:?} carries a `?`. glob_to_regex \
+                     resolves it as IAM's single-character wildcard; the doc claim \
+                     that no shipped pattern uses one is now false and every \
+                     pattern-set expectation in this file must be re-read"
+                );
+            }
+            for resource in statement_resources(stmt) {
+                assert!(
+                    !resource.contains('?'),
+                    "{role}/{sid}: Resource {resource:?} carries a `?`. Same \
+                     consequence as for Action above"
+                );
+            }
         }
     }
 }

--- a/crates/ravel-commit/tests/iam_templates.rs
+++ b/crates/ravel-commit/tests/iam_templates.rs
@@ -153,7 +153,7 @@ const NON_TENANT_WITNESS_KEYS: [&str; 7] = [
 /// and the live `t/*/*/idem/*` MaintainDelete grant, then matched zero keys and
 /// the measurement reported an empty overlap having examined nothing there. The
 /// anti-vacuity guard was an ANY over the whole protected set that `sys/tenancy`
-/// alone satisfied, so the two zero-witness keyspaces went unnoticed (#1346).
+/// alone satisfied, so the two zero-witness keyspaces went unnoticed.
 ///
 /// These are kept out of `representative_keys` because no constructor produces
 /// them, for the same reason the non-tenant witnesses are: they are not evidence
@@ -235,13 +235,14 @@ const BUCKET_ARN: &str = "arn:aws:s3:::my-ravel-bucket";
 const BUCKET_KEY_PREFIX: &str = "arn:aws:s3:::my-ravel-bucket/";
 
 /// Translate an IAM policy glob into an anchored regex. IAM resolves two
-/// wildcard characters inside both `Action` and `Resource` strings: `*` matches
-/// any sequence and `?` matches exactly one character; every other character is
-/// literal. This once handled only `*`; the shipped templates carry no `?`
-/// (asserted by `every_shipped_template_passes_the_choke_point`, not assumed),
-/// so widening it changes no existing match, but a `?` smuggled into an action or
-/// resource pattern is now resolved as the wildcard IAM treats it as instead of
-/// being escaped to a literal `\?` that quietly matches nothing.
+/// wildcard characters inside `Action`, `Resource`, and `s3:prefix` Condition
+/// strings: `*` matches any sequence and `?` matches exactly one character;
+/// every other character is literal. This handles both, so a `?` smuggled into
+/// any of those fields is resolved as the wildcard IAM treats it as instead of
+/// being escaped to a literal `\?` that quietly matches nothing. The shipped
+/// templates carry no `?` in any of the three fields, asserted (not assumed) by
+/// `every_shipped_template_passes_the_choke_point`, which scans Action, Resource,
+/// and the `s3:prefix` values it reads through `list_prefix_patterns`.
 fn glob_to_regex(pattern: &str) -> regex::Regex {
     let mut regex_src = String::from("^");
     for ch in pattern.chars() {
@@ -282,7 +283,7 @@ fn glob_matches(pattern: &str, candidate: &str) -> bool {
 /// `*?*` and `*/*` do not, while each of those matches all 67 representative
 /// keys; `*/*` is the plausible operator spelling of "any tenant, any signal"
 /// and, put in a shipped template's delete `Resource`, left the whole suite
-/// green (issue #1346, hole ten).
+/// green.
 ///
 /// The empty-string test is kept as a disjunct, so the new definition is a
 /// SUPERSET of the old one rather than a trade of one blind spot for another:
@@ -351,7 +352,7 @@ const KMS_OTHER_OPERATIONS: [&str; 2] = ["kms:Decrypt", "kms:Encrypt"];
 /// existed each axis carried its own matcher and only the delete axis resolved
 /// wildcards, so `"Action": "s3:*"` granted PutObject and ListBucket while being
 /// selected by neither -- and the Condition-presence rule, which keys on the
-/// list grant, never fired either (issue #1346, H3). There is now one place that
+/// list grant, never fired either. There is now one place that
 /// decides, so no axis can be wildcard-aware while another is not.
 ///
 /// The asymmetry is deliberate and asserted: the wildcard lives on the policy
@@ -415,7 +416,7 @@ enum ResourceShape<'a> {
     Bucket,
     /// A KMS key ARN.
     KmsKey,
-    /// Anything else, including every shape issue #1346 H1 lists: an S3
+    /// Anything else, including every shape outside the three above: an S3
     /// access-point ARN (`arn:aws:s3:<region>:<account>:accesspoint/...`), an
     /// Object Lambda ARN (`arn:aws:s3-object-lambda:...`), a multi-region access
     /// point (`arn:aws:s3::<account>:accesspoint/...`), the everything-grant
@@ -460,7 +461,7 @@ struct Policy {
 ///
 /// This list is the guard's contract: a statement carrying any key outside it
 /// is one no guard reasons about, so it must fail closed at `load_policy`
-/// rather than be silently skipped (issue #1346).
+/// rather than be silently skipped.
 const HANDLED_STATEMENT_KEYS: &[&str] = &["Sid", "Effect", "Action", "Resource", "Condition"];
 
 /// The complete set of `Condition` operators any guard in this file reads.
@@ -469,7 +470,7 @@ const HANDLED_STATEMENT_KEYS: &[&str] = &["Sid", "Effect", "Action", "Resource",
 /// a different comparison such as `StringNotLike`, or a set-qualified form such
 /// as `ForAnyValue:StringLike` -- carries a constraint no guard reasons about,
 /// so it must fail closed at `validate_statement` rather than pass with its
-/// Condition unexamined (issue #1346).
+/// Condition unexamined.
 const HANDLED_CONDITION_OPERATORS: &[&str] = &["StringLike"];
 
 /// The complete set of `Condition` keys any guard in this file reads, under a
@@ -494,13 +495,10 @@ const NEGATED_OR_PRINCIPAL_KEYS: &[&str] =
 /// unhandled shape is rejected once here instead of slipping past a guard that
 /// only reads the fields it happens to know.
 ///
-/// # The closure argument
+/// # The contract
 ///
-/// Every earlier round of this guard fixed one hole and left another, because
-/// each helper decided for itself which shapes it understood and answered "no
-/// resources to check" for the rest. The fix is structural: ALL shape decisions
-/// happen here, and the helpers are total functions over the shapes that got
-/// through. Concretely, a statement reaching any guard has:
+/// ALL shape decisions happen here, so the helpers are total functions over the
+/// shapes that get through. A statement reaching any guard has:
 ///
 /// - a present string `Sid`, so every message can name it;
 /// - only keys in `HANDLED_STATEMENT_KEYS`, so no permission lives in a field no
@@ -523,8 +521,8 @@ const NEGATED_OR_PRINCIPAL_KEYS: &[&str] =
 ///   sub-shape is the one `StringLike`/`s3:prefix` block
 ///   `list_prefix_patterns` reads.
 ///
-/// A helper downstream can therefore no longer meet a shape it does not
-/// understand. `object_key_patterns` matches all four `ResourceShape` variants:
+/// A helper downstream therefore cannot meet a shape it does not understand.
+/// `object_key_patterns` matches all four `ResourceShape` variants:
 /// it strips `ObjectKey`, skips `Bucket` and `KmsKey` because this function
 /// proved the same statement grants the list or KMS operation whose own guard
 /// reads that exact string, and panics on `Unclassified` because this function
@@ -562,83 +560,71 @@ const NEGATED_OR_PRINCIPAL_KEYS: &[&str] =
 /// reads the result as neither a grant nor a prohibition (the pattern-vs-key
 /// coverage guard) passes `None` and sees both effects on purpose.
 ///
-/// The `Allow` filter closes ONE direction, and the claim is narrowed to it: it
-/// stops a `Deny` being READ AS a grant -- a Deny-derived output read as an
-/// Allow-derived permission, asserting the inverse of the fact (issue #1346,
-/// F1/F2). It does NOT stop a `Deny` WITHDRAWING a grant that a positive guard
-/// then asserts is held: a Deny added alongside a retained Allow, withdrawing
-/// (say) `kms:GenerateDataKey`/`kms:Encrypt` from the only key, leaves
+/// The `Allow` filter closes ONE direction: it stops a `Deny`-derived output
+/// being read as an `Allow`-derived permission, asserting the inverse of the
+/// fact. It does NOT stop a `Deny` WITHDRAWING a grant that a positive guard then
+/// asserts is held: a Deny added alongside a retained Allow, withdrawing (say)
+/// `kms:GenerateDataKey`/`kms:Encrypt` from the only key, leaves
 /// `write_roles_have_kms_generate_data_key` and
 /// `roles_writing_routed_objects_have_kms_grant` green, because those guards read
 /// the retained `Allow` and never subtract the `Deny`. That case is knowingly
-/// left unhandled here. It is availability drift, not permissiveness: the
+/// left unhandled: it is availability drift, not permissiveness, since the
 /// templates would fail CLOSED in production (the write is denied) while the
-/// guard stayed green, so it is strictly safer than the direction the filter
-/// closes. Its precondition is that no shipped template carries a `Deny` that
-/// withdraws a granted KMS/Put capability, which is a property of the four JSON
-/// files rather than of this code and is therefore asserted rather than assumed:
-/// `every_shipped_deny_is_a_delete_only_prohibition` pins that the only shipped
-/// `Deny` is `DenyDeleteProtected` and that every action it names grants a delete
-/// operation and nothing else. Round six stated that premise with a second
-/// clause, "disjoint from every Allow", which is FALSE and was never asserted:
-/// maintain's level-based delete grants and the legal-hold audit-shard
-/// protection cover the same keys (`t/<hash>/u/{l0,c,l1}/0000/...`), so the
-/// delete `Allow` set overstates the capability by exactly the three pattern
-/// pairs `delete_deny_and_allow_overlap_exactly_where_expected` now pins.
-/// Closing the drift would require each positive-capability guard to subtract
-/// the matching `Deny` before asserting; that is a deliberate non-goal. This is
-/// the axis the next reviewer checks the next finding against.
+/// guard stayed green, strictly safer than the direction the filter closes. Its
+/// precondition -- that no shipped template carries a `Deny` withdrawing a
+/// granted KMS/Put capability -- is a property of the four JSON files, so it is
+/// asserted rather than assumed by `every_shipped_deny_is_a_delete_only_prohibition`.
+/// A delete `Deny` can still overlap a delete `Allow`; that overlap is measured
+/// and pinned by `EXPECTED_DELETE_OVERLAPS`, the one home for the Deny-override
+/// fact.
 ///
 /// Rejects, naming the `Sid` (and the statement index) and the offending key or
 /// field:
 /// - a statement that is not a JSON object;
-/// - a missing or non-string `Sid` (`"Sid": 123`): Sid is in the handled set,
-///   but its type went unchecked pre-fix and the `<no Sid>` fallback then named
-///   nothing (issue #1346, F3);
+/// - a missing or non-string `Sid` (`"Sid": 123`), so every other rejection can
+///   name the statement;
 /// - `NotAction`/`NotResource`/`NotPrincipal`/`Principal` (negated or
 ///   principal-scoped: the guard cannot reason about them);
 /// - any other key outside `HANDLED_STATEMENT_KEYS` (e.g. a `Resources` typo);
 /// - an `Effect` that is neither `Allow` nor `Deny`;
 /// - an `Action` or `Resource` that is neither a string nor a non-empty array
-///   of strings (an empty array is vacuously "all strings", so it slipped past
-///   as a valid set the guards then derived nothing from);
-/// - a missing `Resource` key (the exact shape #1346 records being skipped:
-///   the resource guards read `stmt["Resource"]`, find `Null`, and drop the
-///   statement as having nothing to check);
+///   of strings (an empty array is vacuously "all strings", so it would pass as
+///   a valid set the guards then derive nothing from);
+/// - a missing `Resource` key (the resource guards would read `Null` and treat
+///   the statement as having nothing to check);
 /// - an `Action` element that grants no operation in the vocabulary, so no axis
-///   would select the statement (H3);
+///   would select the statement;
 /// - a `Resource` element `classify_resource` cannot place, quoting the value:
 ///   an S3 access-point or Object Lambda or multi-region-access-point ARN, the
 ///   everything-grant `arn:*`, the bare `"*"`, another bucket's ARN, or a
-///   malformed non-ARN such as `my-ravel-bucket/*` (H1);
+///   malformed non-ARN such as `my-ravel-bucket/*`;
 /// - a `Resource` whose shape belongs to an operation class the statement does
 ///   not grant (an `s3:ListBucket` on an object ARN, an `s3:GetObject` on the
 ///   bare bucket ARN, a KMS ARN on a statement granting no KMS operation), and
-///   conversely a granted class with no resource of its shape (an
-///   `s3:ListBucket` that names no bucket ARN -- the H2 hole, where round
-///   three's list-only exemption left a list statement's Resource read by
-///   nothing at all);
-/// - a `Resource` object-key pattern that admits every key in `key_domain()` (a
-///   bucket-relative `arn:aws:s3:::my-ravel-bucket/*`, which strips to `"*"`, or
-///   any other spelling that excludes nothing, such as `"*/*"`): shape-valid but
-///   vacuous, scoping the object grant no more than naming no key would, the
-///   resource-axis sibling of F1's `"*"` s3:prefix (issue #1346, F1 sweep and
-///   hole ten);
+///   conversely a granted class with no resource of its shape (an `s3:ListBucket`
+///   that names no bucket ARN);
+/// - on an `Allow` only, a `Resource` object-key pattern that admits every key in
+///   `key_domain()` (a bucket-relative `arn:aws:s3:::my-ravel-bucket/*`, which
+///   strips to `"*"`, or any other spelling that excludes nothing, such as
+///   `"*/*"`): shape-valid but vacuous, scoping the grant no more than naming no
+///   key would. On a `Deny` such a pattern is maximally constraining, so it is
+///   accepted;
 /// - a Condition whose presence does not track the ListBucket action: a
 ///   ListBucket statement with no Condition (an unconstrained bucket-wide list),
-///   or a Condition on any non-ListBucket statement (read by no guard) (F2);
+///   or a Condition on any non-ListBucket statement (read by no guard);
 /// - a `Condition` whose sub-shape is anything other than the one block a guard
 ///   reads: it must be a non-empty JSON object of handled operators
 ///   (`HANDLED_CONDITION_OPERATORS`, today `StringLike`), each a non-empty map of
 ///   handled condition keys (`HANDLED_CONDITION_KEYS`, today `s3:prefix`) to a
 ///   string or non-empty array of strings. A different operator, a set-qualified
-///   operator, an unhandled key, or an empty `{}`/`{"StringLike":{}}` (which
-///   constrains nothing) is a shape `list_prefix_patterns` cannot read, so it
-///   fails closed here rather than contributing nothing silently;
-/// - an `s3:prefix` VALUE that admits every key in `key_domain()` (a bare `"*"`,
-///   any all-`"*"` run, `"?*"`, `"*/*"`): shape-valid but vacuous, letting a
-///   caller list the whole bucket exactly as an absent Condition would (issue
-///   #1346, F1 and hole ten).
+///   operator, an unhandled key, or an empty `{}`/`{"StringLike":{}}` is a shape
+///   `list_prefix_patterns` cannot read, so it fails closed here rather than
+///   contributing nothing silently;
+/// - on an `Allow` only, an `s3:prefix` VALUE that admits every key in
+///   `key_domain()` (a bare `"*"`, any all-`"*"` run, `"?*"`, `"*/*"`):
+///   shape-valid but vacuous, letting a caller list the whole bucket exactly as
+///   an absent Condition would. On a `Deny` it is a maximal prohibition and is
+///   accepted.
 fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Result<(), String> {
     let obj = stmt
         .as_object()
@@ -648,7 +634,7 @@ fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Res
     // guard's own failure message names it; a missing Sid, or a non-string
     // `"Sid": 123`, was accepted pre-fix through the `<no Sid>` fallback (Sid is
     // in the handled set but its type was never checked), leaving a statement
-    // whose rejections could name nothing (issue #1346, F3).
+    // whose rejections could name nothing.
     let sid = match obj.get("Sid") {
         Some(serde_json::Value::String(s)) => s.as_str(),
         Some(other) => {
@@ -683,15 +669,15 @@ fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Res
         }
     }
 
-    match obj.get("Effect").and_then(|v| v.as_str()) {
-        Some(e) if e.eq_ignore_ascii_case("Allow") || e.eq_ignore_ascii_case("Deny") => {}
+    let effect = match obj.get("Effect").and_then(|v| v.as_str()) {
+        Some(e) if e.eq_ignore_ascii_case("Allow") || e.eq_ignore_ascii_case("Deny") => e,
         other => {
             return Err(format!(
                 "{role}/{sid} (statement #{index}): Effect is neither \"Allow\" nor \
                  \"Deny\": {other:?}"
             ));
         }
-    }
+    };
 
     if !is_string_or_string_array(obj.get("Action")) {
         return Err(format!(
@@ -723,7 +709,7 @@ fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Res
     // `statement_resources` now return exactly what the policy declares.
     let actions = statement_actions(stmt);
     let resources = statement_resources(stmt);
-    validate_actions_and_resources(role, sid, index, &actions, &resources)?;
+    validate_actions_and_resources(role, sid, index, effect, &actions, &resources)?;
 
     // Condition presence must track the list action. `list_prefix_patterns`
     // is the only Condition reader and only reads one when the Action grants
@@ -734,13 +720,10 @@ fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Res
     //    guard: a StringLike/s3:prefix on the protected-delete Deny would pass
     //    validation while, in AWS, a DeleteObject request carries no s3:prefix
     //    context key, so the Deny never fires and protects nothing).
-    // (issue #1346, F2)
     //
     // The list grant is decided by `action_grants`, the same predicate every
     // other axis uses, so `"Action": "s3:*"` -- which grants ListBucket -- is
-    // required to carry a Condition here too. Under round three's exact-name
-    // detection it was not, and `list_prefix_patterns` then read nothing from it
-    // (issue #1346, H3).
+    // required to carry a Condition here too.
     let grants_list = any_action_grants_any(&actions, &S3_BUCKET_OPERATIONS);
     match obj.get("Condition") {
         Some(condition) => {
@@ -752,7 +735,7 @@ fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Res
                      statement sits unexamined and must fail closed"
                 ));
             }
-            validate_condition(role, sid, index, condition)?;
+            validate_condition(role, sid, index, effect, condition)?;
         }
         None => {
             if grants_list {
@@ -773,15 +756,13 @@ fn validate_statement(role: &str, index: usize, stmt: &serde_json::Value) -> Res
 /// operation in the vocabulary, and every resource must have a shape that some
 /// granted operation class asks for, with no granted class left without one.
 ///
-/// This is what makes the resource helpers total. Round three put the same
-/// question inside `bucket_relative_s3_pattern`, which meant each helper decided
-/// on its own which resources it understood, and everything else came back as
-/// "nothing to check": an access-point ARN, an Object Lambda ARN, `arn:*` and a
-/// malformed `my-ravel-bucket/*` were all real S3 object grants reaching outside
-/// the bucket and all silently dropped (H1), and the list-only exemption added to
-/// keep the bare bucket ARN from tripping the strip left list statements'
-/// Resource examined by nothing at all (H2). Asking it here instead answers it
-/// once, for every axis, before any helper runs.
+/// This is what makes the resource helpers total. Deciding it here, once, for
+/// every axis before any helper runs, is what keeps a helper from deciding on its
+/// own which resources it understands and answering "nothing to check" for the
+/// rest: an access-point ARN, an Object Lambda ARN, `arn:*`, or a malformed
+/// `my-ravel-bucket/*` is a real S3 object grant reaching outside the bucket and
+/// must fail here, not be silently dropped, and a list grant's bare bucket ARN
+/// must be examined rather than exempted.
 ///
 /// The three classes are independent, so a statement granting several carries the
 /// resources of each. That is what makes the normal IAM idiom -- one statement
@@ -791,6 +772,7 @@ fn validate_actions_and_resources(
     role: &str,
     sid: &str,
     index: usize,
+    effect: &str,
     actions: &[String],
     resources: &[&str],
 ) -> Result<(), String> {
@@ -829,22 +811,25 @@ fn validate_actions_and_resources(
                     ));
                 }
                 // The object-key VALUE must constrain, not merely have the object
-                // shape: `arn:aws:s3:::my-ravel-bucket/*` strips to `*`, which
-                // matches every key in the bucket, so it scopes the object grant
-                // no more than naming no key prefix at all -- the same vacuity F1
-                // closes for an s3:prefix, on the resource axis (issue #1346, F1
-                // sweep). Vacuity is decided against `key_domain()`, so the
-                // spellings that dodge the empty-string reading (`*/*`, `?*`) are
-                // caught too (issue #1346, hole ten). A bounded prefix (`t/*`,
-                // `sys/*`) excludes keys outside it and is unaffected.
-                if glob_admits_everything(key) {
+                // shape -- but only on an `Allow`. On an `Allow`, a pattern that
+                // matches every key in `key_domain()` scopes the grant no more
+                // than naming no key prefix would, so it is refused. On a `Deny`
+                // the same pattern is MAXIMALLY constraining -- it prohibits every
+                // object in the bucket, the safest hardening an operator can make
+                // -- so it must not be refused with a grant-worded reason. The
+                // justification below is written in terms of a grant and does not
+                // transfer to a prohibition, so the check is gated on the Effect.
+                // Vacuity is decided against `key_domain()`, so `*/*` and `?*`,
+                // which match every key without matching the empty string, are
+                // refused alongside the bare `*`. A bounded prefix (`t/*`,
+                // `sys/*`) excludes some key and is accepted on either Effect.
+                if effect.eq_ignore_ascii_case("Allow") && glob_admits_everything(key) {
                     return Err(format!(
-                        "{role}/{sid} (statement #{index}): Resource {resource:?} strips to the \
-                         object-key pattern {key:?}, which matches every key shape this file \
+                        "{role}/{sid} (statement #{index}): Allow Resource {resource:?} strips to \
+                         the object-key pattern {key:?}, which matches every key shape this file \
                          knows about under {BUCKET_ARN:?} -- a full-bucket object grant constrains \
                          no more than naming no key scope at all; it must name a bounded key \
-                         prefix that excludes some key the system can produce (issue #1346, F1 \
-                         sweep and hole ten)"
+                         prefix that excludes some key the system can produce"
                     ));
                 }
                 saw_object = true;
@@ -922,7 +907,7 @@ fn validate_actions_and_resources(
 /// such as `s3:delimiter`, a non-object Condition, or an empty `{}` /
 /// `{"StringLike": {}}` (a `for` over an empty map iterates zero times, so it used
 /// to return Ok and constrain nothing) -- is a shape no guard reasons about and is
-/// rejected by name (issue #1346, F2). Without this, a ListBucket statement
+/// rejected by name. Without this, a ListBucket statement
 /// carrying such a Condition passes validation and `list_prefix_patterns` then
 /// finds no `["StringLike"]["s3:prefix"]` array and silently contributes nothing.
 ///
@@ -936,11 +921,12 @@ fn validate_actions_and_resources(
 /// `key_domain()` such as `"?*"` or `"*/*"` -- passes every shape check yet lets
 /// a caller list the whole bucket, constraining no more than an absent
 /// Condition. It is rejected for the same reason the empty block is, one level
-/// down in the value (issue #1346, F1 and hole ten).
+/// down in the value.
 fn validate_condition(
     role: &str,
     sid: &str,
     index: usize,
+    effect: &str,
     condition: &serde_json::Value,
 ) -> Result<(), String> {
     let cond_obj = condition.as_object().ok_or_else(|| {
@@ -992,23 +978,24 @@ fn validate_condition(
                      neither a string nor a non-empty array of strings: {value:?}"
                 ));
             }
-            // Shape is not enough: the VALUE must constrain. A shape-valid
-            // s3:prefix that admits everything (a bare "*", any all-"*" run) lets
-            // a caller pass the empty prefix and list the whole bucket, exactly as
-            // an absent Condition would -- the same emptiness the empty-map arms
-            // above reject, one level down in the value (issue #1346, F1). The
-            // empty-block rejection says an empty block "constrains nothing"; that
-            // is equally true of a "*" value, so it fails here too. Gated on
-            // s3:prefix because "admits everything" is a glob-prefix reading; a
-            // future handled key with different value semantics would need its own.
-            if cond_key == "s3:prefix" {
+            // Shape is not enough: the VALUE must constrain -- but only on an
+            // `Allow`, for the same reason the object-key vacuity check is gated
+            // (see `validate_actions_and_resources`). On an `Allow`, a shape-valid
+            // s3:prefix that admits everything lets a caller list the whole bucket
+            // exactly as an absent Condition would. On a `Deny`, an s3:prefix that
+            // matches every request prohibits every list, which is maximally
+            // constraining; refusing it with a grant-worded reason inverts the
+            // fact. Gated on s3:prefix because "admits everything" is a glob-prefix
+            // reading; a future handled key with different value semantics would
+            // need its own.
+            if effect.eq_ignore_ascii_case("Allow") && cond_key == "s3:prefix" {
                 for prefix in condition_value_strings(value) {
                     if glob_admits_everything(prefix) {
                         return Err(format!(
-                            "{role}/{sid} (statement #{index}): Condition {operator:?}.{cond_key:?} \
-                             value {prefix:?} admits every key shape this file knows about, so it \
-                             constrains no more than an absent Condition -- an s3:prefix must \
-                             exclude some key the system can produce (issue #1346, F1 and hole ten)"
+                            "{role}/{sid} (statement #{index}): Allow Condition \
+                             {operator:?}.{cond_key:?} value {prefix:?} admits every key shape this \
+                             file knows about, so it constrains no more than an absent Condition -- \
+                             an s3:prefix must exclude some key the system can produce"
                         ));
                     }
                 }
@@ -1031,7 +1018,7 @@ fn condition_value_strings(value: &serde_json::Value) -> Vec<&str> {
 /// True only for a JSON string or a non-empty array whose every element is a
 /// string. An empty array is rejected: `iter().all(..)` is vacuously true on it,
 /// so `"Action": []` / `"Resource": []` used to pass and every downstream guard
-/// then derived an empty set and skipped the statement (issue #1346).
+/// then derived an empty set and skipped the statement.
 fn is_string_or_string_array(value: Option<&serde_json::Value>) -> bool {
     match value {
         Some(serde_json::Value::String(_)) => true,
@@ -1088,7 +1075,7 @@ fn load_policy(role: &'static str) -> Policy {
 /// is exactly this against the fixed `deploy/iam/{role}.json` paths; a
 /// regression test drives it with a synthetic invalid file so the validation is
 /// exercised through the entry point production uses, not only through
-/// `build_policy` (issue #1346, F4).
+/// `build_policy`.
 fn load_policy_from(role: &'static str, path: &str) -> Policy {
     let text = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
     let json: serde_json::Value =
@@ -1151,7 +1138,7 @@ fn statement_sid(stmt: &serde_json::Value) -> &str {
 /// result as the prefixes a role is ALLOWED to list, so it must pass
 /// `Some("Allow")`: pooling a `Deny` block's `s3:prefix` into that vector would
 /// assert the inverse of the fact, admitting a discovery prefix that an explicit
-/// Deny withdraws (issue #1346, F1). A caller that only checks each prefix names a
+/// Deny withdraws. A caller that only checks each prefix names a
 /// real key shape (`every_in_scope_policy_pattern_matches_a_real_key_shape`) is
 /// effect-agnostic and passes `None`.
 ///
@@ -1216,30 +1203,27 @@ fn policy_statements(policy: &Policy) -> &Vec<serde_json::Value> {
 /// - `ObjectKey` is the pattern to check, returned.
 /// - `Bucket` contributes nothing to strip. Skipping it is safe because
 ///   `validate_actions_and_resources` proved the same statement grants a list
-///   operation, and a list grant is checked on both counts: its Resource must be
-///   exactly this ARN, and its Condition must be the `s3:prefix` block
-///   `list_prefix_patterns` reads. This is the arm that makes the normal mixed
-///   ListBucket+GetObject idiom work without a misleading rejection, and round
-///   three's alternative -- exempting whole list statements at the caller --
-///   is what left list Resources read by nothing (H2).
+///   operation, whose Resource must be exactly this ARN and whose Condition must
+///   be the `s3:prefix` block `list_prefix_patterns` reads. This arm makes the
+///   normal mixed ListBucket+GetObject idiom work without a misleading rejection;
+///   exempting whole list statements at the caller instead would leave their
+///   Resources read by nothing.
 /// - `KmsKey` likewise: the choke point proved the statement grants a KMS
 ///   operation, so `kms_statement_resources` selects it and both KMS resource
 ///   guards run over this exact string.
 /// - `Unclassified` panics. The choke point rejects it, so reaching here means a
 ///   guard ran on a statement that never passed validation (a synthetic fixture
 ///   built straight from `Policy`), and the loud failure is the belt-and-braces
-///   half of the H1 fix.
+///   half of the unclassified-resource fix.
 ///
-/// A bucket-relative FULL-bucket object grant `arn:aws:s3:::my-ravel-bucket/*`
-/// (which strips to `"*"` and matches every key) is now rejected at the choke
-/// point by `validate_actions_and_resources`: it is the vacuous-value sibling of
-/// F1's `"*"` s3:prefix, on the resource axis, so a shape-valid object ARN that
-/// constrains nothing fails there rather than reaching
-/// `every_in_scope_policy_pattern_matches_a_real_key_shape` -- which asserts a
-/// pattern matches AT LEAST ONE real key and so, being a coverage check, cannot
-/// reject an over-broad pattern (issue #1346, F1 sweep). Rejecting an in-bucket
-/// grant that is merely too wide but still bounded (`t/*`) remains a separate
-/// guard, out of scope here.
+/// An `Allow` full-bucket object grant `arn:aws:s3:::my-ravel-bucket/*` (which
+/// strips to `"*"` and matches every key) is rejected earlier, at the choke point
+/// by `validate_actions_and_resources`, so a shape-valid object ARN that
+/// constrains nothing never reaches `every_in_scope_policy_pattern_matches_a_real_key_shape`
+/// -- a coverage check, which asserts a pattern matches AT LEAST ONE real key and
+/// so cannot reject an over-broad pattern. Rejecting an in-bucket grant that is
+/// merely too wide but still bounded (`t/*`) remains a separate guard, out of
+/// scope here.
 fn object_key_patterns(role: &str, sid: &str, resources: &[&str]) -> Vec<String> {
     let mut out = Vec::new();
     for resource in resources {
@@ -1262,13 +1246,10 @@ fn object_key_patterns(role: &str, sid: &str, resources: &[&str]) -> Vec<String>
 /// `effect` (`None` matches any) and whose `Action` grants at least one of
 /// `operations`.
 ///
-/// The single resource-collection loop every S3 axis uses. Round three had four
-/// near-copies of it (read, put, delete-Allow, delete-Deny) that differed in
-/// which actions they selected, whether the selection resolved wildcards, and
-/// what they did with a resource they could not strip; the read copy and the
-/// delete copy then disagreed about the bare bucket ARN, which is how the
-/// list-only exemption got added to one of them. There is now one loop, one
-/// action predicate, and one resource classifier.
+/// The single resource-collection loop every S3 axis uses: one loop, one action
+/// predicate, one resource classifier. Per-axis near-copies would let two of them
+/// disagree about a shape such as the bare bucket ARN, which is what an
+/// exemption added to one copy but not another once did.
 ///
 /// The `continue`s are axis selection, not shape skips: "this statement grants
 /// no operation on my axis" and "this statement is the other Effect". The choke
@@ -1356,7 +1337,7 @@ fn resource_key_patterns(policy: &Policy) -> Vec<String> {
 /// writes a role performs and then demands a KMS grant for them, so a `Deny`
 /// PutObject read as a routed write would demand a KMS grant for a write the role
 /// cannot perform --- the inverse of the fact, since an explicit Deny withdraws
-/// the write (issue #1346, F1/F2). Passing `None` here left `Deny` matching, so
+/// the write. Passing `None` here left `Deny` matching, so
 /// the sentence above was true of Delete/Get and false of Deny; `Some("Allow")`
 /// makes it true.
 ///
@@ -1419,7 +1400,7 @@ const WRITE_ROLES: [&str; 3] = ["gateway", "maintain", "query"];
 /// vector would report a role able to mint ciphertext when the Deny withdraws
 /// exactly that, and would make the negative admin assertion fail on a policy that
 /// safely denies the operation --- the inverse of the fact in both directions
-/// (issue #1346, F1 sweep). A `Deny` KMS statement passes the choke point, so this
+///. A `Deny` KMS statement passes the choke point, so this
 /// case is reachable, not hypothetical.
 ///
 /// Selection goes through `action_selects_kms`, so `KMS:GenerateDataKey*` is
@@ -1458,7 +1439,7 @@ fn kms_actions(policy: &Policy) -> Vec<String> {
 /// `Deny` naming `key/*` is a broad prohibition (safe), yet these guards would
 /// flag it as an account-wide grant --- the inverse of the fact. A `Deny` KMS
 /// statement passes the choke point, so this is reachable; scoping is asked only
-/// of the grants (issue #1346, F1 sweep).
+/// of the grants.
 ///
 /// The returned resources are filtered to `ResourceShape::KmsKey`, so a mixed
 /// statement's S3 object ARNs are not handed to the KMS ARN-shape assertions
@@ -1543,14 +1524,13 @@ fn roles_writing_routed_objects_have_kms_grant() {
 /// assertions on a synthetic policy rather than a re-typed copy of them (the
 /// same pattern `assert_admin_delete_grant_is_scratch_only` uses).
 ///
-/// An EMPTY routed set is a failure here, not a skip. Pre-fix the body read
-/// `if routed.is_empty() { continue; }`, so widening a non-exempt write role's
-/// PutObject `Resource` to a pattern the routing predicate does not recognize
-/// emptied the set and silently retired the KMS requirement for that role: the
-/// guard reported nothing while the role kept its PUT grant (issue #1346, hole
-/// twelve). Every shipped role PUTs at least one `t/<hash>/...` object, so the
-/// only way to reach an empty set is a widening or a deletion, and both must be
-/// loud. The exemption-honesty check reads off the same assertion.
+/// An EMPTY routed set is a failure here, not a skip. A body that read
+/// `if routed.is_empty() { continue; }` let a non-exempt write role widen its
+/// PutObject `Resource` to a pattern the routing predicate does not recognize,
+/// empty the set, and silently retire the KMS requirement for that role while
+/// keeping its PUT grant. Every shipped role PUTs at least one `t/<hash>/...`
+/// object, so the only way to reach an empty set is a widening or a deletion, and
+/// both must be loud. The exemption-honesty check reads off the same assertion.
 fn assert_role_routed_writes_have_kms_grant(policy: &Policy) {
     let role = policy.role;
     let puts = put_resource_key_patterns(policy);
@@ -1637,7 +1617,7 @@ fn assert_role_routed_writes_have_kms_grant(policy: &Policy) {
 // `assert_admin_delete_grant_is_scratch_only` happens to assert exact equality
 // on admin's delete grant. Every other guard asks a one-sided question ("does
 // SOME pattern do X?"), which a Deny turning into an Allow, or vanishing,
-// cannot make false (issue #1346, hole eleven). Generalising that exact-equality
+// cannot make false. Generalising that exact-equality
 // shape to every role and every axis is what makes the Effect load-bearing.
 //
 // The form is deliberate: an Allow set and a Deny set per axis, each by exact
@@ -2118,17 +2098,16 @@ fn every_shipped_deny_is_a_delete_only_prohibition() {
 /// key, exactly. `(Deny pattern, Allow pattern)` pairs, per role, sorted and
 /// deduplicated, witnessed by at least one key in `key_domain()`.
 ///
-/// Round six asserted nothing here and claimed "the only shipped `Deny` is
-/// `DenyDeleteProtected`, a delete-only prohibition DISJOINT FROM EVERY ALLOW".
-/// The delete-only half is true (`every_shipped_deny_is_a_delete_only_prohibition`
-/// pins it); the disjointness half is FALSE, and measuring it is what found that
-/// out. Maintain's level-based delete grants cover the legal-hold audit shard:
-/// an `Signal::Audit` shard-0 key is spelled `t/<hash>/u/{l0,c,l1}/0000/...`, so
-/// `t/*/*/l0/*` and `t/*/u/*/0000/*` both match it. That is the protection
-/// working as ADR-0055 section 3 designs it, not a template bug: an explicit IAM
-/// `Deny` overrides the `Allow`, so the effective capability is correct. What is
-/// wrong is reading the `Allow` set alone as the delete capability the role
-/// HOLDS -- for these three pattern pairs it overstates.
+/// This is the ONE normative home in this file for the Deny-override fact; other
+/// helpers point here rather than restate it. An explicit IAM `Deny` overrides an
+/// `Allow` only for the operations it NAMES, so a delete `Deny` and a delete
+/// `Allow` can cover the same key and the effective capability is still correct.
+/// The shipped overlap is maintain's: its level-based delete grants reach the
+/// legal-hold audit shard, because an `Signal::Audit` shard-0 key is spelled
+/// `t/<hash>/u/{l0,c,l1}/0000/...`, so `t/*/*/l0/*` and `t/*/u/*/0000/*` both
+/// match it. That is ADR-0055 section 3 protection working, not a template bug.
+/// What is wrong is reading the `Allow` set alone as the delete capability the
+/// role HOLDS -- for these three pattern pairs it overstates.
 ///
 /// Pinning the overlap rather than asserting it away fails in both directions: a
 /// new overlap (a widened delete grant reaching a protected keyspace) and a
@@ -2204,7 +2183,7 @@ fn delete_deny_and_allow_overlap_exactly_where_expected() {
         // the overlap below examined nothing for those keyspaces and still
         // reported the pinned overlap set as complete. Refusing each pattern by
         // name fails closed on any protected or granted keyspace the domain does
-        // not model (#1346).
+        // not model.
         for pattern in &protected {
             assert_pattern_is_witnessed(role, "delete Deny (protected)", pattern);
         }
@@ -2330,11 +2309,10 @@ fn all_signals_is_exhaustive_and_witnessed() {
 /// "hold for a different reason than" the legal-hold shard: they are disjoint
 /// from every delete grant, so their `Deny` is belt-and-suspenders, while the
 /// legal-hold shard `t/*/u/*/0000/*` IS reached by maintain's level-based delete
-/// grants and holds only because the explicit `Deny` overrides them. Round eight
-/// added that sentence by inspection; this backs it now that the domain carries
-/// catalog and prov witnesses (`constructor_free_tenant_witness_keys`): no delete
-/// `Allow` pattern in any template matches a witness key of those three
-/// keyspaces.
+/// grants and holds only because the explicit `Deny` overrides them. This backs
+/// that ADR sentence now that the domain carries catalog and prov witnesses
+/// (`constructor_free_tenant_witness_keys`): no delete `Allow` pattern in any
+/// template matches a witness key of those three keyspaces.
 ///
 /// Scoped to DELETE on purpose. The ADR sentence is about delete capability;
 /// get and put legitimately reach catalog and prov (fold reads and writes catalog
@@ -2367,7 +2345,7 @@ fn no_delete_allow_reaches_the_disjoint_protected_keyspaces() {
     // entry here (or this fails loudly and names it), emptying this list fails,
     // and dropping an entry fails. Nothing else asserts this relationship, so a
     // new protected keyspace could otherwise be added with every other assertion
-    // green and its disjointness from delete grants never checked (#1346).
+    // green and its disjointness from delete grants never checked.
     const LEGAL_HOLD_SHARD: &str = "t/*/u/*/0000/*";
     assert!(
         PROTECTED_DELETE_KEYS.contains(&LEGAL_HOLD_SHARD),
@@ -2815,27 +2793,21 @@ fn admin_delete_grant_is_qualify_scratch_only() {
     assert_admin_delete_grant_is_scratch_only(&policy);
 }
 
-/// The pre-fix Allow side of `delete_key_patterns`, kept verbatim so the fixture below
-/// pins the two holes existed independent of the fixed code: delete capability
+/// The historical Allow side of `delete_key_patterns`, kept verbatim so the
+/// fixture below pins two holes independent of the fixed code: delete capability
 /// recognized only by an exact `s3:DeleteObject` match, and any resource not
 /// under the bucket prefix silently dropped (`if let Some(..)` with no `else`).
+/// It spells out exactly the two comparisons whose holes it pins
+/// (`eq_ignore_ascii_case` on the action, `strip_prefix` against a literal ARN);
+/// reusing today's live predicate would make the fixture a tautology the moment
+/// that predicate changed.
 ///
-/// A pre-fix body spells out the comparison whose HOLE it pins, and only that
-/// one: here `eq_ignore_ascii_case` on the action and `strip_prefix` against a
-/// literal ARN on the resource, because those two are the holes. A pre-fix copy
-/// that reused today's predicate for the axis it is proving would stop proving
-/// the hole the moment that predicate changed, which is how a fixture becomes a
-/// tautology.
-///
-/// Everything that is NOT the hole still goes through live code, and that is
-/// deliberate: this body reads `statement_actions`, and
-/// `pre_fix_validate_condition` calls the live `is_string_or_string_array` and
-/// the live handled-operator and handled-key constants. So an assertion whose
-/// whole content is "a pre-fix body came back empty" can be satisfied by a
-/// regression in that live code instead of by the historical hole, and it has
-/// to pin WHY the result was empty from the raw JSON alongside. The fixture
-/// below is the pattern: it asserts the pre-fix delete set exactly, then
-/// asserts separately which of the two holes swallowed the statement.
+/// Everything that is NOT the hole still goes through live code, so an assertion
+/// whose whole content is "this body came back empty" could be satisfied by a
+/// regression in that live code instead of by the hole. The fixture pins WHY the
+/// result was empty from the raw JSON alongside: it asserts the delete set
+/// exactly, then asserts separately which of the two holes swallowed the
+/// statement.
 fn pre_fix_allow_delete_key_patterns(policy: &Policy) -> Vec<String> {
     let mut out = Vec::new();
     for stmt in policy_statements(policy) {
@@ -2866,39 +2838,31 @@ fn pre_fix_allow_delete_key_patterns(policy: &Policy) -> Vec<String> {
     out
 }
 
-/// Regression fixture for the delete-capability holes (issue #1372, the seventh
-/// in the skip-what-you-don't-recognize sequence #1346 tracks). The pre-fix
-/// guard recognized a delete grant only by an exact `s3:DeleteObject` match and
-/// silently dropped any resource not under the bucket prefix. So a statement
-/// granting `s3:*`/`s3:Delete*`/`*` on any resource, or `s3:DeleteObject` on
-/// `"*"` or a different bucket, was invisible to it: the delete-pattern helper
-/// returned an empty set and the assertion "Admin's only delete Allow is
-/// sys/qualify/*" passed while a delete-everywhere grant sat unexamined.
-///
-/// Two independent holes, both closed: the Action is matched as an IAM wildcard
-/// pattern (ASCII-folded, `*`/`?` resolved), and a delete-capable statement
-/// whose Resource is not bucket-relative is a test failure naming the Sid, never
-/// a dropped entry.
+/// Regression fixture for the two delete-capability holes: a delete grant
+/// recognized only by an exact `s3:DeleteObject` match, and a resource not under
+/// the bucket prefix silently dropped. So a statement granting
+/// `s3:*`/`s3:Delete*`/`*` on any resource, or `s3:DeleteObject` on `"*"` or a
+/// different bucket, was invisible: the delete-pattern helper returned an empty
+/// set and "Admin's only delete Allow is sys/qualify/*" passed while a
+/// delete-everywhere grant sat unexamined. Both closed: the Action is matched as
+/// an IAM wildcard pattern (ASCII-folded, `*`/`?` resolved), and a delete-capable
+/// statement whose Resource is not bucket-relative is a test failure naming the
+/// Sid, never a dropped entry.
 ///
 /// Synthetic statements, not `deploy/iam/*.json`: a fixture over the shipped
-/// (correct) admin policy passes whichever way the matcher behaves and proves
-/// nothing about the matcher.
+/// (correct) admin policy passes whichever way the matcher behaves.
 ///
 /// Each fixture carries the WHOLE bypass shape, not just the permissive
-/// statement: admin's shipped `s3:DeleteObject` Allow on `sys/qualify/*`, which
-/// the pre-fix exact match does see; the permissive statement, which it does
-/// not; and a `DenyDeleteProtected` block. That combination is what makes the
-/// fixture reach the same PASSING state under the pre-fix derivation that
-/// admin's real policy reaches, so only the post-fix derivation rejects. A
-/// fixture holding the permissive statement alone panics on the scratch-only
-/// `assert_eq` either way (its delete set can never be `["sys/qualify/*"]`),
-/// which makes a bare `is_err()` unfalsifiable: measured, the suite stayed
-/// 50/0 with both historical holes reintroduced.
-///
-/// So each case asserts in both directions, and names WHICH direction: the
-/// pre-fix derivation returns exactly the scratch prefix (hiding the grant, so
-/// the scratch-only assertion passes over it) and the post-fix guard rejects
-/// with that case's expected message.
+/// statement: admin's shipped `s3:DeleteObject` Allow on `sys/qualify/*` (which
+/// the exact match sees), the permissive statement (which it does not), and a
+/// `DenyDeleteProtected` block. That combination makes the fixture reach the same
+/// PASSING state under the historical derivation that admin's real policy
+/// reaches, so only the post-fix derivation rejects. A fixture holding the
+/// permissive statement alone panics on the scratch-only `assert_eq` either way,
+/// which makes a bare `is_err()` unfalsifiable. So each case asserts in both
+/// directions and names WHICH: the historical derivation returns exactly the
+/// scratch prefix (hiding the grant), and the post-fix guard rejects with that
+/// case's expected message.
 #[test]
 fn wildcard_or_out_of_bucket_delete_grant_is_not_a_bypass() {
     // The two post-fix rejection paths, as a substring of the panic each
@@ -3476,12 +3440,12 @@ fn single_character_wildcard_in_kms_resource_is_not_a_bypass() {
     }
 }
 
-/// Regression fixtures for the fail-closed choke point (issue #1346, the fourth
-/// instance of the skip-what-you-do-not-understand class this guard keeps
-/// repeating: could not read `Resource`; matched the action prefix
-/// case-sensitively; accepted `?` in ARN segments; and now ignores
-/// `NotResource`/`NotAction`). Before this fix, `load_policy` performed no
-/// per-statement validation, so a statement whose permission lived in a field
+/// Regression fixtures for the fail-closed choke point, closing the
+/// skip-what-you-do-not-understand class this guard exists for: a statement that
+/// could not read `Resource`, a case-sensitive action-prefix match, a `?`
+/// accepted in ARN segments, and `NotResource`/`NotAction` ignored. Before this,
+/// `load_policy` performed no per-statement validation, so a statement whose
+/// permission lived in a field
 /// no guard reads -- `NotResource`, `NotAction`, an unrecognized key such as a
 /// `Resources` typo, or a statement with no `Resource` at all -- was loaded and
 /// then silently skipped by whichever guard went looking for a field it did not
@@ -3703,13 +3667,13 @@ fn malformed_effect_action_or_resource_fails_closed() {
     }
 }
 
-/// F2 regression: an empty `Action`/`Resource` array must fail closed. Pre-fix,
+/// An empty `Action`/`Resource` array must fail closed. Before the fix,
 /// `is_string_or_string_array` returned true for `[]` (`iter().all(..)` is
 /// vacuously true on an empty array), so `"Action": []` / `"Resource": []`
-/// passed validation and every downstream guard derived an empty set and
-/// skipped the statement -- the skip class #1346 tracks, one level inside a
-/// handled key. Synthetic, not `deploy/iam/*.json`: the shipped templates carry
-/// no empty arrays.
+/// passed validation and every downstream guard derived an empty set and skipped
+/// the statement -- the same skip class, one level inside a handled key.
+/// Synthetic, not `deploy/iam/*.json`: the shipped templates carry no empty
+/// arrays.
 #[test]
 fn empty_action_or_resource_array_fails_closed() {
     let cases = [
@@ -3949,7 +3913,7 @@ fn discovery_prefix_admitted_for_every_discovering_role() {
         let policy = load_policy(role);
         // Allow-only: an explicit Deny ListBucket withdraws listing, so its
         // s3:prefix is not a prefix the role is ALLOWED to discover. Reading it
-        // here would assert the inverse of the fact (issue #1346, F1).
+        // here would assert the inverse of the fact.
         let patterns = list_prefix_patterns(&policy, Some("Allow"));
         assert!(
             patterns.iter().any(|p| glob_matches(p, "t/")),
@@ -4433,6 +4397,93 @@ fn full_bucket_object_resource_fails_closed() {
         validate_statement("fixture", 0, &bounded).is_ok(),
         "a bounded object prefix must pass: {:?}",
         validate_statement("fixture", 0, &bounded)
+    );
+}
+
+/// The other direction of the resource-vacuity rule: on a `Deny`, an object-key
+/// pattern that matches every key is MAXIMALLY constraining -- it prohibits
+/// every object in the bucket -- so it must LOAD, not be refused with the
+/// grant-worded reason. Widening `DenyDeleteProtected`'s Resource to the whole
+/// bucket is the safest hardening an operator can make (it denies both delete
+/// operations on every object), and before the Effect gate it took the suite red.
+/// Synthetic: no shipped template names a whole-bucket Deny resource.
+#[test]
+fn whole_bucket_deny_resource_is_maximally_constraining_and_loads() {
+    let deny_whole_bucket = serde_json::json!({
+        "Sid": "DenyDeleteProtected",
+        "Effect": "Deny",
+        "Action": ["s3:DeleteObject", "s3:DeleteObjectVersion"],
+        "Resource": "arn:aws:s3:::my-ravel-bucket/*",
+    });
+    // The specific thing: the guard that used to panic on the vacuous key now
+    // returns Ok, so the statement passes the choke point.
+    assert!(
+        validate_statement("fixture", 0, &deny_whole_bucket).is_ok(),
+        "a Deny whose Resource matches every key must pass the choke point: {:?}",
+        validate_statement("fixture", 0, &deny_whole_bucket)
+    );
+    // And a whole policy carrying it loads through build_policy (load_policy's body).
+    let policy = build_policy(
+        "fixture",
+        "<synthetic>",
+        &serde_json::json!({ "Statement": [deny_whole_bucket] }),
+    );
+    assert_eq!(
+        policy_statements(&policy).len(),
+        1,
+        "the synthetic Deny policy must load with its one statement"
+    );
+
+    // The `Allow` side is unchanged. A synthetic `Allow` with the same
+    // whole-bucket object pattern is still refused, with the grant-worded
+    // message. `full_bucket_object_resource_fails_closed` pins this for the
+    // object axis; restated here so both directions sit together.
+    let allow_whole_bucket = serde_json::json!({
+        "Sid": "FullBucketObject",
+        "Effect": "Allow",
+        "Action": "s3:DeleteObject",
+        "Resource": "arn:aws:s3:::my-ravel-bucket/*",
+    });
+    let err = validate_statement("fixture", 0, &allow_whole_bucket)
+        .expect_err("an Allow whose Resource matches every key must still be refused");
+    assert!(
+        err.contains("matches every key"),
+        "the Allow rejection must keep the grant-worded message; got {err:?}"
+    );
+}
+
+/// The list-prefix half of the same rule. On a `Deny` ListBucket, an s3:prefix
+/// that admits every request prohibits every list, which is maximally
+/// constraining, so it must LOAD. On an `Allow` an admits-everything s3:prefix is
+/// still refused (`vacuous_s3_prefix_value_fails_closed` pins that). Synthetic:
+/// no shipped template carries a Deny ListBucket.
+#[test]
+fn whole_bucket_deny_list_prefix_is_maximally_constraining_and_loads() {
+    let deny_star = serde_json::json!({
+        "Sid": "DenyListEverything",
+        "Effect": "Deny",
+        "Action": "s3:ListBucket",
+        "Resource": BUCKET_ARN,
+        "Condition": {"StringLike": {"s3:prefix": ["*"]}},
+    });
+    assert!(
+        validate_statement("fixture", 0, &deny_star).is_ok(),
+        "a Deny s3:prefix `*` denies every list request and must load: {:?}",
+        validate_statement("fixture", 0, &deny_star)
+    );
+
+    // The `Allow` side is unchanged: an admits-everything s3:prefix on an Allow
+    // still fails closed.
+    let allow_star = serde_json::json!({
+        "Sid": "ListEverything",
+        "Effect": "Allow",
+        "Action": "s3:ListBucket",
+        "Resource": BUCKET_ARN,
+        "Condition": {"StringLike": {"s3:prefix": ["*"]}},
+    });
+    assert!(
+        validate_statement("fixture", 0, &allow_star).is_err(),
+        "an Allow s3:prefix `*` must still fail closed"
     );
 }
 
@@ -5199,11 +5250,10 @@ fn load_policy_from_rejects_a_synthetic_invalid_file() {
 }
 
 // ---------------------------------------------------------------------------
-// Round four (issue #1346, holes H1/H2/H3): the redesign's own fixtures.
-//
-// Round three's `bucket_relative_s3_pattern` and the list-only exemption its
-// callers carried, kept verbatim, so each fixture below pins the hole it closes
-// instead of restating today's rule.
+// Fixtures for the total-shape redesign. The earlier
+// `bucket_relative_s3_pattern` and the list-only exemption its callers carried
+// are kept verbatim as `round_three_*` below, so each fixture pins the hole it
+// closes instead of restating today's rule.
 // ---------------------------------------------------------------------------
 
 /// Round three's resource classifier, verbatim: it panicked for exactly two
@@ -5845,6 +5895,21 @@ fn every_shipped_template_passes_the_choke_point() {
                      consequence as for Action above"
                 );
             }
+        }
+
+        // `s3:prefix` Condition values are the third field fed through
+        // `glob_to_regex` (via `glob_admits_everything` in `validate_condition`
+        // and `glob_matches` in `discovery_prefix_admitted_for_every_discovering_role`),
+        // so the no-`?` property must be asserted over them too or the
+        // glob_to_regex doc's citation of this test would overstate its scope.
+        for prefix in list_prefix_patterns(&policy, None) {
+            assert!(
+                !prefix.contains('?'),
+                "{role}: s3:prefix {prefix:?} carries a `?`. glob_to_regex resolves \
+                 it as IAM's single-character wildcard; the doc claim that no \
+                 shipped pattern uses one is now false and every prefix axis in \
+                 this file must be re-read"
+            );
         }
     }
 }

--- a/docs/adrs/0055-storage-credential-scoping.md
+++ b/docs/adrs/0055-storage-credential-scoping.md
@@ -256,10 +256,16 @@ and only over
 `l0/`, `l1/`, `c/`, `idem/`, and the query-audit shard `u/0001/**`
 (amendment below) — never `sys/`, `prov`, `catalog/`, or the legal-hold
 shard `u/0000/**` of the audit prefix. The last of those holds for a
-different reason than the other three: the three protected `sys/` control
-objects (`sys/tenancy`, `sys/qualification`, `sys/gc`), together with `prov`
-and `catalog/`, are disjoint from every delete grant in every template, so
-their `Deny` is belt-and-suspenders.
+different reason than the other three. Take the delete `Allow` patterns of
+all four templates together: they match no key of the form `sys/tenancy`,
+`sys/qualification`, `sys/gc`, `t/<hash>/<signal>/prov`, or
+`t/<hash>/catalog/<signal>/...`, for any `<signal>` the object layout
+defines. So the `Deny` covering those five keyspaces withholds nothing that
+an `Allow` grants, and it is belt-and-suspenders. That disjointness is about
+the delete axis and only the delete axis: `get` and `put` grants do reach
+`prov` and `catalog/` (fold reads and writes catalog objects, the
+log-segment writer writes `prov`), and the same claim over all axes would be
+false.
 `no_delete_allow_reaches_the_disjoint_protected_keyspaces` in
 `crates/ravel-commit/tests/iam_templates.rs` enforces this: it asserts that
 no delete `Allow` pattern in any template matches a witness key of those

--- a/docs/adrs/0055-storage-credential-scoping.md
+++ b/docs/adrs/0055-storage-credential-scoping.md
@@ -255,7 +255,27 @@ compromised Maintain credential retains delete capability over durable data,
 and only over
 `l0/`, `l1/`, `c/`, `idem/`, and the query-audit shard `u/0001/**`
 (amendment below) — never `sys/`, `prov`, `catalog/`, or the legal-hold
-shard `u/0000/**` of the audit prefix, which brings us to §3. Admin's
+shard `u/0000/**` of the audit prefix. The last of those holds for a
+different reason than the other three: the three protected `sys/` control
+objects (`sys/tenancy`, `sys/qualification`, `sys/gc`), together with `prov`
+and `catalog/`, are disjoint from every delete grant in every template, so
+their `Deny` is belt-and-suspenders.
+`no_delete_allow_reaches_the_disjoint_protected_keyspaces` in
+`crates/ravel-commit/tests/iam_templates.rs` enforces this: it asserts that
+no delete `Allow` pattern in any template matches a witness key of those
+five protected patterns. The set is those three named `sys/` control
+objects, not the whole `sys/` prefix, because Admin's `sys/qualify/*`
+scratch-delete grant does reach a key under `sys/` (a
+`sys/qualify/<run-id>/…` object) and is deliberately excluded. An audit
+object is keyed
+`t/<hash>/u/<l0|c|l1>/<shard>/…`, so Maintain's level-based delete grants
+(`t/*/*/l0/*` and its `c`/`l1` siblings) do match legal-hold keys, and the
+`Allow` set alone overstates the capability by exactly that much. What
+withholds it is the explicit `Deny` of §3 over the same keys, which names
+the same two delete actions: a `Deny` overrides an `Allow` only for the
+actions it names, so the deny's action coverage — not a gap in the `Allow`
+patterns — is what makes the shard undeletable. Which brings us to §3.
+Admin's
 `sys/qualify/*` delete (amendment below) reaches only the qualification scratch
 prefix, which is neither tenant data nor a durability anchor.
 

--- a/docs/guides/operations/configuration.md
+++ b/docs/guides/operations/configuration.md
@@ -205,8 +205,14 @@ undeletable even by Maintain.
 shard (`t/*/u/*/0000/*`) is deny-delete for every role including Maintain, so a
 legal hold cannot be destroyed. The query-audit shard (`t/*/u/*/0001/*`) is
 compacted and age-swept on a 90-day window by the Maintain process, so Maintain
-alone grants delete on it. The two are disjoint key paths, so neither grant
-reaches the other shard.
+alone grants delete on it. The two shard paths are disjoint, but Maintain's
+level-based delete grants are not confined to them: an audit object is keyed
+`t/<hash>/u/<level>/<shard>/...`, so `t/*/*/l0/*`, `t/*/*/c/*` and
+`t/*/*/l1/*` match legal-hold keys too. What keeps a legal hold safe is the
+explicit `Deny`, which names both `s3:DeleteObject` and
+`s3:DeleteObjectVersion` on that shard, and a `Deny` overrides an `Allow` only
+for the actions it names. If you edit these policies, keep the deny's action
+list at least as wide as every delete action an `Allow` grants on those keys.
 
 **Tenant discovery needs a bare prefix entry.** Discovery lists the bare,
 delimited `t/` prefix rather than a per-tenant subpath, and under AWS


### PR DESCRIPTION
The guard suite over the four shipped IAM templates in `deploy/iam` has been
blocked seven times by one class of defect: a check that meets a shape or a
value it does not really interrogate, and passes vacuously. This round replaces
sampling with measurement, which is the shape that has actually caught
mutations.

**A vacuity check now asks about keys the system can produce.** The previous
predicate asked whether a pattern matches the empty string, but the classifier
had already rejected the empty key, with a comment saying no key constructor
produces one. So it interrogated a candidate the code declares impossible.
Three spellings dodged it while excluding nothing real: `?*`, `*?*`, and the
plausible operator edit `*/*`, each matching all 67 representative keys.
Vacuity is now defined against the key domain the file can construct, and the
doc comment scopes the claim to that domain rather than asserting more.

That required extending the domain. The representative keys are all tenant
keys, so a literal "matches every representative key" rule would have rejected
`t/*` and failed a correct shipped template. Seven exclusion witnesses, one per
non-tenant keyspace the templates name, sit alongside the corpus. Both
directions are asserted: seven vacuous spellings rejected, ten legitimately
narrow ones accepted, including `t/*`, since rejecting an over-broad but
bounded pattern is a separate concern.

**Grant sets are pinned by exact equality per role and axis.** Nothing
previously asserted that a Deny statement is a Deny; flipping one to Allow
turned six protected key classes into a delete grant with the suite fully
green. An expected-pattern table now pins the Allow and Deny sets for prefixes,
reads, writes, deletes and KMS, by exact equality, so a widened resource, a
flipped effect or a deleted statement all change a set and fail. Glob
difference is not a glob, so the effective set is not faked: both sides are
measured and their overlap is measured with them.

**A claim that rested on the templates rather than the code turned out false.**
The suite documented the shipped Deny as delete-only and disjoint from every
Allow. The first half is now asserted. The second half is wrong: maintain's
level-based delete grants overlap the legal-hold audit-shard protection on
three patterns. The templates are correct, because an explicit IAM Deny wins;
the claim was not. The overlap is pinned as an expectation and the comment
corrected. Two other template-dependent claims are now asserted rather than
assumed.

**An empty derived set is a failure, not a skip.** The routed-write KMS guard
skipped any role whose routed set came out empty, so widening a write role's
resources silenced the requirement instead of tripping it. It now fails on an
empty set, and additionally fails when a non-routing pattern still admits
routed keys.

Seven mutations to shipped templates are recorded with before and after counts,
each reverted afterwards. The four templates are byte-identical to the base and
all four pass unchanged. Suite goes from 14 tests on this PR's base to 51 at its head. (An earlier revision of this description said 39 to 44, which were round seven's figures measured against round six's output rather than against `main`; the same baseline confusion the round-seven review recorded.)

Supersedes #1567.

Fixes: #1346
Refs: #1313


