### PR TITLE
ci: give the features job headroom and stop the sweep rerunning timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,10 @@ jobs:
         run: scripts/guards/check-test-hygiene.sh
       - name: Injected-clock helper guard cases (issue #1260)
         run: bash scripts/tests/check-injected-clock-helpers.test.sh
+      # ci-sweep-cancelled.sh's timeout-vs-supersede discrimination (issue
+      # #1590). Stubbed gh, no network. Bash/jq/awk only, no toolchain.
+      - name: ci-sweep timeout-discrimination cases (issue #1590)
+        run: bash scripts/tests/ci-sweep-cancelled.test.sh
       - name: Injected-clock helper guard (issue #1260)
         run: bash scripts/check-injected-clock-helpers.sh
       # The merge-readiness script's own cases: its jq filters, its verdict
@@ -543,11 +547,28 @@ jobs:
       - name: Flight SQL tests
         run: cargo nextest run --locked -p ravel-server -p ravel-sql --features flight-sql
 
-  # Never-compiled feature combinations (ADR-0053 D6). Five cargo
-  # features are off by default and no other job builds them, so a break in
-  # any of them -- an unreachable e2e test path, four bench binaries that
-  # never link -- ships undetected. This lane proves each combination still
-  # compiles (`cargo check`), and for one of them also runs its tests:
+  # Never-compiled feature combinations (ADR-0053 D6). Cargo features that
+  # are off by default and no other job builds, so a break in any of them --
+  # an unreachable e2e test path, a bench binary that never links -- ships
+  # undetected. These lanes prove each combination still compiles
+  # (`cargo check`), and some also run their tests.
+  #
+  # Split across two jobs for CI headroom (issue #1590). The single
+  # `features` job took ~26m of a 30m cap on main (two consecutive runs:
+  # 26m14s, 26m17s), ~88% of budget before anyone adds a step, and a branch
+  # that added two cargo steps already died at 30m04s. The comment below the
+  # `timeout-minutes` setting recorded that these are "mutually non-sharing
+  # compile configurations ... with no shared incremental state", which is
+  # exactly the property that makes them safe to split: serialising them
+  # shared no cache, so running them as two parallel jobs loses nothing and
+  # halves the wall-clock a single job carries. The SQL-corpus lanes (which
+  # pull the datafusion tree AND run their tests, the heavier half) went to
+  # `features-sql`; the compile probes and the stage-timing test stayed here.
+  # Each job now does a strict subset of the previously-measured 26m, so the
+  # 30m cap carries real headroom on both. A tighter, per-job cap should
+  # follow once the split's own durations are measured on main.
+  #
+  # `features` lanes:
   #   - ravel-server --features otap            (links ravel-otap + arrow tree;
   #                                              the image lanes build it in
   #                                              release together with sql and
@@ -558,30 +579,36 @@ jobs:
   #   - ravel-bench --features profiling        (pprof/inferno flamegraph lane)
   #   - ravel-bench --features flight-lane      (ravel-sql/arrow-flight; the
   #                                              Flight SQL bench lane, PR #724)
-  #   - ravel-bench --features sql-latency      (ravel-sql; the SQL corpus and
-  #                                              its construct gate, ADR-0100)
-  #   - ravel-bench --features sql-latency,profiling,flight-lane (the widest
-  #                                              combination the ClickBench box
-  #                                              builds; RUNS its tests, #714/#732)
   #   - ravel-bench --features stage-timing     (ravel-ingest/stage-timing;
   #                                              per-stage ingest breakdown,
   #                                              ADR-0104. RUNS its test, does
   #                                              not merely compile it)
+  # `features-sql` lanes (defined below, after quickstart):
+  #   - ravel-bench --features sql-latency      (ravel-sql; the SQL corpus and
+  #                                              its construct gate, ADR-0100.
+  #                                              RUNS its tests)
+  #   - ravel-bench --features sql-latency,profiling,flight-lane (the widest
+  #                                              combination the ClickBench box
+  #                                              builds; RUNS its tests, #714/#732)
   #
   # `flight-sql` used to be probed here too. It moved to the `flight-sql` job
   # above, which lints and RUNS it: a compile-only probe let every test behind
   # that feature ship unexecuted.
   #
-  # This job is a required check (main's protect-main ruleset lists it), so a
-  # break here blocks a merge. A feature added to ravel-bench therefore
-  # belongs in the list above in the same change that adds the feature.
+  # Both jobs are required checks: main's protect-main ruleset lists `features`
+  # already, and must be updated to also list `features-sql` or the SQL-corpus
+  # lanes stop blocking a merge (see issue #1590 / this change's report). A
+  # feature added to ravel-bench belongs in whichever job's list above matches
+  # it, in the same change that adds the feature.
   features:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
-    # 30m, not 20m: four separate, mutually non-sharing compile
-    # configurations (arrow, parquet, object_store, datafusion, arrow-flight
-    # all appear across the four probes) with no shared incremental state.
+    # 30m: these lanes are mutually non-sharing compile configurations
+    # (arrow, parquet, object_store, datafusion, arrow-flight appear across
+    # them) with no shared incremental state. The SQL-corpus lanes moved to
+    # `features-sql` for headroom (issue #1590); what remains is a strict
+    # subset of the ~26m the whole job used to take, so 30m now has margin.
     timeout-minutes: 30
     env:
       RUSTC_WRAPPER: sccache
@@ -609,20 +636,6 @@ jobs:
         run: cargo check --locked -p ravel-bench --features profiling
       - name: Check ravel-bench --features flight-lane
         run: cargo check --locked -p ravel-bench --features flight-lane
-      - name: Check ravel-bench --features sql-latency
-        run: cargo check --locked -p ravel-bench --features sql-latency --all-targets
-        # The one lane here that also RUNS its tests. A compile probe is the
-        # right trade for a bench binary that only has to keep linking. It is
-        # the wrong trade for the SQL corpus, whose deliverable IS a
-        # test-enforced gate: every construct a corpus entry names must exist
-        # in the conformance registry as supported. A compile-only probe would
-        # let that gate rot while this lane stayed green, the same failure the
-        # flight-sql note above describes. The compile cost is already paid by
-        # the step above (same feature set, same target dir).
-      - name: Test ravel-bench --features sql-latency
-        run: cargo test --locked -p ravel-bench --features sql-latency
-      - name: Test ravel-bench --features sql-latency,profiling,flight-lane
-        run: cargo test --locked -p ravel-bench --features sql-latency,profiling,flight-lane
       - name: Check ravel-bench --features stage-timing
         run: cargo check --locked -p ravel-bench --features stage-timing --all-targets
         # RUN the stage-timing acceptance test, not merely compile it (ADR-0104
@@ -1715,3 +1728,52 @@ jobs:
       - name: Tear down the compose stack
         if: always() && steps.filter.outputs.run == 'true'
         run: docker compose -f "$COMPOSE_FILE" down -v || true
+
+  # SQL-corpus feature lanes, split out of `features` for CI headroom
+  # (issue #1590). See the comment block above the `features` job for the
+  # full rationale: the single job ran ~26m of a 30m cap, and these lanes --
+  # which pull the datafusion tree and RUN their tests -- are the heavier,
+  # non-cache-sharing half, so they parallelise cleanly rather than
+  # serialising. Placed here, at the end of the jobs list, deliberately away
+  # from the `features` / `supply-chain` boundary so it stays a disjoint hunk
+  # from PR #1583's `stage-timing` job. This job is NOT yet in main's
+  # protect-main ruleset; it must be added there for these lanes to block a
+  # merge.
+  features-sql:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    # 30m: a strict subset of the ~26m the undivided `features` job took, so
+    # this carries real headroom. Tighten once measured on main (issue #1590).
+    timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: ./.github/actions/free-disk-space
+      - name: Install toolchain from rust-toolchain.toml
+        run: rustup show
+      - name: Install sccache
+        id: sccache
+        continue-on-error: true
+        uses: ./.github/actions/setup-sccache
+      - name: Disable sccache if its install flaked
+        if: steps.sccache.outcome == 'failure'
+        run: echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - name: Check ravel-bench --features sql-latency
+        run: cargo check --locked -p ravel-bench --features sql-latency --all-targets
+        # The one lane here that only needs to keep compiling before its test
+        # runs. A compile probe is the right trade for a bench binary that only
+        # has to keep linking. It is the wrong trade for the SQL corpus, whose
+        # deliverable IS a test-enforced gate: every construct a corpus entry
+        # names must exist in the conformance registry as supported. A
+        # compile-only probe would let that gate rot while this lane stayed
+        # green, the same failure the flight-sql note above describes. The
+        # compile cost is already paid by this step (same feature set, same
+        # target dir) before the test step below.
+      - name: Test ravel-bench --features sql-latency
+        run: cargo test --locked -p ravel-bench --features sql-latency
+      - name: Test ravel-bench --features sql-latency,profiling,flight-lane
+        run: cargo test --locked -p ravel-bench --features sql-latency,profiling,flight-lane

--- a/scripts/ci-sweep-cancelled.sh
+++ b/scripts/ci-sweep-cancelled.sh
@@ -6,13 +6,79 @@
 # required check blocks auto-merge the same as a red one. Most come from
 # the auto-merge/late-push concurrency race.
 #
+# BUT a job that hits its own `timeout-minutes` is also reported with
+# conclusion "cancelled", indistinguishable at the run level from the
+# superseded-by-a-new-push case this script exists for. Blind-rerunning a
+# timeout is worse than useless: on a faster runner the rerun can pass and
+# the real cause (a job with no headroom) is never diagnosed. That is issue
+# #1590: swept, rerun passed in 18m29s, timed out again on the next push.
+#
+# So before rerunning a cancelled run, this compares each of its jobs'
+# durations against that job's `timeout-minutes`. A job that ran within
+# about a minute of its cap is treated as a timeout: the run is REFUSED
+# (never rerun, even with -y), the offending job and both numbers are
+# printed, and the script exits non-zero so the refusal is visible rather
+# than silent.
+#
+# Where the cap is read from: the workflow file at the run's OWN commit
+# (gh api .../contents/<path>?ref=<head_sha>), not the checked-out working
+# tree. A PR head can carry a different ci.yml than main, and the cap that
+# governed the run is the one on the run's commit. A job that sets no
+# `timeout-minutes` inherits GitHub's default of 360 minutes; that default
+# is applied explicitly rather than skipping the job.
+#
 # Usage: ci-sweep-cancelled.sh [-y]
 set -euo pipefail
+
+# Exit code when at least one cancelled run was refused as a timeout. Any
+# non-zero would do; a distinct value lets a caller tell "refused a timeout"
+# from a generic failure.
+readonly EXIT_TIMEOUT_REFUSED=3
+
+# GitHub's default job timeout when a job sets no `timeout-minutes`.
+readonly GITHUB_DEFAULT_TIMEOUT_MINUTES=360
+
+# How close to the cap counts as a timeout rather than a supersede.
+readonly TIMEOUT_MARGIN_SECONDS=60
 
 apply=0
 if [[ "${1:-}" == "-y" ]]; then
   apply=1
 fi
+
+repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+
+# Parse job-level `timeout-minutes` out of a workflow YAML file into
+# "<job-key>\t<minutes>" lines. Only the job-level setting (exactly four
+# spaces of indent, directly under a two-space job key) is read; a
+# step-level `timeout-minutes` sits deeper and is ignored. A job with no
+# setting simply produces no line, and the caller applies the default.
+parse_job_timeouts() {
+  local yaml="$1"
+  awk '
+    /^jobs:[[:space:]]*$/ { in_jobs=1; next }
+    in_jobs==1 && /^[^[:space:]#]/ { in_jobs=0 }
+    in_jobs!=1 { next }
+    /^  [A-Za-z0-9_.-]+:[[:space:]]*$/ {
+      line=$0; sub(/^  /,"",line); sub(/:.*$/,"",line); job=line; next
+    }
+    /^    timeout-minutes:[[:space:]]*[0-9]+/ {
+      v=$0; sub(/^[[:space:]]*timeout-minutes:[[:space:]]*/,"",v);
+      sub(/[^0-9].*$/,"",v);
+      if (job!="") print job "\t" v
+    }
+  ' "${yaml}"
+}
+
+# Seconds between two ISO-8601 timestamps, or empty if either is blank.
+duration_seconds() {
+  local started="$1" completed="$2"
+  [[ -z "${started}" || -z "${completed}" ]] && return 0
+  local s e
+  s=$(date -d "${started}" +%s)
+  e=$(date -d "${completed}" +%s)
+  echo $((e - s))
+}
 
 open_prs=$(gh pr list --state open --json number,headRefName,headRefOid \
   --jq '.[] | "\(.number) \(.headRefName) \(.headRefOid)"')
@@ -23,6 +89,7 @@ if [[ -z "${open_prs}" ]]; then
 fi
 
 found=0
+refused=0
 while IFS= read -r row; do
   pr_num="${row%% *}"
   rest="${row#* }"
@@ -39,6 +106,73 @@ while IFS= read -r row; do
     run_id="${run_row%% *}"
     wf_name="${run_row#* }"
     found=1
+
+    # Read the cap from the workflow at the run's own commit. The run meta
+    # gives the workflow path and the head SHA it ran against.
+    meta=$(gh api "repos/${repo}/actions/runs/${run_id}" \
+      --jq '"\(.path)\t\(.head_sha)"' 2>/dev/null || true)
+    wf_path="${meta%%$'\t'*}"
+    wf_sha="${meta##*$'\t'}"
+
+    caps_file=""
+    if [[ -n "${wf_path}" && -n "${wf_sha}" ]]; then
+      wf_yaml=$(gh api "repos/${repo}/contents/${wf_path}?ref=${wf_sha}" \
+        --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+      if [[ -n "${wf_yaml}" ]]; then
+        caps_file=$(mktemp)
+        printf '%s\n' "${wf_yaml}" >"${caps_file}"
+      fi
+    fi
+
+    declare -A cap_map=()
+    if [[ -n "${caps_file}" ]]; then
+      while IFS=$'\t' read -r jk cap; do
+        [[ -z "${jk}" ]] && continue
+        cap_map["${jk}"]="${cap}"
+      done < <(parse_job_timeouts "${caps_file}")
+      rm -f "${caps_file}"
+    fi
+
+    # Inspect each job's duration against its cap. A job within the margin
+    # of its cap marks the whole run as a timeout.
+    timed_out_report=""
+    jobs=$(gh run view "${run_id}" --json jobs \
+      --jq '.jobs[] | "\(.name)\t\(.startedAt)\t\(.completedAt)"' \
+      2>/dev/null || true)
+    if [[ -n "${jobs}" ]]; then
+      while IFS=$'\t' read -r job_name started completed; do
+        [[ -z "${job_name}" ]] && continue
+        dur=$(duration_seconds "${started}" "${completed}")
+        [[ -z "${dur}" ]] && continue
+
+        cap_min="${cap_map[${job_name}]:-}"
+        if [[ -z "${cap_min}" ]]; then
+          stripped="${job_name%% (*}"
+          cap_min="${cap_map[${stripped}]:-}"
+        fi
+        default_note=""
+        if [[ -z "${cap_min}" ]]; then
+          cap_min="${GITHUB_DEFAULT_TIMEOUT_MINUTES}"
+          default_note=" (GitHub default; job sets no timeout-minutes)"
+        fi
+
+        cap_sec=$((cap_min * 60))
+        if ((dur >= cap_sec - TIMEOUT_MARGIN_SECONDS)); then
+          dur_min=$((dur / 60))
+          dur_rem=$((dur % 60))
+          timed_out_report+=$'\n'"    job '${job_name}' ran ${dur_min}m${dur_rem}s against a ${cap_min}m cap${default_note}"
+        fi
+      done <<<"${jobs}"
+    fi
+    unset cap_map
+
+    if [[ -n "${timed_out_report}" ]]; then
+      refused=1
+      echo "PR #${pr_num}: REFUSING to rerun '${wf_name}' run ${run_id} on ${head_sha:0:12}: looks like a TIMEOUT, not a supersede.${timed_out_report}"
+      echo "    A rerun would hide the missing headroom; diagnose the job's budget instead (issue #1590)."
+      continue
+    fi
+
     if [[ ${apply} -eq 1 ]]; then
       echo "PR #${pr_num}: rerunning cancelled '${wf_name}' run ${run_id}"
       # Cancelled jobs do not count as failed, so rerun the whole run.
@@ -51,4 +185,8 @@ done <<<"${open_prs}"
 
 if [[ ${found} -eq 0 ]]; then
   echo "No cancelled runs on open PR heads."
+fi
+
+if [[ ${refused} -eq 1 ]]; then
+  exit "${EXIT_TIMEOUT_REFUSED}"
 fi

--- a/scripts/tests/ci-sweep-cancelled.test.sh
+++ b/scripts/tests/ci-sweep-cancelled.test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Cases for scripts/ci-sweep-cancelled.sh's timeout-vs-supersede
+# discrimination (issue #1590). GitHub reports a TIMED-OUT job with
+# conclusion "cancelled", identical to an ordinary superseded run, so the
+# sweep used to blind-rerun timeouts; on a faster runner the rerun passed
+# and the missing headroom was never diagnosed.
+#
+# All `gh` calls are stubbed; nothing hits the network. Each case builds an
+# isolated stub directory with canned PR/run/job data and a fixture
+# workflow YAML, points the script's `gh` at a dispatcher stub on PATH, and
+# asserts the exact behaviour: which run ids were rerun (recorded by the
+# stub) and the script's exit code.
+#
+# Run by hand:   bash scripts/tests/ci-sweep-cancelled.test.sh
+# Wired into CI: the doc-scripts job in .github/workflows/ci.yml.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# Overridable so the same cases can be run against a pre-fix copy of the
+# script to demonstrate they fail there.
+SWEEP_SCRIPT="${SWEEP_SCRIPT:-${SCRIPT_DIR}/ci-sweep-cancelled.sh}"
+
+pass=0
+fail=0
+
+check_eq() {
+  local label="$1" want="$2" got="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    pass=$((pass + 1))
+    printf 'ok    %s\n' "${label}"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL  %s\n  want: %s\n  got:  %s\n' "${label}" "${want}" "${got}"
+  fi
+}
+
+# A fixture ci.yml: features caps at 30m, quick at 10m, nocap sets none
+# (so it must inherit GitHub's 360m default). A step-level timeout-minutes
+# is included to prove the parser reads only the job-level one.
+fixture_workflow_b64() {
+  base64 -w0 <<'YAML'
+name: ci
+on:
+  push:
+    branches: [main]
+jobs:
+  features:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: a
+        timeout-minutes: 5
+        run: echo hi
+  quick:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - run: echo hi
+  nocap:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+YAML
+}
+
+# Build a stub gh in ${1} that reads canned data from that same directory.
+write_gh_stub() {
+  local dir="$1"
+  cat >"${dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+sub="${1:-}"; shift || true
+case "${sub}" in
+  repo) echo "myorg/myrepo" ;;
+  pr)   cat "${STUB_DIR}/prs.txt" ;;
+  run)
+    action="${1:-}"; shift || true
+    case "${action}" in
+      list) cat "${STUB_DIR}/runs.txt" ;;
+      view) id="${1:-}"; cat "${STUB_DIR}/run-${id}.jobs" ;;
+      rerun) id="${1:-}"; echo "${id}" >>"${STUB_DIR}/reruns.log" ;;
+      *) echo "stub gh: unknown run action ${action}" >&2; exit 2 ;;
+    esac ;;
+  api)
+    url="${1:-}"
+    case "${url}" in
+      */actions/runs/*)
+        id="${url##*/actions/runs/}"; id="${id%%\?*}"; id="${id%%/*}"
+        cat "${STUB_DIR}/run-${id}.meta" ;;
+      */contents/*) cat "${STUB_DIR}/workflow.b64" ;;
+      *) echo "stub gh: unknown api url ${url}" >&2; exit 2 ;;
+    esac ;;
+  *) echo "stub gh: unknown subcommand ${sub}" >&2; exit 2 ;;
+esac
+STUB
+  chmod +x "${dir}/gh"
+}
+
+# Run the sweep against a freshly built stub dir. Echoes nothing; sets the
+# globals RC (exit code) and RERUNS (space-joined rerun ids, empty if none).
+# Args: <apply-flag: -y|""> then the scenario is prepared by the caller into
+# the dir named by $SCN_DIR before calling.
+run_sweep() {
+  local apply_flag="$1"
+  local rc=0
+  PATH="${SCN_DIR}:${PATH}" STUB_DIR="${SCN_DIR}" \
+    bash "${SWEEP_SCRIPT}" ${apply_flag:+"${apply_flag}"} \
+    >"${SCN_DIR}/out.txt" 2>&1 || rc=$?
+  RC="${rc}"
+  if [[ -f "${SCN_DIR}/reruns.log" ]]; then
+    RERUNS="$(tr '\n' ' ' <"${SCN_DIR}/reruns.log" | sed 's/ *$//')"
+  else
+    RERUNS=""
+  fi
+}
+
+new_scenario() {
+  SCN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ci-sweep-test.XXXXXX")"
+  write_gh_stub "${SCN_DIR}"
+  fixture_workflow_b64 >"${SCN_DIR}/workflow.b64"
+  # One open PR whose head SHA the runs are attributed to.
+  printf '10 feature-a aaaaaaaaaaaa\n' >"${SCN_DIR}/prs.txt"
+}
+
+# A single job row: name, start, end (ISO-8601).
+job_row() { printf '%s\t%s\t%s\n' "$1" "$2" "$3"; }
+
+cleanup_dirs=()
+cleanup() { for d in "${cleanup_dirs[@]:-}"; do [[ -n "${d}" ]] && rm -rf "${d}"; done; }
+trap cleanup EXIT
+
+# === Case A: a job within ~1 minute of its cap is a TIMEOUT -> REFUSED.
+#     features cap is 30m; this run's features job ran 29m30s.
+new_scenario; cleanup_dirs+=("${SCN_DIR}")
+printf '100 ci\n' >"${SCN_DIR}/runs.txt"
+printf '.github/workflows/ci.yml\taaaaaaaaaaaa\n' >"${SCN_DIR}/run-100.meta"
+job_row features 2026-09-10T06:00:00Z 2026-09-10T06:29:30Z >"${SCN_DIR}/run-100.jobs"
+run_sweep -y
+check_eq "A: near-cap run is not rerun" "" "${RERUNS}"
+check_eq "A: near-cap run refusal exits 3" "3" "${RC}"
+grep -q "REFUSING" "${SCN_DIR}/out.txt" && a_ref=1 || a_ref=0
+check_eq "A: output says REFUSING" "1" "${a_ref}"
+grep -q "features" "${SCN_DIR}/out.txt" && a_job=1 || a_job=0
+check_eq "A: output names the features job" "1" "${a_job}"
+grep -q "30m cap" "${SCN_DIR}/out.txt" && a_cap=1 || a_cap=0
+check_eq "A: output quotes the 30m cap" "1" "${a_cap}"
+
+# === Case B: a job far below its cap is an ordinary supersede -> RERUN.
+#     features cap is 30m; this run's features job ran 12m.
+new_scenario; cleanup_dirs+=("${SCN_DIR}")
+printf '200 ci\n' >"${SCN_DIR}/runs.txt"
+printf '.github/workflows/ci.yml\taaaaaaaaaaaa\n' >"${SCN_DIR}/run-200.meta"
+job_row features 2026-09-10T06:00:00Z 2026-09-10T06:12:00Z >"${SCN_DIR}/run-200.jobs"
+run_sweep -y
+check_eq "B: far-below run is rerun (exactly once)" "200" "${RERUNS}"
+check_eq "B: far-below run exits 0" "0" "${RC}"
+
+# === Case C1: a job with no timeout-minutes inherits GitHub's 360m default;
+#     20m is far below -> RERUN.
+new_scenario; cleanup_dirs+=("${SCN_DIR}")
+printf '300 ci\n' >"${SCN_DIR}/runs.txt"
+printf '.github/workflows/ci.yml\taaaaaaaaaaaa\n' >"${SCN_DIR}/run-300.meta"
+job_row nocap 2026-09-10T06:00:00Z 2026-09-10T06:20:00Z >"${SCN_DIR}/run-300.jobs"
+run_sweep -y
+check_eq "C1: no-cap job far below the 360m default is rerun" "300" "${RERUNS}"
+check_eq "C1: no-cap far-below exits 0" "0" "${RC}"
+
+# === Case C2: the 360m default is genuinely applied, not skipped: a no-cap
+#     job running 359m50s is within the margin -> REFUSED.
+new_scenario; cleanup_dirs+=("${SCN_DIR}")
+printf '350 ci\n' >"${SCN_DIR}/runs.txt"
+printf '.github/workflows/ci.yml\taaaaaaaaaaaa\n' >"${SCN_DIR}/run-350.meta"
+job_row nocap 2026-09-10T06:00:00Z 2026-09-10T11:59:50Z >"${SCN_DIR}/run-350.jobs"
+run_sweep -y
+check_eq "C2: no-cap job near the 360m default is not rerun" "" "${RERUNS}"
+check_eq "C2: no-cap near-default refusal exits 3" "3" "${RC}"
+grep -q "360m" "${SCN_DIR}/out.txt" && c_def=1 || c_def=0
+check_eq "C2: output quotes the 360m default cap" "1" "${c_def}"
+
+# === Case D: dry run (no -y) reruns nothing, even for a rerunnable run.
+new_scenario; cleanup_dirs+=("${SCN_DIR}")
+printf '400 ci\n' >"${SCN_DIR}/runs.txt"
+printf '.github/workflows/ci.yml\taaaaaaaaaaaa\n' >"${SCN_DIR}/run-400.meta"
+job_row features 2026-09-10T06:00:00Z 2026-09-10T06:12:00Z >"${SCN_DIR}/run-400.jobs"
+run_sweep ""
+check_eq "D: dry run reruns nothing" "" "${RERUNS}"
+check_eq "D: dry run exits 0" "0" "${RC}"
+grep -q "dry run" "${SCN_DIR}/out.txt" && d_dry=1 || d_dry=0
+check_eq "D: dry run says so" "1" "${d_dry}"
+
+echo
+echo "passed: ${pass}  failed: ${fail}"
+[[ ${fail} -eq 0 ]]


### PR DESCRIPTION
The features job carries a 30 minute timeout and already takes about 26 on
main, measured at 26m14s and 26m17s on consecutive runs. That is roughly
88 percent of its budget before anyone adds a step, and nothing in the
file says so, so the next person to add one finds out from a red run.

It already happened. A branch that added two cargo steps to that job died
at 30m04s.

The job is split rather than given a larger cap. Raising it would leave
the next addition in the same trap and would make the budget meaningless.
The split is lossless because the lanes were never sharing anything: the
job's own comment records that these are mutually non-sharing compile
configurations with no shared incremental state, so running them in one
job bought no cache reuse. The two SQL corpus lanes, which pull the
datafusion tree and run tests, move to a new features-sql job; the compile
probes and the stage-timing test stay. Each job now does a strict subset
of the measured 26 minutes, so both have real headroom against 30.

Both keep the 30 minute cap for now rather than a tighter invented one.
Per-lane timings are not available without a run, and the comment says to
tighten once they are measured on main.

The second half is why nobody noticed. GitHub reports a job that hit its
timeout with conclusion cancelled, which is indistinguishable from the
ordinary superseded-by-a-new-push case that ci-sweep-cancelled.sh exists
to rerun. So the sweep reran a timeout, it passed in 18m29s on a faster
runner, and the cause was never diagnosed.

The sweep now compares each job's duration against that job's timeout,
read from the workflow file at the run's own commit rather than from the
working tree, because a PR head can carry a different ci.yml and the cap
that governed the run is the one on its commit. A job within a minute of
its cap marks the run a timeout: refused rather than rerun, with the job
name and both numbers printed, and a distinct exit code. A job that sets
no timeout inherits GitHub's 360 minute default, applied explicitly.

The test pins all of that, and it was demonstrated against the unfixed
script: eight assertions fail there, including that a near-cap run gets
rerun and that the refusal output is absent. The other seven pass against
both, which is deliberate, since they guard the behaviour the sweep is
for: a genuinely superseded run must still be rerun, and a dry run must
still rerun nothing. It runs in the doc-scripts job beside the existing
script tests.

Fixes: #1590
