### PR TITLE
feat(ravel-cli): surface fold counters, column-stats refs, and cstat objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4618,6 +4618,7 @@ dependencies = [
  "ravel-proto",
  "ravel-segment",
  "ravel-types",
+ "serde",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/ravel-catalog/Cargo.toml
+++ b/crates/ravel-catalog/Cargo.toml
@@ -25,6 +25,7 @@ crc32c = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true }
 hex = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -490,9 +490,11 @@ pub struct Catalog {
     /// (ADR-1413 decision 3, normally
     /// [`crate::snapshot_format::DEFAULT_MAX_COLUMN_STATS_BYTES`]), so a fold
     /// test can exercise the degrade loop at a few kilobytes instead of 256
-    /// MiB. `None` in every non-test build path; read through
+    /// MiB. Not `#[cfg(test)]`: `ravel-cli`'s own `catalog fold` test sets
+    /// this through a normal (non-dev) dependency edge on `ravel-catalog`,
+    /// which never compiles with this crate's own `cfg(test)` active.
+    /// `None` in every real production run; read through
     /// [`Catalog::column_stats_part_ceiling`].
-    #[cfg(test)]
     column_stats_part_ceiling_override: Option<u64>,
 }
 
@@ -580,7 +582,6 @@ impl Catalog {
             column_stats_cache,
             warned_decode_failures: Mutex::new(HashSet::new()),
             column_stats_decode_refusals: AtomicU64::new(0),
-            #[cfg(test)]
             column_stats_part_ceiling_override: None,
         })
     }
@@ -1550,19 +1551,23 @@ impl Catalog {
     /// build may override it via [`Catalog::set_column_stats_part_ceiling_for_test`]
     /// to exercise the degrade loop at a few kilobytes.
     pub(crate) fn column_stats_part_ceiling(&self) -> u64 {
-        #[cfg(test)]
         if let Some(ceiling) = self.column_stats_part_ceiling_override {
             return ceiling;
         }
         crate::snapshot_format::DEFAULT_MAX_COLUMN_STATS_BYTES
     }
 
-    /// `#[cfg(test)]`: override the per-part column-statistics ceiling this
+    /// Test-only seam: override the per-part column-statistics ceiling this
     /// catalog's fold enforces, so a test can force the degrade loop (or the
     /// no-dictionary-left refusal) at a size far below the real 256 MiB
-    /// constant without a multi-hundred-megabyte fixture.
-    #[cfg(test)]
-    pub(crate) fn set_column_stats_part_ceiling_for_test(&mut self, ceiling: u64) {
+    /// constant without a multi-hundred-megabyte fixture. `pub`, not
+    /// `#[cfg(test)]`, because `ravel-cli`'s own `catalog fold` test needs it
+    /// through a normal (non-dev) dependency edge, the same way `fold`
+    /// threads `now_ns` as a plain parameter rather than reaching for
+    /// `SystemTime::now()` internally: production code never calls this, and
+    /// every real caller goes through [`Catalog::column_stats_part_ceiling`],
+    /// which returns the real constant whenever no override is set (#1598).
+    pub fn set_column_stats_part_ceiling_for_test(&mut self, ceiling: u64) {
         self.column_stats_part_ceiling_override = Some(ceiling);
     }
 

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -97,7 +97,7 @@ pub struct Transaction {
 }
 
 /// Outcome of one [`Catalog::fold`] call.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct FoldReport {
     /// HEAD's watermark_hour after this call. `None` only when no hour has
     /// ever been sealed for this (tenant, signal) yet.
@@ -131,6 +131,14 @@ pub struct FoldReport {
     pub parts_reused: u64,
     pub list_requests: u64,
     pub get_requests: u64,
+    /// Number of PUT requests this fold issued to the object store, counted
+    /// unconditionally at the point each request is issued -- an
+    /// `AlreadyExists` or another store-side error still counts, since the
+    /// store received the request and, on an ambiguous error, may have
+    /// durably written the object despite the client-visible failure (#1598).
+    /// This is a request-issued counter, not a request-succeeded one: a
+    /// build/PUT failure that leaves a `*_built` field `false` still counted
+    /// its attempt here.
     pub put_requests: u64,
     /// `true` if this fold successfully built and attached a name-postings
     /// index. `false` covers both "no
@@ -1704,7 +1712,7 @@ impl Catalog {
                         column_stats_object_key(tenant, signal, part_watermark, stats_hash16);
                     let size = stats_bytes.len() as u64;
                     let segment_count = v3_segments.len() as u32;
-                    match self
+                    let put_result = self
                         .store()
                         .put(
                             &stats_key,
@@ -1712,15 +1720,18 @@ impl Catalog {
                             PutOptions::create_if_absent()
                                 .with_checksum(UploadChecksum::Crc32c(stats_crc)),
                         )
-                        .await
-                    {
+                        .await;
+                    // Counted unconditionally, before matching the outcome:
+                    // this is a request-issued counter, not a
+                    // request-succeeded one (#1598).
+                    counters.put_requests += 1;
+                    match put_result {
                         Ok(_) => {}
                         // Content-addressed under the object's own hash:
                         // bytes really are identical by construction here.
                         Err(StoreError::AlreadyExists) => {}
                         Err(e) => return Err(CatalogError::Store(e)),
                     }
-                    counters.put_requests += 1;
                     column_stats_part_objects_built += 1;
                     Some(SnapshotColumnStatsPartRef {
                         key: stats_key,
@@ -1731,7 +1742,7 @@ impl Catalog {
                     })
                 };
 
-                match self
+                let put_result = self
                     .store()
                     .put(
                         &part_key,
@@ -1739,8 +1750,12 @@ impl Catalog {
                         PutOptions::create_if_absent()
                             .with_checksum(UploadChecksum::Crc32c(part_crc)),
                     )
-                    .await
-                {
+                    .await;
+                // Counted unconditionally, before matching the outcome: this
+                // is a request-issued counter, not a request-succeeded one
+                // (#1598).
+                counters.put_requests += 1;
+                match put_result {
                     Ok(_) => {}
                     // Content-addressed key: bytes are identical by
                     // construction, so a losing folder's part is as good as
@@ -1748,7 +1763,6 @@ impl Catalog {
                     Err(StoreError::AlreadyExists) => {}
                     Err(e) => return Err(CatalogError::Store(e)),
                 }
-                counters.put_requests += 1;
                 total_part_bytes += part_bytes_len;
                 part_hashes.push(*part_hash.as_bytes());
 
@@ -1838,7 +1852,7 @@ impl Catalog {
                             postings_object_key(tenant, signal, watermark_hour, postings_hash16);
                         let size = postings_bytes.len() as u64;
                         let name_count = names.len() as u32;
-                        match self
+                        let put_result = self
                             .store()
                             .put(
                                 &postings_key,
@@ -1846,10 +1860,14 @@ impl Catalog {
                                 PutOptions::create_if_absent()
                                     .with_checksum(UploadChecksum::Crc32c(postings_crc)),
                             )
-                            .await
-                        {
+                            .await;
+                        // Counted unconditionally: a real (non-AlreadyExists)
+                        // Err here still means the store received a PUT
+                        // request, and may have durably written the object
+                        // despite the client-visible error (#1598).
+                        counters.put_requests += 1;
+                        match put_result {
                             Ok(_) | Err(StoreError::AlreadyExists) => {
-                                counters.put_requests += 1;
                                 postings_built = true;
                                 postings_size = size;
                                 Some(SnapshotPostingsRef {
@@ -2050,7 +2068,7 @@ impl Catalog {
                             column_stats_object_key(tenant, signal, watermark_hour, stats_hash16);
                         let size = stats_bytes.len() as u64;
                         let segment_count = column_segments.len() as u32;
-                        match self
+                        let put_result = self
                             .store()
                             .put(
                                 &stats_key,
@@ -2058,25 +2076,24 @@ impl Catalog {
                                 PutOptions::create_if_absent()
                                     .with_checksum(UploadChecksum::Crc32c(stats_crc)),
                             )
-                            .await
-                        {
-                            Ok(_) | Err(StoreError::AlreadyExists) => {
-                                counters.put_requests += 1;
-                                (
-                                    true,
+                            .await;
+                        // Counted unconditionally: a real (non-AlreadyExists)
+                        // Err here still means the store received a PUT
+                        // request, and may have durably written the object
+                        // despite the client-visible error (#1598).
+                        counters.put_requests += 1;
+                        match put_result {
+                            Ok(_) | Err(StoreError::AlreadyExists) => (
+                                true,
+                                size,
+                                Some(SnapshotColumnStatsRef {
+                                    key: stats_key,
+                                    blake3: stats_hash.as_bytes().to_vec(),
                                     size,
-                                    Some(SnapshotColumnStatsRef {
-                                        key: stats_key,
-                                        blake3: stats_hash.as_bytes().to_vec(),
-                                        size,
-                                        segment_count,
-                                        part_blake3: part_hashes
-                                            .iter()
-                                            .map(|h| h.to_vec())
-                                            .collect(),
-                                    }),
-                                )
-                            }
+                                    segment_count,
+                                    part_blake3: part_hashes.iter().map(|h| h.to_vec()).collect(),
+                                }),
+                            ),
                             Err(err) => {
                                 tracing::warn!(
                                     error = %err,
@@ -2236,7 +2253,7 @@ impl Catalog {
                             );
                             let size = stats_bytes.len() as u64;
                             let segment_count = part_segments.len() as u32;
-                            match self
+                            let put_result = self
                                 .store()
                                 .put(
                                     &stats_key,
@@ -2244,25 +2261,27 @@ impl Catalog {
                                     PutOptions::create_if_absent()
                                         .with_checksum(UploadChecksum::Crc32c(stats_crc)),
                                 )
-                                .await
-                            {
-                                Ok(_) | Err(StoreError::AlreadyExists) => {
-                                    counters.put_requests += 1;
-                                    (
-                                        true,
+                                .await;
+                            // Counted unconditionally: a real (non-AlreadyExists)
+                            // Err here still means the store received a PUT
+                            // request, and may have durably written the object
+                            // despite the client-visible error (#1598).
+                            counters.put_requests += 1;
+                            match put_result {
+                                Ok(_) | Err(StoreError::AlreadyExists) => (
+                                    true,
+                                    size,
+                                    Some(SnapshotColumnStatsPartRef {
+                                        key: stats_key,
+                                        blake3: stats_hash.as_bytes().to_vec(),
                                         size,
-                                        Some(SnapshotColumnStatsPartRef {
-                                            key: stats_key,
-                                            blake3: stats_hash.as_bytes().to_vec(),
-                                            size,
-                                            segment_count,
-                                            part_blake3: part_hashes
-                                                .iter()
-                                                .map(|h| h.to_vec())
-                                                .collect(),
-                                        }),
-                                    )
-                                }
+                                        segment_count,
+                                        part_blake3: part_hashes
+                                            .iter()
+                                            .map(|h| h.to_vec())
+                                            .collect(),
+                                    }),
+                                ),
                                 Err(err) => {
                                     tracing::warn!(
                                         error = %err,
@@ -2326,7 +2345,7 @@ impl Catalog {
                 }
             };
 
-            match self
+            let head_put_result = self
                 .store()
                 .put(
                     &head_key,
@@ -2336,10 +2355,12 @@ impl Catalog {
                         checksum: Some(UploadChecksum::Crc32c(head_crc)),
                     },
                 )
-                .await
-            {
+                .await;
+            // Counted unconditionally, before matching the outcome: this is
+            // a request-issued counter, not a request-succeeded one (#1598).
+            counters.put_requests += 1;
+            match head_put_result {
                 Ok(_) => {
-                    counters.put_requests += 1;
                     return Ok(FoldReport {
                         watermark_hour: Some(watermark_hour),
                         previous_watermark_hour: head_state.watermark_hour(),
@@ -2371,7 +2392,6 @@ impl Catalog {
                 // the top-of-loop no-op check stops cleanly; otherwise we
                 // rebase onto the winner's parts and retry.
                 Err(StoreError::PreconditionFailed) | Err(StoreError::AlreadyExists) => {
-                    counters.put_requests += 1;
                     attempt += 1;
                     if attempt >= MAX_HEAD_CAS_ATTEMPTS {
                         return Err(CatalogError::FoldCasRetriesExhausted {

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -87,9 +87,9 @@ pub use snapshot_format::{
     ColumnStatsHeaderPeek, ColumnStatsLimits, DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES,
     DEFAULT_MAX_COLUMN_STATS_BYTES, DEFAULT_MAX_POSTINGS_BYTES, DEFAULT_MAX_SNAPSHOT_PART_BYTES,
     DecodedColumnStats, DecodedPart, DecodedPostings, HEAD_FORMAT_VERSION, MAGIC, NamePostings,
-    PartLimits, PostingsLimits, SnapshotFormatError, VERSION, decode_column_stats,
-    decode_column_stats_header, decode_head, decode_part, decode_postings, encode_column_stats,
-    encode_head, encode_part, encode_postings, validate_min_max_presence,
+    PartLimits, PostingsLimits, SnapshotFormatError, VERSION, column_stats_segments_concat,
+    decode_column_stats, decode_column_stats_header, decode_head, decode_part, decode_postings,
+    encode_column_stats, encode_head, encode_part, encode_postings, validate_min_max_presence,
 };
 pub use tenant_config::{
     DeclaredColumnType, DeclaredTypedColumn, FIXED_LOGS_SQL_COLUMNS,

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -84,11 +84,12 @@ pub use seal_divergence::{
 };
 pub use snapshot::{SegmentLevel, SegmentOrigin, SegmentOrigins, SegmentRef, Snapshot};
 pub use snapshot_format::{
-    ColumnStatsLimits, DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES, DEFAULT_MAX_COLUMN_STATS_BYTES,
-    DEFAULT_MAX_POSTINGS_BYTES, DEFAULT_MAX_SNAPSHOT_PART_BYTES, DecodedColumnStats, DecodedPart,
-    DecodedPostings, HEAD_FORMAT_VERSION, MAGIC, NamePostings, PartLimits, PostingsLimits,
-    SnapshotFormatError, VERSION, decode_column_stats, decode_head, decode_part, decode_postings,
-    encode_column_stats, encode_head, encode_part, encode_postings, validate_min_max_presence,
+    ColumnStatsHeaderPeek, ColumnStatsLimits, DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES,
+    DEFAULT_MAX_COLUMN_STATS_BYTES, DEFAULT_MAX_POSTINGS_BYTES, DEFAULT_MAX_SNAPSHOT_PART_BYTES,
+    DecodedColumnStats, DecodedPart, DecodedPostings, HEAD_FORMAT_VERSION, MAGIC, NamePostings,
+    PartLimits, PostingsLimits, SnapshotFormatError, VERSION, decode_column_stats,
+    decode_column_stats_header, decode_head, decode_part, decode_postings, encode_column_stats,
+    encode_head, encode_part, encode_postings, validate_min_max_presence,
 };
 pub use tenant_config::{
     DeclaredColumnType, DeclaredTypedColumn, FIXED_LOGS_SQL_COLUMNS,

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -248,12 +248,34 @@ fn frame_column_stats_body(
     Ok(out)
 }
 
-/// Decodes and fully validates a column-statistics object. Every byte is
-/// untrusted; every failure is a typed error, never a panic.
-pub fn decode_column_stats(
+/// A header-only envelope peek: everything [`decode_column_stats`] validates
+/// up to and including the header decode and its self-consistency checks
+/// (format-version/envelope agreement, tenant-hash width, the v3
+/// exactly-one-part rule), but stopping before the `body_uncompressed_len`
+/// ceiling check and never decompressing the body. `body_uncompressed_len`
+/// is on `header`, so a caller can compare it against any ceiling it likes
+/// (or none) without this function needing to know one.
+///
+/// Exists for `ravel-cli inspect cstat`: an object whose declared
+/// `body_uncompressed_len` exceeds the decode ceiling cannot be decoded by
+/// [`decode_column_stats`] at all (that is the point of the ceiling), so a
+/// reader wanting to report "this object is over ceiling" needs a path that
+/// answers the question without decompressing.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnStatsHeaderPeek {
+    pub envelope_version: u8,
+    pub header_len: u32,
+    pub header: ColumnStatsHeader,
+}
+
+/// The envelope-parsing and header-validation prefix shared by
+/// [`decode_column_stats_header`] and [`decode_column_stats`], returning the
+/// validated peek alongside the still-compressed body slice so the full
+/// decoder does not re-parse the envelope. Every check performed here never
+/// requires decompressing `body`.
+fn decode_column_stats_prefix(
     bytes: &[u8],
-    limits: &ColumnStatsLimits,
-) -> Result<DecodedColumnStats, SnapshotFormatError> {
+) -> Result<(ColumnStatsHeaderPeek, &[u8]), SnapshotFormatError> {
     if bytes.len() < MIN_COLUMN_STATS_ENVELOPE_LEN {
         return Err(SnapshotFormatError::ColumnStatsTooSmall { size: bytes.len() });
     }
@@ -320,6 +342,35 @@ pub fn decode_column_stats(
             header.part_blake3.len(),
         ));
     }
+
+    Ok((
+        ColumnStatsHeaderPeek {
+            envelope_version: version,
+            header_len,
+            header,
+        },
+        body,
+    ))
+}
+
+/// Parses and validates a column-statistics object's envelope and header
+/// WITHOUT touching any ceiling and WITHOUT decompressing the body, so an
+/// object whose declared `body_uncompressed_len` is over any ceiling a
+/// caller might check still yields its header rather than an error.
+pub fn decode_column_stats_header(
+    bytes: &[u8],
+) -> Result<ColumnStatsHeaderPeek, SnapshotFormatError> {
+    decode_column_stats_prefix(bytes).map(|(peek, _body)| peek)
+}
+
+/// Decodes and fully validates a column-statistics object. Every byte is
+/// untrusted; every failure is a typed error, never a panic.
+pub fn decode_column_stats(
+    bytes: &[u8],
+    limits: &ColumnStatsLimits,
+) -> Result<DecodedColumnStats, SnapshotFormatError> {
+    let (peek, body) = decode_column_stats_prefix(bytes)?;
+    let header = peek.header;
     if header.body_uncompressed_len > limits.max_column_stats_bytes {
         return Err(SnapshotFormatError::ColumnStatsDecompressedTooLarge {
             declared: header.body_uncompressed_len,
@@ -349,7 +400,7 @@ pub fn decode_column_stats(
             actual: segments.len() as u64,
         });
     }
-    validate_segments(&segments, version)?;
+    validate_segments(&segments, peek.envelope_version)?;
 
     Ok(DecodedColumnStats { header, segments })
 }

--- a/crates/ravel-catalog/src/snapshot_format/mod.rs
+++ b/crates/ravel-catalog/src/snapshot_format/mod.rs
@@ -11,8 +11,9 @@ mod part;
 mod postings;
 
 pub use column_stats::{
-    DecodedColumnStats, column_stats_segments_concat, decode_column_stats, encode_column_stats,
-    encode_column_stats_v2, encode_column_stats_v3, validate_min_max_presence,
+    ColumnStatsHeaderPeek, DecodedColumnStats, column_stats_segments_concat, decode_column_stats,
+    decode_column_stats_header, encode_column_stats, encode_column_stats_v2,
+    encode_column_stats_v3, validate_min_max_presence,
 };
 pub use error::SnapshotFormatError;
 pub use head::{HEAD_FORMAT_VERSION, decode_head, encode_head};

--- a/docs/guides/inspecting-data.md
+++ b/docs/guides/inspecting-data.md
@@ -362,33 +362,44 @@ ravel-cli inspect cstat \
 envelope_version: 3
 header_len: 84
 format_version: 1
-tenant_hash: 3f2a...
-signal: logs
-part_blake3: [98c85b7a...]
+tenant_hash: 3f2a1c9e4b7d0a62
+signal: 3
+part_blake3: 98c85b7a1f2e3d4c
 segment_count: 2617
 body_uncompressed_len: 268427456
-over_ceiling: false (limit 268435456)
-columns with dictionary_present=false: 104
+over_ceiling (body_uncompressed_len > 268435456): false
+  segment shard=0 ingest_hour_bucket=496953 writer_epoch=1 writer_seq=1 column=service.name dictionary_present=true
+  segment shard=0 ingest_hour_bucket=496953 writer_epoch=1 writer_seq=1 column=http.route dictionary_present=false
 ```
 
 A `.cstat` object carries the per-column minimum, maximum, count, sum and
-value dictionary a query uses to skip segments it cannot match. This command
-reads the envelope and header only.
+value dictionary a query uses to skip segments it cannot match.
 
-`body_uncompressed_len` against `over_ceiling` is the field worth reading
-first. A reader refuses any object declaring more than
-`DEFAULT_MAX_COLUMN_STATS_BYTES` (256 MiB) **before** decompressing it, so an
-over-ceiling object is undecodable by every reader and its statistics are not
-being used by anything, however healthy the object looks in a listing. That
-is why this command reports the verdict without decompressing: the objects
-most worth diagnosing are exactly the ones a full decode refuses.
+`signal` is the raw numeric code from the header, not a word: 1 is metrics,
+2 is spans, 3 is logs. `part_blake3` is comma-joined when a header covers
+more than one part.
 
-`columns with dictionary_present=false` counts the dictionaries the fold
-dropped to bring a part under the ceiling. The fold drops whole dictionaries,
-largest first, and never truncates one, so a column either has its full value
-dictionary or none of it. A high count on an object that is under the ceiling
-means the statistics survived but most of the value dictionaries did not, and
-predicate pruning falls back to min/max for those columns.
+`body_uncompressed_len` against the `over_ceiling` verdict is the pair worth
+reading first. A reader refuses any object declaring more than 256 MiB
+**before** decompressing it, so an over-ceiling object is undecodable by
+every reader and nothing is using its statistics, however healthy the object
+looks in a listing. That is why the verdict is computed from the header
+alone: the objects most worth diagnosing are exactly the ones a full decode
+refuses. For those, the command says so instead of failing:
+
+```
+over_ceiling (body_uncompressed_len > 268435456): true
+dictionary_present listing: unavailable, body_uncompressed_len exceeds the decode ceiling and no reader can decompress this object
+```
+
+Under the ceiling, one `segment ... column=... dictionary_present=` line is
+printed per column per segment. `dictionary_present=false` means the fold
+dropped that column's value dictionary to bring the part under the ceiling;
+it drops whole dictionaries, largest first, and never truncates one, so a
+column either has its full dictionary or none of it. A run of `false` on an
+object that is itself under the ceiling means the statistics survived but
+most of the dictionaries did not, and predicate pruning falls back to
+min/max for those columns.
 
 A truncated, bad-magic, wrong-version or checksum-mismatched object fails
 with the specific reason rather than a generic error.

--- a/docs/guides/inspecting-data.md
+++ b/docs/guides/inspecting-data.md
@@ -351,6 +351,48 @@ numeric signal code (`1` = metrics). `ingest_hour_bucket` is the same hour
 encoded in the object's own key, and it is what the catalog groups listings
 by.
 
+## `inspect cstat`: what a column-statistics object declares
+
+```sh
+ravel-cli inspect cstat \
+  "t/3f2a.../catalog/l/idx/20260910T09.76b5680....cstat"
+```
+
+```
+envelope_version: 3
+header_len: 84
+format_version: 1
+tenant_hash: 3f2a...
+signal: logs
+part_blake3: [98c85b7a...]
+segment_count: 2617
+body_uncompressed_len: 268427456
+over_ceiling: false (limit 268435456)
+columns with dictionary_present=false: 104
+```
+
+A `.cstat` object carries the per-column minimum, maximum, count, sum and
+value dictionary a query uses to skip segments it cannot match. This command
+reads the envelope and header only.
+
+`body_uncompressed_len` against `over_ceiling` is the field worth reading
+first. A reader refuses any object declaring more than
+`DEFAULT_MAX_COLUMN_STATS_BYTES` (256 MiB) **before** decompressing it, so an
+over-ceiling object is undecodable by every reader and its statistics are not
+being used by anything, however healthy the object looks in a listing. That
+is why this command reports the verdict without decompressing: the objects
+most worth diagnosing are exactly the ones a full decode refuses.
+
+`columns with dictionary_present=false` counts the dictionaries the fold
+dropped to bring a part under the ceiling. The fold drops whole dictionaries,
+largest first, and never truncates one, so a column either has its full value
+dictionary or none of it. A high count on an object that is under the ceiling
+means the statistics survived but most of the value dictionaries did not, and
+predicate pruning falls back to min/max for those columns.
+
+A truncated, bad-magic, wrong-version or checksum-mismatched object fails
+with the specific reason rather than a generic error.
+
 ## `idem inspect`: what an idempotency marker says
 
 ```sh

--- a/docs/reference/ravel-cli-flags.md
+++ b/docs/reference/ravel-cli-flags.md
@@ -123,6 +123,7 @@ One-shot catalog fold for one (tenant, signal)
 
 | Flag | Environment variable | Default | Help |
 | --- | --- | --- | --- |
+| `--json` |  |  | Print the full `FoldReport` as JSON instead of the human-readable text report. Either form carries every counter on the report |
 | `--max-flush-lifetime` |  |  | Override the fold's `max_flush_lifetime` (humantime duration, e.g. `30m`, `0s`; the same grammar and unit as the `maintain compact-bucket` / `compact-tenant` flag and ravel-server's `--gc-max-flush-lifetime`). An hour seals only at its end plus this plus the clock-skew allowance plus the fold safety margin, so a freshly finished load waits over an hour before its last hours can be folded; lowering this seals them sooner. The flag asserts that no writer is still flushing, not that this host's clock is exact: the clock-skew allowance and the fold safety margin keep their defaults. UNSAFE under a live writer: a commit record published into a bucket this fold already sealed is never picked up by a later incremental fold, which re-lists only hours after the watermark. The default is the safe 1h; use this only for a tenant known quiescent, such as one whose bulk load has finished and whose writer process has exited |
 | `--shards` |  | `4` |  |
 | `--signal` |  | `metrics` | Which signal's snapshot to fold. Defaults to metrics, so an existing invocation keeps its meaning |
@@ -145,6 +146,20 @@ Re-list sealed commit records for one (tenant, signal) and diff against that sig
 | --- | --- | --- | --- |
 | `--signal` |  | `metrics` | Which signal's snapshot to verify. Defaults to metrics |
 | `--tenant` |  |  |  |
+
+## inspect
+
+Inspect a standalone object by key or local path, outside the segment/rlog/rspan/commit/catalog families above
+
+_No flags._
+
+### inspect cstat
+
+Decode a column-statistics (`.cstat`) object's envelope and header (ADR-0850/ADR-0942/ADR-1413), and report whether its declared `body_uncompressed_len` exceeds the decode ceiling, without ever decompressing the body
+
+| Flag | Environment variable | Default | Help |
+| --- | --- | --- | --- |
+| `<KEY>` |  |  | Local file path or object store key |
 
 ## maintain
 

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -198,23 +198,31 @@ fn render_fold_report(
                 // counters, and a report that does not say WHICH signal was
                 // folded cannot be filed against a tenant that has more than
                 // one.
-                obj.insert(
-                    "store".to_string(),
-                    serde_json::Value::String(store_value.to_string()),
-                );
-                obj.insert(
-                    "signal".to_string(),
-                    serde_json::Value::String(signal_word(signal.to_signal()).to_string()),
-                );
-                obj.insert(
-                    "seal_margin".to_string(),
-                    serde_json::Value::String(
-                        humantime::format_duration(Duration::from_nanos(
-                            u64::try_from(seal_margin_ns).unwrap_or(0),
-                        ))
-                        .to_string(),
-                    ),
-                );
+                let seal_margin = humantime::format_duration(Duration::from_nanos(
+                    u64::try_from(seal_margin_ns).unwrap_or(0),
+                ))
+                .to_string();
+                for (key, value) in [
+                    ("store", store_value.to_string()),
+                    ("signal", signal_word(signal.to_signal()).to_string()),
+                    ("seal_margin", seal_margin),
+                ] {
+                    // Refuse rather than overwrite. These three are not
+                    // `FoldReport` fields today; if the struct ever gains one
+                    // of these names, silently replacing its value would make
+                    // `--json` disagree with the human report about a real
+                    // counter, which is the class of drift this flag exists to
+                    // end.
+                    if obj
+                        .insert(key.to_string(), serde_json::Value::String(value))
+                        .is_some()
+                    {
+                        anyhow::bail!(
+                            "FoldReport now has a `{key}` field, which collides with the \
+                             report-level key of the same name; rename one of them"
+                        );
+                    }
+                }
             }
             // `FoldReport` is a struct, so this is unreachable today. Fail
             // loudly rather than silently dropping the store from the output.

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use ravel_catalog::{CatalogConfig, FoldReport, PartLimits};
 use ravel_object_store::{GetRange, ObjectStoreBackend};
+use ravel_proto::catalog::v1::{SnapshotColumnStatsPartRef, SnapshotColumnStatsRef};
 use ravel_types::{Signal, TenantHash, TenantId};
 use uuid::Uuid;
 
@@ -67,6 +68,12 @@ fn seal_margin_ns(config: &CatalogConfig) -> anyhow::Result<i64> {
 /// line, and a fold over a tenant prefix that holds nothing at all on the
 /// defaulted memory store is refused rather than reported as a fold that
 /// sealed nothing (issue #1024).
+///
+/// `json`, when `true`, prints the whole [`FoldReport`] as JSON instead of
+/// the human-readable field-by-field report. Both forms carry every field
+/// (#1598): the human-readable report used to print 13 of 23 and silently
+/// omit the rest.
+#[allow(clippy::too_many_arguments)]
 pub async fn fold(
     store: Arc<dyn ObjectStoreBackend>,
     selection: StoreSelection,
@@ -75,6 +82,41 @@ pub async fn fold(
     signal: SignalArg,
     max_flush_lifetime_ns: Option<i64>,
     now_ns: i64,
+    json: bool,
+) -> anyhow::Result<(FoldReport, String)> {
+    fold_inner(
+        store,
+        selection,
+        tenant,
+        shard_count,
+        signal,
+        max_flush_lifetime_ns,
+        now_ns,
+        json,
+        None,
+    )
+    .await
+}
+
+/// The testable core of [`fold`]. `column_stats_ceiling_override`, when
+/// `Some`, replaces the per-part column-statistics ceiling (normally
+/// [`ravel_catalog::DEFAULT_MAX_COLUMN_STATS_BYTES`], 256 MiB) via
+/// [`ravel_catalog::Catalog::set_column_stats_part_ceiling_for_test`], so a
+/// test can force the degrade loop at a few kilobytes instead of a
+/// multi-hundred-megabyte fixture. `fold` always passes `None`; no CLI flag
+/// exposes this, exactly as `now_ns` is threaded as a plain parameter rather
+/// than read from `SystemTime::now()` internally (#1598).
+#[allow(clippy::too_many_arguments)]
+pub async fn fold_inner(
+    store: Arc<dyn ObjectStoreBackend>,
+    selection: StoreSelection,
+    tenant: &str,
+    shard_count: u32,
+    signal: SignalArg,
+    max_flush_lifetime_ns: Option<i64>,
+    now_ns: i64,
+    json: bool,
+    column_stats_ceiling_override: Option<u64>,
 ) -> anyhow::Result<(FoldReport, String)> {
     let mut catalog_config = CatalogConfig {
         shard_count,
@@ -99,9 +141,12 @@ pub async fn fold(
     // short-circuiting to the single implicit generation 0 and enumerating only
     // `0..--shards` (ADR-0052 sections 4/5, Finding 3). Without this the fold is
     // blind to any reshard and writes an under-scanning HEAD.
-    let catalog = ravel_catalog::Catalog::new(store, catalog_config)
+    let mut catalog = ravel_catalog::Catalog::new(store, catalog_config)
         .map_err(|err| anyhow::anyhow!("failed to build catalog: {err}"))?
         .with_provisioning_enforcement();
+    if let Some(ceiling) = column_stats_ceiling_override {
+        catalog.set_column_stats_part_ceiling_for_test(ceiling);
+    }
 
     let folder_id = Uuid::new_v4();
     let report = catalog
@@ -116,6 +161,27 @@ pub async fn fold(
         .await
         .map_err(|err| anyhow::anyhow!("fold failed: {err}"))?;
 
+    let out = render_fold_report(&report, selection, signal, seal_margin_ns, json)?;
+    print!("{out}");
+    Ok((report, out))
+}
+
+/// Renders a [`FoldReport`] either as JSON (`json: true`) or as the
+/// human-readable field-by-field report (`json: false`). Both forms print
+/// every field on the struct: a reader without `--json` must never be
+/// missing a counter the JSON form carries (#1598).
+fn render_fold_report(
+    report: &FoldReport,
+    selection: StoreSelection,
+    signal: SignalArg,
+    seal_margin_ns: i64,
+    json: bool,
+) -> anyhow::Result<String> {
+    if json {
+        let body = serde_json::to_string_pretty(report)
+            .map_err(|err| anyhow::anyhow!("failed to serialize fold report: {err}"))?;
+        return Ok(format!("{}\n{body}\n", selection.header()));
+    }
     let mut out = String::new();
     out.push_str(&format!("{}\n", selection.header()));
     out.push_str(&format!("signal: {}\n", signal_word(signal.to_signal())));
@@ -135,11 +201,50 @@ pub async fn fold(
     out.push_str(&format!("buckets_folded: {}\n", report.buckets_folded));
     out.push_str(&format!("entry_count: {}\n", report.entry_count));
     out.push_str(&format!("part_bytes: {}\n", report.part_bytes));
+    out.push_str(&format!("parts_total: {}\n", report.parts_total));
+    out.push_str(&format!("parts_reused: {}\n", report.parts_reused));
     out.push_str(&format!("list_requests: {}\n", report.list_requests));
     out.push_str(&format!("get_requests: {}\n", report.get_requests));
     out.push_str(&format!("put_requests: {}\n", report.put_requests));
-    print!("{out}");
-    Ok((report, out))
+    out.push_str(&format!("postings_built: {}\n", report.postings_built));
+    out.push_str(&format!("postings_bytes: {}\n", report.postings_bytes));
+    out.push_str(&format!(
+        "column_stats_built: {}\n",
+        report.column_stats_built
+    ));
+    out.push_str(&format!(
+        "column_stats_bytes: {}\n",
+        report.column_stats_bytes
+    ));
+    out.push_str(&format!(
+        "column_stats_part_built: {}\n",
+        report.column_stats_part_built
+    ));
+    out.push_str(&format!(
+        "column_stats_part_bytes: {}\n",
+        report.column_stats_part_bytes
+    ));
+    out.push_str(&format!(
+        "column_stats_part_objects_built: {}\n",
+        report.column_stats_part_objects_built
+    ));
+    out.push_str(&format!(
+        "column_stats_dictionaries_dropped: {}\n",
+        report.column_stats_dictionaries_dropped
+    ));
+    out.push_str(&format!(
+        "layout_drift_count: {}\n",
+        report.layout_drift_count
+    ));
+    out.push_str(&format!(
+        "frontier_hours_reconciled: {}\n",
+        report.frontier_hours_reconciled
+    ));
+    out.push_str(&format!(
+        "frontier_hours_deferred: {}\n",
+        report.frontier_hours_deferred
+    ));
+    Ok(out)
 }
 
 pub async fn inspect(
@@ -221,6 +326,14 @@ pub async fn render_inspect(
     ));
     out.push_str(&format!("created_unix_ns: {}\n", head.created_unix_ns));
     out.push_str(&format!("parts: {}\n", head.parts.len()));
+    out.push_str(&format!(
+        "column_stats (field 11): {}\n",
+        format_column_stats_ref(head.column_stats.as_ref())
+    ));
+    out.push_str(&format!(
+        "column_stats_part (field 13): {}\n",
+        format_column_stats_part_ref(head.column_stats_part.as_ref())
+    ));
 
     let limits = PartLimits::default();
     for (index, part_ref) in head.parts.iter().enumerate() {
@@ -255,8 +368,33 @@ pub async fn render_inspect(
             "    entries (decoded): {}\n",
             decoded.entries.len()
         ));
+        out.push_str(&format!(
+            "    column_stats (field 7): {}\n",
+            format_column_stats_part_ref(part_ref.column_stats.as_ref())
+        ));
     }
     Ok(())
+}
+
+/// Formats a HEAD-level `SnapshotColumnStatsRef` (field 11, ADR-0850) as a
+/// `key=... size=...` line, or `ABSENT` when the field is unset. Printing
+/// `ABSENT` rather than omitting the line matters: an omitted line and an
+/// unset field are otherwise indistinguishable to a reader (#1598).
+fn format_column_stats_ref(r: Option<&SnapshotColumnStatsRef>) -> String {
+    match r {
+        Some(r) => format!("key={} size={}", r.key, r.size),
+        None => "ABSENT".to_string(),
+    }
+}
+
+/// Formats a `SnapshotColumnStatsPartRef` (HEAD field 13, ADR-0942, or
+/// per-part field 7, ADR-1413 -- both share this message shape) as a
+/// `key=... size=...` line, or `ABSENT` when the field is unset.
+fn format_column_stats_part_ref(r: Option<&SnapshotColumnStatsPartRef>) -> String {
+    match r {
+        Some(r) => format!("key={} size={}", r.key, r.size),
+        None => "ABSENT".to_string(),
+    }
 }
 
 /// The `--signal` spelling of a [`Signal`], so every report names the signal
@@ -299,6 +437,84 @@ fn format_uuid_bytes(bytes: &[u8]) -> String {
     <[u8; 16]>::try_from(bytes)
         .map(|raw| Uuid::from_bytes(raw).to_string())
         .unwrap_or_else(|_| hex::encode(bytes))
+}
+
+/// Decodes a column-statistics (`.cstat`) object's envelope and header
+/// (ADR-0850/ADR-0942/ADR-1413) and prints it. `bytes` is the whole object,
+/// already read by the caller (a local file or an object-store key, via
+/// [`crate::store::read_bytes`]).
+pub fn inspect_cstat(bytes: &[u8]) -> anyhow::Result<()> {
+    let mut out = String::new();
+    let result = render_inspect_cstat(bytes, &mut out);
+    print!("{out}");
+    result
+}
+
+/// Renders `inspect_cstat`'s report into `out`. The header is read with
+/// [`ravel_catalog::decode_column_stats_header`], which never decompresses
+/// the body, so an object whose declared `body_uncompressed_len` exceeds the
+/// decode ceiling still yields every header field and the over-ceiling
+/// verdict rather than an error -- exactly the object no full decode can
+/// ever read (#1598). Only when the object is under ceiling does this go on
+/// to fully decode it (which does decompress) for the per-column
+/// `dictionary_present` listing.
+pub fn render_inspect_cstat(bytes: &[u8], out: &mut String) -> anyhow::Result<()> {
+    let peek = ravel_catalog::decode_column_stats_header(bytes)
+        .map_err(|err| anyhow::anyhow!("cstat envelope/header is corrupt: {err}"))?;
+    out.push_str(&format!("envelope_version: {}\n", peek.envelope_version));
+    out.push_str(&format!("header_len: {}\n", peek.header_len));
+    out.push_str(&format!("format_version: {}\n", peek.header.format_version));
+    out.push_str(&format!(
+        "tenant_hash: {}\n",
+        hex::encode(&peek.header.tenant_hash)
+    ));
+    out.push_str(&format!("signal: {}\n", peek.header.signal));
+    out.push_str(&format!(
+        "part_blake3: {}\n",
+        peek.header
+            .part_blake3
+            .iter()
+            .map(hex::encode)
+            .collect::<Vec<_>>()
+            .join(",")
+    ));
+    out.push_str(&format!("segment_count: {}\n", peek.header.segment_count));
+    out.push_str(&format!(
+        "body_uncompressed_len: {}\n",
+        peek.header.body_uncompressed_len
+    ));
+
+    let ceiling = ravel_catalog::DEFAULT_MAX_COLUMN_STATS_BYTES;
+    let over_ceiling = peek.header.body_uncompressed_len > ceiling;
+    out.push_str(&format!(
+        "over_ceiling (body_uncompressed_len > {ceiling}): {over_ceiling}\n"
+    ));
+    if over_ceiling {
+        out.push_str(
+            "dictionary_present listing: unavailable, body_uncompressed_len exceeds the \
+             decode ceiling and no reader can decompress this object\n",
+        );
+        return Ok(());
+    }
+
+    let limits = ravel_catalog::ColumnStatsLimits::default();
+    let decoded = ravel_catalog::decode_column_stats(bytes, &limits)
+        .map_err(|err| anyhow::anyhow!("cstat body is corrupt: {err}"))?;
+    for segment in &decoded.segments {
+        for column in &segment.columns {
+            out.push_str(&format!(
+                "  segment shard={} ingest_hour_bucket={} writer_epoch={} writer_seq={} \
+                 column={} dictionary_present={}\n",
+                segment.shard,
+                segment.ingest_hour_bucket,
+                segment.writer_epoch,
+                segment.writer_seq,
+                column.name,
+                column.dictionary_present
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Re-lists every sealed commit record directly from the store and diffs it
@@ -530,6 +746,7 @@ mod tests {
             SignalArg::Metrics,
             None,
             now,
+            false,
         )
         .await
         .expect("cli fold");

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -178,9 +178,30 @@ fn render_fold_report(
     json: bool,
 ) -> anyhow::Result<String> {
     if json {
-        let body = serde_json::to_string_pretty(report)
+        // stdout must be ONE JSON document: `--json | jq .put_requests` is the
+        // whole point of the flag, and a `store:` line above the body makes
+        // every consumer skip a first line by undocumented convention. The
+        // store selection still has to be visible (#1024), so it becomes a
+        // field instead: `jq .store` reads `memory (default)`, which is harder
+        // to miss than a header line, not easier.
+        let mut value = serde_json::to_value(report)
             .map_err(|err| anyhow::anyhow!("failed to serialize fold report: {err}"))?;
-        return Ok(format!("{}\n{body}\n", selection.header()));
+        let header = selection.header();
+        let store_value = header.strip_prefix("store: ").unwrap_or(&header);
+        match value.as_object_mut() {
+            Some(obj) => {
+                obj.insert(
+                    "store".to_string(),
+                    serde_json::Value::String(store_value.to_string()),
+                );
+            }
+            // `FoldReport` is a struct, so this is unreachable today. Fail
+            // loudly rather than silently dropping the store from the output.
+            None => anyhow::bail!("fold report did not serialize to a JSON object"),
+        }
+        let body = serde_json::to_string_pretty(&value)
+            .map_err(|err| anyhow::anyhow!("failed to serialize fold report: {err}"))?;
+        return Ok(format!("{body}\n"));
     }
     let mut out = String::new();
     out.push_str(&format!("{}\n", selection.header()));
@@ -349,6 +370,17 @@ pub async fn render_inspect(
             part_ref.size,
             part_ref.entry_count
         ));
+        // Before the fetch, for the same reason the `range=` line above is:
+        // `part_ref.column_stats` comes from the HEAD protobuf already in hand
+        // and needs neither the object nor a successful decode. Emitting it
+        // after the `?`-returning fetch would omit the line entirely for a part
+        // whose object is missing or corrupt, which is the omitted-line-versus-
+        // unset-field ambiguity this output exists to remove, on exactly the
+        // parts worth inspecting.
+        out.push_str(&format!(
+            "    column_stats (field 7): {}\n",
+            format_column_stats_part_ref(part_ref.column_stats.as_ref())
+        ));
         let got = store
             .get(&part_ref.key, GetRange::Full)
             .await
@@ -367,10 +399,6 @@ pub async fn render_inspect(
         out.push_str(&format!(
             "    entries (decoded): {}\n",
             decoded.entries.len()
-        ));
-        out.push_str(&format!(
-            "    column_stats (field 7): {}\n",
-            format_column_stats_part_ref(part_ref.column_stats.as_ref())
         ));
     }
     Ok(())

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -71,8 +71,10 @@ fn seal_margin_ns(config: &CatalogConfig) -> anyhow::Result<i64> {
 ///
 /// `json`, when `true`, prints the whole [`FoldReport`] as JSON instead of
 /// the human-readable field-by-field report. Both forms carry every field
-/// (#1598): the human-readable report used to print 13 of 23 and silently
-/// omit the rest.
+/// (#1598): the human-readable report used to print 10 of `FoldReport`'s 23
+/// fields and silently omit the other 13. (An earlier version of this comment
+/// said "13 of 23", counting the report's printed LINES, three of which
+/// (`store`, `signal`, `seal_margin`) are not `FoldReport` fields at all.)
 #[allow(clippy::too_many_arguments)]
 pub async fn fold(
     store: Arc<dyn ObjectStoreBackend>,
@@ -190,9 +192,28 @@ fn render_fold_report(
         let store_value = header.strip_prefix("store: ").unwrap_or(&header);
         match value.as_object_mut() {
             Some(obj) => {
+                // The three lines the human report carries that are not
+                // `FoldReport` fields. All three belong in the machine-readable
+                // form too: `--json` exists for a harness reading these
+                // counters, and a report that does not say WHICH signal was
+                // folded cannot be filed against a tenant that has more than
+                // one.
                 obj.insert(
                     "store".to_string(),
                     serde_json::Value::String(store_value.to_string()),
+                );
+                obj.insert(
+                    "signal".to_string(),
+                    serde_json::Value::String(signal_word(signal.to_signal()).to_string()),
+                );
+                obj.insert(
+                    "seal_margin".to_string(),
+                    serde_json::Value::String(
+                        humantime::format_duration(Duration::from_nanos(
+                            u64::try_from(seal_margin_ns).unwrap_or(0),
+                        ))
+                        .to_string(),
+                    ),
                 );
             }
             // `FoldReport` is a struct, so this is unreachable today. Fail

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -113,6 +113,9 @@ fn command_hashes_tenant(command: &Command) -> bool {
         | Command::Rspan { .. }
         | Command::Store { .. }
         | Command::Idem { .. }
+        // `inspect cstat` takes an explicit object key, exactly like
+        // `segment inspect`/`rlog inspect`: no tenant to hash.
+        | Command::Inspect { .. }
         // `tenancy show` decodes the marker itself and takes no `--tenant`;
         // `tenancy resolve` (issue #1180) resolves the scheme itself inline
         // (mirroring `show`), rather than going through this shared gate, so
@@ -229,7 +232,9 @@ fn command_is_write(command: &Command) -> bool {
         | Command::Rspan { .. }
         | Command::Idem { .. }
         | Command::Tenancy { .. }
-        | Command::Cache { .. } => false,
+        | Command::Cache { .. }
+        // `inspect cstat` only reads the named object.
+        | Command::Inspect { .. } => false,
     }
 }
 
@@ -259,6 +264,12 @@ enum Command {
     Catalog {
         #[command(subcommand)]
         command: CatalogCommand,
+    },
+    /// Inspect a standalone object by key or local path, outside the
+    /// segment/rlog/rspan/commit/catalog families above.
+    Inspect {
+        #[command(subcommand)]
+        command: InspectCommand,
     },
     /// Run and inspect maintenance: compaction, sweep, retention, version audit.
     Maintain {
@@ -866,6 +877,18 @@ enum SegmentCommand {
 }
 
 #[derive(Debug, Subcommand)]
+enum InspectCommand {
+    /// Decode a column-statistics (`.cstat`) object's envelope and header
+    /// (ADR-0850/ADR-0942/ADR-1413), and report whether its declared
+    /// `body_uncompressed_len` exceeds the decode ceiling, without ever
+    /// decompressing the body.
+    Cstat {
+        /// Local file path or object store key.
+        key: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
 enum RlogCommand {
     Inspect {
         /// Local file path or object store key.
@@ -1161,6 +1184,10 @@ enum CatalogCommand {
         #[arg(long, value_name = "DURATION",
               value_parser = parse_max_flush_lifetime_ns)]
         max_flush_lifetime: Option<i64>,
+        /// Print the full `FoldReport` as JSON instead of the human-readable
+        /// text report. Either form carries every counter on the report.
+        #[arg(long)]
+        json: bool,
     },
     /// Decode and print HEAD and every referenced snapshot part for one
     /// (tenant, signal).
@@ -1291,6 +1318,7 @@ async fn main() -> anyhow::Result<()> {
                     shards,
                     signal,
                     max_flush_lifetime,
+                    json,
                 },
         } => catalog::fold(
             store::build_store(&cli.store)?,
@@ -1300,9 +1328,16 @@ async fn main() -> anyhow::Result<()> {
             signal,
             max_flush_lifetime,
             now_ns()?,
+            json,
         )
         .await
         .map(|_report| ()),
+        Command::Inspect {
+            command: InspectCommand::Cstat { key },
+        } => {
+            let bytes = store::read_bytes(&cli.store, &key).await?;
+            catalog::inspect_cstat(&bytes)
+        }
         Command::Catalog {
             command: CatalogCommand::Inspect { tenant, signal },
         } => {

--- a/services/ravel-cli/tests/catalog.rs
+++ b/services/ravel-cli/tests/catalog.rs
@@ -352,6 +352,25 @@ async fn inspect_preserves_partial_output_when_a_part_fetch_fails() {
         out.contains(&present_key),
         "partial report lost the successfully-fetched part that preceded the failure: {out}"
     );
+    // Every LISTED part carries a field-7 line, including the one whose
+    // object could not be fetched. `part_ref.column_stats` comes from the
+    // HEAD protobuf already in hand, so it does not depend on the fetch, and
+    // omitting the line for a failing part would reintroduce exactly the
+    // omitted-line-versus-unset-field ambiguity the ABSENT marker exists to
+    // remove, on the parts most worth inspecting.
+    //
+    // Prove-the-test: move the `column_stats (field 7)` push_str in
+    // `render_inspect` back below the `store.get(...)?` and this reads 1.
+    assert_eq!(
+        out.matches("column_stats (field 7):").count(),
+        2,
+        "both listed parts must carry a field-7 line, including the one whose \
+         fetch failed: {out}"
+    );
+    assert!(
+        out.contains(&missing_key),
+        "the failing part must still be listed: {out}"
+    );
 }
 
 /// Deliverable 3 (#1598): HEAD field 11 (`SnapshotColumnStatsRef`, ADR-0850),

--- a/services/ravel-cli/tests/catalog.rs
+++ b/services/ravel-cli/tests/catalog.rs
@@ -19,7 +19,9 @@ use ravel_commit::publish::{self, RetryPolicy};
 use ravel_commit::record::{self, NewCommitRecord};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
-use ravel_proto::catalog::v1::{SnapshotHead, SnapshotPartRef};
+use ravel_proto::catalog::v1::{
+    SnapshotColumnStatsPartRef, SnapshotColumnStatsRef, SnapshotHead, SnapshotPartRef,
+};
 use ravel_types::{Signal, TenantId};
 use uuid::Uuid;
 
@@ -97,6 +99,7 @@ async fn fold_then_inspect_then_verify_round_trips_cleanly() {
         SignalArg::Metrics,
         None,
         now_ns(),
+        false,
     )
     .await
     .expect("fold succeeds");
@@ -135,6 +138,7 @@ async fn verify_fails_when_a_sealed_record_is_missing_from_the_snapshot() {
         SignalArg::Metrics,
         None,
         now_ns(),
+        false,
     )
     .await
     .expect("fold succeeds");
@@ -192,6 +196,7 @@ async fn fold_on_the_defaulted_memory_store_refuses_instead_of_sealing_nothing()
         SignalArg::Metrics,
         None,
         now_ns(),
+        false,
     )
     .await
     .expect_err("a fold over an unchosen empty store must refuse");
@@ -346,5 +351,204 @@ async fn inspect_preserves_partial_output_when_a_part_fetch_fails() {
     assert!(
         out.contains(&present_key),
         "partial report lost the successfully-fetched part that preceded the failure: {out}"
+    );
+}
+
+/// Deliverable 3 (#1598): HEAD field 11 (`SnapshotColumnStatsRef`, ADR-0850),
+/// HEAD field 13 (`SnapshotColumnStatsPartRef`, ADR-0942), and per-part field
+/// 7 (`SnapshotColumnStatsPartRef`, ADR-1413) must each print their key and
+/// size when set. Only the present direction is covered here; the sibling
+/// test below covers absent, because a test that only covers "present"
+/// cannot detect the omitted-line-vs-unset-field ambiguity that motivated
+/// this deliverable.
+///
+/// Prove-the-test: delete the `column_stats (field 11)` (or `field 13`, or
+/// `field 7`) `push_str` line from `render_inspect`
+/// (`services/ravel-cli/src/catalog.rs`) and the matching assertion below
+/// fails.
+#[tokio::test]
+async fn inspect_prints_column_stats_refs_when_present() {
+    let store = Arc::new(MemoryStore::new());
+    let tenant_hash = TenantId::new("acme").hash();
+    let head_key = format!(
+        "t/{}/catalog/{}/HEAD",
+        tenant_hash.to_hex(),
+        Signal::Metrics.key_prefix()
+    );
+    let part_key = format!(
+        "t/{}/catalog/{}/part/present",
+        tenant_hash.to_hex(),
+        Signal::Metrics.key_prefix()
+    );
+    let part_bytes = ravel_catalog::encode_part(tenant_hash.0, Signal::Metrics as u32, 1, 0, &[])
+        .expect("encode a valid empty part");
+    store
+        .put(
+            &part_key,
+            Bytes::from(part_bytes.clone()),
+            PutOptions::default(),
+        )
+        .await
+        .expect("seed the part");
+
+    let field11_key = "t/acme/catalog/metrics/idx/present-v1.cstat".to_string();
+    let field13_key = "t/acme/catalog/metrics/idx/present-v2.cstat".to_string();
+    let field7_key = "t/acme/catalog/metrics/idx/present-v3.cstat".to_string();
+
+    let head = SnapshotHead {
+        format_version: ravel_catalog::HEAD_FORMAT_VERSION,
+        tenant_hash: tenant_hash.0.to_vec(),
+        signal: Signal::Metrics as u32,
+        shard_count: 1,
+        watermark_hour: 1,
+        parts: vec![SnapshotPartRef {
+            key: part_key.clone(),
+            blake3: blake3::hash(&part_bytes).as_bytes().to_vec(),
+            size: part_bytes.len() as u64,
+            entry_count: 0,
+            watermark_hour: 1,
+            min_hour: 0,
+            column_stats: Some(SnapshotColumnStatsPartRef {
+                key: field7_key.clone(),
+                blake3: vec![7u8; 32],
+                size: 700,
+                segment_count: 1,
+                part_blake3: vec![],
+            }),
+        }],
+        folder_id: Uuid::new_v4().into_bytes().to_vec(),
+        created_unix_ns: now_ns(),
+        column_stats: Some(SnapshotColumnStatsRef {
+            key: field11_key.clone(),
+            blake3: vec![11u8; 32],
+            size: 1100,
+            segment_count: 1,
+            part_blake3: vec![blake3::hash(&part_bytes).as_bytes().to_vec()],
+        }),
+        column_stats_part: Some(SnapshotColumnStatsPartRef {
+            key: field13_key.clone(),
+            blake3: vec![13u8; 32],
+            size: 1300,
+            segment_count: 1,
+            part_blake3: vec![],
+        }),
+        ..Default::default()
+    };
+    let head_bytes = ravel_catalog::encode_head(&head).expect("encode a valid head");
+    store
+        .put(&head_key, Bytes::from(head_bytes), PutOptions::default())
+        .await
+        .expect("seed the head");
+
+    let mut out = String::new();
+    catalog::render_inspect(
+        store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        "acme",
+        SignalArg::Metrics,
+        &mut out,
+    )
+    .await
+    .expect("inspect succeeds");
+
+    assert!(
+        out.contains(&format!(
+            "column_stats (field 11): key={field11_key} size=1100"
+        )),
+        "HEAD field 11 ref not printed: {out}"
+    );
+    assert!(
+        out.contains(&format!(
+            "column_stats_part (field 13): key={field13_key} size=1300"
+        )),
+        "HEAD field 13 ref not printed: {out}"
+    );
+    assert!(
+        out.contains(&format!(
+            "column_stats (field 7): key={field7_key} size=700"
+        )),
+        "per-part field 7 ref not printed: {out}"
+    );
+}
+
+/// Deliverable 3's absent direction: when field 11, field 13, and the
+/// per-part field 7 are all unset, the report prints an explicit `ABSENT`
+/// marker for each rather than omitting the line. An omitted line and an
+/// unset field are otherwise indistinguishable to a reader, which is exactly
+/// the ambiguity that hid a real defect (#1598).
+#[tokio::test]
+async fn inspect_prints_absent_marker_for_unset_column_stats_refs() {
+    let store = Arc::new(MemoryStore::new());
+    let tenant_hash = TenantId::new("acme").hash();
+    let head_key = format!(
+        "t/{}/catalog/{}/HEAD",
+        tenant_hash.to_hex(),
+        Signal::Metrics.key_prefix()
+    );
+    let part_key = format!(
+        "t/{}/catalog/{}/part/present",
+        tenant_hash.to_hex(),
+        Signal::Metrics.key_prefix()
+    );
+    let part_bytes = ravel_catalog::encode_part(tenant_hash.0, Signal::Metrics as u32, 1, 0, &[])
+        .expect("encode a valid empty part");
+    store
+        .put(
+            &part_key,
+            Bytes::from(part_bytes.clone()),
+            PutOptions::default(),
+        )
+        .await
+        .expect("seed the part");
+
+    let head = SnapshotHead {
+        format_version: ravel_catalog::HEAD_FORMAT_VERSION,
+        tenant_hash: tenant_hash.0.to_vec(),
+        signal: Signal::Metrics as u32,
+        shard_count: 1,
+        watermark_hour: 1,
+        parts: vec![SnapshotPartRef {
+            key: part_key.clone(),
+            blake3: blake3::hash(&part_bytes).as_bytes().to_vec(),
+            size: part_bytes.len() as u64,
+            entry_count: 0,
+            watermark_hour: 1,
+            min_hour: 0,
+            column_stats: None,
+        }],
+        folder_id: Uuid::new_v4().into_bytes().to_vec(),
+        created_unix_ns: now_ns(),
+        column_stats: None,
+        column_stats_part: None,
+        ..Default::default()
+    };
+    let head_bytes = ravel_catalog::encode_head(&head).expect("encode a valid head");
+    store
+        .put(&head_key, Bytes::from(head_bytes), PutOptions::default())
+        .await
+        .expect("seed the head");
+
+    let mut out = String::new();
+    catalog::render_inspect(
+        store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        "acme",
+        SignalArg::Metrics,
+        &mut out,
+    )
+    .await
+    .expect("inspect succeeds");
+
+    assert!(
+        out.contains("column_stats (field 11): ABSENT"),
+        "HEAD field 11 must print an explicit ABSENT marker: {out}"
+    );
+    assert!(
+        out.contains("column_stats_part (field 13): ABSENT"),
+        "HEAD field 13 must print an explicit ABSENT marker: {out}"
+    );
+    assert!(
+        out.contains("column_stats (field 7): ABSENT"),
+        "per-part field 7 must print an explicit ABSENT marker: {out}"
     );
 }

--- a/services/ravel-cli/tests/catalog_column_stats_degrade.rs
+++ b/services/ravel-cli/tests/catalog_column_stats_degrade.rs
@@ -1,0 +1,271 @@
+//! `ravel-cli catalog fold` prints the exact dictionary-drop count when the
+//! degrade loop fires (#1598 deliverable 1). Replicates
+//! `crates/ravel-catalog/src/fold.rs`'s own
+//! `fold_drops_the_largest_dictionaries_until_a_part_fits_the_ceiling`
+//! fixture shape and ceiling-derivation technique, driven through
+//! `ravel-cli`'s own entry point (`catalog::fold_inner`) rather than the
+//! crate-internal `Catalog::fold`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use ravel_catalog::{
+    ColumnStatsLimits, DeclaredColumnType, DeclaredTypedColumn, TenantConfig, TenantLifecycleState,
+    column_stats_segments_concat, decode_column_stats, decode_head, set_tenant_config,
+};
+use ravel_cli::catalog;
+use ravel_cli::maintain::SignalArg;
+use ravel_cli::store::{StoreKind, StoreSelection};
+use ravel_commit::keys;
+use ravel_commit::publish::{self, RetryPolicy};
+use ravel_commit::record::{self, NewCommitRecord};
+use ravel_logseg::{LogRecord, ObjectIdentity, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{GetRange, ObjectStoreBackend};
+use ravel_types::logstream::AttrValue;
+use ravel_types::{Signal, TenantHash, TenantId};
+use uuid::Uuid;
+
+use prost::Message as _;
+
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+const SEALED_AGE_NS: i64 = 3 * NS_PER_HOUR;
+const MEMORY: StoreSelection = StoreSelection::explicit(StoreKind::Memory);
+
+fn now_ns() -> i64 {
+    ravel_cli::now_ns().expect("system clock readable")
+}
+
+fn head_key(tenant: &TenantHash, signal: Signal) -> String {
+    format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
+}
+
+/// Declares `col_a`/`col_b`/`col_c` as typed I64 columns, matching
+/// `fold.rs`'s `set_three_column_config` fixture.
+async fn set_three_column_config(store: &dyn ObjectStoreBackend, tenant: &TenantHash) {
+    let cfg = TenantConfig {
+        typed_attr_columns: Some(vec![
+            DeclaredTypedColumn {
+                key: "col_a".to_string(),
+                ty: DeclaredColumnType::I64,
+            },
+            DeclaredTypedColumn {
+                key: "col_b".to_string(),
+                ty: DeclaredColumnType::I64,
+            },
+            DeclaredTypedColumn {
+                key: "col_c".to_string(),
+                ty: DeclaredColumnType::I64,
+            },
+        ]),
+        ..TenantConfig::new(TenantLifecycleState::Active)
+    };
+    set_tenant_config(store, tenant, &cfg, 1)
+        .await
+        .expect("write tenant config");
+}
+
+/// Publishes one L0 logs segment of `rows` entries, each carrying
+/// `col_a`/`col_b`/`col_c` with deliberately distinct cardinality (`col_a`
+/// all-distinct, `col_b` 30 distinct, `col_c` 3 distinct) so their
+/// per-column dictionaries encode to distinct sizes, matching `fold.rs`'s
+/// `publish_logs_segment_wide` fixture.
+async fn publish_logs_segment_wide(
+    store: &MemoryStore,
+    tenant: &TenantHash,
+    writer_seq: u64,
+    ingest_hour_bucket: u32,
+    rows: usize,
+) {
+    let writer_id = Uuid::new_v4();
+    let base_ts = i64::from(ingest_hour_bucket) * NS_PER_HOUR + 60_000_000_000;
+    let mut min_ts = i64::MAX;
+    let mut max_ts = i64::MIN;
+    let resource = [(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )];
+    let stream_attrs = stream_attrs_bytes(&resource, "scope", "1.0", &[]);
+    let mut w = RlogWriter::new(
+        RlogConfig::default(),
+        ObjectIdentity {
+            tenant_hash: tenant.0,
+            shard: 0,
+            writer_id: writer_id.into_bytes(),
+            writer_epoch: 1,
+            writer_seq,
+        },
+    );
+    for i in 0..rows {
+        let ts = base_ts + i as i64;
+        min_ts = min_ts.min(ts);
+        max_ts = max_ts.max(ts);
+        w.push(LogRecord {
+            stream_id: ravel_logseg::LogStreamId([0u8; 16]),
+            stream_attrs: stream_attrs.clone(),
+            ts_ns: ts,
+            observed_ts_ns: ts,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: format!("row {i}"),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: vec![
+                ("col_a".to_string(), AttrValue::I64(i as i64)),
+                ("col_b".to_string(), AttrValue::I64((i % 30) as i64)),
+                ("col_c".to_string(), AttrValue::I64((i % 3) as i64)),
+            ],
+        })
+        .expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let content_hash = *blake3::hash(&bytes).as_bytes();
+    let record = record::build(NewCommitRecord {
+        tenant_hash: *tenant,
+        signal: Signal::Logs,
+        shard: 0,
+        writer_id,
+        writer_epoch: 1,
+        writer_seq,
+        object_size: bytes.len() as u64,
+        content_hash,
+        sample_count: rows as u64,
+        series_count: 1,
+        min_event_ts_ns: min_ts,
+        max_event_ts_ns: max_ts,
+        min_ingest_ts_ns: min_ts,
+        max_ingest_ts_ns: max_ts,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        created_unix_ns: max_ts,
+        ingest_hour_bucket,
+    })
+    .expect("valid record");
+    let data_key = keys::reconstruct_data_key(&record).expect("data key");
+    publish::put_data_object(store, &data_key, Bytes::from(bytes))
+        .await
+        .expect("put data object");
+    publish::publish(store, &record, &RetryPolicy::default())
+        .await
+        .expect("publish");
+}
+
+/// Deliverable 1 (#1598): `column_stats_dictionaries_dropped` is printed and
+/// exact, mirroring `crates/ravel-catalog/src/fold.rs`'s
+/// `fold_drops_the_largest_dictionaries_until_a_part_fits_the_ceiling`: a
+/// reference fold measures each column's dictionary size, a ceiling is
+/// derived (via the crate-root-exported `column_stats_segments_concat`) that
+/// only the two largest dictionaries fit under, and a fresh fold against
+/// that injected ceiling drops exactly those two.
+///
+/// Prove-the-test: delete the `column_stats_dictionaries_dropped` `push_str`
+/// line from `render_fold_report` (`services/ravel-cli/src/catalog.rs`) and
+/// the final assertion on `printed` below fails.
+#[tokio::test]
+async fn fold_prints_the_exact_dictionaries_dropped_count() {
+    let rows = 300;
+    let tenant_name = "cli-cstat-degrade";
+    let tenant_hash = TenantId::new(tenant_name).hash();
+    let created = now_ns() - SEALED_AGE_NS;
+    let ingest_hour_bucket = u32::try_from(created / NS_PER_HOUR).expect("fits u32");
+
+    // Reference fold at the real (unbounded-for-this-fixture) ceiling: every
+    // dictionary intact.
+    let reference_store = Arc::new(MemoryStore::new());
+    set_three_column_config(reference_store.as_ref(), &tenant_hash).await;
+    publish_logs_segment_wide(
+        reference_store.as_ref(),
+        &tenant_hash,
+        0,
+        ingest_hour_bucket,
+        rows,
+    )
+    .await;
+    let (reference_report, _) = catalog::fold(
+        reference_store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        tenant_name,
+        1,
+        SignalArg::Logs,
+        None,
+        now_ns(),
+        false,
+    )
+    .await
+    .expect("reference fold at the real ceiling never degrades");
+    assert_eq!(
+        reference_report.column_stats_dictionaries_dropped, 0,
+        "the real ceiling admits this small fixture with every dictionary intact"
+    );
+
+    let head_bytes = reference_store
+        .get(&head_key(&tenant_hash, Signal::Logs), GetRange::Full)
+        .await
+        .expect("head present")
+        .data;
+    let reference_head = decode_head(&head_bytes).expect("head decodes");
+    let reference_ref = reference_head.parts[0]
+        .column_stats
+        .clone()
+        .expect("v3 ref");
+    let reference_got = reference_store
+        .get(&reference_ref.key, GetRange::Full)
+        .await
+        .expect("v3 object present");
+    let reference_decoded = decode_column_stats(&reference_got.data, &ColumnStatsLimits::default())
+        .expect("v3 decodes");
+    let reference_columns = reference_decoded.segments[0].columns.clone();
+
+    let mut sizes: Vec<(usize, usize)> = reference_columns
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let size: usize = c.dictionary.iter().map(|e| e.encoded_len()).sum();
+            (i, size)
+        })
+        .collect();
+    sizes.sort_by_key(|(_, size)| std::cmp::Reverse(*size));
+    let largest_idx = sizes[0].0;
+    let second_idx = sizes[1].0;
+    assert_eq!(reference_columns[largest_idx].name, "col_a");
+    assert_eq!(reference_columns[second_idx].name, "col_b");
+
+    let mut post_drop_segments = reference_decoded.segments.clone();
+    post_drop_segments[0].columns[largest_idx].dictionary_present = false;
+    post_drop_segments[0].columns[largest_idx]
+        .dictionary
+        .clear();
+    post_drop_segments[0].columns[second_idx].dictionary_present = false;
+    post_drop_segments[0].columns[second_idx].dictionary.clear();
+    let ceiling = column_stats_segments_concat(&post_drop_segments).len() as u64;
+
+    // Fresh store, byte-identical fixture, ceiling injected via
+    // `fold_inner`'s test-only seam.
+    let store = Arc::new(MemoryStore::new());
+    set_three_column_config(store.as_ref(), &tenant_hash).await;
+    publish_logs_segment_wide(store.as_ref(), &tenant_hash, 0, ingest_hour_bucket, rows).await;
+    let (report, printed) = catalog::fold_inner(
+        store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        tenant_name,
+        1,
+        SignalArg::Logs,
+        None,
+        now_ns(),
+        false,
+        Some(ceiling),
+    )
+    .await
+    .expect("an over-ceiling part degrades rather than refusing");
+
+    assert_eq!(
+        report.column_stats_dictionaries_dropped, 2,
+        "exactly the two largest dictionaries are dropped"
+    );
+    assert!(
+        printed.contains("column_stats_dictionaries_dropped: 2\n"),
+        "the printed report must carry the exact drop count:\n{printed}"
+    );
+}

--- a/services/ravel-cli/tests/catalog_fold_max_flush_lifetime.rs
+++ b/services/ravel-cli/tests/catalog_fold_max_flush_lifetime.rs
@@ -157,6 +157,7 @@ async fn max_flush_lifetime_zero_seals_the_finished_hour_a_default_fold_leaves_a
         SignalArg::Metrics,
         None,
         now,
+        false,
     )
     .await
     .expect("default fold succeeds");
@@ -197,6 +198,7 @@ async fn max_flush_lifetime_zero_seals_the_finished_hour_a_default_fold_leaves_a
         SignalArg::Metrics,
         OVERRIDE,
         now,
+        false,
     )
     .await
     .expect("override fold succeeds");
@@ -248,6 +250,7 @@ async fn a_default_fold_after_an_override_fold_is_a_no_op_at_the_reached_waterma
         SignalArg::Metrics,
         Some(0),
         now,
+        false,
     )
     .await
     .expect("override fold succeeds");
@@ -262,6 +265,7 @@ async fn a_default_fold_after_an_override_fold_is_a_no_op_at_the_reached_waterma
         SignalArg::Metrics,
         None,
         now,
+        false,
     )
     .await
     .expect("second, default fold succeeds");
@@ -378,6 +382,7 @@ async fn a_lifetime_that_overflows_the_seal_margin_is_refused() {
         SignalArg::Metrics,
         Some(i64::MAX),
         now,
+        false,
     )
     .await
     .expect_err("an overflowing seal margin must be refused");

--- a/services/ravel-cli/tests/catalog_fold_report.rs
+++ b/services/ravel-cli/tests/catalog_fold_report.rs
@@ -133,9 +133,14 @@ async fn publish_real_segment(store: &MemoryStore, tenant: &str, shard: u32, cre
         .expect("publish");
 }
 
-/// Deliverable 1 (#1598): the pre-change human-readable report printed 13 of
-/// `FoldReport`'s 23 fields and silently omitted the rest, including
+/// Deliverable 1 (#1598): the pre-change human-readable report printed 10 of
+/// `FoldReport`'s 23 fields and silently omitted the other 13, including
 /// `column_stats_dictionaries_dropped`. Every field must now appear.
+///
+/// The count is 10, not 13: the pre-change report emitted 13 LINES, but
+/// `store`, `signal` and `seal_margin` are not `FoldReport` fields. Measured
+/// against the ADR-1413 T2 fold's own output, which printed exactly those 13
+/// lines.
 ///
 /// Prove-the-test: delete any one of the `push_str` lines this test checks
 /// for in `render_fold_report` (`services/ravel-cli/src/catalog.rs`) and the
@@ -219,9 +224,19 @@ async fn fold_human_report_prints_every_fold_report_field() {
          if FoldReport shrank, update this floor deliberately",
         keys.len()
     );
+    // Compare against the set of keys the report actually emits, not with
+    // `printed.contains("{key}:")`. A substring test is satisfied by a LONGER
+    // field's line, so it is vacuous for any key that is a suffix of another:
+    // `previous_watermark_hour:` contains `watermark_hour:`, and
+    // `column_stats_part_bytes:` contains `part_bytes:`. Deleting either of
+    // those two lines from the renderer left a substring check green.
+    let emitted: std::collections::HashSet<&str> = printed
+        .lines()
+        .filter_map(|line| line.trim_start().split_once(':').map(|(key, _)| key))
+        .collect();
     for key in keys.keys() {
         assert!(
-            printed.contains(&format!("{key}:")),
+            emitted.contains(key.as_str()),
             "FoldReport field {key} is serialized by --json but missing from \
              the human report:\n{printed}"
         );

--- a/services/ravel-cli/tests/catalog_fold_report.rs
+++ b/services/ravel-cli/tests/catalog_fold_report.rs
@@ -14,8 +14,10 @@ use ravel_commit::keys;
 use ravel_commit::publish::{self, RetryPolicy};
 use ravel_commit::record::{self, NewCommitRecord};
 use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::fault::{FaultKind, FaultPlan, FaultStore, Op, Rule, ScriptedFault};
 use ravel_object_store::memory::MemoryStore;
-use ravel_types::{Signal, TenantId};
+use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
+use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL, Sample, SeriesId, Signal, TenantId};
 use uuid::Uuid;
 
 /// Same margin as `tests/catalog.rs`: clears the default 1h20m seal margin
@@ -61,6 +63,69 @@ async fn publish_segment(
     .expect("valid record");
     let data_key = keys::reconstruct_data_key(&rec).expect("data key");
     publish::put_data_object(store, &data_key, Bytes::from(payload))
+        .await
+        .expect("put data object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish");
+}
+
+/// Unlike `publish_segment` above (whose payload is the literal bytes
+/// `seg-{shard}-{seq}`), this writes a real, decodable RSEG v1 segment with
+/// one named series. The fold's postings build needs a segment it can
+/// actually decode before it issues a postings PUT at all, which the
+/// deliverable-2 fault-injection test below needs in order to have a
+/// postings PUT to fault.
+async fn publish_real_segment(store: &MemoryStore, tenant: &str, shard: u32, created_unix_ns: i64) {
+    let tenant_hash = TenantId::new(tenant).hash();
+    let ingest_hour_bucket = u32::try_from(created_unix_ns / 3_600_000_000_000).expect("fits u32");
+    let writer_id = Uuid::new_v4();
+    let series = vec![SeriesInput {
+        series_id: SeriesId([1u8; 16]),
+        labels: LabelSet::new(vec![Label {
+            name: METRIC_NAME_LABEL.to_string(),
+            value: "up".to_string(),
+        }])
+        .expect("valid labels"),
+        samples: vec![Sample {
+            ts_ns: created_unix_ns,
+            value: 1.0,
+        }],
+    }];
+    let identity = SegmentIdentity {
+        tenant_hash: tenant_hash.0,
+        shard,
+        writer_id: writer_id.to_string(),
+        writer_epoch: 1,
+        writer_seq: 1,
+    };
+    let bounds = IngestBounds {
+        min_ingest_ts_ns: created_unix_ns - 1_000,
+        max_ingest_ts_ns: created_unix_ns,
+    };
+    let written = SegmentWriter::write(series, identity, bounds).expect("write RSEG");
+    let rec = record::build(NewCommitRecord {
+        tenant_hash,
+        signal: Signal::Metrics,
+        shard,
+        writer_id,
+        writer_epoch: 1,
+        writer_seq: 1,
+        object_size: written.bytes.len() as u64,
+        content_hash: written.summary.blake3,
+        sample_count: written.summary.sample_count,
+        series_count: written.summary.series_count,
+        min_event_ts_ns: written.summary.min_event_ts_ns,
+        max_event_ts_ns: written.summary.max_event_ts_ns,
+        min_ingest_ts_ns: created_unix_ns - 1_000,
+        max_ingest_ts_ns: created_unix_ns,
+        segment_format_version: 1,
+        created_unix_ns,
+        ingest_hour_bucket,
+    })
+    .expect("valid record");
+    let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+    publish::put_data_object(store, &data_key, written.bytes)
         .await
         .expect("put data object");
     publish::publish(store, &rec, &RetryPolicy::default())
@@ -187,10 +252,18 @@ async fn fold_json_report_serializes_the_whole_fold_report() {
 /// leaves exactly two PUTs: the fresh tail part (`.csnap`) and the HEAD CAS
 /// write.
 ///
-/// Prove-the-test: in `render_fold_report`
-/// (`services/ravel-cli/src/catalog.rs`), or by reverting the `fold.rs` fix
-/// that counts a PUT before matching its outcome, `put_requests` would read
-/// something other than `2` and this assertion fails.
+/// This pins the success-path count only: on this fixture every PUT the
+/// fold issues also succeeds, so it guards against double-counting (e.g. a
+/// stray increment inside *and* outside a `match` arm) rather than against
+/// the issued-but-failed case. It cannot distinguish "count before the
+/// match" from "count inside `Ok(_) | Err(AlreadyExists)`" the fix changed,
+/// because every PUT here lands in `Ok`. That distinction is
+/// `fold_put_requests_counts_an_issued_postings_put_that_failed` below,
+/// which injects a real (non-`AlreadyExists`) PUT failure.
+///
+/// Prove-the-test: delete either `counters.put_requests += 1;` this fixture
+/// reaches (the part PUT at `fold.rs:1757`, or the HEAD PUT at
+/// `fold.rs:2361`) and `put_requests` reads `1` instead of `2` below.
 #[tokio::test]
 async fn fold_put_requests_counts_exactly_the_objects_this_fold_writes() {
     let store = Arc::new(MemoryStore::new());
@@ -229,5 +302,65 @@ async fn fold_put_requests_counts_exactly_the_objects_this_fold_writes() {
     assert_eq!(
         report.put_requests, 2,
         "put_requests must count exactly the part PUT and the HEAD PUT this fold issues:\n{printed}"
+    );
+}
+
+/// Deliverable 2 (#1598): a PUT that was actually issued and came back a
+/// real (non-`AlreadyExists`) error must still count, because the postings
+/// PUT's own failure path degrades rather than failing the fold: it warns,
+/// omits the postings ref, and lets the fold return a normal report
+/// (`crates/ravel-catalog/src/fold.rs`, the postings `match put_result`
+/// block around line 1869). `publish_real_segment` writes a real, decodable
+/// RSEG segment (unlike `publish_segment` above) specifically so
+/// `build_postings` has something to encode and a postings PUT is actually
+/// issued for `FaultStore` to fail.
+///
+/// Prove-the-test: in `fold.rs`, move `counters.put_requests += 1;`
+/// (currently at line 1868, issued unconditionally before the postings
+/// PUT's `match put_result`) down into the `Ok(_) | Err(StoreError::AlreadyExists)`
+/// arm below it. This test's fault fires a real `Transient` error, not
+/// `AlreadyExists`, so the moved increment is skipped and `put_requests`
+/// reads `2` instead of `3`.
+#[tokio::test]
+async fn fold_put_requests_counts_an_issued_postings_put_that_failed() {
+    let store = MemoryStore::new();
+    let tenant = "cli-fold-put-degrade";
+    let created = now_ns() - SEALED_AGE_NS;
+    publish_real_segment(&store, tenant, 0, created).await;
+
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(
+            Op::Put,
+            ScriptedFault::Transient("simulated store outage".to_string()),
+        )
+        .with_key_contains(".npost"),
+    );
+    let fault_store = Arc::new(FaultStore::new(store, plan));
+
+    let (report, printed) = catalog::fold(
+        fault_store.clone() as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        tenant,
+        1,
+        SignalArg::Metrics,
+        None,
+        now_ns(),
+        false,
+    )
+    .await
+    .expect("an issued-but-failed postings PUT must degrade the fold, not fail it");
+
+    assert_eq!(
+        fault_store.fault_count(Op::Put, FaultKind::Transient),
+        1,
+        "the postings PUT fault must actually fire exactly once"
+    );
+    assert!(
+        !report.postings_built,
+        "the faulted postings PUT must degrade: no postings ref is published: {report:?}"
+    );
+    assert_eq!(
+        report.put_requests, 3,
+        "put_requests must count the part PUT, the failed-but-issued postings PUT, and the HEAD PUT:\n{printed}"
     );
 }

--- a/services/ravel-cli/tests/catalog_fold_report.rs
+++ b/services/ravel-cli/tests/catalog_fold_report.rs
@@ -147,7 +147,7 @@ async fn fold_human_report_prints_every_fold_report_field() {
     let created = now_ns() - SEALED_AGE_NS;
     publish_segment(&store, tenant, 0, 1, created).await;
 
-    let (_report, printed) = catalog::fold(
+    let (report, printed) = catalog::fold(
         store as Arc<dyn ObjectStoreBackend>,
         MEMORY,
         tenant,
@@ -200,6 +200,32 @@ async fn fold_human_report_prints_every_fold_report_field() {
             "previously-omitted field {field} missing from report:\n{printed}"
         );
     }
+
+    // The two lists above pin TODAY's field set by hand, which is the same
+    // mechanism that let the human report drift in the first place: add a
+    // `FoldReport` field tomorrow and `--json` carries it for free via
+    // `Serialize` while the text renderer silently omits it, with every
+    // assertion above still green. Derive the expected key set from the
+    // struct instead, so the claim in `render_fold_report`'s doc comment
+    // ("both forms print every field") holds for fields nobody has written
+    // yet. The hand-written lists stay for their documentation value.
+    let value = serde_json::to_value(&report).expect("FoldReport serializes");
+    let keys = value
+        .as_object()
+        .expect("FoldReport is a struct, so it serializes to an object");
+    assert!(
+        keys.len() >= 23,
+        "expected the derived key set to cover the whole struct, got {} keys; \
+         if FoldReport shrank, update this floor deliberately",
+        keys.len()
+    );
+    for key in keys.keys() {
+        assert!(
+            printed.contains(&format!("{key}:")),
+            "FoldReport field {key} is serialized by --json but missing from \
+             the human report:\n{printed}"
+        );
+    }
 }
 
 /// Deliverable 1's `--json` flag: the whole `FoldReport` round-trips through
@@ -224,13 +250,22 @@ async fn fold_json_report_serializes_the_whole_fold_report() {
     .await
     .expect("fold succeeds");
 
-    // First line is the store-selection header (every render function's
-    // first line, human or JSON); the rest is the JSON body.
-    let body = printed
-        .split_once('\n')
-        .map(|(_, rest)| rest)
-        .expect("header line present");
-    let value: serde_json::Value = serde_json::from_str(body).expect("valid JSON");
+    // The WHOLE of stdout must parse, with no header line to skip: `--json`
+    // exists so `... --json | jq .put_requests` works, and a consumer that
+    // has to drop a first line by convention is the defect this asserts
+    // against. Parsing `printed` directly rather than a suffix of it is the
+    // assertion.
+    let value: serde_json::Value = serde_json::from_str(&printed)
+        .unwrap_or_else(|err| panic!("--json stdout must be one JSON document: {err}\n{printed}"));
+    let body = printed.as_str();
+    // #1024 requires the store selection to stay visible. It moved from a
+    // header line into the document, so it is still there and now machine
+    // readable.
+    assert_eq!(
+        value.get("store"),
+        Some(&serde_json::json!("memory")),
+        "the store selection must survive as a field, not a header line:\n{body}"
+    );
     assert_eq!(
         value.get("column_stats_dictionaries_dropped"),
         Some(&serde_json::json!(report.column_stats_dictionaries_dropped)),

--- a/services/ravel-cli/tests/catalog_fold_report.rs
+++ b/services/ravel-cli/tests/catalog_fold_report.rs
@@ -1,0 +1,233 @@
+//! `ravel-cli catalog fold` report completeness (#1598): the human-readable
+//! report must print every `FoldReport` field, `--json` must serialize the
+//! whole struct, and `put_requests` must count every PUT the fold issues.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use ravel_cli::catalog;
+use ravel_cli::maintain::SignalArg;
+use ravel_cli::store::{StoreKind, StoreSelection};
+use ravel_commit::keys;
+use ravel_commit::publish::{self, RetryPolicy};
+use ravel_commit::record::{self, NewCommitRecord};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use ravel_types::{Signal, TenantId};
+use uuid::Uuid;
+
+/// Same margin as `tests/catalog.rs`: clears the default 1h20m seal margin
+/// regardless of which minute of the hour the test runs in.
+const SEALED_AGE_NS: i64 = 3 * 60 * 60 * 1_000_000_000;
+
+const MEMORY: StoreSelection = StoreSelection::explicit(StoreKind::Memory);
+
+fn now_ns() -> i64 {
+    ravel_cli::now_ns().expect("system clock readable")
+}
+
+async fn publish_segment(
+    store: &MemoryStore,
+    tenant: &str,
+    shard: u32,
+    seq: u64,
+    created_unix_ns: i64,
+) {
+    let tenant_hash = TenantId::new(tenant).hash();
+    let ingest_hour_bucket = u32::try_from(created_unix_ns / 3_600_000_000_000).expect("fits u32");
+    let payload = format!("seg-{shard}-{seq}").into_bytes();
+    let content_hash = *blake3::hash(&payload).as_bytes();
+    let rec = record::build(NewCommitRecord {
+        tenant_hash,
+        signal: Signal::Metrics,
+        shard,
+        writer_id: Uuid::new_v4(),
+        writer_epoch: 1,
+        writer_seq: seq,
+        object_size: payload.len() as u64,
+        content_hash,
+        sample_count: 1,
+        series_count: 1,
+        min_event_ts_ns: created_unix_ns - 1_000,
+        max_event_ts_ns: created_unix_ns,
+        min_ingest_ts_ns: created_unix_ns - 1_000,
+        max_ingest_ts_ns: created_unix_ns,
+        segment_format_version: 1,
+        created_unix_ns,
+        ingest_hour_bucket,
+    })
+    .expect("valid record");
+    let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+    publish::put_data_object(store, &data_key, Bytes::from(payload))
+        .await
+        .expect("put data object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish");
+}
+
+/// Deliverable 1 (#1598): the pre-change human-readable report printed 13 of
+/// `FoldReport`'s 23 fields and silently omitted the rest, including
+/// `column_stats_dictionaries_dropped`. Every field must now appear.
+///
+/// Prove-the-test: delete any one of the `push_str` lines this test checks
+/// for in `render_fold_report` (`services/ravel-cli/src/catalog.rs`) and the
+/// matching assertion below fails.
+#[tokio::test]
+async fn fold_human_report_prints_every_fold_report_field() {
+    let store = Arc::new(MemoryStore::new());
+    let tenant = "cli-fold-report-fields";
+    let created = now_ns() - SEALED_AGE_NS;
+    publish_segment(&store, tenant, 0, 1, created).await;
+
+    let (_report, printed) = catalog::fold(
+        store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        tenant,
+        1,
+        SignalArg::Metrics,
+        None,
+        now_ns(),
+        false,
+    )
+    .await
+    .expect("fold succeeds");
+
+    // Fields the pre-change report already printed.
+    for field in [
+        "no_op:",
+        "rebuilt:",
+        "previous_watermark_hour:",
+        "watermark_hour:",
+        "seal_margin:",
+        "buckets_folded:",
+        "entry_count:",
+        "part_bytes:",
+        "list_requests:",
+        "get_requests:",
+        "put_requests:",
+    ] {
+        assert!(
+            printed.contains(field),
+            "already-printed field {field} missing from report:\n{printed}"
+        );
+    }
+    // Fields the pre-change report silently omitted.
+    for field in [
+        "parts_total:",
+        "parts_reused:",
+        "postings_built:",
+        "postings_bytes:",
+        "column_stats_built:",
+        "column_stats_bytes:",
+        "column_stats_part_built:",
+        "column_stats_part_bytes:",
+        "column_stats_part_objects_built:",
+        "column_stats_dictionaries_dropped:",
+        "layout_drift_count:",
+        "frontier_hours_reconciled:",
+        "frontier_hours_deferred:",
+    ] {
+        assert!(
+            printed.contains(field),
+            "previously-omitted field {field} missing from report:\n{printed}"
+        );
+    }
+}
+
+/// Deliverable 1's `--json` flag: the whole `FoldReport` round-trips through
+/// `serde_json`, including a field the human report used to omit.
+#[tokio::test]
+async fn fold_json_report_serializes_the_whole_fold_report() {
+    let store = Arc::new(MemoryStore::new());
+    let tenant = "cli-fold-report-json";
+    let created = now_ns() - SEALED_AGE_NS;
+    publish_segment(&store, tenant, 0, 1, created).await;
+
+    let (report, printed) = catalog::fold(
+        store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        tenant,
+        1,
+        SignalArg::Metrics,
+        None,
+        now_ns(),
+        true,
+    )
+    .await
+    .expect("fold succeeds");
+
+    // First line is the store-selection header (every render function's
+    // first line, human or JSON); the rest is the JSON body.
+    let body = printed
+        .split_once('\n')
+        .map(|(_, rest)| rest)
+        .expect("header line present");
+    let value: serde_json::Value = serde_json::from_str(body).expect("valid JSON");
+    assert_eq!(
+        value.get("column_stats_dictionaries_dropped"),
+        Some(&serde_json::json!(report.column_stats_dictionaries_dropped)),
+        "JSON must carry a field the human report used to omit, got:\n{body}"
+    );
+    assert_eq!(
+        value.get("put_requests"),
+        Some(&serde_json::json!(report.put_requests))
+    );
+}
+
+/// Deliverable 2 (#1598): `put_requests` must count every PUT the fold
+/// issues. `publish_segment`'s payload is not a real encoded segment (it is
+/// the literal bytes `seg-0-1`), so `fetch_segment_names` fails to decode it
+/// and `build_postings` returns `None` (`crates/ravel-catalog/src/fold.rs`
+/// lines 2596-2610): no postings object is built, and this fixture also
+/// declares no typed columns, so no column-statistics object is built either
+/// (ADR-0850/ADR-1413 gate on `typed_attr_columns` being non-empty). That
+/// leaves exactly two PUTs: the fresh tail part (`.csnap`) and the HEAD CAS
+/// write.
+///
+/// Prove-the-test: in `render_fold_report`
+/// (`services/ravel-cli/src/catalog.rs`), or by reverting the `fold.rs` fix
+/// that counts a PUT before matching its outcome, `put_requests` would read
+/// something other than `2` and this assertion fails.
+#[tokio::test]
+async fn fold_put_requests_counts_exactly_the_objects_this_fold_writes() {
+    let store = Arc::new(MemoryStore::new());
+    let tenant = "cli-fold-put-requests";
+    let created = now_ns() - SEALED_AGE_NS;
+    publish_segment(&store, tenant, 0, 1, created).await;
+
+    let (report, printed) = catalog::fold(
+        store as Arc<dyn ObjectStoreBackend>,
+        MEMORY,
+        tenant,
+        1,
+        SignalArg::Metrics,
+        None,
+        now_ns(),
+        false,
+    )
+    .await
+    .expect("fold succeeds");
+
+    assert!(
+        !report.postings_built,
+        "this fixture's payload cannot decode as a real segment, so no postings object is built: {report:?}"
+    );
+    assert!(
+        !report.column_stats_built
+            && !report.column_stats_part_built
+            && report.column_stats_part_objects_built == 0,
+        "fixture declares no typed columns, so no column-stats object is built: {report:?}"
+    );
+    assert_eq!(
+        report.parts_total - report.parts_reused,
+        1,
+        "exactly one fresh tail part is written"
+    );
+    assert_eq!(
+        report.put_requests, 2,
+        "put_requests must count exactly the part PUT and the HEAD PUT this fold issues:\n{printed}"
+    );
+}

--- a/services/ravel-cli/tests/catalog_signal.rs
+++ b/services/ravel-cli/tests/catalog_signal.rs
@@ -201,6 +201,7 @@ async fn fold_signal_logs_folds_the_logs_snapshot_and_a_logs_resolve_reads_no_co
         FOLD_SIGNAL,
         None,
         now_ns(),
+        false,
     )
     .await
     .expect("cli fold succeeds");
@@ -296,6 +297,7 @@ async fn inspect_signal_logs_prints_the_signal_word() {
         SignalArg::Logs,
         None,
         now_ns(),
+        false,
     )
     .await
     .expect("cli fold succeeds");
@@ -339,6 +341,7 @@ async fn verify_signal_logs_checks_the_logs_snapshot() {
         SignalArg::Logs,
         None,
         now_ns(),
+        false,
     )
     .await
     .expect("cli fold succeeds");

--- a/services/ravel-cli/tests/inspect_cstat.rs
+++ b/services/ravel-cli/tests/inspect_cstat.rs
@@ -1,0 +1,212 @@
+//! `ravel-cli inspect cstat` (#1598 deliverable 4): prints the envelope
+//! version, `header_len`, every `ColumnStatsHeader` field, and a per-column
+//! `dictionary_present` listing, driven through the crate's own
+//! `catalog::render_inspect_cstat` entry point. An object whose declared
+//! `body_uncompressed_len` exceeds the decode ceiling must still print the
+//! header and the over-ceiling verdict, without decompressing (no reader can
+//! decompress such an object). A truncated or corrupt object must produce a
+//! typed error, never a panic.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use ravel_catalog::{
+    ColumnStatsLimits, DEFAULT_MAX_COLUMN_STATS_BYTES, decode_column_stats_header,
+    encode_column_stats,
+};
+use ravel_cli::catalog::render_inspect_cstat;
+use ravel_proto::catalog::v1::column_value::Kind;
+use ravel_proto::catalog::v1::{
+    ColumnStat, ColumnStatsHeader, ColumnStatsSegment, ColumnValue, DictEntry,
+};
+
+use proptest::prelude::*;
+use prost::Message as _;
+
+fn i64_value(v: i64) -> ColumnValue {
+    ColumnValue {
+        kind: Some(Kind::I64(v)),
+    }
+}
+
+/// Mirrors `crates/ravel-catalog/src/snapshot_format/column_stats.rs`'s own
+/// `segment()` test fixture: a single I64 column, 10-entry dictionary,
+/// `sum = 45` (0+1+...+9).
+fn fixture_segment() -> ColumnStatsSegment {
+    let dictionary: Vec<DictEntry> = (0..10)
+        .map(|v| DictEntry {
+            value: Some(i64_value(v)),
+            count: 1,
+        })
+        .collect();
+    ColumnStatsSegment {
+        ingest_hour_bucket: 1,
+        shard: 0,
+        writer_id: vec![0xAA; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+        columns: vec![ColumnStat {
+            name: "AdvEngineID".to_string(),
+            declared_type: 2,
+            non_null_count: 10,
+            null_count: 0,
+            min: Some(i64_value(0)),
+            max: Some(i64_value(9)),
+            dictionary_present: true,
+            dictionary,
+            sum: Some(45),
+        }],
+    }
+}
+
+#[test]
+fn inspect_cstat_prints_exact_header_values_and_dictionary_presence() {
+    let segments = vec![fixture_segment()];
+    let bytes = encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &segments)
+        .expect("encodes a valid v1 object");
+
+    let mut out = String::new();
+    render_inspect_cstat(&bytes, &mut out).expect("a valid object under ceiling decodes cleanly");
+
+    assert!(out.contains("envelope_version: 1\n"), "{out}");
+    assert!(out.contains("format_version: 1\n"), "{out}");
+    assert!(
+        out.contains(&format!("tenant_hash: {}\n", hex::encode([0x11; 16]))),
+        "{out}"
+    );
+    assert!(out.contains("signal: 3\n"), "{out}");
+    assert!(
+        out.contains(&format!("part_blake3: {}\n", hex::encode([0x22; 32]))),
+        "{out}"
+    );
+    assert!(out.contains("segment_count: 1\n"), "{out}");
+    assert!(
+        out.contains(&format!(
+            "over_ceiling (body_uncompressed_len > {DEFAULT_MAX_COLUMN_STATS_BYTES}): false\n"
+        )),
+        "{out}"
+    );
+    assert!(
+        out.contains(
+            "segment shard=0 ingest_hour_bucket=1 writer_epoch=1 writer_seq=1 \
+             column=AdvEngineID dictionary_present=true\n"
+        ),
+        "{out}"
+    );
+}
+
+/// Hand-assembles a `.cstat` envelope byte-for-byte per the layout documented
+/// at `crates/ravel-catalog/src/snapshot_format/column_stats.rs:1-19`:
+/// `magic(4) | version(1) | reserved(3) | header_len(u32 LE) | header |
+/// body_len(u64 LE) | body | body_crc32c(u32 LE, over body) |
+/// header_crc32c(u32 LE, over magic..header)`. `decode_column_stats_prefix`
+/// never checks `body_len`/`body` against the header's declared
+/// `body_uncompressed_len` -- only `decode_column_stats` does, after
+/// decompressing -- so an envelope with a small, arbitrary `body` and a
+/// header declaring `body_uncompressed_len` above the ceiling is a valid,
+/// decodable-at-the-header-level object that no full decode can ever read.
+fn encode_forged_envelope(header: &ColumnStatsHeader, body: &[u8]) -> Vec<u8> {
+    let header_bytes = header.encode_to_vec();
+    let mut prefix = Vec::new();
+    prefix.extend_from_slice(b"RCST");
+    prefix.push(1u8);
+    prefix.extend_from_slice(&[0u8; 3]);
+    prefix.extend_from_slice(&(header_bytes.len() as u32).to_le_bytes());
+    prefix.extend_from_slice(&header_bytes);
+    let header_crc = crc32c::crc32c(&prefix);
+
+    let mut out = prefix;
+    out.extend_from_slice(&(body.len() as u64).to_le_bytes());
+    out.extend_from_slice(body);
+    out.extend_from_slice(&crc32c::crc32c(body).to_le_bytes());
+    out.extend_from_slice(&header_crc.to_le_bytes());
+    out
+}
+
+#[test]
+fn inspect_cstat_reports_over_ceiling_without_decompressing() {
+    let header = ColumnStatsHeader {
+        format_version: 1,
+        tenant_hash: vec![0x33; 16],
+        signal: 2,
+        part_blake3: vec![],
+        segment_count: 1,
+        body_uncompressed_len: DEFAULT_MAX_COLUMN_STATS_BYTES + 1,
+    };
+    // Deliberately not a valid zstd stream: the over-ceiling path must never
+    // attempt to decompress this.
+    let body = b"not zstd, and that must never matter here";
+    let bytes = encode_forged_envelope(&header, body);
+
+    // The header-only path proves this by construction: it decodes cleanly
+    // even though `decode_column_stats` (which does decompress) would fail
+    // on this body.
+    decode_column_stats_header(&bytes).expect("header parses without touching the body");
+    ravel_catalog::decode_column_stats(&bytes, &ColumnStatsLimits::default())
+        .expect_err("a real decode must refuse an over-ceiling declared length");
+
+    let mut out = String::new();
+    render_inspect_cstat(&bytes, &mut out)
+        .expect("the over-ceiling verdict is a successful report, not an error");
+
+    assert!(
+        out.contains(&format!(
+            "body_uncompressed_len: {}\n",
+            DEFAULT_MAX_COLUMN_STATS_BYTES + 1
+        )),
+        "{out}"
+    );
+    assert!(
+        out.contains(&format!(
+            "over_ceiling (body_uncompressed_len > {DEFAULT_MAX_COLUMN_STATS_BYTES}): true\n"
+        )),
+        "{out}"
+    );
+    assert!(
+        out.contains("dictionary_present listing: unavailable"),
+        "{out}"
+    );
+}
+
+#[test]
+fn inspect_cstat_on_a_truncated_object_returns_a_typed_error_not_a_panic() {
+    let segments = vec![fixture_segment()];
+    let bytes = encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &segments)
+        .expect("encodes a valid v1 object");
+    let truncated = &bytes[..bytes.len() - 5];
+
+    let mut out = String::new();
+    let result = render_inspect_cstat(truncated, &mut out);
+    assert!(
+        result.is_err(),
+        "a truncated object must be a typed error, not a silent success"
+    );
+}
+
+#[test]
+fn inspect_cstat_on_a_corrupt_object_returns_a_typed_error_not_a_panic() {
+    let segments = vec![fixture_segment()];
+    let mut bytes = encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &segments)
+        .expect("encodes a valid v1 object");
+    // Corrupt the magic so this fails the very first envelope check.
+    bytes[0] ^= 0xFF;
+
+    let mut out = String::new();
+    let result = render_inspect_cstat(&bytes, &mut out);
+    assert!(
+        result.is_err(),
+        "a corrupt magic must be a typed error, not a silent success"
+    );
+}
+
+proptest! {
+    /// The header parse (`decode_column_stats_header`, which
+    /// `render_inspect_cstat` calls first) must never panic on arbitrary
+    /// bytes: every rejection is a typed `SnapshotFormatError`, never a
+    /// panic. This drives the same function the CLI command calls, so a
+    /// counterexample here is a counterexample against the reachable
+    /// `inspect cstat` surface.
+    #[test]
+    fn decode_column_stats_header_never_panics(bytes in proptest::collection::vec(any::<u8>(), 0..512)) {
+        let _ = decode_column_stats_header(&bytes);
+    }
+}


### PR DESCRIPTION
The ADR-1413 T2 measurement could not report two of its six pre-registered
figures, and mis-stated a third, because the CLI does not expose what the
code already computes. Each gap below was a measured instance during that
run, not a hypothetical.

`catalog fold` printed ten of `FoldReport`'s 23 fields and silently
dropped the rest, `column_stats_dictionaries_dropped` among them. That
counter is maintained through the degrade loop and asserted at exact values
by two existing tests, so it was computed, tested, and unreachable through
the command that produces it. It is now printed, with a `--json` flag that
serialises the whole struct.

`put_requests` undercounted. A measured fold reported 4 for a run that wrote
five objects: a v3 per-part `.cstat`, the part `.csnap`, a v1 `.cstat`, a v2
`.cstat`, and HEAD. The undercount was a PUT that failed AFTER being issued.
The postings and column-statistics paths degrade on a store error (warn, omit
the ref, continue to a successful HEAD), and their increment sat inside
`Ok(_) | Err(AlreadyExists)`, so the request that was actually issued vanished
from the count. The counter now increments when the request is issued rather
than when it succeeds, so a PUT failure that leaves a `*_built` field false
still shows the request it cost.

A correction to an earlier draft of this description, caught in review: a
successful HEAD PUT was already counted pre-change, inside its own `Ok` arm.
The reorder does also count a HEAD PUT that fails, but that path returns `Err`
with no `FoldReport`, so that particular increment is never observable. The
code was right; the prose overstated the HEAD case.

Worth recording why that undercount survived: the only non-zero assertion on
`put_requests` anywhere in ravel-catalog's tests is
`assert!(report.put_requests >= 1)` at fold.rs:5652, whose stated claim is
"rebuild must CAS-overwrite the corrupt head". For that claim `>= 1` is
adequate, and it is also incapable of detecting a count that is short. The
two other assertions pin zero. So nothing pinned a positive count, and a
counter that missed the HEAD PUT and every failed-after-issue PUT passed the
suite unchanged. That assertion is pre-existing and out of this change's
scope; it is named here rather than altered.

`catalog inspect` printed no column-statistics lines at all. Attributing the
v3 object to `SnapshotPartRef` field 7 rather than the whole-object fields 11
and 13 required decoding the HEAD protobuf by hand, and that is also how a
dropped field-13 reference was found: the v2 object had been written
successfully and its reference never recorded. The refs are now printed per
part and at top level, each with its key and size, and an absent field is
marked absent rather than omitted, because an omitted line and an unset field
are indistinguishable to a reader and that ambiguity is what hid the defect.

`ravel-cli inspect cstat <key>` is new. It prints the envelope version,
header length and every `ColumnStatsHeader` field, then per-column
`dictionary_present`. It reports whether the body exceeds
`DEFAULT_MAX_COLUMN_STATS_BYTES` without decompressing, so an over-ceiling
object, which no reader can decode and which is the case most worth
diagnosing, still yields an answer instead of an error.

`crates/ravel-catalog` is touched only to make the work reachable: a
header-only peek entry point and one crate-root re-export. No behaviour
change beyond the corrected PUT accounting.

Refs: #1598
Refs: #1413


