### PR TITLE
docs: retire the .cstat whole-object publish in ADR-1413

### DIFF
--- a/docs/adrs/1413-split-cstat-per-part.md
+++ b/docs/adrs/1413-split-cstat-per-part.md
@@ -241,10 +241,12 @@ Each fold wrote three column-statistics objects: the v3 per-part object at
 Both whole-object forms declared ~6.5 GB uncompressed, 24.3x over the 256 MiB
 ceiling, so **neither was decodable by any reader** while both were being
 written on every fold. One of the two was not even referenced from HEAD.
-Retiring them saves roughly 3.4 GiB of PUT and five minutes of fold wall time
-per run, and removes the only consumer of the dropped-reference defect: a
-field-13 reference that is never recorded costs nothing when field 13 is never
-written.
+Retiring them saves 3.32 GiB of PUT and five minutes of fold wall time per
+run. That is 1,775,911,103 + 1,784,045,649 = 3,559,956,752 **wire** bytes, the
+bytes actually transferred, not the ~13 GB the two objects declare
+uncompressed. It also removes the only consumer of the dropped-reference
+defect: a field-13 reference that is never recorded costs nothing when field
+13 is never written.
 
 **Field numbers stay frozen.** The implementing change (#1600) marks 11 and 13
 `reserved` in `proto/ravel/catalog.proto`; today they are still declared as
@@ -345,7 +347,7 @@ and shorter by a release:
   simpler than before this ADR rather than more complex. Fields 11 and 13 are
   `reserved`.
 - The fold stops writing two whole-object artifacts per run. On the reference
-  tenant that is 3.4 GiB of PUT and about five minutes of wall time per fold,
+  tenant that is 3.32 GiB of PUT and about five minutes of wall time per fold,
   for objects that were 24.3x over the decode ceiling and therefore unreadable
   by anything.
 - The per-part ceiling is the existing `DEFAULT_MAX_COLUMN_STATS_BYTES`

--- a/docs/adrs/1413-split-cstat-per-part.md
+++ b/docs/adrs/1413-split-cstat-per-part.md
@@ -189,6 +189,52 @@ other two caches already have. Today's whole-tenant entry is what makes
 "cannot shed" bite hardest, since a single 2 GB entry is atomic under
 eviction; per-part entries return it to ordinary LRU granularity.
 
+### 6. v3 is the only published version: fields 11 and 13 are retired now
+
+Amends decision 3 and the dual-publish item of the migration plan below.
+
+The fold publishes **only** the v3 per-part object under
+`SnapshotPartRef.column_stats` (field 7). It no longer writes the v1
+whole-object (`SnapshotHead.column_stats`, field 11) or the v2 whole-object
+(`SnapshotHead.column_stats_part`, field 13), at any size. The decoder's
+accepted set of `.cstat` envelope versions becomes `{3}`, and the reader's
+fallback ladder in decision 2 collapses to: a covered part has its field-7 ref
+and it decodes, or that part is scanned.
+
+**Why now rather than on the format floors.** The dual-publish window exists
+for one reason, stated in the migration plan below: an older reader that
+ignores field 7 must still find field 13, and retiring it earlier would be the
+writers-before-readers change ADR-0066 decision 1 forbids. The owner directed
+on 2026-09-10 that there is no backward-compatibility constraint before v1.0.0.
+With no older reader to protect, the window has no content, and the second and
+third copies are cost with no consumer. This is the "own change" the migration
+plan already anticipated for field 13; only its trigger moves, from recorded
+format floors to the pre-1.0 directive.
+
+**Why it is safe.** `.cstat` is a Class B derived catalog object (ADR-0066
+decision 4). It is rebuildable from commit records, so no object needs
+migrating and nothing is lost: a tenant's statistics are whatever its next fold
+produces. Objects already written under fields 11 and 13 become unreferenced
+once the reader stops resolving them and are reclaimed by the existing
+`sweep_unreferenced_catalog_objects` lifecycle. No new sweep rule, no migration
+tool, no wipe.
+
+**What this measured on the reference tenant** (#1413, the T2 post-fold run).
+Each fold wrote three column-statistics objects: the v3 per-part object at
+83.4 MiB of wire, and the v1 and v2 whole-object forms at 1.65 and 1.66 GiB.
+Both whole-object forms declared ~6.5 GB uncompressed, 24.3x over the 256 MiB
+ceiling, so **neither was decodable by any reader** while both were being
+written on every fold. One of the two was not even referenced from HEAD.
+Retiring them saves roughly 3.4 GiB of PUT and five minutes of fold wall time
+per run, and removes the only consumer of the dropped-reference defect: a
+field-13 reference that is never recorded costs nothing when field 13 is never
+written.
+
+**Field numbers stay frozen.** 11 and 13 are marked `reserved` in
+`proto/ravel/catalog.proto` and are never reused. Freezing field numbers is
+independent of backward compatibility and still binds: a reused number
+misdecodes silently rather than failing, which no release boundary makes safe.
+
 ## Rejected alternatives
 
 - **Raise `DEFAULT_MAX_COLUMN_STATS_BYTES` to fit the largest tenant.**
@@ -224,29 +270,44 @@ ADR-0942's declaration stands): rebuildable from commit records,
 supersession-swept, no migration tool. The convergence plan is ADR-0942's,
 extended by one version:
 
-- **Dual-publish.** The upgraded fold emits v3 per-part objects under
+**Superseded by decision 6.** The three bullets below described a
+dual-publish and dual-read window sized by ADR-0066 decision 1's
+readers-before-writers rule. That rule is what made the window necessary, and
+the owner's 2026-09-10 pre-1.0 directive removes it. They are kept here as the
+record of what was decided and why, not as the current plan; decision 6 states
+what the fold does now.
+
+- ~~**Dual-publish.** The upgraded fold emits v3 per-part objects under
   `SnapshotPartRef.column_stats` and keeps publishing the field-13 v2
   whole-object until every reader understands the per-part field. Retiring
   field 13 at the first v3 publish would be the writers-before-readers
   change ADR-0066 decision 1 forbids: an older reader ignores field 7 on
-  the part, finds field 13, and reads it as today. For a tenant whose v2
-  object is over the ceiling that reader keeps scanning, which is the
-  current state, not a regression.
-- **Field 13 is retired on the format floor, as its own change** citing the
-  recorded floors (ADR-0066 decision 3), after which the old objects become
-  unreferenced and the existing `sweep_unreferenced_catalog_objects`
-  lifecycle GCs them. No new sweep rule.
-- **Dual-read spans the same window**, per decision 2's fallback order.
-  The accepted read set becomes {1, 2, 3} for that window. ADR-0942's
-  pending retirement of v1 (field 11) is independent of this change and
-  its own reviewed change citing the recorded floors, whether it lands
-  before or after this one; the three-version set is what Class B's
-  rolling-upgrade window costs (a reader is cheap to keep, and the objects
-  are rebuilt by the fold), and it shrinks to {2, 3} and then {3} by those
-  two retirements in turn.
-- **This tenant's 2.0 GB object stays unreadable until its next fold**,
-  which is what makes the per-part path reachable for it. The WARN from the
-  observability half names it until then.
+  the part, finds field 13, and reads it as today.~~
+- ~~**Field 13 is retired on the format floor, as its own change** citing the
+  recorded floors (ADR-0066 decision 3).~~ Decision 6 is that change; the
+  trigger is the pre-1.0 directive rather than the recorded floors. The
+  consequence is unchanged: the old objects become unreferenced and the
+  existing `sweep_unreferenced_catalog_objects` lifecycle GCs them. No new
+  sweep rule.
+- ~~**Dual-read spans the same window**, per decision 2's fallback order. The
+  accepted read set becomes {1, 2, 3} for that window.~~ The accepted read
+  set is `{3}`. ADR-0942's pending retirement of v1 (field 11) is subsumed by
+  decision 6 rather than left independent, since the same directive removes
+  the same constraint.
+
+The convergence plan that remains is the Class B one, unchanged in mechanism
+and shorter by a release:
+
+- **A tenant's statistics are whatever its next fold produces.** Nothing is
+  migrated, because nothing needs to be: `.cstat` is rebuilt from commit
+  records. A tenant folded before this change has field-11 and field-13
+  artifacts that no reader resolves; they are unreferenced and swept.
+- **This tenant's over-ceiling objects stay unreadable until its next fold**,
+  which is what makes the per-part path reachable for it. That was already
+  true of the whole-object forms at 24.3x the ceiling; retiring them changes
+  only whether the fold keeps writing new ones.
+- **Field numbers 11 and 13 are `reserved`, never reused.** This outlives the
+  pre-1.0 window: a reused field number misdecodes silently.
 
 ## Consequences
 
@@ -259,9 +320,15 @@ extended by one version:
   set, idle-tenant sweep and the `build_catalog_with_column_stats_budget`
   start path from the two rejected #1400 fixes (their branches are named
   on that issue) are reviewed plumbing this implementation reuses.
-- One more version byte to keep readable (v1, v2, v3) for the dual-read
-  window, and one more field on `SnapshotPartRef`. Additive only; no
-  renumbering.
+- One more field on `SnapshotPartRef`, additive, no renumbering. Under
+  decision 6 there is no dual-read window: the accepted version set is `{3}`
+  and v1 and v2 readers are deleted rather than carried, so the reader gets
+  simpler than before this ADR rather than more complex. Fields 11 and 13 are
+  `reserved`.
+- The fold stops writing two whole-object artifacts per run. On the reference
+  tenant that is 3.4 GiB of PUT and about five minutes of wall time per fold,
+  for objects that were 24.3x over the decode ceiling and therefore unreadable
+  by anything.
 - The per-part ceiling is the existing `DEFAULT_MAX_COLUMN_STATS_BYTES`
   constant, not a new one; the writer now shares the exact bound the reader
   already enforced, instead of deriving its own from the part.

--- a/docs/adrs/1413-split-cstat-per-part.md
+++ b/docs/adrs/1413-split-cstat-per-part.md
@@ -87,9 +87,8 @@ message SnapshotPartRef {
   // ... existing fields 1-6 unchanged ...
   // Additive, ADR-1413. The per-part column-statistics object covering
   // exactly this part's segments. Absent (proto3 default) means this part
-  // has no per-part statistics; the reader falls back to the whole-object
-  // ref at SnapshotHead field 13 (ADR-0942), then field 11 (ADR-0850), then
-  // to scan. Absence is never an error.
+  // has no per-part statistics and is scanned: under decision 6 there is no
+  // whole-object fallback. Absence is never an error.
   SnapshotColumnStatsPartRef column_stats = 7;
 }
 ```
@@ -116,10 +115,15 @@ keeps the `LoadedColumnStats` shape (a map keyed by content hash), assembled
 from the covered parts, so `unique_column_stat` and every caller in
 `ravel-sql` are unchanged.
 
-Fallback order per part: v3 per-part object, else the whole-object v2 (field
-13), else v1 (field 11), else scan, each under ADR-0942's reader rule that a
-version mismatch, a `blake3` mismatch or a decode failure subtracts that
-object's coverage and scans, never errors. This ADR adds one thing to that
+Per-part resolution, **as amended by decision 6**: a covered part's v3 object
+under field 7 decodes, or that part is scanned. There is no whole-object
+fallback and the accepted version set is `{3}`. ADR-0942's reader rule still
+governs the failure path, so a version mismatch, a `blake3` mismatch or a
+decode failure subtracts that part's coverage and scans, never errors.
+
+~~Fallback order per part: v3 per-part object, else the whole-object v2 (field
+13), else v1 (field 11), else scan.~~ Superseded by decision 6; kept as the
+record of what this ADR originally specified. This ADR adds one thing to that
 rule: a decode failure of an object HEAD references is logged once per
 (tenant, signal, key) at WARN with the declared size and the ceiling
 (landed separately as the observability half of #1400). Absence stays
@@ -137,9 +141,18 @@ being well inside what the reader can safely inflate. One fixed ceiling,
 shared by the v1/v2 whole-object path and the v3 per-part path, is simpler
 and cannot itself be the reason a legal part is refused.
 
-The whole-object v1/v2 ceiling stays at 256 MiB, the same value. Objects
-over it remain unreadable, which is the state today; the per-part path is
-how they become readable, by being re-folded.
+**Amended by decision 6.** ~~The whole-object v1/v2 ceiling stays at 256 MiB,
+the same value. Objects over it remain unreadable, which is the state today;
+the per-part path is how they become readable, by being re-folded.~~ There is
+no whole-object path to hold a ceiling: the fold writes only v3, so 256 MiB is
+now simply the per-part ceiling. Whole-object artifacts already on the store
+stay unread and are swept once nothing references them. The re-fold is still
+how a tenant's statistics become readable, which is the sentence above that
+survives.
+
+The paragraph before this one keeps its reference to the v1/v2 path because it
+explains where the constant CAME FROM, which is a fact about the ADR's
+reasoning rather than a claim about current behaviour.
 
 ### 4. The writer degrades before it refuses
 
@@ -191,7 +204,10 @@ eviction; per-part entries return it to ordinary LRU granularity.
 
 ### 6. v3 is the only published version: fields 11 and 13 are retired now
 
-Amends decision 3 and the dual-publish item of the migration plan below.
+Amends decision 2's per-part resolution order, decision 3, decision 1's
+illustrative proto comment, the data-flow diagram, the verification
+obligations, and the dual-publish item of the migration plan below. Every one
+of those described the dual-publish/dual-read behaviour this decision retires.
 
 The fold publishes **only** the v3 per-part object under
 `SnapshotPartRef.column_stats` (field 7). It no longer writes the v1
@@ -230,9 +246,12 @@ per run, and removes the only consumer of the dropped-reference defect: a
 field-13 reference that is never recorded costs nothing when field 13 is never
 written.
 
-**Field numbers stay frozen.** 11 and 13 are marked `reserved` in
-`proto/ravel/catalog.proto` and are never reused. Freezing field numbers is
-independent of backward compatibility and still binds: a reused number
+**Field numbers stay frozen.** The implementing change (#1600) marks 11 and 13
+`reserved` in `proto/ravel/catalog.proto`; today they are still declared as
+`SnapshotColumnStatsRef column_stats = 11` and
+`SnapshotColumnStatsPartRef column_stats_part = 13`, and this ADR does not
+change the schema. Once reserved they are never reused. Freezing field numbers
+is independent of backward compatibility and still binds: a reused number
 misdecodes silently rather than failing, which no release boundary makes safe.
 
 ## Rejected alternatives
@@ -344,7 +363,7 @@ flowchart LR
   subgraph query["query"]
     R[resolve window] --> C{covered parts}
     C -->|per part| L[load v3 object<br/>under per-part ceiling]
-    C -->|no field 7| F["fallback: field 13 v2, then field 11 v1, then scan"]
+    C -->|no field 7, or decode fails| F["scan that part<br/>(no whole-object fallback, decision 6)"]
     L --> M[LoadedColumnStats<br/>content-hash keyed]
     F --> M
     M --> U[unique_column_stat per segment]
@@ -367,9 +386,15 @@ flowchart LR
   a reader's ceiling is rejected.
 - A query over a window covering k of n parts issues exactly k per-part
   GETs and zero whole-object GETs; pinned to the count, not `< n`.
-- An old reader (v2-only) against a dual-published snapshot reads field 13
-  and gets the current behaviour; a new reader against an old snapshot
-  (no field 7) falls back to field 13. Both pinned.
+- A fold writes exactly one `.cstat` per part and NO whole-object object:
+  the resulting HEAD has field 7 set on every part and neither field 11 nor
+  field 13 set. Pinned to the object count, not just the fields (decision 6).
+- A HEAD carrying only field 11 or only field 13, i.e. a snapshot folded
+  before decision 6, yields no statistics and the query scans, without error
+  and without a GET of those objects. This is the behaviour change and needs
+  its own test in both directions.
+- Sweep reclaims a now-unreferenced former whole-object artifact and spares a
+  referenced v3 per-part object, in one test so the contrast is visible.
 - Resident bytes after loading k parts equal the sum of those k decoded
   sizes exactly, and eviction under the carve removes whole parts in LRU
   order.


### PR DESCRIPTION
Records the owner's 2026-09-10 directive that no backward-compatibility
constraint applies before v1.0.0, and follows it through to what ADR-1413
actually commits the fold to writing.

## What changes

The fold publishes only the v3 per-part object under `SnapshotPartRef`
field 7. It stops writing the v1 whole-object (`SnapshotHead.column_stats`,
field 11) and the v2 whole-object (`SnapshotHead.column_stats_part`,
field 13), at any size. The decoder's accepted version set becomes `{3}`, and
decision 2's fallback ladder collapses to: a covered part has its field-7 ref
and it decodes, or that part is scanned.

## Why

The dual-publish window had exactly one justification, which the ADR's own
migration plan states: an older reader that ignores field 7 must still find
field 13, so retiring it earlier would be the writers-before-readers change
ADR-0066 decision 1 forbids. With no BWC constraint pre-1.0 there is no older
reader, so the window has no content and the extra copies are cost with no
consumer.

The migration plan already scheduled this retirement as its own change, gated
on recorded format floors. Only the trigger moves.

## Why it is safe

`.cstat` is a Class B derived catalog object. Nothing is migrated because
nothing needs to be: a tenant's statistics are whatever its next fold
produces. Artifacts already written under fields 11 and 13 become unreferenced
once the reader stops resolving them and are reclaimed by the existing
`sweep_unreferenced_catalog_objects` lifecycle. No new sweep rule, no
migration tool, no wipe.

Field numbers 11 and 13 are marked reserved and never reused. That constraint
is independent of backward compatibility and still binds, because a reused
field number misdecodes silently rather than failing.

## Evidence

Measured on the ClickBench reference tenant during the ADR-1413 T2 run
(#1413). Every fold wrote three column-statistics objects:

| object | wire | declared uncompressed | vs 256 MiB ceiling | referenced |
|---|---|---|---|---|
| v3 per-part | 83.4 MiB | 268,427,456 B | 1.000x, 8,000 B under | yes |
| v1 whole-object | 1.65 GiB | 6,525,345,609 B | 24.3x OVER | yes |
| v2 whole-object | 1.66 GiB | 6,525,387,481 B | 24.3x OVER | **no** |

Both whole-object forms are refused by the decoder before decompression
(`snapshot_format/column_stats.rs:323` checks
`header.body_uncompressed_len`), so neither was readable by anything while
both were written on every fold. Retiring them saves 3.32 GiB of PUT (3,559,956,752 wire bytes) and
five minutes of fold wall time per run.

It also removes the dropped-reference defect rather than fixing it: the v2
object was written successfully and its field-13 reference was never recorded
in the snapshot. A reference that is never recorded costs nothing when the
field is never written.

## Scope

Docs only. The ADR is the decision record and lands ahead of the
implementation; `docs/catalog-and-mvcc.md` describes behaviour and changes in
the same commit as the code, per the doc-currency rule. The implementation is
tracked separately and waits on the in-flight `crates/ravel-catalog` task for
#1598 rather than racing it in the same crate.

The superseded migration bullets are struck through rather than deleted: an
ADR is a record of what was decided and why, including what stopped being
true.

Refs: #1413

