### PR TITLE
feat(otlp): count normalize rejections and store structured log bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,12 +547,16 @@ jobs:
   # features are off by default and no other job builds them, so a break in
   # any of them -- an unreachable e2e test path, four bench binaries that
   # never link -- ships undetected. This lane proves each combination still
-  # compiles (`cargo check`), and for one of them also runs its tests:
+  # compiles (`cargo check`), and for three of them also runs their tests:
   #   - ravel-server --features otap            (links ravel-otap + arrow tree;
   #                                              the image lanes build it in
   #                                              release together with sql and
-  #                                              flight-sql, this is the fast
-  #                                              probe of the feature alone)
+  #                                              flight-sql, this is the debug
+  #                                              lane for the feature alone.
+  #                                              LINTED with --all-targets and
+  #                                              RUNS its tests: a compile
+  #                                              probe left the feature's own
+  #                                              tests unexecuted)
   #   - ravel-bench --features parquet-baseline (arrow/parquet/object_store)
   #   - ravel-bench --features flight-egress    (ravel-sql/datafusion/flight)
   #   - ravel-bench --features profiling        (pprof/inferno flamegraph lane)
@@ -579,10 +583,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
-    # 30m, not 20m: four separate, mutually non-sharing compile
+    # 40m, not 30m: the probes are separate, mutually non-sharing compile
     # configurations (arrow, parquet, object_store, datafusion, arrow-flight
-    # all appear across the four probes) with no shared incremental state.
-    timeout-minutes: 30
+    # all appear across them) with no shared incremental state, and the otap
+    # lane now also builds ravel-server's test targets and runs them.
+    timeout-minutes: 40
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
@@ -599,8 +604,23 @@ jobs:
         if: steps.sccache.outcome == 'failure'
         run: echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-      - name: Check ravel-server --features otap
-        run: cargo check --locked -p ravel-server --features otap
+        # LINTED and RUN, not compile-probed. `cargo check -p ravel-server
+        # --features otap` never built the crate's test targets, so every test
+        # behind the feature shipped unexecuted and a clippy finding in
+        # feature-gated code could not fail anything. That is the same failure
+        # the `flight-sql` note above describes. `--all-targets` on clippy
+        # builds the test targets the `check` step skipped, so the `cargo test`
+        # below adds the run and little compile.
+      - name: Clippy ravel-server --features otap
+        run: cargo clippy --locked -p ravel-server --features otap --all-targets -- -D warnings
+        # `--lib`, not the whole test set: `tests/cli_reference.rs` asserts
+        # `docs/reference/ravel-server-flags.md` matches the flags of a build
+        # with NO optional features, and that page says in its own header that
+        # `--otap` is absent for that reason. Under `--features otap` the
+        # binary grows `--otap` and that test fails by construction, on any
+        # tree. `--all-targets` on the clippy step above still compiles it.
+      - name: Test ravel-server --features otap
+        run: cargo test --locked -p ravel-server --features otap --lib
       - name: Check ravel-bench --features parquet-baseline
         run: cargo check --locked -p ravel-bench --features parquet-baseline
       - name: Check ravel-bench --features flight-egress

--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ written: the PromQL table from a differential test against a real Prometheus
 binary, and the SQL table from the conformance suite's recorded verdict for
 each construct. The gaps are measured rather than claimed.
 
+Two ingest limits are worth knowing before you point a sender at Ravel:
+
+- Metrics must be cumulative. A delta-temporality `Sum` or `Histogram` is
+  rejected, and the OTLP response says so. Converting delta to cumulative
+  needs per-series state held between requests, and Ravel's compute processes
+  hold no durable local state, so the conversion belongs in the collector: the
+  `deltatocumulative` processor does it, and the
+  [ingest guide](docs/guides/ingest.md#delta-temporality-metrics) has the
+  configuration. Senders you control can usually be set to export cumulative
+  directly instead.
+- A structured log body (an array or a map) is stored as canonical JSON text,
+  not as a nested value. It reads back as a JSON string, so a query that wants
+  a field inside it parses that string.
+
 ## Quickstart
 
 One command starts the whole stack from published images: MinIO for object

--- a/crates/ravel-otlp/src/lib.rs
+++ b/crates/ravel-otlp/src/lib.rs
@@ -26,7 +26,7 @@ pub mod promcompat;
 pub mod traces_limits;
 pub mod traces_normalize;
 
-pub use limits::{IngestLimits, Rejection};
+pub use limits::{AdmissionClass, IngestLimits, NormalizeRejectCounts, Rejection};
 pub use logs_limits::{LogIngestLimits, LogRejection};
 pub use logs_normalize::{LogNormalizeOutput, NormalizedLogRecord, normalize_logs};
 pub use metadata::{MetricKind, MetricMetadata};

--- a/crates/ravel-otlp/src/limits.rs
+++ b/crates/ravel-otlp/src/limits.rs
@@ -386,7 +386,14 @@ impl Rejection {
             | Rejection::IntegerValuePrecisionLoss { .. } => None,
 
             // A grouped rejection carries its own point count; the class is
-            // the shared reason's.
+            // the shared reason's. Delegating is safe only because the metrics
+            // path groups nothing but a `build_resource_labels` failure
+            // (`crate::normalize`), whose reasons are all in the structural arm
+            // above: `LabelNameTooLong`, `LabelValueTooLong`, and
+            // `ComplexAttributeValue`. Grouping a reason that classes `None`
+            // needs this arm to classify the group instead, the way
+            // `crate::logs_limits::LogRejection::admission_class` does, or the
+            // whole-resource loss goes uncounted.
             Rejection::Grouped { reason, .. } => reason.admission_class(),
         }
     }

--- a/crates/ravel-otlp/src/limits.rs
+++ b/crates/ravel-otlp/src/limits.rs
@@ -151,15 +151,13 @@ pub enum Rejection {
     #[error("data point has neither an int nor a double value set")]
     MissingValue,
 
-    #[error("metric type {metric_type} is not supported in phase 1; rejecting {count} data points")]
+    #[error("metric type {metric_type} is not supported; rejecting {count} data points")]
     UnsupportedMetricType {
         metric_type: &'static str,
         count: usize,
     },
 
-    #[error(
-        "only cumulative-temporality sums are supported in phase 1; rejecting {count} data points"
-    )]
+    #[error("only cumulative-temporality sums are supported; rejecting {count} data points")]
     UnsupportedTemporality { count: usize },
 
     #[error("event timestamp is zero")]
@@ -261,7 +259,138 @@ pub enum Rejection {
     },
 }
 
+/// Which admission `reason` a normalization-layer rejection is counted under
+/// (ADR-0051 section 3 layer 3, section 6).
+///
+/// Layer 3 is "structural and event-time bounds, in normalization, per point /
+/// record / span". Those are the only two reasons the layer can produce, so
+/// the classification is total over every rejection that costs the sender a
+/// point, record, or span:
+///
+/// * [`AdmissionClass::Skew`] is the event-time arm: the sender's timestamp
+///   could not be placed in the admission window around ingest time.
+/// * [`AdmissionClass::Structural`] is everything else the layer refuses:
+///   a shape, a type, a limit, or a value the storage format cannot represent.
+///
+/// A rejection that costs the sender nothing (an informational drop of a
+/// histogram `min`/`max`, an exemplar, or a single attribute of an otherwise
+/// admitted record) has no class: it is not an admission rejection and must
+/// never move a rejected counter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionClass {
+    Skew,
+    Structural,
+}
+
+/// Rejected points, records, or spans totalled per [`AdmissionClass`] over one
+/// normalization pass, ready to be recorded against the `reason` label on
+/// `ravel_admission_rejected_total`.
+///
+/// Each unit is counted once, with the same `rejected_count()` multiplier the
+/// OTLP partial-success response reports, so the counter and the response
+/// cannot disagree about how many units a request lost.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NormalizeRejectCounts {
+    pub skew: usize,
+    pub structural: usize,
+}
+
+impl NormalizeRejectCounts {
+    /// Whether anything at all was rejected, so a caller can skip taking a
+    /// counter lock on the (overwhelmingly common) clean request.
+    pub fn is_empty(&self) -> bool {
+        self.skew == 0 && self.structural == 0
+    }
+
+    pub fn add(&mut self, class: Option<AdmissionClass>, count: usize) {
+        match class {
+            Some(AdmissionClass::Skew) => self.skew += count,
+            Some(AdmissionClass::Structural) => self.structural += count,
+            None => {}
+        }
+    }
+
+    /// Total the metric path's rejections by class.
+    pub fn from_metric_rejections(rejected: &[Rejection]) -> Self {
+        let mut counts = Self::default();
+        for rejection in rejected {
+            counts.add(rejection.admission_class(), rejection.rejected_count());
+        }
+        counts
+    }
+
+    /// Total the log path's rejections by class.
+    pub fn from_log_rejections(rejected: &[crate::logs_limits::LogRejection]) -> Self {
+        let mut counts = Self::default();
+        for rejection in rejected {
+            counts.add(rejection.admission_class(), rejection.rejected_count());
+        }
+        counts
+    }
+
+    /// Total the trace path's rejections by class.
+    pub fn from_span_rejections(rejected: &[crate::traces_limits::SpanRejection]) -> Self {
+        let mut counts = Self::default();
+        for rejection in rejected {
+            counts.add(rejection.admission_class(), rejection.rejected_count());
+        }
+        counts
+    }
+}
+
 impl Rejection {
+    /// The admission `reason` this rejection is counted under, or `None` when
+    /// it costs the sender no data point (the informational variants, whose
+    /// [`Rejection::rejected_count`] is 0).
+    ///
+    /// Exhaustive on purpose: a new variant does not compile until it has been
+    /// classified, so a normalize-layer rejection cannot be added and then
+    /// silently go uncounted.
+    pub fn admission_class(&self) -> Option<AdmissionClass> {
+        match self {
+            // Event-time arm. `ZeroTimestamp` belongs here with the two bound
+            // breaches: all three come out of the event-time check, and a zero
+            // event time is unbounded lag against any plausible ingest clock.
+            Rejection::ZeroTimestamp | Rejection::FutureSkew { .. } | Rejection::TooOld { .. } => {
+                Some(AdmissionClass::Skew)
+            }
+
+            // Structural arm: a shape, type, limit, or value the storage
+            // format cannot represent.
+            Rejection::TooManyDataPoints { .. }
+            | Rejection::TooManyResourceAttributes { .. }
+            | Rejection::MetricNameTooLong { .. }
+            | Rejection::EmptyMetricName { .. }
+            | Rejection::TooManyAttributes { .. }
+            | Rejection::LabelNameTooLong { .. }
+            | Rejection::LabelValueTooLong { .. }
+            | Rejection::DuplicateLabelName(_)
+            | Rejection::ComplexAttributeValue
+            | Rejection::MissingValue
+            | Rejection::UnsupportedMetricType { .. }
+            | Rejection::UnsupportedTemporality { .. }
+            | Rejection::OversizedSeriesComponent
+            | Rejection::HistogramBucketCountMismatch { .. }
+            | Rejection::NonFiniteHistogramBound
+            | Rejection::HistogramBoundsNotIncreasing
+            | Rejection::HistogramCountOverflow
+            | Rejection::NativeHistogramScaleUnsupported { .. }
+            | Rejection::NativeHistogramCountInconsistent
+            | Rejection::NativeHistogramCountOverflow
+            | Rejection::NonFiniteQuantile
+            | Rejection::DuplicateQuantile => Some(AdmissionClass::Structural),
+
+            // Informational: the point was admitted and stored.
+            Rejection::HistogramMinMaxDropped { .. }
+            | Rejection::HistogramExemplarsDropped { .. }
+            | Rejection::IntegerValuePrecisionLoss { .. } => None,
+
+            // A grouped rejection carries its own point count; the class is
+            // the shared reason's.
+            Rejection::Grouped { reason, .. } => reason.admission_class(),
+        }
+    }
+
     /// Number of underlying OTLP data points this rejection accounts for.
     /// Summing this over [`crate::normalize::NormalizeOutput::rejected`]
     /// gives the count to report in an OTLP `rejected_data_points` field.
@@ -339,5 +468,26 @@ mod tests {
         };
         assert_eq!(r.rejected_count(), 100_000);
         assert!(r.to_string().contains("100000"));
+    }
+
+    /// `add` routes each class to its own field and leaves the other
+    /// untouched, and `None` moves neither. Pinned in this crate because a
+    /// crate-scoped gate here otherwise cannot catch an arm swap: only the
+    /// server crate exercised this arithmetic before.
+    #[test]
+    fn add_routes_each_class_to_its_own_field() {
+        let mut counts = NormalizeRejectCounts::default();
+        counts.add(Some(AdmissionClass::Skew), 3);
+        assert_eq!(counts.skew, 3);
+        assert_eq!(counts.structural, 0);
+
+        counts.add(Some(AdmissionClass::Structural), 5);
+        assert_eq!(counts.skew, 3);
+        assert_eq!(counts.structural, 5);
+
+        counts.add(None, 100);
+        assert_eq!(counts.skew, 3);
+        assert_eq!(counts.structural, 5);
+        assert!(!counts.is_empty());
     }
 }

--- a/crates/ravel-otlp/src/limits.rs
+++ b/crates/ravel-otlp/src/limits.rs
@@ -470,6 +470,168 @@ mod tests {
         assert!(r.to_string().contains("100000"));
     }
 
+    /// Every [`Rejection`] variant's admission class, one case per variant.
+    ///
+    /// The `match` is exhaustive so a variant added to the enum does not
+    /// compile until it has been given an expected class here, which is what
+    /// stops a new metric-path rejection from going silently unclassified.
+    /// Before this test, `Rejection::admission_class` was covered only by two
+    /// ravel-server integration tests pinning `UnsupportedTemporality` and
+    /// `TooOld`, so every other variant could change arm unnoticed.
+    ///
+    /// `ZeroTimestamp` is the judgement call and is named explicitly below: a
+    /// zero event time is classified as skew, not structural, because it
+    /// comes out of the event-time check and is unbounded lag against any
+    /// plausible ingest clock. Moving it to the structural arm is a change to
+    /// what `ravel_admission_rejected_total{reason=...}` reports, and it
+    /// fails here.
+    #[test]
+    fn every_rejection_variant_has_its_expected_admission_class() {
+        fn expected(rejection: &Rejection) -> Option<AdmissionClass> {
+            let skew = Some(AdmissionClass::Skew);
+            let structural = Some(AdmissionClass::Structural);
+            match rejection {
+                Rejection::ZeroTimestamp => skew,
+                Rejection::FutureSkew { .. } => skew,
+                Rejection::TooOld { .. } => skew,
+
+                Rejection::TooManyDataPoints { .. } => structural,
+                Rejection::TooManyResourceAttributes { .. } => structural,
+                Rejection::MetricNameTooLong { .. } => structural,
+                Rejection::EmptyMetricName { .. } => structural,
+                Rejection::TooManyAttributes { .. } => structural,
+                Rejection::LabelNameTooLong { .. } => structural,
+                Rejection::LabelValueTooLong { .. } => structural,
+                Rejection::DuplicateLabelName(_) => structural,
+                Rejection::ComplexAttributeValue => structural,
+                Rejection::MissingValue => structural,
+                Rejection::UnsupportedMetricType { .. } => structural,
+                Rejection::UnsupportedTemporality { .. } => structural,
+                Rejection::OversizedSeriesComponent => structural,
+                Rejection::HistogramBucketCountMismatch { .. } => structural,
+                Rejection::NonFiniteHistogramBound => structural,
+                Rejection::HistogramBoundsNotIncreasing => structural,
+                Rejection::HistogramCountOverflow => structural,
+                Rejection::NativeHistogramScaleUnsupported { .. } => structural,
+                Rejection::NativeHistogramCountInconsistent => structural,
+                Rejection::NativeHistogramCountOverflow => structural,
+                Rejection::NonFiniteQuantile => structural,
+                Rejection::DuplicateQuantile => structural,
+
+                // Informational: the point was admitted and stored, so it
+                // costs the sender nothing and must move no counter.
+                Rejection::HistogramMinMaxDropped { .. } => None,
+                Rejection::HistogramExemplarsDropped { .. } => None,
+                Rejection::IntegerValuePrecisionLoss { .. } => None,
+
+                // Carries its reason's class, whatever that reason is.
+                Rejection::Grouped { reason, .. } => expected(reason),
+            }
+        }
+
+        // One value per variant. The `match` above does not compile with a
+        // variant missing; this list is what makes each case run.
+        let variants = [
+            Rejection::TooManyDataPoints {
+                count: 1,
+                max: 100_000,
+            },
+            Rejection::TooManyResourceAttributes { count: 1, max: 128 },
+            Rejection::MetricNameTooLong {
+                len: 600,
+                max: 512,
+                count: 1,
+            },
+            Rejection::EmptyMetricName { count: 1 },
+            Rejection::TooManyAttributes {
+                attribute_count: 65,
+                max: 64,
+            },
+            Rejection::LabelNameTooLong { len: 300, max: 256 },
+            Rejection::LabelValueTooLong {
+                len: 5000,
+                max: 4096,
+            },
+            Rejection::DuplicateLabelName("x".to_string()),
+            Rejection::ComplexAttributeValue,
+            Rejection::MissingValue,
+            Rejection::UnsupportedMetricType {
+                metric_type: "histogram",
+                count: 1,
+            },
+            Rejection::UnsupportedTemporality { count: 1 },
+            Rejection::ZeroTimestamp,
+            Rejection::FutureSkew {
+                skew_ns: 1,
+                max_ns: 0,
+            },
+            Rejection::TooOld {
+                lag_ns: 1,
+                max_ns: 0,
+            },
+            Rejection::OversizedSeriesComponent,
+            Rejection::HistogramBucketCountMismatch {
+                bounds: 1,
+                buckets: 1,
+                expected: 2,
+            },
+            Rejection::NonFiniteHistogramBound,
+            Rejection::HistogramBoundsNotIncreasing,
+            Rejection::HistogramCountOverflow,
+            Rejection::NativeHistogramScaleUnsupported { scale: -54 },
+            Rejection::NativeHistogramCountInconsistent,
+            Rejection::NativeHistogramCountOverflow,
+            Rejection::NonFiniteQuantile,
+            Rejection::DuplicateQuantile,
+            Rejection::HistogramMinMaxDropped { count: 1 },
+            Rejection::HistogramExemplarsDropped { count: 1 },
+            Rejection::IntegerValuePrecisionLoss { value: i64::MAX },
+            Rejection::Grouped {
+                reason: Box::new(Rejection::ComplexAttributeValue),
+                count: 3,
+            },
+        ];
+
+        // One entry per variant, each a distinct one, so no variant is
+        // covered twice while another is missing.
+        assert_eq!(variants.len(), 29);
+        for (i, a) in variants.iter().enumerate() {
+            for b in &variants[i + 1..] {
+                assert_ne!(
+                    std::mem::discriminant(a),
+                    std::mem::discriminant(b),
+                    "{a} and {b} are the same variant"
+                );
+            }
+        }
+
+        for rejection in &variants {
+            assert_eq!(
+                rejection.admission_class(),
+                expected(rejection),
+                "{rejection}"
+            );
+        }
+
+        // `ZeroTimestamp` by name, so the judgement call is pinned where a
+        // reader looking for it will find it and not only inside the loop.
+        assert_eq!(
+            Rejection::ZeroTimestamp.admission_class(),
+            Some(AdmissionClass::Skew)
+        );
+
+        // A grouped rejection takes its inner reason's class, including the
+        // skew arm, so the wrapper cannot silently reclassify.
+        assert_eq!(
+            Rejection::Grouped {
+                reason: Box::new(Rejection::ZeroTimestamp),
+                count: 4,
+            }
+            .admission_class(),
+            Some(AdmissionClass::Skew)
+        );
+    }
+
     /// `add` routes each class to its own field and leaves the other
     /// untouched, and `None` moves neither. Pinned in this crate because a
     /// crate-scoped gate here otherwise cannot catch an arm swap: only the

--- a/crates/ravel-otlp/src/logs_limits.rs
+++ b/crates/ravel-otlp/src/logs_limits.rs
@@ -178,15 +178,87 @@ pub enum LogRejection {
 }
 
 impl LogRejection {
+    /// The admission `reason` this rejection is counted under (ADR-0051
+    /// section 3 layer 3), or `None` when it costs the sender no log record.
+    /// Mirrors [`crate::limits::Rejection::admission_class`], and is
+    /// exhaustive for the same reason: a new variant does not compile until it
+    /// has been classified.
+    ///
+    /// The five per-attribute variants class as `None`, not `structural`,
+    /// when they stand on their own: they drop one attribute of a record that
+    /// is still stored (their [`LogRejection::rejected_count`] is 0), so they
+    /// cost the sender no record and must not move a rejected counter. This
+    /// mirrors the traces path, where a stored span's dropped attributes are
+    /// classed `None` for the same reason.
+    ///
+    /// Those same five variants also appear inside a [`LogRejection::Grouped`]
+    /// when a resource- or scope-level attribute set cannot be converted,
+    /// where they do cost whole records (the attributes carry stream identity,
+    /// so nothing under the resource or scope can be admitted). That context
+    /// lives on `Grouped`, which classes `structural` for the group rather
+    /// than delegating to the reason: at record scope the same reason costs
+    /// nothing, so delegating would let a real whole-resource loss go
+    /// uncounted.
+    pub fn admission_class(&self) -> Option<crate::limits::AdmissionClass> {
+        use crate::limits::AdmissionClass;
+        match self {
+            LogRejection::FutureSkew { .. } | LogRejection::TooOld { .. } => {
+                Some(AdmissionClass::Skew)
+            }
+            LogRejection::TooManyRecords { .. }
+            | LogRejection::TooManyAttributes { .. }
+            | LogRejection::BodyTooLong { .. }
+            | LogRejection::TooManyResourceAttributes { .. }
+            | LogRejection::TooManyScopeAttributes { .. }
+            | LogRejection::UnsupportedBodyKind => Some(AdmissionClass::Structural),
+            // Per-attribute drops on an otherwise-stored record: the record
+            // still lands, so these cost the sender nothing and must not move
+            // a rejected counter (their `rejected_count` is 0 for the same
+            // reason). When one of these instead rejects a whole resource or
+            // scope it is wrapped in `Grouped`, whose arm below classes the
+            // group, not the reason.
+            LogRejection::AttributeKeyTooLong { .. }
+            | LogRejection::AttributeValueTooLong { .. }
+            | LogRejection::MissingAttributeValue { .. }
+            | LogRejection::UnsupportedAttributeValue { .. }
+            | LogRejection::AttributeTooDeeplyNested { .. } => None,
+            // A grouped rejection is always a whole-group structural loss: its
+            // reason is either a too-many-attributes breach or an attribute
+            // that could not be converted at resource or scope scope, and skew
+            // is resolved per record after the group check, so it never
+            // groups. Classify by the group rather than by the reason, since
+            // the attribute-conversion reasons class `None` on their own.
+            LogRejection::Grouped { .. } => Some(AdmissionClass::Structural),
+        }
+    }
+
     /// Number of underlying OTLP log records this rejection accounts for.
     /// Summing this over [`crate::logs_normalize::LogNormalizeOutput::rejected`]
     /// gives the count to report in an OTLP `rejected_log_records` field.
     /// Mirrors [`crate::limits::Rejection::rejected_count`].
+    ///
+    /// The five per-attribute variants return 0: they drop one attribute of a
+    /// record that is still stored, so counting them as a rejected record
+    /// over-reports how many records a sender's export lost. They remain
+    /// visible to the sender through the partial-success `error_message`; only
+    /// their contribution to `rejected_log_records` is zero. When one of them
+    /// rejects a whole resource or scope it is carried in
+    /// [`LogRejection::Grouped`], whose own `count` (not the reason's) is read
+    /// here, so a real whole-group loss still counts. This mirrors the traces
+    /// path's [`crate::traces_limits::SpanRejection::rejected_count`].
     pub fn rejected_count(&self) -> usize {
         match self {
             LogRejection::TooManyRecords { count, .. } | LogRejection::Grouped { count, .. } => {
                 *count
             }
+            // The record still lands; only one attribute was dropped. These
+            // must never inflate `rejected_log_records`.
+            LogRejection::AttributeKeyTooLong { .. }
+            | LogRejection::AttributeValueTooLong { .. }
+            | LogRejection::MissingAttributeValue { .. }
+            | LogRejection::UnsupportedAttributeValue { .. }
+            | LogRejection::AttributeTooDeeplyNested { .. } => 0,
+            // Whole-record rejections: the record never reached storage.
             _ => 1,
         }
     }
@@ -255,18 +327,6 @@ mod tests {
             1
         );
         assert_eq!(
-            LogRejection::AttributeKeyTooLong { len: 300, max: 256 }.rejected_count(),
-            1
-        );
-        assert_eq!(
-            LogRejection::AttributeValueTooLong {
-                len: 9000,
-                max: 8192
-            }
-            .rejected_count(),
-            1
-        );
-        assert_eq!(
             LogRejection::BodyTooLong {
                 len: 70_000,
                 max: 65_536
@@ -291,22 +351,6 @@ mod tests {
             1
         );
         assert_eq!(
-            LogRejection::MissingAttributeValue { key: "k".into() }.rejected_count(),
-            1
-        );
-        assert_eq!(
-            LogRejection::UnsupportedAttributeValue { key: "k".into() }.rejected_count(),
-            1
-        );
-        assert_eq!(
-            LogRejection::AttributeTooDeeplyNested {
-                key: "k".into(),
-                max: 100,
-            }
-            .rejected_count(),
-            1
-        );
-        assert_eq!(
             LogRejection::FutureSkew {
                 skew_ns: 700_000_000_000,
                 max_ns: 600_000_000_000,
@@ -322,6 +366,49 @@ mod tests {
             .rejected_count(),
             1
         );
+    }
+
+    /// The five per-attribute variants drop one attribute of a record that is
+    /// still stored, so on their own they cost the sender no record: their
+    /// `rejected_count` is 0 and they carry no admission class. Mirrors the
+    /// traces path's attribute-level rejections.
+    #[test]
+    fn per_attribute_variants_cost_no_record_on_their_own() {
+        let variants = [
+            LogRejection::AttributeKeyTooLong { len: 300, max: 256 },
+            LogRejection::AttributeValueTooLong {
+                len: 9000,
+                max: 8192,
+            },
+            LogRejection::MissingAttributeValue { key: "k".into() },
+            LogRejection::UnsupportedAttributeValue { key: "k".into() },
+            LogRejection::AttributeTooDeeplyNested {
+                key: "k".into(),
+                max: 100,
+            },
+        ];
+        for v in &variants {
+            assert_eq!(v.rejected_count(), 0, "{v:?}");
+            assert_eq!(v.admission_class(), None, "{v:?}");
+        }
+    }
+
+    /// A whole resource or scope lost to an attribute that could not be
+    /// converted is carried as a `Grouped`, and must still count as
+    /// `structural` for its full record count. The reason inside classes
+    /// `None` on its own (previous test), so this pins that the group context
+    /// on `Grouped`, not delegation to the reason, is what counts.
+    #[test]
+    fn grouped_attribute_conversion_failure_counts_as_structural() {
+        let r = LogRejection::Grouped {
+            reason: Box::new(LogRejection::MissingAttributeValue { key: "svc".into() }),
+            count: 7,
+        };
+        assert_eq!(
+            r.admission_class(),
+            Some(crate::limits::AdmissionClass::Structural)
+        );
+        assert_eq!(r.rejected_count(), 7);
     }
 
     #[test]

--- a/crates/ravel-otlp/src/logs_limits.rs
+++ b/crates/ravel-otlp/src/logs_limits.rs
@@ -108,6 +108,12 @@ pub enum LogRejection {
     #[error("attribute value is {len} bytes, more than the limit of {max}")]
     AttributeValueTooLong { len: usize, max: usize },
 
+    /// `len` is the body's own length for a body that arrives as text. For a
+    /// structured body, whose text Ravel renders itself, it is instead the
+    /// point at which rendering stopped, one byte past `max`: the renderer
+    /// works under a byte budget and refuses at the first byte over it, so the
+    /// length the whole text would have reached is never produced and cannot
+    /// be reported. Either way `len > max` and the record is rejected.
     #[error("body is {len} bytes, more than the limit of {max}")]
     BodyTooLong { len: usize, max: usize },
 

--- a/crates/ravel-otlp/src/logs_normalize.rs
+++ b/crates/ravel-otlp/src/logs_normalize.rs
@@ -71,6 +71,11 @@ pub struct NormalizedLogRecord {
 pub struct LogNormalizeOutput {
     pub records: Vec<NormalizedLogRecord>,
     pub rejected: Vec<LogRejection>,
+    /// How many admitted records carried a structured (array or kvlist) body
+    /// that was converted to its canonical JSON form. Every one of these
+    /// records is in `records`: the count is a conversion, never a rejection,
+    /// so an operator alerting on rejection reasons sees nothing from it.
+    pub body_conversions: usize,
 }
 
 /// Decode and normalize log records from `req`.
@@ -94,16 +99,29 @@ pub fn normalize_logs(
                 count: total_records,
                 max: limits.max_records_per_request,
             }],
+            body_conversions: 0,
         };
     }
 
     let mut records = Vec::new();
     let mut rejected = Vec::new();
+    let mut body_conversions = 0;
     for rl in &req.resource_logs {
-        normalize_resource(rl, limits, ingest_ts_ns, &mut records, &mut rejected);
+        normalize_resource(
+            rl,
+            limits,
+            ingest_ts_ns,
+            &mut records,
+            &mut rejected,
+            &mut body_conversions,
+        );
     }
 
-    LogNormalizeOutput { records, rejected }
+    LogNormalizeOutput {
+        records,
+        rejected,
+        body_conversions,
+    }
 }
 
 fn resource_record_count(rl: &ResourceLogs) -> usize {
@@ -116,6 +134,7 @@ fn normalize_resource(
     ingest_ts_ns: i64,
     records: &mut Vec<NormalizedLogRecord>,
     rejected: &mut Vec<LogRejection>,
+    body_conversions: &mut usize,
 ) {
     let resource_record_count = resource_record_count(rl);
     if resource_record_count == 0 {
@@ -154,7 +173,15 @@ fn normalize_resource(
     };
 
     for sl in &rl.scope_logs {
-        normalize_scope(sl, &resource_attrs, limits, ingest_ts_ns, records, rejected);
+        normalize_scope(
+            sl,
+            &resource_attrs,
+            limits,
+            ingest_ts_ns,
+            records,
+            rejected,
+            body_conversions,
+        );
     }
 }
 
@@ -165,6 +192,7 @@ fn normalize_scope(
     ingest_ts_ns: i64,
     records: &mut Vec<NormalizedLogRecord>,
     rejected: &mut Vec<LogRejection>,
+    body_conversions: &mut usize,
 ) {
     let scope_record_count = sl.log_records.len();
     if scope_record_count == 0 {
@@ -205,9 +233,12 @@ fn normalize_scope(
 
     for record in &sl.log_records {
         match normalize_record(record, stream_id, &stream_attrs, limits, ingest_ts_ns) {
-            Ok((normalized, dropped_attrs)) => {
+            Ok((normalized, dropped_attrs, converted_body)) => {
                 records.push(normalized);
                 rejected.extend(dropped_attrs);
+                if converted_body {
+                    *body_conversions += 1;
+                }
             }
             Err(reason) => rejected.push(reason),
         }
@@ -216,14 +247,15 @@ fn normalize_scope(
 
 /// Normalize one record. `Err` drops the whole record; `Ok`'s second element
 /// carries per-attribute rejections for attributes dropped from an otherwise
-/// admitted record.
+/// admitted record, and its third says whether a structured body was
+/// converted to canonical JSON to admit it.
 fn normalize_record(
     record: &LogRecord,
     stream_id: LogStreamId,
     stream_attrs: &[u8],
     limits: &LogIngestLimits,
     ingest_ts_ns: i64,
-) -> Result<(NormalizedLogRecord, Vec<LogRejection>), LogRejection> {
+) -> Result<(NormalizedLogRecord, Vec<LogRejection>, bool), LogRejection> {
     if record.attributes.len() > limits.max_attributes_per_record {
         return Err(LogRejection::TooManyAttributes {
             count: record.attributes.len(),
@@ -231,7 +263,10 @@ fn normalize_record(
         });
     }
 
-    let body = normalize_body(record.body.as_ref())?;
+    let NormalizedBody {
+        text: body,
+        converted: converted_body,
+    } = normalize_body(record.body.as_ref())?;
     if body.len() > limits.max_body_len {
         return Err(LogRejection::BodyTooLong {
             len: body.len(),
@@ -285,6 +320,7 @@ fn normalize_record(
             attrs,
         },
         dropped,
+        converted_body,
     ))
 }
 
@@ -334,25 +370,171 @@ fn checked_record_ts(
     Ok(ts_ns)
 }
 
+/// A normalized record body plus whether producing it converted a structured
+/// value. The flag is what the ingest surface counts as a body conversion,
+/// separately from every rejection reason: the record was stored, so an
+/// operator alerting on rejections must not see this traffic.
+struct NormalizedBody {
+    text: String,
+    converted: bool,
+}
+
+/// The key [`convert_value`] is given for a structured body. It never reaches
+/// a stored attribute name; it appears only in the rejection message for a
+/// body that could not be converted, which this function replaces with
+/// [`LogRejection::UnsupportedBodyKind`] anyway.
+const BODY_KEY: &str = "body";
+
 /// Normalize a record body to the string RLOG stores. A string body maps
 /// directly; scalar bodies take their canonical string form; a bytes body
-/// becomes lowercase hex. Array and kvlist bodies are rejected rather than
-/// stringified: a structured body needs a real storage decision, and a
-/// rejection makes the gap visible instead of inventing lossy semantics.
+/// becomes lowercase hex. An array or kvlist body is converted to its
+/// canonical JSON form (see [`canonical_json`]) and the record is stored:
+/// its attributes, trace id, span id, and timestamp all have lossless
+/// representations, and rejecting the record discarded those too.
 /// An absent body (or an `AnyValue` with no variant set) is the empty string,
 /// which is what `ravel_logseg::LogRecord` uses for an absent field.
-fn normalize_body(body: Option<&AnyValue>) -> Result<String, LogRejection> {
+///
+/// `StringValueStrindex` stays rejected. It is an index into the sender's
+/// shared string table, and no table travels with an
+/// `ExportLogsServiceRequest`: the value it names is not reachable here, so
+/// storing anything at all would fabricate content the sender never sent.
+///
+/// A structured body that [`convert_value`] refuses (nested past
+/// [`MAX_ATTRIBUTE_NESTING_DEPTH`], carrying an unset value, or carrying a
+/// nested string-table reference) is reported as
+/// [`LogRejection::UnsupportedBodyKind`] rather than as the attribute-shaped
+/// rejection the converter returns, because the thing the sender lost is the
+/// body, not an attribute.
+fn normalize_body(body: Option<&AnyValue>) -> Result<NormalizedBody, LogRejection> {
+    let plain = |text: String| {
+        Ok(NormalizedBody {
+            text,
+            converted: false,
+        })
+    };
     match body.and_then(|v| v.value.as_ref()) {
-        None => Ok(String::new()),
-        Some(AnyValueVariant::StringValue(s)) => Ok(s.clone()),
-        Some(AnyValueVariant::BoolValue(b)) => Ok(b.to_string()),
-        Some(AnyValueVariant::IntValue(i)) => Ok(i.to_string()),
-        Some(AnyValueVariant::DoubleValue(d)) => Ok(format_float(*d)),
-        Some(AnyValueVariant::BytesValue(b)) => Ok(hex::encode(b)),
-        Some(AnyValueVariant::ArrayValue(_))
-        | Some(AnyValueVariant::KvlistValue(_))
-        | Some(AnyValueVariant::StringValueStrindex(_)) => Err(LogRejection::UnsupportedBodyKind),
+        None => plain(String::new()),
+        Some(AnyValueVariant::StringValue(s)) => plain(s.clone()),
+        Some(AnyValueVariant::BoolValue(b)) => plain(b.to_string()),
+        Some(AnyValueVariant::IntValue(i)) => plain(i.to_string()),
+        Some(AnyValueVariant::DoubleValue(d)) => plain(format_float(*d)),
+        Some(AnyValueVariant::BytesValue(b)) => plain(hex::encode(b)),
+        Some(AnyValueVariant::ArrayValue(_)) | Some(AnyValueVariant::KvlistValue(_)) => {
+            let value =
+                convert_value(BODY_KEY, body, 1).map_err(|_| LogRejection::UnsupportedBodyKind)?;
+            Ok(NormalizedBody {
+                text: canonical_json(&value),
+                converted: true,
+            })
+        }
+        Some(AnyValueVariant::StringValueStrindex(_)) => Err(LogRejection::UnsupportedBodyKind),
     }
+}
+
+/// The canonical JSON text for a structured body value.
+///
+/// The value model is [`AttrValue`], the same one
+/// [`ravel_types::logstream`] canonicalizes for stream identity, so a body and
+/// an attribute holding the identical OTLP value convert through one mapping.
+/// The rendering rules:
+///
+/// * a map is a JSON object whose entries are ordered exactly as
+///   `ravel_types::logstream` orders an attribute set: by key bytes, ties
+///   broken by the canonical encoding of the value. Two senders that emit the
+///   same kvlist in different orders therefore store byte-identical bodies.
+///   Duplicate keys are kept, not merged: OTLP permits them and dropping one
+///   would lose data.
+/// * a list is a JSON array in input order (list order is significant).
+/// * bytes are lowercase hex in a JSON string, the same rendering a top-level
+///   bytes body gets.
+/// * a non-finite double has no JSON number form, so it renders as the string
+///   `"NaN"`, `"+Inf"`, or `"-Inf"`, matching how a top-level double body of
+///   the same value renders.
+fn canonical_json(value: &AttrValue) -> String {
+    let mut out = String::new();
+    write_canonical_json(&mut out, value);
+    out
+}
+
+fn write_canonical_json(out: &mut String, value: &AttrValue) {
+    match value {
+        AttrValue::Str(s) => write_json_string(out, s),
+        AttrValue::I64(i) => out.push_str(&i.to_string()),
+        AttrValue::F64(f) => {
+            if f.is_finite() {
+                out.push_str(&format_float(*f));
+            } else {
+                write_json_string(out, &format_float(*f));
+            }
+        }
+        AttrValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+        AttrValue::Bytes(b) => write_json_string(out, &hex::encode(b)),
+        AttrValue::List(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_canonical_json(out, item);
+            }
+            out.push(']');
+        }
+        AttrValue::Map(entries) => {
+            let mut ordered: Vec<&(String, AttrValue)> = entries.iter().collect();
+            ordered.sort_by(|a, b| {
+                a.0.as_bytes()
+                    .cmp(b.0.as_bytes())
+                    .then_with(|| canonical_value_bytes(&a.1).cmp(&canonical_value_bytes(&b.1)))
+            });
+            out.push('{');
+            for (i, (key, value)) in ordered.into_iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_json_string(out, key);
+                out.push(':');
+                write_canonical_json(out, value);
+            }
+            out.push('}');
+        }
+    }
+}
+
+/// The canonical encoding of one value, used only as the duplicate-key
+/// tiebreaker in [`write_canonical_json`].
+///
+/// [`ravel_types::logstream`] owns that encoding and exposes it for a whole
+/// attribute set, not for a bare value, so this asks it for a one-entry set
+/// under an empty key. Every such encoding carries the same two-byte prefix
+/// (entry count 1, key length 0), so comparing two of them compares exactly
+/// the two encoded values, which is the tiebreak `encode_attrs` applies. This
+/// crate does not re-implement the encoding.
+fn canonical_value_bytes(value: &AttrValue) -> Vec<u8> {
+    ravel_types::logstream::canonical_attr_bytes(std::slice::from_ref(&(
+        String::new(),
+        value.clone(),
+    )))
+}
+
+/// Write `s` as a JSON string literal (RFC 8259 section 7): the two mandatory
+/// escapes, the five short escapes, and `\u00XX` for the remaining control
+/// characters. Rust strings are UTF-8, so nothing else needs escaping.
+fn write_json_string(out: &mut String, s: &str) {
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0c}' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
 }
 
 /// Convert an attribute set whole: the first failure rejects the set. Used
@@ -748,7 +930,7 @@ mod tests {
     }
 
     #[test]
-    fn array_body_rejects_the_record() {
+    fn array_body_is_stored_as_canonical_json() {
         let out = normalize(request(vec![resource_logs(
             vec![],
             vec![scope_logs(
@@ -757,7 +939,11 @@ mod tests {
                 vec![
                     record(
                         Some(any(AnyValueVariant::ArrayValue(ArrayValue {
-                            values: vec![any(AnyValueVariant::IntValue(1))],
+                            values: vec![
+                                any(AnyValueVariant::IntValue(1)),
+                                any(AnyValueVariant::StringValue("two".into())),
+                                any(AnyValueVariant::BoolValue(true)),
+                            ],
                         }))),
                         vec![],
                         1,
@@ -770,10 +956,191 @@ mod tests {
                 ],
             )],
         )]));
-        assert_eq!(out.records.len(), 1);
-        assert_eq!(out.records[0].body, "ok");
+        assert!(out.rejected.is_empty(), "{:?}", out.rejected);
+        assert_eq!(out.records.len(), 2);
+        assert_eq!(out.records[0].body, r#"[1,"two",true]"#);
+        assert_eq!(out.records[1].body, "ok");
+        assert_eq!(out.body_conversions, 1);
+    }
+
+    #[test]
+    fn kvlist_body_is_stored_in_canonical_key_order() {
+        // Two records carrying the same entries in opposite input order must
+        // store byte-identical bodies: the object is ordered the way
+        // ravel_types::logstream orders an attribute set, not the way the
+        // sender happened to serialize it.
+        let entries = vec![
+            string_kv("zeta", "z"),
+            kv("alpha", AnyValueVariant::IntValue(7)),
+        ];
+        let reversed: Vec<KeyValue> = entries.iter().rev().cloned().collect();
+        let out = normalize(request(vec![resource_logs(
+            vec![],
+            vec![scope_logs(
+                "lib",
+                "1",
+                vec![
+                    record(
+                        Some(any(AnyValueVariant::KvlistValue(KeyValueList {
+                            values: entries,
+                        }))),
+                        vec![],
+                        1,
+                    ),
+                    record(
+                        Some(any(AnyValueVariant::KvlistValue(KeyValueList {
+                            values: reversed,
+                        }))),
+                        vec![],
+                        2,
+                    ),
+                ],
+            )],
+        )]));
+        assert!(out.rejected.is_empty(), "{:?}", out.rejected);
+        assert_eq!(out.records.len(), 2);
+        assert_eq!(out.records[0].body, r#"{"alpha":7,"zeta":"z"}"#);
+        assert_eq!(out.records[1].body, out.records[0].body);
+        assert_eq!(out.body_conversions, 2);
+    }
+
+    #[test]
+    fn duplicate_kvlist_body_keys_are_kept_and_ordered_by_value() {
+        // OTLP permits a repeated key. Both entries survive, tie-broken by
+        // the canonical encoding of the value, so the rendering is stable.
+        let out = normalize(request(vec![resource_logs(
+            vec![],
+            vec![scope_logs(
+                "lib",
+                "1",
+                vec![record(
+                    Some(any(AnyValueVariant::KvlistValue(KeyValueList {
+                        values: vec![
+                            kv("k", AnyValueVariant::IntValue(2)),
+                            kv("k", AnyValueVariant::IntValue(1)),
+                        ],
+                    }))),
+                    vec![],
+                    1,
+                )],
+            )],
+        )]));
+        assert!(out.rejected.is_empty(), "{:?}", out.rejected);
+        assert_eq!(out.records[0].body, r#"{"k":1,"k":2}"#);
+        assert_eq!(out.body_conversions, 1);
+    }
+
+    #[test]
+    fn structured_body_renders_nested_scalars_and_escapes() {
+        let out = normalize(request(vec![resource_logs(
+            vec![],
+            vec![scope_logs(
+                "lib",
+                "1",
+                vec![record(
+                    Some(any(AnyValueVariant::KvlistValue(KeyValueList {
+                        values: vec![
+                            kv("bytes", AnyValueVariant::BytesValue(vec![0xde, 0xad])),
+                            kv("nan", AnyValueVariant::DoubleValue(f64::NAN)),
+                            kv("real", AnyValueVariant::DoubleValue(1.5)),
+                            string_kv("quote\"and\\slash", "line\nbreak\u{1}"),
+                            kv(
+                                "nested",
+                                AnyValueVariant::ArrayValue(ArrayValue {
+                                    values: vec![any(AnyValueVariant::KvlistValue(KeyValueList {
+                                        values: vec![],
+                                    }))],
+                                }),
+                            ),
+                        ],
+                    }))),
+                    vec![],
+                    1,
+                )],
+            )],
+        )]));
+        assert!(out.rejected.is_empty(), "{:?}", out.rejected);
+        assert_eq!(
+            out.records[0].body,
+            format!(
+                r#"{{"bytes":"dead","nan":"{}","nested":[{{}}],"quote\"and\\slash":"line\nbreak\u0001","real":{}}}"#,
+                format_float(f64::NAN),
+                format_float(1.5),
+            )
+        );
+        assert_eq!(out.body_conversions, 1);
+    }
+
+    #[test]
+    fn structured_body_past_the_nesting_bound_is_still_rejected() {
+        let mut value = any(AnyValueVariant::IntValue(1));
+        for _ in 0..MAX_ATTRIBUTE_NESTING_DEPTH {
+            value = any(AnyValueVariant::ArrayValue(ArrayValue {
+                values: vec![value],
+            }));
+        }
+        let out = normalize(request(vec![resource_logs(
+            vec![],
+            vec![scope_logs("lib", "1", vec![record(Some(value), vec![], 1)])],
+        )]));
+        assert!(out.records.is_empty());
         assert_eq!(out.rejected, vec![LogRejection::UnsupportedBodyKind]);
         assert_eq!(out.rejected[0].rejected_count(), 1);
+        assert_eq!(out.body_conversions, 0);
+    }
+
+    #[test]
+    fn string_table_reference_body_is_still_rejected() {
+        // No string table travels with an ExportLogsServiceRequest, so the
+        // referenced text is not reachable here.
+        let out = normalize(request(vec![resource_logs(
+            vec![],
+            vec![scope_logs(
+                "lib",
+                "1",
+                vec![record(
+                    Some(any(AnyValueVariant::StringValueStrindex(3))),
+                    vec![],
+                    1,
+                )],
+            )],
+        )]));
+        assert!(out.records.is_empty());
+        assert_eq!(out.rejected, vec![LogRejection::UnsupportedBodyKind]);
+        assert_eq!(out.body_conversions, 0);
+    }
+
+    #[test]
+    fn oversized_converted_body_is_rejected_as_too_long() {
+        let limits = LogIngestLimits::default();
+        let out = normalize_logs(
+            request(vec![resource_logs(
+                vec![],
+                vec![scope_logs(
+                    "lib",
+                    "1",
+                    vec![record(
+                        Some(any(AnyValueVariant::ArrayValue(ArrayValue {
+                            values: vec![any(AnyValueVariant::StringValue(
+                                "x".repeat(limits.max_body_len),
+                            ))],
+                        }))),
+                        vec![],
+                        1,
+                    )],
+                )],
+            )]),
+            &limits,
+            5_000,
+        );
+        assert!(out.records.is_empty());
+        assert!(
+            matches!(out.rejected.as_slice(), [LogRejection::BodyTooLong { .. }]),
+            "{:?}",
+            out.rejected
+        );
+        // The record was rejected, so no conversion is counted for it.
+        assert_eq!(out.body_conversions, 0);
     }
 
     #[test]
@@ -1012,7 +1379,9 @@ mod tests {
                 max: MAX_ATTRIBUTE_NESTING_DEPTH,
             }]
         );
-        assert_eq!(out.rejected[0].rejected_count(), 1);
+        // The over-nested attribute dropped, but its record was stored, so it
+        // costs the sender no record and its rejected_count is 0.
+        assert_eq!(out.rejected[0].rejected_count(), 0);
     }
 
     // --- convert_value key identity (#808): both recursive arms must report
@@ -1599,6 +1968,79 @@ mod tests {
                 proptest::prop_assert!(is_skew_rejection, "{:?}", out.rejected);
             }
         }
+    }
+
+    /// A stored record whose attributes were dropped must move neither the
+    /// skew nor the structural rejected counter: the record landed, so its
+    /// dropped attributes cost the sender no record. This is the blocker the
+    /// per-context fix closes.
+    #[test]
+    fn stored_record_dropped_attrs_move_no_rejected_counter() {
+        use crate::limits::NormalizeRejectCounts;
+        let limits = LogIngestLimits::default();
+        let big = "x".repeat(limits.max_attribute_value_len + 1);
+        let out = normalize(request(vec![resource_logs(
+            vec![],
+            vec![scope_logs(
+                "lib",
+                "1",
+                vec![record(
+                    Some(any(AnyValueVariant::StringValue("body".into()))),
+                    vec![
+                        string_kv("a", &big),
+                        string_kv("b", &big),
+                        string_kv("c", &big),
+                    ],
+                    1,
+                )],
+            )],
+        )]));
+        // records_stored=1, records_lost=0, structural=0 (was 3 before the fix).
+        assert_eq!(out.records.len(), 1);
+        assert!(out.records[0].attrs.is_empty());
+        assert_eq!(out.rejected.len(), 3);
+        let counts = NormalizeRejectCounts::from_log_rejections(&out.rejected);
+        assert_eq!(counts.structural, 0, "{:?}", out.rejected);
+        assert_eq!(counts.skew, 0);
+        // Partial-success rejected_log_records for the record is 0: it landed.
+        let rejected_records: usize = out.rejected.iter().map(|r| r.rejected_count()).sum();
+        assert_eq!(rejected_records, 0);
+    }
+
+    /// A whole resource lost to an attribute that cannot be converted still
+    /// counts `structural` for its full record count. The `Grouped` carries
+    /// the loss even though its inner reason costs nothing on its own; this
+    /// pins the case the naive enum-level fix breaks.
+    #[test]
+    fn whole_resource_conversion_failure_counts_every_record_structural() {
+        use crate::limits::NormalizeRejectCounts;
+        let out = normalize(request(vec![resource_logs(
+            vec![KeyValue {
+                key: "service.name".to_string(),
+                value: None,
+                ..Default::default()
+            }],
+            vec![scope_logs(
+                "lib",
+                "1",
+                vec![
+                    record(
+                        Some(any(AnyValueVariant::StringValue("a".into()))),
+                        vec![],
+                        1,
+                    ),
+                    record(
+                        Some(any(AnyValueVariant::StringValue("b".into()))),
+                        vec![],
+                        2,
+                    ),
+                ],
+            )],
+        )]));
+        assert!(out.records.is_empty());
+        let counts = NormalizeRejectCounts::from_log_rejections(&out.rejected);
+        assert_eq!(counts.structural, 2, "{:?}", out.rejected);
+        assert_eq!(counts.skew, 0);
     }
 
     #[test]

--- a/crates/ravel-otlp/src/logs_normalize.rs
+++ b/crates/ravel-otlp/src/logs_normalize.rs
@@ -266,7 +266,7 @@ fn normalize_record(
     let NormalizedBody {
         text: body,
         converted: converted_body,
-    } = normalize_body(record.body.as_ref())?;
+    } = normalize_body(record.body.as_ref(), limits.max_body_len)?;
     if body.len() > limits.max_body_len {
         return Err(LogRejection::BodyTooLong {
             len: body.len(),
@@ -405,7 +405,17 @@ const BODY_KEY: &str = "body";
 /// [`LogRejection::UnsupportedBodyKind`] rather than as the attribute-shaped
 /// rejection the converter returns, because the thing the sender lost is the
 /// body, not an attribute.
-fn normalize_body(body: Option<&AnyValue>) -> Result<NormalizedBody, LogRejection> {
+///
+/// `max_body_len` is passed down rather than checked only on the result: a
+/// structured body's canonical text is built under that budget (see
+/// [`canonical_json`]), so a body far larger than any storable record is
+/// refused without being materialized first. The caller still checks the
+/// returned text against the same limit, which is what bounds the
+/// pass-through arms above.
+fn normalize_body(
+    body: Option<&AnyValue>,
+    max_body_len: usize,
+) -> Result<NormalizedBody, LogRejection> {
     let plain = |text: String| {
         Ok(NormalizedBody {
             text,
@@ -423,7 +433,7 @@ fn normalize_body(body: Option<&AnyValue>) -> Result<NormalizedBody, LogRejectio
             let value =
                 convert_value(BODY_KEY, body, 1).map_err(|_| LogRejection::UnsupportedBodyKind)?;
             Ok(NormalizedBody {
-                text: canonical_json(&value),
+                text: canonical_json(&value, max_body_len)?,
                 converted: true,
             })
         }
@@ -450,91 +460,224 @@ fn normalize_body(body: Option<&AnyValue>) -> Result<NormalizedBody, LogRejectio
 /// * a non-finite double has no JSON number form, so it renders as the string
 ///   `"NaN"`, `"+Inf"`, or `"-Inf"`, matching how a top-level double body of
 ///   the same value renders.
-fn canonical_json(value: &AttrValue) -> String {
-    let mut out = String::new();
-    write_canonical_json(&mut out, value);
-    out
+///
+/// The text is built under a hard byte budget. `max_body_len` is the length
+/// the finished text may not exceed, and construction stops with
+/// [`LogRejection::BodyTooLong`] at the first byte that would carry it past
+/// that. The sender controls how much text its value produces (a kvlist tree
+/// nests up to [`MAX_ATTRIBUTE_NESTING_DEPTH`] and fans out freely), so the
+/// bound is enforced while the text is produced rather than on a finished
+/// string: a body that cannot be stored is refused without ever being
+/// materialized. Every byte of the finished text is counted exactly once, so
+/// a value whose text fits within the budget is rendered byte for byte as it
+/// would be with no budget at all.
+fn canonical_json(value: &AttrValue, max_body_len: usize) -> Result<String, LogRejection> {
+    let mut budget = JsonBudget {
+        produced: 0,
+        max: max_body_len,
+    };
+    Ok(build_canonical(value, &mut budget)?.json)
 }
 
-fn write_canonical_json(out: &mut String, value: &AttrValue) {
-    match value {
-        AttrValue::Str(s) => write_json_string(out, s),
-        AttrValue::I64(i) => out.push_str(&i.to_string()),
-        AttrValue::F64(f) => {
-            if f.is_finite() {
-                out.push_str(&format_float(*f));
-            } else {
-                write_json_string(out, &format_float(*f));
+/// Running byte budget for the canonical JSON under construction.
+///
+/// `produced` is the number of bytes of the finished text emitted so far,
+/// each counted exactly once: a nested value's text is counted when it is
+/// written, not again when it is moved into the text of the value enclosing
+/// it. So `produced` never exceeds `max`, and the `String`s alive at any
+/// point during the build hold disjoint pieces of the finished text; the peak
+/// is `max` bytes, not the size of whatever the sender sent.
+struct JsonBudget {
+    produced: usize,
+    max: usize,
+}
+
+impl JsonBudget {
+    /// Append `piece`, or reject when it would carry the text past the
+    /// budget. The rejection's `len` is the length the text would have
+    /// reached at that point, which is the smallest length that is known to
+    /// be over the limit; it is not the length of the sender's value rendered
+    /// in full, because that text is deliberately never built.
+    fn emit(&mut self, out: &mut String, piece: &str) -> Result<(), LogRejection> {
+        let len = self.produced + piece.len();
+        if len > self.max {
+            return Err(LogRejection::BodyTooLong { len, max: self.max });
+        }
+        out.push_str(piece);
+        self.produced = len;
+        Ok(())
+    }
+
+    /// Append `s` as a JSON string literal (RFC 8259 section 7): the two
+    /// mandatory escapes, the five short escapes, and `\u00XX` for the
+    /// remaining control characters. Rust strings are UTF-8, so nothing else
+    /// needs escaping. Emitted one escape at a time so that an oversized
+    /// string is cut off at the budget instead of being escaped in full
+    /// first.
+    fn emit_json_string(&mut self, out: &mut String, s: &str) -> Result<(), LogRejection> {
+        self.emit(out, "\"")?;
+        let mut utf8 = [0u8; 4];
+        for ch in s.chars() {
+            match ch {
+                '"' => self.emit(out, "\\\"")?,
+                '\\' => self.emit(out, "\\\\")?,
+                '\n' => self.emit(out, "\\n")?,
+                '\r' => self.emit(out, "\\r")?,
+                '\t' => self.emit(out, "\\t")?,
+                '\u{08}' => self.emit(out, "\\b")?,
+                '\u{0c}' => self.emit(out, "\\f")?,
+                c if (c as u32) < 0x20 => self.emit(out, &format!("\\u{:04x}", c as u32))?,
+                c => self.emit(out, c.encode_utf8(&mut utf8))?,
             }
         }
-        AttrValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
-        AttrValue::Bytes(b) => write_json_string(out, &hex::encode(b)),
+        self.emit(out, "\"")
+    }
+}
+
+/// One value's canonical JSON text together with its canonical byte
+/// encoding, produced by the same bottom-up pass.
+///
+/// The encoding is what orders a map's entries, and it is carried up rather
+/// than recomputed because a map's entry order depends on its children's
+/// encodings and a child map's encoding depends on its own children's: asking
+/// for a whole subtree's encoding from inside a comparator re-encodes that
+/// subtree once per enclosing level.
+#[derive(Debug)]
+struct CanonicalNode {
+    json: String,
+    encoded: Vec<u8>,
+}
+
+/// Type tags and framing of the frozen `ravel-logstream-v1` value encoding,
+/// mirrored from `ravel_types::logstream`'s `encode_value` and
+/// `encode_attrs`.
+///
+/// `ravel_types::logstream` exposes that encoding only for a whole attribute
+/// set, which encodes every nested value under it, so it cannot be used to
+/// build one value's encoding from its children's already-built ones. The
+/// framing is therefore assembled here, and
+/// `bottom_up_encoding_matches_ravel_types` pins it against
+/// [`ravel_types::logstream::canonical_attr_bytes`], which stays the only
+/// definition of the contract.
+const TAG_STR: u8 = 1;
+const TAG_I64: u8 = 2;
+const TAG_F64: u8 = 3;
+const TAG_BOOL: u8 = 4;
+const TAG_BYTES: u8 = 5;
+const TAG_LIST: u8 = 6;
+const TAG_MAP: u8 = 7;
+
+/// Unsigned LEB128, the length and count prefix of the encoding above.
+fn put_uvarint(out: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            out.push(byte);
+            break;
+        }
+        out.push(byte | 0x80);
+    }
+}
+
+/// Zigzag maps a signed value to an unsigned one (protobuf convention).
+fn zigzag(value: i64) -> u64 {
+    ((value as u64) << 1) ^ ((value >> 63) as u64)
+}
+
+/// Render one value's canonical JSON and canonical encoding in a single
+/// bottom-up pass, under `budget`.
+///
+/// A map's entries are ordered by key bytes, ties broken by the canonical
+/// encoding of the value, which is exactly how
+/// `ravel_types::logstream::encode_attrs` orders an attribute set. The
+/// tiebreak matters only for duplicate keys, which OTLP permits and which are
+/// kept rather than merged.
+///
+/// Recursion is bounded by [`MAX_ATTRIBUTE_NESTING_DEPTH`]: every value
+/// reaching here came through [`convert_value`], which rejects anything
+/// nested deeper.
+fn build_canonical(
+    value: &AttrValue,
+    budget: &mut JsonBudget,
+) -> Result<CanonicalNode, LogRejection> {
+    let mut json = String::new();
+    let mut encoded = Vec::new();
+    match value {
+        AttrValue::Str(s) => {
+            budget.emit_json_string(&mut json, s)?;
+            encoded.push(TAG_STR);
+            put_uvarint(&mut encoded, s.len() as u64);
+            encoded.extend_from_slice(s.as_bytes());
+        }
+        AttrValue::I64(i) => {
+            budget.emit(&mut json, &i.to_string())?;
+            encoded.push(TAG_I64);
+            put_uvarint(&mut encoded, zigzag(*i));
+        }
+        AttrValue::F64(f) => {
+            let text = format_float(*f);
+            if f.is_finite() {
+                budget.emit(&mut json, &text)?;
+            } else {
+                budget.emit_json_string(&mut json, &text)?;
+            }
+            encoded.push(TAG_F64);
+            encoded.extend_from_slice(&f.to_bits().to_le_bytes());
+        }
+        AttrValue::Bool(b) => {
+            budget.emit(&mut json, if *b { "true" } else { "false" })?;
+            encoded.push(TAG_BOOL);
+            encoded.push(u8::from(*b));
+        }
+        AttrValue::Bytes(b) => {
+            budget.emit_json_string(&mut json, &hex::encode(b))?;
+            encoded.push(TAG_BYTES);
+            put_uvarint(&mut encoded, b.len() as u64);
+            encoded.extend_from_slice(b);
+        }
         AttrValue::List(items) => {
-            out.push('[');
+            encoded.push(TAG_LIST);
+            put_uvarint(&mut encoded, items.len() as u64);
+            budget.emit(&mut json, "[")?;
             for (i, item) in items.iter().enumerate() {
                 if i > 0 {
-                    out.push(',');
+                    budget.emit(&mut json, ",")?;
                 }
-                write_canonical_json(out, item);
+                let node = build_canonical(item, budget)?;
+                json.push_str(&node.json);
+                encoded.extend_from_slice(&node.encoded);
             }
-            out.push(']');
+            budget.emit(&mut json, "]")?;
         }
         AttrValue::Map(entries) => {
-            let mut ordered: Vec<&(String, AttrValue)> = entries.iter().collect();
-            ordered.sort_by(|a, b| {
+            let mut built: Vec<(&str, CanonicalNode)> = Vec::with_capacity(entries.len());
+            for (key, value) in entries {
+                built.push((key.as_str(), build_canonical(value, budget)?));
+            }
+            built.sort_by(|a, b| {
                 a.0.as_bytes()
                     .cmp(b.0.as_bytes())
-                    .then_with(|| canonical_value_bytes(&a.1).cmp(&canonical_value_bytes(&b.1)))
+                    .then_with(|| a.1.encoded.cmp(&b.1.encoded))
             });
-            out.push('{');
-            for (i, (key, value)) in ordered.into_iter().enumerate() {
+            encoded.push(TAG_MAP);
+            put_uvarint(&mut encoded, built.len() as u64);
+            budget.emit(&mut json, "{")?;
+            for (i, (key, node)) in built.into_iter().enumerate() {
                 if i > 0 {
-                    out.push(',');
+                    budget.emit(&mut json, ",")?;
                 }
-                write_json_string(out, key);
-                out.push(':');
-                write_canonical_json(out, value);
+                budget.emit_json_string(&mut json, key)?;
+                budget.emit(&mut json, ":")?;
+                json.push_str(&node.json);
+                put_uvarint(&mut encoded, key.len() as u64);
+                encoded.extend_from_slice(key.as_bytes());
+                encoded.extend_from_slice(&node.encoded);
             }
-            out.push('}');
+            budget.emit(&mut json, "}")?;
         }
     }
-}
-
-/// The canonical encoding of one value, used only as the duplicate-key
-/// tiebreaker in [`write_canonical_json`].
-///
-/// [`ravel_types::logstream`] owns that encoding and exposes it for a whole
-/// attribute set, not for a bare value, so this asks it for a one-entry set
-/// under an empty key. Every such encoding carries the same two-byte prefix
-/// (entry count 1, key length 0), so comparing two of them compares exactly
-/// the two encoded values, which is the tiebreak `encode_attrs` applies. This
-/// crate does not re-implement the encoding.
-fn canonical_value_bytes(value: &AttrValue) -> Vec<u8> {
-    ravel_types::logstream::canonical_attr_bytes(std::slice::from_ref(&(
-        String::new(),
-        value.clone(),
-    )))
-}
-
-/// Write `s` as a JSON string literal (RFC 8259 section 7): the two mandatory
-/// escapes, the five short escapes, and `\u00XX` for the remaining control
-/// characters. Rust strings are UTF-8, so nothing else needs escaping.
-fn write_json_string(out: &mut String, s: &str) {
-    out.push('"');
-    for ch in s.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            '\u{08}' => out.push_str("\\b"),
-            '\u{0c}' => out.push_str("\\f"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
-            c => out.push(c),
-        }
-    }
-    out.push('"');
+    Ok(CanonicalNode { json, encoded })
 }
 
 /// Convert an attribute set whole: the first failure rejects the set. Used
@@ -1028,6 +1171,232 @@ mod tests {
         assert!(out.rejected.is_empty(), "{:?}", out.rejected);
         assert_eq!(out.records[0].body, r#"{"k":1,"k":2}"#);
         assert_eq!(out.body_conversions, 1);
+    }
+
+    /// A kvlist tree whose every level is a pair of entries under one
+    /// repeated key: the duplicate-key tiebreak in [`build_canonical`]
+    /// applies at every node, which is the only shape in which the tiebreak
+    /// runs at all (a map with distinct keys never compares two values).
+    /// Leaves are 8-byte strings. `depth` levels give `2 ^ depth` leaves and
+    /// a canonical text of `21 * 2 ^ depth - 11` bytes: 10 per leaf
+    /// (`"abcdefgh"`) plus 11 of framing per internal node
+    /// (`{"k":`, `,"k":`, `}`).
+    fn duplicate_key_kvlist_tree(depth: usize) -> AnyValue {
+        if depth == 0 {
+            return any(AnyValueVariant::StringValue("abcdefgh".to_string()));
+        }
+        let child = duplicate_key_kvlist_tree(depth - 1);
+        any(AnyValueVariant::KvlistValue(KeyValueList {
+            values: vec![kv_with_value("k", child.clone()), kv_with_value("k", child)],
+        }))
+    }
+
+    fn kv_with_value(key: &str, value: AnyValue) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(value),
+            ..Default::default()
+        }
+    }
+
+    /// The canonical text of a body the sender sized is bounded while it is
+    /// produced, not after: a nested duplicate-key body whose text would run
+    /// to megabytes is refused at `max_body_len`, and the `String` under
+    /// construction never grows past `max_body_len` at all.
+    ///
+    /// Depth 16 gives 65 536 leaves and a full text of
+    /// `21 * 2 ^ 16 - 11 = 1_376_245` bytes, so the 65 536-byte budget is
+    /// reached inside the leftmost 4.8% of it. Depth 12 (`21 * 2 ^ 12 - 11 =
+    /// 86_005`) is the shallowest tree of this shape whose text exceeds the
+    /// default budget, so every depth from 12 up aborts; 16 is used for
+    /// margin while staying cheap to build.
+    ///
+    /// The two assertions are the mechanical form of "the work was bounded
+    /// before it was done". Without the budget the text is built in full and
+    /// the record is still rejected, by the length check on the finished
+    /// string, so the rejection alone proves nothing: the reported length
+    /// and `JsonBudget::produced` are what distinguish the two.
+    #[test]
+    fn nested_duplicate_key_body_stops_at_the_budget() {
+        let limits = LogIngestLimits::default();
+        let body = duplicate_key_kvlist_tree(16);
+
+        let out = normalize_logs(
+            request(vec![resource_logs(
+                vec![],
+                vec![scope_logs(
+                    "lib",
+                    "1",
+                    vec![record(Some(body.clone()), vec![], 1)],
+                )],
+            )]),
+            &limits,
+            5_000,
+        );
+        assert!(out.records.is_empty());
+        // Every piece this body emits is one byte wide (`{`, `"`, `k`, `:`,
+        // `,`, `}`, and each leaf character), so the text reached exactly
+        // `max_body_len` and the length the next byte would have taken it to
+        // is one past that. Not a generous upper bound: this is the whole
+        // slack the budget allows on this input.
+        assert_eq!(
+            out.rejected,
+            vec![LogRejection::BodyTooLong {
+                len: limits.max_body_len + 1,
+                max: limits.max_body_len,
+            }]
+        );
+        assert_eq!(out.body_conversions, 0);
+
+        // Same body, straight at the builder, so the bound is asserted on the
+        // text that was actually built rather than inferred from the
+        // rejection.
+        let value = convert_value(BODY_KEY, Some(&body), 1).expect("body converts");
+        let mut budget = JsonBudget {
+            produced: 0,
+            max: limits.max_body_len,
+        };
+        let rejection = build_canonical(&value, &mut budget).expect_err("over budget");
+        assert_eq!(
+            rejection,
+            LogRejection::BodyTooLong {
+                len: limits.max_body_len + 1,
+                max: limits.max_body_len,
+            }
+        );
+        assert_eq!(budget.produced, limits.max_body_len);
+    }
+
+    /// The renderer this file carried before the budget and the bottom-up
+    /// encoding: the duplicate-key tiebreak asks `ravel_types` for a whole
+    /// subtree's encoding from inside the comparator, and clones the subtree
+    /// to ask. Kept as the differential oracle for
+    /// `canonical_json_matches_the_reference_renderer`, so the rewrite is
+    /// pinned to produce the same stored bytes rather than to look
+    /// equivalent.
+    fn reference_canonical_json(value: &AttrValue) -> String {
+        fn reference_value_bytes(value: &AttrValue) -> Vec<u8> {
+            ravel_types::logstream::canonical_attr_bytes(std::slice::from_ref(&(
+                String::new(),
+                value.clone(),
+            )))
+        }
+        fn write_json_string(out: &mut String, s: &str) {
+            out.push('"');
+            for ch in s.chars() {
+                match ch {
+                    '"' => out.push_str("\\\""),
+                    '\\' => out.push_str("\\\\"),
+                    '\n' => out.push_str("\\n"),
+                    '\r' => out.push_str("\\r"),
+                    '\t' => out.push_str("\\t"),
+                    '\u{08}' => out.push_str("\\b"),
+                    '\u{0c}' => out.push_str("\\f"),
+                    c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+                    c => out.push(c),
+                }
+            }
+            out.push('"');
+        }
+        fn write(out: &mut String, value: &AttrValue) {
+            match value {
+                AttrValue::Str(s) => write_json_string(out, s),
+                AttrValue::I64(i) => out.push_str(&i.to_string()),
+                AttrValue::F64(f) => {
+                    if f.is_finite() {
+                        out.push_str(&format_float(*f));
+                    } else {
+                        write_json_string(out, &format_float(*f));
+                    }
+                }
+                AttrValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+                AttrValue::Bytes(b) => write_json_string(out, &hex::encode(b)),
+                AttrValue::List(items) => {
+                    out.push('[');
+                    for (i, item) in items.iter().enumerate() {
+                        if i > 0 {
+                            out.push(',');
+                        }
+                        write(out, item);
+                    }
+                    out.push(']');
+                }
+                AttrValue::Map(entries) => {
+                    let mut ordered: Vec<&(String, AttrValue)> = entries.iter().collect();
+                    ordered.sort_by(|a, b| {
+                        a.0.as_bytes().cmp(b.0.as_bytes()).then_with(|| {
+                            reference_value_bytes(&a.1).cmp(&reference_value_bytes(&b.1))
+                        })
+                    });
+                    out.push('{');
+                    for (i, (key, value)) in ordered.into_iter().enumerate() {
+                        if i > 0 {
+                            out.push(',');
+                        }
+                        write_json_string(out, key);
+                        out.push(':');
+                        write(out, value);
+                    }
+                    out.push('}');
+                }
+            }
+        }
+        let mut out = String::new();
+        write(&mut out, value);
+        out
+    }
+
+    /// Arbitrary nested attribute values, with keys drawn from a two-symbol
+    /// alphabet so duplicate sibling keys (the only input that exercises the
+    /// tiebreak) are common rather than vanishingly rare.
+    fn arbitrary_attr_value() -> impl proptest::strategy::Strategy<Value = AttrValue> {
+        use proptest::prelude::*;
+        let leaf = prop_oneof![
+            proptest::collection::vec(any::<char>(), 0..4)
+                .prop_map(|cs| AttrValue::Str(cs.into_iter().collect())),
+            any::<i64>().prop_map(AttrValue::I64),
+            any::<f64>().prop_map(AttrValue::F64),
+            any::<bool>().prop_map(AttrValue::Bool),
+            proptest::collection::vec(any::<u8>(), 0..4).prop_map(AttrValue::Bytes),
+        ];
+        leaf.prop_recursive(4, 48, 3, |inner| {
+            prop_oneof![
+                proptest::collection::vec(inner.clone(), 0..4).prop_map(AttrValue::List),
+                proptest::collection::vec(("[ab]", inner), 0..4).prop_map(AttrValue::Map),
+            ]
+        })
+    }
+
+    proptest::proptest! {
+        /// The rewrite is byte-identical to the renderer it replaces, for
+        /// every value whose text fits the budget. A stored body is a
+        /// contract query predicates are written against, so "same order,
+        /// same escapes, same duplicate keys kept" is asserted as byte
+        /// equality against the old code, not re-derived from the rules.
+        #[test]
+        fn canonical_json_matches_the_reference_renderer(value in arbitrary_attr_value()) {
+            let rendered = canonical_json(&value, 1 << 20).expect("fits the budget");
+            proptest::prop_assert_eq!(rendered, reference_canonical_json(&value));
+        }
+
+        /// The bottom-up encoding assembled in [`build_canonical`] is the
+        /// same frozen `ravel-logstream-v1` encoding
+        /// [`ravel_types::logstream`] defines. That crate exposes it only for
+        /// a whole attribute set, whose every encoding carries the same
+        /// two-byte prefix (entry count 1, key length 0) for a one-entry set
+        /// under an empty key, so the comparison strips those two bytes. This
+        /// is what keeps the framing mirrored here from drifting from its
+        /// definition.
+        #[test]
+        fn bottom_up_encoding_matches_ravel_types(value in arbitrary_attr_value()) {
+            let mut budget = JsonBudget { produced: 0, max: 1 << 20 };
+            let node = build_canonical(&value, &mut budget).expect("fits the budget");
+            let whole_set = ravel_types::logstream::canonical_attr_bytes(
+                std::slice::from_ref(&(String::new(), value)),
+            );
+            proptest::prop_assert_eq!(&whole_set[..2], &[1u8, 0u8][..]);
+            proptest::prop_assert_eq!(node.encoded, whole_set[2..].to_vec());
+        }
     }
 
     #[test]

--- a/crates/ravel-otlp/src/traces_limits.rs
+++ b/crates/ravel-otlp/src/traces_limits.rs
@@ -272,6 +272,16 @@ impl SpanRejection {
             | SpanRejection::MissingAttributeValue { .. }
             | SpanRejection::UnsupportedAttributeValue { .. }
             | SpanRejection::UnsupportedAttributeKind { .. } => None,
+            // A grouped rejection carries its own span count; the class is the
+            // shared reason's. Delegating is safe only because the traces path
+            // groups nothing but a `TooManyResourceAttributes` or
+            // `TooManyScopeAttributes` breach (`crate::traces_normalize`), both
+            // in the structural arm above; an unconvertible resource or scope
+            // attribute is lossy here rather than group-rejecting. Grouping one
+            // of the `None` variants above needs this arm to classify the group
+            // instead, the way
+            // `crate::logs_limits::LogRejection::admission_class` does, or the
+            // whole-group loss goes uncounted.
             SpanRejection::Grouped { reason, .. } => reason.admission_class(),
         }
     }

--- a/crates/ravel-otlp/src/traces_limits.rs
+++ b/crates/ravel-otlp/src/traces_limits.rs
@@ -240,6 +240,42 @@ pub enum SpanRejection {
 }
 
 impl SpanRejection {
+    /// The admission `reason` this rejection is counted under (ADR-0051
+    /// section 3 layer 3), or `None` when it costs the sender no span. Mirrors
+    /// [`crate::limits::Rejection::admission_class`], and is exhaustive for
+    /// the same reason: a new variant does not compile until it has been
+    /// classified.
+    pub fn admission_class(&self) -> Option<crate::limits::AdmissionClass> {
+        use crate::limits::AdmissionClass;
+        match self {
+            SpanRejection::FutureSkew { .. } | SpanRejection::TooOld { .. } => {
+                Some(AdmissionClass::Skew)
+            }
+            SpanRejection::TooManySpans { .. }
+            | SpanRejection::TooManyAttributes { .. }
+            | SpanRejection::NameTooLong { .. }
+            | SpanRejection::StatusMessageTooLong { .. }
+            | SpanRejection::TooManyResourceAttributes { .. }
+            | SpanRejection::TooManyScopeAttributes { .. }
+            | SpanRejection::InvalidTraceId { .. }
+            | SpanRejection::InvalidSpanId { .. }
+            | SpanRejection::InvalidTimeRange { .. } => Some(AdmissionClass::Structural),
+            // Attribute-, blob-, and parent-edge-level: the span is still
+            // stored, so these cost the sender nothing and must not move a
+            // rejected counter (their `rejected_count` is 0 for the same
+            // reason).
+            SpanRejection::AttributeKeyTooLong { .. }
+            | SpanRejection::AttributeValueTooLong { .. }
+            | SpanRejection::InvalidParentSpanId { .. }
+            | SpanRejection::EventsBlobTooLong { .. }
+            | SpanRejection::LinksBlobTooLong { .. }
+            | SpanRejection::MissingAttributeValue { .. }
+            | SpanRejection::UnsupportedAttributeValue { .. }
+            | SpanRejection::UnsupportedAttributeKind { .. } => None,
+            SpanRejection::Grouped { reason, .. } => reason.admission_class(),
+        }
+    }
+
     /// Number of underlying OTLP spans this rejection accounts for. Summing
     /// this over [`crate::traces_normalize::SpanNormalizeOutput::rejected`]
     /// gives the count to report in an OTLP `rejected_spans` field. Mirrors
@@ -426,5 +462,62 @@ mod tests {
         let msg = r.to_string();
         assert!(msg.contains("5000"), "{msg}");
         assert!(msg.contains("resource has 200 attributes"), "{msg}");
+    }
+
+    /// The eight attribute-, blob-, and parent-edge-level reasons drop part of
+    /// a span that is still stored, so they carry no admission class and must
+    /// never move a rejected counter. Pinned alongside the `rejected_count`
+    /// zeros above so both halves of "the span landed" fail an arm swap.
+    #[test]
+    fn attribute_level_reasons_carry_no_admission_class() {
+        for r in [
+            SpanRejection::AttributeKeyTooLong { len: 300, max: 256 },
+            SpanRejection::AttributeValueTooLong {
+                len: 9000,
+                max: 8192,
+            },
+            SpanRejection::InvalidParentSpanId { len: 5 },
+            SpanRejection::EventsBlobTooLong {
+                len: 70_000,
+                max: 65_536,
+            },
+            SpanRejection::LinksBlobTooLong {
+                len: 70_000,
+                max: 65_536,
+            },
+            SpanRejection::MissingAttributeValue { key: "k".into() },
+            SpanRejection::UnsupportedAttributeValue { key: "k".into() },
+            SpanRejection::UnsupportedAttributeKind { key: "k".into() },
+        ] {
+            assert_eq!(r.admission_class(), None, "{r}");
+        }
+    }
+
+    /// The span counters: `from_span_rejections` totals a stored span's
+    /// dropped attributes to zero and a whole-span event-time breach to one
+    /// skew. This is the record-call side the per-signal counting feeds.
+    #[test]
+    fn from_span_rejections_totals_by_class() {
+        use crate::limits::NormalizeRejectCounts;
+
+        let stored_span_drops = [
+            SpanRejection::AttributeValueTooLong {
+                len: 9000,
+                max: 8192,
+            },
+            SpanRejection::MissingAttributeValue { key: "k".into() },
+        ];
+        let counts = NormalizeRejectCounts::from_span_rejections(&stored_span_drops);
+        assert_eq!(counts.structural, 0);
+        assert_eq!(counts.skew, 0);
+        assert!(counts.is_empty());
+
+        let too_old = [SpanRejection::TooOld {
+            lag_ns: 8_000_000_000_000,
+            max_ns: 7_200_000_000_000,
+        }];
+        let counts = NormalizeRejectCounts::from_span_rejections(&too_old);
+        assert_eq!(counts.skew, 1);
+        assert_eq!(counts.structural, 0);
     }
 }

--- a/deploy/otel/collector-config.yaml
+++ b/deploy/otel/collector-config.yaml
@@ -62,8 +62,13 @@ processors:
     # Drop a series' accumulated state after this long without a new point, so
     # a churning series set cannot grow memory without bound.
     max_stale: 5m
-    # Ceiling on tracked series. Points for series past it pass through
-    # unconverted, and are then rejected by Ravel, rather than being buffered.
+    # Ceiling on tracked series. Once it is reached, points for a series that
+    # is not already tracked are DROPPED by the processor, not buffered and not
+    # forwarded: nothing about them reaches Ravel, so no Ravel rejection
+    # counter moves and the loss is silent from the database's side. The
+    # collector counts them as
+    # `otelcol_deltatocumulative_datapoints_total{error="limit"}`; alert on
+    # that, and size this above the tenant's active series count.
     max_streams: 1000000
   batch:
 

--- a/deploy/otel/collector-config.yaml
+++ b/deploy/otel/collector-config.yaml
@@ -46,6 +46,25 @@ receivers:
       network:
 
 processors:
+  # Ravel stores cumulative metrics only: a delta-temporality Sum or Histogram
+  # is rejected whole at normalization (counted under
+  # `ravel_admission_rejected_total{reason="structural"}`), because converting
+  # delta to cumulative needs per-series state across requests and every Ravel
+  # compute process is disposable. This processor holds that state in the
+  # collector, which is the right place for it, and emits cumulative points.
+  # It runs before `batch` so batching sees the converted points.
+  #
+  # `hostmetrics` emits cumulative sums already, so this is a no-op for the
+  # quickstart's own pipeline. It is here because it is the piece any real
+  # deployment needs the moment an exporter that defaults to delta (the
+  # OpenTelemetry SDKs for .NET, Go, and Python among them) points at Ravel.
+  deltatocumulative:
+    # Drop a series' accumulated state after this long without a new point, so
+    # a churning series set cannot grow memory without bound.
+    max_stale: 5m
+    # Ceiling on tracked series. Points for series past it pass through
+    # unconverted, and are then rejected by Ravel, rather than being buffered.
+    max_streams: 1000000
   batch:
 
 exporters:
@@ -63,7 +82,7 @@ service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [batch]
+      processors: [deltatocumulative, batch]
       exporters: [otlphttp]
   telemetry:
     logs:

--- a/docs/guides/admission-limits.md
+++ b/docs/guides/admission-limits.md
@@ -311,7 +311,7 @@ The admission controller's per-(tenant, signal) counters are rendered on
 | `ravel_admission_admitted_bytes_total` | counter | Bytes charged against the byte-rate layer, which for a compressed request is the decompressed size. |
 | `ravel_ingest_wire_bytes_total` | counter | Request-body bytes as they arrived on the wire. Its ratio to the row above is a tenant's effective compression factor. |
 | `ravel_admission_rejected_total` | counter | Rejections, with a fourth `reason` label: `byte_rate`, `series_rate`, `series_cap`, `clock`, `skew`, `structural`. The first four count whole requests or series; `skew` and `structural` count individual points, log records, or spans, matching what the OTLP partial-success response tells the sender. |
-| `ravel_ingest_body_conversions_total` | counter | Log records stored after a structured body was converted to canonical JSON text. Not a rejection. |
+| `ravel_ingest_body_conversions_total` | counter | Log records whose structured body was converted to canonical JSON text at normalization. Not a rejection, and counted before the stream cap and the write, so not a count of stored records. Normative description: [the observability guide](observability.md#reading-the-reason-label). |
 | `ravel_admission_reconciliation_failures_total` | counter | Reconciliation cycles whose sibling-snapshot read failed. The last-known threshold stays in force, so this says fleet-wide accuracy is degrading, not that ingest is down. |
 
 By default every tenant's rows fold into `tenant_hash="other"`, so the family's

--- a/docs/guides/admission-limits.md
+++ b/docs/guides/admission-limits.md
@@ -310,7 +310,8 @@ The admission controller's per-(tenant, signal) counters are rendered on
 | `ravel_admission_admitted_total` | counter | Requests admitted past the byte-rate layer. |
 | `ravel_admission_admitted_bytes_total` | counter | Bytes charged against the byte-rate layer, which for a compressed request is the decompressed size. |
 | `ravel_ingest_wire_bytes_total` | counter | Request-body bytes as they arrived on the wire. Its ratio to the row above is a tenant's effective compression factor. |
-| `ravel_admission_rejected_total` | counter | Rejections, with a fourth `reason` label: `byte_rate`, `series_rate`, `series_cap`, `clock`. |
+| `ravel_admission_rejected_total` | counter | Rejections, with a fourth `reason` label: `byte_rate`, `series_rate`, `series_cap`, `clock`, `skew`, `structural`. The first four count whole requests or series; `skew` and `structural` count individual points, log records, or spans, matching what the OTLP partial-success response tells the sender. |
+| `ravel_ingest_body_conversions_total` | counter | Log records stored after a structured body was converted to canonical JSON text. Not a rejection. |
 | `ravel_admission_reconciliation_failures_total` | counter | Reconciliation cycles whose sibling-snapshot read failed. The last-known threshold stays in force, so this says fleet-wide accuracy is degrading, not that ingest is down. |
 
 By default every tenant's rows fold into `tenant_hash="other"`, so the family's

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -193,6 +193,66 @@ Two behaviors are worth knowing about, both intentional:
   one named `_foo` both sanitize to `_foo` and become the same series. This
   is a documented consequence of the sanitization rule, not a bug.
 
+## Delta temporality metrics
+
+Ravel stores cumulative metrics only. A `Sum`, `Histogram`, or
+`ExponentialHistogram` whose `aggregation_temporality` is delta (or
+unspecified) is rejected as `UnsupportedTemporality`, and the response reports
+every point under that metric as rejected. This is not a temporary
+restriction: converting delta to cumulative means holding the running total
+for every series between requests, and a Ravel compute process keeps no
+durable local state, so it has nowhere correct to hold it. A process restart
+mid-stream would silently reset the totals.
+
+Temporality is a property of the metric, not of the individual point: the
+`aggregation_temporality` field sits on the `Sum` and `Histogram` messages,
+above the data points, so a metric cannot carry a mix. Rejecting the whole
+metric rejects exactly the points that share the delta temporality, and no
+others.
+
+Convert in the collector instead, which is a stateful process that owns local
+memory. The `deltatocumulative` processor
+(`otel/opentelemetry-collector-contrib`) holds the per-series accumulators and
+emits cumulative points:
+
+```yaml
+processors:
+  deltatocumulative:
+    # Forget a series after this long without a point, so a churning series
+    # set cannot grow memory without bound.
+    max_stale: 5m
+    # Ceiling on tracked series. Points past it pass through unconverted, and
+    # Ravel then rejects them, rather than being buffered.
+    max_streams: 1000000
+  batch:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      # Convert before batching, so batches carry converted points.
+      processors: [deltatocumulative, batch]
+      exporters: [otlphttp]
+```
+
+Two consequences to plan for. The processor's memory is proportional to the
+number of live series, so `max_streams` is a real ceiling and not a formality;
+size it above the tenant's active series count. And the first point of each
+series after a collector restart re-bases that series' accumulator, which
+appears downstream as a counter reset. PromQL's `rate` and `increase` handle
+resets, so query results stay correct, but a dashboard reading a raw counter
+value shows the drop.
+
+The alternative is to configure the sender for cumulative temporality
+directly, which most OpenTelemetry SDKs support through the
+`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative` environment
+variable. That avoids the conversion and its memory entirely, and is the
+better fix where the sender is yours to configure.
+
+Watch `ravel_admission_rejected_total{reason="structural"}`
+([observability guide](observability.md#reading-the-reason-label)) to confirm
+the rejections stopped.
+
 ## Metric metadata and OTLP name suffixing
 
 Ravel captures each metric's type, help, and unit at ingest time and serves it
@@ -363,7 +423,7 @@ Every rejection reason:
 | `AttributeKeyTooLong` | An attribute key exceeds `max_attribute_key_len`. Ravel drops that one attribute, not the record. |
 | `AttributeValueTooLong` | An attribute value's payload exceeds `max_attribute_value_len` (nested list and map entries count toward it). Ravel drops that one attribute, not the record. |
 | `BodyTooLong` | The record body, after normalization to a string, exceeds `max_body_len`. Ravel rejects that record. |
-| `UnsupportedBodyKind` | The body is an OTLP `ArrayValue`, `KvlistValue`, or string-table reference. A structured body has no lossless string form, so Ravel rejects the record rather than stringify it by guess. |
+| `UnsupportedBodyKind` | The body is a string-table reference, which indexes a table the record does not carry, so there is nothing to store. Array and map bodies are converted, not rejected; see below. |
 | `MissingAttributeValue` | An attribute arrived with its `value` field unset. Ravel drops and reports that one attribute; it never silently discards it. |
 | `UnsupportedAttributeValue` | An attribute value is a string-table reference (`strindex`), which carries no value of its own. Ravel drops that one attribute. |
 | `Grouped` | Not a reason of its own. It carries one of the reasons above plus the number of records it applies to, for a rejection that covers a whole resource or scope. Ravel reports it as that inner reason with a count. |
@@ -373,6 +433,32 @@ and `IntValue` become their plain string form. `DoubleValue` uses the same
 float formatting that the metrics path uses. `BytesValue` becomes a hex
 string. A record with no body at all normalizes to an empty body, which is
 legal OTLP, not a rejection.
+
+An `ArrayValue` or `KvlistValue` body is stored as JSON text. The rendering is
+canonical, so two exports of the same body always produce byte-identical
+stored text:
+
+- Map keys are ordered by the same rule that orders attributes in stream
+  identity, which is a byte ordering on the key and then on the encoded value,
+  not the sender's order and not lexicographic ordering of the JSON text. Two
+  entries with the same key are both kept, ordered by their values.
+- Array elements keep the sender's order, which is part of the value.
+- Nested arrays and maps render recursively under the same rules. Nesting is
+  bounded by the same depth limit that applies to attribute values. A body
+  past that depth, or one holding an unset value or a nested string-table
+  reference, is rejected as `UnsupportedBodyKind`: what the sender lost is the
+  body, so the record is reported that way rather than as an attribute
+  problem.
+- A bytes value inside the body renders as a lowercase hex string. A
+  non-finite double renders as the JSON string `"NaN"`, `"Infinity"`, or
+  `"-Infinity"`, since JSON has no literal for them.
+
+The converted text counts against `max_body_len` like any other body, so a
+large structured body can still be rejected as `BodyTooLong`. Conversions are
+counted per tenant and signal in `ravel_ingest_body_conversions_total`. That
+counter is not a rejection counter: every record it counts was stored. It
+exists so that a query returning JSON text where a reader expected a plain
+message has a place to check.
 
 Malformed `trace_id`/`span_id` byte lengths normalize to absent; Ravel does
 not pad or truncate them. Padding would fabricate an id that never existed.

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -221,8 +221,8 @@ processors:
     # Forget a series after this long without a point, so a churning series
     # set cannot grow memory without bound.
     max_stale: 5m
-    # Ceiling on tracked series. Points past it pass through unconverted, and
-    # Ravel then rejects them, rather than being buffered.
+    # Ceiling on tracked series. Points for an untracked series past it are
+    # dropped by the processor, not buffered and not forwarded.
     max_streams: 1000000
   batch:
 
@@ -237,11 +237,17 @@ service:
 
 Two consequences to plan for. The processor's memory is proportional to the
 number of live series, so `max_streams` is a real ceiling and not a formality;
-size it above the tenant's active series count. And the first point of each
-series after a collector restart re-bases that series' accumulator, which
-appears downstream as a counter reset. PromQL's `rate` and `increase` handle
-resets, so query results stay correct, but a dashboard reading a raw counter
-value shows the drop.
+size it above the tenant's active series count. Reaching it costs data rather
+than memory: once the processor is tracking `max_streams` series, a point for
+a series it is not already tracking is dropped inside the collector. It is not
+buffered and it is not forwarded unconverted, so nothing about it reaches
+Ravel and no Ravel rejection counter moves. The only signal is the collector's
+own `otelcol_deltatocumulative_datapoints_total{error="limit"}`; alert on it,
+because from the database's side this loss is invisible. And the first point
+of each series after a collector restart re-bases that series' accumulator,
+which appears downstream as a counter reset. PromQL's `rate` and `increase`
+handle resets, so query results stay correct, but a dashboard reading a raw
+counter value shows the drop.
 
 The alternative is to configure the sender for cumulative temporality
 directly, which most OpenTelemetry SDKs support through the
@@ -450,15 +456,29 @@ stored text:
   body, so the record is reported that way rather than as an attribute
   problem.
 - A bytes value inside the body renders as a lowercase hex string. A
-  non-finite double renders as the JSON string `"NaN"`, `"Infinity"`, or
-  `"-Infinity"`, since JSON has no literal for them.
+  non-finite double renders as the JSON string `"NaN"`, `"+Inf"`, or `"-Inf"`,
+  since JSON has no literal for them. Those are the exact three strings a
+  query predicate has to match; they are the same forms a top-level double
+  body of the same value takes.
 
-The converted text counts against `max_body_len` like any other body, so a
-large structured body can still be rejected as `BodyTooLong`. Conversions are
-counted per tenant and signal in `ravel_ingest_body_conversions_total`. That
-counter is not a rejection counter: every record it counts was stored. It
-exists so that a query returning JSON text where a reader expected a plain
-message has a place to check.
+The converted text is bounded by `max_body_len` like any other body, so a
+large structured body can still be rejected as `BodyTooLong`. The bound is
+applied while the text is produced rather than to a finished string: the
+sender chooses how much text its value renders to, so conversion stops at the
+first byte that would carry the text past `max_body_len` and rejects there,
+without rendering the rest. The `len` such a rejection reports is that
+stopping point, one byte past the limit, not the length the full text would
+have had.
+
+Conversions are counted per tenant and signal in
+`ravel_ingest_body_conversions_total`. That counter is not a rejection
+counter, and it is not a count of stored records either: it is incremented at
+normalization, before the active-stream cap and before the write, so a
+counted record can still be dropped by the cap or lost with a failed write.
+It exists so that a query returning JSON text where a reader expected a plain
+message has a place to check. The
+[observability guide](observability.md#reading-the-reason-label) holds the
+normative description.
 
 Malformed `trace_id`/`span_id` byte lengths normalize to absent; Ravel does
 not pad or truncate them. Padding would fabricate an id that never existed.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -388,8 +388,7 @@ ratios for PromQL to compute, per `cache` and per `tier`.
 Labels: `mode`, `tenant_hash`, `signal`, plus `reason` on the rejection
 counter. This family folds tenants per the rule above. The
 [admission limits guide](admission-limits.md) covers this family in
-operational depth. No alert rule for it is written yet; alert on a rejection
-rate against the workload's expected admission behavior until one is.
+operational depth.
 
 | Metric | Meaning |
 |---|---|
@@ -398,16 +397,105 @@ rate against the workload's expected admission behavior until one is.
 | `ravel_admission_admitted_bytes_total` | Charged (decompressed) bytes admitted past the ingest byte-rate layer, by tenant and signal. For a gzip OTLP request this is the decompressed size; for an uncompressed request it equals the wire size. |
 | `ravel_ingest_wire_bytes_total` | Wire (on-the-wire, compressed when the client compressed) OTLP request-body bytes admitted, by tenant and signal. |
 | `ravel_admission_rejected_total` | Admission rejections, by tenant, signal, and reason. |
+| `ravel_ingest_body_conversions_total` | Log records stored after their structured (array or map) body was converted to canonical JSON text, by tenant and signal. Not a rejection. |
 | `ravel_admission_reconciliation_failures_total` | Fleet-admission reconciliation cycles whose sibling-snapshot read (LIST or GET) failed, by tenant and signal; the last-known soft threshold stays in force. |
 
-The `reason` label carries `byte_rate`, `series_rate`, `series_cap`, or
-`clock`. The active-streams count for logs renders under
+The `reason` label carries `byte_rate`, `series_rate`, `series_cap`, `clock`,
+`skew`, or `structural`. The active-streams count for logs renders under
 `ravel_admission_active_series` with `signal="logs"`, not under a separate
 metric name. A sustained nonzero
 `ravel_admission_reconciliation_failures_total` rate means a process cannot
 read its siblings' snapshots and is falling back to its last-computed soft
 threshold; admission never fails closed on it, so it signals degrading
 fleet-wide accuracy, not that ingest is down.
+
+#### Reading the `reason` label
+
+Each reason answers a different operator question, and the unit each one
+counts differs, so a rate summed across reasons means nothing. Read them
+separately.
+
+| `reason` | Counts | What it means |
+|---|---|---|
+| `byte_rate` | Requests | The tenant sent more charged bytes per second than its ingest byte-rate limit allows. |
+| `clock` | Requests | The receiving replica's own clock was implausible, so the request was refused before any data was read. The fault is the replica's. |
+| `series_rate` | Series | New series or log streams appeared faster than the creation-rate limit allows. |
+| `series_cap` | Series | The tenant is at its active series or stream cap, so points for series past the cap were dropped. |
+| `skew` | Points, records, or spans | The event timestamp sat too far ahead of, or behind, ingest time. A sender clock problem, or a backfill wider than the accepted lag. |
+| `structural` | Points, records, or spans | The data itself cannot be represented: a delta-temporality metric, an over-long label, a body kind with no stored form. Retrying the same payload always fails the same way. |
+
+`skew` and `structural` count individual points, log records, or spans, and
+they match what the sender is told in the OTLP partial-success response, so a
+client that reads `rejected_data_points` and an operator reading this counter
+see the same number. The OTLP Arrow (OTAP) surface has no partial-success
+field, so on that surface this counter is the only place the drop appears.
+
+The two reasons want different alerts. `skew` is usually a fleet-wide clock or
+backfill problem and clears on its own once the sender is fixed; `structural`
+never clears without a change to what the sender emits, so any sustained rate
+is worth paging a human who can go and read
+[the ingest guide's temporality recipe](ingest.md#delta-temporality-metrics).
+
+```yaml
+groups:
+  - name: ravel-ingest-rejections
+    rules:
+      - alert: RavelStructuralRejections
+        expr: |
+          sum by (tenant_hash, signal) (
+            rate(ravel_admission_rejected_total{reason="structural"}[5m])
+          ) > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Tenant {{ $labels.tenant_hash }} is sending {{ $labels.signal }}
+            data Ravel cannot represent
+          description: >-
+            Structural rejections do not clear on retry. Check the OTLP
+            partial-success message the sender receives for the reason, then
+            fix the exporter or add a collector processor for it.
+      - alert: RavelEventTimeSkew
+        expr: |
+          sum by (tenant_hash, signal) (
+            rate(ravel_admission_rejected_total{reason="skew"}[5m])
+          ) > 1
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Tenant {{ $labels.tenant_hash }} is dropping {{ $labels.signal }}
+            data outside the accepted event-time window
+          description: >-
+            This is an absolute rate of rejected points, records, or spans per
+            second, not a fraction of the tenant's traffic. Check sender clock
+            sync first, then whether a backfill is running outside the tenant's
+            accepted ingest lag. Raise the threshold for a tenant that runs a
+            steady expected backfill.
+```
+
+Both rules are absolute rates of rejected units per second, broken out by
+tenant and signal, because there is no per-tenant admitted-points series to
+divide by. `ravel_admission_rejected_total{reason="skew"}` counts individual
+points, records, or spans, while `ravel_admission_admitted_total` counts
+requests; dividing one by the other inflates the result by the mean points per
+request, which is three orders of magnitude at typical batching, so that ratio
+means nothing. An absolute rate tells you how much data a tenant is losing to
+the event-time window. It does not tell you what fraction of that tenant's
+traffic that is, so a large tenant with a steady backfill and a small tenant
+with a broken clock can trip the same threshold; tune the threshold per tenant
+and treat the alert as a prompt to check clock sync and backfill status, not as
+a percentage. The skew rule uses a nonzero threshold because a few late points
+are normal. The structural rule keeps `> 0` because one sender emitting a
+metric type Ravel cannot store drops every point of that metric forever, and
+that is worth seeing even at a low rate.
+
+Neither rule alerts on `ravel_ingest_body_conversions_total`. Every record it
+counts was stored; it exists so a query that returns JSON text where a reader
+expected a plain message has an explanation. A sustained rate means a sender
+is emitting structured log bodies, which is supported, not a fault.
 
 `ravel_ingest_wire_bytes_total` is emitted from the ingest byte-metrics tracker
 rather than the admission snapshot, so its name carries the `ravel_ingest_`

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -397,7 +397,7 @@ operational depth.
 | `ravel_admission_admitted_bytes_total` | Charged (decompressed) bytes admitted past the ingest byte-rate layer, by tenant and signal. For a gzip OTLP request this is the decompressed size; for an uncompressed request it equals the wire size. |
 | `ravel_ingest_wire_bytes_total` | Wire (on-the-wire, compressed when the client compressed) OTLP request-body bytes admitted, by tenant and signal. |
 | `ravel_admission_rejected_total` | Admission rejections, by tenant, signal, and reason. |
-| `ravel_ingest_body_conversions_total` | Log records stored after their structured (array or map) body was converted to canonical JSON text, by tenant and signal. Not a rejection. |
+| `ravel_ingest_body_conversions_total` | Log records whose structured (array or map) body was converted to canonical JSON text at normalization, by tenant and signal. Not a rejection, and not a count of stored records: see "Neither rule alerts on" below. |
 | `ravel_admission_reconciliation_failures_total` | Fleet-admission reconciliation cycles whose sibling-snapshot read (LIST or GET) failed, by tenant and signal; the last-known soft threshold stays in force. |
 
 The `reason` label carries `byte_rate`, `series_rate`, `series_cap`, `clock`,
@@ -492,10 +492,25 @@ are normal. The structural rule keeps `> 0` because one sender emitting a
 metric type Ravel cannot store drops every point of that metric forever, and
 that is worth seeing even at a low rate.
 
-Neither rule alerts on `ravel_ingest_body_conversions_total`. Every record it
-counts was stored; it exists so a query that returns JSON text where a reader
-expected a plain message has an explanation. A sustained rate means a sender
-is emitting structured log bodies, which is supported, not a fault.
+Neither rule alerts on `ravel_ingest_body_conversions_total`. It exists so a
+query that returns JSON text where a reader expected a plain message has an
+explanation. A sustained rate means a sender is emitting structured log bodies,
+which is supported, not a fault.
+
+This paragraph is the normative description of that counter; the ingest guide,
+the admission-limits reference, and the counter's own `HELP` text point here.
+It counts conversions at normalization, not stored records. The logs ingest
+handler increments it as soon as `normalize_logs` returns, which is before the
+layer-4 active-stream cap drops the records whose stream is over the cap, and
+before the shard write runs at all. So a converted record can be counted and
+then not stored: dropped by the stream cap, or lost with every other record in
+a request whose write fails. Read it as a conversion rate, in the sense of "how
+much of this tenant's log traffic arrives with a structured body", and never as
+a count of rows in storage. It is still not a rejection counter, which is why
+it is its own family rather than a `reason` on
+`ravel_admission_rejected_total`: a record it counts was admitted by
+normalization, and an operator alerting on rejection reasons must see nothing
+from it.
 
 `ravel_ingest_wire_bytes_total` is emitted from the ingest byte-metrics tracker
 rather than the admission snapshot, so its name carries the `ravel_ingest_`

--- a/services/ravel-server/src/exemplars.rs
+++ b/services/ravel-server/src/exemplars.rs
@@ -2024,6 +2024,9 @@ mod tests {
             recovery: None,
             provisioning: None,
             metadata_sink: None,
+            normalize_metrics: Arc::new(
+                crate::normalize_reject_metrics::NormalizeRejectMetrics::new(),
+            ),
         };
 
         // A classic histogram data point (le bounds [0.5]) carrying one

--- a/services/ravel-server/src/ingest.rs
+++ b/services/ravel-server/src/ingest.rs
@@ -13,7 +13,7 @@ use ravel_ingest::{
     WriteError, WriteMode, plausible_ingest_clock,
 };
 use ravel_otlp::normalize::normalize_metrics_with_metadata;
-use ravel_otlp::{IngestLimits, Rejection};
+use ravel_otlp::{IngestLimits, NormalizeRejectCounts, Rejection};
 use ravel_types::{CommitToken, ExemplarCap, SeriesId, TenantId};
 
 pub struct IngestState {
@@ -39,6 +39,12 @@ pub struct IngestState {
     /// normalization decoded, synchronously and off the acknowledgement path.
     /// `None` in a unit test or a mode that captures no metadata.
     pub metadata_sink: Option<Arc<MetadataSink>>,
+    /// Per-tenant counter for normalization's own admission decisions
+    /// (ADR-0051 section 3, layer 3), rendered as the `skew` and `structural`
+    /// reasons of `ravel_admission_rejected_total`. Every ingest surface shares
+    /// this one `Arc`, so the counter does not move when a fleet switches
+    /// transport.
+    pub normalize_metrics: Arc<crate::normalize_reject_metrics::NormalizeRejectMetrics>,
 }
 
 pub struct IngestOutcome {
@@ -175,6 +181,15 @@ pub async fn handle_export(
         .collect();
     let normalized = result.output;
     let mut rejected_count: usize = normalized.rejected.iter().map(|r| r.rejected_count()).sum();
+    // Layer 3's rejections, counted where they are observed rather than inside
+    // the normalizer, which knows no tenant. Classified per point, so the
+    // counter moves by exactly what the sender is told in `rejected_data_points`
+    // below.
+    state.normalize_metrics.record(
+        &tenant,
+        ravel_types::Signal::Metrics,
+        NormalizeRejectCounts::from_metric_rejections(&normalized.rejected),
+    );
 
     // Scalar and native-histogram points arrive in separate vectors; both
     // feed one ingest write so a request's points share a single receipt.
@@ -326,6 +341,8 @@ mod tests {
     use ravel_object_store::memory::MemoryStore;
     use ravel_types::Signal;
 
+    use crate::normalize_reject_metrics::NormalizeRejectMetrics;
+
     /// Fixed post-floor fixture base, 2026-01-01T00:00:00Z in nanoseconds
     /// (ADR-0051 amendment): the fixture ingest clock anchors to it so
     /// the receiver-clock plausibility floor admits the request. Never
@@ -351,6 +368,7 @@ mod tests {
             recovery: None,
             provisioning: None,
             metadata_sink: None,
+            normalize_metrics: Arc::new(NormalizeRejectMetrics::new()),
         }
     }
 
@@ -381,6 +399,7 @@ mod tests {
             recovery: None,
             provisioning: None,
             metadata_sink: Some(sink.clone()),
+            normalize_metrics: Arc::new(NormalizeRejectMetrics::new()),
         };
         (state, store, sink)
     }
@@ -389,6 +408,151 @@ mod tests {
         ExportMetricsServiceRequest {
             resource_metrics: vec![],
         }
+    }
+
+    /// `(skew, structural)` summed over the metrics rows of the
+    /// normalize-reject counters, so a test can read the same figures before
+    /// and after an export and assert the delta rather than the total.
+    fn metrics_normalize_totals(state: &IngestState) -> (u64, u64) {
+        state
+            .normalize_metrics
+            .snapshot()
+            .into_iter()
+            .filter(|row| row.signal == Signal::Metrics)
+            .fold((0, 0), |acc, row| {
+                (acc.0 + row.skew_total, acc.1 + row.structural_total)
+            })
+    }
+
+    /// A delta-temporality Sum with `point_count` points, which the normalize
+    /// layer rejects whole (`aggregation_temporality` is a field of the Sum
+    /// message, not of a data point, so every point under it shares one
+    /// temporality).
+    pub(crate) fn delta_sum_request(point_count: usize) -> ExportMetricsServiceRequest {
+        use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+        use opentelemetry_proto::tonic::metrics::v1::{
+            Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, Sum, metric::Data as MetricData,
+        };
+
+        ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: vec![Metric {
+                        name: "requests".to_string(),
+                        data: Some(MetricData::Sum(Sum {
+                            data_points: (0..point_count)
+                                .map(|i| NumberDataPoint {
+                                    time_unix_nano: BASE_TS_NS as u64,
+                                    value: Some(NumberValue::AsDouble(i as f64)),
+                                    ..Default::default()
+                                })
+                                .collect(),
+                            // AGGREGATION_TEMPORALITY_DELTA.
+                            aggregation_temporality: 1,
+                            is_monotonic: true,
+                        })),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    /// Delta temporality is a structural rejection, and the operator-visible
+    /// counter must move by exactly the number of points the response reports
+    /// rejected.
+    #[tokio::test]
+    async fn delta_sum_export_counts_every_point_as_structural() {
+        const POINT_COUNT: usize = 3;
+
+        let state = state();
+        let before = metrics_normalize_totals(&state);
+        let outcome = handle_export(
+            &state,
+            TenantId::new("acme"),
+            WriteMode::Buffered,
+            delta_sum_request(POINT_COUNT),
+            BASE_TS_NS,
+        )
+        .await
+        .expect("buffered write with zero admitted points never fails");
+        let after = metrics_normalize_totals(&state);
+
+        let partial_success = outcome
+            .response
+            .partial_success
+            .expect("the whole delta metric was rejected");
+        assert_eq!(partial_success.rejected_data_points, POINT_COUNT as i64);
+        assert_eq!(
+            (after.0 - before.0, after.1 - before.1),
+            (0, POINT_COUNT as u64),
+            "every rejected point counts once under structural, none under skew"
+        );
+    }
+
+    /// Event-time rejections land under the skew reason, one per rejected
+    /// point, and move nothing else.
+    #[tokio::test]
+    async fn stale_points_count_as_skew() {
+        use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+        use opentelemetry_proto::tonic::metrics::v1::{
+            Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics,
+            metric::Data as MetricData,
+        };
+
+        const POINT_COUNT: usize = 4;
+
+        let state = state();
+        let too_old = BASE_TS_NS - state.limits.max_ingest_lag_ns - 1;
+        let request = ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: vec![Metric {
+                        name: "requests".to_string(),
+                        data: Some(MetricData::Gauge(Gauge {
+                            data_points: (0..POINT_COUNT)
+                                .map(|i| NumberDataPoint {
+                                    time_unix_nano: (too_old - i as i64) as u64,
+                                    value: Some(NumberValue::AsDouble(i as f64)),
+                                    ..Default::default()
+                                })
+                                .collect(),
+                        })),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        let before = metrics_normalize_totals(&state);
+        let outcome = handle_export(
+            &state,
+            TenantId::new("acme"),
+            WriteMode::Buffered,
+            request,
+            BASE_TS_NS,
+        )
+        .await
+        .expect("buffered write with zero admitted points never fails");
+        let after = metrics_normalize_totals(&state);
+
+        assert_eq!(
+            outcome
+                .response
+                .partial_success
+                .expect("every point was too old")
+                .rejected_data_points,
+            POINT_COUNT as i64
+        );
+        assert_eq!(
+            (after.0 - before.0, after.1 - before.1),
+            (POINT_COUNT as u64, 0),
+            "every rejected point counts once under skew, none under structural"
+        );
     }
 
     #[test]
@@ -611,6 +775,7 @@ mod tests {
             recovery: Some(writer),
             provisioning: None,
             metadata_sink: None,
+            normalize_metrics: Arc::new(NormalizeRejectMetrics::new()),
         };
 
         let tenant = TenantId::new("acme");

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -37,6 +37,7 @@ pub mod mcp;
 pub mod mem_stats;
 pub mod metadata_sink_task;
 pub mod metrics;
+pub mod normalize_reject_metrics;
 #[cfg(feature = "otap")]
 pub mod otap_grpc;
 pub mod otlp_grpc;
@@ -1168,6 +1169,7 @@ fn gateway_state(
     provisioning: &Option<Arc<provisioning::ProvisioningRecordWriter>>,
     ingest_concurrency: &Arc<ingest_concurrency::IngestConcurrencyController>,
     ingest_byte_metrics: &Arc<ingest_byte_metrics::IngestByteMetrics>,
+    normalize_reject_metrics: &Arc<normalize_reject_metrics::NormalizeRejectMetrics>,
     ingest_buffer_budget: &Arc<ravel_ingest::IngestByteBudget>,
     metadata_sink: &Option<Arc<ravel_ingest::MetadataSink>>,
 ) -> Arc<otlp_http::GatewayState> {
@@ -1181,6 +1183,7 @@ fn gateway_state(
             recovery: recovery.clone(),
             provisioning: provisioning.clone(),
             metadata_sink: metadata_sink.clone(),
+            normalize_metrics: normalize_reject_metrics.clone(),
         },
         logs_ingest: logs_ingest::LogIngestState {
             router: log_ingest_router.clone(),
@@ -1190,6 +1193,7 @@ fn gateway_state(
             store: store.clone(),
             recovery: recovery.clone(),
             provisioning: provisioning.clone(),
+            normalize_metrics: normalize_reject_metrics.clone(),
         },
         traces_ingest: traces_ingest::SpanIngestState {
             router: span_ingest_router.clone(),
@@ -1199,6 +1203,7 @@ fn gateway_state(
             store: store.clone(),
             recovery: recovery.clone(),
             provisioning: provisioning.clone(),
+            normalize_metrics: normalize_reject_metrics.clone(),
         },
         admission: admission.clone(),
         budget: ingest_buffer_budget.clone(),
@@ -1542,6 +1547,14 @@ pub async fn start(
     // wire-bytes family sums the same tenants the admission family does.
     let ingest_byte_metrics = Arc::new(ingest_byte_metrics::IngestByteMetrics::new());
 
+    // Normalization-layer admission counters (ADR-0051 section 3, layer 3), on
+    // the same terms: one shared instance per process, threaded into every
+    // ingest surface (OTLP HTTP and gRPC, OTAP, both listeners) and read at
+    // scrape time. Sharing the instance is what makes the `skew` and
+    // `structural` reasons transport-independent.
+    let normalize_reject_metrics =
+        Arc::new(normalize_reject_metrics::NormalizeRejectMetrics::new());
+
     // Per-query cost aggregator (ADR-0044 section 4): one per
     // process, shared with every query handler below and read at scrape time by
     // the `/metrics` route. Its per-tenant allowlist is the tenants an operator
@@ -1606,6 +1619,7 @@ pub async fn start(
             &provisioning_writer,
             &ingest_concurrency,
             &ingest_byte_metrics,
+            &normalize_reject_metrics,
             &ingest_buffer_budget,
             &metadata_sink,
         );
@@ -1633,6 +1647,7 @@ pub async fn start(
                 &provisioning_writer,
                 &ingest_concurrency,
                 &ingest_byte_metrics,
+                &normalize_reject_metrics,
                 &ingest_buffer_budget,
                 &metadata_sink,
             );
@@ -1821,6 +1836,7 @@ pub async fn start(
         distrib: distrib_metrics.clone(),
         durable_auth: durable_auth.clone(),
         ingest_byte_metrics: ingest_byte_metrics.clone(),
+        normalize_reject_metrics: normalize_reject_metrics.clone(),
         metadata_cache: metadata_cache.clone(),
         // Filled in below, once the query-serving block has spawned the
         // pipeline; the metrics router is merged after that block for the
@@ -2426,6 +2442,7 @@ pub async fn start(
             &provisioning_writer,
             &ingest_concurrency,
             &ingest_byte_metrics,
+            &normalize_reject_metrics,
             &ingest_buffer_budget,
             &metadata_sink,
         )),

--- a/services/ravel-server/src/logs_ingest.rs
+++ b/services/ravel-server/src/logs_ingest.rs
@@ -232,8 +232,11 @@ pub async fn handle_export_logs(
     let normalized = normalize_logs(request, &state.limits, ingest_ts_ns);
     let mut rejected_count: usize = normalized.rejected.iter().map(|r| r.rejected_count()).sum();
     // Layer 3's rejections, counted where they are observed. The body
-    // conversions alongside them are not rejections: those records are in
-    // `normalized.records` and are about to be written.
+    // conversions alongside them are not rejections: those records passed
+    // normalization and are in `normalized.records`, still facing the
+    // active-stream cap below and the router write (see
+    // docs/guides/observability.md, "Reading the `reason` label", for what
+    // each counter does and does not claim).
     state.normalize_metrics.record(
         &tenant,
         ravel_types::Signal::Logs,

--- a/services/ravel-server/src/logs_ingest.rs
+++ b/services/ravel-server/src/logs_ingest.rs
@@ -14,7 +14,7 @@ use ravel_ingest::{
 };
 use ravel_maintain::config::DEFAULT_IDEM_DEDUP_WINDOW_HOURS;
 use ravel_object_store::ObjectStoreBackend;
-use ravel_otlp::{LogIngestLimits, LogRejection, normalize_logs};
+use ravel_otlp::{LogIngestLimits, LogRejection, NormalizeRejectCounts, normalize_logs};
 use ravel_types::logstream::LogStreamId;
 use ravel_types::{CommitToken, Signal, TenantId};
 
@@ -40,6 +40,11 @@ pub struct LogIngestState {
     /// Durable shard_count provisioning-record writer (ADR-0050 section 5),
     /// pins the (tenant, Logs) record on the tenant's first log write.
     pub provisioning: Option<Arc<crate::provisioning::ProvisioningRecordWriter>>,
+    /// Normalization's own admission decisions for this signal, the log
+    /// counterpart of [`crate::ingest::IngestState::normalize_metrics`]. Also
+    /// counts structured bodies converted rather than rejected, which is not a
+    /// rejection and gets its own family.
+    pub normalize_metrics: Arc<crate::normalize_reject_metrics::NormalizeRejectMetrics>,
 }
 
 #[derive(Debug)]
@@ -226,6 +231,19 @@ pub async fn handle_export_logs(
 
     let normalized = normalize_logs(request, &state.limits, ingest_ts_ns);
     let mut rejected_count: usize = normalized.rejected.iter().map(|r| r.rejected_count()).sum();
+    // Layer 3's rejections, counted where they are observed. The body
+    // conversions alongside them are not rejections: those records are in
+    // `normalized.records` and are about to be written.
+    state.normalize_metrics.record(
+        &tenant,
+        ravel_types::Signal::Logs,
+        NormalizeRejectCounts::from_log_rejections(&normalized.rejected),
+    );
+    state.normalize_metrics.record_body_conversions(
+        &tenant,
+        ravel_types::Signal::Logs,
+        normalized.body_conversions,
+    );
     let mut records = normalized.records;
 
     // Layer 4 (ADR-0051 section 1): stream-creation-rate is a whole-request
@@ -412,6 +430,8 @@ mod tests {
     use ravel_object_store::ObjectStoreBackend;
     use ravel_object_store::memory::MemoryStore;
 
+    use crate::normalize_reject_metrics::NormalizeRejectMetrics;
+
     /// Fixed post-floor fixture base, 2026-01-01T00:00:00Z in nanoseconds
     /// (ADR-0051 amendment): the fixture ingest clock and every log
     /// record timestamp anchor to it so the receiver-clock plausibility floor
@@ -440,6 +460,7 @@ mod tests {
             store,
             recovery: None,
             provisioning: None,
+            normalize_metrics: Arc::new(NormalizeRejectMetrics::new()),
         }
     }
 
@@ -451,6 +472,64 @@ mod tests {
             }),
             ..Default::default()
         }
+    }
+
+    fn int_kv(key: &str, value: i64) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(AnyValueVariant::IntValue(value)),
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// `(skew, structural, body_conversions)` summed over the logs rows of the
+    /// normalize-reject counters, so a test can read the same figures before
+    /// and after an export and assert the delta rather than the total.
+    fn logs_normalize_totals(state: &LogIngestState) -> (u64, u64, u64) {
+        state
+            .normalize_metrics
+            .snapshot()
+            .into_iter()
+            .filter(|row| row.signal == Signal::Logs)
+            .fold((0, 0, 0), |acc, row| {
+                (
+                    acc.0 + row.skew_total,
+                    acc.1 + row.structural_total,
+                    acc.2 + row.body_conversions_total,
+                )
+            })
+    }
+
+    /// Reads back every log record the tenant's L0 data objects hold, so a
+    /// test can assert on what was actually stored rather than on what the
+    /// normalize layer returned.
+    async fn stored_log_records(
+        store: &dyn ObjectStoreBackend,
+        tenant: &str,
+    ) -> Vec<ravel_logseg::LogRecord> {
+        use ravel_logseg::{Predicate, RlogConfig, RlogReader};
+        use ravel_object_store::{GetRange, list_all};
+
+        let prefix = format!("t/{}/l/l0/", TenantId::new(tenant).hash().to_hex());
+        let objects = list_all(store, &prefix)
+            .await
+            .expect("list log data objects");
+        let mut out = Vec::new();
+        for object in objects {
+            let bytes = store
+                .get(&object.key, GetRange::Full)
+                .await
+                .expect("get log data object")
+                .data;
+            let reader = RlogReader::new(&bytes, &RlogConfig::default()).expect("open RLOG object");
+            let (records, _stats) = reader
+                .scan(&Predicate::And(Vec::new()))
+                .expect("unfiltered scan");
+            out.extend(records);
+        }
+        out
     }
 
     fn request(records: Vec<LogRecord>) -> ExportLogsServiceRequest {
@@ -525,13 +604,14 @@ mod tests {
     #[tokio::test]
     async fn all_records_rejected_yields_no_tokens_and_a_partial_success() {
         let state = state();
-        // An ArrayValue body is LogRejection::UnsupportedBodyKind, which drops
-        // the whole record.
+        // A string-table reference body is LogRejection::UnsupportedBodyKind,
+        // which drops the whole record: the table it indexes lives on the OTLP
+        // request, not on the record, so nothing here can resolve it. Array and
+        // kvlist bodies used to reach this same rejection and no longer do;
+        // they convert to canonical JSON and are stored.
         let mut rec = record("unused", Vec::new());
         rec.body = Some(AnyValue {
-            value: Some(AnyValueVariant::ArrayValue(
-                opentelemetry_proto::tonic::common::v1::ArrayValue { values: vec![] },
-            )),
+            value: Some(AnyValueVariant::StringValueStrindex(3)),
         });
 
         let outcome = handle_export_logs(
@@ -551,6 +631,185 @@ mod tests {
             .partial_success
             .expect("the record was rejected");
         assert_eq!(partial_success.rejected_log_records, 1);
+    }
+
+    /// A kvlist body is stored as canonical JSON, and everything else on the
+    /// record survives the conversion. The counters see a conversion, not a
+    /// rejection.
+    #[tokio::test]
+    async fn kvlist_body_is_stored_as_canonical_json_with_the_record_intact() {
+        const TRACE_ID: [u8; 16] = [0x11; 16];
+        const SPAN_ID: [u8; 8] = [0x22; 8];
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let state = state_with_store(1, store.clone());
+
+        let mut rec = record("unused", vec![string_kv("http.route", "/v1/logs")]);
+        rec.body = Some(AnyValue {
+            value: Some(AnyValueVariant::KvlistValue(
+                opentelemetry_proto::tonic::common::v1::KeyValueList {
+                    // Reverse key order on the wire: the stored form must be
+                    // the canonical order, not the sender's.
+                    values: vec![string_kv("zeta", "z"), int_kv("alpha", 7)],
+                },
+            )),
+        });
+        rec.trace_id = TRACE_ID.to_vec();
+        rec.span_id = SPAN_ID.to_vec();
+
+        let before = logs_normalize_totals(&state);
+        let outcome = handle_export_logs(
+            &state,
+            TenantId::new("acme"),
+            WriteMode::Strict,
+            request(vec![rec]),
+            BASE_TS_NS,
+            None,
+        )
+        .await
+        .expect("strict write publishes");
+        assert!(
+            outcome.response.partial_success.is_none(),
+            "a converted body is not a rejection, got {:?}",
+            outcome.response.partial_success
+        );
+        let after = logs_normalize_totals(&state);
+        assert_eq!(
+            (after.0 - before.0, after.1 - before.1, after.2 - before.2),
+            (0, 0, 1),
+            "exactly one conversion, no skew or structural rejection"
+        );
+
+        let stored = stored_log_records(store.as_ref(), "acme").await;
+        assert_eq!(stored.len(), 1, "the record was stored, not dropped");
+        let stored = &stored[0];
+        assert_eq!(stored.body, r#"{"alpha":7,"zeta":"z"}"#);
+        assert_eq!(stored.ts_ns, BASE_TS_NS);
+        assert_eq!(stored.trace_id, Some(TRACE_ID));
+        assert_eq!(stored.span_id, Some(SPAN_ID));
+        assert_eq!(
+            stored.attrs,
+            vec![(
+                "http.route".to_string(),
+                ravel_types::logstream::AttrValue::Str("/v1/logs".to_string())
+            )],
+            "record attributes survive the body conversion"
+        );
+    }
+
+    /// The array-body counterpart of
+    /// `kvlist_body_is_stored_as_canonical_json_with_the_record_intact`:
+    /// element order is the sender's, not sorted.
+    #[tokio::test]
+    async fn array_body_is_stored_as_canonical_json_with_the_record_intact() {
+        const TRACE_ID: [u8; 16] = [0x33; 16];
+        const SPAN_ID: [u8; 8] = [0x44; 8];
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let state = state_with_store(1, store.clone());
+
+        let mut rec = record("unused", vec![string_kv("http.route", "/v1/logs")]);
+        rec.body = Some(AnyValue {
+            value: Some(AnyValueVariant::ArrayValue(
+                opentelemetry_proto::tonic::common::v1::ArrayValue {
+                    values: vec![
+                        AnyValue {
+                            value: Some(AnyValueVariant::IntValue(1)),
+                        },
+                        AnyValue {
+                            value: Some(AnyValueVariant::StringValue("two".to_string())),
+                        },
+                        AnyValue {
+                            value: Some(AnyValueVariant::BoolValue(true)),
+                        },
+                    ],
+                },
+            )),
+        });
+        rec.trace_id = TRACE_ID.to_vec();
+        rec.span_id = SPAN_ID.to_vec();
+
+        let before = logs_normalize_totals(&state);
+        let outcome = handle_export_logs(
+            &state,
+            TenantId::new("acme"),
+            WriteMode::Strict,
+            request(vec![rec]),
+            BASE_TS_NS,
+            None,
+        )
+        .await
+        .expect("strict write publishes");
+        assert!(
+            outcome.response.partial_success.is_none(),
+            "a converted body is not a rejection, got {:?}",
+            outcome.response.partial_success
+        );
+        let after = logs_normalize_totals(&state);
+        assert_eq!(
+            (after.0 - before.0, after.1 - before.1, after.2 - before.2),
+            (0, 0, 1),
+            "exactly one conversion, no skew or structural rejection"
+        );
+
+        let stored = stored_log_records(store.as_ref(), "acme").await;
+        assert_eq!(stored.len(), 1, "the record was stored, not dropped");
+        let stored = &stored[0];
+        assert_eq!(stored.body, r#"[1,"two",true]"#);
+        assert_eq!(stored.ts_ns, BASE_TS_NS);
+        assert_eq!(stored.trace_id, Some(TRACE_ID));
+        assert_eq!(stored.span_id, Some(SPAN_ID));
+        assert_eq!(
+            stored.attrs,
+            vec![(
+                "http.route".to_string(),
+                ravel_types::logstream::AttrValue::Str("/v1/logs".to_string())
+            )],
+            "record attributes survive the body conversion"
+        );
+    }
+
+    /// Event-time rejections land under the skew reason, one per rejected
+    /// record, and move nothing else.
+    #[tokio::test]
+    async fn event_time_rejections_count_as_skew() {
+        let state = state();
+        let too_old = BASE_TS_NS - state.limits.max_ingest_lag_ns - 1;
+        let records: Vec<LogRecord> = (0..3)
+            .map(|i| {
+                let mut rec = record("hello", vec![string_kv("k", "v")]);
+                rec.time_unix_nano = (too_old - i) as u64;
+                rec.observed_time_unix_nano = (too_old - i) as u64;
+                rec
+            })
+            .collect();
+
+        let before = logs_normalize_totals(&state);
+        let outcome = handle_export_logs(
+            &state,
+            TenantId::new("acme"),
+            WriteMode::Strict,
+            request(records),
+            BASE_TS_NS,
+            None,
+        )
+        .await
+        .expect("a write with zero admitted records never fails");
+        let after = logs_normalize_totals(&state);
+
+        assert_eq!(
+            outcome
+                .response
+                .partial_success
+                .expect("all three records were rejected")
+                .rejected_log_records,
+            3
+        );
+        assert_eq!(
+            (after.0 - before.0, after.1 - before.1, after.2 - before.2),
+            (3, 0, 0),
+            "three skew rejections, nothing structural, no conversion"
+        );
     }
 
     #[tokio::test]
@@ -794,6 +1053,7 @@ mod tests {
             store,
             recovery: None,
             provisioning: None,
+            normalize_metrics: Arc::new(NormalizeRejectMetrics::new()),
         }
     }
 

--- a/services/ravel-server/src/logs_ingest.rs
+++ b/services/ravel-server/src/logs_ingest.rs
@@ -298,14 +298,22 @@ pub async fn handle_export_logs(
             LogIngestRequestError::Write(err)
         })?;
 
-    let partial_success = if rejected_count > 0 {
+    // Both rejection sources gate this, because neither alone covers the
+    // request. Gating on `rejected_count` swallows an attribute-only drop: the
+    // record lands, so its count is 0, yet the sender must still learn the
+    // attribute is gone through `error_message` with `rejected_log_records`
+    // reported as 0 (the OTLP-sanctioned warning channel). Gating on
+    // `normalized.rejected` alone swallows a stream-cap drop: the layer-4 cap
+    // rejects whole records that normalized cleanly, so they never appear in
+    // that list.
+    let partial_success = if normalized.rejected.is_empty() && stream_cap_rejected == 0 {
+        None
+    } else {
         let error_message = build_error_message(&normalized.rejected, stream_cap_rejected);
         Some(ExportLogsPartialSuccess {
             rejected_log_records: rejected_count as i64,
             error_message,
         })
-    } else {
-        None
     };
 
     // Ordering (ADR-0051 section 5): the data is durably
@@ -587,8 +595,11 @@ mod tests {
         let partial_success = outcome
             .response
             .partial_success
-            .expect("one attribute rejected");
-        assert_eq!(partial_success.rejected_log_records, 1);
+            .expect("the dropped attribute is reported");
+        assert_eq!(
+            partial_success.rejected_log_records, 0,
+            "no record was lost, only one attribute"
+        );
         assert!(
             partial_success.error_message.contains("attribute value is"),
             "got: {}",

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -2893,16 +2893,17 @@ fn render_admission_family(out: &mut String, mode: Mode, snapshot: &AdmissionCou
     }
 
     // Structured log bodies converted rather than rejected. Deliberately its
-    // own family and not a `reason` on the counter above: these records were
-    // stored, so an operator alerting on rejection reasons must see nothing
-    // from them.
+    // own family and not a `reason` on the counter above: a conversion is not
+    // a rejection, so an operator alerting on rejection reasons must see
+    // nothing from them.
     write_header(
         out,
         "ravel_ingest_body_conversions_total",
-        "Log records admitted after converting a structured (array or kvlist) body to its \
-         canonical JSON form, by tenant and signal. Not a rejection: every record counted here \
-         was stored. A sustained rate means a sender is emitting structured bodies, which query \
-         paths see as JSON text.",
+        "Log records whose structured (array or kvlist) body was converted to its canonical JSON \
+         form at normalization, by tenant and signal. Not a rejection, and not a count of stored \
+         records: it is counted before the active-stream cap and before the write. Read it as a \
+         conversion rate. A sustained rate means a sender is emitting structured bodies, which \
+         query paths see as JSON text.",
         "counter",
     );
     for ((hash, signal), acc) in &ordered {

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -123,15 +123,18 @@ impl Level {
 /// 6, extended by the 2026-08-13 amendment). ADR-0051 named a closed set of
 /// six reasons `{body_size, byte_rate, series_rate, series_cap, skew,
 /// structural}`; the amendment adds a seventh, `clock`, for the receiver-clock
-/// floor. The four here are exactly the ones
-/// `AdmissionController::usage_snapshot` counts today
-/// (`ravel_ingest::TenantUsage`). The remaining three (body_size, skew,
-/// structural) are enforced at layers that keep no per-tenant counter in that
-/// snapshot yet (body size at the transport, skew and structural in
-/// normalization, surfaced there through OTLP partial success), so a variant
-/// for them would render samples no data source can fill. They join this enum
-/// when their counters do, additively, the same way a new `Signal` variant
-/// joins `signal_name`.
+/// floor. Six of the seven are here. Four come from
+/// `AdmissionController::usage_snapshot` (`ravel_ingest::TenantUsage`), which
+/// covers the byte-rate and active-cap layers plus the receiver-clock floor.
+/// The other two, `skew` and `structural`, come from
+/// [`crate::normalize_reject_metrics::NormalizeRejectMetrics`]: the
+/// normalization layer keeps no row in that snapshot, so the ingest surfaces
+/// count its decisions where they observe them.
+///
+/// The seventh, `body_size`, is enforced at the transport and still keeps no
+/// per-tenant counter, so a variant for it would render samples no data source
+/// can fill. It joins this enum when its counter does, additively, the same
+/// way a new `Signal` variant joins `signal_name`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RejectReason {
     ByteRate,
@@ -141,17 +144,29 @@ pub enum RejectReason {
     /// non-representable), so the whole request was rejected 503 / `UNAVAILABLE`
     /// (ADR-0051 amendment). The fault is the replica's, not the data's.
     Clock,
+    /// A point, record, or span whose event timestamp fell outside the
+    /// admissible window (too far in the future, or older than the maximum
+    /// ingest lag). Counted per rejected datum, matching the count the same
+    /// request reports back to the sender through OTLP partial success.
+    Skew,
+    /// A point, record, or span rejected by a structural bound in
+    /// normalization: an unsupported metric type or aggregation temporality, a
+    /// name or attribute over its limit, a malformed identifier, an
+    /// inconsistent histogram. Counted per rejected datum, like `skew`.
+    Structural,
 }
 
 impl RejectReason {
-    /// Every reason with a counter, so the rejected family renders all four
+    /// Every reason with a counter, so the rejected family renders all six
     /// series per (tenant, signal) even when some are zero (the same
     /// zero-is-not-absence discipline the other families keep).
-    const ALL: [RejectReason; 4] = [
+    const ALL: [RejectReason; 6] = [
         RejectReason::ByteRate,
         RejectReason::SeriesRate,
         RejectReason::SeriesCap,
         RejectReason::Clock,
+        RejectReason::Skew,
+        RejectReason::Structural,
     ];
 
     fn name(self) -> &'static str {
@@ -160,6 +175,8 @@ impl RejectReason {
             RejectReason::SeriesRate => "series_rate",
             RejectReason::SeriesCap => "series_cap",
             RejectReason::Clock => "clock",
+            RejectReason::Skew => "skew",
+            RejectReason::Structural => "structural",
         }
     }
 }
@@ -2634,6 +2651,14 @@ pub struct AdmissionCountersSnapshot {
     /// a compressed request, so the wire quantity has no home in that snapshot.
     /// Folded by the same `tenant_labels` gate as `usage`.
     pub wire_bytes: Vec<crate::ingest_byte_metrics::TenantWireBytes>,
+    /// Per-tenant normalization-layer decisions (ADR-0051 section 3, layer 3),
+    /// rendered as the `skew` and `structural` reasons of this family's
+    /// rejection counter plus the separate body-conversion counter. Sourced
+    /// from [`crate::normalize_reject_metrics::NormalizeRejectMetrics`], not
+    /// the admission `usage_snapshot`: the controller enforces layers 2 and 4
+    /// and keeps no row for a decision normalization made. Folded by the same
+    /// `tenant_labels` gate as `usage`.
+    pub normalize_rejects: Vec<crate::normalize_reject_metrics::TenantNormalizeRejects>,
 }
 
 /// The counters this family sums per rendered series. Split out so the fold
@@ -2649,6 +2674,9 @@ struct AdmissionAcc {
     rejected_series_rate: u64,
     rejected_series_cap: u64,
     rejected_clock: u64,
+    rejected_skew: u64,
+    rejected_structural: u64,
+    body_conversions: u64,
     reconciliation_failures: u64,
 }
 
@@ -2659,6 +2687,8 @@ impl AdmissionAcc {
             RejectReason::SeriesRate => self.rejected_series_rate,
             RejectReason::SeriesCap => self.rejected_series_cap,
             RejectReason::Clock => self.rejected_clock,
+            RejectReason::Skew => self.rejected_skew,
+            RejectReason::Structural => self.rejected_structural,
         }
     }
 }
@@ -2705,6 +2735,24 @@ fn render_admission_family(out: &mut String, mode: Mode, snapshot: &AdmissionCou
         acc.reconciliation_failures = acc
             .reconciliation_failures
             .saturating_add(row.reconciliation_failures_total);
+    }
+
+    // Normalization-layer decisions fold into the same rows, under the same
+    // tenant-label gate. A (tenant, signal) that has only these and no
+    // admission-controller usage still gets a full row: every other counter
+    // renders zero, which is what it is, and the rejection reasons the sender
+    // was told about are visible rather than absent.
+    for row in &snapshot.normalize_rejects {
+        let key = (
+            snapshot.tenant_labels.then_some(row.tenant_hash),
+            row.signal,
+        );
+        let acc = rows.entry(key).or_default();
+        acc.rejected_skew = acc.rejected_skew.saturating_add(row.skew_total);
+        acc.rejected_structural = acc.rejected_structural.saturating_add(row.structural_total);
+        acc.body_conversions = acc
+            .body_conversions
+            .saturating_add(row.body_conversions_total);
     }
 
     // A HashMap iterates in an unspecified order; Prometheus does not require
@@ -2824,7 +2872,11 @@ fn render_admission_family(out: &mut String, mode: Mode, snapshot: &AdmissionCou
     write_header(
         out,
         "ravel_admission_rejected_total",
-        "Admission rejections by tenant, signal, and reason (byte_rate, series_rate, series_cap, clock).",
+        "Admission rejections by tenant, signal, and reason (byte_rate, series_rate, series_cap, \
+         clock, skew, structural). byte_rate and clock count whole requests; series_rate and \
+         series_cap count series; skew and structural count individual data points, log records, \
+         or spans rejected in normalization, matching what the sender is told through OTLP \
+         partial success.",
         "counter",
     );
     for ((hash, signal), acc) in &ordered {
@@ -2838,6 +2890,28 @@ fn render_admission_family(out: &mut String, mode: Mode, snapshot: &AdmissionCou
                 acc.rejected(reason),
             );
         }
+    }
+
+    // Structured log bodies converted rather than rejected. Deliberately its
+    // own family and not a `reason` on the counter above: these records were
+    // stored, so an operator alerting on rejection reasons must see nothing
+    // from them.
+    write_header(
+        out,
+        "ravel_ingest_body_conversions_total",
+        "Log records admitted after converting a structured (array or kvlist) body to its \
+         canonical JSON form, by tenant and signal. Not a rejection: every record counted here \
+         was stored. A sustained rate means a sender is emitting structured bodies, which query \
+         paths see as JSON text.",
+        "counter",
+    );
+    for ((hash, signal), acc) in &ordered {
+        write_sample(
+            out,
+            "ravel_ingest_body_conversions_total",
+            &labels(mode, *hash, *signal),
+            acc.body_conversions,
+        );
     }
 
     // Fleet-global reconciliation read failures (ADR-0057 section 3). Same
@@ -3865,6 +3939,12 @@ pub struct MetricsState {
     /// that turned compression off. Always present; empty until an OTLP request
     /// is admitted. Folded by the same `--metrics-tenant-labels` gate.
     pub ingest_byte_metrics: Arc<crate::ingest_byte_metrics::IngestByteMetrics>,
+    /// Per-tenant normalization-layer decisions (ADR-0051 section 3, layer 3),
+    /// rendered as the admission family's `skew` and `structural` reasons and
+    /// its body-conversion counter. The same `Arc` every ingest surface holds.
+    /// Always present; empty until a request is normalized. Folded by the same
+    /// `--metrics-tenant-labels` gate.
+    pub normalize_reject_metrics: Arc<crate::normalize_reject_metrics::NormalizeRejectMetrics>,
     /// The per-process metric-metadata cache (ADR-0085 decision 1), read at
     /// scrape time for its four `query_metadata_cache_*` counters. `Some` only
     /// in a request-serving mode that built one (`Mode::All`/`Mode::Query`);
@@ -4013,6 +4093,7 @@ async fn metrics_handler(State(state): State<MetricsState>) -> impl IntoResponse
         usage: state.admission.usage_snapshot(),
         tenant_labels: state.metrics_tenant_labels,
         wire_bytes: state.ingest_byte_metrics.snapshot(),
+        normalize_rejects: state.normalize_reject_metrics.snapshot(),
     };
 
     // Per-query cost rows, read at scrape time like every other family (a
@@ -6466,6 +6547,7 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             usage,
             tenant_labels: false,
             wire_bytes: Vec::new(),
+            normalize_rejects: Vec::new(),
         };
         let body = render(
             Mode::Gateway,
@@ -6549,6 +6631,7 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             usage: vec![byte_rate, series_rate, series_cap],
             tenant_labels: true,
             wire_bytes: Vec::new(),
+            normalize_rejects: Vec::new(),
         };
         let body = render(
             Mode::Gateway,
@@ -6630,6 +6713,7 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
             usage: vec![row],
             tenant_labels: true,
             wire_bytes: Vec::new(),
+            normalize_rejects: Vec::new(),
         };
         let hash = ravel_types::TenantId::new("skewed").hash().to_hex();
         let body = render(
@@ -6667,6 +6751,79 @@ ravel_cache_disk_entries_expired_max_age_total{mode=\"gateway\",cache=\"catalog\
                  signal=\"metrics\",reason=\"clock\"}} 7"
             )),
             "clock rejection must render distinctly:\n{body}"
+        );
+    }
+
+    /// Normalization's own rejections render under the reserved `skew` and
+    /// `structural` reasons of the same family, and converted structured
+    /// bodies render as their own family rather than as a reason. The tenant
+    /// here has no admission usage row at all, so this also pins that a
+    /// normalize-only (tenant, signal) still renders a full row.
+    #[test]
+    fn admission_family_renders_the_skew_and_structural_reasons() {
+        let hash = ravel_types::TenantId::new("noisy").hash();
+        let snapshot = AdmissionCountersSnapshot {
+            usage: Vec::new(),
+            tenant_labels: true,
+            wire_bytes: Vec::new(),
+            normalize_rejects: vec![crate::normalize_reject_metrics::TenantNormalizeRejects {
+                tenant_hash: hash,
+                signal: Signal::Logs,
+                skew_total: 2,
+                structural_total: 3,
+                body_conversions_total: 4,
+            }],
+        };
+        let body = render(
+            Mode::Gateway,
+            &StoreMetricsSnapshot::default(),
+            &[],
+            &CatalogCountersSnapshot::default(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &snapshot,
+            &[],
+            0,
+            IngestBufferBudgetSnapshot::default(),
+            None,
+            None,
+            &[],
+            None,
+            crate::mem_stats::AllocatorStats::Other { name: "test" },
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let hash = hash.to_hex();
+        assert!(
+            body.contains(&format!(
+                "ravel_admission_rejected_total{{mode=\"gateway\",tenant_hash=\"{hash}\",\
+                 signal=\"logs\",reason=\"skew\"}} 2"
+            )),
+            "event-time rejections must render under reason=skew:\n{body}"
+        );
+        assert!(
+            body.contains(&format!(
+                "ravel_admission_rejected_total{{mode=\"gateway\",tenant_hash=\"{hash}\",\
+                 signal=\"logs\",reason=\"structural\"}} 3"
+            )),
+            "structural rejections must render under reason=structural:\n{body}"
+        );
+        assert!(
+            body.contains(&format!(
+                "ravel_ingest_body_conversions_total{{mode=\"gateway\",tenant_hash=\"{hash}\",\
+                 signal=\"logs\"}} 4"
+            )),
+            "converted bodies are their own family, not a rejection reason:\n{body}"
         );
     }
 

--- a/services/ravel-server/src/normalize_reject_metrics.rs
+++ b/services/ravel-server/src/normalize_reject_metrics.rs
@@ -59,8 +59,12 @@ pub struct TenantNormalizeRejects {
     /// unsupported type or temporality, a name or attribute over its limit, a
     /// malformed identifier.
     pub structural_total: u64,
-    /// Log records admitted after converting a structured body to its
-    /// canonical JSON form. Never a rejection: every one of these was stored.
+    /// Log records whose structured body was converted to its canonical JSON
+    /// form at normalization. Never a rejection, and not a count of stored
+    /// records: the handler adds these as soon as normalization returns, which
+    /// is before the active-stream cap and before the shard write, so a
+    /// counted record can still be dropped or lost. Read it as a conversion
+    /// rate. Normative description: docs/guides/observability.md.
     pub body_conversions_total: u64,
 }
 

--- a/services/ravel-server/src/normalize_reject_metrics.rs
+++ b/services/ravel-server/src/normalize_reject_metrics.rs
@@ -1,0 +1,201 @@
+//! Per-tenant counting of the normalization layer's admission decisions
+//! (ADR-0051 section 3, layer 3).
+//!
+//! Layer 3 enforces structural and event-time bounds per point, record, and
+//! span. Until now its decisions were visible only inside an OTLP
+//! partial-success response: an operator could see a tenant's data being
+//! dropped by a client-side log line, and nothing at all on `/metrics`. This
+//! collector records them under the `skew` and `structural` reasons ADR-0051
+//! section 6 already reserved on `ravel_admission_rejected_total`.
+//!
+//! It is a `ravel-server`-local counter, separate from the `ravel-ingest`
+//! `AdmissionController`'s per-tenant usage, for the same reason
+//! [`crate::ingest_byte_metrics`] is: the controller enforces layers 2 and 4
+//! and its usage snapshot has no row for a decision normalization made.
+//!
+//! Counting happens where the rejection is observed, at the ingest surface
+//! that builds the partial-success response, not inside `ravel-otlp`: the
+//! normalizer is a pure function that knows no tenant, and both the OTLP and
+//! the OTAP surface hand it the same request. That is also what keeps the two
+//! transports counting identically, so switching a fleet from OTLP to OTAP
+//! does not move this signal.
+//!
+//! Body conversions are counted here too, and deliberately not as a
+//! rejection: a structured log body that was converted to canonical JSON was
+//! stored, so an operator alerting on rejection reasons must see nothing from
+//! it. It gets its own family.
+
+use std::collections::HashMap;
+
+use parking_lot::Mutex;
+use ravel_otlp::NormalizeRejectCounts;
+use ravel_types::{Signal, TenantHash, TenantId};
+
+/// Accumulated normalize-layer decisions per `(tenant, signal)`. Keyed by the
+/// tenant hash (not the full id), matching how the admission `/metrics` family
+/// folds tenants, so the rendered cardinality is bounded the same way.
+#[derive(Default)]
+pub struct NormalizeRejectMetrics {
+    rows: Mutex<HashMap<(TenantHash, Signal), Counts>>,
+}
+
+#[derive(Default, Clone, Copy)]
+struct Counts {
+    skew: u64,
+    structural: u64,
+    body_conversions: u64,
+}
+
+/// One `(tenant, signal)` row of accumulated normalize-layer decisions, for
+/// the `/metrics` renderer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TenantNormalizeRejects {
+    pub tenant_hash: TenantHash,
+    pub signal: Signal,
+    /// Points, records, or spans rejected for an event timestamp outside the
+    /// admissible window.
+    pub skew_total: u64,
+    /// Points, records, or spans rejected for a structural bound: an
+    /// unsupported type or temporality, a name or attribute over its limit, a
+    /// malformed identifier.
+    pub structural_total: u64,
+    /// Log records admitted after converting a structured body to its
+    /// canonical JSON form. Never a rejection: every one of these was stored.
+    pub body_conversions_total: u64,
+}
+
+impl NormalizeRejectMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds one request's normalize-layer rejections to `(tenant, signal)`.
+    ///
+    /// `counts` is what the rejections in the normalizer's output classify to,
+    /// already multiplied out: a rejection that drops a whole scope counts
+    /// every point it dropped, matching the `rejected_data_points` the same
+    /// request reports back to the sender.
+    pub fn record(&self, tenant: &TenantId, signal: Signal, counts: NormalizeRejectCounts) {
+        if counts.is_empty() {
+            return;
+        }
+        let mut rows = self.rows.lock();
+        let row = rows.entry((tenant.hash(), signal)).or_default();
+        row.skew = row.skew.saturating_add(counts.skew as u64);
+        row.structural = row.structural.saturating_add(counts.structural as u64);
+    }
+
+    /// Adds `count` admitted-after-conversion log records to `(tenant,
+    /// signal)`. Separate from [`Self::record`] because a conversion is not a
+    /// rejection and must not move a rejection reason.
+    pub fn record_body_conversions(&self, tenant: &TenantId, signal: Signal, count: usize) {
+        if count == 0 {
+            return;
+        }
+        let mut rows = self.rows.lock();
+        let row = rows.entry((tenant.hash(), signal)).or_default();
+        row.body_conversions = row.body_conversions.saturating_add(count as u64);
+    }
+
+    /// A point-in-time copy of every accumulated row, for `/metrics` rendering.
+    pub fn snapshot(&self) -> Vec<TenantNormalizeRejects> {
+        self.rows
+            .lock()
+            .iter()
+            .map(|(&(tenant_hash, signal), counts)| TenantNormalizeRejects {
+                tenant_hash,
+                signal,
+                skew_total: counts.skew,
+                structural_total: counts.structural,
+                body_conversions_total: counts.body_conversions,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn tenant(name: &str) -> TenantId {
+        TenantId::new(name)
+    }
+
+    #[test]
+    fn empty_counts_create_no_row() {
+        let metrics = NormalizeRejectMetrics::new();
+        metrics.record(
+            &tenant("acme"),
+            Signal::Metrics,
+            NormalizeRejectCounts::default(),
+        );
+        metrics.record_body_conversions(&tenant("acme"), Signal::Logs, 0);
+        assert!(metrics.snapshot().is_empty());
+    }
+
+    #[test]
+    fn counts_accumulate_per_tenant_and_signal() {
+        let metrics = NormalizeRejectMetrics::new();
+        metrics.record(
+            &tenant("acme"),
+            Signal::Metrics,
+            NormalizeRejectCounts {
+                skew: 2,
+                structural: 3,
+            },
+        );
+        metrics.record(
+            &tenant("acme"),
+            Signal::Metrics,
+            NormalizeRejectCounts {
+                skew: 1,
+                structural: 0,
+            },
+        );
+        metrics.record(
+            &tenant("acme"),
+            Signal::Logs,
+            NormalizeRejectCounts {
+                skew: 0,
+                structural: 7,
+            },
+        );
+        metrics.record_body_conversions(&tenant("acme"), Signal::Logs, 4);
+        metrics.record(
+            &tenant("other"),
+            Signal::Metrics,
+            NormalizeRejectCounts {
+                skew: 5,
+                structural: 0,
+            },
+        );
+
+        let mut rows = metrics.snapshot();
+        rows.sort_by_key(|r| (r.tenant_hash, r.signal as u8));
+        assert_eq!(rows.len(), 3);
+
+        let acme_metrics = rows
+            .iter()
+            .find(|r| r.tenant_hash == tenant("acme").hash() && r.signal == Signal::Metrics)
+            .expect("acme metrics row");
+        assert_eq!(acme_metrics.skew_total, 3);
+        assert_eq!(acme_metrics.structural_total, 3);
+        assert_eq!(acme_metrics.body_conversions_total, 0);
+
+        let acme_logs = rows
+            .iter()
+            .find(|r| r.tenant_hash == tenant("acme").hash() && r.signal == Signal::Logs)
+            .expect("acme logs row");
+        assert_eq!(acme_logs.skew_total, 0);
+        assert_eq!(acme_logs.structural_total, 7);
+        assert_eq!(acme_logs.body_conversions_total, 4);
+
+        let other = rows
+            .iter()
+            .find(|r| r.tenant_hash == tenant("other").hash())
+            .expect("other tenant row");
+        assert_eq!(other.skew_total, 5);
+        assert_eq!(other.structural_total, 0);
+    }
+}

--- a/services/ravel-server/src/otap_grpc.rs
+++ b/services/ravel-server/src/otap_grpc.rs
@@ -29,6 +29,7 @@ use ravel_otap::normalize::normalize_decoded_with_metadata;
 use ravel_otap::proto::experimental::arrow::v1::arrow_metrics_service_server::ArrowMetricsService;
 use ravel_otap::proto::experimental::arrow::v1::{BatchArrowRecords, BatchStatus, StatusCode};
 use ravel_otap::stream::{DecodeError, DecodedBatch, StreamConfig, StreamState};
+use ravel_otlp::NormalizeRejectCounts;
 use ravel_types::{CommitToken, ExemplarCap, SeriesId, Signal, TenantId};
 use tonic::{Request, Response, Status, Streaming};
 
@@ -352,6 +353,15 @@ async fn write_batch(
     let (result, metadata) =
         normalize_decoded_with_metadata(tenant, decoded, &ingest.limits, ingest_ts_ns, &mut cap);
     let normalized = result.output;
+    // Layer 3's rejections, counted exactly as the OTLP path counts them
+    // (ADR-0051 section 3). OTAP has no partial-success field to carry them,
+    // so before this the only trace of a structurally rejected batch was the
+    // absence of its points: switching transport silently moved the signal.
+    ingest.normalize_metrics.record(
+        tenant,
+        ravel_types::Signal::Metrics,
+        NormalizeRejectCounts::from_metric_rejections(&normalized.rejected),
+    );
     // Synchronous, no I/O, off the acknowledgement path: see the twin call in
     // `crate::ingest::handle_export`.
     if let Some(sink) = &ingest.metadata_sink {
@@ -485,6 +495,9 @@ mod tests {
             recovery: None,
             provisioning: None,
             metadata_sink: None,
+            normalize_metrics: Arc::new(
+                crate::normalize_reject_metrics::NormalizeRejectMetrics::new(),
+            ),
         }
     }
 
@@ -544,5 +557,78 @@ mod tests {
             row.requests_rejected_clock_total, 1,
             "the reason=\"clock\" rejected counter incremented exactly once"
         );
+    }
+
+    /// Fixed post-floor fixture base, 2026-01-01T00:00:00Z in nanoseconds,
+    /// the same anchor the OTLP surface's tests use. Never `SystemTime::now()`.
+    const BASE_TS_NS: i64 = 1_767_225_600_000_000_000;
+
+    /// The same delta-temporality rejection the OTLP surface counts must be
+    /// counted identically here: the reason label is a property of the
+    /// rejection, not of the transport that carried the batch. OTAP has no
+    /// partial-success field, so this counter is the only operator-visible
+    /// trace of the drop.
+    #[tokio::test]
+    async fn delta_sum_batch_counts_every_point_as_structural() {
+        use ravel_otap::encode::{DataPointRow, MetricKind, MetricRow, MetricsStreamEncoder};
+        use ravel_otap::normalize::AGGREGATION_TEMPORALITY_DELTA;
+        use ravel_otap::stream::{StreamConfig, StreamState};
+
+        const POINT_COUNT: usize = 3;
+
+        let ingest = ingest_state();
+        let tenant = TenantId::new("acme");
+        let mut encoder = MetricsStreamEncoder::new("a9").expect("encoder");
+        let batch = encoder
+            .encode_batch(
+                0,
+                &[MetricRow {
+                    name: "requests".to_string(),
+                    kind: MetricKind::Sum {
+                        temporality: AGGREGATION_TEMPORALITY_DELTA,
+                        is_monotonic: true,
+                    },
+                    data_points: (0..POINT_COUNT)
+                        .map(|i| DataPointRow {
+                            time_unix_nano: BASE_TS_NS,
+                            value: i as f64,
+                            flags: 0,
+                            exemplars: vec![],
+                            attrs: vec![],
+                        })
+                        .collect(),
+                }],
+            )
+            .expect("encode a delta Sum batch");
+        let mut state = StreamState::new(StreamConfig::default());
+        let decoded = state.decode(batch).expect("decode the batch back");
+
+        let before = normalize_totals(&ingest, &tenant);
+        let outcome =
+            write_batch(&ingest, &tenant, WriteMode::Buffered, &decoded, BASE_TS_NS).await;
+        assert!(
+            outcome.is_ok(),
+            "a fully rejected batch is still an OK write with no points"
+        );
+        let after = normalize_totals(&ingest, &tenant);
+
+        assert_eq!(
+            (after.0 - before.0, after.1 - before.1),
+            (0, POINT_COUNT as u64),
+            "every rejected point counts once under structural, none under skew"
+        );
+    }
+
+    /// `(skew, structural)` for the tenant's Metrics rows of the
+    /// normalize-reject counters.
+    fn normalize_totals(ingest: &IngestState, tenant: &TenantId) -> (u64, u64) {
+        ingest
+            .normalize_metrics
+            .snapshot()
+            .into_iter()
+            .filter(|row| row.tenant_hash == tenant.hash() && row.signal == Signal::Metrics)
+            .fold((0, 0), |acc, row| {
+                (acc.0 + row.skew_total, acc.1 + row.structural_total)
+            })
     }
 }

--- a/services/ravel-server/src/otlp_http.rs
+++ b/services/ravel-server/src/otlp_http.rs
@@ -952,6 +952,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::ingest_byte_metrics::IngestByteMetrics;
     use crate::ingest_concurrency::{IngestConcurrencyController, IngestConcurrencyLimit};
+    use crate::normalize_reject_metrics::NormalizeRejectMetrics;
 
     const TENANT: &str = "acme";
 
@@ -1001,6 +1002,9 @@ pub(crate) mod tests {
             .with_budget(budget.clone()),
         );
         let admission = Arc::new(AdmissionController::new(Arc::new(SystemClock), limits));
+        // One instance across all three signals, as in `gateway_state`: a test
+        // that reads it sees what a scrape would.
+        let normalize_metrics = Arc::new(NormalizeRejectMetrics::new());
         Arc::new(GatewayState {
             tenant_resolver: Arc::new(FixedTenantResolver(TenantId::new(TENANT))),
             ingest: crate::ingest::IngestState {
@@ -1011,6 +1015,7 @@ pub(crate) mod tests {
                 recovery: None,
                 provisioning: None,
                 metadata_sink: None,
+                normalize_metrics: normalize_metrics.clone(),
             },
             logs_ingest: crate::logs_ingest::LogIngestState {
                 router: log_router,
@@ -1020,6 +1025,7 @@ pub(crate) mod tests {
                 store: store.clone(),
                 recovery: None,
                 provisioning: None,
+                normalize_metrics: normalize_metrics.clone(),
             },
             traces_ingest: crate::traces_ingest::SpanIngestState {
                 router: span_router,
@@ -1029,6 +1035,7 @@ pub(crate) mod tests {
                 store: store.clone(),
                 recovery: None,
                 provisioning: None,
+                normalize_metrics: normalize_metrics.clone(),
             },
             admission,
             budget,

--- a/services/ravel-server/src/tests.rs
+++ b/services/ravel-server/src/tests.rs
@@ -200,6 +200,9 @@ fn harness(store: Arc<dyn ObjectStoreBackend>, configured: HashSet<TenantHash>) 
         ingest_byte_metrics: std::sync::Arc::new(
             crate::ingest_byte_metrics::IngestByteMetrics::new(),
         ),
+        normalize_reject_metrics: std::sync::Arc::new(
+            crate::normalize_reject_metrics::NormalizeRejectMetrics::new(),
+        ),
         metadata_cache: None,
         cache: None,
         cache_max_bytes: 0,

--- a/services/ravel-server/src/traces_ingest.rs
+++ b/services/ravel-server/src/traces_ingest.rs
@@ -13,7 +13,7 @@ use ravel_ingest::{
 };
 use ravel_maintain::config::DEFAULT_IDEM_DEDUP_WINDOW_HOURS;
 use ravel_object_store::ObjectStoreBackend;
-use ravel_otlp::{SpanIngestLimits, SpanRejection, normalize_traces};
+use ravel_otlp::{NormalizeRejectCounts, SpanIngestLimits, SpanRejection, normalize_traces};
 use ravel_types::{CommitToken, Signal, TenantId};
 
 use crate::otlp_http::{
@@ -38,6 +38,9 @@ pub struct SpanIngestState {
     /// Durable shard_count provisioning-record writer (ADR-0050 section 5),
     /// pins the (tenant, Spans) record on the tenant's first span write.
     pub provisioning: Option<Arc<crate::provisioning::ProvisioningRecordWriter>>,
+    /// Normalization's own admission decisions for this signal, the span
+    /// counterpart of [`crate::ingest::IngestState::normalize_metrics`].
+    pub normalize_metrics: Arc<crate::normalize_reject_metrics::NormalizeRejectMetrics>,
 }
 
 pub struct SpanIngestOutcome {
@@ -212,6 +215,14 @@ pub async fn handle_export_traces(
     // of a span that still lands, and `SpanRejection::rejected_count` returns 0
     // for it, so it does not inflate this total.
     let rejected_spans: usize = normalized.rejected.iter().map(|r| r.rejected_count()).sum();
+    // Layer 3's rejections, counted where they are observed. Attribute-level
+    // rejections classify as neither reason for the same reason they do not
+    // reach `rejected_spans`: the span landed.
+    state.normalize_metrics.record(
+        &tenant,
+        ravel_types::Signal::Spans,
+        NormalizeRejectCounts::from_span_rejections(&normalized.rejected),
+    );
 
     // Spans this request actually writes, captured before `spans` is moved.
     let written_count = normalized.spans.len() as u64;
@@ -362,6 +373,8 @@ mod tests {
     use ravel_object_store::ObjectStoreBackend;
     use ravel_object_store::memory::MemoryStore;
 
+    use crate::normalize_reject_metrics::NormalizeRejectMetrics;
+
     /// Fixed post-floor fixture base, 2026-01-01T00:00:00Z in nanoseconds
     /// (ADR-0051 amendment): every fixture clock and span timestamp is
     /// anchored to it so the receiver-clock plausibility floor admits the
@@ -389,6 +402,7 @@ mod tests {
             store,
             recovery: None,
             provisioning: None,
+            normalize_metrics: Arc::new(NormalizeRejectMetrics::new()),
         }
     }
 

--- a/services/ravel-server/tests/admission_reconcile_e2e.rs
+++ b/services/ravel-server/tests/admission_reconcile_e2e.rs
@@ -151,6 +151,9 @@ fn build_process(store: Arc<dyn ObjectStoreBackend>) -> (Arc<AdmissionController
         recovery: None,
         provisioning: None,
         metadata_sink: None,
+        normalize_metrics: Arc::new(
+            ravel_server::normalize_reject_metrics::NormalizeRejectMetrics::new(),
+        ),
     };
     (admission, state)
 }

--- a/services/ravel-server/tests/idempotency_e2e.rs
+++ b/services/ravel-server/tests/idempotency_e2e.rs
@@ -96,6 +96,9 @@ fn log_state(
         store,
         recovery: None,
         provisioning: None,
+        normalize_metrics: Arc::new(
+            ravel_server::normalize_reject_metrics::NormalizeRejectMetrics::new(),
+        ),
     }
 }
 

--- a/services/ravel-server/tests/query_cost_surfaces.rs
+++ b/services/ravel-server/tests/query_cost_surfaces.rs
@@ -211,6 +211,9 @@ fn surfaces(store: Arc<dyn ObjectStoreBackend>, tenant: &TenantId) -> Surfaces {
         ingest_byte_metrics: std::sync::Arc::new(
             ravel_server::ingest_byte_metrics::IngestByteMetrics::new(),
         ),
+        normalize_reject_metrics: std::sync::Arc::new(
+            ravel_server::normalize_reject_metrics::NormalizeRejectMetrics::new(),
+        ),
         metadata_cache: None,
         cache: None,
         cache_max_bytes: 0,
@@ -618,6 +621,9 @@ mod flight {
             durable_auth: None,
             ingest_byte_metrics: std::sync::Arc::new(
                 ravel_server::ingest_byte_metrics::IngestByteMetrics::new(),
+            ),
+            normalize_reject_metrics: std::sync::Arc::new(
+                ravel_server::normalize_reject_metrics::NormalizeRejectMetrics::new(),
             ),
             metadata_cache: None,
             cache: None,

--- a/services/ravel-server/tests/tenant_kms_e2e.rs
+++ b/services/ravel-server/tests/tenant_kms_e2e.rs
@@ -110,6 +110,9 @@ fn log_state(
         store,
         recovery: None,
         provisioning: None,
+        normalize_metrics: Arc::new(
+            ravel_server::normalize_reject_metrics::NormalizeRejectMetrics::new(),
+        ),
     }
 }
 


### PR DESCRIPTION
Closes #1308 and #1309 together, because both needed the same missing counter and splitting them would have produced two versions of it.

**The counter is not a new metric.** Both issues offered "a new reason label or a sibling counter" and neither is what the tree wanted. ADR-0051 section 3 makes normalization the third enforcement layer and already reserves `skew` and `structural` for it, and the `RejectReason` enum's own doc comment says those variants "join this enum when their counters do, additively". So this fills in reserved names rather than inventing one.

**Every rejection variant is classified, and a third class was needed.** All three enums are enumerated, and some variants are neither `skew` nor `structural`: their `rejected_count()` is zero because the record or point was *admitted and stored* and the sender is never told. Those must not move a rejected counter at all. Getting that wrong would have inflated the exact figure an operator alerts on, in the direction that looks like data loss. One judgement call is flagged in the code rather than buried: a zero event timestamp is emitted from the event-time check, not a shape check, and is unbounded lag against any plausible ingest clock, so it counts as skew.

**A defect neither issue mentions.** The OTAP path discarded its normalized rejections entirely. It has no partial-success field, so a fully rejected OTAP batch previously left no trace anywhere: not in the response, not in a counter, not in a log line. Both transports now count, which is what makes the issue's "switching transports does not help" actually true in both directions.

**Structured log bodies are stored instead of dropping the record.** A map or list body previously returned an error that propagated out of record normalization, so the record's attributes, trace id, span id and timestamp went with the body, all of which had lossless representations. They now store as canonical JSON and count as a *conversion*, not a rejection, so an operator alerting on rejection reasons sees nothing from a record that was stored successfully.

`StringValueStrindex` stays a rejection, and the reason is worth stating: no string table travels with an OTLP export request, so the referenced text is not reachable on that path at all. Storing the index, an empty string or a placeholder would fabricate content the sender never sent.

**Delta temporality stays rejected**, with the signal and the workaround it was missing: the counter above, the reason values documented as an alert target with the query to alert on, a `deltatocumulative` processor wired into the collector's metrics pipeline with the recipe in the ingest guide, and the limitation stated in the README support matrix. The operator-facing rejection string no longer promises a roadmap phase.

**One of the issue's own claims is wrong, and is not implemented.** #1308 says the whole metric is dropped rather than the delta points alone. Verified against two sources: `aggregation_temporality` is field 2 of the `Sum` and `Histogram` messages and does not appear on `NumberDataPoint`, and the vendored OTAP spec lists it as a column of the metrics table rather than of the data-point table. A single metric cannot carry two temporalities, so there is no partial drop to implement and dropping the whole metric is correct.

Seven guarded lines were flipped, each with the exact test run and the observed failure recorded, including the reason mapping in both directions and the body conversion restored to its old rejection. Every counter assertion reads the value before and after and asserts the delta, never an absolute, and the rejection counts are exact rather than lower bounds because the temporality path reports the point count it rejected.

One existing test was updated rather than deleted: its fixture used an empty array body, which now converts and stores, so it would no longer have exercised a total rejection. It uses the string-index variant instead, with its assertions unchanged.

Fixes: #1308
Fixes: #1309
Refs: #1313
