### PR TITLE
fix(server): report informational metric drops to the sender

### DIFF
--- a/docs/guides/admission-limits.md
+++ b/docs/guides/admission-limits.md
@@ -122,6 +122,14 @@ points/records/spans and admits the rest through OTLP partial success.
 | Series-creation rate | request | 429 + `Retry-After` | `RESOURCE_EXHAUSTED` | 429 + `Retry-After` |
 | Active-series/stream cap | per series | 200 + partial success | OK + partial success | 204, written-count header excludes rejected samples |
 | Event-time skew | per point | 200 + partial success | OK + partial success | 204, written-count header excludes rejected samples |
+| Informational field drop | per item, costs no item | 200 + partial success, zero count | OTLP: OK + partial success, zero count. OTAP: not reported | not reported (no partial-success message) |
+
+The last row is not an admission limit: it is a field of an admitted item that
+Ravel could not store (a histogram `min`/`max`, an exemplar, an integer past
+2^53, one bad attribute of a log record or span). It appears here because the
+transports answer it differently, and because a zero rejected count with a
+populated `error_message` is easy to mistake for a clean write.
+[ingest.md](ingest.md#zero-count-partial-success) is normative for it.
 
 ### Body size
 

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -183,6 +183,9 @@ Every rejection reason:
 | `FutureSkew` | The event timestamp is ahead of ingest time by more than `max_future_skew_ns`. |
 | `TooOld` | The event timestamp is behind ingest time by more than `max_ingest_lag_ns`. |
 | `OversizedSeriesComponent` | A series identity component (tenant, metric name, or label set) is too large to encode. |
+| `HistogramMinMaxDropped` | Informational. The point is stored; its `min`/`max` fields are not, because they have no Prometheus-convention representation. Zero rejected points; see [Zero-count partial success](#zero-count-partial-success). |
+| `HistogramExemplarsDropped` | Informational. The point is stored; some of its exemplars were malformed or fell past the per-series admission cap. Applies to any metric type, not only histograms. Zero rejected points. |
+| `IntegerValuePrecisionLoss` | Informational. The point is stored, but its `as_int` value has a magnitude above 2^53 and was stored as the nearest `f64`. Zero rejected points. |
 
 Two behaviors are worth knowing about, both intentional:
 
@@ -192,6 +195,43 @@ Two behaviors are worth knowing about, both intentional:
   with `_` in place. It does not shift or prefix. A metric named `1foo` and
   one named `_foo` both sanitize to `_foo` and become the same series. This
   is a documented consequence of the sanitization rule, not a bug.
+
+### Zero-count partial success
+
+Some rejections cost the sender nothing. A histogram data point whose `min`
+and `max` fields have no Prometheus-convention representation is stored
+without them; exemplars past the per-series admission cap are not carried;
+an OTLP `as_int` value with a magnitude above
+2^53 is stored as the nearest `f64`. The same is true of a log record or a
+span with one bad attribute: the attribute is dropped and the record or span
+is stored. In each case the unit itself was admitted, so it contributes zero
+to the rejected count.
+
+Ravel reports these anyway. **The rule every OTLP surface follows is to emit a
+partial success whenever anything was rejected at all, never when some unit
+count is above zero.** A drop of this kind comes back as
+`rejected_data_points = 0` (or `rejected_log_records = 0`, or
+`rejected_spans = 0`) together with a populated `error_message` naming it.
+The OTLP proto documents `error_message` as a channel for warnings on an
+otherwise successful response, and a zero count with a message is that
+channel. Gating on the count instead would return a response byte-identical
+to a clean write, and a sender losing a field on every export would never
+learn it.
+
+Which transport you use decides whether the report reaches you, and the
+transports do not agree:
+
+- **OTLP over HTTP and gRPC**, for metrics, logs, and spans: reported, as
+  above.
+- **OTAP** (metrics only): not reported. `BatchStatus` carries one
+  `status_message` string, and Ravel spends it on the active-series-cap
+  drop count and the commit tokens; no normalization-layer rejection,
+  informational or not, reaches it. The drop is still visible in the
+  per-tenant rejection counters.
+- **Remote Write**: not reported, and there is no partial-success message on
+  that surface to report it in. Its only per-request feedback is the
+  `x-prometheus-remote-write-samples-written` family of headers, which count
+  what was admitted.
 
 ## Delta temporality metrics
 
@@ -417,6 +457,11 @@ The partial-success contract is the same as metrics, with
 `error_message` aggregates by distinct reason with a per-reason count, and its
 length is capped. A request rejected wholesale therefore does not produce a
 response string proportional to its record count.
+
+A dropped attribute is reported the same way, with `rejected_log_records` at 0:
+the record itself was stored, so it costs the sender no record. See
+[Zero-count partial success](#zero-count-partial-success) for the rule and for
+which transports carry it.
 
 Every rejection reason:
 

--- a/services/ravel-server/src/ingest.rs
+++ b/services/ravel-server/src/ingest.rs
@@ -112,6 +112,14 @@ impl IngestRequestError {
 /// HTTP header/body sanity limits.
 const MAX_ERROR_MESSAGE_BYTES: usize = 4096;
 
+/// How many recent rejection groups [`collapse_rejection_variants`] compares a
+/// new rejection against before giving up and starting a new group. Comfortably
+/// above the number of distinct reasons a real request produces (the metrics
+/// [`Rejection`] enum has under thirty variants in total), and small enough that
+/// the scan stays a constant factor rather than turning the collapse quadratic
+/// on a request whose reasons genuinely are all distinct.
+const MAX_PREGROUPED_VARIANTS: usize = 16;
+
 pub async fn handle_export(
     state: &IngestState,
     tenant: TenantId,
@@ -248,14 +256,14 @@ pub async fn handle_export(
             IngestRequestError::Write(err)
         })?;
 
-    // Both rejection sources gate this, because neither alone covers the
-    // request. Gating on `rejected_count` swallows an informational drop: the
-    // point lands, so its count is 0, yet the sender must still learn that its
-    // min/max, its exemplars, or its integer precision is gone, through
-    // `error_message` with `rejected_data_points` reported as 0 (the
-    // OTLP-sanctioned warning channel). Gating on `normalized.rejected` alone
-    // swallows an active-series-cap drop: layer 4 turns away whole points that
-    // normalized cleanly, so they never appear in that list.
+    // Gate on whether anything was rejected at all, never on the unit count: a
+    // zero-count rejection still has to reach the sender. The rule and the
+    // reasoning are in docs/guides/ingest.md, "Zero-count partial success".
+    //
+    // Metrics carry a second term because layer 4's active-series-cap count is
+    // tracked outside `normalized.rejected` and never appears in it, so a gate
+    // reading only that list would report a fully clean write on a request whose
+    // points normalized cleanly and were then turned away by the cap.
     let partial_success = if normalized.rejected.is_empty() && series_cap_rejected == 0 {
         None
     } else {
@@ -272,12 +280,50 @@ pub async fn handle_export(
     })
 }
 
+/// Collapse `rejected` into one entry per distinct rejection value, in
+/// first-appearance order, each carrying the data-point count summed over the
+/// entries it stands for.
+///
+/// This runs before anything is rendered, which is the point of it: normalize
+/// pushes one rejection per data point, so a request of
+/// `max_data_points_per_request` histogram points whose SDK records `min`/`max`
+/// arrives with that many entries, all of them the same variant. Rendering
+/// first would allocate two strings and hash them per point to produce a
+/// message that collapses to a single entry. Collapsing first ties the
+/// rendering work to the number of distinct reasons instead.
+///
+/// The scan is a bounded linear search over the most recent
+/// [`MAX_PREGROUPED_VARIANTS`] groups rather than a hash lookup, because
+/// [`Rejection`] is `Eq` but not `Hash` and the only key available without one
+/// is the rendered text this pass exists to avoid producing. A rejection that
+/// matches nothing in the window simply becomes its own group, which is not a
+/// correctness question: [`build_error_message`] folds groups together by
+/// rendered text afterwards, so an unmatched group costs one extra render and
+/// changes no output.
+fn collapse_rejection_variants(rejected: &[Rejection]) -> Vec<(&Rejection, usize)> {
+    let mut groups: Vec<(&Rejection, usize)> = Vec::new();
+    for rejection in rejected {
+        let n = rejection.rejected_count();
+        let window_start = groups.len().saturating_sub(MAX_PREGROUPED_VARIANTS);
+        let hit = groups[window_start..]
+            .iter()
+            .position(|(seen, _)| *seen == rejection)
+            .map(|offset| window_start + offset);
+        match hit {
+            Some(index) => groups[index].1 += n,
+            None => groups.push((rejection, n)),
+        }
+    }
+    groups
+}
+
 /// Build the OTLP partial-success `error_message` from `rejected`: one entry
 /// per distinct reason with the total point count it covers, rather than
-/// joining one string per rejected point. Distinct reasons are rare relative
-/// to rejected points in the pathological case this guards against (a
-/// whole-resource or whole-metric rejection covering a huge batch collapses
-/// to a single reason), so this stays cheap even when `rejected` is large.
+/// joining one string per rejected point. Identical rejections are collapsed by
+/// [`collapse_rejection_variants`] before any of them is rendered, so the
+/// rendering and hashing cost tracks distinct reasons rather than
+/// `rejected.len()`; two rejection values that differ but render alike are
+/// still folded together here, by their rendered text.
 /// The assembled message is capped at [`MAX_ERROR_MESSAGE_BYTES`]; if more
 /// distinct reasons exist than fit, the message is truncated with a count of
 /// how many were omitted.
@@ -294,26 +340,23 @@ pub async fn handle_export(
 fn build_error_message(rejected: &[Rejection], series_cap_rejected: usize) -> String {
     let mut order: Vec<String> = Vec::new();
     let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    for r in rejected {
-        let key = r.to_string();
-        let n = r.rejected_count();
-        counts
-            .entry(key.clone())
-            .and_modify(|count| *count += n)
-            .or_insert_with(|| {
-                order.push(key);
-                n
-            });
+    for (rejection, n) in collapse_rejection_variants(rejected) {
+        let key = rejection.to_string();
+        if let Some(count) = counts.get_mut(&key) {
+            *count += n;
+        } else {
+            counts.insert(key.clone(), n);
+            order.push(key);
+        }
     }
     if series_cap_rejected > 0 {
         let key = "active series cap exceeded".to_string();
-        counts
-            .entry(key.clone())
-            .and_modify(|count| *count += series_cap_rejected)
-            .or_insert_with(|| {
-                order.push(key);
-                series_cap_rejected
-            });
+        if let Some(count) = counts.get_mut(&key) {
+            *count += series_cap_rejected;
+        } else {
+            counts.insert(key.clone(), series_cap_rejected);
+            order.push(key);
+        }
     }
 
     let mut message = String::new();
@@ -603,6 +646,188 @@ mod tests {
             message.contains("more distinct rejection reason(s) omitted"),
             "expected a truncation indicator, got: {message}"
         );
+    }
+
+    /// The pre-collapse implementation: render every entry, then fold by the
+    /// rendered text. Kept as a test-only oracle so the collapse can be shown
+    /// to change cost and nothing else. Any input for which this and
+    /// [`build_error_message`] disagree is a sender-visible change.
+    fn render_first_reference(rejected: &[Rejection], series_cap_rejected: usize) -> String {
+        let mut order: Vec<String> = Vec::new();
+        let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+        for r in rejected {
+            let key = r.to_string();
+            let n = r.rejected_count();
+            counts
+                .entry(key.clone())
+                .and_modify(|count| *count += n)
+                .or_insert_with(|| {
+                    order.push(key);
+                    n
+                });
+        }
+        if series_cap_rejected > 0 {
+            let key = "active series cap exceeded".to_string();
+            counts
+                .entry(key.clone())
+                .and_modify(|count| *count += series_cap_rejected)
+                .or_insert_with(|| {
+                    order.push(key);
+                    series_cap_rejected
+                });
+        }
+
+        let mut message = String::new();
+        let mut shown = 0usize;
+        for reason in &order {
+            let count = counts[reason];
+            let entry = if count > 1 {
+                format!("{reason} (x{count})")
+            } else {
+                reason.clone()
+            };
+            let sep_len = if message.is_empty() { 0 } else { 2 };
+            if message.len() + sep_len + entry.len() > MAX_ERROR_MESSAGE_BYTES {
+                break;
+            }
+            if !message.is_empty() {
+                message.push_str("; ");
+            }
+            message.push_str(&entry);
+            shown += 1;
+        }
+        if shown < order.len() {
+            message.push_str(&format!(
+                "; ... {} more distinct rejection reason(s) omitted",
+                order.len() - shown
+            ));
+        }
+        message
+    }
+
+    /// A corpus built to exercise every way the collapse could diverge from
+    /// [`render_first_reference`]: more distinct values than the collapse
+    /// window holds, repeats separated by other reasons, a long run of one
+    /// value, and two values that are unequal yet render identically
+    /// (`HistogramMinMaxDropped` does not print its `count`).
+    fn divergence_corpus() -> Vec<Rejection> {
+        let mut rejected = Vec::new();
+        for i in 0..(MAX_PREGROUPED_VARIANTS * 3) {
+            rejected.push(Rejection::DuplicateLabelName(format!("label_{i}")));
+            rejected.push(Rejection::HistogramMinMaxDropped { count: 1 });
+            rejected.push(Rejection::ZeroTimestamp);
+            rejected.push(Rejection::HistogramMinMaxDropped { count: 7 });
+            rejected.push(Rejection::MissingValue);
+        }
+        rejected.extend(
+            std::iter::repeat_n(Rejection::ComplexAttributeValue, 1_000)
+                .chain(std::iter::once(Rejection::ZeroTimestamp)),
+        );
+        rejected
+    }
+
+    #[test]
+    fn build_error_message_renders_one_entry_for_a_request_full_of_one_informational_drop() {
+        // The reviewer's case: every point in a full request carries a min/max
+        // the SDK recorded, so normalize pushes one rejection per point. The
+        // rendered message is one entry, and it carries no count, because an
+        // informational drop costs the sender no data point
+        // (`Rejection::rejected_count` is 0 for this variant) and the renderer
+        // only appends a count above 1.
+        let points = IngestLimits::default().max_data_points_per_request;
+        assert_eq!(points, 100_000, "the limit this case is sized against");
+        let rejected: Vec<Rejection> =
+            std::iter::repeat_n(Rejection::HistogramMinMaxDropped { count: 1 }, points).collect();
+
+        assert_eq!(
+            build_error_message(&rejected, 0),
+            "histogram min/max field(s) dropped: no Prometheus-convention representation"
+        );
+    }
+
+    #[test]
+    fn build_error_message_renders_the_summed_total_for_a_request_full_of_one_reason() {
+        // The same shape for a reason that does cost the sender points: the
+        // 100_000 entries collapse to one entry whose count is their total.
+        let points = IngestLimits::default().max_data_points_per_request;
+        let rejected: Vec<Rejection> =
+            std::iter::repeat_n(Rejection::ZeroTimestamp, points).collect();
+
+        assert_eq!(
+            build_error_message(&rejected, 0),
+            "event timestamp is zero (x100000)"
+        );
+    }
+
+    #[test]
+    fn collapse_rejection_variants_is_sized_by_distinct_reasons_not_by_entries() {
+        // The shape assertion. One group means one render and one hash for the
+        // whole request; a collapse that reverted to per-entry keying would
+        // return `max_data_points_per_request` groups here.
+        let points = IngestLimits::default().max_data_points_per_request;
+        let one_reason: Vec<Rejection> =
+            std::iter::repeat_n(Rejection::HistogramMinMaxDropped { count: 1 }, points).collect();
+        assert_eq!(collapse_rejection_variants(&one_reason).len(), 1);
+
+        // K distinct reasons, interleaved rather than run-length ordered, so
+        // the collapse cannot be passing by only comparing against the group it
+        // just pushed.
+        let distinct = [
+            Rejection::HistogramMinMaxDropped { count: 1 },
+            Rejection::HistogramExemplarsDropped { count: 1 },
+            Rejection::ZeroTimestamp,
+            Rejection::MissingValue,
+            Rejection::ComplexAttributeValue,
+        ];
+        let mixed: Vec<Rejection> = (0..points)
+            .map(|i| distinct[i % distinct.len()].clone())
+            .collect();
+        assert_eq!(
+            collapse_rejection_variants(&mixed).len(),
+            distinct.len(),
+            "one group per distinct reason, whatever the entry count"
+        );
+    }
+
+    #[test]
+    fn collapse_rejection_variants_sums_the_point_count_of_the_entries_it_folds() {
+        // Grouping is on the whole value, so two `EmptyMetricName`s fold only
+        // when their counts match; they render differently otherwise and are
+        // distinct reasons. The folded group carries their summed point count.
+        let rejected = vec![
+            Rejection::EmptyMetricName { count: 3 },
+            Rejection::ZeroTimestamp,
+            Rejection::EmptyMetricName { count: 3 },
+            Rejection::EmptyMetricName { count: 4 },
+        ];
+        let groups = collapse_rejection_variants(&rejected);
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0], (&Rejection::EmptyMetricName { count: 3 }, 6));
+        assert_eq!(groups[1], (&Rejection::ZeroTimestamp, 1));
+        assert_eq!(groups[2], (&Rejection::EmptyMetricName { count: 4 }, 4));
+    }
+
+    #[test]
+    fn build_error_message_is_byte_identical_to_rendering_every_entry_first() {
+        for series_cap_rejected in [0usize, 1, 4_096] {
+            for rejected in [
+                Vec::new(),
+                vec![Rejection::ZeroTimestamp],
+                std::iter::repeat_n(Rejection::HistogramMinMaxDropped { count: 1 }, 10_000)
+                    .collect(),
+                (0..10_000)
+                    .map(|i| Rejection::DuplicateLabelName(format!("label_{i}")))
+                    .collect(),
+                divergence_corpus(),
+            ] {
+                assert_eq!(
+                    build_error_message(&rejected, series_cap_rejected),
+                    render_first_reference(&rejected, series_cap_rejected),
+                    "collapsing changed the message for {} entries with cap {series_cap_rejected}",
+                    rejected.len()
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/services/ravel-server/src/ingest.rs
+++ b/services/ravel-server/src/ingest.rs
@@ -183,8 +183,9 @@ pub async fn handle_export(
     let mut rejected_count: usize = normalized.rejected.iter().map(|r| r.rejected_count()).sum();
     // Layer 3's rejections, counted where they are observed rather than inside
     // the normalizer, which knows no tenant. Classified per point, so the
-    // counter moves by exactly what the sender is told in `rejected_data_points`
-    // below.
+    // counter moves by exactly the normalization share of the
+    // `rejected_data_points` reported below; the layer-4 cap count is added to
+    // that field separately and counted by the admission controller.
     state.normalize_metrics.record(
         &tenant,
         ravel_types::Signal::Metrics,
@@ -247,14 +248,22 @@ pub async fn handle_export(
             IngestRequestError::Write(err)
         })?;
 
-    let partial_success = if rejected_count > 0 {
+    // Both rejection sources gate this, because neither alone covers the
+    // request. Gating on `rejected_count` swallows an informational drop: the
+    // point lands, so its count is 0, yet the sender must still learn that its
+    // min/max, its exemplars, or its integer precision is gone, through
+    // `error_message` with `rejected_data_points` reported as 0 (the
+    // OTLP-sanctioned warning channel). Gating on `normalized.rejected` alone
+    // swallows an active-series-cap drop: layer 4 turns away whole points that
+    // normalized cleanly, so they never appear in that list.
+    let partial_success = if normalized.rejected.is_empty() && series_cap_rejected == 0 {
+        None
+    } else {
         let error_message = build_error_message(&normalized.rejected, series_cap_rejected);
         Some(ExportMetricsPartialSuccess {
             rejected_data_points: rejected_count as i64,
             error_message,
         })
-    } else {
-        None
     };
 
     Ok(IngestOutcome {
@@ -276,6 +285,12 @@ pub async fn handle_export(
 /// `series_cap_rejected` folds in the layer-4 active-series-cap count (0
 /// when nothing was capped) as one more reason, aggregated the same way as
 /// every normalization rejection.
+///
+/// A reason whose `rejected_count()` is 0 still gets an entry, rendered
+/// without a count suffix. That is an informational drop: the point landed
+/// and only a field of it was dropped, so the message is the only channel
+/// that can name it, and filtering zero-count reasons out here would leave
+/// the partial success with an empty `error_message`.
 fn build_error_message(rejected: &[Rejection], series_cap_rejected: usize) -> String {
     let mut order: Vec<String> = Vec::new();
     let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
@@ -336,7 +351,7 @@ fn build_error_message(rejected: &[Rejection], series_cap_rejected: usize) -> St
 mod tests {
     use super::*;
     use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
-    use ravel_ingest::{AdmissionLimits, IngestConfig, SystemClock};
+    use ravel_ingest::{AdmissionLimits, CountLimit, IngestConfig, SystemClock};
     use ravel_object_store::ObjectStoreBackend;
     use ravel_object_store::memory::MemoryStore;
     use ravel_types::Signal;
@@ -350,6 +365,13 @@ mod tests {
     const BASE_TS_NS: i64 = 1_767_225_600_000_000_000;
 
     fn state() -> IngestState {
+        state_with_admission_limits(AdmissionLimits::default())
+    }
+
+    /// The same fixture state as [`state`], with the tenant admission limits
+    /// (layer 4, ADR-0051) supplied, so a test can bound the active-series cap
+    /// low enough to reach the per-series partial-success path.
+    fn state_with_admission_limits(limits: AdmissionLimits) -> IngestState {
         let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
         let router = Arc::new(IngestRouter::new(
             IngestConfig::default(),
@@ -361,10 +383,7 @@ mod tests {
             router,
             limits: IngestLimits::default(),
             ack_deadline: Duration::from_secs(5),
-            admission: Arc::new(AdmissionController::new(
-                Arc::new(SystemClock),
-                AdmissionLimits::default(),
-            )),
+            admission: Arc::new(AdmissionController::new(Arc::new(SystemClock), limits)),
             recovery: None,
             provisioning: None,
             metadata_sink: None,
@@ -724,6 +743,180 @@ mod tests {
         assert_eq!(entries[0].kind, ravel_catalog::MetricKind::Counter);
         assert_eq!(entries[0].help, "size of each request");
         assert_eq!(entries[0].unit, "bytes");
+    }
+
+    /// A cumulative explicit-bucket histogram whose data point carries
+    /// `min`/`max`, which the Prometheus-convention mapping has nowhere to
+    /// store (ADR-0047 decision 6). The point itself is admitted, so the
+    /// rejection's `rejected_count()` is 0.
+    fn histogram_with_min_max_request() -> ExportMetricsServiceRequest {
+        use opentelemetry_proto::tonic::metrics::v1::{
+            Histogram, HistogramDataPoint, Metric, ResourceMetrics, ScopeMetrics,
+            metric::Data as MetricData,
+        };
+
+        ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: vec![Metric {
+                        name: "latency".to_string(),
+                        data: Some(MetricData::Histogram(Histogram {
+                            data_points: vec![HistogramDataPoint {
+                                time_unix_nano: BASE_TS_NS as u64,
+                                count: 3,
+                                sum: Some(6.0),
+                                bucket_counts: vec![1, 2],
+                                explicit_bounds: vec![1.0],
+                                min: Some(0.5),
+                                max: Some(4.0),
+                                ..Default::default()
+                            }],
+                            // AGGREGATION_TEMPORALITY_CUMULATIVE.
+                            aggregation_temporality: 2,
+                        })),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    /// `count` cleanly normalizing gauge points, one distinct series each, so
+    /// a bounded active-series cap turns away exactly `count - cap` of them
+    /// and nothing appears in `normalized.rejected`.
+    fn multi_series_gauge_request(count: usize) -> ExportMetricsServiceRequest {
+        use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+        use opentelemetry_proto::tonic::metrics::v1::{
+            Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics,
+            metric::Data as MetricData,
+        };
+
+        ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: (0..count)
+                        .map(|i| Metric {
+                            name: format!("flood_series_{i}"),
+                            data: Some(MetricData::Gauge(Gauge {
+                                data_points: vec![NumberDataPoint {
+                                    time_unix_nano: BASE_TS_NS as u64,
+                                    value: Some(NumberValue::AsDouble(i as f64)),
+                                    ..Default::default()
+                                }],
+                            })),
+                            ..Default::default()
+                        })
+                        .collect(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    /// An informational drop costs no point, so `rejected_data_points` is 0
+    /// and `error_message` is the only channel that can tell the sender the
+    /// min/max fields are gone. A response that omitted the partial success
+    /// would be byte-identical to a clean write.
+    #[tokio::test]
+    async fn one_dropped_min_max_is_reported_and_the_point_still_lands() {
+        let state = state();
+        let outcome = handle_export(
+            &state,
+            TenantId::new("acme"),
+            WriteMode::Strict,
+            histogram_with_min_max_request(),
+            BASE_TS_NS,
+        )
+        .await
+        .expect("strict write publishes");
+
+        let partial_success = outcome
+            .response
+            .partial_success
+            .expect("the dropped min/max is reported");
+        assert_eq!(
+            partial_success.rejected_data_points, 0,
+            "no point was lost, only the histogram's min/max fields"
+        );
+        assert!(
+            partial_success.error_message.contains("min/max"),
+            "got: {}",
+            partial_success.error_message
+        );
+        assert!(
+            !outcome.tokens.is_empty(),
+            "the point itself is admitted, so at least one shard commits"
+        );
+    }
+
+    /// Every point normalizes cleanly and the layer-4 active-series cap turns
+    /// some away. Capped points never enter `normalized.rejected`, so a gate
+    /// reading only that list would report a fully clean write while real
+    /// points were lost. `admission_e2e.rs`'s `fresh_series_flood_capped_
+    /// per_tenant` covers the same shape over HTTP; this is the unit-level
+    /// guard on the gate itself.
+    #[tokio::test]
+    async fn a_series_cap_rejection_alone_is_reported() {
+        const CAP: usize = 3;
+        const FLOOD: usize = 10;
+
+        let state = state_with_admission_limits(AdmissionLimits {
+            max_active_series: CountLimit::Bounded(CAP as u64),
+            ..AdmissionLimits::default()
+        });
+        let outcome = handle_export(
+            &state,
+            TenantId::new("acme"),
+            WriteMode::Strict,
+            multi_series_gauge_request(FLOOD),
+            BASE_TS_NS,
+        )
+        .await
+        .expect("strict write publishes the admitted points");
+
+        let partial_success = outcome
+            .response
+            .partial_success
+            .expect("the capped series are reported");
+        assert_eq!(
+            partial_success.rejected_data_points,
+            (FLOOD - CAP) as i64,
+            "exactly the points beyond the cap are rejected"
+        );
+        assert!(
+            partial_success
+                .error_message
+                .contains("active series cap exceeded"),
+            "got: {}",
+            partial_success.error_message
+        );
+    }
+
+    /// Nothing rejected and nothing dropped: the response carries no partial
+    /// success at all. This is what a gate widened into always-`Some` breaks,
+    /// telling every sender its clean write was partial.
+    #[tokio::test]
+    async fn a_fully_clean_export_reports_no_partial_success() {
+        let state = state();
+        let outcome = handle_export(
+            &state,
+            TenantId::new("acme"),
+            WriteMode::Strict,
+            multi_series_gauge_request(3),
+            BASE_TS_NS,
+        )
+        .await
+        .expect("strict write publishes");
+
+        assert!(
+            outcome.response.partial_success.is_none(),
+            "nothing was rejected or dropped, got: {:?}",
+            outcome.response.partial_success
+        );
+        assert!(!outcome.tokens.is_empty(), "the points landed");
     }
 
     #[tokio::test]

--- a/services/ravel-server/src/logs_ingest.rs
+++ b/services/ravel-server/src/logs_ingest.rs
@@ -301,14 +301,14 @@ pub async fn handle_export_logs(
             LogIngestRequestError::Write(err)
         })?;
 
-    // Both rejection sources gate this, because neither alone covers the
-    // request. Gating on `rejected_count` swallows an attribute-only drop: the
-    // record lands, so its count is 0, yet the sender must still learn the
-    // attribute is gone through `error_message` with `rejected_log_records`
-    // reported as 0 (the OTLP-sanctioned warning channel). Gating on
-    // `normalized.rejected` alone swallows a stream-cap drop: the layer-4 cap
-    // rejects whole records that normalized cleanly, so they never appear in
-    // that list.
+    // Gate on whether anything was rejected at all, never on the unit count: a
+    // zero-count rejection still has to reach the sender. The rule and the
+    // reasoning are in docs/guides/ingest.md, "Zero-count partial success".
+    //
+    // Logs carry a second term because layer 4's active-stream-cap count is
+    // tracked outside `normalized.rejected` and never appears in it, so a gate
+    // reading only that list would report a fully clean write on a request whose
+    // records normalized cleanly and were then turned away by the cap.
     let partial_success = if normalized.rejected.is_empty() && stream_cap_rejected == 0 {
         None
     } else {

--- a/services/ravel-server/src/traces_ingest.rs
+++ b/services/ravel-server/src/traces_ingest.rs
@@ -255,11 +255,13 @@ pub async fn handle_export_traces(
             SpanIngestRequestError::Write(err)
         })?;
 
-    // Emit partial-success whenever anything was rejected, not only when a
-    // whole span was lost: an attribute-only drop must still be surfaced to the
-    // sender through `error_message`, with `rejected_spans` reported as 0 (the
-    // OTLP-sanctioned warning channel). Gating on the span count instead would
-    // silently swallow attribute drops on an otherwise clean request.
+    // Gate on whether anything was rejected at all, never on the unit count: a
+    // zero-count rejection still has to reach the sender. The rule and the
+    // reasoning are in docs/guides/ingest.md, "Zero-count partial success".
+    //
+    // Spans need only the one term, unlike metrics and logs: ADR-0051 gives
+    // them no layer-4 series/stream admission, so `normalized.rejected` is the
+    // whole rejection signal here and nothing is tracked beside it.
     let partial_success = if normalized.rejected.is_empty() {
         None
     } else {


### PR DESCRIPTION
A metrics data point that lands with its min/max, its exemplars, or integer
precision dropped was reported to the sender as a fully clean write. The reason
was built into an error message and then discarded.

`handle_export` gated the OTLP partial-success message on the rejected-point
count. `Rejection::HistogramMinMaxDropped`, `HistogramExemplarsDropped` and
`IntegerValuePrecisionLoss` all return `rejected_count() == 0`, correctly,
because the point still lands. So the count stayed 0, the gate took the `None`
arm, and the `error_message` naming the drop was thrown away. A sender losing a
histogram's min/max on every request saw a response byte-identical to a clean
one.

The gate now carries both of the request's rejection sources:

```rust
let partial_success = if normalized.rejected.is_empty() && series_cap_rejected == 0 {
```

`rejected_data_points` still carries the point count, which is 0 for an
informational drop. That is the OTLP-sanctioned shape: the proto documents
`error_message` as usable "to convey warnings/suggestions during a successful
response", and a `rejected_<signal>` of 0 as meaning the request was fully
accepted.

Both terms are required. `series_cap_rejected` is the layer-4 active-series-cap
count, tracked separately and folded into the total afterwards; it never appears
in `normalized.rejected`. Gating on the list alone would return `None` on a
request whose points normalized cleanly and were then rejected by the cap: real
points lost, nothing reported. Gating on the count alone is the bug being fixed.
This is the same two-term shape #1580 landed for logs, and unlike traces, which
has one rejection source and correctly gates on one term.

Three flips, each failing exactly its own test:

| gate mutation | fails |
|---|---|
| back to `rejected_count > 0` | `one_dropped_min_max_is_reported_and_the_point_still_lands` |
| narrowed to `normalized.rejected.is_empty()` | `a_series_cap_rejection_alone_is_reported` |
| widened to always `Some` | `a_fully_clean_export_reports_no_partial_success` |

The clean-request test was added even though a no-partial-success test already
existed, because the existing one drives an empty request, which proves nothing
about a request whose points were admitted. Both fail under flip 3.

One load-bearing thing the sweep confirmed rather than assumed:
`build_error_message` does not filter zero-count reasons. `order.push(key)` runs
for every rejection regardless of its count, and the render loop's `if count > 1`
only chooses between `reason (xN)` and a bare `reason`. So the gate fix alone
delivers a non-empty message, proven by the first test asserting the message
contains `min/max`.

The comment sweep also found one false claim and fixed it: "the counter moves by
exactly what the sender is told in `rejected_data_points` below" is untrue
whenever the layer-4 cap fires, since the skew and structural counters move by 0
while `rejected_data_points` reports the capped count.

Gates: fmt, `clippy -p ravel-server --all-targets`, `test -p ravel-server --lib`
at 584 passed, and `admission_e2e` at 5 passed. Also run unasked, since
CLAUDE.md requires them for a `ravel-server` change: the full crate test suite,
and clippy for both the `sql` and `flight-sql` feature lanes. All clean.

Two surfaces have the same blind spot and are not touched here:
`otap_grpc.rs`'s `ack()` gates on the cap count alone, so an informational drop
reads as a clean ack there too, and `remote_write.rs` has no partial-success
channel at all and omits zero-count rejections from its dropped-points counter.
Both worth follow-ups.

Fixes: #1585
Refs: #1313
