### PR TITLE
feat(sql): add a keyset page planner for the MCP paged SQL surface

### DIFF
--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -94,6 +94,7 @@ use futures::{Stream, StreamExt};
 use ravel_catalog::{Catalog, Snapshot};
 use ravel_memory::MemoryBudget;
 use ravel_promql::{LabelMatcher, MatchOp};
+use ravel_query::erasure::{ErasurePredicate, snapshot_pending_erasure_predicates};
 use ravel_query::{
     LogSegmentFetcher, QueryError, RequestBudgets, SegmentAdmission, SegmentFetcher, admit,
     request_budget_exceeded,
@@ -545,6 +546,31 @@ pub struct SqlOutcome {
     /// spilled 4 files" are different findings that a pooled total cannot tell
     /// apart.
     pub spill_by_operator: Vec<OperatorSpill>,
+    /// Which signal this statement read, resolved from its `FROM` clause. The
+    /// same value [`ExplainReport::target`] carries for the same text.
+    ///
+    /// One of the three resolve inputs a paging cursor pins (ADR-1374 D5).
+    /// They are surfaced here, on the outcome, rather than being re-derived by
+    /// the caller: a cursor is only sound if it pins what the query that
+    /// produced the page actually ran against, and a second resolution at mint
+    /// time could see a different snapshot, a different declared set, or a
+    /// newer erasure.
+    pub target: TargetSignal,
+    /// The tenant's declared column set as this query resolved it, in the
+    /// order [`crate::DeclaredColumnSource`] returned. Empty for a tenant with
+    /// no declarations.
+    ///
+    /// A cursor pins this set and D5 expires a cursor whose redemption sees a
+    /// different one, because a declaration changes what the same statement
+    /// projects.
+    pub declared_columns: Vec<DeclaredColumn>,
+    /// The erasure predicates pending in the snapshot this query read, from
+    /// the attempt that succeeded.
+    ///
+    /// A cursor pins these and D5 expires a cursor once a newer intersecting
+    /// erasure is in force, so a later page cannot return rows an erasure
+    /// accepted between pages.
+    pub pending_erasure: Vec<ErasurePredicate>,
 }
 
 /// A shared, cloneable view of the [`QueryAccounting`] for the query currently
@@ -987,6 +1013,12 @@ impl SqlExecutor {
         // one instant together.
         let declared = self.resolve_declared_columns(tenant_hash, req.now_ns).await;
 
+        // Resolved from the statement text alone, so it is attempt-independent
+        // and identical to what `explain` reports for the same text. Resolved
+        // before the loop so a cross-signal statement fails here rather than
+        // after a snapshot resolve has already been paid for.
+        let target = Self::target_signal(&req.sql)?;
+
         // At most two passes: the original and the one retry the
         // consistency model allows. Each pass gets its own QueryAccounting
         // (ADR-0044): a discarded first attempt's counts must never bleed
@@ -1007,6 +1039,10 @@ impl SqlExecutor {
             stats.resolves += 1;
             stats.attempts += 1;
             stats.segments = snapshot.segments.len();
+            // Read off this attempt's snapshot, before it is moved into
+            // `attempt`, so it describes the snapshot the returned rows were
+            // read from and not one a retry resolved afterwards.
+            let pending_erasure = snapshot_pending_erasure_predicates(&snapshot);
 
             let (result, emitted, blocks, spill, spill_by_operator, caps) = self
                 .attempt(tenant_hash, req, snapshot, &accounting, &declared)
@@ -1034,6 +1070,9 @@ impl SqlExecutor {
                         accounting: accounting.snapshot(),
                         estimate,
                         spill_by_operator,
+                        target,
+                        declared_columns: declared.clone(),
+                        pending_erasure,
                     });
                 }
                 Err(err) => match retry_decision(err.is_segment_not_found(), emitted, attempt) {
@@ -3408,6 +3447,8 @@ mod tests {
     use ravel_types::{Label, LabelSet, Sample, SeriesId, TenantId};
     use uuid::Uuid;
 
+    use crate::declared::{DeclaredType, StaticDeclaredColumns};
+
     use super::*;
 
     fn empty_store() -> Arc<InstrumentedStore<FaultStore<MemoryStore>>> {
@@ -3755,6 +3796,87 @@ mod tests {
                 matches!(err, SqlError::CrossSignalQuery),
                 "expected CrossSignalQuery for {sql:?}, got {err:?}"
             );
+        }
+    }
+
+    /// ADR-1374 D5: a cursor pins the declared column set the query it paged
+    /// resolved, so [`SqlOutcome::declared_columns`] carries that set and not
+    /// one a later resolution might see. Asserts the exact set for a tenant
+    /// with declarations and the exact empty set for a tenant with none, over
+    /// the same statement and the same store.
+    #[tokio::test]
+    async fn outcome_declared_columns_are_the_tenants_declared_set() {
+        let declared = vec![
+            DeclaredColumn::new("http_status", DeclaredType::I64),
+            DeclaredColumn::new("region", DeclaredType::Str),
+        ];
+        let store = empty_store();
+        let executor = executor_over(store.clone())
+            .with_declared_column_source(Arc::new(StaticDeclaredColumns::new(declared.clone())));
+        let request = sql_request(
+            "SELECT ts FROM logs",
+            TimeRange {
+                start_ns: 0,
+                end_ns: 2_000,
+            },
+        );
+
+        let outcome = executor
+            .execute(TenantHash([7u8; 16]), &request)
+            .await
+            .expect("a logs query over an empty store succeeds");
+        assert_eq!(
+            outcome.declared_columns, declared,
+            "the outcome must carry the tenant's declared set, in source order"
+        );
+
+        // Same statement, same store, no declared source: the default source
+        // declares nothing, so the set is exactly empty.
+        let bare = executor_over(store);
+        let bare_outcome = bare
+            .execute(TenantHash([7u8; 16]), &request)
+            .await
+            .expect("a logs query over an empty store succeeds");
+        assert_eq!(
+            bare_outcome.declared_columns,
+            Vec::<DeclaredColumn>::new(),
+            "a tenant with no declarations must carry an empty set"
+        );
+    }
+
+    /// ADR-1374 D5: a cursor pins the signal the query it paged resolved. The
+    /// outcome's target must therefore be the same value `explain` reports for
+    /// the same text, since the MCP adapter mints cursors from one and operators
+    /// read the other.
+    #[tokio::test]
+    async fn outcome_target_matches_the_explain_report_target() {
+        let store = empty_store();
+        let executor = executor_over(store);
+        let window = TimeRange {
+            start_ns: 0,
+            end_ns: 2_000,
+        };
+        let tenant_hash = TenantHash([7u8; 16]);
+
+        for (sql, expected) in [
+            ("SELECT ts FROM logs", TargetSignal::Logs),
+            ("SELECT ts FROM samples", TargetSignal::Metrics),
+            ("SELECT trace_id FROM spans", TargetSignal::Spans),
+        ] {
+            let request = sql_request(sql, window);
+            let report = executor
+                .explain(tenant_hash, &request)
+                .await
+                .expect("explain succeeds over an empty store");
+            let outcome = executor
+                .execute(tenant_hash, &request)
+                .await
+                .expect("execute succeeds over an empty store");
+            assert_eq!(
+                outcome.target, report.target,
+                "outcome and explain must agree on the target for {sql:?}"
+            );
+            assert_eq!(outcome.target, expected, "unexpected target for {sql:?}");
         }
     }
 

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -81,6 +81,7 @@ mod memory;
 mod metadata_agg;
 mod minmax;
 mod output;
+mod page_plan;
 mod provider;
 mod pushdown;
 pub mod redact;
@@ -161,6 +162,10 @@ pub use logs_udf::{HAS_WORD_UDF, has_word_udf};
 pub use memory::{CeilingBreach, TenantDelegatingPool, TenantMemoryAccountant};
 pub use metadata_agg::{METADATA_ONLY_AGGREGATE_RULE, MetadataOnlyAggregate, MetadataOnlyExec};
 pub use output::QueryOutput;
+pub use page_plan::{
+    NotTotalOrder, OrderTerm, PAGE_ALIAS, PagePlan, PagePlanError, ResumePosition, ResumeValue,
+    plan_page,
+};
 pub use provider::RavelTableProvider;
 pub use pushdown::Pushdown;
 /// Re-exported beside [`SegmentPin`], whose `level` field has this type: a

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -173,6 +173,11 @@ pub use pushdown::Pushdown;
 /// dependency to name a value it can already read off the struct.
 #[cfg(feature = "pin-codec")]
 pub use ravel_catalog::SegmentLevel;
+/// Re-exported for [`SqlOutcome::pending_erasure`], which is typed as a
+/// `Vec` of these: a caller reading that field off the outcome would
+/// otherwise need its own `ravel-query` dependency to name what it is holding.
+/// Same reason as the [`SegmentLevel`] re-export above.
+pub use ravel_query::erasure::ErasurePredicate;
 pub use redact::{RedactError, redact};
 pub use schema::{internal_schema, public_schema};
 pub use session::{

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -216,7 +216,9 @@
 //!   `|> order_by` cannot reshape the rows after the body;
 //! - `WITH FILL` is [`PagePlanError::UnsupportedOrderOption`], which is the
 //!   only ClickHouse ordering form that adds rows, and its clause-level
-//!   sibling `INTERPOLATE` is [`PagePlanError::UnsupportedOrderingClause`];
+//!   sibling `INTERPOLATE` is [`PagePlanError::UnsupportedOrderingClause`] at
+//!   every depth: the clause is refused rather than reproduced, and only the
+//!   outermost `ORDER BY` reaches [`statement_order_terms`];
 //! - the four dialect clauses that hang off a `Query` rather than off its
 //!   body -- `SETTINGS`, `FORMAT`, a `FOR UPDATE`/`FOR SHARE` lock, and
 //!   `FOR XML`/`FOR JSON` -- are
@@ -433,6 +435,11 @@ pub enum PagePlanError {
     /// so the page was not a differently ordered answer: it was a success
     /// where the caller's own statement is an error, under semantics the
     /// caller never asked for.
+    ///
+    /// Raised at every depth, by [`NestedShapeGuard`] rather than by
+    /// [`statement_order_terms`], because that reads the outermost `ORDER BY`
+    /// alone: a clause on a subquery's ordering went into the derived table
+    /// verbatim and the same false total-order claim came back one level down.
     #[error("the ORDER BY clause `{clause}` cannot be paged")]
     UnsupportedOrderingClause { clause: &'static str },
 
@@ -777,6 +784,11 @@ impl Visitor for NestedShapeGuard<'_> {
     /// place the rewrite decided about a node from a subset of it. It read
     /// three of the ten fields, and the four dialect clauses it did not read
     /// are re-emitted verbatim by `Display for Query` into the derived table.
+    ///
+    /// `order_by` is read here for its `INTERPOLATE` alone, which is the one
+    /// part of an ordering this module refuses rather than reproduces. The
+    /// terms are [`statement_order_terms`]'s, and that reads the outermost
+    /// `Query` only.
     fn pre_visit_query(&mut self, query: &Query) -> ControlFlow<()> {
         let Query {
             // Each CTE carries its own `Query`, which this same visitor
@@ -787,12 +799,13 @@ impl Visitor for NestedShapeGuard<'_> {
             // Visited in turn. Its `SELECT` bodies are `pre_visit_select`
             // below, which is where `TOP` and `INTO` are read.
             body: _,
-            // The outermost one is the effective ordering, read by
-            // `statement_order_terms`. An inner one is re-emitted verbatim, so
-            // every page runs the same ordering over the same rows: it cannot
-            // make consecutive pages be pages of different results, which is
-            // what this guard refuses.
-            order_by: _,
+            // The ordering ITSELF is not this guard's business: the outermost
+            // one is the effective ordering, read by `statement_order_terms`,
+            // and an inner one is re-emitted verbatim, so every page runs the
+            // same ordering over the same rows. Its `INTERPOLATE` is, because
+            // that clause is refused rather than reproduced and only the
+            // outermost `OrderBy` reaches `statement_order_terms`.
+            order_by,
             limit_clause,
             fetch,
             locks,
@@ -826,6 +839,15 @@ impl Visitor for NestedShapeGuard<'_> {
         };
         if let Some(clause) = clause {
             *self.found = Some(PagePlanError::UnsupportedQueryClause { clause });
+            return ControlFlow::Break(());
+        }
+        // Last, so the clause a statement spells alongside this one still
+        // reports itself: `SETTINGS limit = 2` is the row limit, and naming
+        // the `INTERPOLATE` instead would point the caller at the wrong repair.
+        if order_by.as_ref().is_some_and(|o| o.interpolate.is_some()) {
+            *self.found = Some(PagePlanError::UnsupportedOrderingClause {
+                clause: "INTERPOLATE",
+            });
             return ControlFlow::Break(());
         }
         ControlFlow::Continue(())
@@ -1797,19 +1819,21 @@ fn shape_of<'a>(query: &'a Query) -> Option<SelectShape<'a>> {
 /// whenever it only orders, so the clause was dropped with it and the page
 /// ran under an ordering the caller had not written.
 fn statement_order_terms(query: &Query) -> Result<Vec<OrderTerm>, PagePlanError> {
-    let Some(OrderBy { kind, interpolate }) = &query.order_by else {
+    let Some(OrderBy {
+        kind,
+        // `INTERPOLATE` is defined only in terms of a `WITH FILL`, which is
+        // refused per term below, so it cannot add a row on its own. It is
+        // still refused rather than ignored, because DataFusion rejects the
+        // statement and a page that silently drops the clause answers a
+        // statement the engine itself calls an error. The refusal is
+        // `NestedShapeGuard`'s, which has already run over this same `Query`:
+        // this function sees the outermost `ORDER BY` only, and the clause
+        // reaches the derived table from any depth.
+        interpolate: _,
+    }) = &query.order_by
+    else {
         return Ok(Vec::new());
     };
-    // `INTERPOLATE` is defined only in terms of a `WITH FILL`, which is
-    // refused per term below, so it cannot add a row on its own. That is why
-    // it is refused rather than ignored: DataFusion rejects the statement, and
-    // a page that silently drops the clause answers a statement the engine
-    // itself calls an error.
-    if interpolate.is_some() {
-        return Err(PagePlanError::UnsupportedOrderingClause {
-            clause: "INTERPOLATE",
-        });
-    }
     let exprs = match kind {
         OrderByKind::All(_) => return Err(PagePlanError::OrderByAll),
         OrderByKind::Expressions(exprs) => exprs,
@@ -2944,6 +2968,10 @@ mod tests {
     /// [`interpolate_is_an_error_datafusion_raises_and_the_page_would_not`]
     /// is the half of this that text cannot settle: the dropped clause turns
     /// an engine error into a success.
+    ///
+    /// [`refuses_an_interpolate_clause_at_every_nesting_depth`] is the other
+    /// half: the outermost `ORDER BY` is one of five positions the clause
+    /// reaches the derived table from.
     #[test]
     fn refuses_an_interpolate_clause_on_the_ordering() {
         let sql = "SELECT ts, series_id FROM samples ORDER BY ts, series_id \
@@ -2982,6 +3010,65 @@ mod tests {
         )
         .expect("the same ordering without the clause pages");
         assert_eq!(plan.not_total, None);
+    }
+
+    /// `INTERPOLATE` is refused wherever the clause sits, not on the outermost
+    /// `ORDER BY` alone.
+    ///
+    /// [`statement_order_terms`] reads the outermost `ORDER BY` and nothing
+    /// else, so the refusal above covered one position out of five. Every
+    /// other position is a `Query` of its own that `Display for Query`
+    /// re-emits verbatim into the derived table, and the page then planned
+    /// with `not_total: None` over a statement DataFusion raises on. The
+    /// derived-table and CTE spellings were refused before this, but by the
+    /// nullability guards on an unrelated term, so neither said anything about
+    /// the clause.
+    #[test]
+    fn refuses_an_interpolate_clause_at_every_nesting_depth() {
+        let inner = "SELECT ts FROM samples ORDER BY ts INTERPOLATE (value AS value)";
+        let cases = [
+            // The outermost position, which `statement_order_terms` already
+            // covered. Here so the case list is every position rather than
+            // every position the guard added.
+            "SELECT ts, series_id FROM samples ORDER BY ts INTERPOLATE (value AS value)"
+                .to_string(),
+            // A subquery in `WHERE`.
+            format!("SELECT * FROM samples WHERE ts IN ({inner})"),
+            // A scalar subquery in the projection.
+            format!("SELECT ts, series_id, ({inner}) AS m FROM samples ORDER BY ts, series_id"),
+            // A derived table in `FROM`.
+            format!("SELECT ts FROM ({inner}) AS d ORDER BY ts"),
+            // A CTE.
+            format!("WITH c AS ({inner}) SELECT ts FROM samples ORDER BY ts"),
+            // An arm of a set operation.
+            format!("SELECT ts FROM samples UNION ALL {inner}"),
+        ];
+        for sql in cases {
+            let err = plan_page(&sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::UnsupportedOrderingClause {
+                    clause: "INTERPOLATE",
+                },
+                "unexpected refusal for {sql:?}"
+            );
+            assert_eq!(
+                err.to_string(),
+                "the ORDER BY clause `INTERPOLATE` cannot be paged"
+            );
+        }
+
+        // The same statements with the clause gone are not refused for this
+        // reason, so the refusal is about the clause rather than about the
+        // nesting it was written in.
+        let clean = "SELECT ts FROM samples ORDER BY ts";
+        for sql in [
+            format!("SELECT * FROM samples WHERE ts IN ({clean})"),
+            format!("SELECT ts, series_id, ({clean}) AS m FROM samples ORDER BY ts, series_id"),
+        ] {
+            let plan = plan_page(&sql, None).expect("the same nesting without the clause pages");
+            assert_eq!(plan.not_total, None, "{sql:?}");
+        }
     }
 
     /// The four dialect clauses that hang off a `Query` are refused at every

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -182,10 +182,42 @@
 //! The page statement wraps the caller's own statement as a derived table:
 //!
 //! ```text
-//! SELECT * FROM (<statement, its own ORDER BY removed>) AS ravel_page
+//! SELECT * FROM (<statement, its own ORDER BY removed when it only orders>) AS ravel_page
 //!   [WHERE <keyset predicate>]
 //!   ORDER BY <effective terms>
 //! ```
+//!
+//! The caller's own `ORDER BY` is dropped from the derived table only where it
+//! ORDERS the result. Where it SELECTS the result, it is preserved, because
+//! dropping it changes which rows come back rather than which order they come
+//! back in. [`ordering_selects_rows`] is that distinction, and the module's
+//! other refusals are what make its list short: every construct whose row set
+//! reads the statement's own ordering is refused before the rewrite runs,
+//! except one.
+//!
+//! `DISTINCT ON (...)` is that one. The ordering chooses WHICH row of each
+//! `ON` group survives, so `SELECT DISTINCT ON (series_id) ts, series_id FROM
+//! samples ORDER BY series_id, ts DESC` asks for each series' LAST sample and a
+//! page rendered without the inner ordering returned its first, with no error
+//! and `not_total` reported as usual.
+//!
+//! The rest of that class does not reach here:
+//!
+//! - a row limit in any spelling (`LIMIT`, `OFFSET`, `FETCH`, ClickHouse's
+//!   `LIMIT ... BY`, and `TOP`) is [`PagePlanError::RowLimitInStatement`] at
+//!   every depth, which also takes `FETCH ... WITH TIES` with it;
+//! - a pipe operator is [`PagePlanError::PipeOperator`], so a `|> limit` or a
+//!   `|> order_by` cannot reshape the rows after the body;
+//! - `WITH FILL` is [`PagePlanError::UnsupportedOrderOption`], which is the
+//!   only ClickHouse ordering form that adds rows (an `INTERPOLATE` is defined
+//!   only in terms of one, so it cannot change a row set on its own).
+//!
+//! A window function is NOT in the class: `OVER (ORDER BY ...)` carries its
+//! own ordering and no SQL window inherits the statement's. It is still paged
+//! correctly for a second reason, which is the wrap itself: the window is
+//! computed inside the derived table over all the statement's rows, while the
+//! keyset predicate filters outside it, so `count(*) OVER ()` reports the same
+//! total on every page rather than counting down as the walk advances.
 //!
 //! The wrap is what makes the keyset predicate land on the statement's OUTPUT
 //! rows. Injected into the caller's own `WHERE`, it would filter before any
@@ -1846,17 +1878,50 @@ fn non_identity_shape(query: &Query, target: PageTarget) -> Option<&'static str>
     }
 }
 
+/// Whether the statement's own `ORDER BY` decides WHICH rows it returns rather
+/// than only the order they come back in.
+///
+/// The distinction is what [`render_statement`] strips the inner ordering on.
+/// For a statement where the ordering only orders, the outer one dominates and
+/// the inner one is a second sort of the same rows; for a statement where it
+/// selects, dropping it delivers different rows under the same `not_total`
+/// report, which is a wrong answer rather than a slow one.
+///
+/// `DISTINCT ON (...)` is the only construct that reaches here and reads the
+/// ordering: it keeps the FIRST row of each `ON` group under it. The rest of
+/// the class -- every row limit spelling, a pipe operator, and `WITH FILL` --
+/// is refused before the rewrite runs (see the module docs), and a window
+/// function is not in the class at all, because `OVER (ORDER BY ...)` carries
+/// its own ordering and no window inherits the statement's.
+///
+/// Read off the outermost body alone, which is the only ordering
+/// [`render_statement`] removes. An inner `Query` keeps its own `ORDER BY`
+/// verbatim, and a set operation's arm is a bare `SetExpr::Select` that has no
+/// ordering of its own to read: the ordering written after a set operation
+/// belongs to the operation's result, so no arm's `DISTINCT ON` can consume
+/// it.
+fn ordering_selects_rows(query: &Query) -> bool {
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return false;
+    };
+    matches!(select.distinct, Some(Distinct::On(_)))
+}
+
 /// Render the page statement.
 fn render_statement(
     query: &Query,
     terms: &[OrderTerm],
     resume: Option<&ResumePosition>,
 ) -> Result<String, PagePlanError> {
-    // The caller's own `ORDER BY` is dropped from the derived table: the
-    // effective ordering is applied once, outside, where the keyset predicate
-    // is. Leaving it would order the same rows twice.
+    // The caller's own `ORDER BY` is dropped from the derived table when it
+    // only orders: the effective ordering is applied once, outside, where the
+    // keyset predicate is, and leaving it would order the same rows twice. It
+    // is kept when the row set itself reads it, which is a different statement
+    // rather than the same one sorted twice.
     let mut inner = query.clone();
-    inner.order_by = None;
+    if !ordering_selects_rows(&inner) {
+        inner.order_by = None;
+    }
 
     let ordering = terms
         .iter()

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -2079,6 +2079,192 @@ mod tests {
         );
     }
 
+    /// The ClickBench corpus, the largest body of real statements this
+    /// repository holds, read from where the benchmarks keep it rather than
+    /// copied, so a corpus edit shows up here as a failing count.
+    const CLICKBENCH_CORPUS: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/clickbench/hits.corpus.json"
+    ));
+
+    /// Whether a statement carries an `ORDER BY`, which is what makes it a
+    /// candidate for paging at all.
+    fn statement_has_an_order_by(sql: &str) -> bool {
+        sql.split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_ascii_uppercase()
+            .contains("ORDER BY")
+    }
+
+    /// The trailing `LIMIT n [OFFSET m]` of a statement, removed.
+    ///
+    /// A refusal for a row limit is not a prover gap: a page IS a limit, so a
+    /// statement carrying its own is refused by design and there is nothing
+    /// to widen. Setting that clause aside is what makes the rest of the
+    /// tally a measurement of the nullability prover.
+    fn without_a_trailing_row_limit(sql: &str) -> String {
+        let upper = sql.to_ascii_uppercase();
+        let Some(at) = upper.rfind("LIMIT ") else {
+            return sql.to_string();
+        };
+        let tail = sql[at + "LIMIT ".len()..].trim();
+        let mut words = tail.split_whitespace();
+        let digits = |word: &str| !word.is_empty() && word.bytes().all(|b| b.is_ascii_digit());
+        let trailing = match (words.next(), words.next(), words.next(), words.next()) {
+            (Some(rows), None, ..) => digits(rows),
+            (Some(rows), Some(offset), Some(skipped), None) => {
+                digits(rows) && offset.eq_ignore_ascii_case("OFFSET") && digits(skipped)
+            }
+            _ => false,
+        };
+        if trailing {
+            sql[..at].trim_end().to_string()
+        } else {
+            sql.to_string()
+        }
+    }
+
+    /// One statement's outcome, as the label the tally counts.
+    ///
+    /// A refusal is labelled by its variant, and an unproven-nullability
+    /// refusal also by which link of the proof is missing: the two are
+    /// different findings, and collapsing them would hide a prover gap
+    /// widening into a real hazard or the reverse.
+    fn page_plan_outcome(sql: &str) -> String {
+        match plan_page(sql, None) {
+            Ok(plan) if plan.total_order() => "plans, total order".to_string(),
+            Ok(_) => "plans, not a total order".to_string(),
+            Err(PagePlanError::Invalid(_)) => "Invalid".to_string(),
+            Err(PagePlanError::CrossSignal) => "CrossSignal".to_string(),
+            Err(PagePlanError::RowLimitInStatement) => "RowLimitInStatement".to_string(),
+            Err(PagePlanError::PipeOperator) => "PipeOperator".to_string(),
+            Err(PagePlanError::NoOrdering { .. }) => "NoOrdering".to_string(),
+            Err(PagePlanError::OrderByAll) => "OrderByAll".to_string(),
+            Err(PagePlanError::OrderTermNotColumn { .. }) => "OrderTermNotColumn".to_string(),
+            Err(PagePlanError::OrderTermNotProjected { .. }) => "OrderTermNotProjected".to_string(),
+            Err(PagePlanError::UnsupportedOrderOption { .. }) => {
+                "UnsupportedOrderOption".to_string()
+            }
+            Err(PagePlanError::OrderTermNullable { .. }) => "OrderTermNullable".to_string(),
+            Err(PagePlanError::OrderTermNullabilityUnknown { reason, .. }) => {
+                format!("OrderTermNullabilityUnknown: {reason}")
+            }
+            Err(PagePlanError::ResumeArity { .. }) => "ResumeArity".to_string(),
+            Err(PagePlanError::NonFiniteResumeValue) => "NonFiniteResumeValue".to_string(),
+        }
+    }
+
+    fn tally(outcomes: &BTreeMap<String, usize>, prefix: &str) -> usize {
+        outcomes
+            .iter()
+            .filter(|(label, _)| label.starts_with(prefix))
+            .map(|(_, count)| *count)
+            .sum()
+    }
+
+    fn expected(pairs: &[(&str, usize)]) -> BTreeMap<String, usize> {
+        pairs
+            .iter()
+            .map(|(label, count)| ((*label).to_string(), *count))
+            .collect()
+    }
+
+    /// What fraction of the ClickBench corpus this planner can page, pinned
+    /// as exact counts.
+    ///
+    /// This is the figure the tool is judged on, so it is asserted rather
+    /// than printed. Every number here is exact: a bare inequality would
+    /// pass while the planner regressed to refusing everything, which is the
+    /// direction that costs a caller a capability rather than correctness.
+    ///
+    /// Two passes. The first is the corpus as written, where 32 of the 43
+    /// statements carry their own `LIMIT` and are refused for that alone.
+    /// The second strips a trailing `LIMIT n [OFFSET m]`, which is what
+    /// exposes the nullability prover underneath.
+    #[test]
+    fn the_clickbench_corpus_page_plan_outcomes_are_pinned() {
+        let corpus: serde_json::Value =
+            serde_json::from_str(CLICKBENCH_CORPUS).expect("corpus parses");
+        let entries = corpus["entries"].as_array().expect("corpus has entries");
+
+        let mut statements = 0usize;
+        let mut ordered = 0usize;
+        let mut as_written: BTreeMap<String, usize> = BTreeMap::new();
+        let mut without_row_limit: BTreeMap<String, usize> = BTreeMap::new();
+
+        for entry in entries {
+            let sql = entry["sql"].as_str().expect("entry has sql");
+            statements += 1;
+            if statement_has_an_order_by(sql) {
+                ordered += 1;
+            }
+            *as_written.entry(page_plan_outcome(sql)).or_default() += 1;
+            *without_row_limit
+                .entry(page_plan_outcome(&without_a_trailing_row_limit(sql)))
+                .or_default() += 1;
+        }
+
+        assert_eq!(statements, 43, "corpus statement count");
+        assert_eq!(ordered, 32, "corpus statements carrying an ORDER BY");
+
+        assert_eq!(
+            as_written,
+            expected(&[
+                ("NoOrdering", 10),
+                ("OrderTermNotColumn", 1),
+                ("RowLimitInStatement", 32),
+            ]),
+            "outcomes for the corpus as written",
+        );
+        assert_eq!(tally(&as_written, "plans"), 0, "plans, as written");
+        assert_eq!(
+            statements - tally(&as_written, "plans"),
+            43,
+            "refusals, as written",
+        );
+
+        let mut want = expected(&[
+            ("NoOrdering", 11),
+            ("OrderTermNotColumn", 5),
+            ("OrderTermNotProjected", 2),
+            ("plans, not a total order", 1),
+        ]);
+        want.insert(
+            format!(
+                "OrderTermNullabilityUnknown: {}",
+                unproven::NOT_A_BARE_COLUMN
+            ),
+            23,
+        );
+        want.insert(
+            format!(
+                "OrderTermNullabilityUnknown: {}",
+                unproven::NOT_A_SCHEMA_COLUMN
+            ),
+            1,
+        );
+        assert_eq!(
+            without_row_limit, want,
+            "outcomes once a trailing row limit is set aside",
+        );
+        assert_eq!(
+            tally(&without_row_limit, "plans"),
+            1,
+            "plans, row limit set aside",
+        );
+        assert_eq!(
+            statements - tally(&without_row_limit, "plans"),
+            42,
+            "refusals, row limit set aside",
+        );
+        assert_eq!(
+            tally(&without_row_limit, "OrderTermNullab"),
+            24,
+            "nullability refusals, row limit set aside",
+        );
+    }
+
     /// A `samples` statement with no ORDER BY at all is pageable: the row
     /// identity is a complete ordering on its own, so the planner imposes it
     /// rather than refusing.

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -73,14 +73,24 @@
 //! ([`PagePlanError::OrderTermNullable`]): a keyset comparison against NULL is
 //! NULL, so the rows whose term is NULL match no disjunct and appear on no
 //! page at all. That is a wrong answer on both the total and the not-total
-//! path, because the keyset predicate is what resumes both. Only a term that
-//! the text proves NON NULL is admitted: it has to be a bare reference to a
-//! column the target table's public schema declares non-nullable, either
-//! directly or through an alias over one. Everything else is refused,
-//! including a projected expression (whose nullability no schema lookup
-//! answers), a declared column (all nullable), a set-operation body (whose
-//! projection is not readable from the text), an output name projected twice
-//! under different sources, and a statement with no base table at all.
+//! path, because the keyset predicate is rendered whenever a resume is given
+//! and is therefore what resumes both. `not_total: Some(..)` rescues nothing
+//! here: reporting is not a substitute for refusing.
+//!
+//! Only a term the text proves NON NULL is admitted, and the proof is a
+//! schema lookup that holds end to end only when the output name is a bare
+//! reference to a column of the `FROM` relation AND that relation is the
+//! target base table itself. [`SchemaBasis`] is what settles the second half:
+//! a derived table, a CTE, a join, or a `ROLLUP`/`CUBE`/`GROUPING SETS`
+//! grouping each leave the schema answering about a column the ordered value
+//! did not come from.
+//!
+//! The refusal says which of two things went wrong.
+//! [`PagePlanError::OrderTermNullable`] means the term CAN be NULL: the
+//! schema declares that column nullable, and the caller has to order by
+//! something else. [`PagePlanError::OrderTermNullabilityUnknown`] means the
+//! text does not settle it, and names the missing link, because a caller told
+//! that `count(*)` "is not known to be NON NULL" has no repair to make.
 //!
 //! # The rewrite
 //!
@@ -293,6 +303,26 @@ pub enum PagePlanError {
     )]
     OrderTermNullable { column: String },
 
+    /// An `ORDER BY` term whose nullability the text does not settle either
+    /// way.
+    ///
+    /// Distinct from [`Self::OrderTermNullable`], which says the term CAN be
+    /// NULL, and the distinction is the caller's repair. A caller told that
+    /// `count(*)` "is not known to be NON NULL" has nothing to fix and no way
+    /// to tell a planner gap from a real hazard; a caller told which link of
+    /// the proof is missing can rewrite around it, by ordering on a schema
+    /// column rather than a declared one, or by lifting the term out of a
+    /// derived table.
+    #[error(
+        "the ORDER BY term `{column}` cannot be proved NON NULL from the statement \
+         text ({reason}), and a keyset comparison against NULL selects no rows, so \
+         the rows whose `{column}` is NULL would appear on no page"
+    )]
+    OrderTermNullabilityUnknown {
+        column: String,
+        reason: &'static str,
+    },
+
     /// The resume tuple does not have one value per effective term.
     #[error("the resume position has {found} values for {expected} ORDER BY terms")]
     ResumeArity { expected: usize, found: usize },
@@ -452,11 +482,21 @@ pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan,
     }
     // Every effective term, the appended tiebreak included: a NULL anywhere in
     // the ordering drops the rows it covers from every page.
+    let basis = schema_basis(&query, target);
     for term in &terms {
-        if !term_is_non_nullable(target, &projection, &term.column) {
-            return Err(PagePlanError::OrderTermNullable {
-                column: term.column.clone(),
-            });
+        match term_nullability(&basis, &projection, &term.column) {
+            NullProof::NonNull => {}
+            NullProof::Nullable => {
+                return Err(PagePlanError::OrderTermNullable {
+                    column: term.column.clone(),
+                });
+            }
+            NullProof::Unproven(reason) => {
+                return Err(PagePlanError::OrderTermNullabilityUnknown {
+                    column: term.column.clone(),
+                    reason,
+                });
+            }
         }
     }
 
@@ -643,14 +683,19 @@ impl Projection {
         }
     }
 
-    /// The target-table column the output column `column` is a bare reference
-    /// to, or `None` when the text does not name one.
+    /// The column of the `FROM` RELATION that the output column `column` is a
+    /// bare reference to, or `None` when the text does not name one.
     ///
     /// A wildcard answers with the name itself: every output column of a
     /// `SELECT *` is a column of the `FROM` relation under its own name.
     /// `Unknown` answers `None` rather than guessing, which is what makes a
     /// set-operation body fail the nullability check instead of passing it
     /// unexamined.
+    ///
+    /// The name this returns is a name in the `FROM` relation, which is the
+    /// target table's own column only when that relation IS the target table.
+    /// [`SchemaBasis`] is what settles that, and every caller has to consult
+    /// it before turning this name into a schema lookup.
     fn source_column<'a>(&'a self, column: &'a str) -> Option<&'a str> {
         match self {
             Projection::Wildcard => Some(column),
@@ -700,20 +745,152 @@ fn projection_of(query: &Query) -> Projection {
     Projection::Columns(names)
 }
 
-/// Whether the text proves the effective term `column` is NON NULL.
+/// Whether an output name may be resolved against the target table's public
+/// schema at all.
 ///
-/// The proof has to hold end to end: the output column has to be a bare
-/// reference to a column of the target table (so a schema lookup is about the
-/// right value at all), and that column has to be declared non-nullable in the
-/// table's public schema. A statement with no base table has no schema to ask,
-/// and a declared column is absent from the static schema and nullable
-/// anyway, so both answer false.
-fn term_is_non_nullable(target: PageTarget, projection: &Projection, column: &str) -> bool {
+/// [`Projection::source_column`] maps an output name to a name in the `FROM`
+/// relation. Asking the target table's schema about that name is sound only
+/// when the `FROM` relation IS that base table: otherwise the schema answers
+/// about a column the value did not come from, and a NOT NULL declaration
+/// there says nothing about the value being ordered on.
+enum SchemaBasis {
+    /// Output names resolve against this table's public schema.
+    Resolvable(&'static str),
+    /// They do not, for this reason, which the refusal quotes.
+    Unresolvable(&'static str),
+}
+
+/// The reasons a [`PagePlanError::OrderTermNullabilityUnknown`] can carry,
+/// named rather than written inline so a test pins which link of the proof
+/// was missing without restating the sentence, and so two paths cannot drift
+/// into two spellings of one reason.
+mod unproven {
+    pub(super) const NOT_A_BARE_COLUMN: &str = "it is not a bare reference to a column of the FROM relation, so no schema \
+         lookup describes it";
+    pub(super) const NO_BASE_TABLE: &str = "the statement has no base table";
+    pub(super) const WITH_CLAUSE: &str =
+        "a WITH clause can declare the target table's own name and shadow it";
+    pub(super) const SET_OPERATION: &str = "a set operation's projection is not readable here";
+    pub(super) const NOT_ONE_RELATION: &str = "its FROM clause is not one relation";
+    pub(super) const JOINED: &str = "a join leaves an output name resolvable against more than one relation, and an \
+         outer join nulls one side of it";
+    pub(super) const DERIVED_RELATION: &str =
+        "its FROM relation is a derived table or a table function, not the target table";
+    pub(super) const OTHER_RELATION: &str = "its FROM relation is not the target table itself";
+    pub(super) const GROUPING_NULLS: &str = "a ROLLUP, CUBE or GROUPING SETS grouping nulls a grouping column in its \
+         super-aggregate rows";
+    pub(super) const NOT_A_SCHEMA_COLUMN: &str = "it is not a column of the target table's public schema, so it is a declared \
+         column whose nullability the text does not carry";
+    pub(super) const NO_PUBLIC_SCHEMA: &str = "the target table has no public schema here";
+}
+
+/// Whether the statement's own `FROM` relation is the target base table, so
+/// that the table's public schema describes the values it projects.
+///
+/// The three shapes this refuses each produced a plan whose keyset predicate
+/// silently dropped every row with a NULL order term, from every page, with
+/// no error:
+///
+/// - a derived table or a CTE, where the output name is the inner query's
+///   own (`SELECT * FROM (SELECT nullif(value, 0) AS ts, series_id FROM
+///   samples) x ORDER BY ts` proved `ts` off `samples.ts` while the value was
+///   `nullif(value, 0)`);
+/// - the nullable side of an outer join, where the base column really is NOT
+///   NULL and is still NULL for every unmatched row;
+/// - `ROLLUP`, `CUBE` and `GROUPING SETS`, where the schema lookup is correct
+///   and the grouping construct introduces the NULL in the super-aggregate
+///   row.
+///
+/// Two of the refusals are wider than those shapes strictly need, and both
+/// are deliberate. An inner or cross join is refused alongside the outer
+/// ones, because an output name under a join is resolvable against more than
+/// one relation and a single-table lookup cannot say which. A `WITH` clause
+/// is refused even when the `FROM` names the base table, because a CTE can
+/// declare that same name and shadow it.
+fn schema_basis(query: &Query, target: PageTarget) -> SchemaBasis {
     let Some(table) = target.table_name() else {
+        return SchemaBasis::Unresolvable(unproven::NO_BASE_TABLE);
+    };
+    if query.with.is_some() {
+        return SchemaBasis::Unresolvable(unproven::WITH_CLAUSE);
+    }
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return SchemaBasis::Unresolvable(unproven::SET_OPERATION);
+    };
+    let [only] = select.from.as_slice() else {
+        return SchemaBasis::Unresolvable(unproven::NOT_ONE_RELATION);
+    };
+    if !only.joins.is_empty() {
+        return SchemaBasis::Unresolvable(unproven::JOINED);
+    }
+    let TableFactor::Table {
+        name, args: None, ..
+    } = &only.relation
+    else {
+        return SchemaBasis::Unresolvable(unproven::DERIVED_RELATION);
+    };
+    if bare_name(name).as_deref() != Some(table) {
+        return SchemaBasis::Unresolvable(unproven::OTHER_RELATION);
+    }
+    if grouping_can_null_a_grouping_column(&select.group_by) {
+        return SchemaBasis::Unresolvable(unproven::GROUPING_NULLS);
+    }
+    SchemaBasis::Resolvable(table)
+}
+
+/// Whether the `GROUP BY` can emit a row where a grouping column is NULL even
+/// though that column is declared NOT NULL.
+///
+/// `ROLLUP`, `CUBE`, `GROUPING SETS` and ClickHouse's `WITH TOTALS` each add
+/// a super-aggregate row whose unaggregated grouping columns are NULL. Both
+/// spellings count: the modifier form (`GROUP BY a WITH ROLLUP`) and the
+/// expression form (`GROUP BY ROLLUP(a)`). A plain `GROUP BY` and
+/// `GROUP BY ALL` add no such row, so neither is refused here.
+fn grouping_can_null_a_grouping_column(group_by: &GroupByExpr) -> bool {
+    let GroupByExpr::Expressions(exprs, modifiers) = group_by else {
         return false;
     };
+    !modifiers.is_empty()
+        || exprs.iter().any(|expr| {
+            matches!(
+                expr,
+                SqlExpr::Rollup(_) | SqlExpr::Cube(_) | SqlExpr::GroupingSets(_)
+            )
+        })
+}
+
+/// What the statement's text says about whether an effective term can be
+/// NULL.
+///
+/// The two negative answers are kept apart because they call for different
+/// repairs: `Nullable` says the term CAN be NULL and the caller has to order
+/// by something else, while `Unproven` says the text does not settle it, and
+/// names what would.
+enum NullProof {
+    /// Provably NON NULL from the text alone.
+    NonNull,
+    /// The target table's public schema declares this column nullable.
+    Nullable,
+    /// Neither proved. The string is the reason the refusal quotes.
+    Unproven(&'static str),
+}
+
+/// What the text says about the effective term `column`.
+///
+/// The proof has to hold end to end: the output column has to be a bare
+/// reference to a column of the `FROM` relation, that relation has to be the
+/// target base table itself (see [`schema_basis`]), and the column has to be
+/// declared non-nullable in the table's public schema. A declared column is
+/// absent from the static schema, and whether it exists at all depends on the
+/// tenant's declarations rather than on the text, so it is `Unproven` rather
+/// than either answer.
+fn term_nullability(basis: &SchemaBasis, projection: &Projection, column: &str) -> NullProof {
     let Some(source) = projection.source_column(column) else {
-        return false;
+        return NullProof::Unproven(unproven::NOT_A_BARE_COLUMN);
+    };
+    let table = match basis {
+        SchemaBasis::Resolvable(table) => *table,
+        SchemaBasis::Unresolvable(reason) => return NullProof::Unproven(reason),
     };
     let schema = match table {
         SAMPLES_TABLE => public_schema(),
@@ -721,11 +898,13 @@ fn term_is_non_nullable(target: PageTarget, projection: &Projection, column: &st
         SPANS_TABLE => spans_schema(),
         ALERTS_TABLE => alerts_schema(),
         AUDIT_TABLE => audit_schema(),
-        _ => return false,
+        _ => return NullProof::Unproven(unproven::NO_PUBLIC_SCHEMA),
     };
-    schema
-        .field_with_name(source)
-        .is_ok_and(|field| !field.is_nullable())
+    match schema.field_with_name(source) {
+        Ok(field) if !field.is_nullable() => NullProof::NonNull,
+        Ok(_) => NullProof::Nullable,
+        Err(_) => NullProof::Unproven(unproven::NOT_A_SCHEMA_COLUMN),
+    }
 }
 
 /// The parts of a single `SELECT` body that decide whether it projects the
@@ -1387,11 +1566,13 @@ mod tests {
             ),
             // Nullable ordering terms: a projected expression whose
             // nullability no schema lookup answers, and a column the schema
-            // declares nullable outright.
+            // declares nullable outright. The two carry different refusals,
+            // because the repairs differ.
             (
                 "SELECT nullif(value, 0) AS v, ts, series_id FROM samples ORDER BY v",
-                PagePlanError::OrderTermNullable {
+                PagePlanError::OrderTermNullabilityUnknown {
                     column: "v".to_string(),
+                    reason: unproven::NOT_A_BARE_COLUMN,
                 },
             ),
             (
@@ -1574,32 +1755,20 @@ mod tests {
     /// both. Proof of NON NULL has to come from the statement's own text, and
     /// it does for a bare reference to a column the target's public schema
     /// declares non-nullable and for nothing else.
+    ///
+    /// These are the cases where the schema ANSWERS, and answers nullable.
+    /// The cases where it cannot answer carry
+    /// [`PagePlanError::OrderTermNullabilityUnknown`] instead and are pinned
+    /// by the tests below; the split matters because only these have a repair
+    /// the caller can make from the message alone.
     #[test]
     fn refuses_an_ordering_term_that_can_be_null() {
         let cases: Vec<(&str, &str)> = vec![
-            // A projected expression: the case reachable on the TOTAL path.
-            // This used to report `total_order() == true` while every keyset
-            // disjunct was NULL for the rows `nullif` nulled out.
-            (
-                "SELECT nullif(value, 0) AS v, ts, series_id FROM samples ORDER BY v",
-                "v",
-            ),
             // Columns the schemas declare nullable, one per table that has
             // one.
             ("SELECT * FROM logs ORDER BY span_id, ts", "span_id"),
             ("SELECT * FROM spans ORDER BY service_name", "service_name"),
             ("SELECT * FROM alerts ORDER BY alert_id", "alert_id"),
-            // An output name the projection gives twice from different
-            // columns: both are columns, but which one the term means is not
-            // readable from the text, so the nullable one cannot be ruled out.
-            ("SELECT ts AS a, trace_id AS a FROM logs ORDER BY a", "a"),
-            // A set-operation body carries no readable projection at all.
-            (
-                "SELECT ts FROM logs UNION ALL SELECT ts FROM logs ORDER BY ts",
-                "ts",
-            ),
-            // No base table, so there is no schema to prove anything against.
-            ("SELECT 1 AS a ORDER BY a", "a"),
         ];
         for (sql, column) in cases {
             let err = plan_page(sql, None).expect_err("refused");
@@ -1620,6 +1789,56 @@ mod tests {
             );
         }
 
+        // The cases the schema cannot answer for. Each names the link of the
+        // proof that is missing, so a caller can tell a planner gap from a
+        // column that really can be NULL.
+        let unproven_cases: Vec<(&str, &str, &str)> = vec![
+            // A projected expression: the case reachable on the TOTAL path.
+            // This used to report `total_order() == true` while every keyset
+            // disjunct was NULL for the rows `nullif` nulled out.
+            (
+                "SELECT nullif(value, 0) AS v, ts, series_id FROM samples ORDER BY v",
+                "v",
+                unproven::NOT_A_BARE_COLUMN,
+            ),
+            // An output name the projection gives twice from different
+            // columns: both are columns, but which one the term means is not
+            // readable from the text, so the nullable one cannot be ruled out.
+            (
+                "SELECT ts AS a, trace_id AS a FROM logs ORDER BY a",
+                "a",
+                unproven::NOT_A_BARE_COLUMN,
+            ),
+            // A set-operation body carries no readable projection at all.
+            (
+                "SELECT ts FROM logs UNION ALL SELECT ts FROM logs ORDER BY ts",
+                "ts",
+                unproven::NOT_A_BARE_COLUMN,
+            ),
+            // A literal, which no schema lookup reaches.
+            ("SELECT 1 AS a ORDER BY a", "a", unproven::NOT_A_BARE_COLUMN),
+        ];
+        for (sql, column, reason) in unproven_cases {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNullabilityUnknown {
+                    column: column.to_string(),
+                    reason,
+                },
+                "unexpected refusal for {sql:?}"
+            );
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "the ORDER BY term `{column}` cannot be proved NON NULL from the \
+                     statement text ({reason}), and a keyset comparison against NULL \
+                     selects no rows, so the rows whose `{column}` is NULL would \
+                     appear on no page"
+                ),
+            );
+        }
+
         // The non-nullable columns of those same tables still page, including
         // through an alias over one, so the refusal is about nullability and
         // not about the table or about aliasing.
@@ -1633,6 +1852,157 @@ mod tests {
             let plan = plan_page(sql, None);
             assert!(plan.is_ok(), "{sql:?} should plan, got {plan:?}");
         }
+    }
+
+    /// A wildcard over a derived table or a CTE resolves against the inner
+    /// query's output names, not the base table's schema, so no schema lookup
+    /// proves anything about it.
+    ///
+    /// The demonstrated defect: `SELECT * FROM (SELECT nullif(value, 0) AS
+    /// ts, series_id FROM samples) x ORDER BY ts` planned. `referenced_base_
+    /// tables` still reported `samples` underneath the derived table, the
+    /// wildcard answered `ts` with the name itself, and `samples.ts` is
+    /// declared NOT NULL, so the term was proved non-null while the value
+    /// being ordered on was `nullif(value, 0)`. Every row where `value` is 0
+    /// was dropped from every page by the keyset predicate, with no error.
+    #[test]
+    fn refuses_a_wildcard_over_a_derived_table_or_cte() {
+        let derived = plan_page(
+            "SELECT * FROM (SELECT nullif(value, 0) AS ts, series_id FROM samples) AS x \
+             ORDER BY ts",
+            None,
+        )
+        .expect_err("refused");
+        assert_eq!(
+            derived,
+            PagePlanError::OrderTermNullabilityUnknown {
+                column: "ts".to_string(),
+                reason: unproven::DERIVED_RELATION,
+            },
+        );
+
+        let cte = plan_page(
+            "WITH x AS (SELECT nullif(value, 0) AS ts, series_id FROM samples) \
+             SELECT * FROM x ORDER BY ts",
+            None,
+        )
+        .expect_err("refused");
+        assert_eq!(
+            cte,
+            PagePlanError::OrderTermNullabilityUnknown {
+                column: "ts".to_string(),
+                reason: unproven::WITH_CLAUSE,
+            },
+        );
+
+        // A CTE that shadows the target table's own name is the same hole
+        // spelled so the `FROM` relation reads as the base table. It refuses
+        // one step earlier: `referenced_base_tables` subtracts a CTE-declared
+        // name, so the statement resolves to no base table at all.
+        let shadowing = plan_page(
+            "WITH samples AS (SELECT nullif(value, 0) AS ts, series_id FROM samples) \
+             SELECT * FROM samples ORDER BY ts",
+            None,
+        )
+        .expect_err("refused");
+        assert_eq!(
+            shadowing,
+            PagePlanError::OrderTermNullabilityUnknown {
+                column: "ts".to_string(),
+                reason: unproven::NO_BASE_TABLE,
+            },
+        );
+    }
+
+    /// A term aliased off the nullable side of an outer join is NULL for
+    /// every unmatched row, whatever the base column's schema says.
+    ///
+    /// `logs.body` is declared NOT NULL, and `b.body` under a `LEFT JOIN` is
+    /// still NULL for every left row with no match. The schema lookup was
+    /// correct about `logs.body` and wrong about the value.
+    #[test]
+    fn refuses_a_term_from_the_nullable_side_of_an_outer_join() {
+        for join in ["LEFT JOIN", "RIGHT JOIN", "FULL OUTER JOIN"] {
+            let sql = format!(
+                "SELECT a.ts AS ts, b.body AS b_body FROM logs AS a \
+                 {join} logs AS b ON a.ts = b.ts ORDER BY b_body, ts"
+            );
+            let err = plan_page(&sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNullabilityUnknown {
+                    column: "b_body".to_string(),
+                    reason: unproven::JOINED,
+                },
+                "unexpected refusal for {sql:?}"
+            );
+        }
+
+        // An inner join is refused by the same rule, for the narrower reason
+        // stated in `schema_basis`: nothing nulls a column, but an output
+        // name under a join resolves against more than one relation.
+        let inner = plan_page(
+            "SELECT a.ts AS ts, b.body AS b_body FROM logs AS a \
+             INNER JOIN logs AS b ON a.ts = b.ts ORDER BY b_body, ts",
+            None,
+        )
+        .expect_err("refused");
+        assert_eq!(
+            inner,
+            PagePlanError::OrderTermNullabilityUnknown {
+                column: "b_body".to_string(),
+                reason: unproven::JOINED,
+            },
+        );
+    }
+
+    /// `ROLLUP`, `CUBE` and `GROUPING SETS` null a grouping column in their
+    /// super-aggregate rows.
+    ///
+    /// Here the schema lookup is CORRECT -- `logs.severity_text` really is
+    /// NOT NULL -- and the grouping construct introduces the NULL anyway. The
+    /// prover modelled nothing about it, so the super-aggregate row was
+    /// dropped from every page by the keyset predicate.
+    #[test]
+    fn refuses_a_grouping_column_under_rollup_cube_or_grouping_sets() {
+        let groupings = [
+            // The expression spelling.
+            "ROLLUP(severity_text)",
+            "CUBE(severity_text)",
+            "GROUPING SETS ((severity_text), ())",
+            // The modifier spelling of the same thing.
+            "severity_text WITH ROLLUP",
+            "severity_text WITH CUBE",
+        ];
+        for grouping in groupings {
+            let sql = format!(
+                "SELECT severity_text, count(*) AS c FROM logs \
+                 GROUP BY {grouping} ORDER BY severity_text"
+            );
+            let err = plan_page(&sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNullabilityUnknown {
+                    column: "severity_text".to_string(),
+                    reason: unproven::GROUPING_NULLS,
+                },
+                "unexpected refusal for {sql:?}"
+            );
+        }
+
+        // A plain GROUP BY adds no super-aggregate row, so it is not refused
+        // by this rule: the narrowing is about the grouping construct, not
+        // about grouping.
+        let plain = plan_page(
+            "SELECT severity_text, count(*) AS c FROM logs GROUP BY severity_text \
+             ORDER BY severity_text",
+            None,
+        )
+        .expect("planned");
+        assert_eq!(
+            plain.not_total,
+            Some(NotTotalOrder::NoRowIdentity { table: "logs" }),
+        );
     }
 
     /// Every order term is quoted, so a column aliased with a quoted keyword

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -77,20 +77,29 @@
 //! and is therefore what resumes both. `not_total: Some(..)` rescues nothing
 //! here: reporting is not a substitute for refusing.
 //!
-//! Only a term the text proves NON NULL is admitted, and the proof is a
-//! schema lookup that holds end to end only when the output name is a bare
-//! reference to a column of the `FROM` relation AND that relation is the
-//! target base table itself. [`SchemaBasis`] is what settles the second half:
-//! a derived table, a CTE, a join, or a `ROLLUP`/`CUBE`/`GROUPING SETS`
-//! grouping each leave the schema answering about a column the ordered value
-//! did not come from.
+//! Only a term the text proves NON NULL is admitted, and a term reaches that
+//! proof by one of two routes.
+//!
+//! A bare column reference goes through the target table's public schema, and
+//! that lookup holds end to end only when the output name is a bare reference
+//! to a column of the `FROM` relation AND that relation is the target base
+//! table itself. [`SchemaBasis`] is what settles the second half: a derived
+//! table, a CTE, a join, or a `ROLLUP`/`CUBE`/`GROUPING SETS` grouping each
+//! leave the schema answering about a column the ordered value did not come
+//! from.
+//!
+//! An alias over an expression is answered by the expression itself
+//! ([`expression_is_non_null`]), with no schema involved: a literal and a
+//! `count(...)` are NON NULL wherever they are selected from. `SUM`, `MIN`,
+//! `MAX` and `AVG` are not, and keep refusing, because each is NULL over
+//! empty and over all-NULL input.
 //!
 //! The refusal says which of two things went wrong.
 //! [`PagePlanError::OrderTermNullable`] means the term CAN be NULL: the
 //! schema declares that column nullable, and the caller has to order by
 //! something else. [`PagePlanError::OrderTermNullabilityUnknown`] means the
 //! text does not settle it, and names the missing link, because a caller told
-//! that `count(*)` "is not known to be NON NULL" has no repair to make.
+//! that `sum(value)` "is not known to be NON NULL" has no repair to make.
 //!
 //! # The rewrite
 //!
@@ -121,7 +130,7 @@ use std::ops::ControlFlow;
 use datafusion::sql::parser::{DFParser, Statement as DFStatement};
 use datafusion::sql::sqlparser::ast::{
     Distinct, Expr as SqlExpr, GroupByExpr, Ident, ObjectName, OrderBy, OrderByKind, Query, Select,
-    SelectItem, SetExpr, Statement, TableFactor, Visit, Visitor,
+    SelectItem, SetExpr, Statement, TableFactor, UnaryOperator, Value, Visit, Visitor,
 };
 
 use crate::alerts_schema::alerts_schema;
@@ -644,16 +653,22 @@ fn page_target(sql: &str) -> Result<PageTarget, PagePlanError> {
 
 /// What one output column of a `SELECT` list is built from, as far as the
 /// text says. The distinction exists for nullability: a schema lookup answers
-/// for a bare column reference and for nothing else.
+/// for a bare column reference and for nothing else, and an expression
+/// answers for itself.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum OutputSource {
     /// A bare reference to this column of the `FROM` relation, under its own
     /// name or an alias.
     Column(String),
-    /// Anything else: a computed expression, or an output name the projection
-    /// gives twice from different sources. Neither has a column in the
-    /// target's schema to look up.
-    Opaque,
+    /// A computed expression, carried rather than discarded: no schema
+    /// describes it, but the expression itself settles some cases outright.
+    /// A literal is NON NULL whatever it is selected from. Boxed: a
+    /// sqlparser `Expr` is an order of magnitude larger than the other
+    /// variants, and one is held per projected output name.
+    Expression(Box<SqlExpr>),
+    /// An output name the projection gives twice from different sources.
+    /// Which of them an order term means is not readable from the text.
+    Ambiguous,
 }
 
 /// What the statement projects, as far as its text says.
@@ -683,29 +698,41 @@ impl Projection {
         }
     }
 
-    /// The column of the `FROM` RELATION that the output column `column` is a
-    /// bare reference to, or `None` when the text does not name one.
+    /// What the output column `column` is built from, as far as the text
+    /// says.
     ///
     /// A wildcard answers with the name itself: every output column of a
-    /// `SELECT *` is a column of the `FROM` relation under its own name.
-    /// `Unknown` answers `None` rather than guessing, which is what makes a
-    /// set-operation body fail the nullability check instead of passing it
+    /// `SELECT *` is a column of the `FROM` relation under its own name. A
+    /// set-operation body answers `Unreadable` rather than guessing, which is
+    /// what makes it fail the nullability check instead of passing it
     /// unexamined.
     ///
-    /// The name this returns is a name in the `FROM` relation, which is the
-    /// target table's own column only when that relation IS the target table.
-    /// [`SchemaBasis`] is what settles that, and every caller has to consult
-    /// it before turning this name into a schema lookup.
-    fn source_column<'a>(&'a self, column: &'a str) -> Option<&'a str> {
+    /// A [`TermSource::Column`] name is a name in the `FROM` relation, which
+    /// is the target table's own column only when that relation IS the target
+    /// table. [`SchemaBasis`] is what settles that, and every caller has to
+    /// consult it before turning this name into a schema lookup.
+    fn term_source<'a>(&'a self, column: &'a str) -> TermSource<'a> {
         match self {
-            Projection::Wildcard => Some(column),
-            Projection::Unknown => None,
+            Projection::Wildcard => TermSource::Column(column),
+            Projection::Unknown => TermSource::Unreadable(unproven::SET_OPERATION),
             Projection::Columns(items) => match items.get(column) {
-                Some(OutputSource::Column(name)) => Some(name.as_str()),
-                Some(OutputSource::Opaque) | None => None,
+                Some(OutputSource::Column(name)) => TermSource::Column(name.as_str()),
+                Some(OutputSource::Expression(expr)) => TermSource::Expression(expr),
+                Some(OutputSource::Ambiguous) => TermSource::Unreadable(unproven::AMBIGUOUS_NAME),
+                None => TermSource::Unreadable(unproven::NOT_A_BARE_COLUMN),
             },
         }
     }
+}
+
+/// What an `ORDER BY` term resolves to in the projection that produced it.
+enum TermSource<'a> {
+    /// A bare reference to this column of the `FROM` relation.
+    Column(&'a str),
+    /// A computed expression, which the text carries in full.
+    Expression(&'a SqlExpr),
+    /// Neither, for this reason.
+    Unreadable(&'static str),
 }
 
 fn projection_of(query: &Query) -> Projection {
@@ -715,11 +742,11 @@ fn projection_of(query: &Query) -> Projection {
     let mut names: BTreeMap<String, OutputSource> = BTreeMap::new();
     let mut record = |name: String, source: OutputSource| {
         // A name the projection gives twice is ambiguous here even when both
-        // sources are columns, so it degrades to opaque rather than to
+        // sources are columns, so it degrades rather than resolving to
         // whichever item came last.
         let entry = names.entry(name).or_insert_with(|| source.clone());
         if *entry != source {
-            *entry = OutputSource::Opaque;
+            *entry = OutputSource::Ambiguous;
         }
     };
     for item in &select.projection {
@@ -728,7 +755,10 @@ fn projection_of(query: &Query) -> Projection {
                 return Projection::Wildcard;
             }
             SelectItem::ExprWithAlias { expr, alias } => {
-                let source = column_of(expr).map_or(OutputSource::Opaque, OutputSource::Column);
+                let source = match column_of(expr) {
+                    Some(name) => OutputSource::Column(name),
+                    None => OutputSource::Expression(Box::new(expr.clone())),
+                };
                 record(ident_name(alias), source);
             }
             SelectItem::UnnamedExpr(expr) => {
@@ -782,6 +812,10 @@ mod unproven {
     pub(super) const NOT_A_SCHEMA_COLUMN: &str = "it is not a column of the target table's public schema, so it is a declared \
          column whose nullability the text does not carry";
     pub(super) const NO_PUBLIC_SCHEMA: &str = "the target table has no public schema here";
+    pub(super) const AMBIGUOUS_NAME: &str =
+        "the projection gives that output name twice, from different sources";
+    pub(super) const EXPRESSION_NOT_PROVABLE: &str = "the expression it is defined by is not one this planner proves NON NULL, and \
+         SUM, MIN, MAX and AVG are NULL over empty or all-NULL input";
 }
 
 /// Whether the statement's own `FROM` relation is the target base table, so
@@ -877,16 +911,34 @@ enum NullProof {
 
 /// What the text says about the effective term `column`.
 ///
-/// The proof has to hold end to end: the output column has to be a bare
-/// reference to a column of the `FROM` relation, that relation has to be the
-/// target base table itself (see [`schema_basis`]), and the column has to be
-/// declared non-nullable in the table's public schema. A declared column is
-/// absent from the static schema, and whether it exists at all depends on the
-/// tenant's declarations rather than on the text, so it is `Unproven` rather
-/// than either answer.
+/// There are two routes to a proof and the term takes whichever one its
+/// projection offers.
+///
+/// A bare column reference goes through the schema, and that proof has to hold
+/// end to end: the name has to be a column of the `FROM` relation, that
+/// relation has to be the target base table itself (see [`schema_basis`]), and
+/// the column has to be declared non-nullable in the table's public schema. A
+/// declared column is absent from the static schema, and whether it exists at
+/// all depends on the tenant's declarations rather than on the text, so it is
+/// `Unproven` rather than either answer.
+///
+/// An alias over an expression is answered by
+/// [`expression_is_non_null`] reading the expression itself, with no schema
+/// consulted and no basis required: a literal and a `count(...)` are NON NULL
+/// whatever relation they are selected from, including under an outer join or
+/// a `ROLLUP`, because neither is a grouping column that a super-aggregate row
+/// can null.
 fn term_nullability(basis: &SchemaBasis, projection: &Projection, column: &str) -> NullProof {
-    let Some(source) = projection.source_column(column) else {
-        return NullProof::Unproven(unproven::NOT_A_BARE_COLUMN);
+    let source = match projection.term_source(column) {
+        TermSource::Column(source) => source,
+        TermSource::Expression(expr) => {
+            return if expression_is_non_null(expr) {
+                NullProof::NonNull
+            } else {
+                NullProof::Unproven(unproven::EXPRESSION_NOT_PROVABLE)
+            };
+        }
+        TermSource::Unreadable(reason) => return NullProof::Unproven(reason),
     };
     let table = match basis {
         SchemaBasis::Resolvable(table) => *table,
@@ -906,6 +958,50 @@ fn term_nullability(basis: &SchemaBasis, projection: &Projection, column: &str) 
         Err(_) => NullProof::Unproven(unproven::NOT_A_SCHEMA_COLUMN),
     }
 }
+
+/// Whether an expression is NON NULL for every row, from the expression alone.
+///
+/// Deliberately narrow, and the narrowness is the point: this answers only
+/// where the answer needs no schema, no statistics and no knowledge of what
+/// the inputs contain. What it admits:
+///
+/// - a literal other than `NULL`, and other than a placeholder, whose value
+///   arrives at execution time;
+/// - `count(...)` in any spelling, `count(*)` and `count(DISTINCT x)`
+///   included, which returns 0 rather than NULL over empty and over all-NULL
+///   input;
+/// - parentheses, and a unary `+` or `-`, which are NULL exactly when their
+///   operand is.
+///
+/// `SUM`, `MIN`, `MAX` and `AVG` are NOT admitted, and this is a decision
+/// rather than an omission. Each returns NULL over empty input and over input
+/// that is entirely NULL, so an ordering on one can carry a NULL row that the
+/// keyset predicate would drop from every page. Telling the safe uses apart
+/// means knowing whether the statement is grouped and whether any group can be
+/// empty or all-NULL, which is a different analysis from this one; until it
+/// exists all four keep refusing.
+///
+/// Anything else answers `false`, which is a refusal rather than a plan. A
+/// case added here has to hold for every input, not merely for the inputs a
+/// caller had in mind.
+fn expression_is_non_null(expr: &SqlExpr) -> bool {
+    match expr {
+        SqlExpr::Value(value) => !matches!(value.value, Value::Null | Value::Placeholder(_)),
+        SqlExpr::Nested(inner) => expression_is_non_null(inner),
+        SqlExpr::UnaryOp {
+            op: UnaryOperator::Plus | UnaryOperator::Minus,
+            expr,
+        } => expression_is_non_null(expr),
+        SqlExpr::Function(function) => {
+            bare_name(&function.name).is_some_and(|name| name.eq_ignore_ascii_case(COUNT_FUNCTION))
+        }
+        _ => false,
+    }
+}
+
+/// The one aggregate this planner proves NON NULL. Lowercase: [`bare_name`]
+/// lowercases an unquoted identifier.
+const COUNT_FUNCTION: &str = "count";
 
 /// The parts of a single `SELECT` body that decide whether it projects the
 /// scanned rows one-for-one.
@@ -1572,7 +1668,7 @@ mod tests {
                 "SELECT nullif(value, 0) AS v, ts, series_id FROM samples ORDER BY v",
                 PagePlanError::OrderTermNullabilityUnknown {
                     column: "v".to_string(),
-                    reason: unproven::NOT_A_BARE_COLUMN,
+                    reason: unproven::EXPRESSION_NOT_PROVABLE,
                 },
             ),
             (
@@ -1799,7 +1895,7 @@ mod tests {
             (
                 "SELECT nullif(value, 0) AS v, ts, series_id FROM samples ORDER BY v",
                 "v",
-                unproven::NOT_A_BARE_COLUMN,
+                unproven::EXPRESSION_NOT_PROVABLE,
             ),
             // An output name the projection gives twice from different
             // columns: both are columns, but which one the term means is not
@@ -1807,16 +1903,14 @@ mod tests {
             (
                 "SELECT ts AS a, trace_id AS a FROM logs ORDER BY a",
                 "a",
-                unproven::NOT_A_BARE_COLUMN,
+                unproven::AMBIGUOUS_NAME,
             ),
             // A set-operation body carries no readable projection at all.
             (
                 "SELECT ts FROM logs UNION ALL SELECT ts FROM logs ORDER BY ts",
                 "ts",
-                unproven::NOT_A_BARE_COLUMN,
+                unproven::SET_OPERATION,
             ),
-            // A literal, which no schema lookup reaches.
-            ("SELECT 1 AS a ORDER BY a", "a", unproven::NOT_A_BARE_COLUMN),
         ];
         for (sql, column, reason) in unproven_cases {
             let err = plan_page(sql, None).expect_err("refused");
@@ -2079,6 +2173,159 @@ mod tests {
         );
     }
 
+    /// A literal order term plans: no schema describes it and none needs to.
+    ///
+    /// The prover reached a defining COLUMN REFERENCE or nothing, so an alias
+    /// over `1` refused with the same message as a term that can really be
+    /// NULL. A literal is NON NULL in every row of every relation.
+    #[test]
+    fn a_literal_order_term_plans() {
+        for sql in [
+            "SELECT 1 AS a ORDER BY a",
+            "SELECT 'x' AS a ORDER BY a",
+            "SELECT -1 AS a ORDER BY a",
+            "SELECT (1) AS a ORDER BY a",
+            "SELECT 1 AS a, ts, series_id FROM samples ORDER BY a, ts, series_id",
+        ] {
+            let plan = plan_page(sql, None);
+            assert!(plan.is_ok(), "refused {sql:?}: {plan:?}");
+        }
+
+        // A literal NULL and a placeholder are not literals this admits: the
+        // first IS the hazard, and the second carries a value that only
+        // arrives at execution time.
+        for (sql, column) in [
+            ("SELECT NULL AS a ORDER BY a", "a"),
+            ("SELECT $1 AS a ORDER BY a", "a"),
+        ] {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNullabilityUnknown {
+                    column: column.to_string(),
+                    reason: unproven::EXPRESSION_NOT_PROVABLE,
+                },
+                "unexpected refusal for {sql:?}"
+            );
+        }
+    }
+
+    /// `count(...)` is NON NULL in every spelling: it returns 0, never NULL,
+    /// over empty and over all-NULL input.
+    ///
+    /// Ordering on the bare call is still refused, one step earlier and for a
+    /// different reason: every effective term has to be a projected output
+    /// column so the wrap can reference it, and `PagePlanError::
+    /// OrderTermNotColumn` is that rule. The alias is the spelling that
+    /// reaches this prover.
+    #[test]
+    fn count_star_plans_through_an_alias() {
+        for sql in [
+            "SELECT count(*) AS c FROM logs GROUP BY severity_text ORDER BY c",
+            "SELECT COUNT(*) AS c FROM logs GROUP BY severity_text ORDER BY c",
+            "SELECT count(DISTINCT trace_id) AS c FROM logs GROUP BY severity_text ORDER BY c",
+            "SELECT count(trace_id) AS c FROM logs GROUP BY severity_text ORDER BY c",
+            // A grouping construct nulls a grouping COLUMN, never an
+            // aggregate, so ordering on the count alone still plans.
+            "SELECT count(*) AS c FROM logs GROUP BY ROLLUP(severity_text) ORDER BY c",
+        ] {
+            let plan = plan_page(sql, None);
+            assert!(plan.is_ok(), "refused {sql:?}: {plan:?}");
+        }
+
+        let bare =
+            plan_page("SELECT count(*) FROM logs ORDER BY count(*)", None).expect_err("refused");
+        assert_eq!(
+            bare,
+            PagePlanError::OrderTermNotColumn {
+                term: "count(*)".to_string(),
+            },
+        );
+    }
+
+    /// An alias resolves through to the expression that defines it, so the
+    /// answer is about that expression and not about the alias being an
+    /// alias.
+    #[test]
+    fn an_alias_resolves_through_to_its_defining_expression() {
+        // Same alias, same statement shape, opposite answers: the defining
+        // expression is the only thing that differs.
+        let provable = plan_page(
+            "SELECT count(*) AS ordering FROM logs GROUP BY severity_text ORDER BY ordering",
+            None,
+        );
+        assert!(provable.is_ok(), "refused the count: {provable:?}");
+
+        let not_provable = plan_page(
+            "SELECT nullif(count(*), 0) AS ordering FROM logs GROUP BY severity_text \
+             ORDER BY ordering",
+            None,
+        )
+        .expect_err("refused");
+        assert_eq!(
+            not_provable,
+            PagePlanError::OrderTermNullabilityUnknown {
+                column: "ordering".to_string(),
+                reason: unproven::EXPRESSION_NOT_PROVABLE,
+            },
+        );
+
+        // Unary `+`/`-` and parentheses are NULL exactly when their operand
+        // is, so the answer passes through them in both directions.
+        let through = plan_page(
+            "SELECT -count(*) AS ordering FROM logs GROUP BY severity_text ORDER BY ordering",
+            None,
+        );
+        assert!(through.is_ok(), "refused the negated count: {through:?}");
+
+        let through_null =
+            plan_page("SELECT -(NULL) AS ordering ORDER BY ordering", None).expect_err("refused");
+        assert_eq!(
+            through_null,
+            PagePlanError::OrderTermNullabilityUnknown {
+                column: "ordering".to_string(),
+                reason: unproven::EXPRESSION_NOT_PROVABLE,
+            },
+        );
+    }
+
+    /// `SUM`, `MIN`, `MAX` and `AVG` keep refusing, deliberately.
+    ///
+    /// Each returns NULL over empty input and over input that is entirely
+    /// NULL, so an ordering on one can carry a row the keyset predicate drops
+    /// from every page. Admitting them needs the grouped-versus-ungrouped
+    /// analysis this prover does not do; until that exists the refusal is the
+    /// correct answer and this test is what stops it being widened by
+    /// analogy with `count`.
+    #[test]
+    fn sum_min_max_and_avg_still_refuse() {
+        for call in [
+            "sum(value)",
+            "min(value)",
+            "max(value)",
+            "avg(value)",
+            "SUM(value)",
+        ] {
+            let sql = format!(
+                "SELECT {call} AS ordering FROM samples GROUP BY series_id ORDER BY ordering"
+            );
+            let err = plan_page(&sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNullabilityUnknown {
+                    column: "ordering".to_string(),
+                    reason: unproven::EXPRESSION_NOT_PROVABLE,
+                },
+                "unexpected refusal for {sql:?}"
+            );
+            assert!(
+                err.to_string()
+                    .contains("SUM, MIN, MAX and AVG are NULL over empty or all-NULL input"),
+                "the message does not say why: {err}"
+            );
+        }
+    }
+
     /// The ClickBench corpus, the largest body of real statements this
     /// repository holds, read from where the benchmarks keep it rather than
     /// copied, so a corpus edit shows up here as a failing count.
@@ -2181,7 +2428,11 @@ mod tests {
     /// Two passes. The first is the corpus as written, where 32 of the 43
     /// statements carry their own `LIMIT` and are refused for that alone.
     /// The second strips a trailing `LIMIT n [OFFSET m]`, which is what
-    /// exposes the nullability prover underneath.
+    /// exposes the nullability prover underneath: 22 of the 43 plan, and 3
+    /// of the 21 refusals are about nullability. The remaining 18 are about
+    /// the ordering itself, not about NULLs -- no `ORDER BY` at all, a term
+    /// that is not a column, a term the statement does not project -- and
+    /// each is a separate piece of work.
     #[test]
     fn the_clickbench_corpus_page_plan_outcomes_are_pinned() {
         let corpus: serde_json::Value =
@@ -2228,14 +2479,14 @@ mod tests {
             ("NoOrdering", 11),
             ("OrderTermNotColumn", 5),
             ("OrderTermNotProjected", 2),
-            ("plans, not a total order", 1),
+            ("plans, not a total order", 22),
         ]);
         want.insert(
             format!(
                 "OrderTermNullabilityUnknown: {}",
-                unproven::NOT_A_BARE_COLUMN
+                unproven::EXPRESSION_NOT_PROVABLE
             ),
-            23,
+            2,
         );
         want.insert(
             format!(
@@ -2250,17 +2501,17 @@ mod tests {
         );
         assert_eq!(
             tally(&without_row_limit, "plans"),
-            1,
+            22,
             "plans, row limit set aside",
         );
         assert_eq!(
             statements - tally(&without_row_limit, "plans"),
-            42,
+            21,
             "refusals, row limit set aside",
         );
         assert_eq!(
             tally(&without_row_limit, "OrderTermNullab"),
-            24,
+            3,
             "nullability refusals, row limit set aside",
         );
     }

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -80,19 +80,36 @@
 //! Only a term the text proves NON NULL is admitted, and a term reaches that
 //! proof by one of two routes.
 //!
-//! A bare column reference goes through the target table's public schema, and
-//! that lookup holds end to end only when the output name is a bare reference
-//! to a column of the `FROM` relation AND that relation is the target base
-//! table itself. [`SchemaBasis`] is what settles the second half: a derived
-//! table, a CTE, a join, or a `ROLLUP`/`CUBE`/`GROUPING SETS` grouping each
-//! leave the schema answering about a column the ordered value did not come
-//! from.
+//! A [`Provenance::BaseColumn`] goes through the target table's public
+//! schema. That lookup holds end to end by construction of the variant: it
+//! exists only where the output name is a bare reference to a column of the
+//! `FROM` relation AND that relation is the target base table itself, under
+//! its own column names. A derived table, a CTE, a join, a positional
+//! column-rename list on the relation, or a `ROLLUP`/`CUBE`/`GROUPING SETS`
+//! grouping each leave the schema answering about a column the ordered value
+//! did not come from, so none of them yields that variant.
 //!
-//! An alias over an expression is answered by the expression itself
+//! A [`Provenance::Expression`] is answered by the expression itself
 //! ([`expression_is_non_null`]), with no schema involved: a literal and a
 //! `count(...)` are NON NULL wherever they are selected from. `SUM`, `MIN`,
 //! `MAX` and `AVG` are not, and keep refusing, because each is NULL over
 //! empty and over all-NULL input.
+//!
+//! # One resolution from an output name
+//!
+//! Both of those routes, the row-identity claim behind `not_total`, and the
+//! projected-output-column check are all the same question -- what does this
+//! statement's text prove the output name `x` is built from? -- and they are
+//! all asked through [`OutputResolution::resolve`], which is the only way to
+//! ask it. Its [`Provenance`] answer distinguishes a genuine column of the
+//! target base table (the only answer that carries row identity) from an
+//! expression, from a name whose source the text does not settle, and from a
+//! name the statement does not project.
+//!
+//! That the raw output name is unreachable from those consumers is the point
+//! rather than a tidiness. Three rounds of fixes to this defect class each
+//! converted one consumer and left another matching the name itself, so the
+//! same wrong answer came back through a different door.
 //!
 //! The refusal says which of two things went wrong.
 //! [`PagePlanError::OrderTermNullable`] means the term CAN be NULL: the
@@ -124,13 +141,12 @@
 //! support for comparing tuples, and each conjunct is a plain binary
 //! comparison the providers can push down.
 
-use std::collections::BTreeMap;
 use std::ops::ControlFlow;
 
 use datafusion::sql::parser::{DFParser, Statement as DFStatement};
 use datafusion::sql::sqlparser::ast::{
     Distinct, Expr as SqlExpr, GroupByExpr, Ident, ObjectName, OrderBy, OrderByKind, Query, Select,
-    SelectItem, SetExpr, Statement, TableFactor, UnaryOperator, Value, Visit, Visitor,
+    SetExpr, Statement, TableFactor, UnaryOperator, Value, Visit, Visitor,
 };
 
 use crate::alerts_schema::alerts_schema;
@@ -210,10 +226,13 @@ pub enum NotTotalOrder {
     )]
     ShapeNotIdentityPreserving { shape: &'static str },
 
-    /// The tiebreak columns exist but are not in the projection, so a page's
-    /// own rows would not carry the values the next cursor position needs.
+    /// The tiebreak columns exist on the target, and the statement does not
+    /// project each of them AS ITSELF: either it does not project the name at
+    /// all, so a page's own rows would not carry the values the next cursor
+    /// position needs, or it projects that name off something else, so
+    /// ordering on it would not order on the identity column.
     #[error(
-        "the tiebreak columns ({}) are not in the projection",
+        "the tiebreak columns ({}) are not projected as themselves",
         missing.join(", ")
     )]
     TiebreakNotProjected { missing: Vec<String> },
@@ -469,18 +488,21 @@ pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan,
     reject_nested_pipes_and_row_limits(&query)?;
 
     let target = page_target(sql)?;
-    let projection = projection_of(&query);
+    // The one resolution from an output name to what the text proves it holds.
+    // Every check below goes through it; none of them looks a name up for
+    // itself.
+    let names = OutputResolution::of(&query, target);
 
     let mut terms = statement_order_terms(&query)?;
     for term in &terms {
-        if !projection.projects(&term.column) {
+        if matches!(names.resolve(&term.column), Provenance::NotProjected) {
             return Err(PagePlanError::OrderTermNotProjected {
                 column: term.column.clone(),
             });
         }
     }
 
-    let (tiebreak_appended, not_total) = tiebreak(&query, target, &projection, &terms);
+    let (tiebreak_appended, not_total) = tiebreak(&query, target, &names, &terms);
     for column in &tiebreak_appended {
         terms.push(OrderTerm::ascending(column.clone()));
     }
@@ -491,9 +513,8 @@ pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan,
     }
     // Every effective term, the appended tiebreak included: a NULL anywhere in
     // the ordering drops the rows it covers from every page.
-    let basis = schema_basis(&query, target);
     for term in &terms {
-        match term_nullability(&basis, &projection, &term.column) {
+        match term_nullability(&names, &term.column) {
             NullProof::NonNull => {}
             NullProof::Nullable => {
                 return Err(PagePlanError::OrderTermNullable {
@@ -651,143 +672,452 @@ fn page_target(sql: &str) -> Result<PageTarget, PagePlanError> {
     }
 }
 
-/// What one output column of a `SELECT` list is built from, as far as the
-/// text says. The distinction exists for nullability: a schema lookup answers
-/// for a bare column reference and for nothing else, and an expression
-/// answers for itself.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum OutputSource {
-    /// A bare reference to this column of the `FROM` relation, under its own
-    /// name or an alias.
-    Column(String),
-    /// A computed expression, carried rather than discarded: no schema
-    /// describes it, but the expression itself settles some cases outright.
-    /// A literal is NON NULL whatever it is selected from. Boxed: a
-    /// sqlparser `Expr` is an order of magnitude larger than the other
-    /// variants, and one is held per projected output name.
-    Expression(Box<SqlExpr>),
-    /// An output name the projection gives twice from different sources.
-    /// Which of them an order term means is not readable from the text.
-    Ambiguous,
-}
+/// The one resolution from an output name of the statement to what the text
+/// PROVES that name is built from, and the only way to ask the question.
+///
+/// The internals are private to this module for a structural reason rather
+/// than a stylistic one. Three rounds of fixes to one defect class each
+/// converted ONE consumer to a provenance check and left another matching the
+/// raw output name itself, so the same wrong answer came back through a
+/// different door: the nullability prover was gated on whether the `FROM`
+/// relation is the target base table, while the tiebreak went on proving row
+/// identity by looking the string `"series_id"` up among the output names,
+/// which any alias may take (`SELECT ts, value AS series_id FROM samples`
+/// reported a total order over `(ts, value)`, which is not a key, and a walk
+/// over it left a row on no page).
+///
+/// So nothing in here hands a consumer a name to look up for itself:
+/// [`OutputResolution::resolve`] is the only entry point, a [`Provenance`] is
+/// the only thing it returns, and a consumer that wants a base column has to
+/// name the one variant that carries one. Adopting the resolution in some
+/// consumers and not others does not compile.
+mod resolution {
+    use std::collections::{BTreeMap, BTreeSet};
 
-/// What the statement projects, as far as its text says.
-enum Projection {
-    /// A wildcard projects every column of the target, so any column of it is
-    /// available to order by.
-    Wildcard,
-    /// The named output columns (an alias where the item has one, the column
-    /// itself otherwise), each with what it is built from. An item that is
-    /// neither -- a bare expression with no alias -- contributes no name.
-    Columns(BTreeMap<String, OutputSource>),
-    /// The projection is not readable from the text (a set-operation body).
-    Unknown,
-}
-
-impl Projection {
-    /// Whether `column` is available to order by. `Wildcard` and `Unknown`
-    /// both answer yes: neither carries a name list to check against, and
-    /// refusing would reject a `SELECT *` and a `UNION` whose orderings are
-    /// perfectly resolvable. A column that exists in neither surfaces as the
-    /// executor's own plan error, which is the same answer the caller would
-    /// have got for the statement it handed in.
-    fn projects(&self, column: &str) -> bool {
-        match self {
-            Projection::Wildcard | Projection::Unknown => true,
-            Projection::Columns(names) => names.contains_key(column),
-        }
-    }
-
-    /// What the output column `column` is built from, as far as the text
-    /// says.
-    ///
-    /// A wildcard answers with the name itself: every output column of a
-    /// `SELECT *` is a column of the `FROM` relation under its own name. A
-    /// set-operation body answers `Unreadable` rather than guessing, which is
-    /// what makes it fail the nullability check instead of passing it
-    /// unexamined.
-    ///
-    /// A [`TermSource::Column`] name is a name in the `FROM` relation, which
-    /// is the target table's own column only when that relation IS the target
-    /// table. [`SchemaBasis`] is what settles that, and every caller has to
-    /// consult it before turning this name into a schema lookup.
-    fn term_source<'a>(&'a self, column: &'a str) -> TermSource<'a> {
-        match self {
-            Projection::Wildcard => TermSource::Column(column),
-            Projection::Unknown => TermSource::Unreadable(unproven::SET_OPERATION),
-            Projection::Columns(items) => match items.get(column) {
-                Some(OutputSource::Column(name)) => TermSource::Column(name.as_str()),
-                Some(OutputSource::Expression(expr)) => TermSource::Expression(expr),
-                Some(OutputSource::Ambiguous) => TermSource::Unreadable(unproven::AMBIGUOUS_NAME),
-                None => TermSource::Unreadable(unproven::NOT_A_BARE_COLUMN),
-            },
-        }
-    }
-}
-
-/// What an `ORDER BY` term resolves to in the projection that produced it.
-enum TermSource<'a> {
-    /// A bare reference to this column of the `FROM` relation.
-    Column(&'a str),
-    /// A computed expression, which the text carries in full.
-    Expression(&'a SqlExpr),
-    /// Neither, for this reason.
-    Unreadable(&'static str),
-}
-
-fn projection_of(query: &Query) -> Projection {
-    let SetExpr::Select(select) = query.body.as_ref() else {
-        return Projection::Unknown;
+    use datafusion::sql::sqlparser::ast::{
+        Expr as SqlExpr, Query, SelectItem, SetExpr, WildcardAdditionalOptions,
     };
-    let mut names: BTreeMap<String, OutputSource> = BTreeMap::new();
-    let mut record = |name: String, source: OutputSource| {
-        // A name the projection gives twice is ambiguous here even when both
-        // sources are columns, so it degrades rather than resolving to
-        // whichever item came last.
-        let entry = names.entry(name).or_insert_with(|| source.clone());
+
+    use super::{
+        PageTarget, Relation, bare_name, column_of, grouping_can_null_a_grouping_column,
+        ident_name, relation_of, unproven,
+    };
+
+    /// What the statement's text proves one of its output names is built
+    /// from.
+    pub(super) enum Provenance<'a> {
+        /// A genuine column of the target base table: the value under this
+        /// output name IS the value of `column` in `table`'s public schema.
+        ///
+        /// The only variant that carries row identity. A uniqueness claim
+        /// about a set of the scan's columns carries to the output only for
+        /// names that resolve to those columns themselves, so
+        /// [`super::tiebreak`] may claim identity here and nowhere else.
+        BaseColumn {
+            table: &'static str,
+            column: &'a str,
+        },
+        /// A computed expression, carried in full. No schema describes it and
+        /// no row identity attaches to it, but the expression alone settles
+        /// some nullability cases outright: a literal and a `count(...)` are
+        /// NON NULL wherever they are selected from.
+        Expression(&'a SqlExpr),
+        /// The statement projects this name and the text does not say what it
+        /// is built from, for this reason.
+        Opaque(&'static str),
+        /// The statement does not project this name at all.
+        NotProjected,
+    }
+
+    /// What one output column of a `SELECT` list is built from, as far as the
+    /// text says.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum OutputSource {
+        /// A bare reference to this column of the `FROM` relation, under its
+        /// own name or an alias.
+        Column(String),
+        /// A computed expression, carried rather than discarded. Boxed: a
+        /// sqlparser `Expr` is an order of magnitude larger than the other
+        /// variants, and one is held per projected output name.
+        Expression(Box<SqlExpr>),
+        /// An output name the projection gives twice from different sources.
+        /// Which of them an order term means is not readable from the text.
+        Ambiguous,
+        /// A name a projection item declares while what it holds is not
+        /// readable from the text (a multi-alias item's expansion).
+        Unmodelled(&'static str),
+    }
+
+    /// How a name the projection does not declare explicitly is answered.
+    enum Rest {
+        /// Nothing else projects a name, so an undeclared one is not
+        /// projected.
+        Nothing,
+        /// A wildcard projects every column of the `FROM` relation under its
+        /// own name, except the ones `removed` names (an `EXCEPT`, an
+        /// `EXCLUDE`, or a `REPLACE` that supplies its own value instead).
+        Wildcard { removed: BTreeSet<String> },
+        /// The projected names are not readable from the text, for this
+        /// reason.
+        Unreadable(&'static str),
+    }
+
+    /// What the statement projects, as far as its text says.
+    struct Projection {
+        /// The names the projection declares, with what each is built from.
+        /// An item that declares none -- a bare expression with no alias --
+        /// contributes nothing.
+        declared: BTreeMap<String, OutputSource>,
+        /// How a name absent from `declared` is answered.
+        rest: Rest,
+    }
+
+    /// Whether an output name that is a bare column reference may be resolved
+    /// against the target table's public schema at all.
+    ///
+    /// Sound only when the `FROM` relation IS that base table under its own
+    /// column names: otherwise the schema answers about a column the ordered
+    /// value did not come from, and a NOT NULL declaration there says nothing
+    /// about the value.
+    enum Basis {
+        /// Bare column references resolve against this table's public schema.
+        Table(&'static str),
+        /// They do not, for this reason, which the refusal quotes.
+        Unresolvable(&'static str),
+    }
+
+    pub(super) struct OutputResolution {
+        projection: Projection,
+        basis: Basis,
+    }
+
+    impl OutputResolution {
+        /// Read `query`'s projection and `FROM` relation once.
+        pub(super) fn of(query: &Query, target: PageTarget) -> Self {
+            OutputResolution {
+                projection: projection_of(query),
+                basis: basis_of(query, target),
+            }
+        }
+
+        /// What the text proves the output name `name` is built from.
+        pub(super) fn resolve<'r>(&'r self, name: &'r str) -> Provenance<'r> {
+            match self.projection.source_of(name) {
+                Source::Column(column) => match self.basis {
+                    Basis::Table(table) => Provenance::BaseColumn { table, column },
+                    Basis::Unresolvable(reason) => Provenance::Opaque(reason),
+                },
+                Source::Expression(expr) => Provenance::Expression(expr),
+                Source::Opaque(reason) => Provenance::Opaque(reason),
+                Source::Absent => Provenance::NotProjected,
+            }
+        }
+    }
+
+    /// What the projection alone says, before the `FROM` relation is
+    /// consulted. Private: a `Column` here is a name in the `FROM` relation,
+    /// which is the target table's own column only once [`Basis`] says so,
+    /// and that pairing is what [`OutputResolution::resolve`] exists to make
+    /// unskippable.
+    enum Source<'a> {
+        Column(&'a str),
+        Expression(&'a SqlExpr),
+        Opaque(&'static str),
+        Absent,
+    }
+
+    impl Projection {
+        fn source_of<'p>(&'p self, name: &'p str) -> Source<'p> {
+            if let Some(source) = self.declared.get(name) {
+                // A wildcard that still projects a declared name gives the
+                // statement two output columns of it.
+                if let Rest::Wildcard { removed } = &self.rest
+                    && !removed.contains(name)
+                {
+                    return Source::Opaque(unproven::AMBIGUOUS_NAME);
+                }
+                return match source {
+                    OutputSource::Column(column) => Source::Column(column.as_str()),
+                    OutputSource::Expression(expr) => Source::Expression(expr),
+                    OutputSource::Ambiguous => Source::Opaque(unproven::AMBIGUOUS_NAME),
+                    OutputSource::Unmodelled(reason) => Source::Opaque(reason),
+                };
+            }
+            match &self.rest {
+                Rest::Nothing => Source::Absent,
+                Rest::Wildcard { removed } if removed.contains(name) => Source::Absent,
+                Rest::Wildcard { .. } => Source::Column(name),
+                Rest::Unreadable(reason) => Source::Opaque(reason),
+            }
+        }
+    }
+
+    /// Read the whole `SELECT` list, wildcard included.
+    ///
+    /// The wildcard is not a stopping point. It used to return outright, so a
+    /// projection item AFTER one was never read and a name the wildcard
+    /// removed and a later item redefined resolved to the base column of that
+    /// name: `SELECT * EXCEPT (ts), nullif(value, 0) AS ts FROM samples
+    /// ORDER BY ts` proved `ts` NON NULL off `samples.ts` while the ordered
+    /// value was `nullif(value, 0)`, and delivered one of three rows.
+    fn projection_of(query: &Query) -> Projection {
+        let SetExpr::Select(select) = query.body.as_ref() else {
+            return Projection {
+                declared: BTreeMap::new(),
+                rest: Rest::Unreadable(unproven::SET_OPERATION),
+            };
+        };
+        let mut declared: BTreeMap<String, OutputSource> = BTreeMap::new();
+        let mut rest = Rest::Nothing;
+        let mut wildcards = 0usize;
+        for item in &select.projection {
+            match item {
+                SelectItem::Wildcard(options) | SelectItem::QualifiedWildcard(_, options) => {
+                    wildcards += 1;
+                    rest = if wildcards > 1 {
+                        // Two wildcards project one relation's columns twice
+                        // over, so which output column a name means is not
+                        // readable from the text.
+                        Rest::Unreadable(unproven::SEVERAL_WILDCARDS)
+                    } else {
+                        wildcard_rest(options)
+                    };
+                    for (name, source) in wildcard_replacements(options) {
+                        record(&mut declared, name, source);
+                    }
+                }
+                SelectItem::ExprWithAlias { expr, alias } => {
+                    let source = match column_of(expr) {
+                        Some(name) => OutputSource::Column(name),
+                        None => OutputSource::Expression(Box::new(expr.clone())),
+                    };
+                    record(&mut declared, ident_name(alias), source);
+                }
+                SelectItem::UnnamedExpr(expr) => {
+                    if let Some(column) = column_of(expr) {
+                        record(&mut declared, column.clone(), OutputSource::Column(column));
+                    }
+                }
+                // A multi-alias item declares these names over an expansion
+                // this planner does not model, so each is recorded as a name
+                // it holds nothing readable for rather than left out: left
+                // out, a wildcard beside it would answer for the name with
+                // the base column of that name.
+                SelectItem::ExprWithAliases { aliases, .. } => {
+                    for alias in aliases {
+                        record(
+                            &mut declared,
+                            ident_name(alias),
+                            OutputSource::Unmodelled(unproven::MULTI_ALIAS),
+                        );
+                    }
+                }
+            }
+        }
+        Projection { declared, rest }
+    }
+
+    /// A name the projection gives twice is ambiguous even when both sources
+    /// are columns, so it degrades rather than resolving to whichever item
+    /// came last.
+    fn record(declared: &mut BTreeMap<String, OutputSource>, name: String, source: OutputSource) {
+        let entry = declared.entry(name).or_insert_with(|| source.clone());
         if *entry != source {
             *entry = OutputSource::Ambiguous;
         }
-    };
-    for item in &select.projection {
-        match item {
-            SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(_, _) => {
-                return Projection::Wildcard;
+    }
+
+    /// What a wildcard leaves for the names no projection item declares.
+    ///
+    /// `EXCEPT`, `EXCLUDE` and `REPLACE` each remove a name from the
+    /// expansion, the last because it supplies its own value for it. `ILIKE`,
+    /// `RENAME` and a trailing `AS` alias select or rename the expanded
+    /// columns by a rule this planner does not model, so a name under one is
+    /// answered with a reason rather than with the base column of that name.
+    /// (DataFusion 54 refuses to plan the last two outright, which makes the
+    /// refusal here the same answer the caller would have got for the
+    /// statement it handed in.)
+    fn wildcard_rest(options: &WildcardAdditionalOptions) -> Rest {
+        if options.opt_ilike.is_some()
+            || options.opt_rename.is_some()
+            || options.opt_alias.is_some()
+        {
+            return Rest::Unreadable(unproven::WILDCARD_OPTION);
+        }
+        let mut removed: BTreeSet<String> = BTreeSet::new();
+        if let Some(except) = &options.opt_except {
+            for ident in std::iter::once(&except.first_element).chain(&except.additional_elements) {
+                removed.insert(ident_name(ident));
             }
-            SelectItem::ExprWithAlias { expr, alias } => {
-                let source = match column_of(expr) {
-                    Some(name) => OutputSource::Column(name),
-                    None => OutputSource::Expression(Box::new(expr.clone())),
-                };
-                record(ident_name(alias), source);
-            }
-            SelectItem::UnnamedExpr(expr) => {
-                if let Some(column) = column_of(expr) {
-                    record(column.clone(), OutputSource::Column(column));
+        }
+        if let Some(exclude) = &options.opt_exclude {
+            let names = match exclude {
+                datafusion::sql::sqlparser::ast::ExcludeSelectItem::Single(name) => {
+                    std::slice::from_ref(name)
+                }
+                datafusion::sql::sqlparser::ast::ExcludeSelectItem::Multiple(names) => {
+                    names.as_slice()
+                }
+            };
+            for name in names {
+                match bare_name(name) {
+                    Some(name) => {
+                        removed.insert(name);
+                    }
+                    // A qualified EXCLUDE name is not a plain output column,
+                    // so which name it removes is not readable here.
+                    None => return Rest::Unreadable(unproven::WILDCARD_OPTION),
                 }
             }
-            // A multi-alias item names columns this planner does not model, so
-            // it contributes no name: an ordering over one is refused rather
-            // than admitted on a guess.
-            SelectItem::ExprWithAliases { .. } => {}
         }
+        if let Some(replace) = &options.opt_replace {
+            for item in &replace.items {
+                removed.insert(ident_name(&item.column_name));
+            }
+        }
+        Rest::Wildcard { removed }
     }
-    Projection::Columns(names)
+
+    /// The output names a wildcard's `REPLACE` declares, with the expressions
+    /// they are built from. `* REPLACE (nullif(value, 0) AS ts)` projects `ts`
+    /// from that expression, not from `samples.ts`.
+    fn wildcard_replacements(options: &WildcardAdditionalOptions) -> Vec<(String, OutputSource)> {
+        let Some(replace) = &options.opt_replace else {
+            return Vec::new();
+        };
+        replace
+            .items
+            .iter()
+            .map(|item| {
+                let source = match column_of(&item.expr) {
+                    Some(name) => OutputSource::Column(name),
+                    None => OutputSource::Expression(Box::new(item.expr.clone())),
+                };
+                (ident_name(&item.column_name), source)
+            })
+            .collect()
+    }
+
+    /// Whether the statement's own `FROM` relation is the target base table
+    /// under its own column names, so that the table's public schema
+    /// describes the values it projects.
+    ///
+    /// The shapes this refuses each produced a plan whose keyset predicate
+    /// silently dropped rows from every page with no error:
+    ///
+    /// - a derived table or a CTE, where the output name is the inner query's
+    ///   own (`SELECT * FROM (SELECT nullif(value, 0) AS ts, series_id FROM
+    ///   samples) x ORDER BY ts` proved `ts` off `samples.ts` while the value
+    ///   was `nullif(value, 0)`);
+    /// - a positional column-rename list on the relation itself
+    ///   (`FROM samples AS x (ts, series_id, a, b)`), where the schema is
+    ///   asked about `series_id` and the value is `value`;
+    /// - the nullable side of an outer join, where the base column really is
+    ///   NOT NULL and is still NULL for every unmatched row;
+    /// - `ROLLUP`, `CUBE` and `GROUPING SETS`, where the schema lookup is
+    ///   correct and the grouping construct introduces the NULL in the
+    ///   super-aggregate row.
+    ///
+    /// Two of the refusals are wider than those shapes strictly need, and
+    /// both are deliberate. An inner or cross join is refused alongside the
+    /// outer ones, because an output name under a join is resolvable against
+    /// more than one relation and a single-table lookup cannot say which. A
+    /// `WITH` clause is refused even when the `FROM` names the base table,
+    /// because a CTE can declare that same name and shadow it.
+    fn basis_of(query: &Query, target: PageTarget) -> Basis {
+        let Some(table) = target.table_name() else {
+            return Basis::Unresolvable(unproven::NO_BASE_TABLE);
+        };
+        if query.with.is_some() {
+            return Basis::Unresolvable(unproven::WITH_CLAUSE);
+        }
+        let SetExpr::Select(select) = query.body.as_ref() else {
+            return Basis::Unresolvable(unproven::SET_OPERATION);
+        };
+        let [only] = select.from.as_slice() else {
+            return Basis::Unresolvable(unproven::NOT_ONE_RELATION);
+        };
+        if !only.joins.is_empty() {
+            return Basis::Unresolvable(unproven::JOINED);
+        }
+        let name = match relation_of(&only.relation) {
+            Relation::BareTable(name) => name,
+            Relation::Other(reason) => return Basis::Unresolvable(reason),
+        };
+        if bare_name(name).as_deref() != Some(table) {
+            return Basis::Unresolvable(unproven::OTHER_RELATION);
+        }
+        if grouping_can_null_a_grouping_column(&select.group_by) {
+            return Basis::Unresolvable(unproven::GROUPING_NULLS);
+        }
+        Basis::Table(table)
+    }
 }
 
-/// Whether an output name may be resolved against the target table's public
-/// schema at all.
+use resolution::{OutputResolution, Provenance};
+
+/// The `FROM` relation of a single `SELECT` body, for the two questions this
+/// module asks of it: whether the target table's public schema describes the
+/// names it projects, and whether it emits the target's rows one-for-one.
 ///
-/// [`Projection::source_column`] maps an output name to a name in the `FROM`
-/// relation. Asking the target table's schema about that name is sound only
-/// when the `FROM` relation IS that base table: otherwise the schema answers
-/// about a column the value did not come from, and a NOT NULL declaration
-/// there says nothing about the value being ordered on.
-enum SchemaBasis {
-    /// Output names resolve against this table's public schema.
-    Resolvable(&'static str),
-    /// They do not, for this reason, which the refusal quotes.
-    Unresolvable(&'static str),
+/// Both answers used to be read off a `TableFactor::Table { name, args: None,
+/// .. }` pattern, in two independent places. The `..` swallowed `alias`, whose
+/// `columns` field is a POSITIONAL rename list: `FROM samples AS x (ts,
+/// series_id, a, b)` was judged to be `samples` while every column was renamed
+/// underneath it, so `series_id` named `value` and both the row-identity claim
+/// and the schema lookup answered about a different column. It swallowed
+/// `sample` too, so a `TABLESAMPLE` was planned as a total order over rows
+/// that a later DataFusion will re-draw per page.
+///
+/// So the pattern below names every field, with no `..`: a field a later
+/// sqlparser adds is a compile error here rather than a third instance of the
+/// same defect.
+enum Relation<'a> {
+    /// A bare reference to this table: nothing renames its columns, selects a
+    /// subset of its rows, or adds a column to it.
+    BareTable(&'a ObjectName),
+    /// Anything else, with the reason it is not that.
+    Other(&'static str),
+}
+
+fn relation_of(factor: &TableFactor) -> Relation<'_> {
+    let TableFactor::Table {
+        name,
+        alias,
+        args,
+        with_hints,
+        version,
+        with_ordinality,
+        partitions,
+        json_path,
+        sample,
+        index_hints,
+    } = factor
+    else {
+        return Relation::Other(unproven::DERIVED_RELATION);
+    };
+    if args.is_some() {
+        return Relation::Other(unproven::DERIVED_RELATION);
+    }
+    if alias
+        .as_ref()
+        .is_some_and(|alias| !alias.columns.is_empty())
+    {
+        return Relation::Other(unproven::RENAMED_COLUMNS);
+    }
+    if sample.is_some() {
+        return Relation::Other(unproven::SAMPLED_RELATION);
+    }
+    if *with_ordinality
+        || version.is_some()
+        || json_path.is_some()
+        || !with_hints.is_empty()
+        || !partitions.is_empty()
+        || !index_hints.is_empty()
+    {
+        return Relation::Other(unproven::RELATION_MODIFIER);
+    }
+    Relation::BareTable(name)
 }
 
 /// The reasons a [`PagePlanError::OrderTermNullabilityUnknown`] can carry,
@@ -816,60 +1146,18 @@ mod unproven {
         "the projection gives that output name twice, from different sources";
     pub(super) const EXPRESSION_NOT_PROVABLE: &str = "the expression it is defined by is not one this planner proves NON NULL, and \
          SUM, MIN, MAX and AVG are NULL over empty or all-NULL input";
-}
-
-/// Whether the statement's own `FROM` relation is the target base table, so
-/// that the table's public schema describes the values it projects.
-///
-/// The three shapes this refuses each produced a plan whose keyset predicate
-/// silently dropped every row with a NULL order term, from every page, with
-/// no error:
-///
-/// - a derived table or a CTE, where the output name is the inner query's
-///   own (`SELECT * FROM (SELECT nullif(value, 0) AS ts, series_id FROM
-///   samples) x ORDER BY ts` proved `ts` off `samples.ts` while the value was
-///   `nullif(value, 0)`);
-/// - the nullable side of an outer join, where the base column really is NOT
-///   NULL and is still NULL for every unmatched row;
-/// - `ROLLUP`, `CUBE` and `GROUPING SETS`, where the schema lookup is correct
-///   and the grouping construct introduces the NULL in the super-aggregate
-///   row.
-///
-/// Two of the refusals are wider than those shapes strictly need, and both
-/// are deliberate. An inner or cross join is refused alongside the outer
-/// ones, because an output name under a join is resolvable against more than
-/// one relation and a single-table lookup cannot say which. A `WITH` clause
-/// is refused even when the `FROM` names the base table, because a CTE can
-/// declare that same name and shadow it.
-fn schema_basis(query: &Query, target: PageTarget) -> SchemaBasis {
-    let Some(table) = target.table_name() else {
-        return SchemaBasis::Unresolvable(unproven::NO_BASE_TABLE);
-    };
-    if query.with.is_some() {
-        return SchemaBasis::Unresolvable(unproven::WITH_CLAUSE);
-    }
-    let SetExpr::Select(select) = query.body.as_ref() else {
-        return SchemaBasis::Unresolvable(unproven::SET_OPERATION);
-    };
-    let [only] = select.from.as_slice() else {
-        return SchemaBasis::Unresolvable(unproven::NOT_ONE_RELATION);
-    };
-    if !only.joins.is_empty() {
-        return SchemaBasis::Unresolvable(unproven::JOINED);
-    }
-    let TableFactor::Table {
-        name, args: None, ..
-    } = &only.relation
-    else {
-        return SchemaBasis::Unresolvable(unproven::DERIVED_RELATION);
-    };
-    if bare_name(name).as_deref() != Some(table) {
-        return SchemaBasis::Unresolvable(unproven::OTHER_RELATION);
-    }
-    if grouping_can_null_a_grouping_column(&select.group_by) {
-        return SchemaBasis::Unresolvable(unproven::GROUPING_NULLS);
-    }
-    SchemaBasis::Resolvable(table)
+    pub(super) const RENAMED_COLUMNS: &str = "its FROM relation carries a positional column-rename list, so an output name \
+         is not the base column of that name";
+    pub(super) const SAMPLED_RELATION: &str =
+        "its FROM relation is sampled, so it does not emit the target's rows";
+    pub(super) const RELATION_MODIFIER: &str = "its FROM relation carries a modifier that can change the columns or the rows \
+         it emits";
+    pub(super) const SEVERAL_WILDCARDS: &str =
+        "the projection has more than one wildcard, so an output name is given twice";
+    pub(super) const WILDCARD_OPTION: &str = "the wildcard carries an ILIKE, RENAME or AS option, which selects or renames \
+         the expanded columns by a rule this planner does not model";
+    pub(super) const MULTI_ALIAS: &str = "the projection item that names it carries a multi-alias list, whose expansion \
+         this planner does not model";
 }
 
 /// Whether the `GROUP BY` can emit a row where a grouping column is NULL even
@@ -877,12 +1165,19 @@ fn schema_basis(query: &Query, target: PageTarget) -> SchemaBasis {
 ///
 /// `ROLLUP`, `CUBE`, `GROUPING SETS` and ClickHouse's `WITH TOTALS` each add
 /// a super-aggregate row whose unaggregated grouping columns are NULL. Both
-/// spellings count: the modifier form (`GROUP BY a WITH ROLLUP`) and the
-/// expression form (`GROUP BY ROLLUP(a)`). A plain `GROUP BY` and
+/// spellings count, and so does either grouping form carrying them: the
+/// modifier form (`GROUP BY a WITH ROLLUP`, `GROUP BY ALL WITH ROLLUP`) and
+/// the expression form (`GROUP BY ROLLUP(a)`). A plain `GROUP BY` and a bare
 /// `GROUP BY ALL` add no such row, so neither is refused here.
+///
+/// The modifier list has to be read off BOTH grouping forms. Reading it off
+/// the expression form alone refused `GROUP BY a WITH ROLLUP` and admitted
+/// `GROUP BY ALL WITH ROLLUP`, which is the same construct over a column list
+/// the parser did not have to spell out.
 fn grouping_can_null_a_grouping_column(group_by: &GroupByExpr) -> bool {
-    let GroupByExpr::Expressions(exprs, modifiers) = group_by else {
-        return false;
+    let (exprs, modifiers) = match group_by {
+        GroupByExpr::All(modifiers) => ([].as_slice(), modifiers),
+        GroupByExpr::Expressions(exprs, modifiers) => (exprs.as_slice(), modifiers),
     };
     !modifiers.is_empty()
         || exprs.iter().any(|expr| {
@@ -914,35 +1209,36 @@ enum NullProof {
 /// There are two routes to a proof and the term takes whichever one its
 /// projection offers.
 ///
-/// A bare column reference goes through the schema, and that proof has to hold
-/// end to end: the name has to be a column of the `FROM` relation, that
-/// relation has to be the target base table itself (see [`schema_basis`]), and
-/// the column has to be declared non-nullable in the table's public schema. A
-/// declared column is absent from the static schema, and whether it exists at
-/// all depends on the tenant's declarations rather than on the text, so it is
-/// `Unproven` rather than either answer.
+/// A [`Provenance::BaseColumn`] goes through the schema, and that proof holds
+/// end to end by construction of the variant: it exists only where the name is
+/// a column of the `FROM` relation AND that relation is the target base table
+/// itself under its own column names. What is left for this function is the
+/// declaration. A declared column is absent from the static schema, and
+/// whether it exists at all depends on the tenant's declarations rather than
+/// on the text, so it is `Unproven` rather than either answer.
 ///
-/// An alias over an expression is answered by
-/// [`expression_is_non_null`] reading the expression itself, with no schema
-/// consulted and no basis required: a literal and a `count(...)` are NON NULL
-/// whatever relation they are selected from, including under an outer join or
-/// a `ROLLUP`, because neither is a grouping column that a super-aggregate row
-/// can null.
-fn term_nullability(basis: &SchemaBasis, projection: &Projection, column: &str) -> NullProof {
-    let source = match projection.term_source(column) {
-        TermSource::Column(source) => source,
-        TermSource::Expression(expr) => {
+/// A [`Provenance::Expression`] is answered by [`expression_is_non_null`]
+/// reading the expression itself, with no schema consulted and no basis
+/// required: a literal and a `count(...)` are NON NULL whatever relation they
+/// are selected from, including under an outer join or a `ROLLUP`, because
+/// neither is a grouping column that a super-aggregate row can null.
+fn term_nullability(names: &OutputResolution, column: &str) -> NullProof {
+    let (table, source) = match names.resolve(column) {
+        Provenance::BaseColumn { table, column } => (table, column),
+        Provenance::Expression(expr) => {
             return if expression_is_non_null(expr) {
                 NullProof::NonNull
             } else {
                 NullProof::Unproven(unproven::EXPRESSION_NOT_PROVABLE)
             };
         }
-        TermSource::Unreadable(reason) => return NullProof::Unproven(reason),
-    };
-    let table = match basis {
-        SchemaBasis::Resolvable(table) => *table,
-        SchemaBasis::Unresolvable(reason) => return NullProof::Unproven(reason),
+        Provenance::Opaque(reason) => return NullProof::Unproven(reason),
+        // `plan_page` refuses an order term the statement does not project
+        // before it asks about nullability, and `tiebreak` reports a tiebreak
+        // column it cannot find as not-a-total-order rather than appending it.
+        // Answering rather than asserting keeps that ordering a property of
+        // the code above instead of a panic on a production path.
+        Provenance::NotProjected => return NullProof::Unproven(unproven::NOT_A_BARE_COLUMN),
     };
     let schema = match table {
         SAMPLES_TABLE => public_schema(),
@@ -1022,11 +1318,9 @@ fn shape_of<'a>(query: &'a Query) -> Option<SelectShape<'a>> {
     };
     let (from_table, joined) = match select.from.as_slice() {
         [only] => (
-            match &only.relation {
-                TableFactor::Table {
-                    name, args: None, ..
-                } => Some(name),
-                _ => None,
+            match relation_of(&only.relation) {
+                Relation::BareTable(name) => Some(name),
+                Relation::Other(_) => None,
             },
             !only.joins.is_empty(),
         ),
@@ -1102,7 +1396,7 @@ fn statement_order_terms(query: &Query) -> Result<Vec<OrderTerm>, PagePlanError>
 fn tiebreak(
     query: &Query,
     target: PageTarget,
-    projection: &Projection,
+    names: &OutputResolution,
     terms: &[OrderTerm],
 ) -> (Vec<String>, Option<NotTotalOrder>) {
     let identity: &[&str] = match target {
@@ -1130,7 +1424,15 @@ fn tiebreak(
     let mut missing = Vec::new();
     let mut append = Vec::new();
     for column in identity {
-        if !projection.projects(column) {
+        // The output name has to BE the identity column, not merely carry its
+        // name. `SELECT ts, value AS series_id FROM samples` projects the name
+        // `series_id` off `value`, and `(ts, value)` is not a key: the ordering
+        // ties on it and the keyset predicate leaves a tied row on no page.
+        let identical = matches!(
+            names.resolve(column),
+            Provenance::BaseColumn { column: source, .. } if source == *column
+        );
+        if !identical {
             missing.push((*column).to_string());
             continue;
         }
@@ -1305,6 +1607,7 @@ fn quote_ident(column: &str) -> String {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::sync::Arc;
 
     use datafusion::datasource::MemTable;
@@ -2033,7 +2336,7 @@ mod tests {
         }
 
         // An inner join is refused by the same rule, for the narrower reason
-        // stated in `schema_basis`: nothing nulls a column, but an output
+        // stated on `unproven::JOINED`: nothing nulls a column, but an output
         // name under a join resolves against more than one relation.
         let inner = plan_page(
             "SELECT a.ts AS ts, b.body AS b_body FROM logs AS a \
@@ -2433,6 +2736,19 @@ mod tests {
     /// the ordering itself, not about NULLs -- no `ORDER BY` at all, a term
     /// that is not a column, a term the statement does not project -- and
     /// each is a separate piece of work.
+    ///
+    /// What this does NOT cover: the total-order path. The corpus is
+    /// logs-only, `logs` has no row identity, and every statement in it is
+    /// therefore `NotTotalOrder::NoRowIdentity` before the tiebreak, the
+    /// row-identity claim, or the keyset predicate is exercised at all. Zero
+    /// of the 43 statements produce a total-order plan, so no regression in
+    /// that path can move a number here. The coverage for it is the executed
+    /// page walk in `crates/ravel-sql/tests/page_walk.rs`, which pages a
+    /// `samples` fixture with deliberate ties one row at a time and asserts
+    /// multiset equality against the same statement run unpaged. A
+    /// total-order claim is proven there and nowhere else: a plan assertion
+    /// cannot tell a correct claim from one that drops a tied row from every
+    /// page.
     #[test]
     fn the_clickbench_corpus_page_plan_outcomes_are_pinned() {
         let corpus: serde_json::Value =
@@ -2534,5 +2850,211 @@ mod tests {
             ],
         );
         assert!(plan.total_order());
+    }
+
+    /// An output name is not a column. A projection may give an identity
+    /// column's NAME to any expression, and the row-identity claim has to be
+    /// about the column itself: `(ts, value)` is not a key of `samples`, and
+    /// `crates/ravel-sql/tests/page_walk.rs` shows the tied row landing on no
+    /// page when the claim is made on the name alone.
+    #[test]
+    fn an_alias_cannot_take_an_identity_columns_name() {
+        for sql in [
+            "SELECT ts, value AS series_id FROM samples ORDER BY ts",
+            "SELECT ts, labels AS series_id FROM samples ORDER BY ts",
+            "SELECT ts, nullif(value, 0) AS series_id FROM samples ORDER BY ts",
+        ] {
+            let plan = plan_page(sql, None).expect("planned");
+            assert_eq!(
+                plan.not_total,
+                Some(NotTotalOrder::TiebreakNotProjected {
+                    missing: vec!["series_id".to_string()],
+                }),
+                "unexpected total-order claim for {sql:?}"
+            );
+            assert!(!plan.total_order());
+            assert_eq!(plan.tiebreak_appended, Vec::<String>::new());
+        }
+
+        // The same name from the column itself, qualified or aliased to
+        // itself, still IS that column and still carries the identity.
+        for sql in [
+            "SELECT ts, series_id FROM samples ORDER BY ts",
+            "SELECT ts, samples.series_id FROM samples ORDER BY ts",
+            "SELECT ts, series_id AS series_id FROM samples ORDER BY ts",
+        ] {
+            let plan = plan_page(sql, None).expect("planned");
+            assert_eq!(plan.not_total, None, "unexpected refusal for {sql:?}");
+            assert_eq!(plan.tiebreak_appended, vec!["series_id".to_string()]);
+        }
+    }
+
+    /// A `TableAlias`'s `columns` field is a POSITIONAL rename list, so
+    /// `FROM samples AS x (ts, series_id, a, b)` projects `value` under the
+    /// name `series_id`. Both questions asked of the `FROM` relation have to
+    /// see it: the row-identity claim and the schema lookup.
+    #[test]
+    fn a_positional_column_rename_list_is_not_the_target_relation() {
+        // The nullability route is gated by the reading: `ts` and `series_id`
+        // are NOT NULL in the public schema, and the values under those names
+        // here are the first two columns of whatever `x` renames, so the
+        // schema must not be consulted for either.
+        for sql in [
+            "SELECT ts, series_id FROM samples AS x (ts, series_id, a, b) \
+             ORDER BY ts, series_id",
+            "SELECT ts, a FROM samples AS x (ts, series_id, a, b) ORDER BY ts",
+        ] {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNullabilityUnknown {
+                    column: "ts".to_string(),
+                    reason: unproven::RENAMED_COLUMNS,
+                },
+                "unexpected outcome for {sql:?}"
+            );
+        }
+
+        // The row-identity claim is gated by the same reading, which the
+        // shape check reaches first: the relation is not the target table.
+        let (_, not_total) = {
+            let query = parse_query(
+                "SELECT ts, series_id FROM samples AS x (ts, series_id, a, b) \
+                 ORDER BY ts, series_id",
+            )
+            .expect("parsed");
+            let names = OutputResolution::of(&query, PageTarget::Samples);
+            let terms = statement_order_terms(&query).expect("terms");
+            tiebreak(&query, PageTarget::Samples, &names, &terms)
+        };
+        assert_eq!(
+            not_total,
+            Some(NotTotalOrder::ShapeNotIdentityPreserving {
+                shape: "a FROM clause that is not the target table",
+            }),
+        );
+
+        // An alias with NO column list renames the relation only, and both
+        // questions still resolve.
+        let aliased = plan_page("SELECT * FROM samples AS x ORDER BY ts", None).expect("planned");
+        assert!(aliased.total_order());
+    }
+
+    /// A wildcard is not the end of the projection. `EXCEPT`, `EXCLUDE` and
+    /// `REPLACE` each remove a name from the expansion, and an item that
+    /// redefines that name supplies what the ordering actually sorts on.
+    #[test]
+    fn a_wildcard_does_not_answer_for_a_name_a_later_item_redefines() {
+        for sql in [
+            "SELECT * EXCEPT (ts), nullif(value, 0) AS ts FROM samples ORDER BY ts",
+            "SELECT * EXCLUDE (ts), nullif(value, 0) AS ts FROM samples ORDER BY ts",
+            "SELECT * REPLACE (nullif(value, 0) AS ts) FROM samples ORDER BY ts",
+        ] {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNullabilityUnknown {
+                    column: "ts".to_string(),
+                    reason: unproven::EXPRESSION_NOT_PROVABLE,
+                },
+                "unexpected outcome for {sql:?}"
+            );
+        }
+
+        // A removed identity column is not projected at all, so the row
+        // identity does not carry either.
+        let removed =
+            plan_page("SELECT * EXCEPT (series_id) FROM samples", None).expect_err("refused");
+        assert_eq!(removed, PagePlanError::NoOrdering { target: "samples" });
+
+        // A wildcard that does NOT remove the name still expands it, so the
+        // statement gives that output name twice.
+        let twice =
+            plan_page("SELECT *, 1 AS ts FROM samples ORDER BY ts", None).expect_err("refused");
+        assert_eq!(
+            twice,
+            PagePlanError::OrderTermNullabilityUnknown {
+                column: "ts".to_string(),
+                reason: unproven::AMBIGUOUS_NAME,
+            },
+        );
+
+        // Two wildcards expand one relation twice over.
+        let both = plan_page("SELECT *, * FROM samples ORDER BY ts", None).expect_err("refused");
+        assert_eq!(
+            both,
+            PagePlanError::OrderTermNullabilityUnknown {
+                column: "ts".to_string(),
+                reason: unproven::SEVERAL_WILDCARDS,
+            },
+        );
+
+        // A plain wildcard, and one whose removals do not touch the term,
+        // both still resolve through to the base column.
+        for sql in [
+            "SELECT * FROM samples ORDER BY ts",
+            "SELECT * EXCEPT (labels) FROM samples ORDER BY ts",
+            "SELECT * REPLACE (value + 1 AS value) FROM samples ORDER BY ts",
+        ] {
+            let plan = plan_page(sql, None).expect("planned");
+            assert!(plan.total_order(), "unexpected refusal for {sql:?}");
+        }
+    }
+
+    /// `WITH ROLLUP`, `WITH CUBE` and `WITH TOTALS` are modifiers on the
+    /// grouping, and either grouping form can carry them. `GROUP BY ALL WITH
+    /// ROLLUP` is the same super-aggregate row as `GROUP BY a WITH ROLLUP`
+    /// over a column list the parser did not have to spell out.
+    #[test]
+    fn a_grouping_modifier_counts_on_both_grouping_forms() {
+        for sql in [
+            "SELECT ts, count(*) AS hits FROM samples GROUP BY ts WITH ROLLUP ORDER BY ts",
+            "SELECT ts, count(*) AS hits FROM samples GROUP BY ALL WITH ROLLUP ORDER BY ts",
+            "SELECT ts, count(*) AS hits FROM samples GROUP BY ALL WITH CUBE ORDER BY ts",
+            "SELECT ts, count(*) AS hits FROM samples GROUP BY ALL WITH TOTALS ORDER BY ts",
+        ] {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNullabilityUnknown {
+                    column: "ts".to_string(),
+                    reason: unproven::GROUPING_NULLS,
+                },
+                "unexpected outcome for {sql:?}"
+            );
+        }
+
+        // A bare `GROUP BY ALL` adds no super-aggregate row, so the schema
+        // still describes the grouping column. It is not a total order (the
+        // grouping does not preserve rows one-for-one), but it plans.
+        let plain = plan_page(
+            "SELECT ts, count(*) AS hits FROM samples GROUP BY ALL ORDER BY ts",
+            None,
+        )
+        .expect("planned");
+        assert_eq!(
+            plain.not_total,
+            Some(NotTotalOrder::ShapeNotIdentityPreserving { shape: "GROUP BY" }),
+        );
+    }
+
+    /// A sampled relation does not emit the target's rows: the sample is
+    /// re-drawn per execution, so every page would be a fresh draw.
+    #[test]
+    fn a_sampled_relation_is_not_the_targets_rows() {
+        for sql in [
+            "SELECT * FROM samples TABLESAMPLE BERNOULLI (50) ORDER BY ts",
+            "SELECT * FROM samples TABLESAMPLE SYSTEM (50) ORDER BY ts",
+        ] {
+            let plan = plan_page(sql, None);
+            assert_eq!(
+                plan,
+                Err(PagePlanError::OrderTermNullabilityUnknown {
+                    column: "ts".to_string(),
+                    reason: unproven::SAMPLED_RELATION,
+                }),
+                "unexpected outcome for {sql:?}"
+            );
+        }
     }
 }

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -60,6 +60,15 @@
 //! kinds, so a pipe kind added by a later sqlparser is refused too instead of
 //! being silently admitted.
 //!
+//! Both that refusal and the row-limit one
+//! ([`PagePlanError::RowLimitInStatement`]) are taken over EVERY `Query` in
+//! the statement, not the outermost one alone. The wrap re-emits the caller's
+//! text verbatim, so a `LIMIT` inside a `WHERE` subquery, a scalar subquery,
+//! a derived table, an arm of a set operation, or a CTE is still there on
+//! every page, picking a fresh arbitrary set of rows each time it runs. See
+//! [`reject_nested_pipes_and_row_limits`] for what that walk covers and for
+//! why a nested limit is refused even when its own subquery is deterministic.
+//!
 //! An `ORDER BY` term that can be NULL is refused as well
 //! ([`PagePlanError::OrderTermNullable`]): a keyset comparison against NULL is
 //! NULL, so the rows whose term is NULL match no disjunct and appear on no
@@ -97,11 +106,12 @@
 //! comparison the providers can push down.
 
 use std::collections::BTreeMap;
+use std::ops::ControlFlow;
 
 use datafusion::sql::parser::{DFParser, Statement as DFStatement};
 use datafusion::sql::sqlparser::ast::{
-    Distinct, Expr as SqlExpr, GroupByExpr, Ident, ObjectName, OrderBy, OrderByKind, Query,
-    SelectItem, SetExpr, Statement, TableFactor,
+    Distinct, Expr as SqlExpr, GroupByExpr, Ident, ObjectName, OrderBy, OrderByKind, Query, Select,
+    SelectItem, SetExpr, Statement, TableFactor, Visit, Visitor,
 };
 
 use crate::alerts_schema::alerts_schema;
@@ -414,17 +424,10 @@ pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan,
     let query = parse_query(sql)?;
 
     // Before anything else reads the `SELECT` body: a pipe operator makes that
-    // body an incomplete description of the statement, so every check below it
-    // would be answering about the wrong rows.
-    if !query.pipe_operators.is_empty() {
-        return Err(PagePlanError::PipeOperator);
-    }
-    if query.limit_clause.is_some() || query.fetch.is_some() {
-        return Err(PagePlanError::RowLimitInStatement);
-    }
-    if let Some(SelectShape { top: Some(_), .. }) = shape_of(&query) {
-        return Err(PagePlanError::RowLimitInStatement);
-    }
+    // body an incomplete description of the statement, and a row limit at any
+    // depth re-evaluates per page, so every check below either answers about
+    // the wrong rows or answers about rows that change under it.
+    reject_nested_pipes_and_row_limits(&query)?;
 
     let target = page_target(sql)?;
     let projection = projection_of(&query);
@@ -479,6 +482,66 @@ fn parse_query(sql: &str) -> Result<Query, PagePlanError> {
             })),
         },
         _ => Err(PagePlanError::Invalid(ValidationError::Empty)),
+    }
+}
+
+/// Refuse a pipe operator and a row limit wherever either sits, not only on
+/// the outermost `Query`.
+///
+/// Both used to be read off the top-level `Query` alone, which made a pipe or
+/// a limit on any inner query invisible: a subquery in `WHERE`, a scalar
+/// subquery in the projection, a derived table in `FROM`, an arm of a set
+/// operation, and a CTE all carry their own `Query`, and `Display for Query`
+/// re-emits every one of them verbatim into the derived table the rewrite
+/// wraps. An inner `LIMIT 5` then re-evaluates against a fresh arbitrary five
+/// rows on every page, so consecutive pages of one cursor are pages of
+/// different results, with `not_total: None` reported for the whole thing.
+///
+/// Every nested row limit is refused, including one whose own subquery is
+/// totally ordered and therefore picks the same rows every time. Telling those
+/// apart means reading each inner query's ordering and proving it total, which
+/// is a design change; this is a correctness fix, so the conservative refusal
+/// is the decision.
+///
+/// The pipe check is keyed on a pipe being PRESENT rather than on a list of
+/// pipe kinds, so a kind a later sqlparser adds fails closed.
+fn reject_nested_pipes_and_row_limits(query: &Query) -> Result<(), PagePlanError> {
+    let mut found: Option<PagePlanError> = None;
+    let _ = query.visit(&mut NestedShapeGuard { found: &mut found });
+    match found {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+struct NestedShapeGuard<'a> {
+    found: &'a mut Option<PagePlanError>,
+}
+
+impl Visitor for NestedShapeGuard<'_> {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &Query) -> ControlFlow<()> {
+        if !query.pipe_operators.is_empty() {
+            *self.found = Some(PagePlanError::PipeOperator);
+            return ControlFlow::Break(());
+        }
+        if query.limit_clause.is_some() || query.fetch.is_some() {
+            *self.found = Some(PagePlanError::RowLimitInStatement);
+            return ControlFlow::Break(());
+        }
+        ControlFlow::Continue(())
+    }
+
+    /// `TOP` hangs off the `SELECT` body rather than the `Query`, and an arm
+    /// of a set operation is a bare `SetExpr::Select` with no `Query` of its
+    /// own, so it needs its own hook to be seen in every position.
+    fn pre_visit_select(&mut self, select: &Select) -> ControlFlow<()> {
+        if select.top.is_some() {
+            *self.found = Some(PagePlanError::RowLimitInStatement);
+            return ControlFlow::Break(());
+        }
+        ControlFlow::Continue(())
     }
 }
 
@@ -1423,6 +1486,79 @@ mod tests {
                 err.to_string(),
                 "a statement using a pipe operator cannot be paged; a pipe \
                  reshapes the rows after the SELECT body a page is planned from",
+            );
+        }
+    }
+
+    /// A pipe operator is refused wherever it sits, not only on the outermost
+    /// `Query`.
+    ///
+    /// The five positions below each carry their own `Query`, and the guard
+    /// used to read the top-level one alone: every one of these planned, with
+    /// the pipe re-emitted verbatim into the derived table by `Display`. The
+    /// `WHERE`-subquery case is the demonstrated defect -- `SELECT * FROM
+    /// samples WHERE series_id IN (SELECT series_id FROM samples |> LIMIT 5)
+    /// ORDER BY ts` planned with `not_total: None`, so the tool minted a
+    /// cursor over an inner relation that re-picks five arbitrary series on
+    /// every page.
+    #[test]
+    fn refuses_a_pipe_at_every_nesting_depth() {
+        let cases = [
+            // A subquery in WHERE.
+            "SELECT * FROM samples WHERE series_id IN \
+             (SELECT series_id FROM samples |> LIMIT 5) ORDER BY ts",
+            // A scalar subquery in the projection.
+            "SELECT ts, series_id, (SELECT max(value) FROM samples |> LIMIT 1) AS m \
+             FROM samples ORDER BY ts",
+            // A derived table in FROM.
+            "SELECT * FROM (SELECT ts, series_id FROM samples |> WHERE value > 1) AS x \
+             ORDER BY ts",
+            // An arm of a set operation.
+            "SELECT ts FROM samples UNION ALL (SELECT ts FROM samples |> LIMIT 5) ORDER BY ts",
+            // A CTE in a WITH clause.
+            "WITH c AS (SELECT ts, series_id FROM samples |> LIMIT 5) \
+             SELECT * FROM c ORDER BY ts",
+        ];
+        for sql in cases {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(err, PagePlanError::PipeOperator, "unexpected for {sql:?}");
+        }
+    }
+
+    /// A row limit is refused wherever it sits, for the same reason and by the
+    /// same walk.
+    ///
+    /// An inner `LIMIT 5` with no ordering of its own selects five arbitrary
+    /// rows, and it is re-evaluated on every page because the wrap re-emits
+    /// it: page 2 resumes past page 1's last row of a relation that no longer
+    /// contains the same rows. The refusal covers a nested limit that WOULD be
+    /// deterministic too; see [`reject_nested_pipes_and_row_limits`].
+    #[test]
+    fn refuses_a_row_limit_at_every_nesting_depth() {
+        let cases = [
+            // A subquery in WHERE.
+            "SELECT * FROM samples WHERE series_id IN \
+             (SELECT series_id FROM samples LIMIT 5) ORDER BY ts",
+            // A scalar subquery in the projection.
+            "SELECT ts, series_id, (SELECT max(value) FROM samples LIMIT 1) AS m \
+             FROM samples ORDER BY ts",
+            // A derived table in FROM, in all three spellings a row cap has.
+            "SELECT * FROM (SELECT ts, series_id FROM samples LIMIT 5) AS x ORDER BY ts",
+            "SELECT * FROM (SELECT ts, series_id FROM samples OFFSET 5 ROWS) AS x ORDER BY ts",
+            "SELECT * FROM (SELECT TOP 5 ts, series_id FROM samples) AS x ORDER BY ts",
+            // An arm of a set operation, as a Query operand and as a bare
+            // SELECT body carrying a TOP.
+            "SELECT ts FROM samples UNION ALL (SELECT ts FROM samples LIMIT 5) ORDER BY ts",
+            "SELECT ts FROM samples UNION ALL SELECT TOP 5 ts FROM samples ORDER BY ts",
+            // A CTE in a WITH clause.
+            "WITH c AS (SELECT ts, series_id FROM samples LIMIT 5) SELECT * FROM c ORDER BY ts",
+        ];
+        for sql in cases {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::RowLimitInStatement,
+                "unexpected for {sql:?}"
             );
         }
     }

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -140,19 +140,25 @@
 //!
 //! # Every clause of the body is read, or discarded by name
 //!
-//! Three classifications here read the parser's AST, and each one names every
+//! Five classifications here read the parser's AST, and each one names every
 //! field it decides about with no `..` pattern: [`relation_of`] over
 //! `TableFactor::Table`, `resolution::projection_of` over the `SELECT` list,
-//! and [`shape_of`] over the `SELECT` body itself. A field that cannot change
-//! the row set is discarded by name with the reason, not by a wildcard.
+//! [`shape_of`] over the `SELECT` body itself, [`NestedShapeGuard`] over the
+//! `Query`, and [`statement_order_terms`] over the `OrderBy`. A field that
+//! cannot change the row set is discarded by name with the reason, not by a
+//! wildcard.
 //!
-//! The cost of the wildcard has been paid three times, most recently by
-//! [`shape_of`], which read thirteen of the body's twenty-four fields: `SELECT
-//! ts, series_id INTO t2 FROM samples ORDER BY ts` was planned as a total
-//! order and `Display for Query` re-emitted the `INTO` into the derived table,
-//! so every page would have written the table again. What the naming buys is
-//! not the nine or eleven fields that were missed: it is that field
-//! twenty-five of a later sqlparser is a compile error rather than silence.
+//! The cost of the wildcard has been paid five times. [`shape_of`] read
+//! thirteen of the body's twenty-four fields, so `SELECT ts, series_id INTO t2
+//! FROM samples ORDER BY ts` was planned as a total order and `Display for
+//! Query` re-emitted the `INTO` into the derived table, and every page would
+//! have written the table again. [`NestedShapeGuard`] read three of the
+//! `Query`'s ten, so `SETTINGS limit = 2` was a row limit nothing refused, and
+//! three more dialect clauses went into the derived table unread.
+//! [`statement_order_terms`] read one of the `OrderBy`'s two, so an
+//! `INTERPOLATE` was dropped along with the ordering it hangs off. What the
+//! naming buys is not the fields that were missed: it is that the field a
+//! later sqlparser adds is a compile error rather than silence.
 //!
 //! # One resolution from an output name
 //!
@@ -209,8 +215,14 @@
 //! - a pipe operator is [`PagePlanError::PipeOperator`], so a `|> limit` or a
 //!   `|> order_by` cannot reshape the rows after the body;
 //! - `WITH FILL` is [`PagePlanError::UnsupportedOrderOption`], which is the
-//!   only ClickHouse ordering form that adds rows (an `INTERPOLATE` is defined
-//!   only in terms of one, so it cannot change a row set on its own).
+//!   only ClickHouse ordering form that adds rows, and its clause-level
+//!   sibling `INTERPOLATE` is [`PagePlanError::UnsupportedOrderingClause`];
+//! - the four dialect clauses that hang off a `Query` rather than off its
+//!   body -- `SETTINGS`, `FORMAT`, a `FOR UPDATE`/`FOR SHARE` lock, and
+//!   `FOR XML`/`FOR JSON` -- are
+//!   [`PagePlanError::UnsupportedQueryClause`] at every depth, because the
+//!   wrap re-emits each of them verbatim and `SETTINGS limit = 2` is a row
+//!   limit spelled in a way the row-limit refusal does not recognise.
 //!
 //! A window function is NOT in the class: `OVER (ORDER BY ...)` carries its
 //! own ordering and no SQL window inherits the statement's. It is still paged
@@ -407,6 +419,37 @@ pub enum PagePlanError {
         column: String,
         option: &'static str,
     },
+
+    /// A clause hanging off the `ORDER BY` itself rather than off one of its
+    /// terms. `INTERPOLATE (...)` is the only spelling this dialect produces.
+    ///
+    /// Its sibling [`Self::UnsupportedOrderOption`] refuses the TERM-level
+    /// options, which is where this refusal was missing: the clause-level one
+    /// sat behind an `OrderBy { kind, .. }` pattern and was neither read nor
+    /// reproduced. The rewrite drops the statement's own `ORDER BY` when it
+    /// only orders, so the clause went with it, and `SELECT ts, series_id FROM
+    /// samples ORDER BY ts, series_id INTERPOLATE (value AS value)` planned
+    /// with a total-order claim. DataFusion refuses that statement outright,
+    /// so the page was not a differently ordered answer: it was a success
+    /// where the caller's own statement is an error, under semantics the
+    /// caller never asked for.
+    #[error("the ORDER BY clause `{clause}` cannot be paged")]
+    UnsupportedOrderingClause { clause: &'static str },
+
+    /// A dialect clause on a `Query` at any depth that the rewrite re-emits
+    /// verbatim into the derived table: ClickHouse's `SETTINGS` and `FORMAT`,
+    /// a `FOR UPDATE`/`FOR SHARE` lock, and MSSQL's `FOR XML`/`FOR JSON`.
+    ///
+    /// `SETTINGS` is the one that shows why a wildcard over the `Query` fields
+    /// is not good enough here: `SETTINGS limit = 2` is a row limit under a
+    /// name [`Self::RowLimitInStatement`] does not recognise, so the statement
+    /// that caps its own rows was reported as a pageable total order. `FORMAT`
+    /// reshapes the result, `FOR XML`/`FOR JSON` collapse it into one value,
+    /// and a lock clause is not a read. All four are inert against today's
+    /// engine only because DataFusion's planner drops what it does not
+    /// implement, which is not a property of this planner to rely on.
+    #[error("the `{clause}` clause cannot be paged")]
+    UnsupportedQueryClause { clause: &'static str },
 
     /// An `ORDER BY` term the text does not prove NON NULL.
     ///
@@ -729,13 +772,60 @@ struct NestedShapeGuard<'a> {
 impl Visitor for NestedShapeGuard<'_> {
     type Break = ();
 
+    /// Read every field of the `Query`, naming each one, for the same reason
+    /// [`shape_of`] names every field of the `SELECT` body: this was the other
+    /// place the rewrite decided about a node from a subset of it. It read
+    /// three of the ten fields, and the four dialect clauses it did not read
+    /// are re-emitted verbatim by `Display for Query` into the derived table.
     fn pre_visit_query(&mut self, query: &Query) -> ControlFlow<()> {
-        if !query.pipe_operators.is_empty() {
+        let Query {
+            // Each CTE carries its own `Query`, which this same visitor
+            // reaches on its own; a statement carrying a `WITH` at the top is
+            // separately outside the row-identity claim
+            // (`non_identity_shape`).
+            with: _,
+            // Visited in turn. Its `SELECT` bodies are `pre_visit_select`
+            // below, which is where `TOP` and `INTO` are read.
+            body: _,
+            // The outermost one is the effective ordering, read by
+            // `statement_order_terms`. An inner one is re-emitted verbatim, so
+            // every page runs the same ordering over the same rows: it cannot
+            // make consecutive pages be pages of different results, which is
+            // what this guard refuses.
+            order_by: _,
+            limit_clause,
+            fetch,
+            locks,
+            for_clause,
+            settings,
+            format_clause,
+            pipe_operators,
+        } = query;
+
+        if !pipe_operators.is_empty() {
             *self.found = Some(PagePlanError::PipeOperator);
             return ControlFlow::Break(());
         }
-        if query.limit_clause.is_some() || query.fetch.is_some() {
+        if limit_clause.is_some() || fetch.is_some() {
             *self.found = Some(PagePlanError::RowLimitInStatement);
+            return ControlFlow::Break(());
+        }
+        // ClickHouse's `SETTINGS` first, because it is the one that carries a
+        // row limit (`SETTINGS limit = 2`) under a name the check above does
+        // not recognise.
+        let clause = if settings.is_some() {
+            Some("SETTINGS")
+        } else if format_clause.is_some() {
+            Some("FORMAT")
+        } else if !locks.is_empty() {
+            Some("FOR UPDATE/FOR SHARE")
+        } else if for_clause.is_some() {
+            Some("FOR XML/FOR JSON")
+        } else {
+            None
+        };
+        if let Some(clause) = clause {
+            *self.found = Some(PagePlanError::UnsupportedQueryClause { clause });
             return ControlFlow::Break(());
         }
         ControlFlow::Continue(())
@@ -1701,10 +1791,25 @@ fn shape_of<'a>(query: &'a Query) -> Option<SelectShape<'a>> {
 }
 
 /// The statement's own `ORDER BY`, as effective terms.
+///
+/// Both fields of the `OrderBy` are named, with no `..`. The wildcard hid
+/// `interpolate`, and the rewrite drops the statement's own `ORDER BY`
+/// whenever it only orders, so the clause was dropped with it and the page
+/// ran under an ordering the caller had not written.
 fn statement_order_terms(query: &Query) -> Result<Vec<OrderTerm>, PagePlanError> {
-    let Some(OrderBy { kind, .. }) = &query.order_by else {
+    let Some(OrderBy { kind, interpolate }) = &query.order_by else {
         return Ok(Vec::new());
     };
+    // `INTERPOLATE` is defined only in terms of a `WITH FILL`, which is
+    // refused per term below, so it cannot add a row on its own. That is why
+    // it is refused rather than ignored: DataFusion rejects the statement, and
+    // a page that silently drops the clause answers a statement the engine
+    // itself calls an error.
+    if interpolate.is_some() {
+        return Err(PagePlanError::UnsupportedOrderingClause {
+            clause: "INTERPOLATE",
+        });
+    }
     let exprs = match kind {
         OrderByKind::All(_) => return Err(PagePlanError::OrderByAll),
         OrderByKind::Expressions(exprs) => exprs,
@@ -2826,6 +2931,169 @@ mod tests {
         );
     }
 
+    /// An `INTERPOLATE` on the `ORDER BY` is refused, because the rewrite drops
+    /// the ordering it hangs off.
+    ///
+    /// The clause-level half of what [`PagePlanError::UnsupportedOrderOption`]
+    /// refuses per term. It sat behind an `OrderBy { kind, .. }` pattern, so
+    /// nothing read it and nothing reproduced it: `render_statement` removes
+    /// the statement's own `ORDER BY` whenever it only orders, which took the
+    /// `INTERPOLATE` with it, and the plan reported a total order over an
+    /// ordering the caller had not written.
+    ///
+    /// [`interpolate_is_an_error_datafusion_raises_and_the_page_would_not`]
+    /// is the half of this that text cannot settle: the dropped clause turns
+    /// an engine error into a success.
+    #[test]
+    fn refuses_an_interpolate_clause_on_the_ordering() {
+        let sql = "SELECT ts, series_id FROM samples ORDER BY ts, series_id \
+                   INTERPOLATE (value AS value)";
+        let err = plan_page(sql, None).expect_err("refused");
+        assert_eq!(
+            err,
+            PagePlanError::UnsupportedOrderingClause {
+                clause: "INTERPOLATE",
+            },
+        );
+        assert_eq!(
+            err.to_string(),
+            "the ORDER BY clause `INTERPOLATE` cannot be paged"
+        );
+
+        // An empty `INTERPOLATE` is the same clause with no expression list,
+        // and is refused on the same reading rather than on the list's
+        // contents.
+        assert_eq!(
+            plan_page(
+                "SELECT ts, series_id FROM samples ORDER BY ts, series_id INTERPOLATE",
+                None,
+            )
+            .expect_err("refused"),
+            PagePlanError::UnsupportedOrderingClause {
+                clause: "INTERPOLATE",
+            },
+        );
+
+        // Without the clause the same statement still pages, so the refusal is
+        // about the clause and not about the ordering it was written on.
+        let plan = plan_page(
+            "SELECT ts, series_id FROM samples ORDER BY ts, series_id",
+            None,
+        )
+        .expect("the same ordering without the clause pages");
+        assert_eq!(plan.not_total, None);
+    }
+
+    /// The four dialect clauses that hang off a `Query` are refused at every
+    /// depth.
+    ///
+    /// `SETTINGS` is why this is not a tidiness: `SETTINGS limit = 2` caps the
+    /// statement's rows under a name [`PagePlanError::RowLimitInStatement`]
+    /// does not match, and `Display for Query` re-emits it into the derived
+    /// table, so every page would have re-applied it. The other three are
+    /// refused on the reasoning that put them in the same pattern: a `FORMAT`
+    /// reshapes the result, a `FOR XML`/`FOR JSON` collapses it into one
+    /// value, and a lock clause is not a read.
+    #[test]
+    fn refuses_every_dialect_query_clause_at_every_nesting_depth() {
+        let cases = [
+            (
+                "SELECT ts, series_id FROM samples ORDER BY ts SETTINGS limit = 2",
+                "SETTINGS",
+            ),
+            (
+                "SELECT ts, series_id FROM samples ORDER BY ts FORMAT JSONCompact",
+                "FORMAT",
+            ),
+            (
+                "SELECT ts, series_id FROM samples ORDER BY ts FOR UPDATE",
+                "FOR UPDATE/FOR SHARE",
+            ),
+            (
+                "SELECT ts, series_id FROM samples ORDER BY ts FOR XML RAW",
+                "FOR XML/FOR JSON",
+            ),
+            // The same four one level down, where the wrap re-emits them just
+            // as faithfully.
+            (
+                "SELECT * FROM samples WHERE ts IN (SELECT ts FROM samples SETTINGS limit = 2) \
+                 ORDER BY ts",
+                "SETTINGS",
+            ),
+            (
+                "WITH c AS (SELECT ts FROM samples FORMAT JSONCompact) SELECT * FROM samples \
+                 ORDER BY ts",
+                "FORMAT",
+            ),
+            (
+                "SELECT * FROM samples WHERE ts IN (SELECT ts FROM samples FOR UPDATE) \
+                 ORDER BY ts",
+                "FOR UPDATE/FOR SHARE",
+            ),
+            (
+                "SELECT * FROM samples WHERE ts IN (SELECT ts FROM samples FOR XML RAW) \
+                 ORDER BY ts",
+                "FOR XML/FOR JSON",
+            ),
+        ];
+        for (sql, clause) in cases {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::UnsupportedQueryClause { clause },
+                "unexpected refusal for {sql:?}"
+            );
+            assert_eq!(
+                err.to_string(),
+                format!("the `{clause}` clause cannot be paged")
+            );
+        }
+
+        // The row-limit refusal still wins where both are written, so
+        // `SETTINGS` did not become the answer for an ordinary `LIMIT`.
+        assert_eq!(
+            plan_page(
+                "SELECT ts, series_id FROM samples ORDER BY ts LIMIT 2",
+                None
+            )
+            .expect_err("refused"),
+            PagePlanError::RowLimitInStatement,
+        );
+    }
+
+    /// The premise behind refusing `INTERPOLATE` rather than ignoring it:
+    /// DataFusion raises on the caller's statement, and the page the planner
+    /// used to render succeeds.
+    ///
+    /// Answered against the real planner, because it is a claim about what
+    /// DataFusion implements rather than about this module's text. Without the
+    /// refusal the caller hands in an error and gets a page back, under an
+    /// ordering the engine never agreed to.
+    #[tokio::test]
+    async fn interpolate_is_an_error_datafusion_raises_and_the_page_would_not() {
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(public_schema(), vec![vec![]]).expect("mem table");
+        ctx.register_table(SAMPLES_TABLE, Arc::new(table))
+            .expect("registered");
+
+        let sql = "SELECT ts, series_id FROM samples ORDER BY ts, series_id \
+                   INTERPOLATE (value AS value)";
+        ctx.state()
+            .create_logical_plan(sql)
+            .await
+            .expect_err("DataFusion refuses an INTERPOLATE clause");
+
+        // The statement the rewrite would have produced for it, which is the
+        // same text with the clause gone.
+        ctx.state()
+            .create_logical_plan(&format!(
+                "SELECT * FROM (SELECT ts, series_id FROM samples) AS {PAGE_ALIAS} \
+                 ORDER BY \"ts\" ASC, \"series_id\" ASC"
+            ))
+            .await
+            .expect("the page the dropped clause would have planned");
+    }
+
     /// The three `SELECT` body fields this front end cannot reach still carry
     /// their own shape reason.
     ///
@@ -3349,6 +3617,12 @@ mod tests {
             Err(PagePlanError::UnsupportedOrderOption { .. }) => {
                 "UnsupportedOrderOption".to_string()
             }
+            Err(PagePlanError::UnsupportedOrderingClause { .. }) => {
+                "UnsupportedOrderingClause".to_string()
+            }
+            Err(PagePlanError::UnsupportedQueryClause { .. }) => {
+                "UnsupportedQueryClause".to_string()
+            }
             Err(PagePlanError::OrderTermNullable { .. }) => "OrderTermNullable".to_string(),
             Err(PagePlanError::OrderTermNullabilityUnknown { reason, .. }) => {
                 format!("OrderTermNullabilityUnknown: {reason}")
@@ -3402,10 +3676,10 @@ mod tests {
     /// that path can move a number here. The coverage for it is the executed
     /// page walk in `crates/ravel-sql/tests/page_walk.rs`, which pages a
     /// `samples` fixture with deliberate ties one row at a time and asserts
-    /// multiset equality against the same statement run unpaged. A
-    /// total-order claim is proven there and nowhere else: a plan assertion
-    /// cannot tell a correct claim from one that drops a tied row from every
-    /// page.
+    /// that page k holds rows k of the same statement's ordering, as a
+    /// sequence. A total-order claim is proven there and nowhere else: a plan
+    /// assertion cannot tell a correct claim from one that drops a tied row
+    /// from every page.
     #[test]
     fn the_clickbench_corpus_page_plan_outcomes_are_pinned() {
         let corpus: serde_json::Value =

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -24,21 +24,54 @@
 //! Exactly one table has a row identity to build that on. The `samples` scan
 //! emits at most one row per `(series_id, ts)` (`crate::dedup` picks one winner
 //! per group under the full dedup total order), so that pair is a key. The four
-//! RLOG- and RSPAN-backed tables have none: ingest is at-least-once and none of
-//! them carries row identity, so two rows can tie on every orderable column
-//! (`docs/adrs/1374-agent-mcp-server.md` D5 says this of `logs`, and the same
-//! holds for `spans`, `alerts`, and `audit`). For those, a page cannot be made
-//! total by appending anything, so nothing is appended and
-//! [`NotTotalOrder::NoRowIdentity`] says so; D5's own answer for that case is
-//! the equal-group rule the tool applies (fetch `k + 1` rows, drop the whole
-//! trailing group of equal tuples), which is the caller's half and not this
-//! module's.
+//! RLOG- and RSPAN-backed tables have none, because ingest is at-least-once and
+//! nothing above their scans dedups: the same record can arrive twice and two
+//! rows can then tie on every orderable column
+//! (`docs/adrs/1374-agent-mcp-server.md` D5 says this of `logs`, and the
+//! at-least-once argument carries to `spans`, `alerts`, and `audit`).
+//!
+//! `alerts` is the one that looks like an exception and is not. Its public
+//! schema does carry a non-nullable `(writer_id, writer_epoch, writer_seq)`
+//! triple, but that triple is the write identity of the OBJECT a row was read
+//! from, stamped by the scan (ADR-1101 decision 1), not of the row: every row
+//! decoded from one segment carries the same three values. So it cannot break
+//! a tie between two rows of one object, and a retried write puts the second
+//! copy in a different object under a different triple. The conclusion is
+//! [`NotTotalOrder::NoRowIdentity`] for all four either way; D5's own answer
+//! for that case is the equal-group rule the tool applies (fetch `k + 1` rows,
+//! drop the whole trailing group of equal tuples), which is the caller's half
+//! and not this module's.
 //!
 //! The identity claim also depends on the statement's shape, not only on its
 //! target: a `GROUP BY`, a join, a `DISTINCT`, a CTE, or a set operation
 //! projects rows the scan's dedup says nothing about. Those report
 //! [`NotTotalOrder::ShapeNotIdentityPreserving`] rather than a tiebreak that
 //! would be unsound.
+//!
+//! # Two things the text has to be read for, not around
+//!
+//! A pipe operator (`|> ...`) is refused outright
+//! ([`PagePlanError::PipeOperator`]). The parser's default dialect accepts
+//! them, `Display for Query` re-emits them, and every clause this module reads
+//! to classify a statement lives in the `SELECT` body that a pipe runs AFTER:
+//! a pipe can impose a row limit, a join, a set operation, a new projection,
+//! or an ordering, none of which the body carries. So no pipe is admitted, and
+//! the refusal is on the presence of any pipe rather than on a list of pipe
+//! kinds, so a pipe kind added by a later sqlparser is refused too instead of
+//! being silently admitted.
+//!
+//! An `ORDER BY` term that can be NULL is refused as well
+//! ([`PagePlanError::OrderTermNullable`]): a keyset comparison against NULL is
+//! NULL, so the rows whose term is NULL match no disjunct and appear on no
+//! page at all. That is a wrong answer on both the total and the not-total
+//! path, because the keyset predicate is what resumes both. Only a term that
+//! the text proves NON NULL is admitted: it has to be a bare reference to a
+//! column the target table's public schema declares non-nullable, either
+//! directly or through an alias over one. Everything else is refused,
+//! including a projected expression (whose nullability no schema lookup
+//! answers), a declared column (all nullable), a set-operation body (whose
+//! projection is not readable from the text), an output name projected twice
+//! under different sources, and a statement with no base table at all.
 //!
 //! # The rewrite
 //!
@@ -63,7 +96,7 @@
 //! support for comparing tuples, and each conjunct is a plain binary
 //! comparison the providers can push down.
 
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
 use datafusion::sql::parser::{DFParser, Statement as DFStatement};
 use datafusion::sql::sqlparser::ast::{
@@ -71,7 +104,12 @@ use datafusion::sql::sqlparser::ast::{
     SelectItem, SetExpr, Statement, TableFactor,
 };
 
+use crate::alerts_schema::alerts_schema;
+use crate::audit_schema::audit_schema;
+use crate::logs_schema::logs_schema;
+use crate::schema::public_schema;
 use crate::session::{ALERTS_TABLE, AUDIT_TABLE, LOGS_TABLE, SAMPLES_TABLE, SPANS_TABLE};
+use crate::spans_schema::spans_schema;
 use crate::validate::{ValidationError, referenced_base_tables, validate};
 
 /// The alias the page statement gives the caller's own statement as a derived
@@ -176,6 +214,20 @@ pub enum PagePlanError {
     )]
     RowLimitInStatement,
 
+    /// The statement uses a pipe operator (`|> ...`).
+    ///
+    /// Every classification this module makes reads the `SELECT` body, and a
+    /// pipe runs after it: it can impose a row limit, a join, a set operation,
+    /// a projection, or an ordering that the body does not carry, while
+    /// `Display for Query` re-emits the pipe into the derived table. The
+    /// refusal is on the presence of a pipe rather than on its kind, so a kind
+    /// a later sqlparser adds is refused rather than admitted unexamined.
+    #[error(
+        "a statement using a pipe operator cannot be paged; a pipe reshapes \
+         the rows after the SELECT body a page is planned from"
+    )]
+    PipeOperator,
+
     /// There is nothing to order by: the statement carries no `ORDER BY` and
     /// the target has no row identity to impose one from.
     #[error(
@@ -216,6 +268,21 @@ pub enum PagePlanError {
         option: &'static str,
     },
 
+    /// An `ORDER BY` term the text does not prove NON NULL.
+    ///
+    /// Refusing the `NULLS FIRST`/`NULLS LAST` spellings is not enough:
+    /// omitting the option does not remove NULLs from the sequence, it leaves
+    /// their position to a session default. A keyset comparison against a NULL
+    /// is NULL, so every row whose term is NULL matches no disjunct and lands
+    /// on no page, which is a dropped row rather than a mis-ordered one. See
+    /// the module docs for what counts as proof of NON NULL here.
+    #[error(
+        "the ORDER BY term `{column}` is not known to be NON NULL, and a \
+         keyset comparison against NULL selects no rows, so the rows whose \
+         `{column}` is NULL would appear on no page"
+    )]
+    OrderTermNullable { column: String },
+
     /// The resume tuple does not have one value per effective term.
     #[error("the resume position has {found} values for {expected} ORDER BY terms")]
     ResumeArity { expected: usize, found: usize },
@@ -236,9 +303,12 @@ pub enum PagePlanError {
 ///
 /// There is no NULL variant, which is deliberate: every comparison against
 /// NULL is NULL, so a keyset predicate resumed at a NULL selects no rows at
-/// all. A column that can be NULL cannot be paged by this form, and
-/// [`PagePlanError::UnsupportedOrderOption`] refuses the `NULLS FIRST`/`NULLS
-/// LAST` spellings that ask for one explicitly.
+/// all. A term that can be NULL cannot be paged by this form at all, which is
+/// why [`PagePlanError::OrderTermNullable`] refuses one before a resume tuple
+/// is ever rendered against it. [`PagePlanError::UnsupportedOrderOption`]
+/// refuses the `NULLS FIRST`/`NULLS LAST` spellings on top of that, but it is
+/// not what closes this hole: an omitted option still leaves NULL rows in the
+/// sequence.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ResumeValue {
     /// A signed integer column.
@@ -343,17 +413,21 @@ pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan,
     validate(sql)?;
     let query = parse_query(sql)?;
 
+    // Before anything else reads the `SELECT` body: a pipe operator makes that
+    // body an incomplete description of the statement, so every check below it
+    // would be answering about the wrong rows.
+    if !query.pipe_operators.is_empty() {
+        return Err(PagePlanError::PipeOperator);
+    }
     if query.limit_clause.is_some() || query.fetch.is_some() {
+        return Err(PagePlanError::RowLimitInStatement);
+    }
+    if let Some(SelectShape { top: Some(_), .. }) = shape_of(&query) {
         return Err(PagePlanError::RowLimitInStatement);
     }
 
     let target = page_target(sql)?;
     let projection = projection_of(&query);
-    if let Projection::Columns(_) = &projection
-        && let Some(SelectShape { top: Some(_), .. }) = shape_of(&query)
-    {
-        return Err(PagePlanError::RowLimitInStatement);
-    }
 
     let mut terms = statement_order_terms(&query)?;
     for term in &terms {
@@ -372,6 +446,15 @@ pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan,
         return Err(PagePlanError::NoOrdering {
             target: target.describe(),
         });
+    }
+    // Every effective term, the appended tiebreak included: a NULL anywhere in
+    // the ordering drops the rows it covers from every page.
+    for term in &terms {
+        if !term_is_non_nullable(target, &projection, &term.column) {
+            return Err(PagePlanError::OrderTermNullable {
+                column: term.column.clone(),
+            });
+        }
     }
 
     let statement = render_statement(&query, &terms, resume)?;
@@ -456,15 +539,29 @@ fn page_target(sql: &str) -> Result<PageTarget, PagePlanError> {
     }
 }
 
+/// What one output column of a `SELECT` list is built from, as far as the
+/// text says. The distinction exists for nullability: a schema lookup answers
+/// for a bare column reference and for nothing else.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum OutputSource {
+    /// A bare reference to this column of the `FROM` relation, under its own
+    /// name or an alias.
+    Column(String),
+    /// Anything else: a computed expression, or an output name the projection
+    /// gives twice from different sources. Neither has a column in the
+    /// target's schema to look up.
+    Opaque,
+}
+
 /// What the statement projects, as far as its text says.
 enum Projection {
     /// A wildcard projects every column of the target, so any column of it is
     /// available to order by.
     Wildcard,
     /// The named output columns (an alias where the item has one, the column
-    /// itself otherwise). An item that is neither -- a bare expression with no
-    /// alias -- contributes no name.
-    Columns(BTreeSet<String>),
+    /// itself otherwise), each with what it is built from. An item that is
+    /// neither -- a bare expression with no alias -- contributes no name.
+    Columns(BTreeMap<String, OutputSource>),
     /// The projection is not readable from the text (a set-operation body).
     Unknown,
 }
@@ -479,7 +576,26 @@ impl Projection {
     fn projects(&self, column: &str) -> bool {
         match self {
             Projection::Wildcard | Projection::Unknown => true,
-            Projection::Columns(names) => names.contains(column),
+            Projection::Columns(names) => names.contains_key(column),
+        }
+    }
+
+    /// The target-table column the output column `column` is a bare reference
+    /// to, or `None` when the text does not name one.
+    ///
+    /// A wildcard answers with the name itself: every output column of a
+    /// `SELECT *` is a column of the `FROM` relation under its own name.
+    /// `Unknown` answers `None` rather than guessing, which is what makes a
+    /// set-operation body fail the nullability check instead of passing it
+    /// unexamined.
+    fn source_column<'a>(&'a self, column: &'a str) -> Option<&'a str> {
+        match self {
+            Projection::Wildcard => Some(column),
+            Projection::Unknown => None,
+            Projection::Columns(items) => match items.get(column) {
+                Some(OutputSource::Column(name)) => Some(name.as_str()),
+                Some(OutputSource::Opaque) | None => None,
+            },
         }
     }
 }
@@ -488,18 +604,28 @@ fn projection_of(query: &Query) -> Projection {
     let SetExpr::Select(select) = query.body.as_ref() else {
         return Projection::Unknown;
     };
-    let mut names = BTreeSet::new();
+    let mut names: BTreeMap<String, OutputSource> = BTreeMap::new();
+    let mut record = |name: String, source: OutputSource| {
+        // A name the projection gives twice is ambiguous here even when both
+        // sources are columns, so it degrades to opaque rather than to
+        // whichever item came last.
+        let entry = names.entry(name).or_insert_with(|| source.clone());
+        if *entry != source {
+            *entry = OutputSource::Opaque;
+        }
+    };
     for item in &select.projection {
         match item {
             SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(_, _) => {
                 return Projection::Wildcard;
             }
-            SelectItem::ExprWithAlias { alias, .. } => {
-                names.insert(ident_name(alias));
+            SelectItem::ExprWithAlias { expr, alias } => {
+                let source = column_of(expr).map_or(OutputSource::Opaque, OutputSource::Column);
+                record(ident_name(alias), source);
             }
             SelectItem::UnnamedExpr(expr) => {
                 if let Some(column) = column_of(expr) {
-                    names.insert(column);
+                    record(column.clone(), OutputSource::Column(column));
                 }
             }
             // A multi-alias item names columns this planner does not model, so
@@ -509,6 +635,34 @@ fn projection_of(query: &Query) -> Projection {
         }
     }
     Projection::Columns(names)
+}
+
+/// Whether the text proves the effective term `column` is NON NULL.
+///
+/// The proof has to hold end to end: the output column has to be a bare
+/// reference to a column of the target table (so a schema lookup is about the
+/// right value at all), and that column has to be declared non-nullable in the
+/// table's public schema. A statement with no base table has no schema to ask,
+/// and a declared column is absent from the static schema and nullable
+/// anyway, so both answer false.
+fn term_is_non_nullable(target: PageTarget, projection: &Projection, column: &str) -> bool {
+    let Some(table) = target.table_name() else {
+        return false;
+    };
+    let Some(source) = projection.source_column(column) else {
+        return false;
+    };
+    let schema = match table {
+        SAMPLES_TABLE => public_schema(),
+        LOGS_TABLE => logs_schema(),
+        SPANS_TABLE => spans_schema(),
+        ALERTS_TABLE => alerts_schema(),
+        AUDIT_TABLE => audit_schema(),
+        _ => return false,
+    };
+    schema
+        .field_with_name(source)
+        .is_ok_and(|field| !field.is_nullable())
 }
 
 /// The parts of a single `SELECT` body that decide whether it projects the
@@ -663,16 +817,23 @@ fn tiebreak(
 /// grouping, and no dialect clause that reshapes rows. A statement this
 /// passes is one whose result rows are the scan's rows, so the scan's row
 /// identity is the result's.
+///
+/// A pipe operator and a `TOP` clause are refused outright by [`plan_page`]
+/// before this runs, so neither reason can reach a returned plan. They are
+/// named here anyway: this classification has to be complete on its own
+/// reading, not only in combination with what its one caller happens to check
+/// first.
 fn non_identity_shape(query: &Query, target: PageTarget) -> Option<&'static str> {
     if query.with.is_some() {
         return Some("a WITH clause");
+    }
+    if !query.pipe_operators.is_empty() {
+        return Some("a pipe operator");
     }
     let Some(shape) = shape_of(query) else {
         return Some("a set operation");
     };
     if shape.top.is_some() {
-        // Refused as a row limit before this is reached; named here so the
-        // shape check stays exhaustive on its own.
         return Some("a TOP clause");
     }
     if shape.joined {
@@ -789,27 +950,28 @@ fn bare_name(name: &ObjectName) -> Option<String> {
     }
 }
 
-/// `column` as it is written into the page statement: bare when it is a plain
-/// lowercase identifier, double-quoted (with `"` doubled) otherwise.
+/// `column` as it is written into the page statement: always double-quoted,
+/// with `"` doubled.
+///
+/// Unconditionally, with no bare spelling for a plain-looking name. A name
+/// that is all lowercase, digits and underscores can still be a reserved word
+/// (`select`, `order`, `from`), reachable here through a quoted alias, and
+/// emitting one of those bare re-parses it as syntax rather than as the
+/// column: the ordering and the keyset predicate would then be about
+/// something other than the row. Quoting every name is what makes the rewrite
+/// independent of the keyword list of whatever dialect parses it back.
 fn quote_ident(column: &str) -> String {
-    let plain = !column.is_empty()
-        && column
-            .chars()
-            .next()
-            .is_some_and(|c| c.is_ascii_lowercase() || c == '_')
-        && column
-            .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
-    if plain {
-        column.to_string()
-    } else {
-        format!("\"{}\"", column.replace('"', "\"\""))
-    }
+    format!("\"{}\"", column.replace('"', "\"\""))
 }
 
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
+    use std::sync::Arc;
+
+    use datafusion::datasource::MemTable;
+    use datafusion::prelude::SessionContext;
+
     use super::*;
 
     /// The `series_id` value used in every keyset assertion: sixteen `0xab`
@@ -843,7 +1005,7 @@ mod tests {
         assert_eq!(
             plan.statement,
             "SELECT * FROM (SELECT * FROM samples) AS ravel_page \
-             ORDER BY ts ASC, series_id ASC",
+             ORDER BY \"ts\" ASC, \"series_id\" ASC",
         );
 
         // A statement already ordered by the whole identity needs no tiebreak,
@@ -862,7 +1024,7 @@ mod tests {
         assert_eq!(
             complete.statement,
             "SELECT * FROM (SELECT * FROM samples) AS ravel_page \
-             ORDER BY series_id DESC, ts ASC",
+             ORDER BY \"series_id\" DESC, \"ts\" ASC",
         );
     }
 
@@ -884,7 +1046,7 @@ mod tests {
         assert_eq!(logs.order_by, vec![OrderTerm::ascending("ts")]);
         assert_eq!(
             logs.statement,
-            "SELECT * FROM (SELECT * FROM logs) AS ravel_page ORDER BY ts ASC",
+            "SELECT * FROM (SELECT * FROM logs) AS ravel_page ORDER BY \"ts\" ASC",
         );
 
         let grouped = plan_page(
@@ -929,11 +1091,11 @@ mod tests {
             plan.statement,
             format!(
                 "SELECT * FROM (SELECT * FROM samples) AS ravel_page \
-                 WHERE ((ts > arrow_cast(500, 'Timestamp(Nanosecond, None)')) \
-                 OR (ts = arrow_cast(500, 'Timestamp(Nanosecond, None)') \
-                 AND series_id > arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), \
+                 WHERE ((\"ts\" > arrow_cast(500, 'Timestamp(Nanosecond, None)')) \
+                 OR (\"ts\" = arrow_cast(500, 'Timestamp(Nanosecond, None)') \
+                 AND \"series_id\" > arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), \
                  'FixedSizeBinary(16)'))) \
-                 ORDER BY ts ASC, series_id ASC"
+                 ORDER BY \"ts\" ASC, \"series_id\" ASC"
             ),
         );
 
@@ -946,11 +1108,11 @@ mod tests {
             descending.statement,
             format!(
                 "SELECT * FROM (SELECT * FROM samples) AS ravel_page \
-                 WHERE ((ts < arrow_cast(500, 'Timestamp(Nanosecond, None)')) \
-                 OR (ts = arrow_cast(500, 'Timestamp(Nanosecond, None)') \
-                 AND series_id > arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), \
+                 WHERE ((\"ts\" < arrow_cast(500, 'Timestamp(Nanosecond, None)')) \
+                 OR (\"ts\" = arrow_cast(500, 'Timestamp(Nanosecond, None)') \
+                 AND \"series_id\" > arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), \
                  'FixedSizeBinary(16)'))) \
-                 ORDER BY ts DESC, series_id ASC"
+                 ORDER BY \"ts\" DESC, \"series_id\" ASC"
             ),
         );
 
@@ -965,11 +1127,11 @@ mod tests {
             filtered.statement,
             format!(
                 "SELECT * FROM (SELECT * FROM samples WHERE value > 1) AS ravel_page \
-                 WHERE ((ts > arrow_cast(500, 'Timestamp(Nanosecond, None)')) \
-                 OR (ts = arrow_cast(500, 'Timestamp(Nanosecond, None)') \
-                 AND series_id > arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), \
+                 WHERE ((\"ts\" > arrow_cast(500, 'Timestamp(Nanosecond, None)')) \
+                 OR (\"ts\" = arrow_cast(500, 'Timestamp(Nanosecond, None)') \
+                 AND \"series_id\" > arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), \
                  'FixedSizeBinary(16)'))) \
-                 ORDER BY ts ASC, series_id ASC"
+                 ORDER BY \"ts\" ASC, \"series_id\" ASC"
             ),
         );
     }
@@ -1009,9 +1171,25 @@ mod tests {
         assert_eq!(
             plan.statement,
             "SELECT * FROM (SELECT * FROM logs) AS ravel_page \
-             WHERE ((severity_text > 'it''s here') \
-             OR (severity_text = 'it''s here' AND ts > -7)) \
-             ORDER BY severity_text ASC, ts ASC",
+             WHERE ((\"severity_text\" > 'it''s here') \
+             OR (\"severity_text\" = 'it''s here' AND \"ts\" > -7)) \
+             ORDER BY \"severity_text\" ASC, \"ts\" ASC",
+        );
+
+        // The unsigned variant, on the one non-nullable UInt column any public
+        // schema declares: `alerts.writer_seq`.
+        let unsigned = plan_page(
+            "SELECT * FROM alerts ORDER BY writer_seq",
+            Some(&ResumePosition::new(vec![ResumeValue::UInt(
+                18_446_744_073_709_551_615,
+            )])),
+        )
+        .expect("planned");
+        assert_eq!(
+            unsigned.statement,
+            "SELECT * FROM (SELECT * FROM alerts) AS ravel_page \
+             WHERE ((\"writer_seq\" > 18446744073709551615)) \
+             ORDER BY \"writer_seq\" ASC",
         );
 
         let floats = plan_page(
@@ -1024,7 +1202,7 @@ mod tests {
         )
         .expect("planned");
         assert!(
-            floats.statement.contains("value > -0.5"),
+            floats.statement.contains("\"value\" > -0.5"),
             "unexpected float literal in {}",
             floats.statement
         );
@@ -1041,6 +1219,64 @@ mod tests {
         assert_eq!(err, PagePlanError::NonFiniteResumeValue);
     }
 
+    /// Every [`ResumeValue`] variant's exact rendered literal, including the
+    /// three no statement-level assertion can reach.
+    ///
+    /// `Bool` and `Binary` describe declared attribute columns, and `UInt`
+    /// beyond `alerts.writer_seq` likewise: a declared column is nullable, so
+    /// [`PagePlanError::OrderTermNullable`] refuses an ordering on one and no
+    /// page statement can carry the literal. The literal is still this
+    /// module's contract with whatever mints a cursor, so it is pinned here
+    /// rather than left unasserted until a NULL-aware ordering makes those
+    /// columns pageable.
+    #[test]
+    fn every_resume_variant_renders_its_exact_sql_literal() {
+        let cases: Vec<(ResumeValue, String)> = vec![
+            (ResumeValue::Int(-7), "-7".to_string()),
+            (ResumeValue::Int(0), "0".to_string()),
+            (ResumeValue::UInt(0), "0".to_string()),
+            (
+                ResumeValue::UInt(18_446_744_073_709_551_615),
+                "18446744073709551615".to_string(),
+            ),
+            (ResumeValue::Bool(true), "TRUE".to_string()),
+            (ResumeValue::Bool(false), "FALSE".to_string()),
+            (ResumeValue::Float(-0.5), "-0.5".to_string()),
+            (ResumeValue::Float(-0.0), "-0.0".to_string()),
+            (
+                ResumeValue::Str("it's here".to_string()),
+                "'it''s here'".to_string(),
+            ),
+            (
+                ResumeValue::TimestampNanos(500),
+                "arrow_cast(500, 'Timestamp(Nanosecond, None)')".to_string(),
+            ),
+            (
+                ResumeValue::Binary(Vec::new()),
+                "decode('', 'hex')".to_string(),
+            ),
+            (
+                ResumeValue::Binary(vec![0x00, 0xde, 0xad, 0xff]),
+                "decode('00deadff', 'hex')".to_string(),
+            ),
+            (
+                ResumeValue::FixedSizeBinary(vec![0x01, 0x02]),
+                "arrow_cast(decode('0102', 'hex'), 'FixedSizeBinary(2)')".to_string(),
+            ),
+            (
+                ResumeValue::FixedSizeBinary(SERIES_ID.to_vec()),
+                format!("arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), 'FixedSizeBinary(16)')"),
+            ),
+        ];
+        for (value, expected) in &cases {
+            assert_eq!(
+                &value.render().expect("rendered"),
+                expected,
+                "unexpected literal for {value:?}"
+            );
+        }
+    }
+
     /// Everything the planner refuses outright, with the reason each carries.
     /// A refusal is the deliverable for these: a page planned from any of them
     /// would either return rows past a bound the caller set or resume at a
@@ -1055,6 +1291,51 @@ mod tests {
             (
                 "SELECT * FROM samples ORDER BY ts OFFSET 10 ROWS",
                 PagePlanError::RowLimitInStatement,
+            ),
+            // A `TOP` clause is a row limit whatever the projection is. The
+            // wildcard spelling used to slip the check and be planned as a
+            // not-total page that re-applied the caller's own cap per page.
+            (
+                "SELECT TOP 5 * FROM samples ORDER BY ts",
+                PagePlanError::RowLimitInStatement,
+            ),
+            (
+                "SELECT TOP 5 ts, series_id FROM samples ORDER BY ts",
+                PagePlanError::RowLimitInStatement,
+            ),
+            // Pipe operators. The parser's dialect accepts them and `Display`
+            // re-emits them, so a pipe not read here survives into the derived
+            // table with every guard above it satisfied by the SELECT body.
+            (
+                "SELECT * FROM samples |> LIMIT 10",
+                PagePlanError::PipeOperator,
+            ),
+            (
+                "SELECT * FROM samples ORDER BY ts |> LIMIT 10",
+                PagePlanError::PipeOperator,
+            ),
+            (
+                "SELECT * FROM samples ORDER BY ts |> UNION ALL (SELECT * FROM samples)",
+                PagePlanError::PipeOperator,
+            ),
+            (
+                "SELECT * FROM samples ORDER BY ts |> JOIN samples AS s2 ON true",
+                PagePlanError::PipeOperator,
+            ),
+            // Nullable ordering terms: a projected expression whose
+            // nullability no schema lookup answers, and a column the schema
+            // declares nullable outright.
+            (
+                "SELECT nullif(value, 0) AS v, ts, series_id FROM samples ORDER BY v",
+                PagePlanError::OrderTermNullable {
+                    column: "v".to_string(),
+                },
+            ),
+            (
+                "SELECT * FROM logs ORDER BY trace_id, ts",
+                PagePlanError::OrderTermNullable {
+                    column: "trace_id".to_string(),
+                },
             ),
             (
                 "SELECT * FROM samples ORDER BY ts + 1",
@@ -1104,6 +1385,191 @@ mod tests {
         assert!(
             matches!(err, PagePlanError::Invalid(_)),
             "expected a validation refusal, got {err:?}"
+        );
+    }
+
+    /// Every pipe operator is refused, whatever the pipe carries.
+    ///
+    /// The first three are the demonstrated defects of the first cut of this
+    /// module: a pipe row limit was planned with `total_order() == true` and
+    /// the caller's own cap re-applied per page, and a pipe union or join
+    /// reported a total order while the tiebreak columns were no longer a key.
+    /// Every guard above them was satisfied because they all read the `SELECT`
+    /// body, which a pipe runs after. The rest are here because the refusal
+    /// has to rest on the presence of a pipe rather than on a list of kinds:
+    /// one that only reprojects or renames still makes the body an incomplete
+    /// description of the rows, and a kind a later sqlparser adds has to be
+    /// refused without this test being edited.
+    #[test]
+    fn refuses_every_pipe_operator_whatever_it_carries() {
+        let cases = [
+            "SELECT * FROM samples ORDER BY ts |> LIMIT 10",
+            "SELECT * FROM samples ORDER BY ts |> UNION ALL (SELECT * FROM samples)",
+            "SELECT * FROM samples ORDER BY ts |> JOIN samples AS s2 ON true",
+            "SELECT * FROM samples ORDER BY ts |> INTERSECT DISTINCT (SELECT * FROM samples)",
+            "SELECT * FROM samples ORDER BY ts |> EXCEPT DISTINCT (SELECT * FROM samples)",
+            "SELECT * FROM samples ORDER BY ts |> AGGREGATE count(*)",
+            "SELECT * FROM samples ORDER BY ts |> WHERE value > 1",
+            "SELECT * FROM samples ORDER BY ts |> ORDER BY value",
+            "SELECT * FROM samples ORDER BY ts |> SELECT ts",
+            "SELECT * FROM samples ORDER BY ts |> DROP value",
+            "SELECT * FROM samples ORDER BY ts |> AS renamed",
+            "SELECT * FROM samples |> LIMIT 10",
+        ];
+        for sql in cases {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(err, PagePlanError::PipeOperator, "unexpected for {sql:?}");
+            assert_eq!(
+                err.to_string(),
+                "a statement using a pipe operator cannot be paged; a pipe \
+                 reshapes the rows after the SELECT body a page is planned from",
+            );
+        }
+    }
+
+    /// An ordering term that can be NULL is refused rather than served as if
+    /// it were sound.
+    ///
+    /// Refusing the `NULLS FIRST`/`NULLS LAST` spellings does not cover this:
+    /// omitting the option leaves the NULL rows in the sequence at a session
+    /// default's position, and every keyset disjunct is NULL for those rows,
+    /// so they land on no page at all. That is a dropped row on both the total
+    /// and the not-total path, because the keyset predicate is what resumes
+    /// both. Proof of NON NULL has to come from the statement's own text, and
+    /// it does for a bare reference to a column the target's public schema
+    /// declares non-nullable and for nothing else.
+    #[test]
+    fn refuses_an_ordering_term_that_can_be_null() {
+        let cases: Vec<(&str, &str)> = vec![
+            // A projected expression: the case reachable on the TOTAL path.
+            // This used to report `total_order() == true` while every keyset
+            // disjunct was NULL for the rows `nullif` nulled out.
+            (
+                "SELECT nullif(value, 0) AS v, ts, series_id FROM samples ORDER BY v",
+                "v",
+            ),
+            // Columns the schemas declare nullable, one per table that has
+            // one.
+            ("SELECT * FROM logs ORDER BY span_id, ts", "span_id"),
+            ("SELECT * FROM spans ORDER BY service_name", "service_name"),
+            ("SELECT * FROM alerts ORDER BY alert_id", "alert_id"),
+            // An output name the projection gives twice from different
+            // columns: both are columns, but which one the term means is not
+            // readable from the text, so the nullable one cannot be ruled out.
+            ("SELECT ts AS a, trace_id AS a FROM logs ORDER BY a", "a"),
+            // A set-operation body carries no readable projection at all.
+            (
+                "SELECT ts FROM logs UNION ALL SELECT ts FROM logs ORDER BY ts",
+                "ts",
+            ),
+            // No base table, so there is no schema to prove anything against.
+            ("SELECT 1 AS a ORDER BY a", "a"),
+        ];
+        for (sql, column) in cases {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNullable {
+                    column: column.to_string(),
+                },
+                "unexpected refusal for {sql:?}"
+            );
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "the ORDER BY term `{column}` is not known to be NON NULL, \
+                     and a keyset comparison against NULL selects no rows, so \
+                     the rows whose `{column}` is NULL would appear on no page"
+                ),
+            );
+        }
+
+        // The non-nullable columns of those same tables still page, including
+        // through an alias over one, so the refusal is about nullability and
+        // not about the table or about aliasing.
+        for sql in [
+            "SELECT * FROM logs ORDER BY ts, observed_ts, severity_num, body, flags",
+            "SELECT * FROM spans ORDER BY trace_id, span_id, name, start_ts, duration_ns",
+            "SELECT * FROM alerts ORDER BY ts_ns, writer_id, writer_epoch, writer_seq",
+            "SELECT * FROM audit ORDER BY ts_ns, severity_text, body",
+            "SELECT body AS message, ts FROM logs ORDER BY message, ts",
+        ] {
+            let plan = plan_page(sql, None);
+            assert!(plan.is_ok(), "{sql:?} should plan, got {plan:?}");
+        }
+    }
+
+    /// Every order term is quoted, so a column aliased with a quoted keyword
+    /// stays a column reference in the page statement.
+    ///
+    /// The term text is the one place caller-supplied text reaches the
+    /// rewritten statement. Rendered bare, `select` re-parses as syntax rather
+    /// than as the column: the ordering becomes a constant and the keyset
+    /// predicate evaluates to NULL, so the page comes back empty with nothing
+    /// to say why.
+    #[test]
+    fn quotes_every_order_term_so_a_keyword_alias_stays_a_column() {
+        let plan = plan_page(
+            "SELECT ts, body AS \"select\" FROM logs ORDER BY \"select\", ts",
+            Some(&ResumePosition::new(vec![
+                ResumeValue::Str("x".to_string()),
+                ResumeValue::TimestampNanos(9),
+            ])),
+        )
+        .expect("planned");
+        assert_eq!(
+            plan.order_by,
+            vec![OrderTerm::ascending("select"), OrderTerm::ascending("ts")],
+        );
+        assert_eq!(
+            plan.statement,
+            "SELECT * FROM (SELECT ts, body AS \"select\" FROM logs) AS ravel_page \
+             WHERE ((\"select\" > 'x') OR (\"select\" = 'x' \
+             AND \"ts\" > arrow_cast(9, 'Timestamp(Nanosecond, None)'))) \
+             ORDER BY \"select\" ASC, \"ts\" ASC",
+        );
+    }
+
+    /// The one property of the wrap that text alone cannot settle: whether the
+    /// derived-table alias changes how an inner statement with two output
+    /// columns of the same name is planned. Answered against the real planner
+    /// rather than by reasoning about it, on the `samples` schema registered
+    /// as a plain in-memory table, because the question is DataFusion's own
+    /// name resolution and the Ravel session does not touch it.
+    ///
+    /// It does not: the duplicate is rejected inside the inner projection,
+    /// before an alias or an outer `ORDER BY` is reached, so both spellings
+    /// fail with the identical message. That is what lets the planner emit
+    /// such a statement without a check of its own -- the caller gets the same
+    /// plan error for the page as for the statement it handed in, which is the
+    /// property [`Projection::projects`] already relies on.
+    #[tokio::test]
+    async fn duplicate_output_names_fail_the_same_wrapped_as_at_top_level() {
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(public_schema(), vec![vec![]]).expect("mem table");
+        ctx.register_table(SAMPLES_TABLE, Arc::new(table))
+            .expect("registered");
+
+        let inner = "SELECT ts AS a, series_id AS a FROM samples";
+        let top_level = ctx
+            .state()
+            .create_logical_plan(&format!("{inner} ORDER BY a"))
+            .await
+            .expect_err("duplicate output names are a plan error")
+            .to_string();
+        let wrapped = ctx
+            .state()
+            .create_logical_plan(&format!(
+                "SELECT * FROM ({inner}) AS {PAGE_ALIAS} ORDER BY \"a\" ASC"
+            ))
+            .await
+            .expect_err("duplicate output names are a plan error")
+            .to_string();
+
+        assert_eq!(top_level, wrapped);
+        assert!(
+            top_level.contains("Projections require unique expression names"),
+            "unexpected plan error: {top_level}"
         );
     }
 

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -60,22 +60,34 @@
 //! kinds, so a pipe kind added by a later sqlparser is refused too instead of
 //! being silently admitted.
 //!
-//! Both that refusal and the row-limit one
-//! ([`PagePlanError::RowLimitInStatement`]) are taken over EVERY `Query` in
-//! the statement, not the outermost one alone. The wrap re-emits the caller's
-//! text verbatim, so a `LIMIT` inside a `WHERE` subquery, a scalar subquery,
-//! a derived table, an arm of a set operation, or a CTE is still there on
-//! every page, picking a fresh arbitrary set of rows each time it runs. See
-//! [`reject_nested_pipes_and_row_limits`] for what that walk covers and for
-//! why a nested limit is refused even when its own subquery is deterministic.
+//! That refusal, the row-limit one ([`PagePlanError::RowLimitInStatement`])
+//! and the `SELECT ... INTO` one ([`PagePlanError::SelectInto`]) are taken
+//! over EVERY `Query` in the statement, not the outermost one alone. The wrap
+//! re-emits the caller's text verbatim, so a `LIMIT` inside a `WHERE`
+//! subquery, a scalar subquery, a derived table, an arm of a set operation,
+//! or a CTE is still there on every page, picking a fresh arbitrary set of
+//! rows each time it runs. See [`reject_nested_unpageable_clauses`] for what
+//! that walk covers and for why a nested limit is refused even when its own
+//! subquery is deterministic.
 //!
-//! An `ORDER BY` term that can be NULL is refused as well
+//! # What an effective order term has to be
+//!
+//! One rule, and every refusal below is a way of failing it: **a term may
+//! participate in the effective ordering only if the text proves it NON NULL,
+//! a [`ResumeValue`] variant can carry every value its column admits, and the
+//! keyset comparison over that variant is exact for every one of them.**
+//!
+//! All three clauses fail the same way, which is why they are one rule: a row
+//! the keyset predicate cannot place is a row that appears on no page, with no
+//! error. And all three are refusals rather than `not_total: Some(..)`,
+//! because the keyset predicate is rendered whenever a resume is given and is
+//! therefore what resumes BOTH the total and the not-total path. Reporting is
+//! not a substitute for refusing.
+//!
+//! An `ORDER BY` term that can be NULL fails the first clause
 //! ([`PagePlanError::OrderTermNullable`]): a keyset comparison against NULL is
 //! NULL, so the rows whose term is NULL match no disjunct and appear on no
-//! page at all. That is a wrong answer on both the total and the not-total
-//! path, because the keyset predicate is rendered whenever a resume is given
-//! and is therefore what resumes both. `not_total: Some(..)` rescues nothing
-//! here: reporting is not a substitute for refusing.
+//! page at all.
 //!
 //! Only a term the text proves NON NULL is admitted, and a term reaches that
 //! proof by one of two routes.
@@ -94,6 +106,45 @@
 //! `count(...)` are NON NULL wherever they are selected from. `SUM`, `MIN`,
 //! `MAX` and `AVG` are not, and keep refusing, because each is NULL over
 //! empty and over all-NULL input.
+//!
+//! The other two clauses of the rule are read off the term's TYPE, from the
+//! same two routes: the public schema's field type for a base column
+//! ([`cursor_support`]), and the expression itself
+//! ([`expression_cursor_support`]).
+//!
+//! [`PagePlanError::OrderTermNotRepresentable`] is the second clause. No
+//! [`ResumeValue`] variant carries a `Dictionary`, a `Map`, a `Struct`, a
+//! list, a decimal, or a timestamp of any unit but nanoseconds, so a page's
+//! last row cannot be recorded as a cursor position at all: `samples.labels`
+//! and the four `attrs` columns are the reachable cases, and each of them used
+//! to produce a plan whose first page could never be redeemed for a second.
+//!
+//! [`PagePlanError::OrderTermNotExactlyComparable`] is the third. A float
+//! column admits NaN, NaN compares false against every bound, and
+//! [`ResumeValue::Float`] refuses a non-finite value outright, so the rows
+//! whose term is NaN land on no page for exactly the reason a NULL does.
+//! Making the predicate NaN-aware instead of refusing was considered and is
+//! not small: it needs a cursor representation for NaN, an `is_nan` arm per
+//! disjunct so NaN sorts where DataFusion sorts it, and a bit-exact equality
+//! conjunct, because `-0.0 = 0.0` is TRUE in SQL and would make the
+//! lexicographic nesting match the wrong group. Until that exists, every
+//! float term is refused; `samples.value` is the one reachable case.
+//!
+//! # Every clause of the body is read, or discarded by name
+//!
+//! Three classifications here read the parser's AST, and each one names every
+//! field it decides about with no `..` pattern: [`relation_of`] over
+//! `TableFactor::Table`, `resolution::projection_of` over the `SELECT` list,
+//! and [`shape_of`] over the `SELECT` body itself. A field that cannot change
+//! the row set is discarded by name with the reason, not by a wildcard.
+//!
+//! The cost of the wildcard has been paid three times, most recently by
+//! [`shape_of`], which read thirteen of the body's twenty-four fields: `SELECT
+//! ts, series_id INTO t2 FROM samples ORDER BY ts` was planned as a total
+//! order and `Display for Query` re-emitted the `INTO` into the derived table,
+//! so every page would have written the table again. What the naming buys is
+//! not the nine or eleven fields that were missed: it is that field
+//! twenty-five of a later sqlparser is a compile error rather than silence.
 //!
 //! # One resolution from an output name
 //!
@@ -143,6 +194,7 @@
 
 use std::ops::ControlFlow;
 
+use datafusion::arrow::datatypes::{DataType, TimeUnit};
 use datafusion::sql::parser::{DFParser, Statement as DFStatement};
 use datafusion::sql::sqlparser::ast::{
     Distinct, Expr as SqlExpr, GroupByExpr, Ident, ObjectName, OrderBy, OrderByKind, Query, Select,
@@ -351,6 +403,50 @@ pub enum PagePlanError {
         reason: &'static str,
     },
 
+    /// An `ORDER BY` term whose type no [`ResumeValue`] variant can carry.
+    ///
+    /// The second clause of the one rule in the module docs. A page's cursor
+    /// position is the previous page's last row read back as a resume tuple,
+    /// so a term whose value has no variant to be read back into cannot be
+    /// resumed at: the caller either cannot build the second page's position
+    /// at all, or builds it out of something that is not the ordered value.
+    /// The reachable cases are `samples.labels` and the four `attrs` columns,
+    /// all of them `Map` or `Dictionary`.
+    #[error(
+        "the ORDER BY term `{column}` has no cursor representation ({kind}), so \
+         no resume position can carry the value a page ends at"
+    )]
+    OrderTermNotRepresentable { column: String, kind: String },
+
+    /// An `ORDER BY` term a [`ResumeValue`] variant carries, but whose keyset
+    /// comparison is not exact for every value the column admits.
+    ///
+    /// The third clause of the one rule. A float column admits NaN, and NaN
+    /// compares false against every value including itself, so a NaN row
+    /// satisfies no disjunct of the keyset predicate and lands on no page at
+    /// all. That is the same dropped-row failure
+    /// [`Self::OrderTermNullable`] refuses, arriving through the comparison
+    /// rather than through NULL. `samples.value` is the one reachable case.
+    #[error(
+        "the ORDER BY term `{column}` is not exactly comparable ({kind}), so the \
+         keyset predicate cannot place every value it admits and the rows it \
+         cannot place would appear on no page"
+    )]
+    OrderTermNotExactlyComparable { column: String, kind: String },
+
+    /// `SELECT ... INTO ...` at any depth.
+    ///
+    /// The page statement re-emits the caller's text verbatim into a derived
+    /// table, so the `INTO` is re-emitted with it and every page of the walk
+    /// would try to create the same table again. Refused at every depth for
+    /// the same reason a nested row limit is: an inner `Query` is re-emitted
+    /// as faithfully as the outer one.
+    #[error(
+        "a statement carrying SELECT ... INTO cannot be paged; every page \
+         re-emits the INTO and would write the table again"
+    )]
+    SelectInto,
+
     /// The resume tuple does not have one value per effective term.
     #[error("the resume position has {found} values for {expected} ORDER BY terms")]
     ResumeArity { expected: usize, found: usize },
@@ -482,10 +578,11 @@ pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan,
     let query = parse_query(sql)?;
 
     // Before anything else reads the `SELECT` body: a pipe operator makes that
-    // body an incomplete description of the statement, and a row limit at any
-    // depth re-evaluates per page, so every check below either answers about
-    // the wrong rows or answers about rows that change under it.
-    reject_nested_pipes_and_row_limits(&query)?;
+    // body an incomplete description of the statement, a row limit at any depth
+    // re-evaluates per page, and an `INTO` writes a table per page. So every
+    // check below either answers about the wrong rows, answers about rows that
+    // change under it, or answers about a statement that is not a read.
+    reject_nested_unpageable_clauses(&query)?;
 
     let target = page_target(sql)?;
     // The one resolution from an output name to what the text proves it holds.
@@ -511,17 +608,33 @@ pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan,
             target: target.describe(),
         });
     }
-    // Every effective term, the appended tiebreak included: a NULL anywhere in
-    // the ordering drops the rows it covers from every page.
+    // Every effective term, the appended tiebreak included. One rule in three
+    // clauses (see the module docs): a term participates only if the text
+    // proves it NON NULL, a `ResumeValue` variant carries every value its
+    // column admits, and the keyset comparison over that variant is exact for
+    // every one of them. Each clause fails the same way, by leaving a row on
+    // no page with no error raised.
     for term in &terms {
-        match term_nullability(&names, &term.column) {
-            NullProof::NonNull => {}
-            NullProof::Nullable => {
+        match term_admissibility(&names, &term.column) {
+            TermProof::Admissible => {}
+            TermProof::Nullable => {
                 return Err(PagePlanError::OrderTermNullable {
                     column: term.column.clone(),
                 });
             }
-            NullProof::Unproven(reason) => {
+            TermProof::NotRepresentable(kind) => {
+                return Err(PagePlanError::OrderTermNotRepresentable {
+                    column: term.column.clone(),
+                    kind,
+                });
+            }
+            TermProof::NotExactlyComparable(kind) => {
+                return Err(PagePlanError::OrderTermNotExactlyComparable {
+                    column: term.column.clone(),
+                    kind,
+                });
+            }
+            TermProof::Unproven(reason) => {
                 return Err(PagePlanError::OrderTermNullabilityUnknown {
                     column: term.column.clone(),
                     reason,
@@ -555,11 +668,11 @@ fn parse_query(sql: &str) -> Result<Query, PagePlanError> {
     }
 }
 
-/// Refuse a pipe operator and a row limit wherever either sits, not only on
-/// the outermost `Query`.
+/// Refuse a pipe operator, a row limit and a `SELECT ... INTO` wherever any of
+/// them sits, not only on the outermost `Query`.
 ///
-/// Both used to be read off the top-level `Query` alone, which made a pipe or
-/// a limit on any inner query invisible: a subquery in `WHERE`, a scalar
+/// The first two used to be read off the top-level `Query` alone, which made a
+/// pipe or a limit on any inner query invisible: a subquery in `WHERE`, a scalar
 /// subquery in the projection, a derived table in `FROM`, an arm of a set
 /// operation, and a CTE all carry their own `Query`, and `Display for Query`
 /// re-emits every one of them verbatim into the derived table the rewrite
@@ -573,9 +686,12 @@ fn parse_query(sql: &str) -> Result<Query, PagePlanError> {
 /// is a design change; this is a correctness fix, so the conservative refusal
 /// is the decision.
 ///
+/// `SELECT ... INTO` is refused on the same reasoning one level down: it is a
+/// write, and the wrap re-emits it once per page.
+///
 /// The pipe check is keyed on a pipe being PRESENT rather than on a list of
 /// pipe kinds, so a kind a later sqlparser adds fails closed.
-fn reject_nested_pipes_and_row_limits(query: &Query) -> Result<(), PagePlanError> {
+fn reject_nested_unpageable_clauses(query: &Query) -> Result<(), PagePlanError> {
     let mut found: Option<PagePlanError> = None;
     let _ = query.visit(&mut NestedShapeGuard { found: &mut found });
     match found {
@@ -603,12 +719,17 @@ impl Visitor for NestedShapeGuard<'_> {
         ControlFlow::Continue(())
     }
 
-    /// `TOP` hangs off the `SELECT` body rather than the `Query`, and an arm
-    /// of a set operation is a bare `SetExpr::Select` with no `Query` of its
-    /// own, so it needs its own hook to be seen in every position.
+    /// `TOP` and `INTO` hang off the `SELECT` body rather than the `Query`,
+    /// and an arm of a set operation is a bare `SetExpr::Select` with no
+    /// `Query` of its own, so they need their own hook to be seen in every
+    /// position.
     fn pre_visit_select(&mut self, select: &Select) -> ControlFlow<()> {
         if select.top.is_some() {
             *self.found = Some(PagePlanError::RowLimitInStatement);
+            return ControlFlow::Break(());
+        }
+        if select.into.is_some() {
+            *self.found = Some(PagePlanError::SelectInto);
             return ControlFlow::Break(());
         }
         ControlFlow::Continue(())
@@ -1188,20 +1309,154 @@ fn grouping_can_null_a_grouping_column(group_by: &GroupByExpr) -> bool {
         })
 }
 
-/// What the statement's text says about whether an effective term can be
-/// NULL.
+/// What the statement's text says about whether an effective term may
+/// participate in the effective ordering at all.
 ///
-/// The two negative answers are kept apart because they call for different
-/// repairs: `Nullable` says the term CAN be NULL and the caller has to order
-/// by something else, while `Unproven` says the text does not settle it, and
-/// names what would.
-enum NullProof {
-    /// Provably NON NULL from the text alone.
-    NonNull,
+/// One rule in three clauses, and each negative answer names which clause
+/// failed, because each calls for a different repair: `Nullable` says the term
+/// CAN be NULL, `NotRepresentable` says no cursor value can carry it,
+/// `NotExactlyComparable` says a cursor can carry it but the keyset comparison
+/// is not exact over every value it admits, and `Unproven` says the text does
+/// not settle the question and names what would.
+enum TermProof {
+    /// NON NULL, carried exactly by a [`ResumeValue`] variant, and exactly
+    /// comparable over every value the column admits.
+    Admissible,
     /// The target table's public schema declares this column nullable.
     Nullable,
-    /// Neither proved. The string is the reason the refusal quotes.
+    /// No [`ResumeValue`] variant carries a value of this term's type. The
+    /// string names the type.
+    NotRepresentable(String),
+    /// A variant carries it, but `=`, `<` and `>` over that variant do not
+    /// place every value the term admits. The string names the type.
+    NotExactlyComparable(String),
+    /// None of the above is proved. The string is the reason the refusal
+    /// quotes.
     Unproven(&'static str),
+}
+
+/// Whether a cursor can carry a value of an arrow type, and whether the keyset
+/// comparison over the variant that carries it is exact.
+///
+/// The distinction is the point. A `Map` column has no variant at all, so the
+/// caller cannot even read the position a page ended at. A `Float64` column
+/// has one, and the failure arrives one step later: NaN renders no literal
+/// that compares true against itself, so the row carrying it satisfies no
+/// disjunct. Both leave a row on no page; naming which one happened is what
+/// tells the caller whether to project a different column or to order by one.
+enum CursorSupport {
+    /// A [`ResumeValue`] variant carries every value of the type, and `=`, `<`
+    /// and `>` over it agree with the sort for every one of them.
+    Exact,
+    /// A variant carries the value, but the comparison is not exact over every
+    /// value the type admits. The string names the type.
+    Inexact(String),
+    /// No variant carries a value of this type. The string names the type.
+    Unrepresentable(String),
+}
+
+/// The cursor support of an arrow type.
+///
+/// Listed positively, with the catch-all on the unrepresentable side: a type a
+/// later arrow adds, or a schema column whose type changes, is refused rather
+/// than assumed to have a variant. The `Timestamp` arm is pinned to
+/// `Nanosecond` with no timezone because that is what
+/// [`ResumeValue::TimestampNanos`] renders; another unit or a timezone would
+/// compare a nanosecond count against a differently scaled column.
+fn cursor_support(data_type: &DataType) -> CursorSupport {
+    match data_type {
+        DataType::Boolean
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Binary
+        | DataType::LargeBinary
+        | DataType::FixedSizeBinary(_)
+        | DataType::Timestamp(TimeUnit::Nanosecond, None) => CursorSupport::Exact,
+        DataType::Float16 | DataType::Float32 | DataType::Float64 => {
+            CursorSupport::Inexact(format!("type {}", type_label(data_type)))
+        }
+        other => CursorSupport::Unrepresentable(format!("type {}", type_label(other))),
+    }
+}
+
+/// An arrow type as a refusal message names it.
+///
+/// `Display for DataType` is `Debug`, and the `Debug` of the one type a caller
+/// actually hits here (`samples.labels`, a `Dictionary` over a `Map`) prints
+/// every `Field` of the map's entry struct. A refusal a caller has to scroll
+/// is a refusal a caller does not read, so the nested types are named and not
+/// expanded.
+fn type_label(data_type: &DataType) -> String {
+    match data_type {
+        DataType::Dictionary(key, value) => {
+            format!("Dictionary({}, {})", type_label(key), type_label(value))
+        }
+        DataType::Map(..) => "Map".to_string(),
+        DataType::Struct(_) => "Struct".to_string(),
+        DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(..) => {
+            "List".to_string()
+        }
+        other => format!("{other:?}"),
+    }
+}
+
+/// The cursor support of an expression term, from the expression alone.
+///
+/// Only reached for an expression [`expression_is_non_null`] admits, so the
+/// shapes that arrive are a non-NULL literal, a `count(...)`, parentheses and
+/// a unary sign. Everything else is unrepresentable rather than assumed, on
+/// the same fail-closed reading as [`cursor_support`]'s catch-all.
+fn expression_cursor_support(expr: &SqlExpr) -> CursorSupport {
+    match expr {
+        SqlExpr::Value(value) => literal_cursor_support(&value.value),
+        SqlExpr::Nested(inner) => expression_cursor_support(inner),
+        SqlExpr::UnaryOp {
+            op: UnaryOperator::Plus | UnaryOperator::Minus,
+            expr,
+        } => expression_cursor_support(expr),
+        // `count(...)` is a row count: a non-negative integer, which
+        // `ResumeValue::Int` carries exactly. The name is re-checked here
+        // rather than inherited from the nullability proof, so the two cannot
+        // drift into admitting different function sets.
+        SqlExpr::Function(function)
+            if bare_name(&function.name)
+                .is_some_and(|name| name.eq_ignore_ascii_case(COUNT_FUNCTION)) =>
+        {
+            CursorSupport::Exact
+        }
+        other => CursorSupport::Unrepresentable(format!("the expression `{other}`")),
+    }
+}
+
+/// The cursor support of a literal term.
+///
+/// A literal column admits exactly the one value written, so the question is
+/// only whether a variant renders that value back identically. An integer
+/// does. A decimal or exponent literal is parsed to a type the dialect
+/// chooses, `Decimal128` among them, and comparing it against a rendered
+/// float is neither of this planner's decisions to make, so it is refused.
+fn literal_cursor_support(value: &Value) -> CursorSupport {
+    match value {
+        Value::Number(text, _) => {
+            if text.parse::<i64>().is_ok() || text.parse::<u64>().is_ok() {
+                CursorSupport::Exact
+            } else {
+                CursorSupport::Unrepresentable(format!("the numeric literal {text}"))
+            }
+        }
+        Value::SingleQuotedString(_) | Value::DoubleQuotedString(_) | Value::Boolean(_) => {
+            CursorSupport::Exact
+        }
+        other => CursorSupport::Unrepresentable(format!("the literal {other}")),
+    }
 }
 
 /// What the text says about the effective term `column`.
@@ -1213,32 +1468,37 @@ enum NullProof {
 /// end to end by construction of the variant: it exists only where the name is
 /// a column of the `FROM` relation AND that relation is the target base table
 /// itself under its own column names. What is left for this function is the
-/// declaration. A declared column is absent from the static schema, and
-/// whether it exists at all depends on the tenant's declarations rather than
-/// on the text, so it is `Unproven` rather than either answer.
+/// declaration and the declared type. A declared column is absent from the
+/// static schema, and whether it exists at all depends on the tenant's
+/// declarations rather than on the text, so it is `Unproven` rather than any
+/// other answer.
 ///
-/// A [`Provenance::Expression`] is answered by [`expression_is_non_null`]
-/// reading the expression itself, with no schema consulted and no basis
-/// required: a literal and a `count(...)` are NON NULL whatever relation they
-/// are selected from, including under an outer join or a `ROLLUP`, because
-/// neither is a grouping column that a super-aggregate row can null.
-fn term_nullability(names: &OutputResolution, column: &str) -> NullProof {
+/// A [`Provenance::Expression`] is answered by [`expression_is_non_null`] and
+/// [`expression_cursor_support`] reading the expression itself, with no schema
+/// consulted and no basis required: a literal and a `count(...)` are NON NULL
+/// whatever relation they are selected from, including under an outer join or
+/// a `ROLLUP`, because neither is a grouping column that a super-aggregate row
+/// can null.
+fn term_admissibility(names: &OutputResolution, column: &str) -> TermProof {
     let (table, source) = match names.resolve(column) {
         Provenance::BaseColumn { table, column } => (table, column),
         Provenance::Expression(expr) => {
-            return if expression_is_non_null(expr) {
-                NullProof::NonNull
-            } else {
-                NullProof::Unproven(unproven::EXPRESSION_NOT_PROVABLE)
+            if !expression_is_non_null(expr) {
+                return TermProof::Unproven(unproven::EXPRESSION_NOT_PROVABLE);
+            }
+            return match expression_cursor_support(expr) {
+                CursorSupport::Exact => TermProof::Admissible,
+                CursorSupport::Inexact(kind) => TermProof::NotExactlyComparable(kind),
+                CursorSupport::Unrepresentable(kind) => TermProof::NotRepresentable(kind),
             };
         }
-        Provenance::Opaque(reason) => return NullProof::Unproven(reason),
+        Provenance::Opaque(reason) => return TermProof::Unproven(reason),
         // `plan_page` refuses an order term the statement does not project
-        // before it asks about nullability, and `tiebreak` reports a tiebreak
-        // column it cannot find as not-a-total-order rather than appending it.
-        // Answering rather than asserting keeps that ordering a property of
-        // the code above instead of a panic on a production path.
-        Provenance::NotProjected => return NullProof::Unproven(unproven::NOT_A_BARE_COLUMN),
+        // before it asks this, and `tiebreak` reports a tiebreak column it
+        // cannot find as not-a-total-order rather than appending it. Answering
+        // rather than asserting keeps that ordering a property of the code
+        // above instead of a panic on a production path.
+        Provenance::NotProjected => return TermProof::Unproven(unproven::NOT_A_BARE_COLUMN),
     };
     let schema = match table {
         SAMPLES_TABLE => public_schema(),
@@ -1246,12 +1506,18 @@ fn term_nullability(names: &OutputResolution, column: &str) -> NullProof {
         SPANS_TABLE => spans_schema(),
         ALERTS_TABLE => alerts_schema(),
         AUDIT_TABLE => audit_schema(),
-        _ => return NullProof::Unproven(unproven::NO_PUBLIC_SCHEMA),
+        _ => return TermProof::Unproven(unproven::NO_PUBLIC_SCHEMA),
     };
-    match schema.field_with_name(source) {
-        Ok(field) if !field.is_nullable() => NullProof::NonNull,
-        Ok(_) => NullProof::Nullable,
-        Err(_) => NullProof::Unproven(unproven::NOT_A_SCHEMA_COLUMN),
+    let Ok(field) = schema.field_with_name(source) else {
+        return TermProof::Unproven(unproven::NOT_A_SCHEMA_COLUMN);
+    };
+    if field.is_nullable() {
+        return TermProof::Nullable;
+    }
+    match cursor_support(field.data_type()) {
+        CursorSupport::Exact => TermProof::Admissible,
+        CursorSupport::Inexact(kind) => TermProof::NotExactlyComparable(kind),
+        CursorSupport::Unrepresentable(kind) => TermProof::NotRepresentable(kind),
     }
 }
 
@@ -1309,14 +1575,78 @@ struct SelectShape<'a> {
     grouped: bool,
     having: bool,
     qualify: bool,
+    into: bool,
+    exclude: bool,
+    select_modifier: bool,
+    value_table_mode: bool,
     other_clause: bool,
 }
 
+/// Read the whole `SELECT` body, naming every field.
+///
+/// [`relation_of`] already destructures `TableFactor::Table` with no `..`, and
+/// [`resolution::projection_of`] already reads every `SelectItem`; this was the
+/// one classification left reading a subset of what it decided about. It read
+/// thirteen of the body's twenty-four fields and said nothing about the other
+/// eleven, so `SELECT ts INTO t2 FROM samples ORDER BY ts` was planned as a
+/// total order and the `INTO` was re-emitted into the derived table, once per
+/// page.
+///
+/// So the pattern below binds every field, with no `..`. Each one is either
+/// classified or discarded by name with the reason it cannot change the row
+/// set. Field twenty-five of a later sqlparser is then a compile error here
+/// rather than another clause this function silently did not read.
 fn shape_of<'a>(query: &'a Query) -> Option<SelectShape<'a>> {
     let SetExpr::Select(select) = query.body.as_ref() else {
         return None;
     };
-    let (from_table, joined) = match select.from.as_slice() {
+    let Select {
+        // Source span of the `SELECT` keyword. Carries no semantics.
+        select_token: _,
+        // Advisory. A hint may change the plan a statement runs under, never
+        // which rows it returns, and `Display` re-emits it into the derived
+        // table unchanged, so every page runs under the same hint.
+        optimizer_hints: _,
+        distinct,
+        select_modifiers,
+        top,
+        // Says only where a `TOP` was written relative to `DISTINCT`. `top`
+        // itself is the reason, and is refused outright before this runs.
+        top_before_distinct: _,
+        // Read by `resolution::projection_of`, which is the one place an
+        // output name resolves to what it is built from. Reading it a second
+        // time here is exactly how the same wrong answer came back through a
+        // second door in earlier rounds.
+        projection: _,
+        exclude,
+        into,
+        from,
+        lateral_views,
+        prewhere,
+        // `WHERE` selects a subset of the target's rows, and each surviving row
+        // is still one scanned row under its own identity, so it does not
+        // change this classification. The keyset predicate is applied outside
+        // the derived table, so it composes with this rather than replacing it.
+        selection: _,
+        connect_by,
+        group_by,
+        cluster_by,
+        distribute_by,
+        sort_by,
+        having,
+        named_window,
+        qualify,
+        // Says only where `QUALIFY` was written relative to `WINDOW`. Both
+        // clauses are reasons in their own right below.
+        window_before_qualify: _,
+        value_table_mode,
+        // `FROM t SELECT ...` is this same body written the other way round.
+        // It selects the same rows, and `Display` re-emits whichever spelling
+        // it read, so the derived table is the caller's statement either way.
+        flavor: _,
+    } = select.as_ref();
+
+    let (from_table, joined) = match from.as_slice() {
         [only] => (
             match relation_of(&only.relation) {
                 Relation::BareTable(name) => Some(name),
@@ -1324,27 +1654,31 @@ fn shape_of<'a>(query: &'a Query) -> Option<SelectShape<'a>> {
             },
             !only.joins.is_empty(),
         ),
-        _ => (None, select.from.len() > 1),
+        _ => (None, from.len() > 1),
     };
-    let grouped = match &select.group_by {
+    let grouped = match group_by {
         GroupByExpr::All(_) => true,
         GroupByExpr::Expressions(exprs, modifiers) => !exprs.is_empty() || !modifiers.is_empty(),
     };
     Some(SelectShape {
-        top: select.top.as_ref().map(|_| ()),
+        top: top.as_ref().map(|_| ()),
         from_table,
         joined,
-        distinct: select.distinct.as_ref(),
+        distinct: distinct.as_ref(),
         grouped,
-        having: select.having.is_some(),
-        qualify: select.qualify.is_some(),
-        other_clause: !select.cluster_by.is_empty()
-            || !select.distribute_by.is_empty()
-            || !select.sort_by.is_empty()
-            || !select.lateral_views.is_empty()
-            || !select.connect_by.is_empty()
-            || select.prewhere.is_some()
-            || !select.named_window.is_empty(),
+        having: having.is_some(),
+        qualify: qualify.is_some(),
+        into: into.is_some(),
+        exclude: exclude.is_some(),
+        select_modifier: select_modifiers.is_some(),
+        value_table_mode: value_table_mode.is_some(),
+        other_clause: !cluster_by.is_empty()
+            || !distribute_by.is_empty()
+            || !sort_by.is_empty()
+            || !lateral_views.is_empty()
+            || !connect_by.is_empty()
+            || prewhere.is_some()
+            || !named_window.is_empty(),
     })
 }
 
@@ -1458,11 +1792,11 @@ fn tiebreak(
 /// passes is one whose result rows are the scan's rows, so the scan's row
 /// identity is the result's.
 ///
-/// A pipe operator and a `TOP` clause are refused outright by [`plan_page`]
-/// before this runs, so neither reason can reach a returned plan. They are
-/// named here anyway: this classification has to be complete on its own
-/// reading, not only in combination with what its one caller happens to check
-/// first.
+/// A pipe operator, a `TOP` clause and a `SELECT ... INTO` are refused
+/// outright by [`plan_page`] before this runs, so none of those reasons can
+/// reach a returned plan. They are named here anyway: this classification has
+/// to be complete on its own reading, not only in combination with what its
+/// one caller happens to check first.
 fn non_identity_shape(query: &Query, target: PageTarget) -> Option<&'static str> {
     if query.with.is_some() {
         return Some("a WITH clause");
@@ -1490,6 +1824,29 @@ fn non_identity_shape(query: &Query, target: PageTarget) -> Option<&'static str>
     }
     if shape.qualify {
         return Some("QUALIFY");
+    }
+    if shape.into {
+        return Some("SELECT ... INTO");
+    }
+    // An `EXCLUDE` list drops columns from the projection, so an output name
+    // the resolution answered for may not be projected at all. Its own reason
+    // rather than the alias-column-list one the generic dialect's misparse
+    // produces today: the refusal has to still be right when a dialect that
+    // parses `EXCLUDE` as `EXCLUDE` reaches here.
+    if shape.exclude {
+        return Some("an EXCLUDE list");
+    }
+    // MySQL's `SQL_CALC_FOUND_ROWS`, `HIGH_PRIORITY` and `STRAIGHT_JOIN`.
+    // Refused rather than modelled: one of them is defined in terms of a
+    // `LIMIT` this planner owns.
+    if shape.select_modifier {
+        return Some("a dialect SELECT modifier");
+    }
+    // `SELECT AS VALUE` and `SELECT AS STRUCT` re-wrap each row into one
+    // struct-valued column, so the output names the resolution resolved are
+    // not the output names at all.
+    if shape.value_table_mode {
+        return Some("SELECT AS VALUE or AS STRUCT");
     }
     if shape.other_clause {
         return Some("a row-reshaping clause");
@@ -1833,27 +2190,33 @@ mod tests {
              ORDER BY \"writer_seq\" ASC",
         );
 
-        let floats = plan_page(
-            "SELECT * FROM samples ORDER BY value, ts, series_id",
+        // The fixed-width binary variant, on `samples.series_id`.
+        let fixed = plan_page(
+            "SELECT * FROM samples ORDER BY series_id, ts",
             Some(&ResumePosition::new(vec![
-                ResumeValue::Float(-0.5),
-                ResumeValue::TimestampNanos(1),
                 ResumeValue::FixedSizeBinary(SERIES_ID.to_vec()),
+                ResumeValue::TimestampNanos(1),
             ])),
         )
         .expect("planned");
         assert!(
-            floats.statement.contains("\"value\" > -0.5"),
-            "unexpected float literal in {}",
-            floats.statement
+            fixed.statement.contains(&format!(
+                "\"series_id\" > arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), \
+                 'FixedSizeBinary(16)')"
+            )),
+            "unexpected fixed size binary literal in {}",
+            fixed.statement
         );
 
+        // `NonFiniteResumeValue` stays reachable through `plan_page` even
+        // though no float column can be an order term any more: the resume
+        // tuple is the caller's, and nothing binds a tuple position's variant
+        // to the type of the term it is compared against.
         let err = plan_page(
-            "SELECT * FROM samples ORDER BY value, ts, series_id",
+            "SELECT * FROM logs ORDER BY severity_text, ts",
             Some(&ResumePosition::new(vec![
                 ResumeValue::Float(f64::NAN),
                 ResumeValue::TimestampNanos(1),
-                ResumeValue::FixedSizeBinary(SERIES_ID.to_vec()),
             ])),
         )
         .expect_err("refused");
@@ -1866,10 +2229,13 @@ mod tests {
     /// `Bool` and `Binary` describe declared attribute columns, and `UInt`
     /// beyond `alerts.writer_seq` likewise: a declared column is nullable, so
     /// [`PagePlanError::OrderTermNullable`] refuses an ordering on one and no
-    /// page statement can carry the literal. The literal is still this
-    /// module's contract with whatever mints a cursor, so it is pinned here
-    /// rather than left unasserted until a NULL-aware ordering makes those
-    /// columns pageable.
+    /// page statement can carry the literal. `Float` is now in the same
+    /// position for a different reason:
+    /// [`PagePlanError::OrderTermNotExactlyComparable`] refuses every float
+    /// order term, so no page statement renders one either. The literal is
+    /// still this module's contract with whatever mints a cursor, and a
+    /// caller-supplied tuple can still carry any variant against any term, so
+    /// it is pinned here rather than left unasserted.
     #[test]
     fn every_resume_variant_renders_its_exact_sql_literal() {
         let cases: Vec<(ResumeValue, String)> = vec![
@@ -2112,7 +2478,7 @@ mod tests {
     /// rows, and it is re-evaluated on every page because the wrap re-emits
     /// it: page 2 resumes past page 1's last row of a relation that no longer
     /// contains the same rows. The refusal covers a nested limit that WOULD be
-    /// deterministic too; see [`reject_nested_pipes_and_row_limits`].
+    /// deterministic too; see [`reject_nested_unpageable_clauses`].
     #[test]
     fn refuses_a_row_limit_at_every_nesting_depth() {
         let cases = [
@@ -2249,6 +2615,234 @@ mod tests {
             let plan = plan_page(sql, None);
             assert!(plan.is_ok(), "{sql:?} should plan, got {plan:?}");
         }
+    }
+
+    /// An order term whose type no [`ResumeValue`] variant can carry is
+    /// refused.
+    ///
+    /// The second clause of the one rule. Before this, the term-type set was
+    /// never checked against the cursor's at all: `ORDER BY labels` planned
+    /// with `not_total: None`, so the planner claimed a total order over a
+    /// term no caller could read a resume position off. The failure surfaced
+    /// one layer out, in the page-walk harness, as `no resume value for an
+    /// order term of type Dictionary(Int32, Map(...))`: the harness was
+    /// panicking on a plan the planner had already blessed.
+    #[test]
+    fn refuses_an_order_term_no_cursor_value_can_carry() {
+        let cases: Vec<(&str, &str, &str)> = vec![
+            (
+                "SELECT * FROM samples ORDER BY labels",
+                "labels",
+                "type Dictionary(Int32, Map)",
+            ),
+            ("SELECT * FROM logs ORDER BY attrs, ts", "attrs", "type Map"),
+            (
+                "SELECT * FROM spans ORDER BY attrs, trace_id",
+                "attrs",
+                "type Map",
+            ),
+            (
+                "SELECT * FROM alerts ORDER BY attrs, ts_ns",
+                "attrs",
+                "type Map",
+            ),
+            (
+                "SELECT * FROM audit ORDER BY attrs, ts_ns",
+                "attrs",
+                "type Map",
+            ),
+            // A projected literal is NON NULL, so it passes the first clause
+            // and reaches this one. An integer literal has a variant; a
+            // decimal literal's type is the dialect's choice, so it does not.
+            (
+                "SELECT 1.5 AS a, ts, series_id FROM samples ORDER BY a",
+                "a",
+                "the numeric literal 1.5",
+            ),
+        ];
+        for (sql, column, kind) in cases {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNotRepresentable {
+                    column: column.to_string(),
+                    kind: kind.to_string(),
+                },
+                "unexpected refusal for {sql:?}"
+            );
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "the ORDER BY term `{column}` has no cursor representation \
+                     ({kind}), so no resume position can carry the value a page \
+                     ends at"
+                ),
+            );
+        }
+
+        // An integer literal still plans, so the refusal is about the cursor's
+        // variant set and not about literals.
+        let plan = plan_page("SELECT 1 AS a, ts, series_id FROM samples ORDER BY a", None)
+            .expect("an integer literal term plans");
+        assert_eq!(plan.order_by.len(), 3, "a, ts, series_id");
+    }
+
+    /// A float order term is refused, because the keyset comparison over it is
+    /// not exact for every value the column admits.
+    ///
+    /// The third clause of the one rule, and the one where a variant EXISTS.
+    /// `ResumeValue::Float` carries any finite float, so nothing upstream
+    /// refuses `ORDER BY value`; the failure is in the comparison. NaN is
+    /// false against every value including itself, so a NaN row satisfies no
+    /// disjunct of `(value > v) OR (value = v AND ...)` and appears on no
+    /// page, exactly as a NULL would.
+    ///
+    /// Refusal rather than a NaN-aware predicate, and the cost is why: NaN
+    /// awareness needs a cursor representation for NaN (the variant refuses
+    /// one today), an `is_nan` arm per disjunct so NaN sorts where DataFusion
+    /// sorts it, and a bit-exact equality conjunct, because `-0.0 = 0.0` is
+    /// TRUE in SQL and would make the lexicographic nesting descend into the
+    /// wrong equal group.
+    #[test]
+    fn refuses_a_float_order_term_because_nan_lands_on_no_page() {
+        for sql in [
+            "SELECT * FROM samples ORDER BY value, ts, series_id",
+            "SELECT ts, series_id, value FROM samples ORDER BY value DESC, ts",
+            "SELECT value AS v, ts, series_id FROM samples ORDER BY v",
+        ] {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::OrderTermNotExactlyComparable {
+                    column: match sql.contains(" AS v") {
+                        true => "v".to_string(),
+                        false => "value".to_string(),
+                    },
+                    kind: "type Float64".to_string(),
+                },
+                "unexpected refusal for {sql:?}"
+            );
+        }
+
+        let err = plan_page("SELECT * FROM samples ORDER BY value", None).expect_err("refused");
+        assert_eq!(
+            err.to_string(),
+            "the ORDER BY term `value` is not exactly comparable (type Float64), \
+             so the keyset predicate cannot place every value it admits and the \
+             rows it cannot place would appear on no page",
+        );
+
+        // The same table still pages on its identity columns, so the refusal
+        // is about the term's type and not about `samples`.
+        let plan = plan_page("SELECT * FROM samples ORDER BY ts DESC, series_id", None)
+            .expect("the identity columns still page");
+        assert_eq!(plan.not_total, None);
+    }
+
+    /// `SELECT ... INTO` is refused at every depth.
+    ///
+    /// The one field of the `SELECT` body this dialect reaches that the shape
+    /// classification did not read. `SELECT ts, series_id INTO t2 FROM samples
+    /// ORDER BY ts` planned with `not_total: None` and re-emitted `INTO t2`
+    /// into the derived table, so every page of the walk would have tried to
+    /// write the table again.
+    #[test]
+    fn refuses_select_into_at_every_nesting_depth() {
+        for sql in [
+            "SELECT ts, series_id INTO t2 FROM samples ORDER BY ts",
+            "SELECT * FROM samples WHERE ts IN (SELECT ts INTO t3 FROM samples) ORDER BY ts",
+            "WITH c AS (SELECT ts INTO t4 FROM samples) SELECT * FROM samples ORDER BY ts",
+        ] {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(
+                err,
+                PagePlanError::SelectInto,
+                "unexpected refusal for {sql:?}"
+            );
+        }
+        assert_eq!(
+            PagePlanError::SelectInto.to_string(),
+            "a statement carrying SELECT ... INTO cannot be paged; every page \
+             re-emits the INTO and would write the table again",
+        );
+    }
+
+    /// The three `SELECT` body fields this front end cannot reach still carry
+    /// their own shape reason.
+    ///
+    /// `EXCLUDE`, MySQL's `SELECT` modifiers and BigQuery's `SELECT AS
+    /// VALUE`/`AS STRUCT` are each gated on a dialect `DFParser` does not use,
+    /// so none of them can arrive through [`plan_page`] today. They are
+    /// classified anyway, and parsed here through the dialect that produces
+    /// them, because the alternative to a reason is silence: a front end that
+    /// later admits one of these would otherwise page it as a total order
+    /// without anything failing.
+    ///
+    /// `EXCLUDE` is the case that shows why the reason has to be its own.
+    /// Through this front end, `SELECT ts, series_id FROM samples EXCLUDE
+    /// (value) ORDER BY ts` is not an `EXCLUDE` at all: the generic dialect
+    /// reads `EXCLUDE` as a table alias with a positional column list, so it
+    /// is refused as `RENAMED_COLUMNS`, which is the right outcome for the
+    /// wrong statement.
+    #[test]
+    fn every_unreachable_select_body_field_still_carries_a_reason() {
+        use datafusion::sql::sqlparser::dialect::{
+            BigQueryDialect, Dialect, MySqlDialect, RedshiftSqlDialect,
+        };
+        use datafusion::sql::sqlparser::parser::Parser;
+
+        fn query_of(dialect: &dyn Dialect, sql: &str) -> Query {
+            let statements = Parser::parse_sql(dialect, sql).expect("parsed");
+            match statements.first() {
+                Some(Statement::Query(query)) => query.as_ref().clone(),
+                other => panic!("{sql:?} did not parse as a query: {other:?}"),
+            }
+        }
+
+        let cases: Vec<(&dyn Dialect, &str, &str)> = vec![
+            (
+                // After a non-wildcard projection: an `EXCLUDE` straight after
+                // a wildcard is a `WildcardAdditionalOptions` field instead,
+                // which `resolution::wildcard_rest` already reads.
+                &RedshiftSqlDialect {},
+                "SELECT ts, series_id EXCLUDE (value) FROM samples",
+                "an EXCLUDE list",
+            ),
+            (
+                &MySqlDialect {},
+                "SELECT SQL_CALC_FOUND_ROWS ts, series_id FROM samples",
+                "a dialect SELECT modifier",
+            ),
+            (
+                &BigQueryDialect {},
+                "SELECT AS STRUCT ts, series_id FROM samples",
+                "SELECT AS VALUE or AS STRUCT",
+            ),
+        ];
+        for (dialect, sql, reason) in cases {
+            let query = query_of(dialect, sql);
+            assert_eq!(
+                non_identity_shape(&query, PageTarget::Samples),
+                Some(reason),
+                "unexpected shape reason for {sql:?}",
+            );
+        }
+
+        // The same three statements through this front end's own dialect: two
+        // do not parse as those constructs at all, and the third is refused
+        // for a different reason. That is what makes the classifications above
+        // unreachable today rather than redundant.
+        assert_eq!(
+            plan_page(
+                "SELECT ts, series_id FROM samples EXCLUDE (value) ORDER BY ts",
+                None
+            ),
+            Err(PagePlanError::OrderTermNullabilityUnknown {
+                column: "ts".to_string(),
+                reason: unproven::RENAMED_COLUMNS,
+            }),
+            "the generic dialect reads EXCLUDE as a positional alias list",
+        );
     }
 
     /// A wildcard over a derived table or a CTE resolves against the inner
@@ -2700,6 +3294,13 @@ mod tests {
             Err(PagePlanError::OrderTermNullabilityUnknown { reason, .. }) => {
                 format!("OrderTermNullabilityUnknown: {reason}")
             }
+            Err(PagePlanError::OrderTermNotRepresentable { .. }) => {
+                "OrderTermNotRepresentable".to_string()
+            }
+            Err(PagePlanError::OrderTermNotExactlyComparable { .. }) => {
+                "OrderTermNotExactlyComparable".to_string()
+            }
+            Err(PagePlanError::SelectInto) => "SelectInto".to_string(),
             Err(PagePlanError::ResumeArity { .. }) => "ResumeArity".to_string(),
             Err(PagePlanError::NonFiniteResumeValue) => "NonFiniteResumeValue".to_string(),
         }

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -74,12 +74,14 @@
 //!
 //! One rule, and every refusal below is a way of failing it: **a term may
 //! participate in the effective ordering only if the text proves it NON NULL,
-//! a [`ResumeValue`] variant can carry every value its column admits, and the
-//! keyset comparison over that variant is exact for every one of them.**
+//! and a [`ResumeValue`] variant can carry every value its column admits,
+//! exactly -- rendered to a literal the engine reads back as the same value,
+//! so the keyset comparison against it is the comparison the sort made.**
 //!
-//! All three clauses fail the same way, which is why they are one rule: a row
-//! the keyset predicate cannot place is a row that appears on no page, with no
-//! error. And all three are refusals rather than `not_total: Some(..)`,
+//! Both clauses fail the same way, which is why they are one rule: a row the
+//! keyset predicate cannot place, or cannot resume from, is a row that appears
+//! on no page, with no error. And both are refusals rather than
+//! `not_total: Some(..)`,
 //! because the keyset predicate is rendered whenever a resume is given and is
 //! therefore what resumes BOTH the total and the not-total path. Reporting is
 //! not a substitute for refusing.
@@ -107,28 +109,34 @@
 //! `MAX` and `AVG` are not, and keep refusing, because each is NULL over
 //! empty and over all-NULL input.
 //!
-//! The other two clauses of the rule are read off the term's TYPE, from the
-//! same two routes: the public schema's field type for a base column
+//! The other clauses of the rule are read off the term's TYPE, from the same
+//! two routes: the public schema's field type for a base column
 //! ([`cursor_support`]), and the expression itself
-//! ([`expression_cursor_support`]).
+//! ([`expression_cursor_support`]). Both answer
+//! [`PagePlanError::OrderTermNotRepresentable`], and a type fails that check
+//! in either of two ways.
 //!
-//! [`PagePlanError::OrderTermNotRepresentable`] is the second clause. No
-//! [`ResumeValue`] variant carries a `Dictionary`, a `Map`, a `Struct`, a
-//! list, a decimal, or a timestamp of any unit but nanoseconds, so a page's
-//! last row cannot be recorded as a cursor position at all: `samples.labels`
-//! and the four `attrs` columns are the reachable cases, and each of them used
-//! to produce a plan whose first page could never be redeemed for a second.
+//! It can have no [`ResumeValue`] variant at all. Nothing carries a
+//! `Dictionary`, a `Map`, a `Struct`, a list, a decimal, or a timestamp of any
+//! unit but nanoseconds, so a page's last row cannot be recorded as a cursor
+//! position: `samples.labels` and the four `attrs` columns are the reachable
+//! cases, and each of them used to produce a plan whose first page could never
+//! be redeemed for a second.
 //!
-//! [`PagePlanError::OrderTermNotExactlyComparable`] is the third. A float
-//! column admits NaN, NaN compares false against every bound, and
-//! [`ResumeValue::Float`] refuses a non-finite value outright, so the rows
-//! whose term is NaN land on no page for exactly the reason a NULL does.
-//! Making the predicate NaN-aware instead of refusing was considered and is
-//! not small: it needs a cursor representation for NaN, an `is_nan` arm per
-//! disjunct so NaN sorts where DataFusion sorts it, and a bit-exact equality
-//! conjunct, because `-0.0 = 0.0` is TRUE in SQL and would make the
-//! lexicographic nesting match the wrong group. Until that exists, every
-//! float term is refused; `samples.value` is the one reachable case.
+//! Or it can have a variant that does not carry every value the column admits,
+//! which is the float case. A `Float64` column admits NaN and the infinities,
+//! and [`ResumeValue::Float`] refuses all three
+//! ([`PagePlanError::NonFiniteResumeValue`]), because none has a SQL literal
+//! to splice. Comparison is not the problem: DataFusion orders floats totally,
+//! so `NaN = NaN` is TRUE, `NaN` sorts after every number, `-0.0` sorts before
+//! `0.0`, and a keyset predicate does place a NaN row on a page. What it
+//! cannot do is resume FROM one. A page whose last row carries NaN mints no
+//! cursor, so under `ORDER BY value` the walk dies on the last page and under
+//! `ORDER BY value DESC` it dies on the first, and every row it had not
+//! reached appears on no page. Carrying NaN in a cursor instead of refusing
+//! the term needs a literal DataFusion parses back to the same bit pattern and
+//! a disjunct that places it where the sort does; until that exists, every
+//! float term is refused, and `samples.value` is the one reachable case.
 //!
 //! # Every clause of the body is read, or discarded by name
 //!
@@ -403,36 +411,26 @@ pub enum PagePlanError {
         reason: &'static str,
     },
 
-    /// An `ORDER BY` term whose type no [`ResumeValue`] variant can carry.
+    /// An `ORDER BY` term whose values a [`ResumeValue`] cannot carry.
     ///
     /// The second clause of the one rule in the module docs. A page's cursor
     /// position is the previous page's last row read back as a resume tuple,
-    /// so a term whose value has no variant to be read back into cannot be
+    /// so a term whose value cannot be read back into a variant cannot be
     /// resumed at: the caller either cannot build the second page's position
     /// at all, or builds it out of something that is not the ordered value.
-    /// The reachable cases are `samples.labels` and the four `attrs` columns,
-    /// all of them `Map` or `Dictionary`.
+    ///
+    /// Two shapes fail it. A type with no variant at all: `samples.labels` and
+    /// the four `attrs` columns, all of them `Map` or `Dictionary`. And a type
+    /// whose variant does not cover it, which is every float column, because
+    /// `Float64` admits NaN and the infinities and
+    /// [`Self::NonFiniteResumeValue`] refuses all three. `samples.value` is
+    /// the reachable case of the second shape.
     #[error(
-        "the ORDER BY term `{column}` has no cursor representation ({kind}), so \
-         no resume position can carry the value a page ends at"
+        "the ORDER BY term `{column}` has values no resume position can carry \
+         ({kind}), so a page ending on one would mint no cursor and every row \
+         after it would appear on no page"
     )]
     OrderTermNotRepresentable { column: String, kind: String },
-
-    /// An `ORDER BY` term a [`ResumeValue`] variant carries, but whose keyset
-    /// comparison is not exact for every value the column admits.
-    ///
-    /// The third clause of the one rule. A float column admits NaN, and NaN
-    /// compares false against every value including itself, so a NaN row
-    /// satisfies no disjunct of the keyset predicate and lands on no page at
-    /// all. That is the same dropped-row failure
-    /// [`Self::OrderTermNullable`] refuses, arriving through the comparison
-    /// rather than through NULL. `samples.value` is the one reachable case.
-    #[error(
-        "the ORDER BY term `{column}` is not exactly comparable ({kind}), so the \
-         keyset predicate cannot place every value it admits and the rows it \
-         cannot place would appear on no page"
-    )]
-    OrderTermNotExactlyComparable { column: String, kind: String },
 
     /// `SELECT ... INTO ...` at any depth.
     ///
@@ -451,9 +449,8 @@ pub enum PagePlanError {
     #[error("the resume position has {found} values for {expected} ORDER BY terms")]
     ResumeArity { expected: usize, found: usize },
 
-    /// A NaN or infinite resume value. Neither has a SQL literal, and NaN
-    /// compares false against everything, so a page resumed at one would be
-    /// empty rather than wrong-by-a-row.
+    /// A NaN or infinite resume value. Neither has a SQL literal to splice, so
+    /// there is no page to plan rather than a page that is wrong by a row.
     #[error("a resume value is not finite, so it has no SQL literal")]
     NonFiniteResumeValue,
 }
@@ -608,12 +605,11 @@ pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan,
             target: target.describe(),
         });
     }
-    // Every effective term, the appended tiebreak included. One rule in three
+    // Every effective term, the appended tiebreak included. One rule in two
     // clauses (see the module docs): a term participates only if the text
-    // proves it NON NULL, a `ResumeValue` variant carries every value its
-    // column admits, and the keyset comparison over that variant is exact for
-    // every one of them. Each clause fails the same way, by leaving a row on
-    // no page with no error raised.
+    // proves it NON NULL, and a `ResumeValue` variant carries every value its
+    // column admits, exactly. Both fail the same way, by leaving a row on no
+    // page with no error raised.
     for term in &terms {
         match term_admissibility(&names, &term.column) {
             TermProof::Admissible => {}
@@ -624,12 +620,6 @@ pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan,
             }
             TermProof::NotRepresentable(kind) => {
                 return Err(PagePlanError::OrderTermNotRepresentable {
-                    column: term.column.clone(),
-                    kind,
-                });
-            }
-            TermProof::NotExactlyComparable(kind) => {
-                return Err(PagePlanError::OrderTermNotExactlyComparable {
                     column: term.column.clone(),
                     kind,
                 });
@@ -1312,46 +1302,41 @@ fn grouping_can_null_a_grouping_column(group_by: &GroupByExpr) -> bool {
 /// What the statement's text says about whether an effective term may
 /// participate in the effective ordering at all.
 ///
-/// One rule in three clauses, and each negative answer names which clause
+/// One rule in two clauses, and each negative answer names which clause
 /// failed, because each calls for a different repair: `Nullable` says the term
-/// CAN be NULL, `NotRepresentable` says no cursor value can carry it,
-/// `NotExactlyComparable` says a cursor can carry it but the keyset comparison
-/// is not exact over every value it admits, and `Unproven` says the text does
-/// not settle the question and names what would.
+/// CAN be NULL, `NotRepresentable` says no cursor value can carry every value
+/// it admits, and `Unproven` says the text does not settle the question and
+/// names what would.
 enum TermProof {
-    /// NON NULL, carried exactly by a [`ResumeValue`] variant, and exactly
-    /// comparable over every value the column admits.
+    /// NON NULL, and carried exactly by a [`ResumeValue`] variant for every
+    /// value the column admits.
     Admissible,
     /// The target table's public schema declares this column nullable.
     Nullable,
-    /// No [`ResumeValue`] variant carries a value of this term's type. The
-    /// string names the type.
+    /// No [`ResumeValue`] variant carries every value of this term's type. The
+    /// string names the type and, where the type is partly carried, what it
+    /// admits that no variant holds.
     NotRepresentable(String),
-    /// A variant carries it, but `=`, `<` and `>` over that variant do not
-    /// place every value the term admits. The string names the type.
-    NotExactlyComparable(String),
-    /// None of the above is proved. The string is the reason the refusal
+    /// Neither of the above is proved. The string is the reason the refusal
     /// quotes.
     Unproven(&'static str),
 }
 
-/// Whether a cursor can carry a value of an arrow type, and whether the keyset
-/// comparison over the variant that carries it is exact.
+/// Whether a cursor can carry every value of an arrow type.
 ///
-/// The distinction is the point. A `Map` column has no variant at all, so the
-/// caller cannot even read the position a page ended at. A `Float64` column
-/// has one, and the failure arrives one step later: NaN renders no literal
-/// that compares true against itself, so the row carrying it satisfies no
-/// disjunct. Both leave a row on no page; naming which one happened is what
-/// tells the caller whether to project a different column or to order by one.
+/// `Exact` is the whole domain of the type, rendered to a literal the engine
+/// reads back as the same value. Anything short of that is
+/// `Unrepresentable`, whether the type has no [`ResumeValue`] variant at all
+/// (a `Map`) or has one that does not cover it (a `Float64`, whose NaN and
+/// infinities [`ResumeValue::Float`] refuses). The two are one answer here
+/// because they have one consequence: a page ending on such a value mints no
+/// cursor, so the string carries the distinction into the refusal instead.
 enum CursorSupport {
-    /// A [`ResumeValue`] variant carries every value of the type, and `=`, `<`
-    /// and `>` over it agree with the sort for every one of them.
+    /// A [`ResumeValue`] variant carries every value of the type, and the
+    /// literal it renders reads back as the same value.
     Exact,
-    /// A variant carries the value, but the comparison is not exact over every
-    /// value the type admits. The string names the type.
-    Inexact(String),
-    /// No variant carries a value of this type. The string names the type.
+    /// Some value of the type reaches no [`ResumeValue`]. The string names the
+    /// type and what it admits that no variant holds.
     Unrepresentable(String),
 }
 
@@ -1381,7 +1366,10 @@ fn cursor_support(data_type: &DataType) -> CursorSupport {
         | DataType::FixedSizeBinary(_)
         | DataType::Timestamp(TimeUnit::Nanosecond, None) => CursorSupport::Exact,
         DataType::Float16 | DataType::Float32 | DataType::Float64 => {
-            CursorSupport::Inexact(format!("type {}", type_label(data_type)))
+            CursorSupport::Unrepresentable(format!(
+                "type {} admits NaN and the infinities, which no resume value carries",
+                type_label(data_type),
+            ))
         }
         other => CursorSupport::Unrepresentable(format!("type {}", type_label(other))),
     }
@@ -1488,7 +1476,6 @@ fn term_admissibility(names: &OutputResolution, column: &str) -> TermProof {
             }
             return match expression_cursor_support(expr) {
                 CursorSupport::Exact => TermProof::Admissible,
-                CursorSupport::Inexact(kind) => TermProof::NotExactlyComparable(kind),
                 CursorSupport::Unrepresentable(kind) => TermProof::NotRepresentable(kind),
             };
         }
@@ -1516,7 +1503,6 @@ fn term_admissibility(names: &OutputResolution, column: &str) -> TermProof {
     }
     match cursor_support(field.data_type()) {
         CursorSupport::Exact => TermProof::Admissible,
-        CursorSupport::Inexact(kind) => TermProof::NotExactlyComparable(kind),
         CursorSupport::Unrepresentable(kind) => TermProof::NotRepresentable(kind),
     }
 }
@@ -2231,7 +2217,7 @@ mod tests {
     /// [`PagePlanError::OrderTermNullable`] refuses an ordering on one and no
     /// page statement can carry the literal. `Float` is now in the same
     /// position for a different reason:
-    /// [`PagePlanError::OrderTermNotExactlyComparable`] refuses every float
+    /// [`PagePlanError::OrderTermNotRepresentable`] refuses every float
     /// order term, so no page statement renders one either. The literal is
     /// still this module's contract with whatever mints a cursor, and a
     /// caller-supplied tuple can still carry any variant against any term, so
@@ -2673,9 +2659,9 @@ mod tests {
             assert_eq!(
                 err.to_string(),
                 format!(
-                    "the ORDER BY term `{column}` has no cursor representation \
-                     ({kind}), so no resume position can carry the value a page \
-                     ends at"
+                    "the ORDER BY term `{column}` has values no resume position can \
+                     carry ({kind}), so a page ending on one would mint no cursor \
+                     and every row after it would appear on no page"
                 ),
             );
         }
@@ -2687,24 +2673,25 @@ mod tests {
         assert_eq!(plan.order_by.len(), 3, "a, ts, series_id");
     }
 
-    /// A float order term is refused, because the keyset comparison over it is
-    /// not exact for every value the column admits.
+    /// A float order term is refused, because no cursor can carry the NaN and
+    /// the infinities the column admits.
     ///
-    /// The third clause of the one rule, and the one where a variant EXISTS.
-    /// `ResumeValue::Float` carries any finite float, so nothing upstream
-    /// refuses `ORDER BY value`; the failure is in the comparison. NaN is
-    /// false against every value including itself, so a NaN row satisfies no
-    /// disjunct of `(value > v) OR (value = v AND ...)` and appears on no
-    /// page, exactly as a NULL would.
+    /// The half of the second clause where a variant EXISTS and does not cover
+    /// the type. `ResumeValue::Float` carries any FINITE float, so nothing
+    /// upstream refuses `ORDER BY value`, and the comparison is not the
+    /// problem: DataFusion orders floats totally, so `NaN = NaN` is TRUE and a
+    /// keyset disjunct does place a NaN row on a page. What no caller can do
+    /// is resume FROM that row. Rendering its cursor position hits
+    /// [`PagePlanError::NonFiniteResumeValue`], so the page after it is never
+    /// planned and every row the walk had not reached appears on no page.
     ///
-    /// Refusal rather than a NaN-aware predicate, and the cost is why: NaN
-    /// awareness needs a cursor representation for NaN (the variant refuses
-    /// one today), an `is_nan` arm per disjunct so NaN sorts where DataFusion
-    /// sorts it, and a bit-exact equality conjunct, because `-0.0 = 0.0` is
-    /// TRUE in SQL and would make the lexicographic nesting descend into the
-    /// wrong equal group.
+    /// Refusal rather than a NaN-carrying cursor, and the cost is why: it
+    /// needs a literal DataFusion parses back to the same bit pattern (the
+    /// variant renders none today, and `'NaN'::double` is not `{:?}` output),
+    /// plus a disjunct that places it where the sort does, at the DESC end
+    /// under `ORDER BY value` and at the ASC end under `DESC`.
     #[test]
-    fn refuses_a_float_order_term_because_nan_lands_on_no_page() {
+    fn refuses_a_float_order_term_because_no_cursor_carries_nan() {
         for sql in [
             "SELECT * FROM samples ORDER BY value, ts, series_id",
             "SELECT ts, series_id, value FROM samples ORDER BY value DESC, ts",
@@ -2713,23 +2700,30 @@ mod tests {
             let err = plan_page(sql, None).expect_err("refused");
             assert_eq!(
                 err,
-                PagePlanError::OrderTermNotExactlyComparable {
+                PagePlanError::OrderTermNotRepresentable {
                     column: match sql.contains(" AS v") {
                         true => "v".to_string(),
                         false => "value".to_string(),
                     },
-                    kind: "type Float64".to_string(),
+                    kind: "type Float64 admits NaN and the infinities, which no \
+                           resume value carries"
+                        .to_string(),
                 },
                 "unexpected refusal for {sql:?}"
             );
         }
 
-        let err = plan_page("SELECT * FROM samples ORDER BY value", None).expect_err("refused");
+        // The refusal's own premise: the value a page over a float term would
+        // end at is exactly the one no cursor renders.
         assert_eq!(
-            err.to_string(),
-            "the ORDER BY term `value` is not exactly comparable (type Float64), \
-             so the keyset predicate cannot place every value it admits and the \
-             rows it cannot place would appear on no page",
+            ResumeValue::Float(f64::NAN).render().expect_err("refused"),
+            PagePlanError::NonFiniteResumeValue,
+        );
+        assert_eq!(
+            ResumeValue::Float(f64::INFINITY)
+                .render()
+                .expect_err("refused"),
+            PagePlanError::NonFiniteResumeValue,
         );
 
         // The same table still pages on its identity columns, so the refusal
@@ -3296,9 +3290,6 @@ mod tests {
             }
             Err(PagePlanError::OrderTermNotRepresentable { .. }) => {
                 "OrderTermNotRepresentable".to_string()
-            }
-            Err(PagePlanError::OrderTermNotExactlyComparable { .. }) => {
-                "OrderTermNotExactlyComparable".to_string()
             }
             Err(PagePlanError::SelectInto) => "SelectInto".to_string(),
             Err(PagePlanError::ResumeArity { .. }) => "ResumeArity".to_string(),

--- a/crates/ravel-sql/src/page_plan.rs
+++ b/crates/ravel-sql/src/page_plan.rs
@@ -1,0 +1,1129 @@
+//! The text-to-text page planner behind the paging MCP tools (ADR-1374 D5).
+//!
+//! [`plan_page`] takes a statement and an optional resume position and returns
+//! the statement to execute for that page, the effective `ORDER BY` it will be
+//! ordered by, and whether that ordering is a TOTAL order. It executes
+//! nothing, resolves nothing, and is not async: the only thing it touches is
+//! SQL text.
+//!
+//! It lives here rather than in `ravel-mcp` because this crate already owns
+//! the SQL parser (ADR-1374 D1 keeps SQL parsing behind the engine boundary):
+//! a second front end in the MCP crate could classify a statement differently
+//! from the one that plans it, which is the gap `crate::validate` exists to
+//! close for the security gate and this module closes for paging.
+//!
+//! # What a total order means here
+//!
+//! D5 mints a cursor for `ravel_query_sql` "only when the `ORDER BY`, plus a
+//! deterministic tiebreak that the tool appends, is a total order over the
+//! projection". Total means the effective ordering uniquely determines the row
+//! sequence, so a strict keyset predicate cannot skip a row: with two rows
+//! equal on every term, the predicate that excludes the page's last row
+//! excludes its twin as well.
+//!
+//! Exactly one table has a row identity to build that on. The `samples` scan
+//! emits at most one row per `(series_id, ts)` (`crate::dedup` picks one winner
+//! per group under the full dedup total order), so that pair is a key. The four
+//! RLOG- and RSPAN-backed tables have none: ingest is at-least-once and none of
+//! them carries row identity, so two rows can tie on every orderable column
+//! (`docs/adrs/1374-agent-mcp-server.md` D5 says this of `logs`, and the same
+//! holds for `spans`, `alerts`, and `audit`). For those, a page cannot be made
+//! total by appending anything, so nothing is appended and
+//! [`NotTotalOrder::NoRowIdentity`] says so; D5's own answer for that case is
+//! the equal-group rule the tool applies (fetch `k + 1` rows, drop the whole
+//! trailing group of equal tuples), which is the caller's half and not this
+//! module's.
+//!
+//! The identity claim also depends on the statement's shape, not only on its
+//! target: a `GROUP BY`, a join, a `DISTINCT`, a CTE, or a set operation
+//! projects rows the scan's dedup says nothing about. Those report
+//! [`NotTotalOrder::ShapeNotIdentityPreserving`] rather than a tiebreak that
+//! would be unsound.
+//!
+//! # The rewrite
+//!
+//! The page statement wraps the caller's own statement as a derived table:
+//!
+//! ```text
+//! SELECT * FROM (<statement, its own ORDER BY removed>) AS ravel_page
+//!   [WHERE <keyset predicate>]
+//!   ORDER BY <effective terms>
+//! ```
+//!
+//! The wrap is what makes the keyset predicate land on the statement's OUTPUT
+//! rows. Injected into the caller's own `WHERE`, it would filter before any
+//! aggregation, so a page of an aggregate result would drop input rows instead
+//! of resuming after the last emitted one. The wrap is also why every
+//! effective term has to name a projected output column: a page's rows are all
+//! the redeeming caller has to read the next cursor position from.
+//!
+//! The keyset predicate is the expanded lexicographic form
+//! (`(a > v1) OR (a = v1 AND b > v2) OR ...`), with the comparison flipped per
+//! `DESC` term, rather than a row-value comparison: the expanded form needs no
+//! support for comparing tuples, and each conjunct is a plain binary
+//! comparison the providers can push down.
+
+use std::collections::BTreeSet;
+
+use datafusion::sql::parser::{DFParser, Statement as DFStatement};
+use datafusion::sql::sqlparser::ast::{
+    Distinct, Expr as SqlExpr, GroupByExpr, Ident, ObjectName, OrderBy, OrderByKind, Query,
+    SelectItem, SetExpr, Statement, TableFactor,
+};
+
+use crate::session::{ALERTS_TABLE, AUDIT_TABLE, LOGS_TABLE, SAMPLES_TABLE, SPANS_TABLE};
+use crate::validate::{ValidationError, referenced_base_tables, validate};
+
+/// The alias the page statement gives the caller's own statement as a derived
+/// table. Exposed because it is part of the rewritten text: an operator reading
+/// a page statement (or a plan for one) sees this name.
+pub const PAGE_ALIAS: &str = "ravel_page";
+
+/// The `samples` row identity: post-dedup, at most one row exists per
+/// `(series_id, ts)`, so ordering by both uniquely determines the sequence.
+/// In `ORDER BY` order, event time first, which is the order every paging
+/// caller wants and the one the scan already emits.
+const SAMPLES_ROW_IDENTITY: [&str; 2] = ["ts", "series_id"];
+
+/// One term of the effective ordering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrderTerm {
+    /// The output column this term orders on, unquoted.
+    pub column: String,
+    /// `DESC` when true, `ASC` when false. An absent `ASC`/`DESC` in the
+    /// statement is `ASC`, matching SQL's own default, and is rendered
+    /// explicitly into the page statement so the pinned ordering and the
+    /// executed one cannot disagree.
+    pub descending: bool,
+}
+
+impl OrderTerm {
+    /// An ascending term on `column`.
+    pub fn ascending(column: impl Into<String>) -> Self {
+        OrderTerm {
+            column: column.into(),
+            descending: false,
+        }
+    }
+
+    /// A descending term on `column`.
+    pub fn descending(column: impl Into<String>) -> Self {
+        OrderTerm {
+            column: column.into(),
+            descending: true,
+        }
+    }
+
+    /// This term as it is rendered into the page statement's `ORDER BY`.
+    pub fn render(&self) -> String {
+        let direction = if self.descending { "DESC" } else { "ASC" };
+        format!("{} {}", quote_ident(&self.column), direction)
+    }
+}
+
+/// Why an effective ordering is not a total order. A plan carrying one of
+/// these is still executable and still pageable under D5's equal-group rule;
+/// what it cannot support is a strict keyset predicate that assumes no ties.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NotTotalOrder {
+    /// The target table has no row identity: ingest is at-least-once and two
+    /// rows can tie on every orderable column, so no appended tiebreak makes
+    /// the ordering unique.
+    #[error(
+        "the {table} table has no row identity, so no appended tiebreak makes \
+         an ordering over it unique"
+    )]
+    NoRowIdentity { table: &'static str },
+
+    /// The statement does not project the target's rows one-for-one, so the
+    /// scan's row identity says nothing about the result's.
+    #[error(
+        "the statement's shape ({shape}) does not preserve the scanned rows \
+         one-for-one, so the target's row identity does not carry to the result"
+    )]
+    ShapeNotIdentityPreserving { shape: &'static str },
+
+    /// The tiebreak columns exist but are not in the projection, so a page's
+    /// own rows would not carry the values the next cursor position needs.
+    #[error(
+        "the tiebreak columns ({}) are not in the projection",
+        missing.join(", ")
+    )]
+    TiebreakNotProjected { missing: Vec<String> },
+}
+
+/// A statement that cannot be paged at all.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PagePlanError {
+    /// The statement is not a single read-only `SELECT`. The gate is
+    /// `crate::validate`, the same one the executor runs, so a statement this
+    /// accepts is one the executor would accept too.
+    #[error("{0}")]
+    Invalid(#[from] ValidationError),
+
+    /// The statement names two or more of the five tables. One snapshot per
+    /// query admits one signal, so there is no page to plan.
+    #[error("a statement naming two signals cannot be paged")]
+    CrossSignal,
+
+    /// The statement carries its own `LIMIT`, `OFFSET`, `FETCH`, or `TOP`. The
+    /// paging tool owns the row cap; a statement-level one would either be
+    /// re-applied per page (returning rows past the bound the caller set) or
+    /// silently dropped.
+    #[error(
+        "a statement carrying its own LIMIT, OFFSET, FETCH or TOP cannot be \
+         paged; the page size is the tool's row cap"
+    )]
+    RowLimitInStatement,
+
+    /// There is nothing to order by: the statement carries no `ORDER BY` and
+    /// the target has no row identity to impose one from.
+    #[error(
+        "no deterministic page exists: the statement carries no ORDER BY and \
+         {target} has no row identity to impose one"
+    )]
+    NoOrdering { target: &'static str },
+
+    /// `ORDER BY ALL`: the term list is not known from the text alone.
+    ///
+    /// Not reachable through today's front end: `DFParser`'s dialect parses
+    /// `ORDER BY all` as a column reference named `all`, so the AST variant
+    /// this maps is never produced. It stays a typed refusal rather than an
+    /// `unreachable!()` because the alternative to a refusal here is planning
+    /// a page over an ordering whose terms were never read.
+    #[error("ORDER BY ALL cannot be paged")]
+    OrderByAll,
+
+    /// An `ORDER BY` term that is not a plain column reference. A keyset
+    /// predicate has to name the term on the left of a comparison, and an
+    /// expression term would have to be re-derived rather than read off a row.
+    #[error("the ORDER BY term `{term}` is not a column reference")]
+    OrderTermNotColumn { term: String },
+
+    /// An `ORDER BY` term that names a column the statement does not project.
+    #[error(
+        "the ORDER BY term `{column}` is not in the projection, so a page's \
+         own rows do not carry the next cursor position"
+    )]
+    OrderTermNotProjected { column: String },
+
+    /// `NULLS FIRST`/`NULLS LAST` or a `WITH FILL` modifier on a term. A
+    /// keyset predicate over a NULL is NULL, so neither can be reproduced by
+    /// the rewrite.
+    #[error("the ORDER BY option `{option}` on `{column}` cannot be paged")]
+    UnsupportedOrderOption {
+        column: String,
+        option: &'static str,
+    },
+
+    /// The resume tuple does not have one value per effective term.
+    #[error("the resume position has {found} values for {expected} ORDER BY terms")]
+    ResumeArity { expected: usize, found: usize },
+
+    /// A NaN or infinite resume value. Neither has a SQL literal, and NaN
+    /// compares false against everything, so a page resumed at one would be
+    /// empty rather than wrong-by-a-row.
+    #[error("a resume value is not finite, so it has no SQL literal")]
+    NonFiniteResumeValue,
+}
+
+/// One value of a resume tuple: the previous page's last row, one value per
+/// effective `ORDER BY` term.
+///
+/// A typed value rather than caller-supplied literal text. The rewrite splices
+/// these into a statement, and a `String` of SQL would put the caller in
+/// control of that statement's text.
+///
+/// There is no NULL variant, which is deliberate: every comparison against
+/// NULL is NULL, so a keyset predicate resumed at a NULL selects no rows at
+/// all. A column that can be NULL cannot be paged by this form, and
+/// [`PagePlanError::UnsupportedOrderOption`] refuses the `NULLS FIRST`/`NULLS
+/// LAST` spellings that ask for one explicitly.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResumeValue {
+    /// A signed integer column.
+    Int(i64),
+    /// An unsigned integer column (`generation`, `writer_seq`).
+    UInt(u64),
+    /// A boolean column (a declared `Bool` attribute).
+    Bool(bool),
+    /// A float column (`value`). NaN and the infinities are refused.
+    Float(f64),
+    /// A string column, rendered as a single-quoted literal with `'` doubled.
+    Str(String),
+    /// A nanosecond event time (`ts`, `start_ts`, `ts_ns`), rendered as an
+    /// `arrow_cast` into the column's own `Timestamp(Nanosecond, None)` type
+    /// so the comparison needs no coercion and no calendar formatting.
+    TimestampNanos(i64),
+    /// A variable-width binary column, rendered as a hex `decode`.
+    Binary(Vec<u8>),
+    /// A fixed-width binary column (`series_id`, `trace_id`, `span_id`),
+    /// rendered as the same `decode` cast to the width of the value given.
+    FixedSizeBinary(Vec<u8>),
+}
+
+impl ResumeValue {
+    /// This value as a SQL literal expression.
+    fn render(&self) -> Result<String, PagePlanError> {
+        Ok(match self {
+            ResumeValue::Int(v) => v.to_string(),
+            ResumeValue::UInt(v) => v.to_string(),
+            ResumeValue::Bool(v) => if *v { "TRUE" } else { "FALSE" }.to_string(),
+            ResumeValue::Float(v) => {
+                if !v.is_finite() {
+                    return Err(PagePlanError::NonFiniteResumeValue);
+                }
+                // `{:?}`, not `{}`: Debug for f64 prints the shortest text that
+                // round-trips to the same bits, and this repo compares floats
+                // by bit pattern.
+                format!("{v:?}")
+            }
+            ResumeValue::Str(s) => format!("'{}'", s.replace('\'', "''")),
+            ResumeValue::TimestampNanos(ns) => {
+                format!("arrow_cast({ns}, 'Timestamp(Nanosecond, None)')")
+            }
+            ResumeValue::Binary(bytes) => format!("decode('{}', 'hex')", hex::encode(bytes)),
+            ResumeValue::FixedSizeBinary(bytes) => format!(
+                "arrow_cast(decode('{}', 'hex'), 'FixedSizeBinary({})')",
+                hex::encode(bytes),
+                bytes.len()
+            ),
+        })
+    }
+}
+
+/// Where the previous page stopped: its last row's values, in the order of the
+/// [`PagePlan::order_by`] the page was taken under.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResumePosition {
+    pub tuple: Vec<ResumeValue>,
+}
+
+impl ResumePosition {
+    /// A position from one value per term.
+    pub fn new(tuple: Vec<ResumeValue>) -> Self {
+        ResumePosition { tuple }
+    }
+}
+
+/// One page's plan: what to execute, what ordering it runs under, and whether
+/// that ordering admits a strict keyset predicate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PagePlan {
+    /// The statement to execute for this page.
+    pub statement: String,
+    /// The effective ordering, in term order: the statement's own terms
+    /// followed by whatever [`Self::tiebreak_appended`] names.
+    pub order_by: Vec<OrderTerm>,
+    /// The columns this planner appended to the statement's own `ORDER BY`,
+    /// in the order they were appended. Empty when the statement's own
+    /// ordering already determined the sequence, and when nothing could make
+    /// it total.
+    pub tiebreak_appended: Vec<String>,
+    /// Why [`Self::order_by`] is not a total order, or `None` when it is.
+    pub not_total: Option<NotTotalOrder>,
+}
+
+impl PagePlan {
+    /// Whether the effective ordering uniquely determines the row sequence.
+    /// True is what D5 requires before a cursor with a strict keyset predicate
+    /// may be minted.
+    pub fn total_order(&self) -> bool {
+        self.not_total.is_none()
+    }
+}
+
+/// Plan one page of `sql`, resuming after `resume` when one is given.
+///
+/// See the module docs for the rewrite's shape and for what total order means
+/// here. Pure text-to-text: nothing is resolved, planned, or executed.
+pub fn plan_page(sql: &str, resume: Option<&ResumePosition>) -> Result<PagePlan, PagePlanError> {
+    // The security gate first, exactly as the executor runs it, so this
+    // function never rewrites a statement the executor would refuse.
+    validate(sql)?;
+    let query = parse_query(sql)?;
+
+    if query.limit_clause.is_some() || query.fetch.is_some() {
+        return Err(PagePlanError::RowLimitInStatement);
+    }
+
+    let target = page_target(sql)?;
+    let projection = projection_of(&query);
+    if let Projection::Columns(_) = &projection
+        && let Some(SelectShape { top: Some(_), .. }) = shape_of(&query)
+    {
+        return Err(PagePlanError::RowLimitInStatement);
+    }
+
+    let mut terms = statement_order_terms(&query)?;
+    for term in &terms {
+        if !projection.projects(&term.column) {
+            return Err(PagePlanError::OrderTermNotProjected {
+                column: term.column.clone(),
+            });
+        }
+    }
+
+    let (tiebreak_appended, not_total) = tiebreak(&query, target, &projection, &terms);
+    for column in &tiebreak_appended {
+        terms.push(OrderTerm::ascending(column.clone()));
+    }
+    if terms.is_empty() {
+        return Err(PagePlanError::NoOrdering {
+            target: target.describe(),
+        });
+    }
+
+    let statement = render_statement(&query, &terms, resume)?;
+    Ok(PagePlan {
+        statement,
+        order_by: terms,
+        tiebreak_appended,
+        not_total,
+    })
+}
+
+/// The single `Statement::Query` of `sql`. Every other shape is unreachable:
+/// [`validate`] has already accepted the text, and it accepts exactly one
+/// statement and only a `Statement::Query`.
+fn parse_query(sql: &str) -> Result<Query, PagePlanError> {
+    let statements = DFParser::parse_sql(sql).map_err(|e| ValidationError::Parse(e.to_string()))?;
+    match statements.front() {
+        Some(DFStatement::Statement(inner)) => match inner.as_ref() {
+            Statement::Query(query) => Ok(query.as_ref().clone()),
+            _ => Err(PagePlanError::Invalid(ValidationError::NotReadOnly {
+                kind: "the statement",
+            })),
+        },
+        _ => Err(PagePlanError::Invalid(ValidationError::Empty)),
+    }
+}
+
+/// The table a page is taken over, for the row-identity question alone.
+///
+/// Mirrors `SqlExecutor::target_signal`'s mapping of the `FROM` clause,
+/// including its CTE handling (both read `referenced_base_tables`) and its
+/// refusal of a statement naming two tables. It does not reuse `TargetSignal`
+/// because the distinction that matters here is not the signal: it is whether
+/// the target has a row identity, and whether it has a real table at all (a
+/// constant statement resolves as metrics and has neither).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PageTarget {
+    /// The `samples` table, the one target with a row identity.
+    Samples,
+    /// One of the four tables that have none.
+    NoIdentity(&'static str),
+    /// A statement naming no real table (`SELECT 1`, or one whose only source
+    /// is a CTE over no base table).
+    NoTable,
+}
+
+impl PageTarget {
+    /// The table this target's rows come from, or `None` for a statement with
+    /// no base table.
+    fn table_name(self) -> Option<&'static str> {
+        match self {
+            PageTarget::Samples => Some(SAMPLES_TABLE),
+            PageTarget::NoIdentity(table) => Some(table),
+            PageTarget::NoTable => None,
+        }
+    }
+
+    /// This target as a refusal message names it.
+    fn describe(self) -> &'static str {
+        self.table_name()
+            .unwrap_or("a statement with no base table")
+    }
+}
+
+fn page_target(sql: &str) -> Result<PageTarget, PagePlanError> {
+    let tables = referenced_base_tables(sql)?;
+    let named: Vec<PageTarget> = [
+        (SAMPLES_TABLE, PageTarget::Samples),
+        (LOGS_TABLE, PageTarget::NoIdentity(LOGS_TABLE)),
+        (SPANS_TABLE, PageTarget::NoIdentity(SPANS_TABLE)),
+        (ALERTS_TABLE, PageTarget::NoIdentity(ALERTS_TABLE)),
+        (AUDIT_TABLE, PageTarget::NoIdentity(AUDIT_TABLE)),
+    ]
+    .into_iter()
+    .filter(|(name, _)| tables.contains(*name))
+    .map(|(_, target)| target)
+    .collect();
+    match named.as_slice() {
+        [] => Ok(PageTarget::NoTable),
+        [one] => Ok(*one),
+        _ => Err(PagePlanError::CrossSignal),
+    }
+}
+
+/// What the statement projects, as far as its text says.
+enum Projection {
+    /// A wildcard projects every column of the target, so any column of it is
+    /// available to order by.
+    Wildcard,
+    /// The named output columns (an alias where the item has one, the column
+    /// itself otherwise). An item that is neither -- a bare expression with no
+    /// alias -- contributes no name.
+    Columns(BTreeSet<String>),
+    /// The projection is not readable from the text (a set-operation body).
+    Unknown,
+}
+
+impl Projection {
+    /// Whether `column` is available to order by. `Wildcard` and `Unknown`
+    /// both answer yes: neither carries a name list to check against, and
+    /// refusing would reject a `SELECT *` and a `UNION` whose orderings are
+    /// perfectly resolvable. A column that exists in neither surfaces as the
+    /// executor's own plan error, which is the same answer the caller would
+    /// have got for the statement it handed in.
+    fn projects(&self, column: &str) -> bool {
+        match self {
+            Projection::Wildcard | Projection::Unknown => true,
+            Projection::Columns(names) => names.contains(column),
+        }
+    }
+}
+
+fn projection_of(query: &Query) -> Projection {
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return Projection::Unknown;
+    };
+    let mut names = BTreeSet::new();
+    for item in &select.projection {
+        match item {
+            SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(_, _) => {
+                return Projection::Wildcard;
+            }
+            SelectItem::ExprWithAlias { alias, .. } => {
+                names.insert(ident_name(alias));
+            }
+            SelectItem::UnnamedExpr(expr) => {
+                if let Some(column) = column_of(expr) {
+                    names.insert(column);
+                }
+            }
+            // A multi-alias item names columns this planner does not model, so
+            // it contributes no name: an ordering over one is refused rather
+            // than admitted on a guess.
+            SelectItem::ExprWithAliases { .. } => {}
+        }
+    }
+    Projection::Columns(names)
+}
+
+/// The parts of a single `SELECT` body that decide whether it projects the
+/// scanned rows one-for-one.
+struct SelectShape<'a> {
+    top: Option<()>,
+    from_table: Option<&'a ObjectName>,
+    joined: bool,
+    distinct: Option<&'a Distinct>,
+    grouped: bool,
+    having: bool,
+    qualify: bool,
+    other_clause: bool,
+}
+
+fn shape_of<'a>(query: &'a Query) -> Option<SelectShape<'a>> {
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return None;
+    };
+    let (from_table, joined) = match select.from.as_slice() {
+        [only] => (
+            match &only.relation {
+                TableFactor::Table {
+                    name, args: None, ..
+                } => Some(name),
+                _ => None,
+            },
+            !only.joins.is_empty(),
+        ),
+        _ => (None, select.from.len() > 1),
+    };
+    let grouped = match &select.group_by {
+        GroupByExpr::All(_) => true,
+        GroupByExpr::Expressions(exprs, modifiers) => !exprs.is_empty() || !modifiers.is_empty(),
+    };
+    Some(SelectShape {
+        top: select.top.as_ref().map(|_| ()),
+        from_table,
+        joined,
+        distinct: select.distinct.as_ref(),
+        grouped,
+        having: select.having.is_some(),
+        qualify: select.qualify.is_some(),
+        other_clause: !select.cluster_by.is_empty()
+            || !select.distribute_by.is_empty()
+            || !select.sort_by.is_empty()
+            || !select.lateral_views.is_empty()
+            || !select.connect_by.is_empty()
+            || select.prewhere.is_some()
+            || !select.named_window.is_empty(),
+    })
+}
+
+/// The statement's own `ORDER BY`, as effective terms.
+fn statement_order_terms(query: &Query) -> Result<Vec<OrderTerm>, PagePlanError> {
+    let Some(OrderBy { kind, .. }) = &query.order_by else {
+        return Ok(Vec::new());
+    };
+    let exprs = match kind {
+        OrderByKind::All(_) => return Err(PagePlanError::OrderByAll),
+        OrderByKind::Expressions(exprs) => exprs,
+    };
+    let mut terms = Vec::with_capacity(exprs.len());
+    for expr in exprs {
+        let Some(column) = column_of(&expr.expr) else {
+            return Err(PagePlanError::OrderTermNotColumn {
+                term: expr.expr.to_string(),
+            });
+        };
+        if expr.options.nulls_first.is_some() {
+            return Err(PagePlanError::UnsupportedOrderOption {
+                column,
+                option: "NULLS FIRST/LAST",
+            });
+        }
+        if expr.with_fill.is_some() {
+            return Err(PagePlanError::UnsupportedOrderOption {
+                column,
+                option: "WITH FILL",
+            });
+        }
+        terms.push(OrderTerm {
+            column,
+            descending: expr.options.asc == Some(false),
+        });
+    }
+    Ok(terms)
+}
+
+/// The tiebreak columns to append, and why the result is not total when it is
+/// not.
+///
+/// The two are decided together because they are one question: a target with a
+/// row identity whose columns are all projected gets the missing ones
+/// appended and is total; every other case appends nothing and names its
+/// reason. Appending a column that cannot make the ordering unique would put
+/// a term in the pinned `ORDER BY` that buys the caller nothing and costs a
+/// sort.
+fn tiebreak(
+    query: &Query,
+    target: PageTarget,
+    projection: &Projection,
+    terms: &[OrderTerm],
+) -> (Vec<String>, Option<NotTotalOrder>) {
+    let identity: &[&str] = match target {
+        PageTarget::Samples => &SAMPLES_ROW_IDENTITY,
+        PageTarget::NoIdentity(table) => {
+            return (Vec::new(), Some(NotTotalOrder::NoRowIdentity { table }));
+        }
+        PageTarget::NoTable => {
+            return (
+                Vec::new(),
+                Some(NotTotalOrder::ShapeNotIdentityPreserving {
+                    shape: "no base table",
+                }),
+            );
+        }
+    };
+
+    if let Some(shape) = non_identity_shape(query, target) {
+        return (
+            Vec::new(),
+            Some(NotTotalOrder::ShapeNotIdentityPreserving { shape }),
+        );
+    }
+
+    let mut missing = Vec::new();
+    let mut append = Vec::new();
+    for column in identity {
+        if !projection.projects(column) {
+            missing.push((*column).to_string());
+            continue;
+        }
+        if !terms.iter().any(|term| term.column == *column) {
+            append.push((*column).to_string());
+        }
+    }
+    if !missing.is_empty() {
+        return (
+            Vec::new(),
+            Some(NotTotalOrder::TiebreakNotProjected { missing }),
+        );
+    }
+    (append, None)
+}
+
+/// The first shape reason this statement does not project its target's rows
+/// one-for-one, or `None` when it does.
+///
+/// Conservative by construction: it names a reason for everything except a
+/// single `SELECT` straight off the target table with no CTE, no join, no
+/// grouping, and no dialect clause that reshapes rows. A statement this
+/// passes is one whose result rows are the scan's rows, so the scan's row
+/// identity is the result's.
+fn non_identity_shape(query: &Query, target: PageTarget) -> Option<&'static str> {
+    if query.with.is_some() {
+        return Some("a WITH clause");
+    }
+    let Some(shape) = shape_of(query) else {
+        return Some("a set operation");
+    };
+    if shape.top.is_some() {
+        // Refused as a row limit before this is reached; named here so the
+        // shape check stays exhaustive on its own.
+        return Some("a TOP clause");
+    }
+    if shape.joined {
+        return Some("a join");
+    }
+    if shape.distinct.is_some() {
+        return Some("DISTINCT");
+    }
+    if shape.grouped {
+        return Some("GROUP BY");
+    }
+    if shape.having {
+        return Some("HAVING");
+    }
+    if shape.qualify {
+        return Some("QUALIFY");
+    }
+    if shape.other_clause {
+        return Some("a row-reshaping clause");
+    }
+    match (shape.from_table, target.table_name()) {
+        // The `FROM` has to be the target table itself: a derived table or a
+        // table function projects rows this planner cannot reason about, and
+        // `referenced_base_tables` would still report the target underneath it.
+        (Some(name), Some(table)) if bare_name(name).as_deref() == Some(table) => None,
+        _ => Some("a FROM clause that is not the target table"),
+    }
+}
+
+/// Render the page statement.
+fn render_statement(
+    query: &Query,
+    terms: &[OrderTerm],
+    resume: Option<&ResumePosition>,
+) -> Result<String, PagePlanError> {
+    // The caller's own `ORDER BY` is dropped from the derived table: the
+    // effective ordering is applied once, outside, where the keyset predicate
+    // is. Leaving it would order the same rows twice.
+    let mut inner = query.clone();
+    inner.order_by = None;
+
+    let ordering = terms
+        .iter()
+        .map(OrderTerm::render)
+        .collect::<Vec<String>>()
+        .join(", ");
+    let filter = match resume {
+        Some(position) => format!(" WHERE {}", keyset_predicate(terms, &position.tuple)?),
+        None => String::new(),
+    };
+    Ok(format!(
+        "SELECT * FROM ({inner}) AS {PAGE_ALIAS}{filter} ORDER BY {ordering}"
+    ))
+}
+
+/// The strict lexicographic keyset predicate for `terms` at `tuple`.
+fn keyset_predicate(terms: &[OrderTerm], tuple: &[ResumeValue]) -> Result<String, PagePlanError> {
+    if terms.len() != tuple.len() {
+        return Err(PagePlanError::ResumeArity {
+            expected: terms.len(),
+            found: tuple.len(),
+        });
+    }
+    let values = tuple
+        .iter()
+        .map(ResumeValue::render)
+        .collect::<Result<Vec<String>, PagePlanError>>()?;
+    let mut disjuncts = Vec::with_capacity(terms.len());
+    for (index, term) in terms.iter().enumerate() {
+        let mut conjuncts = Vec::with_capacity(index + 1);
+        for (earlier, value) in terms.iter().zip(&values).take(index) {
+            conjuncts.push(format!("{} = {}", quote_ident(&earlier.column), value));
+        }
+        let operator = if term.descending { "<" } else { ">" };
+        let value = values.get(index).map_or("", String::as_str);
+        conjuncts.push(format!(
+            "{} {} {}",
+            quote_ident(&term.column),
+            operator,
+            value
+        ));
+        disjuncts.push(format!("({})", conjuncts.join(" AND ")));
+    }
+    Ok(format!("({})", disjuncts.join(" OR ")))
+}
+
+/// The column an expression names, or `None` when it is not a column
+/// reference. A qualified reference (`logs.ts`) contributes its last part,
+/// which is the output column name.
+fn column_of(expr: &SqlExpr) -> Option<String> {
+    match expr {
+        SqlExpr::Identifier(ident) => Some(ident_name(ident)),
+        SqlExpr::CompoundIdentifier(parts) => parts.last().map(ident_name),
+        _ => None,
+    }
+}
+
+/// An identifier's name. An unquoted identifier is lowercased, matching how
+/// the planner resolves one; a quoted identifier keeps its case.
+fn ident_name(ident: &Ident) -> String {
+    if ident.quote_style.is_some() {
+        ident.value.clone()
+    } else {
+        ident.value.to_ascii_lowercase()
+    }
+}
+
+/// A table's bare name, lowercased, or `None` when it is qualified or built by
+/// a dialect-specific function part.
+fn bare_name(name: &ObjectName) -> Option<String> {
+    match name.0.as_slice() {
+        [only] => only.as_ident().map(ident_name),
+        _ => None,
+    }
+}
+
+/// `column` as it is written into the page statement: bare when it is a plain
+/// lowercase identifier, double-quoted (with `"` doubled) otherwise.
+fn quote_ident(column: &str) -> String {
+    let plain = !column.is_empty()
+        && column
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_lowercase() || c == '_')
+        && column
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+    if plain {
+        column.to_string()
+    } else {
+        format!("\"{}\"", column.replace('"', "\"\""))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// The `series_id` value used in every keyset assertion: sixteen `0xab`
+    /// bytes, which is a canonical series id's width (ADR-0005).
+    const SERIES_ID: [u8; 16] = [0xab; 16];
+
+    /// Its hex rendering, spelled out so the assertions below pin the exact
+    /// literal text rather than recomputing it the way the code under test
+    /// does.
+    const SERIES_ID_HEX: &str = "abababababababababababababababab";
+
+    /// ADR-1374 D5: `ravel_query_sql` mints a cursor only when the ORDER BY
+    /// plus an appended deterministic tiebreak is a total order. A `samples`
+    /// statement ordered by `ts` alone is not unique (one timestamp, many
+    /// series), so the planner appends the rest of the row identity and reports
+    /// a total order.
+    #[test]
+    fn appends_the_row_identity_tiebreak_and_reports_a_total_order() {
+        let plan = plan_page("SELECT * FROM samples ORDER BY ts", None).expect("planned");
+
+        assert_eq!(plan.tiebreak_appended, vec!["series_id".to_string()]);
+        assert_eq!(
+            plan.order_by,
+            vec![
+                OrderTerm::ascending("ts"),
+                OrderTerm::ascending("series_id")
+            ],
+        );
+        assert_eq!(plan.not_total, None);
+        assert!(plan.total_order());
+        assert_eq!(
+            plan.statement,
+            "SELECT * FROM (SELECT * FROM samples) AS ravel_page \
+             ORDER BY ts ASC, series_id ASC",
+        );
+
+        // A statement already ordered by the whole identity needs no tiebreak,
+        // and the appended list is empty rather than a repeat of its terms.
+        let complete =
+            plan_page("SELECT * FROM samples ORDER BY series_id DESC, ts", None).expect("planned");
+        assert_eq!(complete.tiebreak_appended, Vec::<String>::new());
+        assert_eq!(
+            complete.order_by,
+            vec![
+                OrderTerm::descending("series_id"),
+                OrderTerm::ascending("ts"),
+            ],
+        );
+        assert!(complete.total_order());
+        assert_eq!(
+            complete.statement,
+            "SELECT * FROM (SELECT * FROM samples) AS ravel_page \
+             ORDER BY series_id DESC, ts ASC",
+        );
+    }
+
+    /// The two ways an ordering cannot be made unique, each reported rather
+    /// than guessed at. `logs` has no row identity, so no tiebreak exists to
+    /// append; a grouped `samples` statement does not project the scan's rows
+    /// one-for-one, so the identity that exists does not carry to its result.
+    /// Both are reported as not-total plans, not refusals: D5 pages them under
+    /// the equal-group rule instead of a keyset predicate.
+    #[test]
+    fn reports_not_total_for_an_ordering_it_cannot_make_unique() {
+        let logs = plan_page("SELECT * FROM logs ORDER BY ts", None).expect("planned");
+        assert_eq!(
+            logs.not_total,
+            Some(NotTotalOrder::NoRowIdentity { table: "logs" }),
+        );
+        assert!(!logs.total_order());
+        assert_eq!(logs.tiebreak_appended, Vec::<String>::new());
+        assert_eq!(logs.order_by, vec![OrderTerm::ascending("ts")]);
+        assert_eq!(
+            logs.statement,
+            "SELECT * FROM (SELECT * FROM logs) AS ravel_page ORDER BY ts ASC",
+        );
+
+        let grouped = plan_page(
+            "SELECT ts, count(*) AS hits FROM samples GROUP BY ts ORDER BY ts",
+            None,
+        )
+        .expect("planned");
+        assert_eq!(
+            grouped.not_total,
+            Some(NotTotalOrder::ShapeNotIdentityPreserving { shape: "GROUP BY" }),
+        );
+        assert!(!grouped.total_order());
+        assert_eq!(grouped.tiebreak_appended, Vec::<String>::new());
+        assert_eq!(grouped.order_by, vec![OrderTerm::ascending("ts")]);
+
+        // A projection that omits an identity column is the third case: the
+        // columns exist on the table but a page's own rows would not carry the
+        // values the next cursor position needs.
+        let narrow = plan_page("SELECT ts FROM samples ORDER BY ts", None).expect("planned");
+        assert_eq!(
+            narrow.not_total,
+            Some(NotTotalOrder::TiebreakNotProjected {
+                missing: vec!["series_id".to_string()],
+            }),
+        );
+        assert!(!narrow.total_order());
+        assert_eq!(narrow.tiebreak_appended, Vec::<String>::new());
+    }
+
+    /// A resume position becomes the strict lexicographic keyset predicate,
+    /// with the comparison flipped per DESC term. Asserted as exact statement
+    /// text: the whole point of the planner is the text it emits.
+    #[test]
+    fn a_resume_position_becomes_the_expected_keyset_predicate() {
+        let resume = ResumePosition::new(vec![
+            ResumeValue::TimestampNanos(500),
+            ResumeValue::FixedSizeBinary(SERIES_ID.to_vec()),
+        ]);
+
+        let plan = plan_page("SELECT * FROM samples ORDER BY ts", Some(&resume)).expect("planned");
+        assert_eq!(
+            plan.statement,
+            format!(
+                "SELECT * FROM (SELECT * FROM samples) AS ravel_page \
+                 WHERE ((ts > arrow_cast(500, 'Timestamp(Nanosecond, None)')) \
+                 OR (ts = arrow_cast(500, 'Timestamp(Nanosecond, None)') \
+                 AND series_id > arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), \
+                 'FixedSizeBinary(16)'))) \
+                 ORDER BY ts ASC, series_id ASC"
+            ),
+        );
+
+        // Descending on the leading term flips only that term's comparison;
+        // the equality conjunct and the appended ascending tiebreak are
+        // unchanged.
+        let descending =
+            plan_page("SELECT * FROM samples ORDER BY ts DESC", Some(&resume)).expect("planned");
+        assert_eq!(
+            descending.statement,
+            format!(
+                "SELECT * FROM (SELECT * FROM samples) AS ravel_page \
+                 WHERE ((ts < arrow_cast(500, 'Timestamp(Nanosecond, None)')) \
+                 OR (ts = arrow_cast(500, 'Timestamp(Nanosecond, None)') \
+                 AND series_id > arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), \
+                 'FixedSizeBinary(16)'))) \
+                 ORDER BY ts DESC, series_id ASC"
+            ),
+        );
+
+        // The caller's own predicate survives inside the derived table, and
+        // the keyset lands outside it.
+        let filtered = plan_page(
+            "SELECT * FROM samples WHERE value > 1 ORDER BY ts",
+            Some(&resume),
+        )
+        .expect("planned");
+        assert_eq!(
+            filtered.statement,
+            format!(
+                "SELECT * FROM (SELECT * FROM samples WHERE value > 1) AS ravel_page \
+                 WHERE ((ts > arrow_cast(500, 'Timestamp(Nanosecond, None)')) \
+                 OR (ts = arrow_cast(500, 'Timestamp(Nanosecond, None)') \
+                 AND series_id > arrow_cast(decode('{SERIES_ID_HEX}', 'hex'), \
+                 'FixedSizeBinary(16)'))) \
+                 ORDER BY ts ASC, series_id ASC"
+            ),
+        );
+    }
+
+    /// A resume tuple that does not match the effective terms is refused
+    /// rather than truncated: the effective terms include whatever tiebreak
+    /// was appended, so the arity a caller has to supply is the plan's, not
+    /// the statement's.
+    #[test]
+    fn a_resume_tuple_of_the_wrong_arity_is_refused() {
+        let err = plan_page(
+            "SELECT * FROM samples ORDER BY ts",
+            Some(&ResumePosition::new(vec![ResumeValue::TimestampNanos(500)])),
+        )
+        .expect_err("refused");
+        assert_eq!(
+            err,
+            PagePlanError::ResumeArity {
+                expected: 2,
+                found: 1,
+            },
+        );
+    }
+
+    /// Each resume value renders as the literal form its column type compares
+    /// against without coercion, and a string closes over its own quote.
+    #[test]
+    fn resume_values_render_as_their_sql_literals() {
+        let plan = plan_page(
+            "SELECT * FROM logs ORDER BY severity_text, ts",
+            Some(&ResumePosition::new(vec![
+                ResumeValue::Str("it's here".to_string()),
+                ResumeValue::Int(-7),
+            ])),
+        )
+        .expect("planned");
+        assert_eq!(
+            plan.statement,
+            "SELECT * FROM (SELECT * FROM logs) AS ravel_page \
+             WHERE ((severity_text > 'it''s here') \
+             OR (severity_text = 'it''s here' AND ts > -7)) \
+             ORDER BY severity_text ASC, ts ASC",
+        );
+
+        let floats = plan_page(
+            "SELECT * FROM samples ORDER BY value, ts, series_id",
+            Some(&ResumePosition::new(vec![
+                ResumeValue::Float(-0.5),
+                ResumeValue::TimestampNanos(1),
+                ResumeValue::FixedSizeBinary(SERIES_ID.to_vec()),
+            ])),
+        )
+        .expect("planned");
+        assert!(
+            floats.statement.contains("value > -0.5"),
+            "unexpected float literal in {}",
+            floats.statement
+        );
+
+        let err = plan_page(
+            "SELECT * FROM samples ORDER BY value, ts, series_id",
+            Some(&ResumePosition::new(vec![
+                ResumeValue::Float(f64::NAN),
+                ResumeValue::TimestampNanos(1),
+                ResumeValue::FixedSizeBinary(SERIES_ID.to_vec()),
+            ])),
+        )
+        .expect_err("refused");
+        assert_eq!(err, PagePlanError::NonFiniteResumeValue);
+    }
+
+    /// Everything the planner refuses outright, with the reason each carries.
+    /// A refusal is the deliverable for these: a page planned from any of them
+    /// would either return rows past a bound the caller set or resume at a
+    /// position it cannot reproduce.
+    #[test]
+    fn refuses_the_statements_that_have_no_deterministic_page() {
+        let cases: Vec<(&str, PagePlanError)> = vec![
+            (
+                "SELECT * FROM samples ORDER BY ts LIMIT 10",
+                PagePlanError::RowLimitInStatement,
+            ),
+            (
+                "SELECT * FROM samples ORDER BY ts OFFSET 10 ROWS",
+                PagePlanError::RowLimitInStatement,
+            ),
+            (
+                "SELECT * FROM samples ORDER BY ts + 1",
+                PagePlanError::OrderTermNotColumn {
+                    term: "ts + 1".to_string(),
+                },
+            ),
+            (
+                "SELECT ts, series_id FROM samples ORDER BY value",
+                PagePlanError::OrderTermNotProjected {
+                    column: "value".to_string(),
+                },
+            ),
+            (
+                "SELECT * FROM samples ORDER BY ts NULLS LAST",
+                PagePlanError::UnsupportedOrderOption {
+                    column: "ts".to_string(),
+                    option: "NULLS FIRST/LAST",
+                },
+            ),
+            (
+                "SELECT * FROM logs JOIN samples ON logs.ts = samples.ts ORDER BY logs.ts",
+                PagePlanError::CrossSignal,
+            ),
+            (
+                "SELECT * FROM logs",
+                PagePlanError::NoOrdering { target: "logs" },
+            ),
+            (
+                "SELECT 1",
+                PagePlanError::NoOrdering {
+                    target: "a statement with no base table",
+                },
+            ),
+        ];
+        for (sql, expected) in cases {
+            let err = plan_page(sql, None).expect_err("refused");
+            assert_eq!(err, expected, "unexpected refusal for {sql:?}");
+        }
+    }
+
+    /// The validation gate runs first and unchanged, so a statement the
+    /// executor would refuse is never rewritten into a pageable one.
+    #[test]
+    fn refuses_what_the_read_only_gate_refuses() {
+        let err = plan_page("DELETE FROM samples", None).expect_err("refused");
+        assert!(
+            matches!(err, PagePlanError::Invalid(_)),
+            "expected a validation refusal, got {err:?}"
+        );
+    }
+
+    /// A `samples` statement with no ORDER BY at all is pageable: the row
+    /// identity is a complete ordering on its own, so the planner imposes it
+    /// rather than refusing.
+    #[test]
+    fn imposes_the_row_identity_on_a_statement_with_no_ordering() {
+        let plan = plan_page("SELECT * FROM samples", None).expect("planned");
+        assert_eq!(
+            plan.tiebreak_appended,
+            vec!["ts".to_string(), "series_id".to_string()],
+        );
+        assert_eq!(
+            plan.order_by,
+            vec![
+                OrderTerm::ascending("ts"),
+                OrderTerm::ascending("series_id")
+            ],
+        );
+        assert!(plan.total_order());
+    }
+}

--- a/crates/ravel-sql/tests/page_walk.rs
+++ b/crates/ravel-sql/tests/page_walk.rs
@@ -13,24 +13,64 @@
 //! assertion cannot see that the name the tiebreak claimed row identity on
 //! belongs to a different value than the one the schema described.
 //!
-//! So this suite executes. For every statement the planner reports a total
-//! order for, it pages the statement with a row cap of 1, collects the rows
-//! every page returned, and asserts MULTISET EQUALITY against the same
-//! statement run unpaged. A row count is not enough: a count still passes when
-//! one row is dropped and another duplicated, and both happen under a keyset
-//! predicate built over the wrong column.
+//! # What the walk asserts
+//!
+//! For every statement the planner reports a total order for, this suite pages
+//! the statement with a row cap of 1 and asserts that **page k holds rows k of
+//! the unpaged ordering, as a sequence**. Not the set of rows the walk
+//! returned: the sequence, page by page, in page order.
+//!
+//! A multiset comparison of the walked rows against the unpaged result is the
+//! weaker statement this suite used to make, and it is order-blind by
+//! construction. It cannot see a `DESC` term the planner read as `ASC`, and it
+//! cannot see a page statement rendered with no `ORDER BY` on the wrapper at
+//! all: both still deliver every row exactly once, in an order no caller
+//! asked for. The whole point of a total-order claim is the sequence, so the
+//! sequence is what gets asserted.
+//!
+//! The ordering compared against is [`reference_statement`]: the caller's own
+//! text, plus whatever columns the plan says it appended as a tiebreak, run
+//! unpaged. It is deliberately NOT built from `plan.order_by`, because a plan
+//! that misread the caller's `ORDER BY ts DESC` as ascending would then be
+//! compared against its own misreading and agree with itself. Building the
+//! reference from the caller's text hands the reading of it to DataFusion.
+//! The reference is proved to be a reordering of the unpaged result, and
+//! nothing else, by a multiset comparison against it.
+//!
+//! Two more properties fall out of asserting per page rather than over the
+//! concatenation: a page that returns fewer rows than the cap while rows
+//! remain is a finding (it breaks the indexing the claim rests on), and a walk
+//! that ends early is reported against the ordering's length rather than
+//! against a row set that happens to match.
 //!
 //! # The fixture has to be able to fail
 //!
-//! [`samples_fixture`] carries deliberate ties and a deliberate NULL source:
-//! two rows share `(ts, value)` under distinct `series_id`, and one row's
-//! `value` is `0.0`, so a projected `nullif(value, 0)` is NULL for it. Without
-//! the ties, a keyset predicate over the wrong pair of columns still walks
-//! every row and the suite is a tautology; without the zero, a projection that
-//! shadows a NOT NULL name with a nullable expression loses nothing.
-//! [`the_fixture_can_expose_a_broken_keyset_predicate`] pins both properties as
-//! exact counts, so a later edit to the fixture that removes them fails here
-//! rather than quietly turning every walk below into a statement about nothing.
+//! [`FIXTURE`] is six rows in deliberately unsorted insertion order, each
+//! property present because a mutation of the planner survives without it:
+//!
+//! - two rows share `(ts, value)` under distinct `series_id`, so a keyset
+//!   predicate over the wrong pair of columns cannot walk the tie;
+//! - one `value` is `0.0`, so a projected `nullif(value, 0)` is NULL for it
+//!   and a projection that shadows a NOT NULL name with a nullable expression
+//!   loses rows;
+//! - one `value` is `-0.0`, which DataFusion holds to be a DIFFERENT value
+//!   from `0.0` (it compares floats by a total order, so `-0.0 = 0` is FALSE
+//!   and `-0.0` sorts first);
+//! - one `value` is NaN, which no cursor can carry, so a page ending on it
+//!   mints no resume position;
+//! - `series_id` is anti-correlated with `ts` at the head of the ordering (the
+//!   smallest `ts` carries the largest `series_id`), so a tiebreak that orders
+//!   on the wrong one of the two produces a different sequence rather than the
+//!   same one;
+//! - one `ts` is not a multiple of 1000 ns, so a truncating or rescaling
+//!   round trip through a cursor value is visible;
+//! - the same walk runs over a one-row table (an empty second page) and a
+//!   zero-row table (an empty first page).
+//!
+//! [`the_fixture_can_expose_a_broken_keyset_predicate`] pins every one of
+//! those as an exact count, so a later edit to the fixture that removes one
+//! fails there rather than quietly turning the walks into a statement about
+//! nothing.
 //!
 //! `samples` is registered as a plain in-memory table over
 //! `ravel_sql::public_schema()`. The planner's row-identity claim is about what
@@ -56,7 +96,7 @@ use datafusion::datasource::MemTable;
 use datafusion::execution::context::SessionContext;
 use datafusion::prelude::SessionConfig;
 use ravel_sql::{
-    PagePlanError, ResumePosition, ResumeValue, SAMPLES_TABLE, plan_page, public_schema,
+    PagePlan, PagePlanError, ResumePosition, ResumeValue, SAMPLES_TABLE, plan_page, public_schema,
 };
 
 /// The `ts` the two tied rows share.
@@ -66,12 +106,26 @@ const TIED_TS: i64 = 1_000;
 /// this same number rather than NULL for both.
 const TIED_VALUE: f64 = 1.0;
 
-/// The third row's `value`. Zero, which is what makes a projected
-/// `nullif(value, 0)` NULL for exactly one row of the fixture.
+/// The `value` that a projected `nullif(value, 0)` turns into NULL.
 const NULLING_VALUE: f64 = 0.0;
 
-/// The third row's `ts`, distinct from [`TIED_TS`].
+/// A `value` distinct from [`NULLING_VALUE`] under DataFusion's total float
+/// order: `-0.0 = 0` is FALSE and `-0.0` sorts before `0.0`, so the two zero
+/// rows are two values rather than one repeated.
+const NEGATIVE_ZERO: f64 = -0.0;
+
+/// A `ts` distinct from [`TIED_TS`], on the row carrying [`NULLING_VALUE`].
 const LONE_TS: i64 = 2_000;
+
+/// The smallest `ts` in the fixture, on the row carrying the largest
+/// `series_id`. That anti-correlation is what makes ordering on `ts` and
+/// ordering on `series_id` produce different sequences over this fixture.
+const ANTI_TS: i64 = 500;
+
+/// A `ts` that is not a multiple of 1000 ns, so a cursor round trip that
+/// truncates or rescales the value lands the walk on the wrong row rather than
+/// on the same one.
+const ODD_TS: i64 = 1_234_567;
 
 /// A page's row cap. One row per page is the smallest cap and the one that
 /// makes a lost row visible at the first tie rather than only when a tie
@@ -79,31 +133,84 @@ const LONE_TS: i64 = 2_000;
 const PAGE_CAP: usize = 1;
 
 /// How many pages a walk may take before it is treated as non-terminating.
-/// Three rows at a cap of one needs four pages including the empty last one;
+/// Six rows at a cap of one needs seven pages including the empty last one;
 /// anything near this bound is a planner that is not advancing.
 const MAX_PAGES: usize = 32;
 
-/// Three rows, two of them tied on `(ts, value)`, one of them carrying the
-/// `value` that a projected `nullif(value, 0)` turns into NULL.
-///
-/// The `series_id`s are distinct, so the fixture respects the `samples` row
-/// identity the planner's total-order claim rests on: `(series_id, ts)` is
-/// unique across the three rows.
-fn samples_fixture() -> RecordBatch {
-    let ts = TimestampNanosecondArray::from(vec![TIED_TS, TIED_TS, LONE_TS]);
-    let value = Float64Array::from(vec![TIED_VALUE, TIED_VALUE, NULLING_VALUE]);
-    let series_id = FixedSizeBinaryArray::try_from_iter([[1u8; 16], [2u8; 16], [3u8; 16]].iter())
-        .expect("series id array");
+/// One fixture row. `labels` is not a parameter: it is NOT NULL and its
+/// content is irrelevant to paging, so every row carries an empty label set.
+#[derive(Clone, Copy)]
+struct FixtureRow {
+    ts: i64,
+    value: f64,
+    series_id: [u8; 16],
+}
+
+/// The six-row fixture, in insertion order, which is deliberately not the
+/// order any statement below asks for.
+const FIXTURE: &[FixtureRow] = &[
+    FixtureRow {
+        ts: TIED_TS,
+        value: TIED_VALUE,
+        series_id: [1u8; 16],
+    },
+    FixtureRow {
+        ts: TIED_TS,
+        value: TIED_VALUE,
+        series_id: [2u8; 16],
+    },
+    FixtureRow {
+        ts: LONE_TS,
+        value: NULLING_VALUE,
+        series_id: [3u8; 16],
+    },
+    // Anti-correlated: the smallest `ts` under the largest `series_id`.
+    FixtureRow {
+        ts: ANTI_TS,
+        value: 3.0,
+        series_id: [9u8; 16],
+    },
+    FixtureRow {
+        ts: ODD_TS,
+        value: f64::NAN,
+        series_id: [4u8; 16],
+    },
+    FixtureRow {
+        ts: 3_000,
+        value: NEGATIVE_ZERO,
+        series_id: [5u8; 16],
+    },
+];
+
+/// One row, so a walk's second page is the empty one.
+const ONE_ROW: &[FixtureRow] = &[FixtureRow {
+    ts: TIED_TS,
+    value: TIED_VALUE,
+    series_id: [1u8; 16],
+}];
+
+/// No rows, so a walk's first page is the empty one.
+const NO_ROWS: &[FixtureRow] = &[];
+
+/// `rows` as a `samples` batch.
+fn samples_batch(rows: &[FixtureRow]) -> RecordBatch {
+    let ts = TimestampNanosecondArray::from(rows.iter().map(|row| row.ts).collect::<Vec<i64>>());
+    let value = Float64Array::from(rows.iter().map(|row| row.value).collect::<Vec<f64>>());
+    let series_id = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+        rows.iter().map(|row| Some(row.series_id)),
+        16,
+    )
+    .expect("series id array");
 
     // One empty label set per row. The label content is irrelevant to paging
     // and the column is NOT NULL, so it has to be present and well-formed.
     let mut maps = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
-    for _ in 0..3 {
+    for _ in rows {
         maps.append(true).expect("label map append");
     }
     let maps: MapArray = maps.finish();
     let labels = DictionaryArray::<Int32Type>::try_new(
-        Int32Array::from(vec![0, 1, 2]),
+        Int32Array::from((0..rows.len() as i32).collect::<Vec<i32>>()),
         Arc::new(maps) as ArrayRef,
     )
     .expect("labels dictionary");
@@ -120,18 +227,23 @@ fn samples_fixture() -> RecordBatch {
     .expect("fixture batch")
 }
 
-/// A context with the fixture registered as `samples`.
+/// A context with `rows` registered as `samples`.
 ///
 /// One target partition, so `collect` returns the sorted rows in the order the
 /// `ORDER BY` produced them and "the first row of the result" is the row a
 /// page cap of one would keep.
-fn context() -> SessionContext {
+fn context_of(rows: &[FixtureRow]) -> SessionContext {
     let ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
     let table =
-        MemTable::try_new(public_schema(), vec![vec![samples_fixture()]]).expect("mem table");
+        MemTable::try_new(public_schema(), vec![vec![samples_batch(rows)]]).expect("mem table");
     ctx.register_table(SAMPLES_TABLE, Arc::new(table))
         .expect("registered samples");
     ctx
+}
+
+/// A context over the full [`FIXTURE`].
+fn context() -> SessionContext {
+    context_of(FIXTURE)
 }
 
 async fn execute(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
@@ -147,8 +259,8 @@ async fn execute(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
 ///
 /// Rendered rather than compared as arrays because the statements below
 /// project different column sets and types, `labels` among them, and the only
-/// property under test is which rows came back. NULL renders as the literal
-/// `NULL`, distinct from an empty string.
+/// property under test is which rows came back in which order. NULL renders as
+/// the literal `NULL`, distinct from an empty string.
 fn rows_of(batches: &[RecordBatch]) -> Vec<Vec<String>> {
     let options = FormatOptions::default().with_null("NULL");
     let mut rows = Vec::new();
@@ -172,16 +284,40 @@ fn rows_of(batches: &[RecordBatch]) -> Vec<Vec<String>> {
     rows
 }
 
-/// `rows` as a multiset: the row-to-count map two walks are compared by.
-///
-/// A count alone passes when one row is dropped and another duplicated, which
-/// is what a keyset predicate over a mis-resolved column actually does.
+/// `rows` as a multiset: the row-to-count map two results are compared by when
+/// only their contents are under test.
 fn multiset(rows: &[Vec<String>]) -> BTreeMap<Vec<String>, usize> {
     let mut counts: BTreeMap<Vec<String>, usize> = BTreeMap::new();
     for row in rows {
         *counts.entry(row.clone()).or_default() += 1;
     }
     counts
+}
+
+/// The statement whose unpaged result is the ordering a walk of `sql` has to
+/// reproduce page by page: the caller's own text, plus the tiebreak columns
+/// the plan says it appended, which the planner always appends ascending.
+///
+/// Built from the caller's text and not from `plan.order_by` on purpose. A
+/// planner that reads `ORDER BY ts DESC` as ascending renders an ascending
+/// `order_by`, and a reference built from that would be ascending too and
+/// agree with the walk. Handing the caller's text to DataFusion instead means
+/// the direction under test is never the planner's own reading of it.
+fn reference_statement(sql: &str, plan: &PagePlan) -> String {
+    if plan.tiebreak_appended.is_empty() {
+        return sql.to_string();
+    }
+    let appended = plan
+        .tiebreak_appended
+        .iter()
+        .map(|column| format!("\"{column}\" ASC"))
+        .collect::<Vec<String>>()
+        .join(", ");
+    if sql.to_ascii_uppercase().contains(" ORDER BY ") {
+        format!("{sql}, {appended}")
+    } else {
+        format!("{sql} ORDER BY {appended}")
+    }
 }
 
 /// The resume value for one order-term column of one row, or `None` when that
@@ -262,6 +398,10 @@ fn resume_value(array: &ArrayRef, index: usize) -> Option<ResumeValue> {
                 .value(index)
                 .to_vec(),
         ),
+        // Reachable only from a plan that claimed a total order over a term no
+        // cursor can carry, which `plan_page` now refuses outright
+        // (`OrderTermNotRepresentable`). It stays as the harness's own last
+        // check on that refusal.
         other => panic!("no resume value for an order term of type {other}"),
     };
     Some(value)
@@ -269,8 +409,9 @@ fn resume_value(array: &ArrayRef, index: usize) -> Option<ResumeValue> {
 
 /// What an executed walk found.
 struct Walk {
-    /// The rows the walk collected, page by page, in page order.
-    rows: Vec<Vec<String>>,
+    /// The rows each non-empty page returned, in page order. The terminating
+    /// empty page contributes no entry; [`Self::pages`] counts it.
+    page_rows: Vec<Vec<Vec<String>>>,
     /// The pages taken, the terminating empty one included.
     pages: usize,
     /// Set when the walk stopped because the last row's order term was NULL,
@@ -278,11 +419,18 @@ struct Walk {
     stopped_at_null: Option<String>,
 }
 
+impl Walk {
+    /// Every row the walk collected, page order preserved.
+    fn rows(&self) -> Vec<Vec<String>> {
+        self.page_rows.iter().flatten().cloned().collect()
+    }
+}
+
 /// Page `sql` with a cap of [`PAGE_CAP`] rows, from the first page to the
 /// empty one, exactly as a paging caller would: each page's statement comes
 /// from `plan_page` resumed at the previous page's last row.
 async fn walk(ctx: &SessionContext, sql: &str) -> Walk {
-    let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut page_rows: Vec<Vec<Vec<String>>> = Vec::new();
     let mut resume: Option<ResumePosition> = None;
     let mut pages = 0usize;
     loop {
@@ -297,7 +445,7 @@ async fn walk(ctx: &SessionContext, sql: &str) -> Walk {
         let page: Vec<Vec<String>> = rows_of(&batches).into_iter().take(PAGE_CAP).collect();
         if page.is_empty() {
             return Walk {
-                rows,
+                page_rows,
                 pages,
                 stopped_at_null: None,
             };
@@ -316,16 +464,16 @@ async fn walk(ctx: &SessionContext, sql: &str) -> Walk {
             match resume_value(column, offset) {
                 Some(value) => tuple.push(value),
                 None => {
-                    rows.extend(page);
+                    page_rows.push(page);
                     return Walk {
-                        rows,
+                        page_rows,
                         pages,
                         stopped_at_null: Some(term.column.clone()),
                     };
                 }
             }
         }
-        rows.extend(page);
+        page_rows.push(page);
         resume = Some(ResumePosition::new(tuple));
     }
 }
@@ -341,6 +489,55 @@ fn row_at(batches: &[RecordBatch], index: usize) -> (&RecordBatch, usize) {
         remaining -= batch.num_rows();
     }
     panic!("row {index} is past the end of the result");
+}
+
+/// Where the walk's page sequence departs from `reference`, or `None` when
+/// page k held rows k of it from the first page to the last.
+fn sequence_finding(reference: &[Vec<String>], found: &Walk) -> Option<String> {
+    let mut cursor = 0usize;
+    for (index, page) in found.page_rows.iter().enumerate() {
+        let page_number = index + 1;
+        let end = cursor + page.len();
+        if end > reference.len() {
+            return Some(format!(
+                "page {page_number} runs past the end of the ordering: it starts at ordering \
+                 row {cursor} and holds {} rows, and the ordering has {}",
+                page.len(),
+                reference.len(),
+            ));
+        }
+        if page.as_slice() != &reference[cursor..end] {
+            return Some(format!(
+                "page {page_number} is not rows {cursor}..{end} of the ordering\n      page     \
+                 {page:?}\n      ordering {:?}",
+                &reference[cursor..end],
+            ));
+        }
+        if page.len() != PAGE_CAP && end != reference.len() {
+            return Some(format!(
+                "page {page_number} returned {} of the {PAGE_CAP} rows a page holds while {} \
+                 rows were still unwalked, so page k stopped meaning rows k of the ordering",
+                page.len(),
+                reference.len() - end,
+            ));
+        }
+        cursor = end;
+    }
+    let stopped = match &found.stopped_at_null {
+        Some(column) => format!(", stopped at a NULL {column}"),
+        None => String::new(),
+    };
+    if cursor != reference.len() {
+        return Some(format!(
+            "the walk delivered {cursor} of the ordering's {} rows in {} pages{stopped}",
+            reference.len(),
+            found.pages,
+        ));
+    }
+    found
+        .stopped_at_null
+        .as_ref()
+        .map(|column| format!("the walk delivered every row but stopped at a NULL {column}"))
 }
 
 /// The four statements this round exists for, plus the shapes that must keep
@@ -368,29 +565,26 @@ const STATEMENTS: &[&str] = &[
     "SELECT * FROM samples",
     "SELECT ts, series_id FROM samples ORDER BY ts",
     "SELECT ts, series_id, value FROM samples ORDER BY ts DESC, series_id",
+    "SELECT ts, series_id FROM samples ORDER BY series_id",
     "SELECT * FROM samples WHERE value > 0.5 ORDER BY ts",
-    // Refused now rather than walked: `value` is a float, and NaN satisfies no
-    // disjunct of a keyset predicate. Kept in the table so the refusal is
-    // exercised on the same path the walks take.
+    // Refused now rather than walked, both for a term whose values no cursor
+    // carries. `value` is a float, so it admits the NaN that
+    // `ResumeValue::Float` refuses; `labels` is a `Dictionary` over a `Map`,
+    // which no variant carries at all. Kept in the table so both refusals are
+    // exercised on the same path the walks take: a planner that admits either
+    // one reaches the cursor mint and dies there.
     "SELECT ts, series_id, value FROM samples ORDER BY value DESC, ts",
+    "SELECT * FROM samples ORDER BY labels, ts, series_id",
 ];
 
-/// The acceptance gate: every statement the planner claims a total order for
-/// pages to exactly the rows it returns unpaged.
-///
-/// Statements the planner refuses, and statements it plans with a
-/// `not_total` reason, are outside the claim: D5 pages the second kind under
-/// the equal-group rule, which is the caller's half and not this planner's. So
-/// a refusal and a not-total plan both satisfy this test, and the pinned
-/// classification in [`the_four_defect_statements_are_classified_exactly`] is
-/// what stops a fix from satisfying it by refusing everything.
-#[tokio::test]
-async fn a_total_order_claim_survives_an_executed_page_walk() {
-    let ctx = context();
+/// Walk every total-order statement over one fixture, returning how many were
+/// walked and what each departure from the ordering was.
+async fn walk_findings(rows: &[FixtureRow]) -> (usize, Vec<String>) {
+    let ctx = context_of(rows);
     let mut walked = 0usize;
     // Collected rather than asserted per statement: the first failing walk is
     // not the only one, and a suite that stops at it hides how wide the defect
-    // is. Every finding below names the rows that went missing.
+    // is.
     let mut findings: Vec<String> = Vec::new();
     for sql in STATEMENTS {
         let plan = match plan_page(sql, None) {
@@ -402,46 +596,67 @@ async fn a_total_order_claim_survives_an_executed_page_walk() {
         }
         walked += 1;
 
-        let unpaged = multiset(&rows_of(&execute(&ctx, sql).await));
-        let found = walk(&ctx, sql).await;
-        let walked_rows = multiset(&found.rows);
-        if walked_rows == unpaged && found.stopped_at_null.is_none() {
+        let unpaged = rows_of(&execute(&ctx, sql).await);
+        let reference_sql = reference_statement(sql, &plan);
+        let reference = rows_of(&execute(&ctx, &reference_sql).await);
+        // The reference has to be the same rows in some order, or the sequence
+        // assertion below is about the wrong result rather than about the walk.
+        if multiset(&reference) != multiset(&unpaged) {
+            findings.push(format!(
+                "{sql:?}\n    the tiebreak reference {reference_sql:?} returned {} rows against \
+                 the statement's own {}",
+                reference.len(),
+                unpaged.len(),
+            ));
             continue;
         }
 
-        let mut missing: Vec<String> = Vec::new();
-        for (row, count) in &unpaged {
-            let seen = walked_rows.get(row).copied().unwrap_or(0);
-            if seen != *count {
-                missing.push(format!("{row:?} unpaged {count} times, walked {seen}"));
-            }
+        let found = walk(&ctx, sql).await;
+        if let Some(finding) = sequence_finding(&reference, &found) {
+            findings.push(format!(
+                "{sql:?}\n    order_by {:?}, tiebreak {:?}, ordering {reference_sql:?}\n    \
+                 {finding}",
+                plan.order_by
+                    .iter()
+                    .map(|term| term.render())
+                    .collect::<Vec<String>>(),
+                plan.tiebreak_appended,
+            ));
         }
-        for (row, count) in &walked_rows {
-            if !unpaged.contains_key(row) {
-                missing.push(format!("{row:?} walked {count} times, never unpaged"));
-            }
-        }
-        findings.push(format!(
-            "{sql:?}\n    order_by {:?}, tiebreak {:?}\n    {} pages at a cap of \
-             {PAGE_CAP} returned {} of {} rows{}\n    {}",
-            plan.order_by
-                .iter()
-                .map(|term| term.render())
-                .collect::<Vec<String>>(),
-            plan.tiebreak_appended,
-            found.pages,
-            found.rows.len(),
-            unpaged.values().sum::<usize>(),
-            match &found.stopped_at_null {
-                Some(column) => format!(", stopped at a NULL {column}"),
-                None => String::new(),
-            },
-            missing.join("\n    "),
-        ));
+    }
+    (walked, findings)
+}
+
+/// The acceptance gate: every statement the planner claims a total order for
+/// pages to the unpaged ordering, page k holding rows k of it.
+///
+/// Statements the planner refuses, and statements it plans with a
+/// `not_total` reason, are outside the claim: D5 pages the second kind under
+/// the equal-group rule, which is the caller's half and not this planner's. So
+/// a refusal and a not-total plan both satisfy this test, and the pinned
+/// classification in [`the_four_defect_statements_are_classified_exactly`] is
+/// what stops a fix from satisfying it by refusing everything.
+#[tokio::test]
+async fn a_total_order_claim_survives_an_executed_page_walk() {
+    let fixtures: [(&str, &[FixtureRow]); 3] = [
+        ("the six-row fixture", FIXTURE),
+        ("a one-row table", ONE_ROW),
+        ("an empty table", NO_ROWS),
+    ];
+    let mut walked = 0usize;
+    let mut findings: Vec<String> = Vec::new();
+    for (label, rows) in fixtures {
+        let (count, found) = walk_findings(rows).await;
+        walked += count;
+        findings.extend(
+            found
+                .into_iter()
+                .map(|finding| format!("{label}: {finding}")),
+        );
     }
     assert!(
         findings.is_empty(),
-        "{} of {walked} total-order claims lost rows under an executed walk:\n  {}",
+        "{} of {walked} total-order claims did not page to their own ordering:\n  {}",
         findings.len(),
         findings.join("\n  "),
     );
@@ -452,17 +667,46 @@ async fn a_total_order_claim_survives_an_executed_page_walk() {
     );
 }
 
+/// A one-row table ends the walk on an empty SECOND page, and a zero-row table
+/// on an empty FIRST one.
+///
+/// Both are page counts the six-row fixture cannot produce, and both are the
+/// boundary a resume position is never built at: the first has exactly one
+/// cursor mint and the second has none.
+#[tokio::test]
+async fn a_walk_terminates_on_an_empty_page_at_both_table_boundaries() {
+    let sql = "SELECT * FROM samples ORDER BY ts";
+
+    let one = walk(&context_of(ONE_ROW), sql).await;
+    assert_eq!(one.pages, 2, "pages over a one-row table");
+    assert_eq!(
+        one.page_rows.len(),
+        1,
+        "non-empty pages over a one-row table"
+    );
+    assert_eq!(one.rows().len(), 1, "rows walked from a one-row table");
+    assert_eq!(one.stopped_at_null, None);
+
+    let none = walk(&context_of(NO_ROWS), sql).await;
+    assert_eq!(none.pages, 1, "pages over an empty table");
+    assert!(
+        none.page_rows.is_empty(),
+        "non-empty pages over an empty table"
+    );
+    assert_eq!(none.stopped_at_null, None);
+}
+
 /// The fixture can actually expose the defects it is here to expose.
 ///
-/// Pinned as exact counts. A fixture edit that drops the tie or the zero
-/// leaves every walk above passing over rows that no keyset predicate could
-/// lose, which is how a suite of this shape goes vacuous.
+/// Pinned as exact counts. A fixture edit that drops one of these leaves every
+/// walk above passing over rows that no mutation of the planner could disturb,
+/// which is how a suite of this shape goes vacuous.
 #[tokio::test]
 async fn the_fixture_can_expose_a_broken_keyset_predicate() {
     let ctx = context();
 
     let rows = rows_of(&execute(&ctx, "SELECT ts, value, series_id FROM samples").await);
-    assert_eq!(rows.len(), 3, "fixture row count");
+    assert_eq!(rows.len(), 6, "fixture row count");
 
     let tied = rows_of(
         &execute(
@@ -488,6 +732,9 @@ async fn the_fixture_can_expose_a_broken_keyset_predicate() {
         "rows sharing one (ts, value)",
     );
 
+    // One, not two: DataFusion compares floats by a total order, so `-0.0 = 0`
+    // is FALSE and only the positive zero is NULLed. Measured, not assumed:
+    // `SELECT value, value = 0 FROM samples` returns false for the `-0.0` row.
     let nulled = rows_of(
         &execute(
             &ctx,
@@ -500,6 +747,18 @@ async fn the_fixture_can_expose_a_broken_keyset_predicate() {
         vec![vec!["1".to_string()]],
         "rows a projected nullif(value, 0) nulls",
     );
+    let zeroes = rows_of(
+        &execute(
+            &ctx,
+            "SELECT count(*) AS n FROM samples WHERE value = 0 OR value = -0.0",
+        )
+        .await,
+    );
+    assert_eq!(
+        zeroes,
+        vec![vec!["2".to_string()]],
+        "the two zero rows are distinct values, not one repeated",
+    );
 
     let distinct_identity = rows_of(
         &execute(
@@ -510,8 +769,44 @@ async fn the_fixture_can_expose_a_broken_keyset_predicate() {
     );
     assert_eq!(
         distinct_identity,
-        vec![vec!["3".to_string()]],
+        vec![vec!["6".to_string()]],
         "the fixture respects the samples row identity",
+    );
+
+    let rendered = rows_of(&execute(&ctx, "SELECT value FROM samples").await);
+    let negative_zeroes = rendered.iter().filter(|row| row[0] == "-0.0").count();
+    assert_eq!(negative_zeroes, 1, "rows rendering as a negative zero");
+    let nans = rendered.iter().filter(|row| row[0] == "NaN").count();
+    assert_eq!(nans, 1, "rows rendering as NaN");
+
+    let odd_ts = rows_of(
+        &execute(
+            &ctx,
+            "SELECT count(*) AS n FROM samples WHERE arrow_cast(ts, 'Int64') % 1000 != 0",
+        )
+        .await,
+    );
+    assert_eq!(
+        odd_ts,
+        vec![vec!["2".to_string()]],
+        "rows whose ts is not a whole microsecond",
+    );
+
+    // Anti-correlation: ordering on `ts` and ordering on `series_id` do not
+    // agree at the head, so a tiebreak that appends the wrong one of the two
+    // produces a different sequence rather than the same one.
+    let by_ts = rows_of(&execute(&ctx, "SELECT series_id FROM samples ORDER BY ts LIMIT 1").await);
+    let by_series = rows_of(
+        &execute(
+            &ctx,
+            "SELECT series_id FROM samples ORDER BY series_id DESC LIMIT 1",
+        )
+        .await,
+    );
+    assert_eq!(
+        by_ts, by_series,
+        "the smallest ts does not carry the largest series_id, so the fixture is \
+         not anti-correlated",
     );
 }
 
@@ -564,6 +859,7 @@ fn the_four_defect_statements_are_classified_exactly() {
         // passes here. `value DESC` used to be this case and is now refused
         // outright: a float term admits NaN, which no keyset disjunct places.
         "SELECT ts, series_id, value FROM samples ORDER BY ts DESC, series_id",
+        "SELECT ts, series_id FROM samples ORDER BY series_id",
         "SELECT * FROM samples WHERE value > 0.5 ORDER BY ts",
     ];
     for sql in must_stay_total {

--- a/crates/ravel-sql/tests/page_walk.rs
+++ b/crates/ravel-sql/tests/page_walk.rs
@@ -37,6 +37,15 @@
 //! The reference is proved to be a reordering of the unpaged result, and
 //! nothing else, by a multiset comparison against it.
 //!
+//! That reference is built by PARSING the caller's statement and appending the
+//! tiebreak terms to its `ORDER BY` in the AST, not by concatenating text onto
+//! it. Independence from the plan is the only reason the reference is worth
+//! having, and string surgery is not independent: `", ts ASC"` appended to a
+//! statement whose text does not end where the appender assumed lands inside
+//! something else, and the reference is then wrong in the same direction as
+//! the plan it is checking. A parse that fails, or a statement whose ordering
+//! has no term list to append to, is a panic rather than a fallback spelling.
+//!
 //! Two more properties fall out of asserting per page rather than over the
 //! concatenation: a page that returns fewer rows than the cap while rows
 //! remain is a finding (it breaks the indexing the claim rests on), and a walk
@@ -45,11 +54,17 @@
 //!
 //! # The fixture has to be able to fail
 //!
-//! [`FIXTURE`] is six rows in deliberately unsorted insertion order, each
+//! [`FIXTURE`] is seven rows in deliberately unsorted insertion order, each
 //! property present because a mutation of the planner survives without it:
 //!
 //! - two rows share `(ts, value)` under distinct `series_id`, so a keyset
 //!   predicate over the wrong pair of columns cannot walk the tie;
+//! - that tied pair is stored in DESCENDING `series_id` order, so its
+//!   insertion order is not its tiebreak order: a wrapper `ORDER BY` that
+//!   drops a term the keyset predicate still carries returns the pair the
+//!   other way round rather than the same way round by luck;
+//! - two rows share one `series_id` under distinct `ts`, so a row identity
+//!   declared as `series_id` alone is not a key over this fixture;
 //! - one `value` is `0.0`, so a projected `nullif(value, 0)` is NULL for it
 //!   and a projection that shadows a NOT NULL name with a nullable expression
 //!   loses rows;
@@ -72,6 +87,8 @@
 //! fails there rather than quietly turning the walks into a statement about
 //! nothing.
 //!
+//! # Two tables, because one table hides a whole class of mutation
+//!
 //! `samples` is registered as a plain in-memory table over
 //! `ravel_sql::public_schema()`. The planner's row-identity claim is about what
 //! the `samples` scan emits (at most one row per `(series_id, ts)`, which the
@@ -79,6 +96,28 @@
 //! resolution, wildcard expansion, positional column aliases, keyset
 //! comparison, NULL semantics -- is DataFusion's, which a `MemTable` exercises
 //! exactly as the real provider would.
+//!
+//! `logs` is registered beside it, over `ravel_sql::logs_schema()`, and its
+//! fixture carries the duplicate row that makes `logs` have no row identity in
+//! the first place: ingest is at-least-once, so the same record can arrive
+//! twice and two rows can tie on every orderable column. Nothing in
+//! [`STATEMENTS`] over `logs` is walked today, because the planner reports
+//! [`ravel_sql::NotTotalOrder::NoRowIdentity`] for all four RLOG- and
+//! RSPAN-backed tables and the walk is a statement about total-order claims
+//! only. Registering it is what makes the reverse direction fail: a planner
+//! that starts claiming a total order over one of those tables walks these
+//! statements, and the duplicate row then leaves a row on no page. Without a
+//! second table the harness cannot execute such a statement at all, so that
+//! whole class of mutation passes every test here by construction.
+//!
+//! The walked set is not row-wise selects alone either. Two window statements
+//! are in it, because a window statement DOES plan with a total-order claim in
+//! production and the wrap is what makes it page correctly: the window runs
+//! inside the derived table over all the statement's rows while the keyset
+//! predicate filters outside it, so `count(*) OVER ()` reports the same total
+//! on every page rather than counting down as the walk advances. A statement
+//! whose result depends on rows a keyset filter would remove and which the
+//! planner cannot page is asserted as a refusal rather than omitted.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -88,15 +127,20 @@ use std::sync::Arc;
 use datafusion::arrow::array::{
     Array, ArrayRef, BinaryArray, BooleanArray, DictionaryArray, FixedSizeBinaryArray,
     Float64Array, Int32Array, Int64Array, MapArray, MapBuilder, RecordBatch, StringArray,
-    StringBuilder, TimestampNanosecondArray, UInt64Array,
+    StringBuilder, TimestampNanosecondArray, UInt8Array, UInt32Array, UInt64Array,
 };
 use datafusion::arrow::datatypes::{DataType, Int32Type, TimeUnit};
 use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
 use datafusion::datasource::MemTable;
 use datafusion::execution::context::SessionContext;
 use datafusion::prelude::SessionConfig;
+use datafusion::sql::parser::{DFParser, Statement as DFStatement};
+use datafusion::sql::sqlparser::ast::{
+    Expr as SqlExpr, Ident, OrderBy, OrderByExpr, OrderByKind, OrderByOptions, Statement,
+};
 use ravel_sql::{
-    PagePlan, PagePlanError, ResumePosition, ResumeValue, SAMPLES_TABLE, plan_page, public_schema,
+    LOGS_TABLE, NotTotalOrder, PagePlan, PagePlanError, ResumePosition, ResumeValue, SAMPLES_TABLE,
+    logs_schema, plan_page, public_schema,
 };
 
 /// The `ts` the two tied rows share.
@@ -105,6 +149,22 @@ const TIED_TS: i64 = 1_000;
 /// The `value` the two tied rows share. Non-zero, so `nullif(value, 0)` is
 /// this same number rather than NULL for both.
 const TIED_VALUE: f64 = 1.0;
+
+/// The `series_id` two rows carry under distinct `ts`, so `series_id` alone is
+/// not a key over this fixture. It is also the lower half of the tied pair,
+/// which is stored second.
+const REPEATED_SERIES: [u8; 16] = [1u8; 16];
+
+/// Its hex rendering, spelled out rather than recomputed, so an assertion pins
+/// the literal text a walk returns.
+const REPEATED_SERIES_HEX: &str = "01010101010101010101010101010101";
+
+/// The upper half of the tied pair, stored FIRST, so the pair's insertion
+/// order is the reverse of its tiebreak order.
+const TIED_HIGH_SERIES: [u8; 16] = [2u8; 16];
+
+/// Its hex rendering. See [`REPEATED_SERIES_HEX`].
+const TIED_HIGH_SERIES_HEX: &str = "02020202020202020202020202020202";
 
 /// The `value` that a projected `nullif(value, 0)` turns into NULL.
 const NULLING_VALUE: f64 = 0.0;
@@ -116,6 +176,11 @@ const NEGATIVE_ZERO: f64 = -0.0;
 
 /// A `ts` distinct from [`TIED_TS`], on the row carrying [`NULLING_VALUE`].
 const LONE_TS: i64 = 2_000;
+
+/// The `ts` of the second row carrying [`REPEATED_SERIES`]. Larger than
+/// [`TIED_TS`], so under `ORDER BY series_id` the two rows of that series are
+/// adjacent and a keyset predicate over `series_id` alone skips the second.
+const REPEATED_SERIES_TS: i64 = 4_000;
 
 /// The smallest `ts` in the fixture, on the row carrying the largest
 /// `series_id`. That anti-correlation is what makes ordering on `ts` and
@@ -133,7 +198,7 @@ const ODD_TS: i64 = 1_234_567;
 const PAGE_CAP: usize = 1;
 
 /// How many pages a walk may take before it is treated as non-terminating.
-/// Six rows at a cap of one needs seven pages including the empty last one;
+/// Seven rows at a cap of one needs eight pages including the empty last one;
 /// anything near this bound is a planner that is not advancing.
 const MAX_PAGES: usize = 32;
 
@@ -146,18 +211,21 @@ struct FixtureRow {
     series_id: [u8; 16],
 }
 
-/// The six-row fixture, in insertion order, which is deliberately not the
+/// The seven-row fixture, in insertion order, which is deliberately not the
 /// order any statement below asks for.
 const FIXTURE: &[FixtureRow] = &[
+    // The tied pair, stored in DESCENDING `series_id` order: a wrapper
+    // ordering that drops `series_id` returns these two the other way round
+    // from the reference, rather than agreeing with it by luck.
     FixtureRow {
         ts: TIED_TS,
         value: TIED_VALUE,
-        series_id: [1u8; 16],
+        series_id: TIED_HIGH_SERIES,
     },
     FixtureRow {
         ts: TIED_TS,
         value: TIED_VALUE,
-        series_id: [2u8; 16],
+        series_id: REPEATED_SERIES,
     },
     FixtureRow {
         ts: LONE_TS,
@@ -180,17 +248,65 @@ const FIXTURE: &[FixtureRow] = &[
         value: NEGATIVE_ZERO,
         series_id: [5u8; 16],
     },
+    // Shares `REPEATED_SERIES` with the second row under a different `ts`, so
+    // a row identity of `series_id` alone ties here and loses a row.
+    FixtureRow {
+        ts: REPEATED_SERIES_TS,
+        value: 2.0,
+        series_id: REPEATED_SERIES,
+    },
 ];
 
 /// One row, so a walk's second page is the empty one.
 const ONE_ROW: &[FixtureRow] = &[FixtureRow {
     ts: TIED_TS,
     value: TIED_VALUE,
-    series_id: [1u8; 16],
+    series_id: REPEATED_SERIES,
 }];
 
 /// No rows, so a walk's first page is the empty one.
 const NO_ROWS: &[FixtureRow] = &[];
+
+/// One `logs` fixture row. Every other column of the public `logs` schema is
+/// constant or NULL across the fixture: what this table is here for is the
+/// absence of a row identity, not the breadth of its schema.
+#[derive(Clone, Copy)]
+struct LogRow {
+    ts: i64,
+    severity_num: u8,
+    body: &'static str,
+}
+
+/// The `ts` the duplicate `logs` rows share.
+const LOG_DUPLICATE_TS: i64 = 1_000;
+
+/// The body the duplicate `logs` rows share.
+const LOG_DUPLICATE_BODY: &str = "the record that arrived twice";
+
+/// The `logs` fixture: three rows, two of which are equal in EVERY column.
+///
+/// That duplicate is the reason `logs` has no row identity (ingest is
+/// at-least-once and nothing above the RLOG scan dedups), so it is the thing a
+/// planner that wrongly claimed one would lose: no ordering over these columns
+/// separates the pair, and a strict keyset predicate positioned at either one
+/// excludes both.
+const LOG_FIXTURE: &[LogRow] = &[
+    LogRow {
+        ts: LOG_DUPLICATE_TS,
+        severity_num: 9,
+        body: LOG_DUPLICATE_BODY,
+    },
+    LogRow {
+        ts: LOG_DUPLICATE_TS,
+        severity_num: 9,
+        body: LOG_DUPLICATE_BODY,
+    },
+    LogRow {
+        ts: 2_000,
+        severity_num: 17,
+        body: "a later record",
+    },
+];
 
 /// `rows` as a `samples` batch.
 fn samples_batch(rows: &[FixtureRow]) -> RecordBatch {
@@ -227,17 +343,77 @@ fn samples_batch(rows: &[FixtureRow]) -> RecordBatch {
     .expect("fixture batch")
 }
 
-/// A context with `rows` registered as `samples`.
+/// `rows` as a `logs` batch, over the public `logs` schema in its field order.
+fn logs_batch(rows: &[LogRow]) -> RecordBatch {
+    let ts = TimestampNanosecondArray::from(rows.iter().map(|row| row.ts).collect::<Vec<i64>>());
+    let observed_ts =
+        TimestampNanosecondArray::from(rows.iter().map(|row| row.ts).collect::<Vec<i64>>());
+    let severity_num =
+        UInt8Array::from(rows.iter().map(|row| row.severity_num).collect::<Vec<u8>>());
+    let severity_text = StringArray::from(rows.iter().map(|_| "INFO").collect::<Vec<&str>>());
+    let body = StringArray::from(rows.iter().map(|row| row.body).collect::<Vec<&str>>());
+    // Both id columns are nullable on the public schema, and an absent id is a
+    // NULL cell: the fixture carries no trace context at all.
+    let trace_id = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+        rows.iter().map(|_| None::<[u8; 16]>),
+        16,
+    )
+    .expect("trace id array");
+    let span_id = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+        rows.iter().map(|_| None::<[u8; 8]>),
+        8,
+    )
+    .expect("span id array");
+    let flags = UInt32Array::from(rows.iter().map(|_| 0u32).collect::<Vec<u32>>());
+
+    let mut maps = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+    for _ in rows {
+        maps.append(true).expect("attrs map append");
+    }
+    let attrs: MapArray = maps.finish();
+
+    RecordBatch::try_new(
+        logs_schema(),
+        vec![
+            Arc::new(ts),
+            Arc::new(observed_ts),
+            Arc::new(severity_num),
+            Arc::new(severity_text),
+            Arc::new(body),
+            Arc::new(trace_id),
+            Arc::new(span_id),
+            Arc::new(flags),
+            Arc::new(attrs),
+        ],
+    )
+    .expect("logs fixture batch")
+}
+
+/// A context with `rows` registered as `samples` and [`LOG_FIXTURE`]
+/// registered as `logs`.
+///
+/// The `logs` table does not vary with `rows`: it is the no-row-identity
+/// target, and what it contributes is the duplicate row, not a row count that
+/// tracks the `samples` fixture.
 ///
 /// One target partition, so `collect` returns the sorted rows in the order the
 /// `ORDER BY` produced them and "the first row of the result" is the row a
-/// page cap of one would keep.
+/// page cap of one would keep. Multi-partition execution is deliberately out
+/// of scope here: with more than one partition a statement with no total order
+/// has no single answer to compare a walk against, so the pinned partition is
+/// what makes "page k holds rows k of the ordering" a statement at all. A
+/// harness for the multi-partition case is separate work, not a widening of
+/// this one.
 fn context_of(rows: &[FixtureRow]) -> SessionContext {
     let ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
-    let table =
+    let samples =
         MemTable::try_new(public_schema(), vec![vec![samples_batch(rows)]]).expect("mem table");
-    ctx.register_table(SAMPLES_TABLE, Arc::new(table))
+    ctx.register_table(SAMPLES_TABLE, Arc::new(samples))
         .expect("registered samples");
+    let logs = MemTable::try_new(logs_schema(), vec![vec![logs_batch(LOG_FIXTURE)]])
+        .expect("logs mem table");
+    ctx.register_table(LOGS_TABLE, Arc::new(logs))
+        .expect("registered logs");
     ctx
 }
 
@@ -303,21 +479,59 @@ fn multiset(rows: &[Vec<String>]) -> BTreeMap<Vec<String>, usize> {
 /// `order_by`, and a reference built from that would be ascending too and
 /// agree with the walk. Handing the caller's text to DataFusion instead means
 /// the direction under test is never the planner's own reading of it.
+///
+/// The appending is done in the AST and rendered back, not spliced into the
+/// text. A reference assembled by string concatenation is independent of the
+/// plan only for statements whose text happens to end where the concatenation
+/// assumed: a term list appended after a trailing comment, inside a quoted
+/// alias, or onto an `ORDER BY` the scan for one did not find lands somewhere
+/// other than the ordering, and the resulting reference is wrong in the same
+/// direction as a plan that misread the same text. Parsing is what makes the
+/// two readings independent.
 fn reference_statement(sql: &str, plan: &PagePlan) -> String {
     if plan.tiebreak_appended.is_empty() {
         return sql.to_string();
     }
-    let appended = plan
+    let mut statements = DFParser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("the reference for {sql:?} does not parse: {e}"));
+    let Some(DFStatement::Statement(statement)) = statements.pop_front() else {
+        panic!("the reference for {sql:?} is not one plain SQL statement");
+    };
+    let Statement::Query(mut query) = *statement else {
+        panic!("the reference for {sql:?} is not a query");
+    };
+
+    let appended: Vec<OrderByExpr> = plan
         .tiebreak_appended
         .iter()
-        .map(|column| format!("\"{column}\" ASC"))
-        .collect::<Vec<String>>()
-        .join(", ");
-    if sql.to_ascii_uppercase().contains(" ORDER BY ") {
-        format!("{sql}, {appended}")
-    } else {
-        format!("{sql} ORDER BY {appended}")
+        .map(|column| OrderByExpr {
+            expr: SqlExpr::Identifier(Ident::with_quote('"', column.as_str())),
+            options: OrderByOptions {
+                asc: Some(true),
+                nulls_first: None,
+            },
+            with_fill: None,
+        })
+        .collect();
+    match query.order_by.as_mut() {
+        Some(OrderBy {
+            kind: OrderByKind::Expressions(exprs),
+            ..
+        }) => exprs.extend(appended),
+        // `ORDER BY ALL` has no term list to append to, and `plan_page` refuses
+        // it outright, so a plan that reached here carrying a tiebreak over one
+        // is a finding rather than a case to spell.
+        Some(OrderBy { kind, .. }) => {
+            panic!("the reference for {sql:?} orders by {kind:?}, which has no term list")
+        }
+        None => {
+            query.order_by = Some(OrderBy {
+                kind: OrderByKind::Expressions(appended),
+                interpolate: None,
+            });
+        }
     }
+    query.to_string()
 }
 
 /// The resume value for one order-term column of one row, or `None` when that
@@ -367,6 +581,20 @@ fn resume_value(array: &ArrayRef, index: usize) -> Option<ResumeValue> {
                 .expect("uint64 array")
                 .value(index),
         ),
+        DataType::UInt8 => ResumeValue::UInt(u64::from(
+            array
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .expect("uint8 array")
+                .value(index),
+        )),
+        DataType::UInt32 => ResumeValue::UInt(u64::from(
+            array
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .expect("uint32 array")
+                .value(index),
+        )),
         DataType::Boolean => ResumeValue::Bool(
             array
                 .as_any()
@@ -540,8 +768,18 @@ fn sequence_finding(reference: &[Vec<String>], found: &Walk) -> Option<String> {
         .map(|column| format!("the walk delivered every row but stopped at a NULL {column}"))
 }
 
-/// The four statements this round exists for, plus the shapes that must keep
-/// walking so a fix cannot be a blanket refusal.
+/// The `DISTINCT ON` statement, which asks for the LAST sample of each series.
+///
+/// Its own `ORDER BY` is what chooses the surviving row of each group, so it
+/// is the one statement here whose answer changes when the wrap drops that
+/// ordering. Over [`FIXTURE`] the choice is observable on exactly one series:
+/// [`REPEATED_SERIES`] carries `ts` [`TIED_TS`] and [`REPEATED_SERIES_TS`],
+/// and this statement asks for the second.
+const DISTINCT_ON_STATEMENT: &str =
+    "SELECT DISTINCT ON (series_id) ts, series_id FROM samples ORDER BY series_id, ts DESC";
+
+/// The statements this suite walks, plus the shapes that must keep walking so
+/// a fix cannot be a blanket refusal.
 ///
 /// Each is a caller-plausible statement, not a contrived one: an alias that
 /// happens to take a row-identity column's name, a positional column-rename
@@ -567,6 +805,20 @@ const STATEMENTS: &[&str] = &[
     "SELECT ts, series_id, value FROM samples ORDER BY ts DESC, series_id",
     "SELECT ts, series_id FROM samples ORDER BY series_id",
     "SELECT * FROM samples WHERE value > 0.5 ORDER BY ts",
+    // An order term whose output name is a reserved word under a quoted alias
+    // that is not all lowercase. The rewrite quotes every name it emits, and
+    // this is what asserts that behaviourally rather than by reading the
+    // rendered text: emitted bare, `ORDER BY Select ASC` re-parses as syntax
+    // and the page does not plan at all.
+    "SELECT ts, series_id, ts AS \"Select\" FROM samples ORDER BY \"Select\", ts, series_id",
+    // Two window statements. Both plan with a total-order claim, and both are
+    // correct only because the keyset predicate sits OUTSIDE the derived
+    // table: the window sees all the statement's rows on every page. A
+    // `count(*) OVER ()` that counted down as the walk advanced, or a `rank()`
+    // that restarted at 1, is a different result per page rather than a
+    // differently ordered one.
+    "SELECT ts, series_id, count(*) OVER () AS n FROM samples ORDER BY ts, series_id",
+    "SELECT ts, series_id, rank() OVER (ORDER BY ts) AS rk FROM samples ORDER BY ts, series_id",
     // Refused now rather than walked, both for a term whose values no cursor
     // carries. `value` is a float, so it admits the NaN that
     // `ResumeValue::Float` refuses; `labels` is a `Dictionary` over a `Map`,
@@ -575,6 +827,13 @@ const STATEMENTS: &[&str] = &[
     // one reaches the cursor mint and dies there.
     "SELECT ts, series_id, value FROM samples ORDER BY value DESC, ts",
     "SELECT * FROM samples ORDER BY labels, ts, series_id",
+    // The no-row-identity target. Not walked today: the planner reports
+    // `NoRowIdentity` for `logs`, so these are outside the total-order claim.
+    // They are here for the reverse direction, which no plan assertion can
+    // make: a planner that starts claiming a total order over `logs` walks
+    // these, and `LOG_FIXTURE`'s duplicate row then appears on no page.
+    "SELECT ts, body FROM logs ORDER BY ts",
+    "SELECT ts, severity_num, body FROM logs ORDER BY ts DESC, severity_num",
 ];
 
 /// Walk every total-order statement over one fixture, returning how many were
@@ -639,7 +898,7 @@ async fn walk_findings(rows: &[FixtureRow]) -> (usize, Vec<String>) {
 #[tokio::test]
 async fn a_total_order_claim_survives_an_executed_page_walk() {
     let fixtures: [(&str, &[FixtureRow]); 3] = [
-        ("the six-row fixture", FIXTURE),
+        ("the seven-row fixture", FIXTURE),
         ("a one-row table", ONE_ROW),
         ("an empty table", NO_ROWS),
     ];
@@ -660,17 +919,21 @@ async fn a_total_order_claim_survives_an_executed_page_walk() {
         findings.len(),
         findings.join("\n  "),
     );
-    assert!(
-        walked > 0,
-        "no statement in the table claimed a total order, so the gate asserted \
-         nothing",
+    // Nine per fixture, three fixtures. Pinned exactly rather than as
+    // `walked > 0`: a change that drops a statement out of the total-order
+    // class leaves this gate passing over a smaller set, which is the way a
+    // suite of this shape goes quiet without going red.
+    assert_eq!(
+        walked, 27,
+        "the walked set changed size, so this gate is asserting about a different \
+         set of statements than the one it was sized for",
     );
 }
 
 /// A one-row table ends the walk on an empty SECOND page, and a zero-row table
 /// on an empty FIRST one.
 ///
-/// Both are page counts the six-row fixture cannot produce, and both are the
+/// Both are page counts the seven-row fixture cannot produce, and both are the
 /// boundary a resume position is never built at: the first has exactly one
 /// cursor mint and the second has none.
 #[tokio::test]
@@ -696,6 +959,56 @@ async fn a_walk_terminates_on_an_empty_page_at_both_table_boundaries() {
     assert_eq!(none.stopped_at_null, None);
 }
 
+/// A `DISTINCT ON` page delivers the rows the caller's own statement delivers.
+///
+/// The statement's `ORDER BY` chooses WHICH row of each `ON` group survives,
+/// so it is not a sort the wrap can drop and re-impose from outside: dropped,
+/// the group keeps a different row and the page is a wrong answer rather than
+/// a differently ordered one. The assertion is behavioural on purpose --
+/// nothing here reads the rendered statement -- because the defect was a
+/// delivered row, not a rendering.
+///
+/// The walk is asserted as well as the first page: with one row per `ON`
+/// group, `series_id` is unique over the result, so a strict keyset predicate
+/// over the effective ordering is sound and every page has to keep choosing
+/// the same row of the group it lands in.
+#[tokio::test]
+async fn a_distinct_on_page_delivers_the_rows_the_statement_itself_returns() {
+    let ctx = context();
+    let plan = plan_page(DISTINCT_ON_STATEMENT, None).expect("planned");
+    // `DISTINCT` does not preserve the scan's rows one-for-one, so the plan
+    // says so. The fix is to page it correctly, not to claim a total order.
+    assert_eq!(
+        plan.not_total,
+        Some(NotTotalOrder::ShapeNotIdentityPreserving { shape: "DISTINCT" }),
+    );
+
+    let direct = rows_of(&execute(&ctx, DISTINCT_ON_STATEMENT).await);
+    // The series the choice is observable on: the one carrying two rows.
+    assert_eq!(
+        direct.first().map(Vec::as_slice),
+        Some(
+            [
+                "1970-01-01T00:00:00.000004".to_string(),
+                REPEATED_SERIES_HEX.to_string(),
+            ]
+            .as_slice()
+        ),
+        "the statement itself does not return the LAST sample of the repeated \
+         series, so this statement cannot show the ordering being dropped",
+    );
+
+    let paged = rows_of(&execute(&ctx, &plan.statement).await);
+    assert_eq!(
+        paged, direct,
+        "the page statement delivered different rows than the caller's own statement",
+    );
+
+    let found = walk(&ctx, DISTINCT_ON_STATEMENT).await;
+    assert_eq!(sequence_finding(&direct, &found), None);
+    assert_eq!(found.rows(), direct, "the walked sequence");
+}
+
 /// The fixture can actually expose the defects it is here to expose.
 ///
 /// Pinned as exact counts. A fixture edit that drops one of these leaves every
@@ -706,7 +1019,7 @@ async fn the_fixture_can_expose_a_broken_keyset_predicate() {
     let ctx = context();
 
     let rows = rows_of(&execute(&ctx, "SELECT ts, value, series_id FROM samples").await);
-    assert_eq!(rows.len(), 6, "fixture row count");
+    assert_eq!(rows.len(), 7, "fixture row count");
 
     let tied = rows_of(
         &execute(
@@ -730,6 +1043,51 @@ async fn the_fixture_can_expose_a_broken_keyset_predicate() {
         tied_rows,
         vec![vec!["2".to_string()]],
         "rows sharing one (ts, value)",
+    );
+
+    // The tied pair's stored order is the reverse of its tiebreak order. A
+    // wrapper `ORDER BY` that drops `series_id` sorts on `ts` alone, which
+    // leaves these two in the order the scan produced them, and that has to be
+    // the WRONG order for the walk to see it.
+    let scan_order = rows_of(&execute(&ctx, "SELECT series_id FROM samples").await);
+    assert_eq!(
+        &scan_order[..2],
+        &[
+            vec![TIED_HIGH_SERIES_HEX.to_string()],
+            vec![REPEATED_SERIES_HEX.to_string()],
+        ],
+        "the tied pair is not stored in descending series_id order, so dropping \
+         the series_id term from the wrapper ordering returns the same sequence \
+         anyway",
+    );
+
+    // One series carries two rows, so `series_id` alone is not a key here.
+    let repeated_series = rows_of(
+        &execute(
+            &ctx,
+            "SELECT count(*) AS n FROM (SELECT series_id FROM samples GROUP BY series_id \
+             HAVING count(*) > 1)",
+        )
+        .await,
+    );
+    assert_eq!(
+        repeated_series,
+        vec![vec!["1".to_string()]],
+        "series carrying more than one row",
+    );
+    let repeated_series_rows = rows_of(
+        &execute(
+            &ctx,
+            "SELECT count(*) AS n FROM samples WHERE series_id = \
+             arrow_cast(decode('01010101010101010101010101010101', 'hex'), \
+             'FixedSizeBinary(16)')",
+        )
+        .await,
+    );
+    assert_eq!(
+        repeated_series_rows,
+        vec![vec!["2".to_string()]],
+        "rows sharing one series_id",
     );
 
     // One, not two: DataFusion compares floats by a total order, so `-0.0 = 0`
@@ -769,7 +1127,7 @@ async fn the_fixture_can_expose_a_broken_keyset_predicate() {
     );
     assert_eq!(
         distinct_identity,
-        vec![vec!["6".to_string()]],
+        vec![vec!["7".to_string()]],
         "the fixture respects the samples row identity",
     );
 
@@ -807,6 +1165,25 @@ async fn the_fixture_can_expose_a_broken_keyset_predicate() {
         by_ts, by_series,
         "the smallest ts does not carry the largest series_id, so the fixture is \
          not anti-correlated",
+    );
+
+    // The `logs` fixture's own property: two rows equal in every column, which
+    // is what no ordering over the table can separate.
+    let log_rows = rows_of(&execute(&ctx, "SELECT ts, severity_num, body FROM logs").await);
+    assert_eq!(log_rows.len(), 3, "logs fixture row count");
+    let log_duplicates = rows_of(
+        &execute(
+            &ctx,
+            "SELECT count(*) AS n FROM (SELECT ts, observed_ts, severity_num, severity_text, \
+             body, trace_id, span_id, flags FROM logs GROUP BY ts, observed_ts, severity_num, \
+             severity_text, body, trace_id, span_id, flags HAVING count(*) > 1)",
+        )
+        .await,
+    );
+    assert_eq!(
+        log_duplicates,
+        vec![vec!["1".to_string()]],
+        "groups of logs rows equal on every orderable column",
     );
 }
 
@@ -861,6 +1238,9 @@ fn the_four_defect_statements_are_classified_exactly() {
         "SELECT ts, series_id, value FROM samples ORDER BY ts DESC, series_id",
         "SELECT ts, series_id FROM samples ORDER BY series_id",
         "SELECT * FROM samples WHERE value > 0.5 ORDER BY ts",
+        "SELECT ts, series_id, ts AS \"Select\" FROM samples ORDER BY \"Select\", ts, series_id",
+        "SELECT ts, series_id, count(*) OVER () AS n FROM samples ORDER BY ts, series_id",
+        "SELECT ts, series_id, rank() OVER (ORDER BY ts) AS rk FROM samples ORDER BY ts, series_id",
     ];
     for sql in must_stay_total {
         let plan = plan_page(sql, None).unwrap_or_else(|e| panic!("{sql:?} refused: {e}"));
@@ -869,4 +1249,54 @@ fn the_four_defect_statements_are_classified_exactly() {
             "{sql:?} lost its total order, so the fix is a blanket refusal",
         );
     }
+}
+
+/// What the harness's second table is registered for: the statements over it
+/// must never be claimed as a total order, and the ones whose result depends
+/// on rows a keyset filter would remove must be refused or reported not-total
+/// rather than paged.
+///
+/// This is the direction the walk itself cannot assert. The walk skips a
+/// not-total plan by construction, so `logs` contributes nothing to it until a
+/// planner starts claiming otherwise -- at which point these statements are
+/// walked, over a fixture whose duplicate row no ordering separates.
+#[test]
+fn the_no_row_identity_target_is_never_claimed_as_a_total_order() {
+    for sql in [
+        "SELECT ts, body FROM logs ORDER BY ts",
+        "SELECT ts, severity_num, body FROM logs ORDER BY ts DESC, severity_num",
+    ] {
+        let plan = plan_page(sql, None).unwrap_or_else(|e| panic!("{sql:?} refused: {e}"));
+        assert_eq!(
+            plan.not_total,
+            Some(NotTotalOrder::NoRowIdentity { table: LOGS_TABLE }),
+            "{sql:?}",
+        );
+        assert!(plan.tiebreak_appended.is_empty(), "{sql:?}");
+    }
+
+    // A result the keyset predicate would change if it reached the scanned
+    // rows: every row of the input contributes to the one row out. There is
+    // nothing to order by, so it is refused, and a refusal is a pass.
+    assert!(
+        matches!(
+            plan_page("SELECT count(*) AS n FROM samples", None),
+            Err(PagePlanError::NoOrdering {
+                target: SAMPLES_TABLE
+            })
+        ),
+        "an aggregate over every row was not refused",
+    );
+    // The grouped form has something to order by and is reported not-total,
+    // which is the other acceptable answer: D5 pages it under the equal-group
+    // rule, never under a strict keyset predicate.
+    let grouped = plan_page(
+        "SELECT ts, count(*) AS n FROM samples GROUP BY ts ORDER BY ts",
+        None,
+    )
+    .expect("planned");
+    assert_eq!(
+        grouped.not_total,
+        Some(NotTotalOrder::ShapeNotIdentityPreserving { shape: "GROUP BY" }),
+    );
 }

--- a/crates/ravel-sql/tests/page_walk.rs
+++ b/crates/ravel-sql/tests/page_walk.rs
@@ -367,8 +367,12 @@ const STATEMENTS: &[&str] = &[
     "SELECT * FROM samples ORDER BY ts",
     "SELECT * FROM samples",
     "SELECT ts, series_id FROM samples ORDER BY ts",
-    "SELECT ts, series_id, value FROM samples ORDER BY value DESC, ts",
+    "SELECT ts, series_id, value FROM samples ORDER BY ts DESC, series_id",
     "SELECT * FROM samples WHERE value > 0.5 ORDER BY ts",
+    // Refused now rather than walked: `value` is a float, and NaN satisfies no
+    // disjunct of a keyset predicate. Kept in the table so the refusal is
+    // exercised on the same path the walks take.
+    "SELECT ts, series_id, value FROM samples ORDER BY value DESC, ts",
 ];
 
 /// The acceptance gate: every statement the planner claims a total order for
@@ -556,7 +560,10 @@ fn the_four_defect_statements_are_classified_exactly() {
         "SELECT * FROM samples ORDER BY ts",
         "SELECT * FROM samples",
         "SELECT ts, series_id FROM samples ORDER BY ts",
-        "SELECT ts, series_id, value FROM samples ORDER BY value DESC, ts",
+        // A DESC term, so a fix that reads every term as ASC is not a fix that
+        // passes here. `value DESC` used to be this case and is now refused
+        // outright: a float term admits NaN, which no keyset disjunct places.
+        "SELECT ts, series_id, value FROM samples ORDER BY ts DESC, series_id",
         "SELECT * FROM samples WHERE value > 0.5 ORDER BY ts",
     ];
     for sql in must_stay_total {

--- a/crates/ravel-sql/tests/page_walk.rs
+++ b/crates/ravel-sql/tests/page_walk.rs
@@ -1,0 +1,569 @@
+//! Executed page walks over `plan_page` (ADR-1374 D5).
+//!
+//! The rule this file exists to establish: **a total-order claim is proven by
+//! an executed walk, never by a plan assertion.**
+//!
+//! `plan_page` reports `not_total: None` to say that its effective `ORDER BY`
+//! uniquely determines the row sequence, which is what lets a caller page with
+//! a strict keyset predicate. Every assertion about that claim in
+//! `crate::page_plan`'s own unit tests reads the returned plan: the tiebreak
+//! list, the `not_total` field, the rendered statement text. None of them runs
+//! the statement. Three rounds of fixes to the same defect class each passed
+//! their own plan assertions and each still lost rows, because a plan
+//! assertion cannot see that the name the tiebreak claimed row identity on
+//! belongs to a different value than the one the schema described.
+//!
+//! So this suite executes. For every statement the planner reports a total
+//! order for, it pages the statement with a row cap of 1, collects the rows
+//! every page returned, and asserts MULTISET EQUALITY against the same
+//! statement run unpaged. A row count is not enough: a count still passes when
+//! one row is dropped and another duplicated, and both happen under a keyset
+//! predicate built over the wrong column.
+//!
+//! # The fixture has to be able to fail
+//!
+//! [`samples_fixture`] carries deliberate ties and a deliberate NULL source:
+//! two rows share `(ts, value)` under distinct `series_id`, and one row's
+//! `value` is `0.0`, so a projected `nullif(value, 0)` is NULL for it. Without
+//! the ties, a keyset predicate over the wrong pair of columns still walks
+//! every row and the suite is a tautology; without the zero, a projection that
+//! shadows a NOT NULL name with a nullable expression loses nothing.
+//! [`the_fixture_can_expose_a_broken_keyset_predicate`] pins both properties as
+//! exact counts, so a later edit to the fixture that removes them fails here
+//! rather than quietly turning every walk below into a statement about nothing.
+//!
+//! `samples` is registered as a plain in-memory table over
+//! `ravel_sql::public_schema()`. The planner's row-identity claim is about what
+//! the `samples` scan emits (at most one row per `(series_id, ts)`, which the
+//! fixture respects), and everything a page walk depends on above that -- name
+//! resolution, wildcard expansion, positional column aliases, keyset
+//! comparison, NULL semantics -- is DataFusion's, which a `MemTable` exercises
+//! exactly as the real provider would.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, ArrayRef, BinaryArray, BooleanArray, DictionaryArray, FixedSizeBinaryArray,
+    Float64Array, Int32Array, Int64Array, MapArray, MapBuilder, RecordBatch, StringArray,
+    StringBuilder, TimestampNanosecondArray, UInt64Array,
+};
+use datafusion::arrow::datatypes::{DataType, Int32Type, TimeUnit};
+use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
+use datafusion::datasource::MemTable;
+use datafusion::execution::context::SessionContext;
+use datafusion::prelude::SessionConfig;
+use ravel_sql::{
+    PagePlanError, ResumePosition, ResumeValue, SAMPLES_TABLE, plan_page, public_schema,
+};
+
+/// The `ts` the two tied rows share.
+const TIED_TS: i64 = 1_000;
+
+/// The `value` the two tied rows share. Non-zero, so `nullif(value, 0)` is
+/// this same number rather than NULL for both.
+const TIED_VALUE: f64 = 1.0;
+
+/// The third row's `value`. Zero, which is what makes a projected
+/// `nullif(value, 0)` NULL for exactly one row of the fixture.
+const NULLING_VALUE: f64 = 0.0;
+
+/// The third row's `ts`, distinct from [`TIED_TS`].
+const LONE_TS: i64 = 2_000;
+
+/// A page's row cap. One row per page is the smallest cap and the one that
+/// makes a lost row visible at the first tie rather than only when a tie
+/// straddles a page boundary of some larger size.
+const PAGE_CAP: usize = 1;
+
+/// How many pages a walk may take before it is treated as non-terminating.
+/// Three rows at a cap of one needs four pages including the empty last one;
+/// anything near this bound is a planner that is not advancing.
+const MAX_PAGES: usize = 32;
+
+/// Three rows, two of them tied on `(ts, value)`, one of them carrying the
+/// `value` that a projected `nullif(value, 0)` turns into NULL.
+///
+/// The `series_id`s are distinct, so the fixture respects the `samples` row
+/// identity the planner's total-order claim rests on: `(series_id, ts)` is
+/// unique across the three rows.
+fn samples_fixture() -> RecordBatch {
+    let ts = TimestampNanosecondArray::from(vec![TIED_TS, TIED_TS, LONE_TS]);
+    let value = Float64Array::from(vec![TIED_VALUE, TIED_VALUE, NULLING_VALUE]);
+    let series_id = FixedSizeBinaryArray::try_from_iter([[1u8; 16], [2u8; 16], [3u8; 16]].iter())
+        .expect("series id array");
+
+    // One empty label set per row. The label content is irrelevant to paging
+    // and the column is NOT NULL, so it has to be present and well-formed.
+    let mut maps = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+    for _ in 0..3 {
+        maps.append(true).expect("label map append");
+    }
+    let maps: MapArray = maps.finish();
+    let labels = DictionaryArray::<Int32Type>::try_new(
+        Int32Array::from(vec![0, 1, 2]),
+        Arc::new(maps) as ArrayRef,
+    )
+    .expect("labels dictionary");
+
+    RecordBatch::try_new(
+        public_schema(),
+        vec![
+            Arc::new(ts),
+            Arc::new(value),
+            Arc::new(series_id),
+            Arc::new(labels),
+        ],
+    )
+    .expect("fixture batch")
+}
+
+/// A context with the fixture registered as `samples`.
+///
+/// One target partition, so `collect` returns the sorted rows in the order the
+/// `ORDER BY` produced them and "the first row of the result" is the row a
+/// page cap of one would keep.
+fn context() -> SessionContext {
+    let ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+    let table =
+        MemTable::try_new(public_schema(), vec![vec![samples_fixture()]]).expect("mem table");
+    ctx.register_table(SAMPLES_TABLE, Arc::new(table))
+        .expect("registered samples");
+    ctx
+}
+
+async fn execute(ctx: &SessionContext, sql: &str) -> Vec<RecordBatch> {
+    ctx.sql(sql)
+        .await
+        .unwrap_or_else(|e| panic!("planning {sql:?}: {e}"))
+        .collect()
+        .await
+        .unwrap_or_else(|e| panic!("executing {sql:?}: {e}"))
+}
+
+/// Every row of `batches`, each rendered one string per column.
+///
+/// Rendered rather than compared as arrays because the statements below
+/// project different column sets and types, `labels` among them, and the only
+/// property under test is which rows came back. NULL renders as the literal
+/// `NULL`, distinct from an empty string.
+fn rows_of(batches: &[RecordBatch]) -> Vec<Vec<String>> {
+    let options = FormatOptions::default().with_null("NULL");
+    let mut rows = Vec::new();
+    for batch in batches {
+        let formatters: Vec<ArrayFormatter<'_>> = batch
+            .columns()
+            .iter()
+            .map(|column| {
+                ArrayFormatter::try_new(column.as_ref(), &options).expect("array formatter")
+            })
+            .collect();
+        for index in 0..batch.num_rows() {
+            rows.push(
+                formatters
+                    .iter()
+                    .map(|formatter| formatter.value(index).to_string())
+                    .collect(),
+            );
+        }
+    }
+    rows
+}
+
+/// `rows` as a multiset: the row-to-count map two walks are compared by.
+///
+/// A count alone passes when one row is dropped and another duplicated, which
+/// is what a keyset predicate over a mis-resolved column actually does.
+fn multiset(rows: &[Vec<String>]) -> BTreeMap<Vec<String>, usize> {
+    let mut counts: BTreeMap<Vec<String>, usize> = BTreeMap::new();
+    for row in rows {
+        *counts.entry(row.clone()).or_default() += 1;
+    }
+    counts
+}
+
+/// The resume value for one order-term column of one row, or `None` when that
+/// value is NULL.
+///
+/// A NULL is not a resume value ([`ResumeValue`] has no NULL variant, because
+/// every comparison against NULL is NULL), so a walk that reaches one cannot
+/// continue. That is itself a finding, and [`walk`] reports it rather than
+/// treating the walk as finished.
+fn resume_value(array: &ArrayRef, index: usize) -> Option<ResumeValue> {
+    if array.is_null(index) {
+        return None;
+    }
+    let value = match array.data_type() {
+        DataType::Timestamp(TimeUnit::Nanosecond, None) => ResumeValue::TimestampNanos(
+            array
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .expect("timestamp array")
+                .value(index),
+        ),
+        DataType::Float64 => ResumeValue::Float(
+            array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("float array")
+                .value(index),
+        ),
+        DataType::Int64 => ResumeValue::Int(
+            array
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("int64 array")
+                .value(index),
+        ),
+        DataType::Int32 => ResumeValue::Int(i64::from(
+            array
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("int32 array")
+                .value(index),
+        )),
+        DataType::UInt64 => ResumeValue::UInt(
+            array
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("uint64 array")
+                .value(index),
+        ),
+        DataType::Boolean => ResumeValue::Bool(
+            array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("boolean array")
+                .value(index),
+        ),
+        DataType::Utf8 => ResumeValue::Str(
+            array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("string array")
+                .value(index)
+                .to_string(),
+        ),
+        DataType::FixedSizeBinary(_) => ResumeValue::FixedSizeBinary(
+            array
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .expect("fixed size binary array")
+                .value(index)
+                .to_vec(),
+        ),
+        DataType::Binary => ResumeValue::Binary(
+            array
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .expect("binary array")
+                .value(index)
+                .to_vec(),
+        ),
+        other => panic!("no resume value for an order term of type {other}"),
+    };
+    Some(value)
+}
+
+/// What an executed walk found.
+struct Walk {
+    /// The rows the walk collected, page by page, in page order.
+    rows: Vec<Vec<String>>,
+    /// The pages taken, the terminating empty one included.
+    pages: usize,
+    /// Set when the walk stopped because the last row's order term was NULL,
+    /// so no resume position could be built from it.
+    stopped_at_null: Option<String>,
+}
+
+/// Page `sql` with a cap of [`PAGE_CAP`] rows, from the first page to the
+/// empty one, exactly as a paging caller would: each page's statement comes
+/// from `plan_page` resumed at the previous page's last row.
+async fn walk(ctx: &SessionContext, sql: &str) -> Walk {
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut resume: Option<ResumePosition> = None;
+    let mut pages = 0usize;
+    loop {
+        pages += 1;
+        assert!(
+            pages <= MAX_PAGES,
+            "walk of {sql:?} did not terminate within {MAX_PAGES} pages",
+        );
+        let plan = plan_page(sql, resume.as_ref())
+            .unwrap_or_else(|e| panic!("page {pages} of {sql:?} would not plan: {e}"));
+        let batches = execute(ctx, &plan.statement).await;
+        let page: Vec<Vec<String>> = rows_of(&batches).into_iter().take(PAGE_CAP).collect();
+        if page.is_empty() {
+            return Walk {
+                rows,
+                pages,
+                stopped_at_null: None,
+            };
+        }
+
+        // The cursor position is read off the page's own last row, which is
+        // the only thing a redeeming caller has.
+        let kept = page.len();
+        let last = kept - 1;
+        let mut tuple = Vec::with_capacity(plan.order_by.len());
+        for term in &plan.order_by {
+            let (batch, offset) = row_at(&batches, last);
+            let column = batch
+                .column_by_name(&term.column)
+                .unwrap_or_else(|| panic!("page of {sql:?} does not carry {:?}", term.column));
+            match resume_value(column, offset) {
+                Some(value) => tuple.push(value),
+                None => {
+                    rows.extend(page);
+                    return Walk {
+                        rows,
+                        pages,
+                        stopped_at_null: Some(term.column.clone()),
+                    };
+                }
+            }
+        }
+        rows.extend(page);
+        resume = Some(ResumePosition::new(tuple));
+    }
+}
+
+/// The batch holding global row `index` of `batches`, and that row's offset
+/// inside it.
+fn row_at(batches: &[RecordBatch], index: usize) -> (&RecordBatch, usize) {
+    let mut remaining = index;
+    for batch in batches {
+        if remaining < batch.num_rows() {
+            return (batch, remaining);
+        }
+        remaining -= batch.num_rows();
+    }
+    panic!("row {index} is past the end of the result");
+}
+
+/// The four statements this round exists for, plus the shapes that must keep
+/// walking so a fix cannot be a blanket refusal.
+///
+/// Each is a caller-plausible statement, not a contrived one: an alias that
+/// happens to take a row-identity column's name, a positional column-rename
+/// list, a wildcard with a shadowing item after it, and a constant projection.
+const STATEMENTS: &[&str] = &[
+    // F1: `series_id` as the OUTPUT name of `value`. The tiebreak's row
+    // identity is claimed by matching that name.
+    "SELECT ts, value AS series_id FROM samples ORDER BY ts",
+    // F2: a positional column-rename list on the target table. The output
+    // `series_id` is `value` and the output `ts` is `ts`.
+    "SELECT ts, series_id FROM samples AS x (ts, series_id, a, b) ORDER BY ts, series_id",
+    // F3: a wildcard, then an item that shadows the name it excluded.
+    "SELECT * EXCEPT (ts), nullif(value, 0) AS ts FROM samples ORDER BY ts",
+    "SELECT * EXCLUDE (ts), nullif(value, 0) AS ts FROM samples ORDER BY ts",
+    "SELECT * REPLACE (nullif(value, 0) AS ts) FROM samples ORDER BY ts",
+    // A constant projection under the identity column names.
+    "SELECT 1 AS ts, 2 AS series_id FROM samples",
+    // The shapes a fix must not break: these walk every row today and have to
+    // keep doing so.
+    "SELECT * FROM samples ORDER BY ts",
+    "SELECT * FROM samples",
+    "SELECT ts, series_id FROM samples ORDER BY ts",
+    "SELECT ts, series_id, value FROM samples ORDER BY value DESC, ts",
+    "SELECT * FROM samples WHERE value > 0.5 ORDER BY ts",
+];
+
+/// The acceptance gate: every statement the planner claims a total order for
+/// pages to exactly the rows it returns unpaged.
+///
+/// Statements the planner refuses, and statements it plans with a
+/// `not_total` reason, are outside the claim: D5 pages the second kind under
+/// the equal-group rule, which is the caller's half and not this planner's. So
+/// a refusal and a not-total plan both satisfy this test, and the pinned
+/// classification in [`the_four_defect_statements_are_classified_exactly`] is
+/// what stops a fix from satisfying it by refusing everything.
+#[tokio::test]
+async fn a_total_order_claim_survives_an_executed_page_walk() {
+    let ctx = context();
+    let mut walked = 0usize;
+    // Collected rather than asserted per statement: the first failing walk is
+    // not the only one, and a suite that stops at it hides how wide the defect
+    // is. Every finding below names the rows that went missing.
+    let mut findings: Vec<String> = Vec::new();
+    for sql in STATEMENTS {
+        let plan = match plan_page(sql, None) {
+            Ok(plan) => plan,
+            Err(_) => continue,
+        };
+        if plan.not_total.is_some() {
+            continue;
+        }
+        walked += 1;
+
+        let unpaged = multiset(&rows_of(&execute(&ctx, sql).await));
+        let found = walk(&ctx, sql).await;
+        let walked_rows = multiset(&found.rows);
+        if walked_rows == unpaged && found.stopped_at_null.is_none() {
+            continue;
+        }
+
+        let mut missing: Vec<String> = Vec::new();
+        for (row, count) in &unpaged {
+            let seen = walked_rows.get(row).copied().unwrap_or(0);
+            if seen != *count {
+                missing.push(format!("{row:?} unpaged {count} times, walked {seen}"));
+            }
+        }
+        for (row, count) in &walked_rows {
+            if !unpaged.contains_key(row) {
+                missing.push(format!("{row:?} walked {count} times, never unpaged"));
+            }
+        }
+        findings.push(format!(
+            "{sql:?}\n    order_by {:?}, tiebreak {:?}\n    {} pages at a cap of \
+             {PAGE_CAP} returned {} of {} rows{}\n    {}",
+            plan.order_by
+                .iter()
+                .map(|term| term.render())
+                .collect::<Vec<String>>(),
+            plan.tiebreak_appended,
+            found.pages,
+            found.rows.len(),
+            unpaged.values().sum::<usize>(),
+            match &found.stopped_at_null {
+                Some(column) => format!(", stopped at a NULL {column}"),
+                None => String::new(),
+            },
+            missing.join("\n    "),
+        ));
+    }
+    assert!(
+        findings.is_empty(),
+        "{} of {walked} total-order claims lost rows under an executed walk:\n  {}",
+        findings.len(),
+        findings.join("\n  "),
+    );
+    assert!(
+        walked > 0,
+        "no statement in the table claimed a total order, so the gate asserted \
+         nothing",
+    );
+}
+
+/// The fixture can actually expose the defects it is here to expose.
+///
+/// Pinned as exact counts. A fixture edit that drops the tie or the zero
+/// leaves every walk above passing over rows that no keyset predicate could
+/// lose, which is how a suite of this shape goes vacuous.
+#[tokio::test]
+async fn the_fixture_can_expose_a_broken_keyset_predicate() {
+    let ctx = context();
+
+    let rows = rows_of(&execute(&ctx, "SELECT ts, value, series_id FROM samples").await);
+    assert_eq!(rows.len(), 3, "fixture row count");
+
+    let tied = rows_of(
+        &execute(
+            &ctx,
+            "SELECT count(*) AS n FROM (SELECT ts, value FROM samples GROUP BY ts, value \
+             HAVING count(*) > 1)",
+        )
+        .await,
+    );
+    assert_eq!(tied, vec![vec!["1".to_string()]], "groups of tied rows");
+
+    let tied_rows = rows_of(
+        &execute(
+            &ctx,
+            "SELECT count(*) AS n FROM samples WHERE ts = arrow_cast(1000, \
+             'Timestamp(Nanosecond, None)') AND value = 1.0",
+        )
+        .await,
+    );
+    assert_eq!(
+        tied_rows,
+        vec![vec!["2".to_string()]],
+        "rows sharing one (ts, value)",
+    );
+
+    let nulled = rows_of(
+        &execute(
+            &ctx,
+            "SELECT count(*) AS n FROM samples WHERE nullif(value, 0) IS NULL",
+        )
+        .await,
+    );
+    assert_eq!(
+        nulled,
+        vec![vec!["1".to_string()]],
+        "rows a projected nullif(value, 0) nulls",
+    );
+
+    let distinct_identity = rows_of(
+        &execute(
+            &ctx,
+            "SELECT count(*) AS n FROM (SELECT DISTINCT ts, series_id FROM samples)",
+        )
+        .await,
+    );
+    assert_eq!(
+        distinct_identity,
+        vec![vec!["3".to_string()]],
+        "the fixture respects the samples row identity",
+    );
+}
+
+/// The exact classification of the six statements the four defects are
+/// demonstrated by, so a fix cannot pass
+/// [`a_total_order_claim_survives_an_executed_page_walk`] by refusing every
+/// statement in the table.
+///
+/// `Refused` and `NotTotal` are both acceptable outcomes for these six: the
+/// planner's job is not to page them, it is to not claim they page under a
+/// keyset predicate. What is pinned is that none of them is `Total`, and that
+/// the statements below them in [`STATEMENTS`] still are.
+#[test]
+fn the_four_defect_statements_are_classified_exactly() {
+    let must_not_be_total = [
+        "SELECT ts, value AS series_id FROM samples ORDER BY ts",
+        "SELECT ts, series_id FROM samples AS x (ts, series_id, a, b) ORDER BY ts, series_id",
+        "SELECT * EXCEPT (ts), nullif(value, 0) AS ts FROM samples ORDER BY ts",
+        "SELECT * EXCLUDE (ts), nullif(value, 0) AS ts FROM samples ORDER BY ts",
+        "SELECT * REPLACE (nullif(value, 0) AS ts) FROM samples ORDER BY ts",
+        "SELECT 1 AS ts, 2 AS series_id FROM samples",
+    ];
+    let mut claimed: Vec<String> = Vec::new();
+    for sql in must_not_be_total {
+        match plan_page(sql, None) {
+            Ok(plan) if plan.not_total.is_none() => claimed.push(format!(
+                "{sql:?} over {:?}",
+                plan.order_by
+                    .iter()
+                    .map(|term| term.render())
+                    .collect::<Vec<String>>(),
+            )),
+            Ok(_) => {}
+            Err(PagePlanError::Invalid(e)) => panic!("{sql:?} failed validation: {e}"),
+            Err(_) => {}
+        }
+    }
+    assert!(
+        claimed.is_empty(),
+        "{} statements still claim a total order:\n  {}",
+        claimed.len(),
+        claimed.join("\n  "),
+    );
+
+    let must_stay_total = [
+        "SELECT * FROM samples ORDER BY ts",
+        "SELECT * FROM samples",
+        "SELECT ts, series_id FROM samples ORDER BY ts",
+        "SELECT ts, series_id, value FROM samples ORDER BY value DESC, ts",
+        "SELECT * FROM samples WHERE value > 0.5 ORDER BY ts",
+    ];
+    for sql in must_stay_total {
+        let plan = plan_page(sql, None).unwrap_or_else(|e| panic!("{sql:?} refused: {e}"));
+        assert_eq!(
+            plan.not_total, None,
+            "{sql:?} lost its total order, so the fix is a blanket refusal",
+        );
+    }
+}

--- a/crates/ravel-sql/tests/page_walk.rs
+++ b/crates/ravel-sql/tests/page_walk.rs
@@ -167,6 +167,12 @@
 //! numbers -- 7, 6, 5, 4, 3, 2, 1 for the count, and 1 seven times over for the
 //! rank -- rather than through the parse error that same mutation happens to
 //! raise first on the `DISTINCT ON` statement.
+//!
+//! Each of those two also asserts that its statement is still IN
+//! [`STATEMENTS`]. Without that the entries pinned nothing on their own:
+//! deleting both and adjusting the walked count left every test here green,
+//! because the two that read the window column reach their statement through
+//! a constant rather than through the table.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -908,8 +914,10 @@ const STATEMENTS: &[&str] = &[
     // correct only because the keyset predicate sits OUTSIDE the derived
     // table: the window sees all the statement's rows on every page. What each
     // one reports per page is asserted by value in
-    // [`a_window_is_computed_over_every_row_of_the_statement`]; here they are
-    // walked for their ordering like any other statement.
+    // [`a_count_window_reports_the_whole_row_count_on_every_page`] and
+    // [`a_rank_window_ranks_against_the_whole_row_set`], and each of those
+    // asserts its own membership here; this is where they are walked for
+    // their ordering like any other statement.
     WINDOW_COUNT_STATEMENT,
     WINDOW_RANK_STATEMENT,
     // Refused now rather than walked, both for a term whose values no cursor
@@ -1078,8 +1086,17 @@ async fn a_walk_terminates_on_an_empty_page_at_both_table_boundaries() {
 /// preserved inner `ORDER BY` makes the same mutation a PARSE error first: a
 /// suite that only caught it there would be reporting a syntax failure on an
 /// unrelated statement, which says nothing about where a window is computed.
+///
+/// Membership in [`STATEMENTS`] is asserted here rather than left to the
+/// count in [`a_total_order_claim_survives_an_executed_page_walk`]: that count
+/// moves with any edit to the table, so deleting the entry and adjusting the
+/// 30 left the whole suite green while nothing walked a window statement.
 #[tokio::test]
 async fn a_count_window_reports_the_whole_row_count_on_every_page() {
+    assert!(
+        STATEMENTS.contains(&WINDOW_COUNT_STATEMENT),
+        "the count window statement left STATEMENTS, so no walk covers its ordering",
+    );
     let found = walk(&context(), WINDOW_COUNT_STATEMENT).await;
     assert_eq!(found.pages, 8, "pages of the count window walk");
     assert_eq!(
@@ -1101,8 +1118,15 @@ async fn a_count_window_reports_the_whole_row_count_on_every_page() {
 /// rather than an obviously shrinking total. [`WINDOW_RANKS`] is the sequence
 /// only the whole row set produces: it skips 3, because the pair tied at
 /// [`TIED_TS`] takes rank 2 twice.
+///
+/// Its membership in [`STATEMENTS`] is asserted for the same reason as the
+/// count window's.
 #[tokio::test]
 async fn a_rank_window_ranks_against_the_whole_row_set() {
+    assert!(
+        STATEMENTS.contains(&WINDOW_RANK_STATEMENT),
+        "the rank window statement left STATEMENTS, so no walk covers its ordering",
+    );
     let found = walk(&context(), WINDOW_RANK_STATEMENT).await;
     assert_eq!(found.pages, 8, "pages of the rank window walk");
     assert_eq!(

--- a/crates/ravel-sql/tests/page_walk.rs
+++ b/crates/ravel-sql/tests/page_walk.rs
@@ -46,11 +46,16 @@
 //! the plan it is checking. A parse that fails, or a statement whose ordering
 //! has no term list to append to, is a panic rather than a fallback spelling.
 //!
-//! Two more properties fall out of asserting per page rather than over the
-//! concatenation: a page that returns fewer rows than the cap while rows
-//! remain is a finding (it breaks the indexing the claim rests on), and a walk
-//! that ends early is reported against the ordering's length rather than
-//! against a row set that happens to match.
+//! [`COMMENT_TERMINATED_STATEMENT`] is what makes that a claim rather than a
+//! preference. It is in the walked set precisely because its text does not
+//! survive concatenation: everything appended after it is inside a `--`
+//! comment, so a concatenating builder produces a reference with no ordering
+//! at all. Every other walked statement agrees under both spellings, which is
+//! why the parse could be reverted with nothing going red before it was added.
+//!
+//! One more property falls out of asserting per page rather than over the
+//! concatenation: a walk that ends early is reported against the ordering's
+//! length rather than against a row set that happens to match.
 //!
 //! # The fixture has to be able to fail
 //!
@@ -78,14 +83,46 @@
 //!   on the wrong one of the two produces a different sequence rather than the
 //!   same one;
 //! - one `ts` is not a multiple of 1000 ns, so a truncating or rescaling
-//!   round trip through a cursor value is visible;
-//! - the same walk runs over a one-row table (an empty second page) and a
-//!   zero-row table (an empty first page).
+//!   round trip through a cursor value is visible.
 //!
 //! [`the_fixture_can_expose_a_broken_keyset_predicate`] pins every one of
 //! those as an exact count, so a later edit to the fixture that removes one
 //! fails there rather than quietly turning the walks into a statement about
 //! nothing.
+//!
+//! # What the three fixtures each cover, and what the walked count is not
+//!
+//! Every statement is walked over three `samples` fixtures, so the pinned
+//! count in [`a_total_order_claim_survives_an_executed_page_walk`] is three
+//! times the walked statement count. That number is a real pin and it does
+//! move, but it is not a breadth figure, and reading it as one overstates what
+//! the suite covers.
+//!
+//! Only [`FIXTURE`] can say anything about an ORDERING. It is the seven-row
+//! table, it is the one that carries every property listed above, and every
+//! mutation this suite has caught was caught by it.
+//!
+//! [`ONE_ROW`] and [`NO_ROWS`] cover the walk's PAGE BOUNDARIES and nothing
+//! else: a one-row table has exactly one cursor mint and ends on an empty
+//! SECOND page, and an empty table has no mint at all and ends on an empty
+//! FIRST page. Neither can distinguish two orderings, because one row admits
+//! one sequence and no rows admit none. They are worth their third of the
+//! count for the boundaries alone --
+//! [`a_walk_terminates_on_an_empty_page_at_both_table_boundaries`] pins those
+//! two page counts directly -- but a mutation that reorders rows is invisible
+//! to both. Widening the ordering coverage means more STATEMENTS or more
+//! fixture properties, never more rows in these two.
+//!
+//! [`LOG_FIXTURE`] does not vary across that axis at all: `logs` is registered
+//! identically under all three, because what it is here for is the absence of
+//! a row identity rather than a row count that tracks `samples`. It is still
+//! registered under all three rather than only under [`FIXTURE`], so that
+//! every statement in [`STATEMENTS`] can execute under every fixture: a
+//! context missing the table would turn the planner regression this table
+//! exists to catch into a "table not found" panic under two of the three,
+//! which is a worse report of the same thing. What it does mean is that a
+//! `logs` walk under the second and third fixtures would repeat the first
+//! exactly, so the reverse direction is covered once, not three times.
 //!
 //! # Two tables, because one table hides a whole class of mutation
 //!
@@ -118,6 +155,18 @@
 //! on every page rather than counting down as the walk advances. A statement
 //! whose result depends on rows a keyset filter would remove and which the
 //! planner cannot page is asserted as a refusal rather than omitted.
+//!
+//! Walking them is not what makes them carry their weight, and for one round
+//! they did not carry it: the walk compares a page against the same statement
+//! run unpaged, so a window value that changed per page changes on both sides
+//! and the sequence still matches. What pins them is
+//! [`a_count_window_reports_the_whole_row_count_on_every_page`] and
+//! [`a_rank_window_ranks_against_the_whole_row_set`], which assert the window
+//! column BY VALUE over the walk. Those are what fail when the keyset
+//! predicate moves inside the derived table, and they fail on the window's own
+//! numbers -- 7, 6, 5, 4, 3, 2, 1 for the count, and 1 seven times over for the
+//! rank -- rather than through the parse error that same mutation happens to
+//! raise first on the `DISTINCT ON` statement.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -721,6 +770,13 @@ fn row_at(batches: &[RecordBatch], index: usize) -> (&RecordBatch, usize) {
 
 /// Where the walk's page sequence departs from `reference`, or `None` when
 /// page k held rows k of it from the first page to the last.
+///
+/// There is no short-page check here, because a short page cannot occur: the
+/// page statement carries no row cap of its own, so [`walk`] imposes
+/// [`PAGE_CAP`] with its own `take`, and a page that would have been short is
+/// the empty one that ends the walk. A page that returns too FEW rows shows up
+/// in the final length comparison below instead, as a walk that delivered
+/// fewer rows than the ordering holds.
 fn sequence_finding(reference: &[Vec<String>], found: &Walk) -> Option<String> {
     let mut cursor = 0usize;
     for (index, page) in found.page_rows.iter().enumerate() {
@@ -739,14 +795,6 @@ fn sequence_finding(reference: &[Vec<String>], found: &Walk) -> Option<String> {
                 "page {page_number} is not rows {cursor}..{end} of the ordering\n      page     \
                  {page:?}\n      ordering {:?}",
                 &reference[cursor..end],
-            ));
-        }
-        if page.len() != PAGE_CAP && end != reference.len() {
-            return Some(format!(
-                "page {page_number} returned {} of the {PAGE_CAP} rows a page holds while {} \
-                 rows were still unwalked, so page k stopped meaning rows k of the ordering",
-                page.len(),
-                reference.len() - end,
             ));
         }
         cursor = end;
@@ -778,6 +826,48 @@ fn sequence_finding(reference: &[Vec<String>], found: &Walk) -> Option<String> {
 const DISTINCT_ON_STATEMENT: &str =
     "SELECT DISTINCT ON (series_id) ts, series_id FROM samples ORDER BY series_id, ts DESC";
 
+/// The walked statement whose TEXT does not survive naive concatenation, so it
+/// is what makes [`reference_statement`]'s parse load-bearing.
+///
+/// A `--` comment runs to the end of the line, so everything appended after
+/// this statement's text is inside it. The statement carries no `ORDER BY`, so
+/// the reference has a whole `ORDER BY "ts" ASC, "series_id" ASC` to append,
+/// and a concatenating builder puts all of it in the comment: the reference is
+/// then the statement itself, unordered, which is [`FIXTURE`]'s deliberately
+/// unsorted insertion order rather than any ordering the walk produces.
+///
+/// Chosen over a trailing comment on a statement that DOES carry an `ORDER BY`
+/// because that form would leave the reference ordered by the caller's own
+/// terms and differ from the walk only on the tied pair, which puts the
+/// assertion at the mercy of whether a sort happens to be stable. Here the
+/// reference and the walk disagree on the first row.
+const COMMENT_TERMINATED_STATEMENT: &str =
+    "SELECT ts, series_id FROM samples -- the ordering is appended after this, not into it";
+
+/// A window whose value is a property of the WHOLE statement's row set: the
+/// count of every row it returns, which is [`FIXTURE`]'s seven on every page.
+const WINDOW_COUNT_STATEMENT: &str =
+    "SELECT ts, series_id, count(*) OVER () AS n FROM samples ORDER BY ts, series_id";
+
+/// A window whose value is each row's position in the whole statement's row
+/// set. Its `ORDER BY ts` ties the two rows at [`TIED_TS`], so the ranks it
+/// produces are not the row numbers and a walk cannot reproduce them by
+/// counting pages.
+const WINDOW_RANK_STATEMENT: &str =
+    "SELECT ts, series_id, rank() OVER (ORDER BY ts) AS rk FROM samples ORDER BY ts, series_id";
+
+/// What [`WINDOW_COUNT_STATEMENT`] reports on every one of its rows: the
+/// fixture's row count, spelled out rather than derived from `FIXTURE.len()`,
+/// so a page that reports the count of its own filtered input cannot agree
+/// with it by following the same fixture edit.
+const WINDOW_COUNTS: [&str; 7] = ["7", "7", "7", "7", "7", "7", "7"];
+
+/// What [`WINDOW_RANK_STATEMENT`] reports, in the order its own `ORDER BY ts,
+/// series_id` returns the rows: `ts` ascending is 500, 1000, 1000, 2000, 3000,
+/// 4000, 1234567, and the pair tied at 1000 takes rank 2 twice and leaves rank
+/// 3 unused.
+const WINDOW_RANKS: [&str; 7] = ["1", "2", "2", "4", "5", "6", "7"];
+
 /// The statements this suite walks, plus the shapes that must keep walking so
 /// a fix cannot be a blanket refusal.
 ///
@@ -801,6 +891,9 @@ const STATEMENTS: &[&str] = &[
     // keep doing so.
     "SELECT * FROM samples ORDER BY ts",
     "SELECT * FROM samples",
+    // The statement whose text does not survive concatenation. See
+    // [`COMMENT_TERMINATED_STATEMENT`].
+    COMMENT_TERMINATED_STATEMENT,
     "SELECT ts, series_id FROM samples ORDER BY ts",
     "SELECT ts, series_id, value FROM samples ORDER BY ts DESC, series_id",
     "SELECT ts, series_id FROM samples ORDER BY series_id",
@@ -813,12 +906,12 @@ const STATEMENTS: &[&str] = &[
     "SELECT ts, series_id, ts AS \"Select\" FROM samples ORDER BY \"Select\", ts, series_id",
     // Two window statements. Both plan with a total-order claim, and both are
     // correct only because the keyset predicate sits OUTSIDE the derived
-    // table: the window sees all the statement's rows on every page. A
-    // `count(*) OVER ()` that counted down as the walk advanced, or a `rank()`
-    // that restarted at 1, is a different result per page rather than a
-    // differently ordered one.
-    "SELECT ts, series_id, count(*) OVER () AS n FROM samples ORDER BY ts, series_id",
-    "SELECT ts, series_id, rank() OVER (ORDER BY ts) AS rk FROM samples ORDER BY ts, series_id",
+    // table: the window sees all the statement's rows on every page. What each
+    // one reports per page is asserted by value in
+    // [`a_window_is_computed_over_every_row_of_the_statement`]; here they are
+    // walked for their ordering like any other statement.
+    WINDOW_COUNT_STATEMENT,
+    WINDOW_RANK_STATEMENT,
     // Refused now rather than walked, both for a term whose values no cursor
     // carries. `value` is a float, so it admits the NaN that
     // `ResumeValue::Float` refuses; `labels` is a `Dictionary` over a `Map`,
@@ -919,12 +1012,17 @@ async fn a_total_order_claim_survives_an_executed_page_walk() {
         findings.len(),
         findings.join("\n  "),
     );
-    // Nine per fixture, three fixtures. Pinned exactly rather than as
+    // Ten per fixture, three fixtures. Pinned exactly rather than as
     // `walked > 0`: a change that drops a statement out of the total-order
     // class leaves this gate passing over a smaller set, which is the way a
     // suite of this shape goes quiet without going red.
+    //
+    // What the 30 is and is not: see the module docs. Ten of the walks are
+    // over seven rows and are what every mutation caught so far was caught by;
+    // the other twenty are over a one-row and a zero-row table, and what they
+    // exercise is the walk's page boundaries, not any ordering.
     assert_eq!(
-        walked, 27,
+        walked, 30,
         "the walked set changed size, so this gate is asserting about a different \
          set of statements than the one it was sized for",
     );
@@ -957,6 +1055,73 @@ async fn a_walk_terminates_on_an_empty_page_at_both_table_boundaries() {
         "non-empty pages over an empty table"
     );
     assert_eq!(none.stopped_at_null, None);
+}
+
+/// `count(*) OVER ()` reports the whole statement's row count on every page.
+///
+/// The property the walk itself cannot assert, and the reason the window
+/// statements are in [`STATEMENTS`] at all. The walk compares each page
+/// against the same statement run unpaged, so a window value that changed per
+/// page would have to disturb the ORDERING as well to be visible there. It
+/// does not: the rows come back in the same sequence carrying a different
+/// number, and the number is what the caller reads.
+///
+/// So the values are asserted here, by value, as the sequence the pages
+/// deliver them in. That is what makes the keyset predicate's POSITION
+/// load-bearing rather than incidental: the rewrite puts it outside the
+/// derived table, so the window is computed over all seven rows on every page.
+/// Moved inside, it counts the rows that survived the cursor filter and
+/// reports 7, 6, 5, 4, 3, 2, 1 down the walk.
+///
+/// Asserted directly rather than through [`STATEMENTS`] because that loop
+/// reaches a window statement only after the `DISTINCT ON` one, whose
+/// preserved inner `ORDER BY` makes the same mutation a PARSE error first: a
+/// suite that only caught it there would be reporting a syntax failure on an
+/// unrelated statement, which says nothing about where a window is computed.
+#[tokio::test]
+async fn a_count_window_reports_the_whole_row_count_on_every_page() {
+    let found = walk(&context(), WINDOW_COUNT_STATEMENT).await;
+    assert_eq!(found.pages, 8, "pages of the count window walk");
+    assert_eq!(
+        window_column(&found),
+        WINDOW_COUNTS,
+        "count(*) OVER () did not report the statement's whole row count on \
+         every page, so the keyset predicate reached the rows the window was \
+         computed over",
+    );
+}
+
+/// `rank() OVER (ORDER BY ts)` ranks each row against the whole statement's
+/// row set.
+///
+/// The same property as
+/// [`a_count_window_reports_the_whole_row_count_on_every_page`] read through a
+/// window whose value is per row rather than per result, so a page that
+/// recomputed it over its own rows alone would report a plausible-looking 1
+/// rather than an obviously shrinking total. [`WINDOW_RANKS`] is the sequence
+/// only the whole row set produces: it skips 3, because the pair tied at
+/// [`TIED_TS`] takes rank 2 twice.
+#[tokio::test]
+async fn a_rank_window_ranks_against_the_whole_row_set() {
+    let found = walk(&context(), WINDOW_RANK_STATEMENT).await;
+    assert_eq!(found.pages, 8, "pages of the rank window walk");
+    assert_eq!(
+        window_column(&found),
+        WINDOW_RANKS,
+        "rank() OVER (ORDER BY ts) did not rank each row against the \
+         statement's whole row set, so the keyset predicate reached the rows \
+         the window was computed over",
+    );
+}
+
+/// The window column of a walk over [`WINDOW_COUNT_STATEMENT`] or
+/// [`WINDOW_RANK_STATEMENT`]: the third projected column, in page order.
+fn window_column(found: &Walk) -> Vec<String> {
+    found
+        .rows()
+        .iter()
+        .map(|row| row[2].clone())
+        .collect::<Vec<String>>()
 }
 
 /// A `DISTINCT ON` page delivers the rows the caller's own statement delivers.
@@ -1239,8 +1404,9 @@ fn the_four_defect_statements_are_classified_exactly() {
         "SELECT ts, series_id FROM samples ORDER BY series_id",
         "SELECT * FROM samples WHERE value > 0.5 ORDER BY ts",
         "SELECT ts, series_id, ts AS \"Select\" FROM samples ORDER BY \"Select\", ts, series_id",
-        "SELECT ts, series_id, count(*) OVER () AS n FROM samples ORDER BY ts, series_id",
-        "SELECT ts, series_id, rank() OVER (ORDER BY ts) AS rk FROM samples ORDER BY ts, series_id",
+        COMMENT_TERMINATED_STATEMENT,
+        WINDOW_COUNT_STATEMENT,
+        WINDOW_RANK_STATEMENT,
     ];
     for sql in must_stay_total {
         let plan = plan_page(sql, None).unwrap_or_else(|e| panic!("{sql:?} refused: {e}"));


### PR DESCRIPTION
Adds `plan_page` to ravel-sql, which rewrites a SELECT into a keyset-paged
form, and extends `SqlOutcome` with the inputs a paging cursor must pin.

The rewrite wraps the statement as a derived table, strips its ORDER BY,
applies the keyset predicate outside it and reapplies the ordering there.
Putting the keyset on the wrapper rather than the scan means an aggregate
page resumes after the last emitted row instead of filtering the rows the
aggregate reads.

## What the total-order claim rests on

`not_total: None` claims paging delivers every row exactly once. A wrong
claim loses or duplicates rows silently, so the planner refuses wherever it
cannot prove otherwise, and the proof has to come from the statement text.

An output name resolves through one provenance, and the raw name is not
reachable from its consumers. That is what stops an alias taking an identity
column's name, a positional rename list masquerading as the base table, or a
wildcard answering for a name a later item redefines. Each of those returned
a wrong row before it was closed.

Term types are checked against what a cursor can carry. A term whose type has
no resume representation, or a float column that admits NaN, cannot
participate in a total order.

Constructs where an ordering selects rows rather than merely ordering them
keep their inner ORDER BY; `DISTINCT ON` is the case that proves the rule,
since there the ordering chooses which row survives each group. Pipes, row
limits, INTERPOLATE and four dialect clauses refuse at every nesting depth
rather than only at the top level.

The relation, the projection, the statement body and the query are read by
exhaustive destructuring, so a field added to any of those by a future parser
release is a compile error rather than a silent admission. Two of this
series' defects were hidden behind a `..`.

That guarantee does not yet extend to every node that decides name
resolution: `WildcardAdditionalOptions` and `OrderByExpr`/`OrderByOptions`
are still read field-by-field rather than destructured. Every field is read
today, so there is no defect, but those two do not carry the compile error
the four above do. Tracked as a follow-up rather than fixed here.

## How the claim is tested

By executing page walks, not by asserting on plan shape. A plan that claims
a total order looks identical to one that has it, which is why three earlier
rounds passed their own tests while losing rows.

The harness pages at a cap of one and asserts page k holds rows k of the
unpaged ordering as a sequence. Its reference ordering is built from the
caller's own parsed statement rather than from the plan, so a planner that
misreads a direction is not compared against its own misreading. The fixture
carries ties, anti-correlated ids, NaN, negative zero, non-round timestamps,
a duplicate row on a table with no row identity, and one-row and empty
tables for the page boundaries.

Refs: #1571
