### PR TITLE
docs: record that inline set -e is inert, and how to measure it

### DIFF
--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -50,13 +50,27 @@ DEGRADED-BOX TRIPWIRE, your very first command, before reading anything:
     time git config user.name "Ravel Fleet Executor"
 
 You need both of these before your first commit anyway. Read the elapsed
-time. If either took more than 30 seconds, STOP: do not read a file, do
-not start the work. Report `DEGRADED EXECUTOR: git config took <N>s` and
-end the task. The pool contains at least one box where trivial commands
-take 90 to 120 seconds, and on it the four-hour ceiling arrives before a
-first commit does, so COMMIT EARLY below cannot save you. Ending in two
-minutes with a report costs a redispatch; carrying on costs the whole
-task, and 2h50m and 3h29m have each been lost that way.
+time on the FIRST one before running the second: if it took more than 30
+seconds, stop there. Waiting for both doubles the worst case, since the
+box this exists for takes 90 to 120 seconds per command, and two of them
+is three to four minutes rather than the two this paragraph used to
+claim.
+
+On a breach, STOP: do not read a file, do not start the work. Report
+
+    DEGRADED EXECUTOR: git config took <N>s
+    <the output of `uname -a`>
+    <the output of `nproc`>
+
+and end the task. The two extra lines are what make the report
+actionable: one lost task tells the orchestrator the pool has a bad box,
+and the box's identity is what lets it be quarantined instead of
+rediscovered next week by a different task.
+
+The four-hour ceiling arrives on that box before a first commit does, so
+COMMIT EARLY below cannot save you. Ending in two minutes with a report
+costs a redispatch; carrying on costs the whole task, and 2h50m and
+3h29m have each been lost that way.
 
 COMMIT EARLY: `git commit -s` the first state that compiles, before you
 go on to the rest. Never put any command in the background and never end

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,6 +500,38 @@ into a false green. When you write or edit any such script:
   after an `if`/`fi` block reports the `if` construct, not the command
   (this exact bug made a draft of `verify-dispatch-gates.sh` report PASS
   on everything).
+- `set -e` at the top of a Bash tool call does NOTHING. The block is
+  `eval`'d (zsh's own `(eval):N:` error prefix gives it away), and
+  ERREXIT does not apply to the enclosing eval'd context, so it is inert
+  at every depth: top level, inside `( ... )`, and inside a function. A
+  partial rebase was pushed under one, and the fix that re-pushed under
+  another was equally ungated and merely had nothing left to catch.
+  SCRIPT FILES ARE UNAFFECTED: everything under `scripts/` runs as its
+  own shell and its `set -e` behaves normally. This is about inline shell
+  only. What works inline is one explicit refusal per dangerous step,
+  `cmd || { echo "refused: ..." >&2; exit 1; }` or
+  `if ! cmd; then ... exit 1; fi`. `echo "EXIT=$?"` reports and
+  continues; printing a number beside a dangerous action is not a gate,
+  and it relies on your attention at the moment you are most hurried.
+  Verifying this rule is itself the trap, and four attempts across two
+  sessions all failed the same way, by measuring a neighbouring shell:
+  `bash -c 'set -e; ...'` and `zsh -c '...'` spawn a clean shell where it
+  works, running the probe from inside a `.sh` file does the same, and
+  appending `|| echo aborted` to see whether something aborts puts it in
+  a condition context, which suppresses ERREXIT and disables the very
+  behaviour being measured. Probe it inline, unconditioned, and read `$?`
+  on the following line.
+- Never pass `--body` inline to `gh issue comment` or `gh pr comment`
+  when the text contains backticks. The shell command-substitutes them,
+  the identifier runs as a command, its empty output is substituted, and
+  `gh` exits 0 and returns a URL: the published text is missing exactly
+  the names the argument rested on. Two sessions hit this within an hour.
+  Use `--body-file` or `-F body=@file` with text written by the Write
+  tool or a quoted heredoc, then verify the artifact rather than the exit
+  code: `gh api repos/<o>/<r>/issues/comments/<id> --jq .body` piped to
+  `grep -cF` for an identifier you expect, plus a second grep for a
+  string you know is absent so that a zero means something. Repair in
+  place with `gh api -X PATCH .../issues/comments/<id> -F body=@file`.
 - Never name a variable `status`, `path`, `argv`, or `PWD`: zsh reserves
   them, and assignment kills the loop with `read-only variable`.
 - Never pipe a gate OR A GUARD through `grep`, `head`, or `tail`, and never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -528,10 +528,21 @@ into a false green. When you write or edit any such script:
   the names the argument rested on. Two sessions hit this within an hour.
   Use `--body-file` or `-F body=@file` with text written by the Write
   tool or a quoted heredoc, then verify the artifact rather than the exit
-  code: `gh api repos/<o>/<r>/issues/comments/<id> --jq .body` piped to
-  `grep -cF` for an identifier you expect, plus a second grep for a
-  string you know is absent so that a zero means something. Repair in
-  place with `gh api -X PATCH .../issues/comments/<id> -F body=@file`.
+  code. Save the body to a file first and refuse on a failed fetch,
+  because piping `gh api` into `grep -cF` loses the API status to the
+  pipeline and a failed call returns the same `0` as a response missing
+  the identifier, which is the could-not-ask/asked-and-got-nothing
+  collapse this file warns about elsewhere:
+
+      gh api repos/<o>/<r>/issues/comments/<id> --jq .body > /tmp/posted.txt \
+        || { echo "could not fetch the comment" >&2; exit 1; }
+      grep -cF '<an identifier you expect>' /tmp/posted.txt   # want >= 1
+      grep -cF '<a string you know is absent>' /tmp/posted.txt # want 0
+
+  Do not reach for `PIPESTATUS` instead: it is a bashism and expands to
+  the empty string in zsh, so it prints `EXIT=` and reads as success.
+  Repair in place with
+  `gh api -X PATCH .../issues/comments/<id> -F body=@file`.
 - Never name a variable `status`, `path`, `argv`, or `PWD`: zsh reserves
   them, and assignment kills the loop with `read-only variable`.
 - Never pipe a gate OR A GUARD through `grep`, `head`, or `tail`, and never


### PR DESCRIPTION
Three documentation changes, all from things measured during last night's landings rather than reasoned about.

## `set -e` at the top of a Bash tool call does nothing

The block is `eval`'d — zsh's own `(eval):N:` error prefix gives it away — and ERREXIT does not apply to the enclosing eval'd context. It is inert at **every** depth: top level, inside `( ... )`, and inside a function.

This cost something. A rebase conflicted, the block carried on, and a partial rebase was pushed to #1527: six commits instead of seven, four files instead of five, missing the CI step that was that PR's own blocker. The "fix" that re-pushed under another `set -e` was equally ungated and merely had nothing left to catch — worse, because it was recorded as resolved.

What caught it was the branch's file count being 4 where 5 was expected. Not the freshness guard, not the suite; both passed on the conflicted tree.

**Script files are unaffected**, and the entry says so twice. Everything under `scripts/` runs as its own shell with `set -e` behaving normally. Without that scope the entry reads as a reason to audit forty files.

The third part of the entry is the one neither session would have written a day ago: **how to measure it wrong**. Four attempts across two sessions all failed the same way, by probing a neighbouring shell.

- `bash -c 'set -e; false; echo X'` spawns a clean shell where it works
- `zsh -c '...'` likewise
- running the probe from inside a `.sh` file does the same thing one layer down
- appending `|| echo aborted` to see whether something aborts puts it in a condition context, which suppresses ERREXIT and disables the behaviour being measured

The environment under test sits one keystroke from four that behave correctly, so the obvious verification is the one that misleads. Probe inline, unconditioned, and read `$?` on the following line.

## `gh ... --body` inline eats backticks and still exits 0

The shell command-substitutes them, the identifier runs as a command, its empty output is substituted, and `gh` returns a URL. The published comment is missing exactly the names the argument rested on. Two sessions hit this within an hour; one comment read "That is wrong: reads and asserts", having lost both identifiers.

Use `--body-file` or `-F body=@file`, then verify the **artifact** rather than the exit code, with a fixed-string grep for an identifier you expect plus a second for a string you know is absent, so a zero means something.

## The degraded-box tripwire now names the box

`uname -a` and `nproc` beside the elapsed time. One lost task tells the orchestrator the pool has a bad box; the box's identity is what lets it be quarantined instead of rediscovered next week by a different task.

It also checks the first command before running the second. Two commands at 90–120s each is three to four minutes, not the two the paragraph claimed.

## Gates

`check_docs.py` clean, headroom suite 11/11, hook suite 83/83. Both guard suites added yesterday now run in `doc-scripts`, so a docs change to their rules is covered by CI rather than by memory.
