### PR TITLE
docs(mcp): settle eight MCP contract decisions and correct snapshot_id

### DIFF
--- a/crates/ravel-mcp/src/envelope.rs
+++ b/crates/ravel-mcp/src/envelope.rs
@@ -791,12 +791,6 @@ const _: () = assert!(
     "the empty-resolve warning must point at the ingest watermark field"
 );
 
-/// Serialized JSON string length of one byte inside a string, mirroring
-/// [`escaped_char_len`] for the ASCII range: every byte
-/// [`IDENTITY_FIELDS`] and [`IDENTITY_WARNING_SUFFIX`] can contain today.
-/// Kept separate from `escaped_char_len` because a `const fn` cannot decode
-/// UTF-8 through `str::chars` on stable Rust, and these two string sources
-/// are ASCII by construction (field names and fixed English prose).
 /// Whether two ASCII strings are equal, for the const assertions above:
 /// `str` has no `const` equality on stable Rust.
 const fn ascii_eq(a: &str, b: &str) -> bool {
@@ -820,6 +814,12 @@ const fn max_len(a: usize, b: usize) -> usize {
     if a > b { a } else { b }
 }
 
+/// Serialized JSON string length of one byte inside a string, mirroring
+/// [`escaped_char_len`] for the ASCII range: every byte
+/// [`IDENTITY_FIELDS`] and [`IDENTITY_WARNING_SUFFIX`] can contain today.
+/// Kept separate from `escaped_char_len` because a `const fn` cannot decode
+/// UTF-8 through `str::chars` on stable Rust, and these two string sources
+/// are ASCII by construction (field names and fixed English prose).
 const fn ascii_escaped_byte_len(b: u8) -> usize {
     match b {
         b'"' | b'\\' => 2,

--- a/crates/ravel-mcp/src/envelope.rs
+++ b/crates/ravel-mcp/src/envelope.rs
@@ -113,7 +113,7 @@ const TIME_RANGE_BOUND: usize = 32;
 const QUERY_ID_BOUND: usize = 128;
 const AUDIT_REF_BOUND: usize = 128;
 const SNAPSHOT_ID_BOUND: usize = 128;
-const WATERMARK_HOUR_BOUND: usize = 32;
+const INGEST_WATERMARK_HOUR_BOUND: usize = 32;
 const APPROXIMATION_BOUND: usize = 256;
 const FAILURE_COUNTER_BOUND: usize = 128;
 
@@ -126,7 +126,7 @@ const FIXED_SCALAR_BOUNDS: usize = SIGNAL_BOUND
     + QUERY_ID_BOUND
     + AUDIT_REF_BOUND
     + SNAPSHOT_ID_BOUND
-    + WATERMARK_HOUR_BOUND
+    + INGEST_WATERMARK_HOUR_BOUND
     + APPROXIMATION_BOUND
     + FAILURE_COUNTER_BOUND;
 
@@ -160,7 +160,7 @@ const MAX_SHORTEN_PASSES: usize = 16;
 /// `zero_row_envelope_with_maximal_metadata_fits_under_the_floor`, which
 /// fails if a field is added or renamed without revisiting the arithmetic
 /// below.
-const EMPTY_ENVELOPE_SERIALIZED_LEN: usize = 852;
+const EMPTY_ENVELOPE_SERIALIZED_LEN: usize = 859;
 
 /// Room for the skeleton parts that grow without being payload: the counters
 /// widening from `0` to their full decimal form, `status` from `ok` to
@@ -420,9 +420,32 @@ pub struct Ids {
 #[derive(Debug, Clone, Default, Serialize, JsonSchema)]
 pub struct Visibility {
     pub snapshot_id: String,
-    pub watermark_hour: String,
+    /// Freshness: the greatest ingest hour among the segments this operation
+    /// resolved, as the decimal unix hour in a JSON string (D4's precision
+    /// rule carries integers as strings). It is not `YYYYMMDDHH`, and it is
+    /// not the catalog's `YYYYMMDDTHH` key text.
+    ///
+    /// Deliberately not spelled `watermark_hour`: that name is the FOLD
+    /// watermark everywhere else in this system (docs/catalog-and-mvcc.md
+    /// makes HEAD's `watermark_hour` authoritative, and ravel-catalog and
+    /// ravel-maintain carry it through `SnapshotPartRef` and `PartHeader`).
+    /// This is a different quantity, and a reader who conflates the two reads
+    /// a cost boundary as a freshness claim.
+    pub ingest_watermark_hour: String,
     pub pinned: bool,
     pub min_commit_tokens_applied: Vec<String>,
+    /// Set by an operation that resolved a snapshot and got no segments back,
+    /// which is the one case where [`Self::ingest_watermark_hour`] has no
+    /// value to report: it is the greatest ingest hour among the resolved
+    /// segments, and there are none.
+    ///
+    /// Not a wire field. It selects which warning
+    /// [`Envelope::warn_unreported_identity`] emits for the empty watermark,
+    /// so a caller can tell an empty resolve from an operation that never
+    /// measures the field at all. Both leave the string empty, and the
+    /// distinction is not recoverable from the envelope without it.
+    #[serde(skip)]
+    pub resolved_no_segments: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, JsonSchema)]
@@ -734,7 +757,7 @@ const MARKER_SERIALIZED_LEN: usize = TRUNCATION_MARKER.len() + 2;
 /// [`Envelope::warn_unreported_identity`] warns about them.
 const IDENTITY_FIELDS: [&str; 4] = [
     "visibility.snapshot_id",
-    "visibility.watermark_hour",
+    "visibility.ingest_watermark_hour",
     "ids.query_id",
     "ids.audit_ref",
 ];
@@ -743,12 +766,60 @@ const IDENTITY_FIELDS: [&str; 4] = [
 /// field name in [`IDENTITY_FIELDS`].
 const IDENTITY_WARNING_SUFFIX: &str = " is not reported by this operation";
 
+/// What [`Envelope::warn_unreported_identity`] appends instead, for the one
+/// field and the one case where the operation did measure and the quantity
+/// has no value: a resolve that returned no segments has no greatest ingest
+/// hour among them.
+///
+/// Different words from [`IDENTITY_WARNING_SUFFIX`] on purpose. That one is a
+/// statement about the operation ("this tool never reports the field"), and a
+/// caller reading it on an empty resolve would conclude the freshness of its
+/// own tenant is unknowable through this tool rather than that the window it
+/// asked about is empty. `ravel_describe_data` exists to answer exactly that
+/// question, so the two cases have to be told apart in the text.
+const EMPTY_RESOLVE_WARNING_SUFFIX: &str = " is absent: this operation resolved no segments";
+
+/// Index in [`IDENTITY_FIELDS`] of the one field
+/// [`EMPTY_RESOLVE_WARNING_SUFFIX`] can apply to.
+const INGEST_WATERMARK_HOUR_IDENTITY_INDEX: usize = 1;
+
+const _: () = assert!(
+    ascii_eq(
+        IDENTITY_FIELDS[INGEST_WATERMARK_HOUR_IDENTITY_INDEX],
+        "visibility.ingest_watermark_hour"
+    ),
+    "the empty-resolve warning must point at the ingest watermark field"
+);
+
 /// Serialized JSON string length of one byte inside a string, mirroring
 /// [`escaped_char_len`] for the ASCII range: every byte
 /// [`IDENTITY_FIELDS`] and [`IDENTITY_WARNING_SUFFIX`] can contain today.
 /// Kept separate from `escaped_char_len` because a `const fn` cannot decode
 /// UTF-8 through `str::chars` on stable Rust, and these two string sources
 /// are ASCII by construction (field names and fixed English prose).
+/// Whether two ASCII strings are equal, for the const assertions above:
+/// `str` has no `const` equality on stable Rust.
+const fn ascii_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// The larger of two lengths, for the const arithmetic below: `usize::max` is
+/// not `const` on stable Rust.
+const fn max_len(a: usize, b: usize) -> usize {
+    if a > b { a } else { b }
+}
+
 const fn ascii_escaped_byte_len(b: u8) -> usize {
     match b {
         b'"' | b'\\' => 2,
@@ -786,11 +857,22 @@ const fn ascii_pair_serialized_len(a: &str, b: &str) -> usize {
 /// Derived from the strings themselves so a changed field name or a changed
 /// wording cannot drift silently from what [`Envelope::fit`] reserves room
 /// for.
+///
+/// The ingest watermark field takes whichever of its two messages is longer:
+/// one envelope carries either the not-reported wording or the
+/// [`EMPTY_RESOLVE_WARNING_SUFFIX`] one for that field, never both.
 const fn identity_warnings_allowance() -> usize {
     let mut total = 0usize;
     let mut i = 0usize;
     while i < IDENTITY_FIELDS.len() {
-        total += ascii_pair_serialized_len(IDENTITY_FIELDS[i], IDENTITY_WARNING_SUFFIX) + 1;
+        let mut entry = ascii_pair_serialized_len(IDENTITY_FIELDS[i], IDENTITY_WARNING_SUFFIX);
+        if i == INGEST_WATERMARK_HOUR_IDENTITY_INDEX {
+            entry = max_len(
+                entry,
+                ascii_pair_serialized_len(IDENTITY_FIELDS[i], EMPTY_RESOLVE_WARNING_SUFFIX),
+            );
+        }
+        total += entry + 1;
         i += 1;
     }
     total
@@ -989,7 +1071,7 @@ impl Envelope {
             + serialized_str_len(&self.ids.query_id)
             + serialized_str_len(&self.ids.audit_ref)
             + serialized_str_len(&self.visibility.snapshot_id)
-            + serialized_str_len(&self.visibility.watermark_hour)
+            + serialized_str_len(&self.visibility.ingest_watermark_hour)
             + entry_serialized_len(&self.budget.effective)
             + entry_serialized_len(&self.budget.actual)
             + entry_serialized_len(&self.budget.estimate);
@@ -1055,8 +1137,8 @@ impl Envelope {
             SNAPSHOT_ID_BOUND,
         ));
         cut += u64::from(bound_scalar(
-            &mut self.visibility.watermark_hour,
-            WATERMARK_HOUR_BOUND,
+            &mut self.visibility.ingest_watermark_hour,
+            INGEST_WATERMARK_HOUR_BOUND,
         ));
         if let Some(approximation) = &mut self.accuracy.approximation {
             cut += u64::from(bound_scalar(approximation, APPROXIMATION_BOUND));
@@ -1301,13 +1383,23 @@ impl Envelope {
 
     /// Names every D4 identity field this envelope did not measure.
     ///
-    /// D4 types `visibility.snapshot_id`, `visibility.watermark_hour`,
+    /// D4 types `visibility.snapshot_id`, `visibility.ingest_watermark_hour`,
     /// `ids.query_id`, and `ids.audit_ref` as strings, so an operation that
     /// never resolved one serializes `""`. An empty string is a value: a
     /// caller cannot tell it apart from an id that really is empty, and a
     /// reader collecting snapshot ids across calls would collect blanks as if
     /// they were measurements. Saying in `warnings` that the field is not
     /// reported by this operation is the honest form.
+    ///
+    /// One empty field has a second reason, and it gets its own wording. The
+    /// ingest watermark is the greatest ingest hour among the segments the
+    /// operation resolved, so a resolve that returned none has nothing to
+    /// report even though it measured. `visibility.resolved_no_segments` is
+    /// how the operation says so, and it swaps
+    /// [`IDENTITY_WARNING_SUFFIX`] for [`EMPTY_RESOLVE_WARNING_SUFFIX`] on
+    /// that field alone. The two never both appear for it: the operation
+    /// either reports the field or does not, and if it does not, exactly one
+    /// of the two reasons holds.
     ///
     /// Every envelope that reaches a caller goes through [`finish`](Self::finish),
     /// which is what calls this: a crate that built its own envelope and
@@ -1323,15 +1415,24 @@ impl Envelope {
     fn warn_unreported_identity(&mut self) {
         let reported = [
             !self.visibility.snapshot_id.is_empty(),
-            !self.visibility.watermark_hour.is_empty(),
+            !self.visibility.ingest_watermark_hour.is_empty(),
             !self.ids.query_id.is_empty(),
             !self.ids.audit_ref.is_empty(),
         ];
+        let empty_resolve = self.visibility.resolved_no_segments;
         let mut identity_warnings: Vec<String> = IDENTITY_FIELDS
             .iter()
+            .enumerate()
             .zip(reported)
             .filter(|(_, reported)| !reported)
-            .map(|(field, _)| format!("{field}{IDENTITY_WARNING_SUFFIX}"))
+            .map(|((index, field), _)| {
+                let suffix = if index == INGEST_WATERMARK_HOUR_IDENTITY_INDEX && empty_resolve {
+                    EMPTY_RESOLVE_WARNING_SUFFIX
+                } else {
+                    IDENTITY_WARNING_SUFFIX
+                };
+                format!("{field}{suffix}")
+            })
             .collect();
         if !identity_warnings.is_empty() {
             identity_warnings.append(&mut self.warnings);
@@ -1458,18 +1559,18 @@ mod tests {
 
     /// Four rows of known serialized size (150,004 B each: a `Cell::Str` of
     /// 150,000 plain ASCII bytes is two bytes of array brackets plus two of
-    /// quotes wider than its body). The fixed part here is 856 B, not the
-    /// 852 B of a bare default envelope: `presentation.effective_max_response_bytes`
+    /// quotes wider than its body). The fixed part here is 863 B, not the
+    /// 859 B of a bare default envelope: `presentation.effective_max_response_bytes`
     /// and `presentation.bytes_cap_hit` are both set (to the requested cap
     /// and to `true`) before the row scan runs, and a 6-digit cap widens the
     /// first from 1 digit to 6 while `bytes_cap_hit` narrows from `false` to
-    /// `true`, a net +4 B. From that fixed part the running total is 150,860
-    /// after the first row and 300,865 after the second (one more byte for
+    /// `true`, a net +4 B. From that fixed part the running total is 150,867
+    /// after the first row and 300,872 after the second (one more byte for
     /// the comma between them). `fit` packs rows against its cap minus
     /// [`IDENTITY_WARNINGS_ALLOWANCE`] (the room it reserves for
     /// [`Envelope::finish`]'s identity warnings), so the requested cap here
     /// is that total plus the allowance: internally `fit` targets exactly
-    /// 300,865 again, keeps exactly those two rows and omits the other two,
+    /// 300,872 again, keeps exactly those two rows and omits the other two,
     /// and the fitted envelope's real serialized size lands on that same
     /// total, unaffected by the reservation because `finish` is never called
     /// in this test.
@@ -1482,20 +1583,20 @@ mod tests {
             .map(|&n| vec![Cell::Str("a".repeat(n))])
             .collect();
 
-        let fitted = envelope.fit(300_865 + IDENTITY_WARNINGS_ALLOWANCE as u64);
+        let fitted = envelope.fit(300_872 + IDENTITY_WARNINGS_ALLOWANCE as u64);
 
         assert_eq!(fitted.presentation.rows_omitted, 2);
         assert_eq!(fitted.data.rows.len(), 2);
         assert_eq!(fitted.presentation.cells_truncated, 0);
-        assert_eq!(serialized_len(&fitted), 300_865);
+        assert_eq!(serialized_len(&fitted), 300_872);
     }
 
     /// 5,000 one-cell rows (the D4 `MAX_ROWS_CEILING`), each a small fixed
     /// size, under a cap that admits a precomputed count: with the same
-    /// 856 B fixed part as above (the 256 KiB floor is a 6-digit cap too)
+    /// 863 B fixed part as above (the 256 KiB floor is a 6-digit cap too)
     /// and 204 B rows (a 200-byte `Cell::Str` plus its two bytes of
     /// brackets and two of quotes), the running total after `k` rows is
-    /// `855 + 205*k`. `fit` packs rows against the floor minus
+    /// `862 + 205*k`. `fit` packs rows against the floor minus
     /// [`IDENTITY_WARNINGS_ALLOWANCE`], not the floor itself, so the
     /// crossing point is one row earlier than it would be without that
     /// reservation: between the 1,273rd and 1,274th row -- except
@@ -1520,7 +1621,7 @@ mod tests {
         assert_eq!(fitted.data.rows.len(), 1_273);
         assert_eq!(fitted.presentation.rows_omitted, 5_000 - 1_273);
         assert_eq!(fitted.presentation.cells_truncated, 0);
-        assert_eq!(serialized_len(&fitted), 855 + 205 * 1_273 + 3);
+        assert_eq!(serialized_len(&fitted), 862 + 205 * 1_273 + 3);
         assert!(serialized_len(&fitted) <= MAX_RESPONSE_BYTES_FLOOR as usize);
     }
 
@@ -1584,27 +1685,27 @@ mod tests {
     /// three tests detect a cut measured in source bytes: such a cut either
     /// overruns the cap or, once the re-measure loop has clamped it, lands on
     /// the 256 B floor instead of this figure.
-    const KEPT_CELL_SERIALIZED_LEN: usize = 261_028;
+    const KEPT_CELL_SERIALIZED_LEN: usize = 261_000;
     /// The whole envelope's exact serialized size for those same cases.
-    const FITTED_ENVELOPE_SERIALIZED_LEN: usize = 261_918;
+    const FITTED_ENVELOPE_SERIALIZED_LEN: usize = 261_897;
 
     /// `\n ` alternates a character that serializes to two bytes with one
-    /// that serializes to one. At this cap the shrink loop's convergence
-    /// lands the kept cell on the same exact serialized length as the pure
-    /// quote body above: both bodies have more than enough source characters
-    /// to hit the budget precisely regardless of their escape ratio, so the
-    /// two constants below are not required to differ, and today they do
-    /// not.
-    const KEPT_CONTROL_CELL_SERIALIZED_LEN: usize = 261_028;
-    const FITTED_CONTROL_ENVELOPE_SERIALIZED_LEN: usize = 261_918;
+    /// that serializes to one, and that is what makes the kept cell one byte
+    /// wider here than for the pure quote body above. A cut lands on a source
+    /// character boundary, so a body of nothing but two-byte escapes can only
+    /// reach an even serialized length; a mixed body can also reach the odd
+    /// one just below the budget. The two constants below are not required to
+    /// agree, and today they do not.
+    const KEPT_CONTROL_CELL_SERIALIZED_LEN: usize = 261_001;
+    const FITTED_CONTROL_ENVELOPE_SERIALIZED_LEN: usize = 261_898;
 
     /// Serialized size of a 200-row page of one hex id column, every id at
     /// the 64-character bound: 13,801 B of rows (200 cells of 68 B, their
-    /// commas, and the array brackets) plus 889 B of envelope fields, far
+    /// commas, and the array brackets) plus 896 B of envelope fields, far
     /// under the 256 KiB floor. Pinned so a hex id that grew past its bound
     /// shows up here as a size change rather than as a cell `fit` silently
     /// skipped.
-    const HEX_ID_PAGE_SERIALIZED_LEN: usize = 14_690;
+    const HEX_ID_PAGE_SERIALIZED_LEN: usize = 14_697;
 
     /// Serialized size of a zero-row envelope with every metadata field at
     /// both its D4 bounds, every scalar filling the D4 scalar allowance, and
@@ -1620,7 +1721,7 @@ mod tests {
     /// floor is the [`MAXIMAL_FIXED_PART`] assertion beside that constant,
     /// which adds the skeleton, its slack, and the identity-warning
     /// allowance on top of the documented bounds.
-    const MAXIMAL_METADATA_ENVELOPE_LEN: usize = 109_902;
+    const MAXIMAL_METADATA_ENVELOPE_LEN: usize = 109_909;
     const _: () = assert!(
         MAXIMAL_METADATA_ENVELOPE_LEN < 110_592,
         "the maximal fixed part must stay under this test's 108 KiB tripwire"
@@ -1904,7 +2005,10 @@ mod tests {
         envelope.ids.query_id = "q".repeat(4096);
         envelope.ids.audit_ref = "a".repeat(4096);
         envelope.visibility.snapshot_id = "v".repeat(4096);
-        envelope.visibility.watermark_hour = "2026090800".to_string();
+        // The decimal unix hour, which is what this field carries: 496896 is
+        // 2026-09-08T00:00:00Z. Not YYYYMMDDHH, and not the catalog's
+        // YYYYMMDDTHH key text.
+        envelope.visibility.ingest_watermark_hour = "496896".to_string();
         envelope.accuracy.approximation = Some("x".repeat(4096));
         envelope.presentation.cursor = Some("k".repeat(3 * 1024));
         envelope.budget.effective = AnyJson(Value::String("b".repeat(1000)));
@@ -1930,7 +2034,7 @@ mod tests {
         // against the allowance there is room left for the message's own
         // text once the plan is at its floor.
         assert!(failure.message.ends_with(TRUNCATION_MARKER));
-        assert_eq!(serialized_str_len(&failure.message), 2_037);
+        assert_eq!(serialized_str_len(&failure.message), 2_041);
         assert_eq!(
             serialized_str_len(failure.counter.as_deref().expect("a counter")),
             FAILURE_COUNTER_BOUND
@@ -1957,7 +2061,7 @@ mod tests {
             APPROXIMATION_BOUND
         );
         // Already inside their bounds, so untouched by the cut.
-        assert_eq!(fitted.visibility.watermark_hour, "2026090800");
+        assert_eq!(fitted.visibility.ingest_watermark_hour, "496896");
         // The stage before it brought the scalars inside the allowance, so
         // the budget values are never reached.
         assert_eq!(
@@ -2189,7 +2293,7 @@ mod tests {
         envelope.ids.query_id = "q".repeat(QUERY_ID_BOUND - 2);
         envelope.ids.audit_ref = "a".repeat(AUDIT_REF_BOUND - 2);
         envelope.visibility.snapshot_id = "v".repeat(SNAPSHOT_ID_BOUND - 2);
-        envelope.visibility.watermark_hour = "h".repeat(WATERMARK_HOUR_BOUND - 2);
+        envelope.visibility.ingest_watermark_hour = "h".repeat(INGEST_WATERMARK_HOUR_BOUND - 2);
         envelope.visibility.pinned = true;
         envelope.visibility.min_commit_tokens_applied = (0..MAX_MIN_COMMIT_TOKENS)
             .map(|i| format!("{i:0>2}_{}", "m".repeat(123)))
@@ -2666,7 +2770,7 @@ mod tests {
             finished.warnings,
             vec![
                 "visibility.snapshot_id is not reported by this operation".to_string(),
-                "visibility.watermark_hour is not reported by this operation".to_string(),
+                "visibility.ingest_watermark_hour is not reported by this operation".to_string(),
                 "ids.query_id is not reported by this operation".to_string(),
                 "ids.audit_ref is not reported by this operation".to_string(),
             ]
@@ -2680,11 +2784,59 @@ mod tests {
         assert_eq!(
             finished.warnings,
             vec![
-                "visibility.watermark_hour is not reported by this operation".to_string(),
+                "visibility.ingest_watermark_hour is not reported by this operation".to_string(),
                 "ids.query_id is not reported by this operation".to_string(),
                 "ids.audit_ref is not reported by this operation".to_string(),
             ]
         );
+    }
+
+    /// An operation that resolved and got no segments back is not an
+    /// operation that does not report freshness. The ingest watermark is the
+    /// greatest ingest hour among the segments resolved, so an empty resolve
+    /// leaves it with no value while having measured perfectly well, and that
+    /// is precisely the state `ravel_describe_data` exists to report. A
+    /// caller that reads the not-reported wording there concludes its
+    /// tenant's freshness is unknowable through this tool rather than that
+    /// the window it asked about is empty.
+    ///
+    /// Both strings are pinned whole, and asserted to differ: the agent
+    /// corpus D8 requires keys on telling these two apart, so the wording is
+    /// a contract rather than incidental prose.
+    #[test]
+    fn an_empty_resolve_warns_in_different_words_than_an_unmeasured_watermark() {
+        const NOT_REPORTED: &str =
+            "visibility.ingest_watermark_hour is not reported by this operation";
+        const EMPTY_RESOLVE: &str =
+            "visibility.ingest_watermark_hour is absent: this operation resolved no segments";
+        assert_ne!(NOT_REPORTED, EMPTY_RESOLVE);
+
+        let unmeasured = envelope_with_rows(1, |i| vec![Cell::Int(i as i128)]).finish(false);
+        assert!(unmeasured.warnings.contains(&NOT_REPORTED.to_string()));
+        assert!(!unmeasured.warnings.contains(&EMPTY_RESOLVE.to_string()));
+
+        let mut empty = envelope_with_rows(0, |i| vec![Cell::Int(i as i128)]);
+        empty.visibility.resolved_no_segments = true;
+        let empty = empty.finish(false);
+        assert_eq!(
+            empty.warnings,
+            vec![
+                "visibility.snapshot_id is not reported by this operation".to_string(),
+                EMPTY_RESOLVE.to_string(),
+                "ids.query_id is not reported by this operation".to_string(),
+                "ids.audit_ref is not reported by this operation".to_string(),
+            ]
+        );
+
+        // A resolve that found segments reports the hour, and neither wording
+        // applies: the flag only ever selects between the two reasons a field
+        // is absent, and never suppresses one that is present.
+        let mut measured = envelope_with_rows(1, |i| vec![Cell::Int(i as i128)]);
+        measured.visibility.ingest_watermark_hour = "496896".to_string();
+        measured.visibility.resolved_no_segments = true;
+        let measured = measured.finish(false);
+        assert!(!measured.warnings.contains(&NOT_REPORTED.to_string()));
+        assert!(!measured.warnings.contains(&EMPTY_RESOLVE.to_string()));
     }
 
     /// An envelope that already carries `MAX_WARNINGS` warnings, each at the
@@ -2722,6 +2874,29 @@ mod tests {
                 finished.warnings
             );
         }
+        assert!(serialized_len(&finished) <= MAX_RESPONSE_BYTES_FLOOR as usize);
+
+        // The empty-resolve wording is the longer of the two messages the
+        // watermark field can carry, so it is the one the allowance has to
+        // cover. Same envelope, same cap, that message instead.
+        let mut envelope = envelope_with_rows(1, |i| vec![Cell::Int(i as i128)]);
+        envelope.warnings = (0..MAX_WARNINGS)
+            .map(|i| format!("{i:0>2}_{}", "w".repeat(507)))
+            .collect();
+        envelope.visibility.resolved_no_segments = true;
+
+        let finished = envelope.fit(MAX_RESPONSE_BYTES_FLOOR).finish(false);
+
+        assert_eq!(finished.warnings.len(), MAX_WARNINGS);
+        let expected = format!(
+            "{}{EMPTY_RESOLVE_WARNING_SUFFIX}",
+            IDENTITY_FIELDS[INGEST_WATERMARK_HOUR_IDENTITY_INDEX]
+        );
+        assert!(
+            finished.warnings.contains(&expected),
+            "{expected:?} is missing from {:?}",
+            finished.warnings
+        );
         assert!(serialized_len(&finished) <= MAX_RESPONSE_BYTES_FLOOR as usize);
     }
 

--- a/crates/ravel-mcp/src/tools/capabilities.rs
+++ b/crates/ravel-mcp/src/tools/capabilities.rs
@@ -279,7 +279,7 @@ mod tests {
             envelope.warnings,
             vec![
                 "visibility.snapshot_id is not reported by this operation".to_string(),
-                "visibility.watermark_hour is not reported by this operation".to_string(),
+                "visibility.ingest_watermark_hour is not reported by this operation".to_string(),
                 "ids.query_id is not reported by this operation".to_string(),
                 "ids.audit_ref is not reported by this operation".to_string(),
             ]

--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -756,7 +756,8 @@ against the 256 KiB `max_response_bytes` floor.
    envelope frame. It still holds for the `data` block, which the adapter
    keeps building.
 
-**Amendment (2026-09-13).** Five contract decisions and one correction.
+**Amendment (2026-09-13).** Seven contract decisions and one correction. The
+correction is item 6.
 
 1. `FindLabelsInput.filter` is a case-sensitive substring match over the
    strings the tool is about to return. It applies after the list is
@@ -775,7 +776,8 @@ against the 256 KiB `max_response_bytes` floor.
    removed from the tool rather than accepted and ignored, and the tool emits
    no `evidence` block. Nothing defines what a label list attests to, and the
    port between the tool layer and the engine does not carry what minting a
-   reference would need.
+   reference would need. `FindLabelsInput` still declares the field today;
+   issue #1605 is the follow-up that removes it.
 3. A paged `ravel_describe_data` pins page one's freshness watermark into the
    cursor, and every later page reports that same value. A page sequence that
    re-measures per page describes a moving state, with nothing telling the
@@ -790,12 +792,16 @@ against the 256 KiB `max_response_bytes` floor.
      cover, and docs/consistency-model.md states that the fold never changes
      which commits a query sees.
    - Its lag is large. An hour seals only once `now >= end(hour) +
-     max_flush_lifetime + clock_skew_allowance + fold_safety_margin`, which
-     at the defaults of 1 h, 5 m and 15 m puts the worst case between an
-     acknowledged write and a covering watermark at about 2 h 25 m, once the
-     fold's 5 m interval and the 30 s HEAD cache are counted. Reporting that
-     as freshness would tell an agent its data may be hours stale while it
-     holds an answer resolved a minute ago.
+     max_flush_lifetime + clock_skew_allowance + fold_safety_margin`. Six
+     terms separate an acknowledged write from a watermark that covers it:
+     up to 1 h from the write itself to `end(hour)`, which the seal
+     condition's own `end(hour)` implies; then `max_flush_lifetime` 1 h,
+     `clock_skew_allowance` 5 m and `fold_safety_margin` 15 m at their
+     defaults; then the fold's 5 m interval and the 30 s HEAD cache. The
+     worst case is their sum, 2 h 25 m 30 s, which this ADR and
+     docs/reference/mcp.md both quote as about 2 h 25 m. Reporting that as
+     freshness would tell an agent its data may be hours stale while it holds
+     an answer resolved a minute ago.
    - It is the costlier of the two. The value is not on the returned
      `Snapshot`; it lives in a crate-private struct, so a query-path caller
      needs a ravel-catalog signature change or an extra HEAD GET outside the
@@ -816,19 +822,78 @@ against the 256 KiB `max_response_bytes` floor.
 
    The pinned watermark is a new cursor field, so `CURSOR_VERSION` goes from
    4 to 5, with a test that a version 4 token decodes as invalid, matching
-   the three that already exist for earlier versions.
+   the one that already exists for version 3. That is the only earlier-layout
+   test in `crates/ravel-mcp/src/cursor.rs` today: the other two tests that
+   manipulate a version byte cover a future cursor version and an evidence
+   token, neither of which is an earlier cursor layout.
 5. A redeeming resolve runs at the cursor's `mint_ns`, not at the redeeming
-   call's clock. A page sequence that re-lists at the current instant walks a
-   moving snapshot, and pinning a watermark while resolving against a later
-   one makes the pin decorative. Nothing in the code states this today and
-   there is no production caller, so this ADR is where it is settled.
+   call's clock. This restates and explains the rule the 2026-09-12
+   amendment's item 4 already settled. It is not a refinement of that rule
+   and does not override it; what is new here is the reason. A page sequence
+   that re-lists at the current instant walks a moving snapshot, and pinning
+   a watermark while resolving against a later one makes the pin decorative.
+   Nothing in the code states the rule today and there is no production
+   caller, so this is where the reasoning is recorded.
 6. Correction. D5 defines `visibility.snapshot_id` as a hash of the pinned
    segment set. The amendment that replaced the segment-enumeration cursor
    with the resolve-input cursor deleted that set, and the code followed it
    at `CURSOR_VERSION` 4, so the set exists nowhere in the system. No later
-   amendment respecifies the derivation. `snapshot_id` is a hash over the
-   same resolve inputs the cursor pins: the signal, the half-open time range,
-   the minimum commit-token watermark, the pending erasure predicates, and
-   the declared column set. Two calls resolving the same inputs report the
-   same `snapshot_id`. It identifies those inputs, not the segments they
-   resolved to.
+   amendment respecifies the derivation. `snapshot_id` is a hash over seven
+   inputs: the tenant hash, the signal, the half-open time range, the
+   minimum commit-token watermark, the pending erasure predicates, the
+   declared column set, and the resolve instant. Two calls resolving the same
+   seven report the same `snapshot_id`. It identifies those inputs, not the
+   segments they resolved to.
+
+   The first five of those are the resolve inputs the cursor pins. The
+   remaining two are in the preimage because leaving either out makes the id
+   collide across resolves that are not the same resolve. Without the tenant
+   hash, two tenants asking for the same signal and window with no declared
+   columns and no pending erasure predicates report a byte-identical
+   `snapshot_id` over disjoint data, which is a cross-tenant collision in a
+   field agents are told to compare. Without the resolve instant, two calls a
+   day apart over the same historical window report the same id while
+   resolving different segment sets, because the live listing above the fold
+   watermark picks up whatever committed in between. A redemption is not an
+   exception: the 2026-09-12 amendment's item 4 makes a redeeming resolve run
+   at the cursor's own `mint_ns`, so every page of one sequence resolves at
+   one instant and reports one id.
+
+Two further decisions follow from item 4. Both are settled here rather than
+left to the implementation.
+
+7. The envelope field is `visibility.ingest_watermark_hour`, not
+   `visibility.watermark_hour`, and it carries the decimal unix hour as a
+   JSON string. Two separate points.
+
+   The name. `watermark_hour` is already the fold watermark's name
+   system-wide: docs/catalog-and-mvcc.md makes HEAD's `watermark_hour`
+   authoritative, and ravel-catalog and ravel-maintain carry that field
+   through `SnapshotPartRef` and `PartHeader`. Item 4 defines the envelope's
+   quantity as explicitly not that one, so keeping the shared name would
+   leave a reader to conclude from the name that a cost boundary is a
+   freshness claim. Nothing populates the field today, which makes the rename
+   free now and impossible once an agent reads it.
+
+   The rendering, previously unstated anywhere. The value is the decimal unix
+   hour -- the count of whole hours since the epoch -- as a JSON string, per
+   D4's precision rule that integers travel as JSON strings. It is not
+   `YYYYMMDDHH`, and it is not the catalog's `YYYYMMDDTHH` object-key text.
+   The field keeps its 32 B scalar sub-bound: that bound measures the value,
+   which the rename does not touch.
+8. An empty resolve reports the field absent, in its own words. The watermark
+   is the greatest ingest hour among the segments the resolve returned, so a
+   resolve that returned none has no value to report even though it measured.
+   That is exactly the state `ravel_describe_data` exists to answer, and D8
+   requires the agent corpus to cover it.
+
+   D4 types the field as a string, so an empty resolve serializes `""`, the
+   same as an operation that never reports freshness at all. The `warnings`
+   entry is what separates them, and the two entries say different things:
+   `visibility.ingest_watermark_hour is not reported by this operation` for
+   the operation that does not measure, and
+   `visibility.ingest_watermark_hour is absent: this operation resolved no
+   segments` for the resolve that measured and found nothing. A caller that
+   reads the first wording on an empty tenant concludes its own freshness is
+   unknowable through this tool rather than that the window it asked about is
+   empty, which is the opposite of what the call established.

--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -755,3 +755,80 @@ against the 256 KiB `max_response_bytes` floor.
    port returning finished envelopes. That reason is superseded for the
    envelope frame. It still holds for the `data` block, which the adapter
    keeps building.
+
+**Amendment (2026-09-13).** Five contract decisions and one correction.
+
+1. `FindLabelsInput.filter` is a case-sensitive substring match over the
+   strings the tool is about to return. It applies after the list is
+   produced and before the page cap. So a returned page is complete for that
+   filter, and a truncation report means more matches genuinely exist. The
+   filter is reported in `scope.predicates_applied`. It is case-sensitive
+   because label names and values are exact byte strings and canonical series
+   identity is exact. A case-insensitive match would need a Unicode
+   case-folding rule that nothing else in the system defines. An empty filter
+   string is `invalid_argument`, not a match of everything. A filter does not
+   satisfy the rule that refuses an unfiltered tenant-wide list. That rule
+   keys on a selector or a label name, each of which bounds the resolution. A
+   filter bounds only the output, so a request carrying a filter and neither
+   of the other two is still refused.
+2. `ravel_find_labels` takes no `evidence_ref` in this phase. The input is
+   removed from the tool rather than accepted and ignored, and the tool emits
+   no `evidence` block. Nothing defines what a label list attests to, and the
+   port between the tool layer and the engine does not carry what minting a
+   reference would need.
+3. A paged `ravel_describe_data` pins page one's freshness watermark into the
+   cursor, and every later page reports that same value. A page sequence that
+   re-measures per page describes a moving state, with nothing telling the
+   agent that two pages disagree because time passed rather than because the
+   data differs.
+4. That freshness watermark is the maximum `ingest_hour_bucket` across the
+   segments in the resolved snapshot. It is not the catalog fold watermark.
+   Four reasons, each a live constraint:
+   - The fold watermark is a cost boundary, not a freshness one. A resolve
+     serves hours at or below it from snapshot parts and lists everything
+     above it live, so a query already sees data the watermark does not
+     cover, and docs/consistency-model.md states that the fold never changes
+     which commits a query sees.
+   - Its lag is large. An hour seals only once `now >= end(hour) +
+     max_flush_lifetime + clock_skew_allowance + fold_safety_margin`, which
+     at the defaults of 1 h, 5 m and 15 m puts the worst case between an
+     acknowledged write and a covering watermark at about 2 h 25 m, once the
+     fold's 5 m interval and the 30 s HEAD cache are counted. Reporting that
+     as freshness would tell an agent its data may be hours stale while it
+     holds an answer resolved a minute ago.
+   - It is the costlier of the two. The value is not on the returned
+     `Snapshot`; it lives in a crate-private struct, so a query-path caller
+     needs a ravel-catalog signature change or an extra HEAD GET outside the
+     catalog's 30 s cache. The maximum `ingest_hour_bucket` over
+     `Snapshot::segments` is an in-memory fold over a vector the caller
+     already owns.
+   - It is ingest time, not event time, so a client's clock cannot move it.
+
+   Event-time bounds are a different quantity. `min_event_ts_ns` and
+   `max_event_ts_ns` across the resolved set describe what the data covers
+   and belong in the `coverage` block, not in `visibility`.
+
+   The pinned value is page one's measurement. A later page may have resolved
+   over a superset, because the live listing above the fold watermark picks
+   up whatever committed since. The cursor has always pinned resolve inputs
+   and a lower bound rather than an enumeration, and this field is the same
+   kind of thing.
+
+   The pinned watermark is a new cursor field, so `CURSOR_VERSION` goes from
+   4 to 5, with a test that a version 4 token decodes as invalid, matching
+   the three that already exist for earlier versions.
+5. A redeeming resolve runs at the cursor's `mint_ns`, not at the redeeming
+   call's clock. A page sequence that re-lists at the current instant walks a
+   moving snapshot, and pinning a watermark while resolving against a later
+   one makes the pin decorative. Nothing in the code states this today and
+   there is no production caller, so this ADR is where it is settled.
+6. Correction. D5 defines `visibility.snapshot_id` as a hash of the pinned
+   segment set. The amendment that replaced the segment-enumeration cursor
+   with the resolve-input cursor deleted that set, and the code followed it
+   at `CURSOR_VERSION` 4, so the set exists nowhere in the system. No later
+   amendment respecifies the derivation. `snapshot_id` is a hash over the
+   same resolve inputs the cursor pins: the signal, the half-open time range,
+   the minimum commit-token watermark, the pending erasure predicates, and
+   the declared column set. Two calls resolving the same inputs report the
+   same `snapshot_id`. It identifies those inputs, not the segments they
+   resolved to.

--- a/docs/adrs/1374-agent-mcp-server.md
+++ b/docs/adrs/1374-agent-mcp-server.md
@@ -247,6 +247,9 @@ Every tool returns one envelope:
 }
 ```
 
+The 2026-09-13 amendment's item 7 renames `watermark_hour` above to
+`ingest_watermark_hour`, and this skeleton keeps the original name.
+
 `plan` carries the plan text that `ravel_explain_query` returns and stays
 `null` on every other tool.
 
@@ -845,19 +848,17 @@ correction is item 6.
    seven report the same `snapshot_id`. It identifies those inputs, not the
    segments they resolved to.
 
-   The first five of those are the resolve inputs the cursor pins. The
-   remaining two are in the preimage because leaving either out makes the id
-   collide across resolves that are not the same resolve. Without the tenant
-   hash, two tenants asking for the same signal and window with no declared
-   columns and no pending erasure predicates report a byte-identical
-   `snapshot_id` over disjoint data, which is a cross-tenant collision in a
-   field agents are told to compare. Without the resolve instant, two calls a
-   day apart over the same historical window report the same id while
-   resolving different segment sets, because the live listing above the fold
-   watermark picks up whatever committed in between. A redemption is not an
-   exception: the 2026-09-12 amendment's item 4 makes a redeeming resolve run
-   at the cursor's own `mint_ns`, so every page of one sequence resolves at
-   one instant and reports one id.
+   Each of the seven avoids a collision across resolves that are not the
+   same resolve. Without the tenant hash, two tenants resolving the same
+   signal over the same window report a byte-identical `snapshot_id` over
+   disjoint data. Without the resolve instant, two calls a day apart over
+   the same historical window report the same id while resolving different
+   segment sets. The live listing above the fold watermark picks up
+   whatever committed in between. A cursor pins the same resolve inputs
+   plus its keyset position, which is why every page of one sequence
+   reports the same id. A redemption is not an exception. The 2026-09-12
+   amendment's item 4 makes a redeeming resolve run at the cursor's own
+   `mint_ns`. So every page of one sequence resolves at one instant.
 
 Two further decisions follow from item 4. Both are settled here rather than
 left to the implementation.

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -56,10 +56,13 @@ maintenance.
 ### Find labels
 
 - `ravel_find_labels`: metric names for a selector, label names, or the
-  values of one label under a selector. The result states whether the list
-  is declared through configuration, observed from data, or exact. Ask for a
-  tenant-wide list with no filter and the tool refuses, naming the bounded
-  form to ask for instead.
+  values of one label under a selector. The list is observed from the data
+  over the window you asked for, and the result states whether it is
+  complete for that window. A call bounded by neither a selector nor a label
+  name is refused, naming the bounded form to ask for instead. An optional
+  `filter` does not satisfy that bound: a selector or a label name narrows
+  what the call resolves, a filter narrows only what it returns, so a call
+  carrying a filter and neither of the other two is still refused.
 
 ### Check a query before you run it
 
@@ -105,8 +108,10 @@ One of four values, each a different fact about the result:
 
 - `ok`: the query completed. A query with zero matching rows is `ok`. A
   `LIMIT` the data did not fill is still `ok`.
-- `ok_bounded`: a row cap stopped the result and more rows exist, but the
-  statement has no total order, so no cursor exists for the rest.
+- `ok_bounded`: a cap stopped the result and more rows exist, but no cursor
+  exists for the rest, because the statement has no total order or the tool
+  mints no cursor. `presentation` states which cap stopped it. A
+  `ravel_find_labels` page cut short by the byte cap reports this way.
 - `ok_page`: a cap stopped the result and a cursor exists. `presentation`
   states whether the row cap, the byte cap, or both caused it.
 - `error`: the call failed. `failure` names why.
@@ -136,9 +141,17 @@ the deployment writes one.
 
 ### `visibility`
 
-The snapshot this call read: `snapshot_id`, the `watermark_hour` the catalog
-has folded up to, which `min_commit_tokens_applied` the call honored, and
-`pinned`, whether this call's snapshot stays held for a later paged call.
+The snapshot this call read: `snapshot_id`, `ingest_watermark_hour`, which
+`min_commit_tokens_applied` the call honored, and `pinned`, whether this
+call's snapshot stays held for a later paged call.
+
+`ingest_watermark_hour` is the greatest ingest hour among the segments this
+call resolved, as a decimal unix hour in a string. It is a freshness bound,
+not the catalog's fold watermark: the fold is a cost boundary that a query
+reads past routinely, and it lags an acknowledged write by around 2 h 25 m,
+which would read as staleness that is not there. A call that resolved no
+segments has no such hour to report, so it leaves the field empty and says
+so in `warnings`.
 
 ### `coverage`
 
@@ -172,9 +185,9 @@ an upper envelope, never a prediction, and the field says so.
 
 ### `evidence`
 
-A list of references, each an opaque `ref` token plus a `sha256` of the
+A list of references, each an opaque `ref` token plus a `blake3_256` of the
 canonical row bytes it covers. Redeem a reference later to prove a row has
-not changed.
+not changed. `ravel_find_labels` emits no `evidence` block.
 
 ### `warnings` and `next_steps`
 
@@ -226,7 +239,11 @@ Defaults and floors:
   `presentation.cursor` when more families exist. Request the next page
   with the same signal and that cursor. The cursor follows the same
   codec, tenant binding, and lifetime as every other cursor.
-- `ravel_find_labels`: 2,000 segments admitted for label resolution.
+- `ravel_find_labels`: 2,000 segments admitted for label resolution. It
+  takes no `max_rows`: a page is bounded by bytes alone, and a page cut
+  short reports through `presentation.bytes_cap_hit` and
+  `presentation.rows_omitted`. A page with `bytes_cap_hit` false is the
+  complete match set for the window and filter you asked for.
 
 `ravel_explain_query` compares its cost estimate to the effective budget
 before you run anything. When the estimate exceeds the budget, the call
@@ -266,10 +283,12 @@ When no complete group fits in the row cap, the server returns the
 rows it has, up to the row cap, with status `ok_bounded` and no cursor.
 `next_steps` names narrowing `time_range`.
 
-Every data tool accepts an optional `evidence_ref` input. Redeeming a
-reference re-executes the tool with the reference's own arguments. The
-re-execution runs against the reference's pinned snapshot while the pin is
-valid. The server then compares the sha256 of the canonical row bytes.
+Every data tool but `ravel_find_labels` accepts an optional `evidence_ref`
+input. That tool takes none and emits no `evidence` block: nothing defines
+what a label list attests to. Redeeming a reference re-executes the tool
+with the reference's own arguments. The re-execution runs against the
+reference's pinned snapshot while the pin is valid. The server then compares
+the BLAKE3-256 digest of the canonical row bytes.
 After the pin expires, redemption re-executes fresh instead of using the
 pin. It reports `pinned: false` and states whether the hash matched.
 `cursor_invalid` and `cursor_expired` do not apply to an evidence reference
@@ -313,9 +332,12 @@ empty case in order:
    Compare `scope.time_range` to what you meant to ask, and check the
    signal with a wider window.
 3. **The data exists but has not become visible yet.** Compare
-   `visibility.watermark_hour` to your window's end. A window that reaches
-   past the watermark can be honestly empty for now and non-empty once the
-   catalog catches up.
+   `visibility.ingest_watermark_hour` to your window's end. A window that
+   reaches past that hour can be honestly empty for now and non-empty once
+   the newer data is ingested. If the field is empty, read `warnings`: an
+   absent value means either that this operation does not report it or that
+   the call resolved no segments at all, and the two say so in different
+   words.
 4. **A predicate matched nothing.** Read `scope.predicates_applied` to see
    the predicate the server actually ran, which can differ from what you
    typed, for example when a typed-attribute-column name did not match and

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -23,7 +23,7 @@ the envelope, and the empty-result checklist.
 | --- | --- | --- | --- | --- | --- |
 | `ravel_capabilities` | Protocol and server version, served tools (`tools.enabled`) and declared-but-unserved ones (`tools.catalogued`), effective budget ceilings, dialect summaries, tenant hash, enabled signals | none | `data` | none; reads no data | `unauthorized`, `invalid_argument`, `internal` |
 | `ravel_describe_data` | Effective schema, indexed keys, metric families, freshness watermark, coverage window, exact row counts where available | `signal`, an optional `cursor` | `data`, `scope`, `visibility`, `coverage`, `presentation` | 100 metric families per page | `unauthorized`, `invalid_argument`, `unavailable`, `deadline`, `cursor_expired`, `cursor_invalid`, `internal` |
-| `ravel_find_labels` | Metric names, label names, or label values for a selector | a selector or a label name, plus a filter, `time_range` (required), an optional `evidence_ref`, `deadline_ms`, `max_response_bytes`. An unfiltered tenant-wide list is refused | `data`, `scope`, `coverage`, `evidence` | 2,000 segments admitted for resolution | `unauthorized`, `missing_argument`, `invalid_argument`, `budget_exceeded`, `deadline`, `unavailable`, `internal` |
+| `ravel_find_labels` | Metric names, label names, or label values for a selector | a selector or a label name, an optional `filter`, `time_range` (required), `deadline_ms`, `max_response_bytes`. A call carrying neither a selector nor a label name is refused, whatever its filter | `data`, `scope`, `coverage` | 2,000 segments admitted for resolution | `unauthorized`, `missing_argument`, `invalid_argument`, `budget_exceeded`, `deadline`, `unavailable`, `internal` |
 | `ravel_explain_query` | Validate a SQL or PromQL statement, estimate its cost, and return the plan shape. No scan runs. | `query`, `time_range`, `deadline_ms`, `max_response_bytes` | `data` (effective schema as `data.columns`, zero rows), `scope`, `budget`, `plan` (a text block that the explain tool alone populates) | compares the estimate against the effective budget | `unauthorized`, `invalid_argument`, `validation`, `unsupported`, `budget_estimate_exceeds_ceiling`, `internal` |
 | `ravel_query_sql` | One `SELECT` over one table | `query`, `time_range` (required), `max_rows`, lowerable budgets, an optional `cursor`, an optional `evidence_ref` | `data`, `scope`, `visibility`, `accuracy`, `presentation`, `budget`, `evidence` | `max_rows` 200, ceiling 5,000; `max_response_bytes` 512 KiB default, 256 KiB floor | `unauthorized`, `missing_argument`, `invalid_argument`, `validation`, `unsupported`, `budget_exceeded`, `deadline`, `unavailable`, `snapshot_invalidated`, `cursor_expired`, `cursor_invalid`, `internal` |
 | `ravel_query_promql` | Instant or range PromQL evaluation | `query`, either `time_range` and `step` or `evaluation_time` (exactly one mode), partial-coverage consent, an optional `evidence_ref`, `deadline_ms`, `max_bytes_scanned`, `max_response_bytes`, `max_rows`, `max_segments`, `max_store_requests` | `data`, `scope`, `coverage`, `accuracy`, `budget`, `evidence` | `max_response_bytes` 512 KiB default, 256 KiB floor | `unauthorized`, `missing_argument`, `invalid_argument`, `budget_exceeded`, `deadline`, `unavailable`, `snapshot_invalidated`, `internal` |
@@ -34,6 +34,26 @@ the envelope, and the empty-result checklist.
 
 `ravel_capabilities` and `ravel_describe_data` return metadata only.
 Neither tool accepts `evidence_ref` or emits an `evidence` block.
+`ravel_find_labels` accepts no `evidence_ref` and emits no `evidence`
+block either: nothing defines what a label list attests to, so the tool
+mints no reference.
+
+### Filtering a label list
+
+`ravel_find_labels` takes an optional `filter`, a case-sensitive substring
+match over the strings the call is about to return. It is applied after the
+list is produced and before the page cap, so a returned page is complete
+for that filter, and a truncation report means more matches exist. The
+filter is reported in `scope.predicates_applied`.
+
+The match is case-sensitive because label names and values are exact byte
+strings. An empty `filter` string is `invalid_argument`, not a request to
+match everything.
+
+A filter does not stand in for a selector or a label name. Those bound
+which data the call resolves; a filter bounds only the output. A call that
+carries a filter and neither of the other two is still refused with
+`invalid_argument`.
 
 ## The envelope
 
@@ -101,12 +121,35 @@ A result with rows and `ok_bounded` means more rows exist and the
 server minted no cursor. A genuinely empty result is `ok` with
 `row_count` 0.
 
+## Snapshot identity and freshness
+
+`visibility.snapshot_id` is a hash over the resolve inputs a cursor pins:
+the signal, the half-open time range, the minimum commit-token watermark,
+the erasure predicates pending at resolve time, and the typed attribute
+columns declared. Two calls that resolve the same inputs report the same
+`snapshot_id`. It identifies those inputs, not the set of segments they
+resolved to, so a later call reporting the same value is not a promise
+that it read the same objects.
+
+`visibility.watermark_hour` is the greatest ingest hour bucket among the
+segments the call's snapshot resolved to. It is an ingest-time bound, so
+no client clock moves it, and it is not the catalog's fold watermark. The
+fold watermark is a cost boundary: a resolve serves hours at or below it
+from snapshot parts and lists everything above it live, so a query
+routinely reads data the fold has not reached. It also lags an
+acknowledged write by around 2 h 25 m under the default flush lifetime,
+skew allowance, and fold margins, which would read as hours of staleness
+beside an answer resolved a minute ago.
+
+Event-time bounds are a different quantity. What the data covers in event
+time is reported under `coverage`, not here.
+
 ## Failure classes
 
 | Class | Meaning |
 | --- | --- |
 | `unauthorized` | The credential does not resolve to a tenant. |
-| `invalid_argument` | An argument is well-formed but not acceptable as given: two mutually exclusive fields set together, a value out of range, an unfiltered tenant-wide list. |
+| `invalid_argument` | An argument is well-formed but not acceptable as given: two mutually exclusive fields set together, a value out of range, an empty `filter` string, a label list bounded by neither a selector nor a label name. |
 | `missing_argument` | A required argument, most often a time input, was not sent. |
 | `validation` | The query engine rejected the statement itself. The message is the engine's own text, safe to show. |
 | `unsupported` | The request names a construct or an operation the tool does not implement. |
@@ -144,6 +187,11 @@ input and nothing more: redemption never compares it against a watermark
 observed later, because commit tokens from different writers have no
 ordering between them to compare, and whether a pinned token is still
 satisfiable is the catalog's answer at resolve time.
+
+That resolve also runs at the instant the cursor was minted, not at the
+redeeming call's clock. A page sequence that re-listed at the current
+instant would walk a moving snapshot, and pinning a watermark while
+resolving against a later one would leave the pin decorative.
 
 Redemption refuses a structurally valid, correctly bound cursor with
 `cursor_expired` in two cases. The first is that its effective deadline has
@@ -196,12 +244,21 @@ rows it has, up to the row cap, with status `ok_bounded` and no cursor.
 with the same signal and that cursor. The cursor follows the same codec,
 tenant binding, and lifetime as every other cursor.
 
-Every data tool accepts an optional `evidence_ref` input. Redeeming a
-reference re-executes the tool with the reference's own arguments. The
-re-execution runs against the reference's pinned snapshot while the pin is
-valid. The server then compares the BLAKE3-256 digest of the canonical row
-bytes. The digest travels in the evidence entry's `blake3_256` field, named
-for the function that produced it.
+Page one's freshness watermark is pinned into that cursor, and every later
+page reports the same value in `visibility.watermark_hour`. A sequence that
+re-measured the watermark per page would describe a moving state, with
+nothing to say whether two pages differ because time passed or because the
+data differs. The pinned value is page one's measurement: a later page may
+resolve over a superset of page one's segments, because the live listing
+above the fold watermark picks up whatever has committed since.
+
+Every data tool except `ravel_find_labels` accepts an optional
+`evidence_ref` input. Redeeming a reference re-executes the tool with the
+reference's own arguments. The re-execution runs against the reference's
+pinned snapshot while the pin is valid. The server then compares the
+BLAKE3-256 digest of the canonical row bytes. The digest travels in the
+evidence entry's `blake3_256` field, named for the function that produced
+it.
 After the pin expires, redemption re-executes fresh instead of using the
 pin. It reports `pinned: false` and states whether the hash matched.
 `cursor_invalid` and `cursor_expired` do not apply to an evidence reference

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -140,14 +140,14 @@ same seven report the same `snapshot_id`. It identifies those inputs, not
 the set of segments they resolved to, so a later call reporting the same
 value is not a promise that it read the same objects.
 
-The first five of those are the resolve inputs a cursor pins. The tenant
-hash and the resolve instant are in the hash because without them the value
-collides across calls that are not the same resolve: two tenants asking the
-same question of disjoint data would report one id, and two calls a day
-apart over the same historical window would report one id while reading
-different segments. Every page of one cursor sequence still reports one id,
-because a redemption resolves at the instant the cursor was minted rather
-than at the redeeming call's clock.
+Each of the seven avoids a collision across calls that are not the same
+resolve. Without the tenant hash, two tenants asking the same question of
+disjoint data would report one id. Without the resolve instant, two calls
+a day apart over the same historical window would report one id while
+reading different segments. A cursor pins the same resolve inputs plus
+its keyset position, so every page of one cursor sequence reports one id.
+A redemption resolves at the instant the cursor was minted, not at the
+redeeming call's clock.
 
 `visibility.ingest_watermark_hour` is the greatest ingest hour bucket among
 the segments the call's snapshot resolved to. It travels as the decimal unix

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -23,7 +23,7 @@ the envelope, and the empty-result checklist.
 | --- | --- | --- | --- | --- | --- |
 | `ravel_capabilities` | Protocol and server version, served tools (`tools.enabled`) and declared-but-unserved ones (`tools.catalogued`), effective budget ceilings, dialect summaries, tenant hash, enabled signals | none | `data` | none; reads no data | `unauthorized`, `invalid_argument`, `internal` |
 | `ravel_describe_data` | Effective schema, indexed keys, metric families, freshness watermark, coverage window, exact row counts where available | `signal`, an optional `cursor` | `data`, `scope`, `visibility`, `coverage`, `presentation` | 100 metric families per page | `unauthorized`, `invalid_argument`, `unavailable`, `deadline`, `cursor_expired`, `cursor_invalid`, `internal` |
-| `ravel_find_labels` | Metric names, label names, or label values for a selector | a selector or a label name, an optional `filter`, `time_range` (required), `deadline_ms`, `max_response_bytes`. A call carrying neither a selector nor a label name is refused, whatever its filter | `data`, `scope`, `coverage` | 2,000 segments admitted for resolution | `unauthorized`, `missing_argument`, `invalid_argument`, `budget_exceeded`, `deadline`, `unavailable`, `internal` |
+| `ravel_find_labels` | Metric names, label names, or label values for a selector | a selector or a label name, an optional `filter`, `time_range` (required), `deadline_ms`, `max_response_bytes`. A call carrying neither a selector nor a label name is refused, whatever its filter | `data`, `scope`, `coverage`, `presentation` | 2,000 segments admitted for resolution; `max_response_bytes` 512 KiB default, 256 KiB floor. No `max_rows`: a page is bounded by bytes, and a page cut short reports through `presentation.bytes_cap_hit` and `presentation.rows_omitted` | `unauthorized`, `missing_argument`, `invalid_argument`, `budget_exceeded`, `deadline`, `unavailable`, `internal` |
 | `ravel_explain_query` | Validate a SQL or PromQL statement, estimate its cost, and return the plan shape. No scan runs. | `query`, `time_range`, `deadline_ms`, `max_response_bytes` | `data` (effective schema as `data.columns`, zero rows), `scope`, `budget`, `plan` (a text block that the explain tool alone populates) | compares the estimate against the effective budget | `unauthorized`, `invalid_argument`, `validation`, `unsupported`, `budget_estimate_exceeds_ceiling`, `internal` |
 | `ravel_query_sql` | One `SELECT` over one table | `query`, `time_range` (required), `max_rows`, lowerable budgets, an optional `cursor`, an optional `evidence_ref` | `data`, `scope`, `visibility`, `accuracy`, `presentation`, `budget`, `evidence` | `max_rows` 200, ceiling 5,000; `max_response_bytes` 512 KiB default, 256 KiB floor | `unauthorized`, `missing_argument`, `invalid_argument`, `validation`, `unsupported`, `budget_exceeded`, `deadline`, `unavailable`, `snapshot_invalidated`, `cursor_expired`, `cursor_invalid`, `internal` |
 | `ravel_query_promql` | Instant or range PromQL evaluation | `query`, either `time_range` and `step` or `evaluation_time` (exactly one mode), partial-coverage consent, an optional `evidence_ref`, `deadline_ms`, `max_bytes_scanned`, `max_response_bytes`, `max_rows`, `max_segments`, `max_store_requests` | `data`, `scope`, `coverage`, `accuracy`, `budget`, `evidence` | `max_response_bytes` 512 KiB default, 256 KiB floor | `unauthorized`, `missing_argument`, `invalid_argument`, `budget_exceeded`, `deadline`, `unavailable`, `snapshot_invalidated`, `internal` |
@@ -45,6 +45,15 @@ match over the strings the call is about to return. It is applied after the
 list is produced and before the page cap, so a returned page is complete
 for that filter, and a truncation report means more matches exist. The
 filter is reported in `scope.predicates_applied`.
+
+The page cap that follows the filter is the byte cap. This tool advertises
+no `max_rows`; what bounds a page is `max_response_bytes`, 512 KiB by
+default with a 256 KiB floor. So the guarantee reads exactly: every string
+matching the filter that fits inside the byte cap is on the page. If the cap
+stopped the page short, `presentation.bytes_cap_hit` is set and
+`presentation.rows_omitted` counts what did not fit, and the status is
+`ok_bounded` rather than `ok`. A page with `bytes_cap_hit` false is the
+complete match set for that filter over the requested window.
 
 The match is case-sensitive because label names and values are exact byte
 strings. An empty `filter` string is `invalid_argument`, not a request to
@@ -69,7 +78,7 @@ field means and how to read it.
   "plan": null,
   "scope": {"signal": "", "table": "", "time_range": {}, "predicates_applied": [], "order_by": []},
   "ids": {"query_id": "", "audit_ref": ""},
-  "visibility": {"snapshot_id": "", "watermark_hour": "", "pinned": false, "min_commit_tokens_applied": []},
+  "visibility": {"snapshot_id": "", "ingest_watermark_hour": "", "pinned": false, "min_commit_tokens_applied": []},
   "coverage": {"complete": true, "partial": false, "fragments": [], "unindexed_predicates": []},
   "accuracy": {"exact": true, "approximation": null, "lower_bound_count": false},
   "presentation": {"max_rows": 200, "row_cap_hit": false, "bytes_cap_hit": false, "rows_omitted": 0, "cells_truncated": 0, "metadata_elided": 0, "entries_truncated": 0, "scalars_truncated": 0, "effective_max_response_bytes": 524288, "floor_applied": false, "cursor": null},
@@ -123,23 +132,48 @@ server minted no cursor. A genuinely empty result is `ok` with
 
 ## Snapshot identity and freshness
 
-`visibility.snapshot_id` is a hash over the resolve inputs a cursor pins:
-the signal, the half-open time range, the minimum commit-token watermark,
-the erasure predicates pending at resolve time, and the typed attribute
-columns declared. Two calls that resolve the same inputs report the same
-`snapshot_id`. It identifies those inputs, not the set of segments they
-resolved to, so a later call reporting the same value is not a promise
-that it read the same objects.
+`visibility.snapshot_id` is a hash over seven inputs: the tenant hash, the
+signal, the half-open time range, the minimum commit-token watermark, the
+erasure predicates pending at resolve time, the typed attribute columns
+declared, and the instant the resolve ran at. Two calls that resolve the
+same seven report the same `snapshot_id`. It identifies those inputs, not
+the set of segments they resolved to, so a later call reporting the same
+value is not a promise that it read the same objects.
 
-`visibility.watermark_hour` is the greatest ingest hour bucket among the
-segments the call's snapshot resolved to. It is an ingest-time bound, so
-no client clock moves it, and it is not the catalog's fold watermark. The
-fold watermark is a cost boundary: a resolve serves hours at or below it
-from snapshot parts and lists everything above it live, so a query
-routinely reads data the fold has not reached. It also lags an
-acknowledged write by around 2 h 25 m under the default flush lifetime,
-skew allowance, and fold margins, which would read as hours of staleness
-beside an answer resolved a minute ago.
+The first five of those are the resolve inputs a cursor pins. The tenant
+hash and the resolve instant are in the hash because without them the value
+collides across calls that are not the same resolve: two tenants asking the
+same question of disjoint data would report one id, and two calls a day
+apart over the same historical window would report one id while reading
+different segments. Every page of one cursor sequence still reports one id,
+because a redemption resolves at the instant the cursor was minted rather
+than at the redeeming call's clock.
+
+`visibility.ingest_watermark_hour` is the greatest ingest hour bucket among
+the segments the call's snapshot resolved to. It travels as the decimal unix
+hour -- whole hours since the epoch -- in a JSON string, like every other
+integer in the envelope. It is not `YYYYMMDDHH`, and it is not the
+`YYYYMMDDTHH` text that appears in object keys.
+
+It is an ingest-time bound, so no client clock moves it, and it is not the
+catalog's fold watermark. The name says so: `watermark_hour` unqualified is
+the fold watermark everywhere else in Ravel, and this is a different
+quantity. The fold watermark is a cost boundary: a resolve serves hours at
+or below it from snapshot parts and lists everything above it live, so a
+query routinely reads data the fold has not reached. It also lags an
+acknowledged write by around 2 h 25 m: up to 1 h from the write to the end
+of its ingest hour, then the 1 h flush lifetime, the 5 m skew allowance and
+the 15 m fold margin, then the fold's 5 m interval and the 30 s HEAD cache,
+2 h 25 m 30 s in all. Reported as freshness that would read as hours of
+staleness beside an answer resolved a minute ago.
+
+A resolve that returned no segments has no greatest ingest hour to report.
+It reports the field empty and says which of the two reasons applies in
+`warnings`: `visibility.ingest_watermark_hour is absent: this operation
+resolved no segments` for an empty resolve, against
+`visibility.ingest_watermark_hour is not reported by this operation` for a
+tool that never measures freshness at all. An empty resolve is a result, not
+a gap in the tool.
 
 Event-time bounds are a different quantity. What the data covers in event
 time is reported under `coverage`, not here.
@@ -245,10 +279,10 @@ with the same signal and that cursor. The cursor follows the same codec,
 tenant binding, and lifetime as every other cursor.
 
 Page one's freshness watermark is pinned into that cursor, and every later
-page reports the same value in `visibility.watermark_hour`. A sequence that
-re-measured the watermark per page would describe a moving state, with
-nothing to say whether two pages differ because time passed or because the
-data differs. The pinned value is page one's measurement: a later page may
+page reports the same value in `visibility.ingest_watermark_hour`. A
+sequence that re-measured the watermark per page would describe a moving
+state, with nothing to say whether two pages differ because time passed or
+because the data differs. The pinned value is page one's measurement: a later page may
 resolve over a superset of page one's segments, because the live listing
 above the fold watermark picks up whatever has committed since.
 

--- a/services/ravel-server/src/mcp/envelope.rs
+++ b/services/ravel-server/src/mcp/envelope.rs
@@ -805,7 +805,7 @@ mod tests {
             fitted.warnings,
             vec![
                 "visibility.snapshot_id is not reported by this operation".to_string(),
-                "visibility.watermark_hour is not reported by this operation".to_string(),
+                "visibility.ingest_watermark_hour is not reported by this operation".to_string(),
                 "ids.query_id is not reported by this operation".to_string(),
                 "ids.audit_ref is not reported by this operation".to_string(),
             ]
@@ -813,7 +813,7 @@ mod tests {
         // The fields themselves are still the empty strings D4's typing
         // forces; the warnings are what makes them readable as absent.
         assert!(fitted.visibility.snapshot_id.is_empty());
-        assert!(fitted.visibility.watermark_hour.is_empty());
+        assert!(fitted.visibility.ingest_watermark_hour.is_empty());
         assert!(fitted.ids.query_id.is_empty());
         assert!(fitted.ids.audit_ref.is_empty());
     }
@@ -833,7 +833,7 @@ mod tests {
         assert_eq!(
             fitted.warnings,
             vec![
-                "visibility.watermark_hour is not reported by this operation".to_string(),
+                "visibility.ingest_watermark_hour is not reported by this operation".to_string(),
                 "ids.query_id is not reported by this operation".to_string(),
                 "ids.audit_ref is not reported by this operation".to_string(),
             ]


### PR DESCRIPTION
Records eight decisions on the agent MCP surface as one dated amendment, and
corrects a definition that described something already deleted. Two of the
eight are code changes; the rest are documentation.

## The code changes, which are the parts to review closely

**The envelope field is renamed** `visibility.watermark_hour` to
`visibility.ingest_watermark_hour`. `watermark_hour` is already the name of
the catalog fold watermark across ravel-catalog and ravel-maintain, and this
amendment defines the envelope's quantity as explicitly not that. The agents
guide had already read one as the other. Nothing populates the field yet, so
the rename is free now and impossible after the first producer lands. Twelve
pinned serialized-length constants move with it, all by the same 7 bytes the
JSON key grows, plus 21 bytes of identity-warning allowance.

**An empty resolve now says so.** The freshness watermark has no value when
the snapshot resolves to zero segments, which is the case describe exists to
answer. The envelope previously emitted the same operation-level warning it
uses for a field this operation never measures, so a caller could not tell an
empty tenant from an unmeasured field. Those are now two distinct messages,
pinned by a test that asserts both exact strings and that they differ.

## The decisions recorded

The label filter is a case-sensitive substring match applied after the list is
produced and before the byte cap, so a page is complete for its filter. An
empty filter is an invalid argument, and a filter alone does not satisfy the
rule refusing an unfiltered tenant-wide list, because it bounds output rather
than resolution.

`ravel_find_labels` takes no evidence reference this phase; the input is
removed rather than accepted and ignored, since nothing defines what a label
list attests to. Issue #1605 removes the struct field.

A paged describe pins page one's watermark into the cursor and every page
reports it. That watermark is the maximum ingest hour across the resolved
snapshot, not the fold watermark, which is a cost boundary lagging by about
two and a half hours at the defaults. A redeeming resolve runs at the
cursor's mint instant.

## The correction

The envelope's `snapshot_id` was defined as a hash of the pinned segment set,
which an earlier amendment deleted and the code followed. It is a hash over
the seven resolve inputs, and it identifies those inputs rather than the
segments they resolved to.

Refs: #1571
