### PR TITLE
docs: correct two stated defaults and add a drift test for them

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ Ravel ingests OTLP natively and answers PromQL and SQL. Everything below is
 either in the published container image or behind a named cargo feature, and the
 matrix says which.
 
+The matrix describes `main`, not a release. Its "In published image" column
+means the surface is compiled into the image built from `main`, so a surface
+that lands after the tag the quickstart pins is not yet in the image you get by
+following the quickstart. Every entry below is in the pinned `0.15.0` image;
+`git log v0.15.0..main` is what tells you whether that is still true after the
+next feature lands, and `CHANGELOG.md` records which release each surface first
+shipped in. Two entries missed the previous pinned tag this way: the `alerts`
+and `audit` SQL tables were registered, and PromQL over logs was answered, only
+after `0.13.0` was cut, so a reader following the README against that image got
+a missing table and an empty vector.
+
 <!-- BEGIN SUPPORT MATRIX -->
 
 | Surface | Signals | Feature gate | In published image |

--- a/docs/consistency-model.md
+++ b/docs/consistency-model.md
@@ -309,7 +309,7 @@ each degraded path resolves) is in docs/catalog-and-mvcc.md.
 
 ## Recent-hours read path
 
-`max_segments` (default 1024) caps only the sealed, below-watermark set a
+`max_segments` (default 1,000,000) caps only the sealed, below-watermark set a
 resolve extracts from snapshot parts. Recent segments listed live above the
 fold watermark and token-resolved segments from an explicit
 `min_commit_token` are exempt from that cap, so a hot tenant's open hour and a
@@ -406,12 +406,16 @@ tiers) is predicate-granular deletion built on the same durable-transaction,
 logical-exclusion, physical-removal shape as every other deletion. Query
 exclusion is immediate and cache-tight: no query whose snapshot resolves after
 the request ack returns matching records, from store or any cache tier, and
-in-flight queries drain within the query deadline, which is at most
-`max_query_duration`. The erasure stage bounds are a guarantee, not a target:
+in-flight queries drain within the query deadline, the engine's enforced query
+timeout, 11 min by default. That deadline is a distinct quantity from
+`max_query_duration`, the GC protection budget it fits under, 1 h by default:
+the first is what the engine cancels a query at, the second is how long the
+sweeps keep an input readable for a query that pinned it. Sizing a drain
+window uses the first. The erasure stage bounds are a guarantee, not a target:
 
 | Stage | Guarantee | Worst-case bound (defaults) |
 |---|---|---|
-| Query exclusion | No query whose snapshot resolves after the request ack returns matching records, from store or any cache tier | immediate; all in-flight queries drain within the query deadline (30 s by default, never more than `max_query_duration`, 1 h) |
+| Query exclusion | No query whose snapshot resolves after the request ack returns matching records, from store or any cache tier | immediate; all in-flight queries drain within the query deadline, the engine's enforced query timeout, 11 min by default, validated at startup against `max_query_duration`, the GC protection budget it fits under, 1 h by default |
 | Rewrite complete (`.done`) | Every record that existed when the request was acknowledged is gone from every live commit-record segment a snapshot resolves, verified through the catalog resolver. A bucket still open at the ack is covered once it seals: completion waits for that seal and the rewrite that follows it rather than excluding the bucket. Records ingested after the ack are outside the request's scope. Index entries and derived datasets carry no subject values, so they are free of matching records by construction | `erasure_rewrite_deadline`, default 72 h; a pending request older than this raises an alarm metric. The wait for a bucket open at the ack is bounded by `max_ingest_lag` + one bucket span + `max_flush_lifetime` + `clock_skew_allowance` (4 h 5 min with defaults), well inside that deadline |
 | Physical bytes gone from the bucket | Superseded inputs swept | `.done` + `protection_horizon` (default `max_query_duration` + `grace` + `clock_skew_allowance` = 1 h + 24 h + 5 min) + one sweep interval (default 5 min); with defaults, about four days end to end (72 h + 25 h 5 min + 5 min) |
 | Physical bytes gone from query-node disk caches | Non-durable local copies aged out | sweep + disk-tier entry max-age (24 h); or immediately, by deleting cache directories (ADR-0046: a node with its cache directory deleted mid-flight answers every query correctly) |

--- a/services/ravel-server/tests/consistency_model_defaults.rs
+++ b/services/ravel-server/tests/consistency_model_defaults.rs
@@ -1,0 +1,254 @@
+//! Drift check for the numeric defaults `docs/consistency-model.md` states
+//! against the constants the server derives them from (issue #1311). Both
+//! sides are read rather than restated: the code side is the constant itself,
+//! the doc side is the figure parsed out of the sentence that makes the claim.
+//! Editing either one alone fails here, which is the point. The document is
+//! normative for acknowledgement, visibility, and erasure bounds, so a stale
+//! figure in it is read as a guarantee: the query-deadline row was wrong by a
+//! factor of 22 in the direction that under-sizes a DSAR drain window.
+//!
+//! Each claim is anchored on the exact prose that introduces its figure, and
+//! every test asserts how many occurrences of its anchor the document must
+//! have, so a rewrite that drops one of the two places a quantity is stated
+//! fails rather than passing on the survivor.
+#![allow(clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+
+use ravel_maintain::config::DEFAULT_MAX_QUERY_DURATION_NS;
+use ravel_server::config::{DERIVED_MAX_SEGMENTS, DERIVED_QUERY_DEADLINE};
+
+const NS_PER_HOUR: i64 = 3_600 * 1_000_000_000;
+
+/// The prose that introduces the engine's query deadline, in both the section
+/// body and the erasure table.
+const DEADLINE_ANCHOR: &str = "the query deadline, the engine's enforced query timeout, ";
+
+/// The prose that introduces the GC protection budget the deadline fits under,
+/// in the same two places.
+const CEILING_ANCHOR: &str = "`max_query_duration`, the GC protection budget it fits under, ";
+
+/// The prose that introduces the sealed-set fan-out cap.
+const SEGMENTS_ANCHOR: &str = "`max_segments` (default ";
+
+/// `docs/consistency-model.md`, resolved from this crate's manifest directory
+/// rather than the process working directory, which differs between a
+/// crate-scoped `cargo test` and one run from the workspace root.
+fn doc_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("docs")
+        .join("consistency-model.md")
+}
+
+/// The document with every run of whitespace collapsed to a single space, so a
+/// claim the 80-column wrap split across two lines still matches one anchor.
+fn normalized_doc() -> String {
+    let path = doc_path();
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// The figure and its unit word immediately after every occurrence of
+/// `anchor`. One entry per occurrence, so a caller can require the count it
+/// expects instead of trusting the first hit. Thousands separators are
+/// accepted and stripped; the unit is the alphabetic run after the digits, and
+/// is empty when a delimiter follows them directly.
+fn figures_after(doc: &str, anchor: &str) -> Vec<(u64, String)> {
+    let mut found = Vec::new();
+    let mut rest = doc;
+    while let Some(at) = rest.find(anchor) {
+        let tail = &rest[at + anchor.len()..];
+        let digits: String = tail
+            .chars()
+            .take_while(|c| c.is_ascii_digit() || *c == ',' || *c == '_')
+            .collect();
+        let value = digits
+            .replace([',', '_'], "")
+            .parse::<u64>()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "docs/consistency-model.md states no figure after {anchor:?}: \
+                     read {digits:?} ({e}). The anchor and the figure must stay \
+                     adjacent, or this check silently stops covering the claim."
+                )
+            });
+        let unit: String = tail[digits.len()..]
+            .trim_start()
+            .chars()
+            .take_while(|c| c.is_ascii_alphabetic())
+            .collect();
+        found.push((value, unit));
+        rest = tail;
+    }
+    found
+}
+
+/// `value` with comma thousands separators, the grouping the repository's own
+/// prose uses for this magnitude.
+fn grouped(value: usize) -> String {
+    let digits = value.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (i, ch) in digits.char_indices() {
+        if i > 0 && (digits.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// The query deadline the document states is the deadline
+/// [`DERIVED_QUERY_DEADLINE`] gives an operator who sets no flag. Stated in
+/// two places, and both must agree with the constant.
+#[test]
+fn query_deadline_figure_matches_the_derived_constant() {
+    let doc = normalized_doc();
+    let figures = figures_after(&doc, DEADLINE_ANCHOR);
+    assert_eq!(
+        figures.len(),
+        2,
+        "docs/consistency-model.md must state the query deadline in both the \
+         erasure section body and the erasure table, using the phrase \
+         {DEADLINE_ANCHOR:?}; found {} occurrence(s)",
+        figures.len()
+    );
+
+    let seconds = DERIVED_QUERY_DEADLINE.as_secs();
+    assert_eq!(
+        seconds % 60,
+        0,
+        "DERIVED_QUERY_DEADLINE is {DERIVED_QUERY_DEADLINE:?}, no longer a \
+         whole number of minutes, so the document cannot state it in minutes; \
+         change the unit in both places and here together"
+    );
+    let expected = seconds / 60;
+
+    for (value, unit) in &figures {
+        assert_eq!(
+            unit, "min",
+            "the query deadline in docs/consistency-model.md must be stated in \
+             minutes to match DERIVED_QUERY_DEADLINE, not in {unit:?}"
+        );
+        assert_eq!(
+            *value, expected,
+            "docs/consistency-model.md states a query deadline of {value} min \
+             but ravel-server derives DERIVED_QUERY_DEADLINE = {expected} min. \
+             A compliance owner sizes an erasure drain window from that table, \
+             so the doc figure must track the constant."
+        );
+    }
+}
+
+/// The `max_query_duration` ceiling the same two places state is the `sys/gc`
+/// default, and the deadline really does fit under it.
+#[test]
+fn max_query_duration_ceiling_figure_matches_the_gc_default() {
+    let doc = normalized_doc();
+    let figures = figures_after(&doc, CEILING_ANCHOR);
+    assert_eq!(
+        figures.len(),
+        2,
+        "docs/consistency-model.md must state the max_query_duration ceiling \
+         beside the query deadline in both places, using the phrase \
+         {CEILING_ANCHOR:?}; found {} occurrence(s)",
+        figures.len()
+    );
+
+    assert_eq!(
+        DEFAULT_MAX_QUERY_DURATION_NS % NS_PER_HOUR,
+        0,
+        "DEFAULT_MAX_QUERY_DURATION_NS is {DEFAULT_MAX_QUERY_DURATION_NS} ns, \
+         no longer a whole number of hours, so the document cannot state it in \
+         hours"
+    );
+    let expected = DEFAULT_MAX_QUERY_DURATION_NS / NS_PER_HOUR;
+
+    for (value, unit) in &figures {
+        assert_eq!(
+            unit, "h",
+            "the max_query_duration ceiling in docs/consistency-model.md must \
+             be stated in hours to match DEFAULT_MAX_QUERY_DURATION_NS, not in \
+             {unit:?}"
+        );
+        assert_eq!(
+            i64::try_from(*value).expect("the stated ceiling fits in i64"),
+            expected,
+            "docs/consistency-model.md states a max_query_duration ceiling of \
+             {value} h but ravel-maintain's DEFAULT_MAX_QUERY_DURATION_NS is \
+             {expected} h"
+        );
+    }
+
+    // The document says the deadline fits under the ceiling. That ordering is
+    // what makes the GC protection budget cover a query the engine has not yet
+    // cancelled, so it is a claim, not a restatement.
+    let ceiling_ns =
+        u128::try_from(DEFAULT_MAX_QUERY_DURATION_NS).expect("the default ceiling is positive");
+    assert!(
+        DERIVED_QUERY_DEADLINE.as_nanos() < ceiling_ns,
+        "the derived query deadline {DERIVED_QUERY_DEADLINE:?} must fit under \
+         the default max_query_duration of {DEFAULT_MAX_QUERY_DURATION_NS} ns, \
+         which is what docs/consistency-model.md tells an operator"
+    );
+}
+
+/// The sealed-set fan-out cap the document states is the one an unset
+/// `--max-segments` reaches the engine as, [`DERIVED_MAX_SEGMENTS`], not the
+/// engine crate's much smaller compiled-in `EngineConfig::default()`.
+#[test]
+fn max_segments_figure_matches_the_derived_constant() {
+    let doc = normalized_doc();
+    let figures = figures_after(&doc, SEGMENTS_ANCHOR);
+    assert_eq!(
+        figures.len(),
+        1,
+        "docs/consistency-model.md must state the max_segments default exactly \
+         once, using the phrase {SEGMENTS_ANCHOR:?}; found {} occurrence(s)",
+        figures.len()
+    );
+
+    let (value, _unit) = &figures[0];
+    assert_eq!(
+        usize::try_from(*value).expect("the stated cap fits in usize"),
+        DERIVED_MAX_SEGMENTS,
+        "docs/consistency-model.md states a max_segments default of {value} but \
+         ravel-server derives DERIVED_MAX_SEGMENTS = {DERIVED_MAX_SEGMENTS}"
+    );
+
+    // The rendering is pinned too, so the figure stays readable at this
+    // magnitude instead of drifting to an ungrouped digit run.
+    let rendered = format!("{SEGMENTS_ANCHOR}{})", grouped(DERIVED_MAX_SEGMENTS));
+    assert!(
+        doc.contains(&rendered),
+        "docs/consistency-model.md must render the max_segments default with \
+         comma thousands separators, as {rendered:?}"
+    );
+}
+
+/// The claim the anchors rest on: the document really was read, and the
+/// erasure table that carries two of the three figures is still in it. A
+/// missing file or a renamed section would otherwise make every assertion
+/// above vacuous by never finding an anchor to check.
+#[test]
+fn the_document_and_its_erasure_table_are_present() {
+    let doc = normalized_doc();
+    assert!(
+        doc.len() > 10_000,
+        "docs/consistency-model.md read back as {} bytes, so the path is wrong \
+         or the file was truncated",
+        doc.len()
+    );
+    assert!(
+        doc.contains("## Selective subject erasure"),
+        "docs/consistency-model.md is missing the selective subject erasure \
+         section that carries the erasure stage bounds table"
+    );
+    assert!(
+        doc.contains("| Stage | Guarantee | Worst-case bound (defaults) |"),
+        "docs/consistency-model.md is missing the erasure stage bounds table \
+         header, so the table the deadline row lives in has been restructured"
+    );
+}


### PR DESCRIPTION
Two normative defaults in `docs/consistency-model.md` were wrong, and nothing
checked them. Both had been corrected once before in the chain that merged as
#1369, and both were still wrong on `main` when this started.

| doc claim | code derives |
|---|---|
| `:414` query deadline "30 s by default" | `DERIVED_QUERY_DEADLINE = Duration::from_secs(11 * 60)` (`config.rs:2176`) |
| `:312` `max_segments` "default 1024" | `DERIVED_MAX_SEGMENTS = 1_000_000` (`config.rs:2169`) |

The first is safety-relevant in the unsafe direction: it sits in the erasure
guarantee table, so a compliance owner sizing a DSAR drain window from it
believes in-flight queries drain in 30 seconds when they have eleven minutes, a
factor of 22. `:409` leaned on the same quantity without stating a figure and
conflated the query deadline with `max_query_duration`. The fix keeps the 1 h
`max_query_duration` ceiling, which does still hold, and adds one sentence
naming which of the two sizes a drain window, since conflating them is what made
the 22x error read as correct.

**The point of the change is the test, not the two numbers.** They drifted twice,
so `consistency_model_defaults.rs` now reads both sides: the constant from code,
and the figure parsed out of the doc at a named prose anchor. A test that only
read the code would let the doc drift freely, which is the actual defect.

Three properties make the parsing worth preferring over string-containment:

- the doc is read with whitespace collapsed, so the 80-column wrap splitting a
  claim across lines does not matter;
- a missing or non-adjacent figure **panics with a named message** instead of
  degrading to a pass;
- each test asserts its anchor's occurrence count (2 for the deadline, 2 for the
  ceiling, 1 for `max_segments`), so a rewrite that drops one of the two places
  a quantity is stated fails rather than passing on the survivor.

A fourth test asserts the file, the erasure section and the table header exist
at all, without which a rename would make the other three vacuous by finding no
anchor. Unit and value are compared separately, so a `30 s` regression fails on
the unit and a `12 min` regression fails on the value.

Prove-the-test ran in both directions for each row: change the constant, change
the doc.

**Row 6's premise was stale and the round wrote against reality instead.** The
issue and my spec both say the quickstart pins `0.13.0`; it pins **`0.15.0`**
(`README.md:329`, `deploy/docker-compose/ravel.yml:53`). The issue's timeline is
correct as stated — `v0.13.0` is `4bc0723f` at 2026-09-03 07:52, the alerts and
audit table registration landed 19:50 the same day, PromQL over logs later
still — but all three are in `v0.14.0` and `v0.15.0`, verified with
`git merge-base --is-ancestor`. The audit query pipeline install is in `v0.15.0`
too, so that table actually returns rows in the pinned image.

So the concrete instance is closed and the class is not: the matrix's "In
published image" column is still tied to no tag. The README now states the rule
(the matrix describes `main`; a surface landing after the pinned tag is not in
the image), the two commands that answer it next time, and the `0.13.0` case as
the concrete reason. The matrix block itself is untouched, since
`check_docs.py:check_feature` validates that column and the new prose sits
outside the `BEGIN/END SUPPORT MATRIX` markers.

Gates: fmt, `clippy -p ravel-server --all-targets`, the new test file, the lib
suite, and `check_docs.py` clean. `Refs: #1311` rather than `Fixes:`, since rows
other than 1, 2 and 6 remain.

One environment note for future dispatches, not part of this change:
`/var/lib/fleet/work` is not a durable log location on that executor pool. A
directory created there vanished mid-task under a harness sweep; `/var/tmp`
held.

Refs: #1311, #1313
