### PR TITLE
feat(catalog): retire the v1/v2 whole-object column-statistics publish

### DIFF
--- a/crates/ravel-catalog/src/cache.rs
+++ b/crates/ravel-catalog/src/cache.rs
@@ -707,8 +707,6 @@ mod tests {
             folder_id: uuid::Uuid::new_v4().into_bytes().to_vec(),
             created_unix_ns: 0,
             shard_generation_count: 1,
-            column_stats: None,
-            column_stats_part: None,
         }
     }
 

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -1035,9 +1035,9 @@ impl Catalog {
     }
 
     /// Resolve exact per-segment column statistics for `(tenant, signal)`
-    /// over the query window `[range, now_ns]` (ADR-0850, ADR-1413), for a
-    /// query engine to join against its own resolved snapshot's live segments
-    /// via [`LoadedColumnStats::stat_for`]. `Ok(None)` means no usable
+    /// over the query window `[range, now_ns]` (ADR-1413), for a query engine
+    /// to join against its own resolved snapshot's live segments via
+    /// [`LoadedColumnStats::stat_for`]. `Ok(None)` means no usable
     /// column-stats object covers any part this window touches (nothing
     /// folded yet, no configured typed columns, or the last fold's
     /// column-stats build/PUT failed): the caller must fall back to
@@ -1050,30 +1050,17 @@ impl Catalog {
     /// narrow window against a many-part tenant issues per-part GETs for
     /// exactly those parts, never the whole tenant.
     ///
-    /// Fallback per covered part (ADR-1413 decision 2, extending ADR-0942's
-    /// reader rule): the part's own v3 object (`parts[i].column_stats`, field
-    /// 7) is tried first. A part with no such ref, or whose object fails to
-    /// load (blake3 mismatch, decode refusal, missing object), needs the
-    /// whole-tenant v2 object (`column_stats_part`, field 13). A decoded v2
-    /// object can legitimately omit a covered part's segment (the fold's
-    /// per-entry build has its own warn-and-omit path), so loading v2 alone
-    /// does not prove every still-needed part was answered. No v2 record
-    /// field identifies which physical part it belongs to (`writer_id` is a
-    /// content hash, unrelated to any part's own blake3), so this compares
-    /// the number of segments v2 actually decoded against the sum of
-    /// `entry_count` declared across every part in the HEAD -- the total v2
-    /// claims to cover -- and only falls through to the whole-tenant v1
-    /// object (`column_stats`, field 11) when the decoded count falls short
-    /// of that total. A part answered by none of the three is simply left
-    /// uncovered and the caller scans it.
-    /// Each whole-object ref is fetched at most once per call, and only when
-    /// at least one covered part still needs it -- so one call can issue
-    /// both a v2 GET and a v1 GET when v2 leaves a gap, which is the
-    /// intended cost of closing that gap, not a regression. Every failure
-    /// degrades silently EXCEPT a decode refusal, which emits one
-    /// `tracing::warn!` per object key and increments
-    /// [`Catalog::column_stats_decode_refusals`] before degrading (issue
-    /// #1400).
+    /// Per covered part (ADR-1413 decision 6): the part's own v3 object
+    /// (`parts[i].column_stats`, field 7) is the only source. A part with no
+    /// such ref, or whose object fails to load (blake3 mismatch, decode
+    /// refusal, missing object), is simply left uncovered and the caller
+    /// scans it -- there is no whole-object fallback; the fold no longer
+    /// publishes the whole-tenant v1/v2 objects at any size, and a HEAD still
+    /// carrying either from before this change is decoded with no slot for
+    /// them (the fields are `reserved`). Every failure degrades silently
+    /// EXCEPT a decode refusal, which emits one `tracing::warn!` per object
+    /// key and increments [`Catalog::column_stats_decode_refusals`] before
+    /// degrading (issue #1400).
     pub async fn load_column_stats(
         &self,
         tenant: &TenantHash,
@@ -1127,8 +1114,7 @@ impl Catalog {
         // changes this fingerprint, so a stale entry always misses -- the
         // same guarantee issue #888 gives the single-whole-object case,
         // extended per part.
-        let fingerprint =
-            Self::column_stats_fingerprint(&covered, head.v2.as_ref(), head.v1.as_ref());
+        let fingerprint = Self::column_stats_fingerprint(&covered);
         let cache_key: ColumnStatsCacheKey = (*tenant, signal, window_start_hour, window_end_hour);
         let cache_hit = self
             .column_stats_cache
@@ -1144,106 +1130,23 @@ impl Catalog {
         > = HashMap::new();
         let mut by_content_hash: HashMap<[u8; 32], ravel_proto::catalog::v1::ColumnStatsSegment> =
             HashMap::new();
-        let mut needs_fallback: Vec<&ravel_proto::catalog::v1::SnapshotPartRef> = Vec::new();
 
         for part in &covered {
-            match column_stats_resolve::resolve_part_stats_ref(part) {
-                Some(resolved) => {
-                    match column_stats_resolve::fetch_stats_object(&getter, tenant, &resolved)
-                        .await?
-                    {
-                        column_stats_resolve::FetchOutcome::Loaded(decoded) => {
-                            segments.extend(decoded.segments);
-                            by_content_hash.extend(decoded.by_content_hash);
-                        }
-                        // Store read or stale binding: subtract this part's
-                        // coverage and fall back below, silently.
-                        column_stats_resolve::FetchOutcome::Absent => needs_fallback.push(part),
-                        // The part's own ref points at an object the reader
-                        // refused to decode: log once per key, count, and
-                        // fall back below (issue #1400).
-                        column_stats_resolve::FetchOutcome::DecodeRefused(err) => {
-                            self.note_column_stats_decode_refusal(
-                                tenant,
-                                signal,
-                                &resolved.key,
-                                &err,
-                            );
-                            needs_fallback.push(part);
-                        }
-                    }
-                }
-                None => needs_fallback.push(part),
-            }
-        }
-
-        if !needs_fallback.is_empty() {
-            // Insert-if-absent only: a part already answered by its own v3
-            // object above must never be overwritten by a whole-object
-            // record for the same key, so v3 always wins on collision.
-            //
-            // A decoded v2 object can legitimately OMIT a covered part's
-            // segment (fold.rs's per-entry v3/v2 loop warns and omits a
-            // segment whose build failed, then still publishes), so a
-            // successful v2 decode does not mean every part in
-            // `needs_fallback` was actually answered. There is no way to
-            // attribute a specific decoded segment to a specific part from
-            // here (`writer_id` is a content hash, architecturally unrelated
-            // to any `SnapshotPartRef.blake3`, and fetching part bodies to
-            // find out is exactly what this whole-object fallback exists to
-            // avoid). What IS available without an extra GET is each part's
-            // own declared `entry_count` on the HEAD (the count fold.rs
-            // populates for every part) and how many segments v2 actually
-            // decoded: if the decoded count falls short of the total entries
-            // declared across every part in the HEAD -- the full set v2
-            // claims to cover -- at least one segment was dropped somewhere,
-            // so `needs_fallback` is left as-is and v1 is still consulted;
-            // if it meets or exceeds that total, v2 fully answered every
-            // part and v1 is skipped, same as before this fix.
-            if let Some(v2) = &head.v2 {
-                match column_stats_resolve::fetch_stats_object(&getter, tenant, v2).await? {
+            // No field-7 ref at all: the part is simply left uncovered.
+            if let Some(resolved) = column_stats_resolve::resolve_part_stats_ref(part) {
+                match column_stats_resolve::fetch_stats_object(&getter, tenant, &resolved).await? {
                     column_stats_resolve::FetchOutcome::Loaded(decoded) => {
-                        // Saturating: `entry_count` is decoded input, and a
-                        // wrapped-small total would clear the fallback set
-                        // too eagerly, which is the one direction this check
-                        // must never fail in.
-                        let declared_entries: u64 = head
-                            .parts
-                            .iter()
-                            .fold(0u64, |acc, part| acc.saturating_add(part.entry_count));
-                        let decoded_entries =
-                            (decoded.segments.len() + decoded.by_content_hash.len()) as u64;
-                        for (k, v) in decoded.segments {
-                            segments.entry(k).or_insert(v);
-                        }
-                        for (k, v) in decoded.by_content_hash {
-                            by_content_hash.entry(k).or_insert(v);
-                        }
-                        if decoded_entries >= declared_entries {
-                            needs_fallback.clear();
-                        }
+                        segments.extend(decoded.segments);
+                        by_content_hash.extend(decoded.by_content_hash);
                     }
+                    // Store read or stale binding: this part is simply
+                    // left uncovered, silently.
                     column_stats_resolve::FetchOutcome::Absent => {}
+                    // The part's own ref points at an object the reader
+                    // refused to decode: log once per key, count, and
+                    // leave the part uncovered (issue #1400).
                     column_stats_resolve::FetchOutcome::DecodeRefused(err) => {
-                        self.note_column_stats_decode_refusal(tenant, signal, &v2.key, &err);
-                    }
-                }
-            }
-            if !needs_fallback.is_empty()
-                && let Some(v1) = &head.v1
-            {
-                match column_stats_resolve::fetch_stats_object(&getter, tenant, v1).await? {
-                    column_stats_resolve::FetchOutcome::Loaded(decoded) => {
-                        for (k, v) in decoded.segments {
-                            segments.entry(k).or_insert(v);
-                        }
-                        for (k, v) in decoded.by_content_hash {
-                            by_content_hash.entry(k).or_insert(v);
-                        }
-                    }
-                    column_stats_resolve::FetchOutcome::Absent => {}
-                    column_stats_resolve::FetchOutcome::DecodeRefused(err) => {
-                        self.note_column_stats_decode_refusal(tenant, signal, &v1.key, &err);
+                        self.note_column_stats_decode_refusal(tenant, signal, &resolved.key, &err);
                     }
                 }
             }
@@ -1266,24 +1169,13 @@ impl Catalog {
 
     /// The declared-blake3 fingerprint [`Catalog::load_column_stats`] keys its
     /// reuse cache on: each covered part's v3 ref blake3 (or a zero sentinel
-    /// when the part carries none), in `covered`'s order, followed by the
-    /// whole-tenant v2 and v1 ref blake3 (each zero-sentinel when absent).
-    /// Computed entirely from HEAD-derived refs, with no object GET, so a
-    /// cache check costs nothing beyond the HEAD read already paid for.
-    fn column_stats_fingerprint(
-        covered: &[ravel_proto::catalog::v1::SnapshotPartRef],
-        v2: Option<&column_stats_resolve::ResolvedStatsRef>,
-        v1: Option<&column_stats_resolve::ResolvedStatsRef>,
-    ) -> [u8; 32] {
-        let mut buf = Vec::with_capacity((covered.len() + 2) * 32);
+    /// when the part carries none), in `covered`'s order. Computed entirely
+    /// from HEAD-derived refs, with no object GET, so a cache check costs
+    /// nothing beyond the HEAD read already paid for.
+    fn column_stats_fingerprint(covered: &[ravel_proto::catalog::v1::SnapshotPartRef]) -> [u8; 32] {
+        let mut buf = Vec::with_capacity(covered.len() * 32);
         for part in covered {
             match column_stats_resolve::resolve_part_stats_ref(part) {
-                Some(resolved) => buf.extend_from_slice(&resolved.blake3),
-                None => buf.extend_from_slice(&[0u8; 32]),
-            }
-        }
-        for whole in [v2, v1] {
-            match whole {
                 Some(resolved) => buf.extend_from_slice(&resolved.blake3),
                 None => buf.extend_from_slice(&[0u8; 32]),
             }
@@ -5197,8 +5089,6 @@ mod tests {
             folder_id: Uuid::new_v4().into_bytes().to_vec(),
             created_unix_ns: 0,
             shard_generation_count: 1,
-            column_stats: None,
-            column_stats_part: None,
         }
     }
 
@@ -6102,8 +5992,6 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            column_stats: None,
-            column_stats_part: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         store
@@ -6202,8 +6090,6 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 2,
-            column_stats: None,
-            column_stats_part: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         inner
@@ -7562,105 +7448,8 @@ mod tests {
     async fn load_column_stats_charges_exactly_two_accounted_gets() {
         let store = Arc::new(MemoryStore::new());
         let signal = Signal::Logs;
-        let signal_num = signal::to_proto(signal) as u32;
-
-        // One empty snapshot part.
-        let part_bytes =
-            crate::snapshot_format::encode_part(tenant().0, signal_num, 8, 10, &[]).expect("part");
-        let part_hash = *blake3::hash(&part_bytes).as_bytes();
-        let part_key = format!("t/{}/catalog/l/snap/empty.csnap", tenant().to_hex());
-        store
-            .put(
-                &part_key,
-                Bytes::from(part_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put part");
-
-        // A consistent single-segment column-stats object bound to that part.
-        let segments = vec![ravel_proto::catalog::v1::ColumnStatsSegment {
-            ingest_hour_bucket: 1,
-            shard: 0,
-            writer_id: vec![0xAA; 16],
-            writer_epoch: 1,
-            writer_seq: 1,
-            columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                name: "status".to_string(),
-                declared_type: 2,
-                non_null_count: 1,
-                null_count: 0,
-                min: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(1)),
-                }),
-                max: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(1)),
-                }),
-                dictionary_present: true,
-                dictionary: vec![ravel_proto::catalog::v1::DictEntry {
-                    value: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(1)),
-                    }),
-                    count: 1,
-                }],
-                sum: Some(1),
-            }],
-        }];
-        let stats_bytes = crate::snapshot_format::encode_column_stats(
-            tenant().0,
-            signal_num,
-            vec![part_hash.to_vec()],
-            &segments,
-        )
-        .expect("encode column stats");
-        let stats_hash = *blake3::hash(&stats_bytes).as_bytes();
-        let stats_key = format!("t/{}/catalog/l/cstat/one.cstat", tenant().to_hex());
-        store
-            .put(
-                &stats_key,
-                Bytes::from(stats_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put stats");
-
-        let head = ravel_proto::catalog::v1::SnapshotHead {
-            format_version: crate::snapshot_format::HEAD_FORMAT_VERSION,
-            tenant_hash: tenant().0.to_vec(),
-            signal: signal_num,
-            shard_count: 8,
-            watermark_hour: 10,
-            parts: vec![ravel_proto::catalog::v1::SnapshotPartRef {
-                key: part_key,
-                blake3: part_hash.to_vec(),
-                size: part_bytes.len() as u64,
-                entry_count: 0,
-                watermark_hour: 10,
-                min_hour: 0,
-                column_stats: None,
-            }],
-            folder_id: Uuid::new_v4().into_bytes().to_vec(),
-            created_unix_ns: 0,
-            postings: None,
-            shard_generation_count: 1,
-            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
-                key: stats_key,
-                blake3: stats_hash.to_vec(),
-                size: stats_bytes.len() as u64,
-                segment_count: 1,
-                part_blake3: vec![part_hash.to_vec()],
-            }),
-            column_stats_part: None,
-        };
-        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
-        store
-            .put(
-                &crate::fold::head_object_key(&tenant(), signal),
-                Bytes::from(head_bytes),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put head");
+        let part_hash = *blake3::hash(b"part-0").as_bytes();
+        install_logs_stats(&store, part_hash, 1).await;
 
         let catalog = Catalog::new(store.clone(), config(8)).expect("catalog");
         let acc = QueryAccounting::new();
@@ -7670,7 +7459,11 @@ mod tests {
             .await
             .expect("load ok")
             .expect("stats present");
-        assert_eq!(loaded.segments.len(), 1, "the one segment's stats loaded");
+        assert_eq!(
+            loaded.by_content_hash.len(),
+            1,
+            "the one segment's stats loaded"
+        );
 
         let snap = acc.snapshot();
         assert_eq!(
@@ -7695,14 +7488,16 @@ mod tests {
         );
     }
 
-    /// Write a folded HEAD plus its `.cstat` object for `tenant`/`signal`, whose
-    /// one segment carries a single I64 `status` column with the exact value
-    /// `value` (min == max == `value`, one non-null row). `part_hash` binds the
-    /// HEAD's part set to the stats object; reusing the same `part_hash` across
-    /// calls keeps the part binding fixed so a re-resolve is driven purely by
-    /// the stats object's content hash changing with `value`. The object keys
-    /// are namespaced by tenant hex and signal prefix so distinct
-    /// `(tenant, signal)` installs never collide in one store.
+    /// Write a folded HEAD plus its per-part v3 `.cstat` object (ADR-1413
+    /// decision 6, #1600: the v3 per-part ref is the only surviving published
+    /// form) for `tenant`/`signal`, whose one segment carries a single I64
+    /// `status` column with the exact value `value` (min == max == `value`,
+    /// one non-null row). `part_hash` binds the HEAD's part set to the stats
+    /// object; reusing the same `part_hash` across calls keeps the part
+    /// binding fixed so a re-resolve is driven purely by the stats object's
+    /// content hash changing with `value`. The object keys are namespaced by
+    /// tenant hex and signal prefix so distinct `(tenant, signal)` installs
+    /// never collide in one store.
     async fn install_stats(
         store: &MemoryStore,
         tenant: TenantHash,
@@ -7716,7 +7511,7 @@ mod tests {
         let segments = vec![ravel_proto::catalog::v1::ColumnStatsSegment {
             ingest_hour_bucket: 1,
             shard: 0,
-            writer_id: vec![0xAA; 16],
+            writer_id: part_hash.to_vec(),
             writer_epoch: 1,
             writer_seq: 1,
             columns: vec![ravel_proto::catalog::v1::ColumnStat {
@@ -7740,13 +7535,14 @@ mod tests {
                 sum: Some(value),
             }],
         }];
-        let stats_bytes = crate::snapshot_format::encode_column_stats(
+        let stats_bytes = crate::snapshot_format::encode_column_stats_v3(
             tenant.0,
             signal_num,
-            vec![part_hash.to_vec()],
+            part_hash,
             &segments,
+            crate::snapshot_format::DEFAULT_MAX_COLUMN_STATS_BYTES,
         )
-        .expect("encode column stats");
+        .expect("encode v3 column stats");
         let stats_hash = *blake3::hash(&stats_bytes).as_bytes();
         let stats_key = format!("t/{}/catalog/{prefix}/cstat/one.cstat", tenant.to_hex());
         store
@@ -7771,20 +7567,18 @@ mod tests {
                 entry_count: 0,
                 watermark_hour: 10,
                 min_hour: 0,
-                column_stats: None,
+                column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
+                    key: stats_key,
+                    blake3: stats_hash.to_vec(),
+                    size: stats_bytes.len() as u64,
+                    segment_count: 1,
+                    part_blake3: vec![part_hash.to_vec()],
+                }),
             }],
             folder_id: Uuid::new_v4().into_bytes().to_vec(),
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
-                key: stats_key,
-                blake3: stats_hash.to_vec(),
-                size: stats_bytes.len() as u64,
-                segment_count: 1,
-                part_blake3: vec![part_hash.to_vec()],
-            }),
-            column_stats_part: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         store
@@ -7806,68 +7600,20 @@ mod tests {
     /// The exact I64 `status` value carried by the one segment of a loaded
     /// column-stats object built by [`install_logs_stats`].
     fn loaded_value(loaded: &LoadedColumnStats) -> i64 {
-        let segment = loaded.segments.values().next().expect("one segment");
+        let segment = loaded.by_content_hash.values().next().expect("one segment");
         match &segment.columns[0].min.as_ref().expect("min present").kind {
             Some(ravel_proto::catalog::v1::column_value::Kind::I64(v)) => *v,
             other => panic!("expected an I64 min, got {other:?}"),
         }
     }
 
-    /// A well-framed **v1** column-statistics envelope whose header DECLARES
-    /// `declared_len` uncompressed body bytes over an empty body: the
-    /// small-object / large-declared-length shape issue #1400 describes. Every
-    /// framing invariant `decode_column_stats` checks before its size gate holds
-    /// (magic, version byte, reserved, header and body crc, tenant-hash length,
-    /// header/envelope version agreement), so decode reaches the
-    /// `body_uncompressed_len > cap` check and returns
-    /// `ColumnStatsDecompressedTooLarge` without inflating a 256 MiB body.
-    ///
-    /// Hand-framed rather than built through `encode_column_stats`, which
-    /// derives `body_uncompressed_len` from the actual segments and so can never
-    /// declare a length its body does not carry.
-    fn frame_oversized_cstat(
-        tenant: TenantHash,
-        signal: Signal,
-        part_hash: [u8; 32],
-        declared_len: u64,
-    ) -> Vec<u8> {
-        use crate::snapshot_format::{COLUMN_STATS_MAGIC, COLUMN_STATS_RESERVED, ZSTD_LEVEL};
-
-        let version: u8 = 1;
-        let body = zstd::bulk::compress(b"", ZSTD_LEVEL).expect("compress empty body");
-        let header = ravel_proto::catalog::v1::ColumnStatsHeader {
-            format_version: u32::from(version),
-            tenant_hash: tenant.0.to_vec(),
-            signal: signal::to_proto(signal) as u32,
-            part_blake3: vec![part_hash.to_vec()],
-            segment_count: 0,
-            body_uncompressed_len: declared_len,
-        };
-        let header_bytes = header.encode_to_vec();
-        let header_len = header_bytes.len() as u32;
-
-        let mut out = Vec::new();
-        out.extend_from_slice(&COLUMN_STATS_MAGIC);
-        out.push(version);
-        out.extend_from_slice(&COLUMN_STATS_RESERVED);
-        out.extend_from_slice(&header_len.to_le_bytes());
-        out.extend_from_slice(&header_bytes);
-        let header_crc = crc32c::crc32c(&out);
-
-        out.extend_from_slice(&(body.len() as u64).to_le_bytes());
-        out.extend_from_slice(&body);
-        let body_crc = crc32c::crc32c(&body);
-        out.extend_from_slice(&body_crc.to_le_bytes());
-        out.extend_from_slice(&header_crc.to_le_bytes());
-        out
-    }
-
-    /// Write a folded HEAD for `(tenant, signal)` whose `column_stats` ref points
-    /// at `stats_key`, holding the oversized-declared object
-    /// [`frame_oversized_cstat`] builds. HEAD's part set and the ref's blake3
-    /// bind correctly, so a load's blake3 gate passes and decode is what refuses
-    /// (issue #1400). No snapshot part object is written: this path never
-    /// fetches one.
+    /// Write a folded HEAD for `(tenant, signal)` whose one part's field-7
+    /// `column_stats` ref points at `stats_key`, holding the oversized-declared
+    /// v3 object [`frame_oversized_cstat_v3`] builds (ADR-1413 decision 6,
+    /// #1600: the per-part v3 ref is the only surviving published form). The
+    /// part's own blake3 binds correctly, so a load's blake3 gate passes and
+    /// decode is what refuses (issue #1400). No snapshot part object is
+    /// written: this path never fetches one.
     async fn install_oversized_stats(
         store: &MemoryStore,
         tenant: TenantHash,
@@ -7878,7 +7624,7 @@ mod tests {
     ) {
         let signal_num = signal::to_proto(signal) as u32;
         let prefix = signal.key_prefix();
-        let stats_bytes = frame_oversized_cstat(tenant, signal, part_hash, declared_len);
+        let stats_bytes = frame_oversized_cstat_v3(tenant, signal, part_hash, declared_len);
         let stats_hash = *blake3::hash(&stats_bytes).as_bytes();
         store
             .put(
@@ -7902,20 +7648,18 @@ mod tests {
                 entry_count: 0,
                 watermark_hour: 10,
                 min_hour: 0,
-                column_stats: None,
+                column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
+                    key: stats_key.to_string(),
+                    blake3: stats_hash.to_vec(),
+                    size: stats_bytes.len() as u64,
+                    segment_count: 0,
+                    part_blake3: vec![part_hash.to_vec()],
+                }),
             }],
             folder_id: Uuid::new_v4().into_bytes().to_vec(),
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
-                key: stats_key.to_string(),
-                blake3: stats_hash.to_vec(),
-                size: stats_bytes.len() as u64,
-                segment_count: 0,
-                part_blake3: vec![part_hash.to_vec()],
-            }),
-            column_stats_part: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         store
@@ -8841,6 +8585,30 @@ mod tests {
         }
     }
 
+    /// Appends a length-delimited field to an already-encoded protobuf
+    /// message. Fields 11 and 13 on `SnapshotHead` (ADR-1413 decision 6,
+    /// #1600) are `reserved` and have no struct field to set, so this is the
+    /// only way to construct a HEAD that still carries one, the way a HEAD
+    /// folded before this change would. `SnapshotHead::decode` (a plain
+    /// `prost::Message::decode`) skips a field number it does not recognize,
+    /// so appending is equivalent to the field having been encoded in its
+    /// original position.
+    fn append_raw_field(
+        mut message_bytes: Vec<u8>,
+        field_number: u32,
+        field_value: &impl prost::Message,
+    ) -> Vec<u8> {
+        prost::encoding::encode_key(
+            field_number,
+            prost::encoding::WireType::LengthDelimited,
+            &mut message_bytes,
+        );
+        let payload = field_value.encode_to_vec();
+        prost::encoding::encode_varint(payload.len() as u64, &mut message_bytes);
+        message_bytes.extend_from_slice(&payload);
+        message_bytes
+    }
+
     /// A well-framed **v3** column-statistics envelope (single `part_blake3`,
     /// matching [`crate::snapshot_format::encode_column_stats_v3`]'s shape)
     /// whose header DECLARES `declared_len` uncompressed body bytes over an
@@ -8884,17 +8652,24 @@ mod tests {
         out
     }
 
-    /// ADR-1413 decision 2: a query window covering exactly K of a tenant's
-    /// N (here 3) snapshot parts issues exactly one per-part v3 GET for each
-    /// of the K covered parts, plus the one HEAD GET -- never a whole-object
-    /// (field 13 or field 11) GET, and never a GET for an uncovered part.
+    /// ADR-1413 decision 2 (#1600): a query window covering exactly K of a
+    /// tenant's N (here 3) snapshot parts issues exactly one per-part v3 GET
+    /// for each of the K covered parts, plus the one HEAD GET -- never a
+    /// whole-object (field 13 or field 11) GET, and never a GET for an
+    /// uncovered part. The HEAD also carries stale field-11 and field-13
+    /// whole-object poison refs, wire-injected with `append_raw_field` since
+    /// both fields are `reserved` and have no struct field to set: exactly
+    /// the shape a pre-#1600 fold would have produced. Retiring the fallback
+    /// ladder means neither is ever read, covered or not.
     ///
     /// Prove-the-test: this pins `Catalog::load_column_stats`'s per-part loop
     /// (`for part in &covered`) actually consulting `parts_intersecting`'s
     /// narrowed set rather than HEAD's full `parts` list. Flip that loop's
     /// `for part in &covered` to `for part in &head.parts` and the key-set
     /// assertion below fails: three `.cstat` GETs fire (including the
-    /// excluded part's), not two.
+    /// excluded part's), not two. Reintroducing a whole-object fallback read
+    /// makes it fail differently: the poisoned field-11/field-13 keys appear
+    /// in `cstat_gets` and the GET count climbs past 3.
     #[tokio::test]
     async fn query_over_k_of_n_parts_issues_exactly_k_per_part_gets_and_no_whole_object_get() {
         let inner = MemoryStore::new();
@@ -9028,22 +8803,28 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
-                key: v1_key.clone(),
-                blake3: v1_hash.to_vec(),
-                size: v1_bytes.len() as u64,
-                segment_count: 1,
-                part_blake3: all_parts.clone(),
-            }),
-            column_stats_part: Some(ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
-                key: v2_key.clone(),
-                blake3: v2_hash.to_vec(),
-                size: v2_bytes.len() as u64,
-                segment_count: 1,
-                part_blake3: all_parts.clone(),
-            }),
+        };
+        // Fields 11 and 13 are `reserved` (ADR-1413 decision 6, #1600) and have
+        // no struct field to set; wire-inject them raw so this HEAD is exactly
+        // the shape a pre-#1600 fold would have produced, still carrying both
+        // stale whole-object poison refs.
+        let stale_field_11 = ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
+            key: v1_key.clone(),
+            blake3: v1_hash.to_vec(),
+            size: v1_bytes.len() as u64,
+            segment_count: 1,
+            part_blake3: all_parts.clone(),
+        };
+        let stale_field_13 = ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
+            key: v2_key.clone(),
+            blake3: v2_hash.to_vec(),
+            size: v2_bytes.len() as u64,
+            segment_count: 1,
+            part_blake3: all_parts.clone(),
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
+        let head_bytes = append_raw_field(head_bytes, 11, &stale_field_11);
+        let head_bytes = append_raw_field(head_bytes, 13, &stale_field_13);
         inner
             .put(
                 &crate::fold::head_object_key(&tenant(), signal),
@@ -9222,11 +9003,6 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            // No field 11, no field 13: nothing for a rejected part to fall
-            // back to, so a rejection here must surface as no coverage at
-            // all, not a quiet reroute to a whole-object answer.
-            column_stats: None,
-            column_stats_part: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         store
@@ -9254,21 +9030,19 @@ mod tests {
         );
     }
 
-    /// ADR-1413 decision 2: a covered part with no v3 ref (field 7 absent)
-    /// falls back to the whole-tenant object, and the fallback answers that
-    /// part's segment -- the query still gets exact statistics for every
-    /// live segment, not just the parts that got their own object. The
-    /// whole-object GET fires exactly once even though only one covered part
-    /// needed it.
+    /// ADR-1413 decision 6 (#1600): a part with no v3 ref (field 7 absent) is
+    /// simply uncovered -- the query scans it rather than falling back to a
+    /// whole-tenant object. This fixture plants a stale field 13 (v2
+    /// whole-tenant) ref bound to both parts, left over from before the
+    /// retirement, to prove it is never read: the field-13 GET must never
+    /// fire and part y must not appear in the loaded statistics.
     ///
-    /// Prove-the-test: this pins the per-part loop's
-    /// `None => needs_fallback.push(part)` arm (`resolve_part_stats_ref`
-    /// returning `None`). Flip that arm to `None => {}` (silently drop a part
-    /// with no ref instead of falling back for it) and the
-    /// "every segment covered" assertion below fails: the fallback GET never
-    /// fires and part y's segment is missing from `by_content_hash`.
+    /// Prove-the-test: reintroducing the deleted field-13 fallback (resolving
+    /// `head.column_stats_part` when a part's own ref is absent) makes this
+    /// fail: `v2_gets` becomes 1 and part y's content hash appears in
+    /// `by_content_hash`.
     #[tokio::test]
-    async fn a_part_without_field_seven_falls_back_to_the_whole_object() {
+    async fn a_part_without_field_seven_is_uncovered_even_with_a_stale_field_thirteen() {
         let inner = MemoryStore::new();
         let signal = Signal::Logs;
         let signal_num = signal::to_proto(signal) as u32;
@@ -9365,16 +9139,23 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            column_stats: None,
-            column_stats_part: Some(ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
-                key: v2_key.clone(),
-                blake3: v2_hash.to_vec(),
-                size: v2_bytes.len() as u64,
-                segment_count: 1,
-                part_blake3: vec![part_x_hash.to_vec(), part_y_hash.to_vec()],
-            }),
         };
-        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
+        // Field 13 no longer exists on the generated struct, so a stale
+        // whole-tenant ref (as an old, pre-#1600 HEAD would carry) is
+        // planted directly on the wire: this is the only way to prove the
+        // retired field is ignored on read rather than merely unwritable.
+        let stale_field_13 = ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
+            key: v2_key.clone(),
+            blake3: v2_hash.to_vec(),
+            size: v2_bytes.len() as u64,
+            segment_count: 1,
+            part_blake3: vec![part_x_hash.to_vec(), part_y_hash.to_vec()],
+        };
+        let head_bytes = append_raw_field(
+            crate::snapshot_format::encode_head(&head).expect("encode head"),
+            13,
+            &stale_field_13,
+        );
         inner
             .put(
                 &crate::fold::head_object_key(&tenant(), signal),
@@ -9397,13 +9178,13 @@ mod tests {
 
         let v2_gets = store.get_keys().iter().filter(|k| *k == &v2_key).count();
         assert_eq!(
-            v2_gets, 1,
-            "the whole-object fallback is fetched exactly once"
+            v2_gets, 0,
+            "the stale field-13 object is never fetched: field 13 is retired"
         );
         assert_eq!(
             acc.snapshot().s3_requests(AccountedOp::Get),
-            3,
-            "HEAD, part x's own v3 object, and one whole-object fallback"
+            2,
+            "HEAD plus part x's own v3 object only; no whole-object GET"
         );
 
         assert!(
@@ -9411,13 +9192,14 @@ mod tests {
             "part x's own v3 record loaded"
         );
         assert!(
-            loaded.by_content_hash.contains_key(&content_y),
-            "part y's fallback record loaded"
+            !loaded.by_content_hash.contains_key(&content_y),
+            "part y has no field-7 ref, so it is uncovered rather than answered \
+             from the stale field-13 fallback"
         );
         assert_eq!(
             loaded.by_content_hash.len(),
-            2,
-            "every covered segment has exact statistics"
+            1,
+            "only part x's own object contributes statistics"
         );
     }
 
@@ -9513,8 +9295,6 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            column_stats: None,
-            column_stats_part: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         store
@@ -9570,32 +9350,21 @@ mod tests {
         );
     }
 
-    /// A two-part HEAD carrying only the whole-tenant **v2** ref (field 13),
-    /// no field 7 on either part. This is NOT the pre-#1413 shape: no reader
-    /// on `main` before this branch ever read field 13 at all, so against
-    /// this exact fixture the pre-change reader returned `Ok(None)` after
-    /// one GET (HEAD alone) and no statistics -- field 13 was write-only
-    /// until ADR-1413 added a reader for it. What this test actually pins is
-    /// NEW-code behavior: every part with no v3 ref (field 7 absent)
-    /// degrades to `needs_fallback` and the one whole-object v2 GET answers
-    /// all of them together, exactly once, regardless of how many parts the
-    /// window covers -- never a wasted per-part attempt. The GET count (2:
-    /// HEAD plus the one whole-object GET) happens to equal the pre-#1413
-    /// count for the *single-part v1* shape
-    /// (`load_column_stats_charges_exactly_two_accounted_gets`), which is a
-    /// coincidence of both being "one whole-object GET", not evidence this
-    /// fixture matches pre-change behavior.
+    /// ADR-1413 decision 6 (#1600): a HEAD carrying ONLY a stale field 13
+    /// (the retired whole-tenant v2 ref), no field 7 on either part, yields
+    /// NO statistics -- the query scans instead, and the field-13 object is
+    /// never fetched. Field 13 has no struct field to set (it is `reserved`
+    /// on the wire), so the ref is planted with a raw wire append
+    /// (`append_raw_field`), the way a HEAD folded before this change would
+    /// actually carry one.
     ///
-    /// Prove-the-test: this pins `resolve_part_stats_ref` returning `None`
-    /// for a part with no ref translating directly into `needs_fallback`,
-    /// never a wasted GET attempt. Flip `resolve_part_stats_ref`
-    /// (column_stats_resolve.rs) to fabricate a ref out of the part's own
-    /// blake3 instead of reading `part.column_stats`, and this test's GET
-    /// count climbs to 4 (two failed per-part GET attempts before falling
-    /// back), against the 2 pinned below.
+    /// Prove-the-test: reintroducing a `head.column_stats_part` fallback
+    /// read in the per-part resolution loop makes this fail: `loaded`
+    /// becomes `Some` with both parts' statistics, and the v2 object is
+    /// fetched once instead of never.
     #[tokio::test]
-    async fn two_part_head_with_only_field_thirteen_loads_stats_in_two_gets() {
-        let store = Arc::new(MemoryStore::new());
+    async fn head_with_only_field_thirteen_yields_no_statistics_and_scans() {
+        let inner = MemoryStore::new();
         let signal = Signal::Logs;
         let signal_num = signal::to_proto(signal) as u32;
         let prefix = signal.key_prefix();
@@ -9673,7 +9442,7 @@ mod tests {
             "t/{}/catalog/{prefix}/cstat/legacy.cstat",
             tenant().to_hex()
         );
-        store
+        inner
             .put(
                 &v2_key,
                 Bytes::from(v2_bytes.clone()),
@@ -9712,16 +9481,20 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            column_stats: None,
-            column_stats_part: Some(ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
-                key: v2_key.clone(),
-                blake3: v2_hash.to_vec(),
-                size: v2_bytes.len() as u64,
-                segment_count: 2,
-                part_blake3: vec![part_1_hash.to_vec(), part_2_hash.to_vec()],
-            }),
         };
-        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
+        let stale_field_13 = ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
+            key: v2_key.clone(),
+            blake3: v2_hash.to_vec(),
+            size: v2_bytes.len() as u64,
+            segment_count: 2,
+            part_blake3: vec![part_1_hash.to_vec(), part_2_hash.to_vec()],
+        };
+        let head_bytes = append_raw_field(
+            crate::snapshot_format::encode_head(&head).expect("encode head"),
+            13,
+            &stale_field_13,
+        );
+        let store = Arc::new(KeyLoggingStore::new(inner));
         store
             .put(
                 &crate::fold::head_object_key(&tenant(), signal),
@@ -9738,45 +9511,41 @@ mod tests {
         let loaded = catalog
             .load_column_stats(&tenant(), signal, range, now_ns, &acc)
             .await
-            .expect("load ok")
-            .expect("stats present");
+            .expect("load ok");
 
+        assert!(
+            loaded.is_none(),
+            "field 13 is retired: no per-part ref anywhere yields no statistics, not a \
+             whole-object fallback: {loaded:?}"
+        );
         assert_eq!(
             acc.snapshot().s3_requests(AccountedOp::Get),
-            2,
-            "HEAD plus the one whole-object v2 GET, never a per-part attempt"
+            1,
+            "HEAD only; the stale field-13 object is never fetched"
         );
-        assert_eq!(
-            loaded.by_content_hash.len(),
-            2,
-            "both parts' statistics loaded from the one whole-object v2 fallback"
-        );
-        assert!(loaded.by_content_hash.contains_key(&content_1));
-        assert!(loaded.by_content_hash.contains_key(&content_2));
+        let v2_gets = store.get_keys().iter().filter(|k| *k == &v2_key).count();
+        assert_eq!(v2_gets, 0, "the field-13 object is never fetched");
     }
 
-    /// The real pre-#1413 shape: a multi-part legacy HEAD carrying only the
-    /// whole-tenant **v1** ref (field 11), no field 13 and no field 7
-    /// anywhere -- the only shape a genuinely pre-#1413 fold could have
-    /// written. This is the counterpart
-    /// [`two_part_head_with_only_field_thirteen_loads_stats_in_two_gets`]
-    /// was mislabeled as: unlike that fixture, field 11 WAS read before this
-    /// branch, so this is the one case where the new per-part loop's
-    /// behavior can be compared directly against the pre-#1413 reader on the
-    /// same bytes. The new per-part loop finds no field-7 ref on either
-    /// part, pushes both to `needs_fallback`, and the single whole-object v1
-    /// GET answers both -- the same one-whole-object-GET shape
-    /// `load_column_stats_charges_exactly_two_accounted_gets` already pins
-    /// for a single part, extended here to two.
+    /// ADR-1413 decision 6 (#1600): a genuinely pre-#1413 HEAD -- carrying
+    /// only the whole-tenant **v1** ref (field 11), no field 13 and no field
+    /// 7 anywhere, the only shape a fold from that era could have written --
+    /// yields NO statistics under the new reader, and the query scans
+    /// instead. `SnapshotColumnStatsRef` (the v1 ref's original message type)
+    /// no longer exists in the generated code at all, so the ref is planted
+    /// with a raw wire append (`append_raw_field`) using
+    /// `SnapshotColumnStatsPartRef`'s identical field shape (key, blake3,
+    /// size, segment_count, part_blake3) -- the wire bytes this produces for
+    /// field 11 are indistinguishable from what the original v1 message type
+    /// would have encoded.
     ///
-    /// Prove-the-test: this pins the same `resolve_part_stats_ref` ->
-    /// `needs_fallback` path as its v2 counterpart, but against field 11
-    /// instead of field 13. Flip `resolve_part_stats_ref` to fabricate a ref
-    /// out of the part's own blake3 instead of reading `part.column_stats`,
-    /// and this test's GET count climbs to 4.
+    /// Prove-the-test: reintroducing a `head.column_stats` (field 11)
+    /// fallback read in the per-part resolution loop makes this fail:
+    /// `loaded` becomes `Some` with both legacy parts' statistics, and the
+    /// v1 object is fetched once instead of never.
     #[tokio::test]
-    async fn multi_part_legacy_v1_only_head_loads_stats_in_two_gets() {
-        let store = Arc::new(MemoryStore::new());
+    async fn head_with_only_field_eleven_yields_no_statistics_and_scans() {
+        let inner = MemoryStore::new();
         let signal = Signal::Logs;
         let signal_num = signal::to_proto(signal) as u32;
         let prefix = signal.key_prefix();
@@ -9855,212 +9624,6 @@ mod tests {
             "t/{}/catalog/{prefix}/cstat/pre-1413.cstat",
             tenant().to_hex()
         );
-        store
-            .put(
-                &v1_key,
-                Bytes::from(v1_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put v1");
-
-        let head = ravel_proto::catalog::v1::SnapshotHead {
-            format_version: crate::snapshot_format::HEAD_FORMAT_VERSION,
-            tenant_hash: tenant().0.to_vec(),
-            signal: signal_num,
-            shard_count: 8,
-            watermark_hour: 19,
-            parts: vec![
-                ravel_proto::catalog::v1::SnapshotPartRef {
-                    key: "unused-1".to_string(),
-                    blake3: part_1_hash.to_vec(),
-                    size: 1,
-                    entry_count: 0,
-                    watermark_hour: 9,
-                    min_hour: 0,
-                    column_stats: None,
-                },
-                ravel_proto::catalog::v1::SnapshotPartRef {
-                    key: "unused-2".to_string(),
-                    blake3: part_2_hash.to_vec(),
-                    size: 1,
-                    entry_count: 0,
-                    watermark_hour: 19,
-                    min_hour: 10,
-                    column_stats: None,
-                },
-            ],
-            folder_id: Uuid::new_v4().into_bytes().to_vec(),
-            created_unix_ns: 0,
-            postings: None,
-            shard_generation_count: 1,
-            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
-                key: v1_key.clone(),
-                blake3: v1_hash.to_vec(),
-                size: v1_bytes.len() as u64,
-                segment_count: 2,
-                part_blake3: vec![part_1_hash.to_vec(), part_2_hash.to_vec()],
-            }),
-            column_stats_part: None,
-        };
-        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
-        store
-            .put(
-                &crate::fold::head_object_key(&tenant(), signal),
-                Bytes::from(head_bytes),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put head");
-
-        let catalog = Catalog::new(store.clone(), config(8)).expect("catalog");
-        let acc = QueryAccounting::new();
-        let (range, now_ns) = full_window();
-
-        let loaded = catalog
-            .load_column_stats(&tenant(), signal, range, now_ns, &acc)
-            .await
-            .expect("load ok")
-            .expect("stats present");
-
-        assert_eq!(
-            acc.snapshot().s3_requests(AccountedOp::Get),
-            2,
-            "HEAD plus the one whole-object v1 GET, never a per-part attempt"
-        );
-        assert_eq!(
-            loaded.segments.len(),
-            2,
-            "both legacy parts' statistics loaded from the one whole-object v1 fallback"
-        );
-    }
-
-    /// ADR-1413 decision 2's fallback order is v3, else v2 (field 13), else
-    /// v1 (field 11). No existing test covers a HEAD carrying BOTH
-    /// whole-object refs at once: this branch is the first reader that can
-    /// answer field 13 at all, so a tenant whose fold wrote both (a fold
-    /// that upgraded mid-tenant-lifetime, writing the new v2 object forward
-    /// while an old v1 object still lingers unreferenced-by-readers) now
-    /// switches from "v1 answers everything" to "v2 answers everything",
-    /// silently, on upgrade. This pins that precedence directly: field 13
-    /// and field 11 disagree on both segments' values, so answering from the
-    /// wrong one is visible in the result, not just in a GET count.
-    ///
-    /// Prove-the-test: this pins the `whole_loaded` short-circuit in
-    /// `load_column_stats` (`if !whole_loaded && let Some(v1) = &head.v1`).
-    /// Deleting the `!whole_loaded &&` guard (always trying v1 too) leaves
-    /// the assertions on VALUES and GET COUNT both intact only by accident
-    /// of `entry().or_insert()` losing the race to v2's already-inserted
-    /// keys -- but the v1 KEY then appears in `store.get_keys()`, which the
-    /// assertion below catches even though the loaded values would not.
-    #[tokio::test]
-    async fn head_with_both_field_thirteen_and_field_eleven_prefers_field_thirteen() {
-        let inner = MemoryStore::new();
-        let signal = Signal::Logs;
-        let signal_num = signal::to_proto(signal) as u32;
-        let prefix = signal.key_prefix();
-
-        let part_1_hash = *blake3::hash(b"both-refs-part-1").as_bytes();
-        let part_2_hash = *blake3::hash(b"both-refs-part-2").as_bytes();
-        let all_parts = vec![part_1_hash.to_vec(), part_2_hash.to_vec()];
-        let content_1 = *blake3::hash(b"both-refs-content-1").as_bytes();
-        let content_2 = *blake3::hash(b"both-refs-content-2").as_bytes();
-
-        fn i64_column(value: i64) -> ravel_proto::catalog::v1::ColumnStat {
-            ravel_proto::catalog::v1::ColumnStat {
-                name: "status".to_string(),
-                declared_type: 2,
-                non_null_count: 1,
-                null_count: 0,
-                min: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(value)),
-                }),
-                max: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(value)),
-                }),
-                dictionary_present: true,
-                dictionary: vec![ravel_proto::catalog::v1::DictEntry {
-                    value: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(value)),
-                    }),
-                    count: 1,
-                }],
-                sum: Some(value),
-            }
-        }
-
-        // field 13 (v2), content-hash-keyed: the values the query MUST see.
-        let v2_segments = vec![
-            ravel_proto::catalog::v1::ColumnStatsSegment {
-                ingest_hour_bucket: 1,
-                shard: 0,
-                writer_id: content_1.to_vec(),
-                writer_epoch: 1,
-                writer_seq: 1,
-                columns: vec![i64_column(100)],
-            },
-            ravel_proto::catalog::v1::ColumnStatsSegment {
-                ingest_hour_bucket: 1,
-                shard: 0,
-                writer_id: content_2.to_vec(),
-                writer_epoch: 1,
-                writer_seq: 1,
-                columns: vec![i64_column(200)],
-            },
-        ];
-        let v2_bytes = crate::snapshot_format::encode_column_stats_v2(
-            tenant().0,
-            signal_num,
-            all_parts.clone(),
-            &v2_segments,
-        )
-        .expect("encode v2");
-        let v2_hash = *blake3::hash(&v2_bytes).as_bytes();
-        let v2_key = format!(
-            "t/{}/catalog/{prefix}/cstat/both-refs-v2.cstat",
-            tenant().to_hex()
-        );
-        inner
-            .put(
-                &v2_key,
-                Bytes::from(v2_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put v2");
-
-        // field 11 (v1), identity-keyed: disagreeing values, so answering
-        // from this instead of v2 is visible in the result.
-        let v1_segments = vec![
-            ravel_proto::catalog::v1::ColumnStatsSegment {
-                ingest_hour_bucket: 1,
-                shard: 0,
-                writer_id: vec![0xAA; 16],
-                writer_epoch: 1,
-                writer_seq: 1,
-                columns: vec![i64_column(900)],
-            },
-            ravel_proto::catalog::v1::ColumnStatsSegment {
-                ingest_hour_bucket: 1,
-                shard: 0,
-                writer_id: vec![0xAA; 16],
-                writer_epoch: 1,
-                writer_seq: 2,
-                columns: vec![i64_column(901)],
-            },
-        ];
-        let v1_bytes = crate::snapshot_format::encode_column_stats(
-            tenant().0,
-            signal_num,
-            all_parts.clone(),
-            &v1_segments,
-        )
-        .expect("encode v1");
-        let v1_hash = *blake3::hash(&v1_bytes).as_bytes();
-        let v1_key = format!(
-            "t/{}/catalog/{prefix}/cstat/both-refs-v1.cstat",
-            tenant().to_hex()
-        );
         inner
             .put(
                 &v1_key,
@@ -10100,32 +9663,29 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
-                key: v1_key.clone(),
-                blake3: v1_hash.to_vec(),
-                size: v1_bytes.len() as u64,
-                segment_count: 2,
-                part_blake3: all_parts.clone(),
-            }),
-            column_stats_part: Some(ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
-                key: v2_key.clone(),
-                blake3: v2_hash.to_vec(),
-                size: v2_bytes.len() as u64,
-                segment_count: 2,
-                part_blake3: all_parts.clone(),
-            }),
         };
-        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
-        inner
-            .put(
-                &crate::fold::head_object_key(&tenant(), signal),
-                Bytes::from(head_bytes),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put head");
-
+        let stale_field_11 = ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
+            key: v1_key.clone(),
+            blake3: v1_hash.to_vec(),
+            size: v1_bytes.len() as u64,
+            segment_count: 2,
+            part_blake3: vec![part_1_hash.to_vec(), part_2_hash.to_vec()],
+        };
+        let head_bytes = append_raw_field(
+            crate::snapshot_format::encode_head(&head).expect("encode head"),
+            11,
+            &stale_field_11,
+        );
         let store = Arc::new(KeyLoggingStore::new(inner));
+        store
+            .put(
+                &crate::fold::head_object_key(&tenant(), signal),
+                Bytes::from(head_bytes),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put head");
+
         let catalog = Catalog::new(store.clone(), config(8)).expect("catalog");
         let acc = QueryAccounting::new();
         let (range, now_ns) = full_window();
@@ -10133,913 +9693,19 @@ mod tests {
         let loaded = catalog
             .load_column_stats(&tenant(), signal, range, now_ns, &acc)
             .await
-            .expect("load ok")
-            .expect("stats present");
-
-        let cstat_gets: Vec<String> = store
-            .get_keys()
-            .into_iter()
-            .filter(|k| k.ends_with(".cstat"))
-            .collect();
-        assert_eq!(
-            cstat_gets,
-            vec![v2_key.clone()],
-            "field 13 (v2) is fetched; field 11 (v1) is never even attempted \
-             once v2 answers every part: {cstat_gets:?}"
-        );
-
-        assert_eq!(
-            acc.snapshot().s3_requests(AccountedOp::Get),
-            2,
-            "HEAD plus the one v2 GET, no v1 GET"
-        );
+            .expect("load ok");
 
         assert!(
-            loaded.segments.is_empty(),
-            "the identity-keyed v1 map must stay empty: v1 was never loaded"
-        );
-        assert_eq!(
-            loaded.by_content_hash.len(),
-            2,
-            "both segments answered from v2"
-        );
-        let seg_1 = loaded
-            .by_content_hash
-            .get(&content_1)
-            .expect("part 1 answered from v2");
-        assert_eq!(
-            column_stats_resolve::unique_column_stat(seg_1, "status")
-                .and_then(|c| c.min.as_ref())
-                .and_then(|v| v.kind.as_ref()),
-            Some(&ravel_proto::catalog::v1::column_value::Kind::I64(100)),
-            "v2's value (100), never v1's disagreeing value (900)"
-        );
-        let seg_2 = loaded
-            .by_content_hash
-            .get(&content_2)
-            .expect("part 2 answered from v2");
-        assert_eq!(
-            column_stats_resolve::unique_column_stat(seg_2, "status")
-                .and_then(|c| c.min.as_ref())
-                .and_then(|v| v.kind.as_ref()),
-            Some(&ravel_proto::catalog::v1::column_value::Kind::I64(200)),
-            "v2's value (200), never v1's disagreeing value (901)"
-        );
-    }
-
-    /// `entry_count` is decoded input and the HEAD validator bounds it
-    /// nowhere, so the declared-entry sum must saturate. A plain `.sum()`
-    /// panics here under the dev and ci profiles, which keep overflow
-    /// checks on, and wraps under release: a wrapped-small total clears the
-    /// fallback set, skips field 11 and drops the covered part's
-    /// statistics, which is the one direction this comparison must never
-    /// fail in. This is the corrupt-input case for a path whose whole
-    /// contract is to degrade rather than error.
-    ///
-    /// FLIP: change the fold to `head.parts.iter().map(|p| p.entry_count)
-    /// .sum()` and this panics in a debug build; in release the v1 key
-    /// disappears from `cstat_gets`.
-    #[tokio::test]
-    async fn an_absurd_declared_entry_count_saturates_rather_than_wrapping() {
-        let inner = MemoryStore::new();
-        let signal = Signal::Logs;
-        let signal_num = signal::to_proto(signal) as u32;
-        let prefix = signal.key_prefix();
-
-        let part_a = *blake3::hash(b"sat-covered-part").as_bytes();
-        let part_b = *blake3::hash(b"sat-absurd-part").as_bytes();
-        let all_parts = vec![part_a.to_vec(), part_b.to_vec()];
-
-        // One record in v2, for the part the query does NOT cover.
-        let v2_segments = vec![ravel_proto::catalog::v1::ColumnStatsSegment {
-            ingest_hour_bucket: 100,
-            shard: 0,
-            writer_id: vec![0xE1; 32],
-            writer_epoch: 1,
-            writer_seq: 1,
-            columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                name: "status".to_string(),
-                declared_type: 2,
-                non_null_count: 1,
-                null_count: 0,
-                min: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(7)),
-                }),
-                max: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(7)),
-                }),
-                dictionary_present: false,
-                dictionary: vec![],
-                sum: Some(7),
-            }],
-        }];
-        let v2_bytes = crate::snapshot_format::encode_column_stats_v2(
-            tenant().0,
-            signal_num,
-            all_parts.clone(),
-            &v2_segments,
-        )
-        .expect("encode v2");
-        let v2_hash = *blake3::hash(&v2_bytes).as_bytes();
-        let v2_key = format!(
-            "t/{}/catalog/{prefix}/cstat/sat-v2.cstat",
-            tenant().to_hex()
-        );
-        inner
-            .put(
-                &v2_key,
-                Bytes::from(v2_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put v2");
-
-        let v1_segments = vec![ravel_proto::catalog::v1::ColumnStatsSegment {
-            ingest_hour_bucket: 0,
-            shard: 0,
-            writer_id: vec![0xE2; 16],
-            writer_epoch: 1,
-            writer_seq: 1,
-            columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                name: "status".to_string(),
-                declared_type: 2,
-                non_null_count: 1,
-                null_count: 0,
-                min: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(4242)),
-                }),
-                max: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(4242)),
-                }),
-                dictionary_present: false,
-                dictionary: vec![],
-                sum: Some(4242),
-            }],
-        }];
-        let v1_bytes = crate::snapshot_format::encode_column_stats(
-            tenant().0,
-            signal_num,
-            all_parts.clone(),
-            &v1_segments,
-        )
-        .expect("encode v1");
-        let v1_hash = *blake3::hash(&v1_bytes).as_bytes();
-        let v1_key = format!(
-            "t/{}/catalog/{prefix}/cstat/sat-v1.cstat",
-            tenant().to_hex()
-        );
-        inner
-            .put(
-                &v1_key,
-                Bytes::from(v1_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put v1");
-
-        // u64::MAX + 2 wraps to 1 without saturation, which would clear the
-        // fallback set on the single record v2 carries.
-        let head = ravel_proto::catalog::v1::SnapshotHead {
-            format_version: crate::snapshot_format::HEAD_FORMAT_VERSION,
-            tenant_hash: tenant().0.to_vec(),
-            signal: signal_num,
-            shard_count: 8,
-            watermark_hour: 100,
-            parts: vec![
-                ravel_proto::catalog::v1::SnapshotPartRef {
-                    key: "sat-a".to_string(),
-                    blake3: part_a.to_vec(),
-                    size: 1,
-                    entry_count: u64::MAX,
-                    watermark_hour: 0,
-                    min_hour: 0,
-                    column_stats: None,
-                },
-                ravel_proto::catalog::v1::SnapshotPartRef {
-                    key: "sat-b".to_string(),
-                    blake3: part_b.to_vec(),
-                    size: 1,
-                    entry_count: 2,
-                    watermark_hour: 100,
-                    min_hour: 100,
-                    column_stats: None,
-                },
-            ],
-            folder_id: Uuid::new_v4().into_bytes().to_vec(),
-            created_unix_ns: 0,
-            postings: None,
-            shard_generation_count: 1,
-            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
-                key: v1_key.clone(),
-                blake3: v1_hash.to_vec(),
-                size: v1_bytes.len() as u64,
-                segment_count: 1,
-                part_blake3: all_parts.clone(),
-            }),
-            column_stats_part: Some(ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
-                key: v2_key.clone(),
-                blake3: v2_hash.to_vec(),
-                size: v2_bytes.len() as u64,
-                segment_count: 1,
-                part_blake3: all_parts.clone(),
-            }),
-        };
-        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
-        inner
-            .put(
-                &crate::fold::head_object_key(&tenant(), signal),
-                Bytes::from(head_bytes),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put head");
-
-        let store = Arc::new(KeyLoggingStore::new(inner));
-        let catalog = Catalog::new(store.clone(), config(8)).expect("catalog");
-        let acc = QueryAccounting::new();
-        let range = TimeRange {
-            start_ns: 0,
-            end_ns: 3_600_000_000_000,
-        };
-        let loaded = catalog
-            .load_column_stats(&tenant(), signal, range, 3_600_000_000_000, &acc)
-            .await
-            .expect("load ok")
-            .expect("stats present");
-
-        let cstat_gets: Vec<String> = store
-            .get_keys()
-            .into_iter()
-            .filter(|k| k.ends_with(".cstat"))
-            .collect();
-        assert_eq!(
-            cstat_gets,
-            vec![v2_key.clone(), v1_key.clone()],
-            "a saturated declared total keeps the gap open, so field 11 is \
-             still read: {cstat_gets:?}"
-        );
-        assert_eq!(
-            loaded.segments.len(),
-            1,
-            "the identity-keyed record field 11 carried for the covered part"
-        );
-    }
-
-    /// The equality case, which is the ONLY one a healthy fold produces:
-    /// every entry covered, nothing omitted, nothing deduped, so decoded
-    /// equals declared exactly. The comparison must be `>=` and not `>`.
-    ///
-    /// Nothing pinned this before. Nineteen of the twenty HEAD fixtures in
-    /// this file declare `entry_count: 0`, so the check was satisfied by
-    /// `n >= 0`; the twentieth, the gap test below, declares 1 and decodes
-    /// 0, where `>` and `>=` agree. So no fixture reached the boundary, and
-    /// weakening it to `>` left all 53 column-statistics tests green while
-    /// making every tenant that falls back pay a second whole-object GET
-    /// forever, undetected.
-    ///
-    /// FLIP: change `decoded_entries >= declared_entries` to `>` and the
-    /// v1 key appears in `cstat_gets`.
-    #[tokio::test]
-    async fn v2_covering_exactly_the_declared_entries_skips_field_eleven() {
-        let inner = MemoryStore::new();
-        let signal = Signal::Logs;
-        let signal_num = signal::to_proto(signal) as u32;
-        let prefix = signal.key_prefix();
-
-        let part_hash = *blake3::hash(b"exact-cover-part").as_bytes();
-        let all_parts = vec![part_hash.to_vec()];
-
-        // One declared entry, one record in v2: the healthy fold's output.
-        let v2_segments = vec![ravel_proto::catalog::v1::ColumnStatsSegment {
-            ingest_hour_bucket: 0,
-            shard: 0,
-            writer_id: vec![0xD1; 32],
-            writer_epoch: 1,
-            writer_seq: 1,
-            columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                name: "status".to_string(),
-                declared_type: 2,
-                non_null_count: 1,
-                null_count: 0,
-                min: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(31)),
-                }),
-                max: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(31)),
-                }),
-                dictionary_present: false,
-                dictionary: vec![],
-                sum: Some(31),
-            }],
-        }];
-        let v2_bytes = crate::snapshot_format::encode_column_stats_v2(
-            tenant().0,
-            signal_num,
-            all_parts.clone(),
-            &v2_segments,
-        )
-        .expect("encode v2");
-        let v2_hash = *blake3::hash(&v2_bytes).as_bytes();
-        let v2_key = format!(
-            "t/{}/catalog/{prefix}/cstat/exact-v2.cstat",
-            tenant().to_hex()
-        );
-        inner
-            .put(
-                &v2_key,
-                Bytes::from(v2_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put v2");
-
-        // Field 11 exists and is deliberately never read: if it were, the
-        // GET assertion below would see it.
-        let v1_bytes = crate::snapshot_format::encode_column_stats(
-            tenant().0,
-            signal_num,
-            all_parts.clone(),
-            &[],
-        )
-        .expect("encode v1");
-        let v1_hash = *blake3::hash(&v1_bytes).as_bytes();
-        let v1_key = format!(
-            "t/{}/catalog/{prefix}/cstat/exact-v1.cstat",
-            tenant().to_hex()
-        );
-        inner
-            .put(
-                &v1_key,
-                Bytes::from(v1_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put v1");
-
-        let head = ravel_proto::catalog::v1::SnapshotHead {
-            format_version: crate::snapshot_format::HEAD_FORMAT_VERSION,
-            tenant_hash: tenant().0.to_vec(),
-            signal: signal_num,
-            shard_count: 8,
-            watermark_hour: 19,
-            parts: vec![ravel_proto::catalog::v1::SnapshotPartRef {
-                key: "exact-part".to_string(),
-                blake3: part_hash.to_vec(),
-                size: 1,
-                entry_count: 1,
-                watermark_hour: 19,
-                min_hour: 0,
-                column_stats: None,
-            }],
-            folder_id: Uuid::new_v4().into_bytes().to_vec(),
-            created_unix_ns: 0,
-            postings: None,
-            shard_generation_count: 1,
-            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
-                key: v1_key.clone(),
-                blake3: v1_hash.to_vec(),
-                size: v1_bytes.len() as u64,
-                segment_count: 0,
-                part_blake3: all_parts.clone(),
-            }),
-            column_stats_part: Some(ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
-                key: v2_key.clone(),
-                blake3: v2_hash.to_vec(),
-                size: v2_bytes.len() as u64,
-                segment_count: 1,
-                part_blake3: all_parts.clone(),
-            }),
-        };
-        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
-        inner
-            .put(
-                &crate::fold::head_object_key(&tenant(), signal),
-                Bytes::from(head_bytes),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put head");
-
-        let store = Arc::new(KeyLoggingStore::new(inner));
-        let catalog = Catalog::new(store.clone(), config(8)).expect("catalog");
-        let acc = QueryAccounting::new();
-        let (range, now_ns) = full_window();
-
-        let loaded = catalog
-            .load_column_stats(&tenant(), signal, range, now_ns, &acc)
-            .await
-            .expect("load ok")
-            .expect("stats present");
-
-        let cstat_gets: Vec<String> = store
-            .get_keys()
-            .into_iter()
-            .filter(|k| k.ends_with(".cstat"))
-            .collect();
-        assert_eq!(
-            cstat_gets,
-            vec![v2_key.clone()],
-            "v2 covered all 1 declared entry, so field 11 must NOT be read: {cstat_gets:?}"
-        );
-        assert_eq!(
-            loaded.by_content_hash.len(),
-            1,
-            "the one content-hash-keyed record v2 carried"
-        );
-    }
-
-    /// The coverage check sums `entry_count` over EVERY part on the HEAD,
-    /// not over the covered subset in `needs_fallback`, and that choice is
-    /// load-bearing rather than incidental. A v2 object is bound to the
-    /// whole part list (`resolve_stats_head` sets `expected_part_blake3`
-    /// from `head.parts`, and `fetch_stats_object` rejects any object whose
-    /// header binding differs), so the only consistent comparison is
-    /// whole-head decoded against whole-head declared.
-    ///
-    /// Summing over `covered` instead is the simplification a later reader
-    /// reaches for, since `needs_fallback` holds only covered parts, and it
-    /// silently reintroduces the bug this fix exists to remove. Here the
-    /// window covers part A alone, whose one segment v2 omitted, while part
-    /// B sits outside the window with all five of its records present in
-    /// v2. Whole-head: 5 >= 6 is false, so v1 is consulted and A gets its
-    /// statistic. Covered-only: 5 >= 1 is true, the fallback set is
-    /// cleared, v1 is skipped, and A is scanned with field 11 holding what
-    /// it needed.
-    ///
-    /// FLIP: change `head.parts.iter()` to `covered.iter()` in
-    /// `load_column_stats`'s declared-entry sum and the v1 GET disappears
-    /// from `cstat_gets`.
-    #[tokio::test]
-    async fn the_coverage_check_sums_every_part_not_just_the_covered_ones() {
-        let inner = MemoryStore::new();
-        let signal = Signal::Logs;
-        let signal_num = signal::to_proto(signal) as u32;
-        let prefix = signal.key_prefix();
-
-        let part_a = *blake3::hash(b"narrow-covered-part").as_bytes();
-        let part_b = *blake3::hash(b"narrow-distant-part").as_bytes();
-        let all_parts = vec![part_a.to_vec(), part_b.to_vec()];
-
-        // v2 carries part B's five records and none of part A's: the
-        // warn-and-omit shape, but with the omission in the part the query
-        // actually covers.
-        let v2_segments = vec![
-            ravel_proto::catalog::v1::ColumnStatsSegment {
-                ingest_hour_bucket: 100,
-                shard: 0,
-                writer_id: vec![0xC0; 32],
-                writer_epoch: 1,
-                writer_seq: 1,
-                columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                    name: "status".to_string(),
-                    declared_type: 2,
-                    non_null_count: 1,
-                    null_count: 0,
-                    min: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(700)),
-                    }),
-                    max: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(700)),
-                    }),
-                    dictionary_present: false,
-                    dictionary: vec![],
-                    sum: Some(700),
-                }],
-            },
-            ravel_proto::catalog::v1::ColumnStatsSegment {
-                ingest_hour_bucket: 100,
-                shard: 0,
-                writer_id: vec![0xC1; 32],
-                writer_epoch: 1,
-                writer_seq: 1,
-                columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                    name: "status".to_string(),
-                    declared_type: 2,
-                    non_null_count: 1,
-                    null_count: 0,
-                    min: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(701)),
-                    }),
-                    max: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(701)),
-                    }),
-                    dictionary_present: false,
-                    dictionary: vec![],
-                    sum: Some(701),
-                }],
-            },
-            ravel_proto::catalog::v1::ColumnStatsSegment {
-                ingest_hour_bucket: 100,
-                shard: 0,
-                writer_id: vec![0xC2; 32],
-                writer_epoch: 1,
-                writer_seq: 1,
-                columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                    name: "status".to_string(),
-                    declared_type: 2,
-                    non_null_count: 1,
-                    null_count: 0,
-                    min: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(702)),
-                    }),
-                    max: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(702)),
-                    }),
-                    dictionary_present: false,
-                    dictionary: vec![],
-                    sum: Some(702),
-                }],
-            },
-            ravel_proto::catalog::v1::ColumnStatsSegment {
-                ingest_hour_bucket: 100,
-                shard: 0,
-                writer_id: vec![0xC3; 32],
-                writer_epoch: 1,
-                writer_seq: 1,
-                columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                    name: "status".to_string(),
-                    declared_type: 2,
-                    non_null_count: 1,
-                    null_count: 0,
-                    min: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(703)),
-                    }),
-                    max: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(703)),
-                    }),
-                    dictionary_present: false,
-                    dictionary: vec![],
-                    sum: Some(703),
-                }],
-            },
-            ravel_proto::catalog::v1::ColumnStatsSegment {
-                ingest_hour_bucket: 100,
-                shard: 0,
-                writer_id: vec![0xC4; 32],
-                writer_epoch: 1,
-                writer_seq: 1,
-                columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                    name: "status".to_string(),
-                    declared_type: 2,
-                    non_null_count: 1,
-                    null_count: 0,
-                    min: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(704)),
-                    }),
-                    max: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(704)),
-                    }),
-                    dictionary_present: false,
-                    dictionary: vec![],
-                    sum: Some(704),
-                }],
-            },
-        ];
-        let v2_bytes = crate::snapshot_format::encode_column_stats_v2(
-            tenant().0,
-            signal_num,
-            all_parts.clone(),
-            &v2_segments,
-        )
-        .expect("encode v2");
-        let v2_hash = *blake3::hash(&v2_bytes).as_bytes();
-        let v2_key = format!(
-            "t/{}/catalog/{prefix}/cstat/narrow-v2.cstat",
-            tenant().to_hex()
-        );
-        inner
-            .put(
-                &v2_key,
-                Bytes::from(v2_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put v2");
-
-        // field 11 holds the record for part A that v2 dropped.
-        let v1_segments = vec![ravel_proto::catalog::v1::ColumnStatsSegment {
-            ingest_hour_bucket: 0,
-            shard: 0,
-            writer_id: vec![0xAA; 16],
-            writer_epoch: 1,
-            writer_seq: 1,
-            columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                name: "status".to_string(),
-                declared_type: 2,
-                non_null_count: 1,
-                null_count: 0,
-                min: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(999)),
-                }),
-                max: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(999)),
-                }),
-                dictionary_present: false,
-                dictionary: vec![],
-                sum: Some(999),
-            }],
-        }];
-        let v1_bytes = crate::snapshot_format::encode_column_stats(
-            tenant().0,
-            signal_num,
-            all_parts.clone(),
-            &v1_segments,
-        )
-        .expect("encode v1");
-        let v1_hash = *blake3::hash(&v1_bytes).as_bytes();
-        let v1_key = format!(
-            "t/{}/catalog/{prefix}/cstat/narrow-v1.cstat",
-            tenant().to_hex()
-        );
-        inner
-            .put(
-                &v1_key,
-                Bytes::from(v1_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put v1");
-
-        let head = ravel_proto::catalog::v1::SnapshotHead {
-            format_version: crate::snapshot_format::HEAD_FORMAT_VERSION,
-            tenant_hash: tenant().0.to_vec(),
-            signal: signal_num,
-            shard_count: 8,
-            watermark_hour: 100,
-            parts: vec![
-                ravel_proto::catalog::v1::SnapshotPartRef {
-                    key: "narrow-a".to_string(),
-                    blake3: part_a.to_vec(),
-                    size: 1,
-                    entry_count: 1,
-                    watermark_hour: 0,
-                    min_hour: 0,
-                    column_stats: None,
-                },
-                ravel_proto::catalog::v1::SnapshotPartRef {
-                    key: "narrow-b".to_string(),
-                    blake3: part_b.to_vec(),
-                    size: 1,
-                    entry_count: 5,
-                    watermark_hour: 100,
-                    min_hour: 100,
-                    column_stats: None,
-                },
-            ],
-            folder_id: Uuid::new_v4().into_bytes().to_vec(),
-            created_unix_ns: 0,
-            postings: None,
-            shard_generation_count: 1,
-            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
-                key: v1_key.clone(),
-                blake3: v1_hash.to_vec(),
-                size: v1_bytes.len() as u64,
-                segment_count: 1,
-                part_blake3: all_parts.clone(),
-            }),
-            column_stats_part: Some(ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
-                key: v2_key.clone(),
-                blake3: v2_hash.to_vec(),
-                size: v2_bytes.len() as u64,
-                segment_count: 5,
-                part_blake3: all_parts.clone(),
-            }),
-        };
-        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
-        inner
-            .put(
-                &crate::fold::head_object_key(&tenant(), signal),
-                Bytes::from(head_bytes),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put head");
-
-        let store = Arc::new(KeyLoggingStore::new(inner));
-        let catalog = Catalog::new(store.clone(), config(8)).expect("catalog");
-        let acc = QueryAccounting::new();
-
-        // Hour 0 only: part A intersects, part B at hour 100 does not.
-        let range = TimeRange {
-            start_ns: 0,
-            end_ns: 3_600_000_000_000,
-        };
-        let loaded = catalog
-            .load_column_stats(&tenant(), signal, range, 3_600_000_000_000, &acc)
-            .await
-            .expect("load ok")
-            .expect("stats present");
-
-        let cstat_gets: Vec<String> = store
-            .get_keys()
-            .into_iter()
-            .filter(|k| k.ends_with(".cstat"))
-            .collect();
-        assert_eq!(
-            cstat_gets,
-            vec![v2_key.clone(), v1_key.clone()],
-            "v2 covers 5 of the head's 6 declared entries, so the gap stands \
-             and field 11 must be read: {cstat_gets:?}"
-        );
-        assert_eq!(
-            loaded.segments.len(),
-            1,
-            "the identity-keyed record field 11 carried for the covered part"
-        );
-    }
-
-    /// A single-part HEAD with no field-7 (v3) ref on its one part, a
-    /// field-13 (v2) object that OMITS that part's segment (the fold's
-    /// per-entry build has its own warn-and-omit path: a segment whose
-    /// build fails is dropped and the fold still publishes), and a
-    /// field-11 (v1) object that carries it. Before the fix, the old code
-    /// set `whole_loaded = true` on ANY `FetchOutcome::Loaded` from v2,
-    /// including an empty one, so v1 was never even attempted and the part
-    /// was left with zero statistics -- a silent full scan, even though
-    /// field 11 had the answer the whole time.
-    ///
-    /// Prove-the-test (the flipped line): `cstat_gets` below pins
-    /// `vec![v2_key.clone(), v1_key.clone()]`. Against the pre-fix
-    /// `whole_loaded` short-circuit this is `vec![v2_key.clone()]` --
-    /// field 11 is never attempted -- and the GET count pinned two lines
-    /// below is 2, not 3. Under the pre-fix code `loaded` doesn't merely
-    /// come back short a segment: `load_column_stats` returns `Ok(None)`
-    /// entirely (both `segments` and `by_content_hash` are empty), so
-    /// `.expect("stats present")` below panics outright and the query
-    /// this fixture represents falls back to a full scan.
-    #[tokio::test]
-    async fn v2_gap_left_by_warn_and_omit_falls_back_to_field_eleven() {
-        let inner = MemoryStore::new();
-        let signal = Signal::Logs;
-        let signal_num = signal::to_proto(signal) as u32;
-        let prefix = signal.key_prefix();
-
-        let part_hash = *blake3::hash(b"gap-part").as_bytes();
-        let all_parts = vec![part_hash.to_vec()];
-
-        // field 13 (v2): a structurally valid object that covers this
-        // part's blake3 in its header binding but carries zero segments --
-        // exactly what the fold's warn-and-omit path produces when this
-        // part's one segment failed to build.
-        let v2_bytes = crate::snapshot_format::encode_column_stats_v2(
-            tenant().0,
-            signal_num,
-            all_parts.clone(),
-            &[],
-        )
-        .expect("encode v2");
-        let v2_hash = *blake3::hash(&v2_bytes).as_bytes();
-        let v2_key = format!(
-            "t/{}/catalog/{prefix}/cstat/gap-v2.cstat",
-            tenant().to_hex()
-        );
-        inner
-            .put(
-                &v2_key,
-                Bytes::from(v2_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put v2");
-
-        // field 11 (v1), identity-keyed: the record v2 dropped.
-        let v1_segments = vec![ravel_proto::catalog::v1::ColumnStatsSegment {
-            ingest_hour_bucket: 1,
-            shard: 0,
-            writer_id: vec![0xBB; 16],
-            writer_epoch: 1,
-            writer_seq: 1,
-            columns: vec![ravel_proto::catalog::v1::ColumnStat {
-                name: "status".to_string(),
-                declared_type: 2,
-                non_null_count: 1,
-                null_count: 0,
-                min: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(555)),
-                }),
-                max: Some(ravel_proto::catalog::v1::ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(555)),
-                }),
-                dictionary_present: true,
-                dictionary: vec![ravel_proto::catalog::v1::DictEntry {
-                    value: Some(ravel_proto::catalog::v1::ColumnValue {
-                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(555)),
-                    }),
-                    count: 1,
-                }],
-                sum: Some(555),
-            }],
-        }];
-        let v1_bytes = crate::snapshot_format::encode_column_stats(
-            tenant().0,
-            signal_num,
-            all_parts.clone(),
-            &v1_segments,
-        )
-        .expect("encode v1");
-        let v1_hash = *blake3::hash(&v1_bytes).as_bytes();
-        let v1_key = format!(
-            "t/{}/catalog/{prefix}/cstat/gap-v1.cstat",
-            tenant().to_hex()
-        );
-        inner
-            .put(
-                &v1_key,
-                Bytes::from(v1_bytes.clone()),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put v1");
-
-        let head = ravel_proto::catalog::v1::SnapshotHead {
-            format_version: crate::snapshot_format::HEAD_FORMAT_VERSION,
-            tenant_hash: tenant().0.to_vec(),
-            signal: signal_num,
-            shard_count: 8,
-            watermark_hour: 19,
-            parts: vec![ravel_proto::catalog::v1::SnapshotPartRef {
-                key: "unused-gap".to_string(),
-                blake3: part_hash.to_vec(),
-                size: 1,
-                entry_count: 1,
-                watermark_hour: 19,
-                min_hour: 0,
-                column_stats: None,
-            }],
-            folder_id: Uuid::new_v4().into_bytes().to_vec(),
-            created_unix_ns: 0,
-            postings: None,
-            shard_generation_count: 1,
-            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
-                key: v1_key.clone(),
-                blake3: v1_hash.to_vec(),
-                size: v1_bytes.len() as u64,
-                segment_count: 1,
-                part_blake3: all_parts.clone(),
-            }),
-            column_stats_part: Some(ravel_proto::catalog::v1::SnapshotColumnStatsPartRef {
-                key: v2_key.clone(),
-                blake3: v2_hash.to_vec(),
-                size: v2_bytes.len() as u64,
-                segment_count: 0,
-                part_blake3: all_parts.clone(),
-            }),
-        };
-        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
-        inner
-            .put(
-                &crate::fold::head_object_key(&tenant(), signal),
-                Bytes::from(head_bytes),
-                PutOptions::default(),
-            )
-            .await
-            .expect("put head");
-
-        let store = Arc::new(KeyLoggingStore::new(inner));
-        let catalog = Catalog::new(store.clone(), config(8)).expect("catalog");
-        let acc = QueryAccounting::new();
-        let (range, now_ns) = full_window();
-
-        let loaded = catalog
-            .load_column_stats(&tenant(), signal, range, now_ns, &acc)
-            .await
-            .expect("load ok")
-            .expect("stats present");
-
-        let cstat_gets: Vec<String> = store
-            .get_keys()
-            .into_iter()
-            .filter(|k| k.ends_with(".cstat"))
-            .collect();
-        assert_eq!(
-            cstat_gets,
-            vec![v2_key.clone(), v1_key.clone()],
-            "v2's empty coverage of a declared, entry-carrying part forces \
-             field 11 to be read too: {cstat_gets:?}"
+            loaded.is_none(),
+            "field 11 is retired: no per-part ref anywhere yields no statistics, not a \
+             whole-object fallback: {loaded:?}"
         );
         assert_eq!(
             acc.snapshot().s3_requests(AccountedOp::Get),
-            3,
-            "HEAD, the v2 GET that comes back empty, and the v1 GET that fills the gap"
-        );
-
-        assert_eq!(
-            loaded.by_content_hash.len(),
-            0,
-            "v2 contributed no content-hash-keyed record for this part"
-        );
-        assert_eq!(
-            loaded.segments.len(),
             1,
-            "exactly the one identity-keyed record field 11 carried, no more"
+            "HEAD only; the stale field-11 object is never fetched"
         );
-        let seg = loaded.segments.values().next().expect("the one v1 segment");
-        assert_eq!(
-            column_stats_resolve::unique_column_stat(seg, "status")
-                .and_then(|c| c.min.as_ref())
-                .and_then(|v| v.kind.as_ref()),
-            Some(&ravel_proto::catalog::v1::column_value::Kind::I64(555)),
-            "the value field 11 carried for the part v2 omitted"
-        );
+        let v1_gets = store.get_keys().iter().filter(|k| *k == &v1_key).count();
+        assert_eq!(v1_gets, 0, "the field-11 object is never fetched");
     }
 }

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -8662,14 +8662,23 @@ mod tests {
     /// the shape a pre-#1600 fold would have produced. Retiring the fallback
     /// ladder means neither is ever read, covered or not.
     ///
-    /// Prove-the-test: this pins `Catalog::load_column_stats`'s per-part loop
-    /// (`for part in &covered`) actually consulting `parts_intersecting`'s
-    /// narrowed set rather than HEAD's full `parts` list. Flip that loop's
-    /// `for part in &covered` to `for part in &head.parts` and the key-set
-    /// assertion below fails: three `.cstat` GETs fire (including the
-    /// excluded part's), not two. Reintroducing a whole-object fallback read
-    /// makes it fail differently: the poisoned field-11/field-13 keys appear
-    /// in `cstat_gets` and the GET count climbs past 3.
+    /// Prove-the-test: the excluded part 'a' carries no field-7 ref at all
+    /// (`column_stats: None`), so neither flipping this loop's `for part in
+    /// &covered` to `for part in &head.parts` nor reintroducing the genuine
+    /// pre-#1600 `needs_fallback` ladder (verified directly against the
+    /// pre-#1600 tree, commit `5d40a50`'s parent) changes this fixture's
+    /// outcome: both covered parts (b, c) already resolve successfully, so no
+    /// fallback of any kind is ever consulted for either, whole-object
+    /// machinery present or not. This test instead pins the fixed
+    /// covered-part key set and GET count against a poisoned HEAD; the
+    /// mutation that DOES break it is `resolve_part_stats_ref`
+    /// (`column_stats_resolve.rs`) fabricating a ref from a part's own
+    /// blake3 when `column_stats` is absent instead of returning `None` --
+    /// verified directly, this leaves the assertions below unaffected too,
+    /// because the fabricated ref would only apply to excluded part 'a'; see
+    /// [`head_with_only_field_thirteen_yields_no_statistics_and_scans`] for
+    /// the fixture where that same mutation (and reintroducing genuine
+    /// pre-#1600 code) both do fail.
     #[tokio::test]
     async fn query_over_k_of_n_parts_issues_exactly_k_per_part_gets_and_no_whole_object_get() {
         let inner = MemoryStore::new();
@@ -9358,10 +9367,16 @@ mod tests {
     /// (`append_raw_field`), the way a HEAD folded before this change would
     /// actually carry one.
     ///
-    /// Prove-the-test: reintroducing a `head.column_stats_part` fallback
-    /// read in the per-part resolution loop makes this fail: `loaded`
-    /// becomes `Some` with both parts' statistics, and the v2 object is
-    /// fetched once instead of never.
+    /// Prove-the-test: verified two ways. (1) Reintroducing the genuine
+    /// pre-#1600 `needs_fallback` ladder and its real `head.v1`/`head.v2`
+    /// fields (the pre-#1600 tree, commit `5d40a50`'s parent, run with this
+    /// exact test body) makes this fail: `loaded` becomes `Some` with both
+    /// parts' statistics, at 2 accounted GETs (HEAD plus the one whole-object
+    /// fallback), not 1. (2) Against CURRENT code, mutating
+    /// `resolve_part_stats_ref` (`column_stats_resolve.rs`) to fabricate a
+    /// ref from a part's own blake3 when `column_stats` is absent, instead of
+    /// returning `None`, also makes this fail: the accounted GET count climbs
+    /// to 3 (HEAD plus one fabricated-ref attempt per part), not 1.
     #[tokio::test]
     async fn head_with_only_field_thirteen_yields_no_statistics_and_scans() {
         let inner = MemoryStore::new();

--- a/crates/ravel-catalog/src/column_stats_build.rs
+++ b/crates/ravel-catalog/src/column_stats_build.rs
@@ -1006,24 +1006,25 @@ mod tests {
     /// query scans it.)
     #[test]
     fn decode_previous_column_stats_mismatched_part_binding_is_graceful() {
-        // A v2 record carries the covered part content hash in writer_id.
+        // A v3 record carries the covered part content hash in writer_id.
         let seg = ColumnStatsSegment {
             ingest_hour_bucket: 1,
             shard: 0,
-            writer_id: vec![0xCC; 32],
+            writer_id: [0x0Au8; 32].to_vec(),
             writer_epoch: 0,
             writer_seq: 0,
             columns: vec![],
         };
         let part_a = [0x0Au8; 32];
         let part_b = [0x0Bu8; 32];
-        let bytes = crate::snapshot_format::encode_column_stats_v2(
+        let bytes = crate::snapshot_format::encode_column_stats_v3(
             TENANT.0,
             3,
-            vec![part_a.to_vec()],
+            part_a,
             std::slice::from_ref(&seg),
+            crate::snapshot_format::DEFAULT_MAX_COLUMN_STATS_BYTES,
         )
-        .expect("v2 encodes");
+        .expect("v3 encodes");
         let limits = crate::snapshot_format::ColumnStatsLimits::default();
 
         // Asked for part B: the binding does not match -> typed graceful error.
@@ -1034,6 +1035,6 @@ mod tests {
         // Asked for the true binding: decodes, record is content-hash keyed.
         let ok = decode_previous_column_stats(&bytes, &[part_a], &limits).expect("binding matches");
         assert_eq!(ok.len(), 1);
-        assert_eq!(ok[0].writer_id, vec![0xCC; 32]);
+        assert_eq!(ok[0].writer_id, part_a.to_vec());
     }
 }

--- a/crates/ravel-catalog/src/column_stats_resolve.rs
+++ b/crates/ravel-catalog/src/column_stats_resolve.rs
@@ -1,41 +1,38 @@
-//! Column-statistics load for the query-time metadata-only path (ADR-0850,
-//! ADR-0942, ADR-1413). Like [`crate::covering_postings::load_covering_postings`]
-//! it fetches HEAD and follows the statistics refs it carries, but it fetches
-//! NO snapshot part body: it needs only each part's blake3 (already carried in
+//! Column-statistics load for the query-time metadata-only path (ADR-1413).
+//! Like [`crate::covering_postings::load_covering_postings`] it fetches HEAD
+//! and follows the statistics refs it carries, but it fetches NO snapshot part
+//! body: it needs only each part's blake3 (already carried in
 //! `SnapshotHead.parts`) to bind an object to this HEAD's part set. Every GET
 //! runs through the caller's accounted, semaphore-bounded funnel (issue #850).
 //!
-//! ADR-1413 splits `.cstat` per snapshot part: a covered part with a
+//! `.cstat` is split per snapshot part (ADR-1413): a covered part with a
 //! `column_stats` ref (field 7, v3) is read as its own small object, keyed by
-//! content hash. A part with no such ref, or whose v3 object fails to load,
-//! falls back to the whole-tenant v2 object (`SnapshotHead.column_stats_part`,
-//! field 13), then the whole-tenant v1 object (`SnapshotHead.column_stats`,
-//! field 11), then the part is simply left uncovered and the query scans it.
-//! This is ADR-0942's reader rule (a version mismatch, a `blake3` mismatch, or
-//! a decode failure subtracts coverage and never errors the query), applied
-//! per part instead of once for the whole tenant.
+//! content hash. A part with no such ref, or whose v3 object fails to load, is
+//! simply left uncovered and the query scans it (ADR-1413 decision 6: the
+//! whole-tenant v1/v2 objects and the fallback ladder that once read them are
+//! retired; the fold no longer publishes them at any size).
 //!
-//! # Two keying schemes, one result
+//! # One keying scheme
 //!
-//! v1 records key by the five-field `EntryIdentity` tuple
-//! (`fold::entry_identity`); v2 and v3 records key by content hash
-//! (`SegmentRef::content_hash` / `SnapshotEntry::content_hash`, ADR-0942),
-//! carried in the same `ColumnStatsSegment.writer_id` slot at 32 bytes instead
-//! of 16. [`LoadedColumnStats`] carries both maps; [`LoadedColumnStats::stat_for`]
-//! checks the content-hash map first (so a part with a per-part v3 or a
-//! whole-tenant v2 hit wins) and falls back to the identity map (v1) so
-//! `ravel-sql` need not know which version answered.
+//! Records key by content hash (`SegmentRef::content_hash` /
+//! `SnapshotEntry::content_hash`, ADR-0942), carried in
+//! `ColumnStatsSegment.writer_id` at 32 bytes. [`LoadedColumnStats`] keeps a
+//! legacy `segments` map keyed by the five-field `EntryIdentity` tuple
+//! (`fold::entry_identity`) for the retired v1 keying scheme; nothing
+//! populates it anymore, so it is always empty, but its removal would ripple
+//! into `ravel-sql`'s consumption of this type and is out of this change's
+//! scope.
 //!
 //! # Degrade-to-`None`, one loud exception
 //!
 //! Column statistics are an OPTIONAL metadata artifact, so every failure short
 //! of an isolation breach degrades: no HEAD yet, no ref at all, any GET error,
 //! a blake3 mismatch, a decode error, or a part-binding mismatch. One of those
-//! degrades is not silent: a DECODE failure on an object HEAD (or a covered
-//! part) actually references means the fold wrote an object the reader cannot
-//! open, so the fetch path surfaces it as [`FetchOutcome::DecodeRefused`]
-//! (rather than folding it into a bare miss) for the caller to log once and
-//! count (issue #1400). The query still scans; only its visibility changes.
+//! degrades is not silent: a DECODE failure on an object a covered part
+//! actually references means the fold wrote an object the reader cannot open,
+//! so the fetch path surfaces it as [`FetchOutcome::DecodeRefused`] (rather
+//! than folding it into a bare miss) for the caller to log once and count
+//! (issue #1400). The query still scans; only its visibility changes.
 //! `decode_column_stats` does not itself check part-binding against a
 //! caller-supplied part list (unlike `decode_postings`); this loader performs
 //! that check itself, exactly as
@@ -65,11 +62,14 @@ use crate::snapshot_format::{
 /// statistics and the query scans it.
 #[derive(Clone, Debug, Default)]
 pub struct LoadedColumnStats {
-    /// v1 records, keyed by the same
-    /// `(ingest_hour_bucket, shard, writer_id, writer_epoch, writer_seq)`
-    /// identity `fold::entry_identity` uses.
+    /// Retired v1 keying scheme
+    /// (`(ingest_hour_bucket, shard, writer_id, writer_epoch, writer_seq)`,
+    /// `fold::entry_identity`). Nothing populates this map anymore (ADR-1413
+    /// decision 6): it is always empty. Kept rather than removed because
+    /// removing it ripples into `ravel-sql`'s consumption of this type,
+    /// outside this change's scope.
     pub segments: HashMap<EntryIdentity, ColumnStatsSegment>,
-    /// v2 and v3 records, keyed by content hash (`SegmentRef::content_hash`,
+    /// v3 per-part records, keyed by content hash (`SegmentRef::content_hash`,
     /// ADR-0942).
     pub by_content_hash: HashMap<[u8; 32], ColumnStatsSegment>,
     /// The covered parts' blake3 hashes this load was assembled for, in
@@ -137,9 +137,9 @@ impl LoadedColumnStats {
         segment_bytes + part_bytes
     }
 
-    /// The exact statistics for a live segment, preferring the content-hash
-    /// keyed record (a per-part v3 object or the whole-tenant v2 object,
-    /// ADR-0942) and falling back to the identity-keyed v1 record. Returns
+    /// The exact statistics for a live segment: the content-hash keyed record
+    /// (a per-part v3 object, ADR-0942), falling back to the retired
+    /// identity-keyed v1 map (always empty since ADR-1413 decision 6). Returns
     /// `None` when neither map carries an entry: the segment has no exact
     /// statistics and the caller must scan it.
     pub fn stat_for(
@@ -153,10 +153,9 @@ impl LoadedColumnStats {
     }
 }
 
-/// A resolved reference to one column-statistics object: its key, content
-/// hash, and the part set it must be bound against. Shared shape for all
-/// three object kinds (v1 field 11, v2 field 13, v3 field 7 on one part) --
-/// only how each is built from HEAD differs.
+/// A resolved reference to one per-part column-statistics object: its key,
+/// content hash, and the part it must be bound against
+/// (`SnapshotPartRef.column_stats`, field 7, always v3).
 #[derive(Clone, Debug)]
 pub(crate) struct ResolvedStatsRef {
     /// Object key of the `.cstat` object.
@@ -164,33 +163,25 @@ pub(crate) struct ResolvedStatsRef {
     /// Content hash of the referenced object, the fetch's blake3 gate and the
     /// cache's primary key.
     pub blake3: [u8; 32],
-    /// The part set this object is bound to: every tenant part for v1/v2, or
-    /// exactly the one covered part for v3. A fetch is valid only against this
-    /// exact part set (ADR-0942's binding check).
+    /// The part set this object is bound to: exactly the one covered part. A
+    /// fetch is valid only against this exact part set (ADR-0942's binding
+    /// check).
     pub expected_part_blake3: Vec<[u8; 32]>,
-    /// The envelope `format_version` (1, 2, or 3) the slot this ref was read
-    /// from promises: field 11 always names a v1 object, field 13 always v2,
-    /// and a part's field 7 always v3. `fetch_stats_object` is shared verbatim
-    /// across all three slots, and `decode_column_stats` only checks the
-    /// envelope byte against the object's OWN header, never against which
-    /// slot the caller read it from -- so without this field, a v1 object
-    /// planted (or left behind by a downgrade) under a v3 ref decodes clean
-    /// and lands in the identity-keyed `segments` map, where
-    /// `LoadedColumnStats::stat_for` then serves it as a global fallback for
-    /// every segment in the query instead of the one part it was bound to.
+    /// The envelope `format_version` a part's field 7 always promises: 3.
+    /// `decode_column_stats` only checks the envelope byte against the
+    /// object's OWN header, never against which slot the caller read it from
+    /// -- so without this field, a stale object of some other version left
+    /// under a v3 ref could decode clean and be served as this part's
+    /// statistics.
     pub expected_version: u32,
 }
 
-/// HEAD's part list plus its two whole-object statistics refs, resolved from
-/// one HEAD GET. The per-part v3 refs live on each `SnapshotPartRef` itself
-/// (`parts[i].column_stats`) and are read directly by the caller via
-/// [`resolve_part_stats_ref`] for whichever parts its query window covers.
+/// HEAD's part list, resolved from one HEAD GET. The per-part v3 refs live on
+/// each `SnapshotPartRef` itself (`parts[i].column_stats`) and are read
+/// directly by the caller via [`resolve_part_stats_ref`] for whichever parts
+/// its query window covers.
 pub(crate) struct ResolvedStatsHead {
     pub parts: Vec<SnapshotPartRef>,
-    /// Whole-tenant v1 object (`SnapshotHead.column_stats`, field 11).
-    pub v1: Option<ResolvedStatsRef>,
-    /// Whole-tenant v2 object (`SnapshotHead.column_stats_part`, field 13).
-    pub v2: Option<ResolvedStatsRef>,
 }
 
 /// Outcome of [`fetch_stats_object`]: an object the reader decoded, or one of
@@ -258,10 +249,9 @@ fn head_key(tenant: &TenantHash, signal: Signal) -> String {
 }
 
 /// Read the current folded snapshot HEAD for `(tenant, signal)` and return its
-/// part list plus both whole-object statistics refs, or `Ok(None)` when no
-/// HEAD exists yet. The first GET of the load: it never fetches a statistics
-/// object itself, so a caller can consult a reuse cache before paying for any
-/// of the per-part or whole-object fetches.
+/// part list, or `Ok(None)` when no HEAD exists yet. The first GET of the
+/// load: it never fetches a statistics object itself, so a caller can consult
+/// a reuse cache before paying for any per-part fetch.
 ///
 /// The HEAD GET is issued through `getter`, so it is credited to the caller's
 /// [`QueryAccounting`](ravel_types::accounting::QueryAccounting) and bounded
@@ -283,43 +273,7 @@ pub(crate) async fn resolve_stats_head(
         source,
     })?;
 
-    // The parts themselves are NOT fetched here: this resolve needs only each
-    // part's blake3 (already carried in HEAD) to bind the whole-object
-    // statistics refs to this HEAD's part set.
-    let mut all_part_blake3: Vec<[u8; 32]> = Vec::with_capacity(head.parts.len());
-    for part_ref in &head.parts {
-        let Ok(part_blake3) = <[u8; 32]>::try_from(part_ref.blake3.as_slice()) else {
-            return Ok(None);
-        };
-        all_part_blake3.push(part_blake3);
-    }
-
-    let v1 = head.column_stats.as_ref().and_then(|stats_ref| {
-        <[u8; 32]>::try_from(stats_ref.blake3.as_slice())
-            .ok()
-            .map(|blake3| ResolvedStatsRef {
-                key: stats_ref.key.clone(),
-                blake3,
-                expected_part_blake3: all_part_blake3.clone(),
-                expected_version: 1,
-            })
-    });
-    let v2 = head.column_stats_part.as_ref().and_then(|stats_ref| {
-        <[u8; 32]>::try_from(stats_ref.blake3.as_slice())
-            .ok()
-            .map(|blake3| ResolvedStatsRef {
-                key: stats_ref.key.clone(),
-                blake3,
-                expected_part_blake3: all_part_blake3.clone(),
-                expected_version: 2,
-            })
-    });
-
-    Ok(Some(ResolvedStatsHead {
-        parts: head.parts,
-        v1,
-        v2,
-    }))
+    Ok(Some(ResolvedStatsHead { parts: head.parts }))
 }
 
 /// The per-part v3 ref carried on `part.column_stats` (field 7), or `None`
@@ -340,14 +294,14 @@ pub(crate) fn resolve_part_stats_ref(part: &SnapshotPartRef) -> Option<ResolvedS
 }
 
 /// GET, blake3-verify, tenant-check, part-bind, and decode the object named by
-/// `resolved`. Every degrade-to-miss case from the [module docs](self) is
-/// enforced here against `resolved`'s content hash and part binding, so the
-/// identical check applies whether `resolved` names a v1, v2, or v3 object.
+/// `resolved` (always a per-part v3 object). Every degrade-to-miss case from
+/// the [module docs](self) is enforced here against `resolved`'s content hash
+/// and part binding.
 ///
-/// A record's `writer_id` selects which map it lands in: 16 bytes is the v1
-/// `EntryIdentity` tuple, 32 bytes is a v2/v3 content hash (ADR-0942's
-/// overloaded slot). Any other length is a malformed record and is dropped,
-/// exactly as before this ADR.
+/// A record's `writer_id` selects which map it lands in: 16 bytes is the
+/// retired v1 `EntryIdentity` tuple (never produced anymore), 32 bytes is a
+/// v3 content hash (ADR-0942's overloaded slot). Any other length is a
+/// malformed record and is dropped.
 pub(crate) async fn fetch_stats_object(
     getter: &impl AccountedRecordGet,
     tenant: &TenantHash,
@@ -373,13 +327,11 @@ pub(crate) async fn fetch_stats_object(
         Err(err) => return Ok(FetchOutcome::DecodeRefused(err)),
     };
 
-    // The slot `resolved` was read from (field 11, 13, or a part's field 7)
-    // promises a specific envelope version; `decode_column_stats` only checks
-    // the envelope byte against the object's OWN header, never against which
-    // slot named it. A mismatch here means the object at `resolved.key` is not
-    // the version this slot is defined to hold (a stale object left behind by
-    // a downgrade, or a future writer bug), so it must not be accepted into
-    // this version's map: degrade like any other stale binding.
+    // A part's field 7 promises a v3 envelope; `decode_column_stats` only
+    // checks the envelope byte against the object's OWN header, never against
+    // which slot named it. A mismatch here means the object at `resolved.key`
+    // is not v3 (a stale object left behind by a downgrade, or a future writer
+    // bug), so it must not be accepted: degrade like any other stale binding.
     if decoded.header.tenant_hash != tenant.0.to_vec() {
         return Err(LoadColumnStatsError::TenantHashMismatch {
             key: resolved.key.clone(),

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -24,8 +24,8 @@ use ravel_object_store::{
     Version, list_all,
 };
 use ravel_proto::catalog::v1::{
-    ColumnStatsSegment, SnapshotColumnStatsPartRef, SnapshotColumnStatsRef, SnapshotEntry,
-    SnapshotHead, SnapshotPartRef, SnapshotPostingsRef,
+    ColumnStatsSegment, SnapshotColumnStatsPartRef, SnapshotEntry, SnapshotHead, SnapshotPartRef,
+    SnapshotPostingsRef,
 };
 use ravel_proto::commit::v1::{CommitRecord, CompactionPart, CompactionRecord, RewriteRecord};
 use ravel_segment::{ExpectedIdentity, ReaderLimits, SegmentError};
@@ -148,27 +148,6 @@ pub struct FoldReport {
     /// Encoded size of the postings object, in bytes. `0` when
     /// `postings_built` is `false`.
     pub postings_bytes: u64,
-    /// `true` if this fold successfully built and attached a column-statistics
-    /// object (ADR-0850). `false` covers "the tenant has no configured typed
-    /// attribute columns" (nothing to build), a no-op fold, and "the build
-    /// failed and the fold proceeded without a column-stats ref" -- exactly
-    /// the same three-way ambiguity `postings_built` already accepts.
-    pub column_stats_built: bool,
-    /// Encoded size of the column-stats object, in bytes. `0` when
-    /// `column_stats_built` is `false`.
-    pub column_stats_bytes: u64,
-    /// `true` if this fold successfully built and attached the part-hash-keyed
-    /// (v2) column-statistics object under `SnapshotHead.column_stats_part`
-    /// (field 13, ADR-0942). Covers L0 and L1 uniformly. `false` carries the
-    /// same three-way ambiguity as [`Self::column_stats_built`]: no configured
-    /// typed columns, a no-op fold, or a build/PUT failure the fold proceeded
-    /// past. Independent of [`Self::column_stats_built`]: during the
-    /// dual-publish window both the v1 (field 11) and v2 (field 13) objects are
-    /// written each fold.
-    pub column_stats_part_built: bool,
-    /// Encoded size of the v2 part-hash-keyed column-stats object, in bytes.
-    /// `0` when `column_stats_part_built` is `false`.
-    pub column_stats_part_bytes: u64,
     /// Number of per-part (v3, ADR-1413) column-statistics objects this fold
     /// built and PUT, one per newly written or rewritten part (never for a
     /// part carried forward by reference: its existing
@@ -269,14 +248,15 @@ impl HeadState {
     }
 }
 
-/// Orders v2 column-statistics records by their join key (the covered part's
-/// content hash, carried in `writer_id`) and collapses repeats.
+/// Orders per-part (v3) column-statistics records by their join key (the
+/// covered part's content hash, carried in `writer_id`) and collapses
+/// repeats.
 ///
-/// `encode_column_stats_v2` rejects a repeated key outright, and the fold
-/// treats that error as "no field 13 this time", so one repeat would strip the
-/// tenant's part-bound statistics on this and every later fold. A repeated key
-/// means two entries cover a byte-identical part, so their records carry the
-/// same statistics and keeping one is exact rather than a narrowing.
+/// `encode_column_stats_v3` rejects a repeated key outright, and the fold
+/// treats that error as "no field 7 ref for this part", so one repeat would
+/// strip the part's statistics. A repeated key means two entries cover a
+/// byte-identical part, so their records carry the same statistics and
+/// keeping one is exact rather than a narrowing.
 fn sort_and_dedup_part_segments(segments: &mut Vec<ColumnStatsSegment>) {
     segments.sort_by(|a, b| a.writer_id.cmp(&b.writer_id));
     segments.dedup_by(|a, b| a.writer_id == b.writer_id);
@@ -1900,409 +1880,6 @@ impl Catalog {
                 None => None,
             };
 
-            // Column statistics (ADR-0850): exact per-object statistics for
-            // the tenant's configured typed logs attribute columns. Unlike
-            // postings, the baseline is joined by identity
-            // (`entry_identity`), not ordinal position: a segment's exact
-            // statistics never change once written, so any L0 entry present
-            // in both the previous fold's column-stats object and this
-            // fold's entry set is reused verbatim with no re-fetch, and only
-            // a genuinely new L0 entry is fetched and scanned. This also
-            // makes the `reconciled`/`rebuilt` ordinal-invalidation concern
-            // that forces postings to restart from scratch moot here: a
-            // selective-erasure rewrite or a compaction excludes its
-            // superseded L0 entries from `entries` entirely (replacing them
-            // with an L1 entry under an unrelated identity,
-            // `classify_bucket`'s supersession handling above), so an erased
-            // entry's identity simply stops appearing in `entries` and its
-            // stale baseline statistics are never carried forward -- not
-            // because this code checks for erasure, but because the entry it
-            // would apply to is no longer in the set being folded.
-            //
-            // This v1 publish is restricted to level-0 entries: an L1 entry's
-            // writer_id/writer_epoch slots are repurposed
-            // (`build_l1_snapshot_entry`) and carry no real writer identity, so
-            // the five-field tuple a v1 record keys by cannot address one. L1
-            // coverage is the v2 (field-13) publish below, which keys by the
-            // covered part's content hash instead.
-            //
-            // A single segment's fetch/decode/tally failure never aborts the
-            // whole column-stats artifact (`column_stats_build`'s module
-            // docs): that segment is simply absent from `column_segments`,
-            // which the query-time reader already treats as "no stats here,
-            // fall back to scanning."
-            //
-            // One tally per covered object serves BOTH publishes (#964): the
-            // two passes cover the same L0 entries, and each fetching and
-            // scanning the object for itself cost two reads per L0 part where
-            // one does. The cache itself is constructed before the retry
-            // loop, so a lost CAS keeps its tallies too.
-            let (column_stats_built, column_stats_size, column_stats_ref) = if typed_attr_columns
-                .is_empty()
-            {
-                (false, 0u64, None)
-            } else {
-                let baseline: HashMap<EntryIdentity, ColumnStatsSegment> = if rebuilt {
-                    HashMap::new()
-                } else if let HeadState::Valid { head, .. } = &head_state
-                    && let Some(stats_ref) = &head.column_stats
-                {
-                    match self.store().get(&stats_ref.key, GetRange::Full).await {
-                        Ok(got) => {
-                            counters.get_requests += 1;
-                            // The previous fold's `.cstat` header is bound to
-                            // the parts THAT fold recorded on this HEAD, not to
-                            // the parts this fold just encoded (`part_hashes`).
-                            // Any incremental fold that appends entries rewrites
-                            // at least the tail part's hash, so binding against
-                            // `part_hashes` would reject the baseline on every
-                            // append and recompute every L0 segment. Bind
-                            // against `head.parts`, exactly as
-                            // `load_previous_postings` does. A malformed part
-                            // blake3 (never for a validated HEAD) yields an
-                            // empty expected set, so the binding check below
-                            // fails and the baseline is dropped -- fail safe.
-                            let expected_part_blake3: Vec<[u8; 32]> = head
-                                .parts
-                                .iter()
-                                .map(|p| <[u8; 32]>::try_from(p.blake3.as_slice()))
-                                .collect::<Result<_, _>>()
-                                .unwrap_or_default();
-                            match column_stats_build::decode_previous_column_stats(
-                                &got.data,
-                                &expected_part_blake3,
-                                &crate::snapshot_format::ColumnStatsLimits::default(),
-                            ) {
-                                Ok(segments) => segments
-                                    .into_iter()
-                                    .map(|segment| {
-                                        let identity: EntryIdentity = (
-                                            segment.ingest_hour_bucket,
-                                            segment.shard,
-                                            segment.writer_id.clone(),
-                                            segment.writer_epoch,
-                                            segment.writer_seq,
-                                        );
-                                        (identity, segment)
-                                    })
-                                    .collect(),
-                                Err(err) => {
-                                    tracing::warn!(
-                                        error = %err,
-                                        tenant = %tenant.to_hex(),
-                                        "previous column-stats object failed to decode or bind to this fold's parts; rebuilding every segment's statistics"
-                                    );
-                                    HashMap::new()
-                                }
-                            }
-                        }
-                        Err(err) => {
-                            tracing::warn!(
-                                error = %err,
-                                tenant = %tenant.to_hex(),
-                                "previous column-stats object GET failed; rebuilding every segment's statistics"
-                            );
-                            HashMap::new()
-                        }
-                    }
-                } else {
-                    HashMap::new()
-                };
-
-                let mut column_segments: Vec<ColumnStatsSegment> = Vec::new();
-                for entry in entries.iter().filter(|e| e.level == 0) {
-                    let identity = entry_identity(entry);
-                    if let Some(existing) = baseline.get(&identity) {
-                        column_segments.push(existing.clone());
-                        continue;
-                    }
-                    match column_stats_cache
-                        .segment_column_stats(self.store(), tenant, signal, entry)
-                        .await
-                    {
-                        Ok((segment, fetch)) => {
-                            if fetch == column_stats_build::StatsFetch::Issued {
-                                counters.get_requests += 1;
-                            }
-                            column_segments.push(segment);
-                        }
-                        Err(err) => {
-                            tracing::warn!(
-                                error = %err,
-                                tenant = %tenant.to_hex(),
-                                ingest_hour_bucket = entry.ingest_hour_bucket,
-                                shard = entry.shard,
-                                "column-stats build failed for one segment; it has no stats entry and queries over it fall back to scanning"
-                            );
-                        }
-                    }
-                }
-                column_segments.sort_by(|a, b| {
-                    (
-                        a.ingest_hour_bucket,
-                        a.shard,
-                        a.writer_id.as_slice(),
-                        a.writer_epoch,
-                        a.writer_seq,
-                    )
-                        .cmp(&(
-                            b.ingest_hour_bucket,
-                            b.shard,
-                            b.writer_id.as_slice(),
-                            b.writer_epoch,
-                            b.writer_seq,
-                        ))
-                });
-
-                match snapshot_format::encode_column_stats(
-                    tenant.0,
-                    signal_num,
-                    part_hashes.iter().map(|h| h.to_vec()).collect(),
-                    &column_segments,
-                ) {
-                    Ok(stats_bytes) => {
-                        let stats_crc = crc32c::crc32c(&stats_bytes);
-                        let stats_hash = blake3::hash(&stats_bytes);
-                        let stats_hash16 = &stats_hash.to_hex()[..16];
-                        let stats_key =
-                            column_stats_object_key(tenant, signal, watermark_hour, stats_hash16);
-                        let size = stats_bytes.len() as u64;
-                        let segment_count = column_segments.len() as u32;
-                        let put_result = self
-                            .store()
-                            .put(
-                                &stats_key,
-                                Bytes::from(stats_bytes),
-                                PutOptions::create_if_absent()
-                                    .with_checksum(UploadChecksum::Crc32c(stats_crc)),
-                            )
-                            .await;
-                        // Counted unconditionally: a real (non-AlreadyExists)
-                        // Err here still means the store received a PUT
-                        // request, and may have durably written the object
-                        // despite the client-visible error (#1598).
-                        counters.put_requests += 1;
-                        match put_result {
-                            Ok(_) | Err(StoreError::AlreadyExists) => (
-                                true,
-                                size,
-                                Some(SnapshotColumnStatsRef {
-                                    key: stats_key,
-                                    blake3: stats_hash.as_bytes().to_vec(),
-                                    size,
-                                    segment_count,
-                                    part_blake3: part_hashes.iter().map(|h| h.to_vec()).collect(),
-                                }),
-                            ),
-                            Err(err) => {
-                                tracing::warn!(
-                                    error = %err,
-                                    tenant = %tenant.to_hex(),
-                                    "column-stats PUT failed, folding without a column-stats ref"
-                                );
-                                (false, 0, None)
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        tracing::warn!(
-                            error = %err,
-                            tenant = %tenant.to_hex(),
-                            "column-stats encode failed, folding without a column-stats ref"
-                        );
-                        (false, 0, None)
-                    }
-                }
-            };
-
-            // ADR-0942 part-hash-keyed column statistics (envelope v2, HEAD
-            // field 13). This is a DUAL PUBLISH, not a replacement: the v1
-            // (field-11) block above still runs and writes its L0-tuple-keyed
-            // object unchanged. This block additionally covers BOTH L0 and L1
-            // entries, binding each record to its covered part's `content_hash`
-            // so two L1 parts of one (shard, hour) bucket -- which collapse to
-            // one nil-writer tuple on the reader side -- get two distinct
-            // records. Retiring field 11 is a separate, floor-citing change
-            // (ADR-0066 decision 1); dropping it here would silently take L0
-            // coverage from any reader predating field 13.
-            //
-            // A v2 record carries its covered part's content hash in the
-            // writer_id slot (the join key; ADR-0942, the record shape is
-            // frozen so no new field is added). The baseline is joined by that
-            // content hash (a segment's exact statistics never change once its
-            // content-addressed object is written), reused from the previous
-            // fold's v2 object, and bound to the previous HEAD's parts exactly
-            // as the v1 baseline is. On the first upgraded fold there is no
-            // field-13 baseline, so every entry is tallied once; thereafter
-            // only genuinely new parts are. An L0 entry the v1 pass above
-            // already tallied costs no second read: both passes go through the
-            // same `column_stats_cache` (#964).
-            let (column_stats_part_built, column_stats_part_size, column_stats_part_ref) =
-                if typed_attr_columns.is_empty() {
-                    (false, 0u64, None)
-                } else {
-                    let v2_baseline: HashMap<Vec<u8>, ColumnStatsSegment> = if rebuilt {
-                        HashMap::new()
-                    } else if let HeadState::Valid { head, .. } = &head_state
-                        && let Some(stats_ref) = &head.column_stats_part
-                    {
-                        match self.store().get(&stats_ref.key, GetRange::Full).await {
-                            Ok(got) => {
-                                counters.get_requests += 1;
-                                let expected_part_blake3: Vec<[u8; 32]> = head
-                                    .parts
-                                    .iter()
-                                    .map(|p| <[u8; 32]>::try_from(p.blake3.as_slice()))
-                                    .collect::<Result<_, _>>()
-                                    .unwrap_or_default();
-                                match column_stats_build::decode_previous_column_stats(
-                                    &got.data,
-                                    &expected_part_blake3,
-                                    &crate::snapshot_format::ColumnStatsLimits::default(),
-                                ) {
-                                    Ok(segments) => segments
-                                        .into_iter()
-                                        // v2 records carry the part content hash
-                                        // in writer_id; key the reuse map by it.
-                                        .map(|segment| (segment.writer_id.clone(), segment))
-                                        .collect(),
-                                    Err(err) => {
-                                        tracing::warn!(
-                                            error = %err,
-                                            tenant = %tenant.to_hex(),
-                                            "previous part-bound column-stats object failed to decode or bind to this fold's parts; rebuilding every segment's statistics"
-                                        );
-                                        HashMap::new()
-                                    }
-                                }
-                            }
-                            Err(err) => {
-                                tracing::warn!(
-                                    error = %err,
-                                    tenant = %tenant.to_hex(),
-                                    "previous part-bound column-stats object GET failed; rebuilding every segment's statistics"
-                                );
-                                HashMap::new()
-                            }
-                        }
-                    } else {
-                        HashMap::new()
-                    };
-
-                    let mut part_segments: Vec<ColumnStatsSegment> = Vec::new();
-                    for entry in entries.iter() {
-                        if let Some(existing) = v2_baseline.get(&entry.content_hash) {
-                            part_segments.push(existing.clone());
-                            continue;
-                        }
-                        match column_stats_cache
-                            .segment_column_stats(self.store(), tenant, signal, entry)
-                            .await
-                        {
-                            Ok((mut segment, fetch)) => {
-                                if fetch == column_stats_build::StatsFetch::Issued {
-                                    counters.get_requests += 1;
-                                }
-                                // The v2 join key: bind the record to its
-                                // covered part's content hash (== the reader's
-                                // `SegmentRef.content_hash`), uniform for L0 and
-                                // L1 and unique per part, carried in writer_id.
-                                // This overwrites the tuple's writer_id, which
-                                // is only informational in a v2 record.
-                                segment.writer_id = entry.content_hash.clone();
-                                part_segments.push(segment);
-                            }
-                            Err(err) => {
-                                tracing::warn!(
-                                    error = %err,
-                                    tenant = %tenant.to_hex(),
-                                    ingest_hour_bucket = entry.ingest_hour_bucket,
-                                    shard = entry.shard,
-                                    level = entry.level,
-                                    "part-bound column-stats build failed for one segment; it has no stats entry and queries over it fall back to scanning"
-                                );
-                            }
-                        }
-                    }
-                    // v2 records sort by their content hash (in writer_id).
-                    // Two entries can carry the same content hash: one bucket
-                    // can hold compaction records with different input sets and
-                    // a rewrite record that all reference a byte-identical
-                    // output part. `encode_column_stats_v2` rejects the whole
-                    // artifact on a repeated key, which would drop field 13 for
-                    // the tenant on this and every later fold, so collapse the
-                    // repeats first. A shared content hash means a byte-identical
-                    // part, so the records are equal and keeping one is exact.
-                    sort_and_dedup_part_segments(&mut part_segments);
-
-                    match snapshot_format::encode_column_stats_v2(
-                        tenant.0,
-                        signal_num,
-                        part_hashes.iter().map(|h| h.to_vec()).collect(),
-                        &part_segments,
-                    ) {
-                        Ok(stats_bytes) => {
-                            let stats_crc = crc32c::crc32c(&stats_bytes);
-                            let stats_hash = blake3::hash(&stats_bytes);
-                            let stats_hash16 = &stats_hash.to_hex()[..16];
-                            let stats_key = column_stats_object_key(
-                                tenant,
-                                signal,
-                                watermark_hour,
-                                stats_hash16,
-                            );
-                            let size = stats_bytes.len() as u64;
-                            let segment_count = part_segments.len() as u32;
-                            let put_result = self
-                                .store()
-                                .put(
-                                    &stats_key,
-                                    Bytes::from(stats_bytes),
-                                    PutOptions::create_if_absent()
-                                        .with_checksum(UploadChecksum::Crc32c(stats_crc)),
-                                )
-                                .await;
-                            // Counted unconditionally: a real (non-AlreadyExists)
-                            // Err here still means the store received a PUT
-                            // request, and may have durably written the object
-                            // despite the client-visible error (#1598).
-                            counters.put_requests += 1;
-                            match put_result {
-                                Ok(_) | Err(StoreError::AlreadyExists) => (
-                                    true,
-                                    size,
-                                    Some(SnapshotColumnStatsPartRef {
-                                        key: stats_key,
-                                        blake3: stats_hash.as_bytes().to_vec(),
-                                        size,
-                                        segment_count,
-                                        part_blake3: part_hashes
-                                            .iter()
-                                            .map(|h| h.to_vec())
-                                            .collect(),
-                                    }),
-                                ),
-                                Err(err) => {
-                                    tracing::warn!(
-                                        error = %err,
-                                        tenant = %tenant.to_hex(),
-                                        "part-bound column-stats PUT failed, folding without a field-13 ref"
-                                    );
-                                    (false, 0, None)
-                                }
-                            }
-                        }
-                        Err(err) => {
-                            tracing::warn!(
-                                error = %err,
-                                tenant = %tenant.to_hex(),
-                                "part-bound column-stats encode failed, folding without a field-13 ref"
-                            );
-                            (false, 0, None)
-                        }
-                    }
-                };
-
             let new_head = SnapshotHead {
                 format_version: HEAD_FORMAT_VERSION,
                 tenant_hash: tenant.0.to_vec(),
@@ -2316,12 +1893,6 @@ impl Catalog {
                 // `validate_head` enforces for a multi-part head.
                 parts: part_refs.clone(),
                 postings: postings_ref,
-                column_stats: column_stats_ref,
-                // ADR-0942 A2: the part-hash-keyed (v2) column-stats object,
-                // covering L0 and L1. Absent (None) when the tenant has no
-                // configured typed columns or the build/PUT failed; a reader
-                // treats absence as fall-back-to-scan, never an error.
-                column_stats_part: column_stats_part_ref,
                 folder_id: folder_id.into_bytes().to_vec(),
                 created_unix_ns: now_ns,
                 shard_generation_count,
@@ -2376,10 +1947,6 @@ impl Catalog {
                         put_requests: counters.put_requests,
                         postings_built,
                         postings_bytes: postings_size,
-                        column_stats_built,
-                        column_stats_bytes: column_stats_size,
-                        column_stats_part_built,
-                        column_stats_part_bytes: column_stats_part_size,
                         column_stats_part_objects_built,
                         column_stats_dictionaries_dropped,
                         layout_drift_count,
@@ -3136,10 +2703,6 @@ fn no_op_report(watermark_hour: Option<u32>, counters: RequestCounters) -> FoldR
         put_requests: counters.put_requests,
         postings_built: false,
         postings_bytes: 0,
-        column_stats_built: false,
-        column_stats_bytes: 0,
-        column_stats_part_built: false,
-        column_stats_part_bytes: 0,
         column_stats_part_objects_built: 0,
         column_stats_dictionaries_dropped: 0,
         layout_drift_count: 0,
@@ -3522,8 +3085,8 @@ mod tests {
             .expect("first fold");
         assert!(first.rebuilt, "first fold rebuilds from the commit layout");
         assert!(
-            first.column_stats_built,
-            "the first fold builds column statistics over both hour-10 segments"
+            first.column_stats_part_objects_built > 0,
+            "the first fold builds per-part column statistics over the hour-10 segments"
         );
 
         // A new segment in a later hour, then an incremental second fold.
@@ -3544,8 +3107,8 @@ mod tests {
             .expect("second fold");
         assert!(!second.rebuilt, "the second fold is incremental");
         assert!(
-            second.column_stats_built,
-            "the second fold rebuilds the artifact"
+            second.column_stats_part_objects_built > 0,
+            "the second fold builds a per-part statistics object for the new part"
         );
 
         // The reuse assertion, by objects read. Segment B is the clean
@@ -3555,54 +3118,29 @@ mod tests {
         //
         // Segment A is read exactly once, by the name-postings pass, which
         // aborts on the first L0 entry because a logs RLOG object is not a
-        // metrics RSEG. None of the three column-stats publishes reads it:
-        // the v1 (tuple-keyed), v2 (content-hash-keyed), and v3
-        // (content-hash-keyed, per part) baselines all cover it.
+        // metrics RSEG. The v3 (content-hash-keyed, per part) baseline
+        // covers it without a second read.
         assert_eq!(
             store.count_gets_of(&key_a),
             1,
-            "only the postings pass reads A; all three publishes reuse its baseline record"
+            "only the postings pass reads A; the v3 publish reuses its baseline record"
         );
         assert_eq!(
             store.count_gets_of(&key_b),
             0,
             "segment B's stats were reused, not recomputed"
         );
-        // Issue #964: the one genuinely new segment is read ONCE for all
-        // three publishes. Against the pre-fix two-fetch code this is 2.
+        // Issue #964: the one genuinely new segment is read ONCE.
         assert_eq!(
             store.count_gets_of(&key_c),
             1,
-            "the new hour-11 segment is fetched once, for all three publishes"
+            "the new hour-11 segment is fetched once"
         );
 
-        // Reuse still produced a complete artifact covering all three segments.
-        //
-        // Coverage is asserted on the map the reader actually fills: since
-        // ADR-1413 the per-part v3 object answers this load and its records
-        // are content-hash keyed, so `segments`, which holds only the
-        // identity-keyed records of a v1 whole-object fallback, stays empty.
-        // The old `segments.len() == 3` was asserting that the fallback had
-        // been taken.
-        //
-        // Emptiness of `segments` is NOT the thing to assert in its place: it
-        // survives the failure that matters. If the per-part path is lost,
-        // the v2 whole-object (field 13) answers instead, which is also
-        // content-hash keyed, so the count is still 3 and `segments` is still
-        // empty. What pins the per-part path is that both whole-object
-        // fallbacks exist here and neither is read.
-        let head_after = read_logs_head(store.as_ref()).await;
-        let v1_key = head_after
-            .column_stats
-            .as_ref()
-            .map(|r| r.key.clone())
-            .expect("the fold dual-publishes a v1 whole-object artifact");
-        let v2_key = head_after
-            .column_stats_part
-            .as_ref()
-            .map(|r| r.key.clone())
-            .expect("the fold dual-publishes a v2 whole-object artifact");
-
+        // Reuse still produced a complete artifact covering all three
+        // segments. Since ADR-1413 the per-part v3 object answers this load
+        // and its records are content-hash keyed, so they land in
+        // `by_content_hash`, not the always-empty `segments` map.
         store.clear_gets();
         let acc = QueryAccounting::new();
         let loaded = catalog
@@ -3623,16 +3161,6 @@ mod tests {
             loaded.by_content_hash.len(),
             3,
             "the reused baseline plus the new segment cover all three"
-        );
-        assert_eq!(
-            store.count_gets_of(&v1_key),
-            0,
-            "the v1 whole-object artifact exists and must not be read: the per-part object answers"
-        );
-        assert_eq!(
-            store.count_gets_of(&v2_key),
-            0,
-            "the v2 whole-object artifact exists and must not be read: the per-part object answers"
         );
     }
 
@@ -4175,13 +3703,13 @@ mod tests {
         assert_eq!(col.sum, Some(sum));
     }
 
-    /// ADR-0942 (deliverables 1 & 3): a fold over an L1-COMPACTED fixture builds
-    /// part-bound (v2, field 13) records for the L1 entries, with EXACT expected
-    /// values, and two L1 parts of one (shard, hour) bucket -- the collision the
-    /// old five-field tuple key could not represent, because a reconstructed L1
-    /// SegmentRef carries writer_id nil / epoch 0 / seq 0 -- produce two DISTINCT
-    /// records keyed by their distinct content hashes, neither overwriting the
-    /// other.
+    /// ADR-1413: a fold over an L1-COMPACTED fixture builds the per-part (v3,
+    /// field 7) object over the L1 entries, with EXACT expected values, and
+    /// two L1 parts of one (shard, hour) bucket -- the collision the old
+    /// five-field tuple key could not represent, because a reconstructed L1
+    /// SegmentRef carries writer_id nil / epoch 0 / seq 0 -- produce two
+    /// DISTINCT records keyed by their distinct content hashes within that
+    /// one part's object, neither overwriting the other.
     #[tokio::test]
     async fn l1_compacted_fold_builds_part_bound_records_with_exact_values() {
         let store = Arc::new(MemoryStore::new());
@@ -4211,9 +3739,9 @@ mod tests {
             .expect("fold");
         assert!(report.rebuilt, "first fold rebuilds from the commit layout");
         assert_eq!(report.entry_count, 2, "two L1 parts folded");
-        assert!(
-            report.column_stats_part_built,
-            "the part-bound (field 13) object is built over the L1 entries"
+        assert_eq!(
+            report.column_stats_part_objects_built, 1,
+            "both L1 entries seal into one output part, so one v3 object is built"
         );
 
         let head = read_logs_head(store.as_ref()).await;
@@ -4221,23 +3749,28 @@ mod tests {
         let entries = collect_head_entries(store.as_ref(), &head).await;
         assert_eq!(entries.len(), 2);
         assert!(entries.iter().all(|e| e.level == 1), "genuinely L1 fixture");
+        assert_eq!(
+            head.parts.len(),
+            1,
+            "one output part covers both L1 entries"
+        );
 
-        let stats_ref = head
-            .column_stats_part
+        let stats_ref = head.parts[0]
+            .column_stats
             .clone()
-            .expect("field 13 present after folding L1 parts");
+            .expect("field 7 present after folding L1 parts");
         let got = store
             .get(&stats_ref.key, GetRange::Full)
             .await
-            .expect("v2 object present");
+            .expect("v3 object present");
         let decoded = snapshot_format::decode_column_stats(
             &got.data,
             &crate::snapshot_format::ColumnStatsLimits::default(),
         )
-        .expect("v2 decodes");
+        .expect("v3 decodes");
         assert_eq!(
-            decoded.header.format_version, 2,
-            "part-bound object is envelope v2"
+            decoded.header.format_version, 3,
+            "per-part object is envelope v3"
         );
         assert_eq!(
             decoded.segments.len(),
@@ -4278,14 +3811,14 @@ mod tests {
         out
     }
 
-    /// ADR-1413 (deliverables 1, 3, 4): a fold whose entry count crosses
+    /// ADR-1413 decision 6 (#1600): a fold whose entry count crosses
     /// `snapshot_part_max_entries` produces a multi-part HEAD, and EACH newly
     /// written part gets its OWN v3 (field 7) column-statistics object, not
-    /// one shared whole-tenant object. The pre-existing v1 (field 11) and v2
-    /// (field 13) whole-tenant objects are unaffected: this is a
-    /// dual-publish addition, not a replacement.
+    /// one shared whole-tenant object -- and no whole-tenant v1/v2 object is
+    /// published at all: the store holds EXACTLY one `.cstat` object per
+    /// part, never a whole-tenant one, at any size.
     #[tokio::test]
-    async fn fold_publishes_a_v3_object_per_part_and_keeps_field_13() {
+    async fn fold_over_two_parts_writes_exactly_two_cstat_objects_and_no_whole_object() {
         let store = Arc::new(MemoryStore::new());
         set_status_column_config(store.as_ref()).await;
 
@@ -4320,16 +3853,20 @@ mod tests {
             report.column_stats_part_objects_built, 2,
             "one v3 object per newly written part"
         );
-        assert!(
-            report.column_stats_part_built,
-            "field 13 (v2 whole-tenant) is still built alongside the per-part objects"
-        );
 
         let head = read_logs_head(store.as_ref()).await;
         assert_eq!(head.parts.len(), 2);
         assert!(
-            head.column_stats_part.is_some(),
-            "field 13 present: dual-publish, not a replacement"
+            head.parts.iter().all(|p| p.column_stats.is_some()),
+            "field 7 set on both parts"
+        );
+
+        let all_keys = list_all_keys(store.as_ref(), "").await;
+        let cstat_keys: Vec<&String> = all_keys.iter().filter(|k| k.ends_with(".cstat")).collect();
+        assert_eq!(
+            cstat_keys.len(),
+            2,
+            "exactly two .cstat objects in the store, one per part: {cstat_keys:?}"
         );
 
         for part in &head.parts {
@@ -5005,421 +4542,6 @@ mod tests {
             &segments,
         )
         .expect("encodes once the repeat is collapsed");
-    }
-
-    /// ADR-0942 (deliverable 2): the fold DUAL-PUBLISHES. After a fold over an
-    /// L0 fixture, HEAD carries both the v1 field-11 object and the v2 field-13
-    /// object, and the field-11 object is byte-for-byte identical to what the
-    /// pre-change fold wrote for the same input (reconstructed here from the
-    /// canonical v1 encoder over the same L0 segment stats).
-    #[tokio::test]
-    async fn fold_dual_publishes_v1_and_v2_and_v1_object_is_byte_identical() {
-        let store = Arc::new(MemoryStore::new());
-        set_status_column_config(store.as_ref()).await;
-
-        publish_logs_segment(store.as_ref(), 1, 10, &[200, 404, 200]).await;
-        publish_logs_segment(store.as_ref(), 2, 10, &[500, 200]).await;
-
-        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
-        let report = catalog
-            .fold(
-                &tenant(),
-                Signal::Logs,
-                Uuid::new_v4(),
-                now_at_seal(10),
-                &[],
-                None,
-            )
-            .await
-            .expect("fold");
-        assert!(report.column_stats_built, "field 11 (v1) built");
-        assert!(report.column_stats_part_built, "field 13 (v2) built");
-
-        let head = read_logs_head(store.as_ref()).await;
-        let v1_ref = head.column_stats.clone().expect("field 11 present");
-        let v2_ref = head.column_stats_part.clone().expect("field 13 present");
-        assert_ne!(v1_ref.key, v2_ref.key, "v1 and v2 are distinct objects");
-
-        // Reconstruct the canonical v1 object over the same L0 segment stats and
-        // the same part set, exactly as the pre-change fold did.
-        let entries = collect_head_entries(store.as_ref(), &head).await;
-        let typed = vec![crate::tenant_config::DeclaredTypedColumn {
-            key: "status".to_string(),
-            ty: crate::tenant_config::DeclaredColumnType::I64,
-        }];
-        let mut l0: Vec<ColumnStatsSegment> = Vec::new();
-        for entry in entries.iter().filter(|e| e.level == 0) {
-            let seg = column_stats_build::fetch_segment_column_stats(
-                store.as_ref(),
-                &tenant(),
-                Signal::Logs,
-                entry,
-                &typed,
-            )
-            .await
-            .expect("l0 stats");
-            l0.push(seg);
-        }
-        l0.sort_by(|a, b| {
-            (
-                a.ingest_hour_bucket,
-                a.shard,
-                a.writer_id.as_slice(),
-                a.writer_epoch,
-                a.writer_seq,
-            )
-                .cmp(&(
-                    b.ingest_hour_bucket,
-                    b.shard,
-                    b.writer_id.as_slice(),
-                    b.writer_epoch,
-                    b.writer_seq,
-                ))
-        });
-        let part_blake3: Vec<Vec<u8>> = head.parts.iter().map(|p| p.blake3.clone()).collect();
-        let signal_num = signal::to_proto(Signal::Logs) as u32;
-        let expected_v1 =
-            snapshot_format::encode_column_stats(tenant().0, signal_num, part_blake3, &l0)
-                .expect("canonical v1 encodes");
-
-        let got_v1 = store
-            .get(&v1_ref.key, GetRange::Full)
-            .await
-            .expect("v1 object present")
-            .data;
-        assert_eq!(
-            got_v1.as_ref(),
-            expected_v1.as_slice(),
-            "field-11 v1 object is byte-identical to the canonical v1 encode"
-        );
-        assert_eq!(got_v1[4], 1, "field-11 object is envelope v1");
-
-        // The two objects differ only in keying: v1 records key by the tuple
-        // with a 16-byte writer_id uuid; v2 records key by the 32-byte part
-        // content hash carried in writer_id.
-        let limits = crate::snapshot_format::ColumnStatsLimits::default();
-        let dec_v1 = snapshot_format::decode_column_stats(&got_v1, &limits).expect("v1 decodes");
-        assert!(
-            dec_v1.segments.iter().all(|s| s.writer_id.len() == 16),
-            "v1 records carry the 16-byte writer uuid"
-        );
-        let got_v2 = store
-            .get(&v2_ref.key, GetRange::Full)
-            .await
-            .expect("v2 object present")
-            .data;
-        assert_eq!(got_v2[4], 2, "field-13 object is envelope v2");
-        let dec_v2 = snapshot_format::decode_column_stats(&got_v2, &limits).expect("v2 decodes");
-        assert_eq!(dec_v2.segments.len(), 2, "v2 covers both L0 segments");
-        assert!(
-            dec_v2.segments.iter().all(|s| s.writer_id.len() == 32),
-            "every v2 record is keyed by a 32-byte part content hash"
-        );
-        // Each v2 record's key is exactly the L0 entry's content hash.
-        let entry_hashes: std::collections::HashSet<Vec<u8>> = entries
-            .iter()
-            .filter(|e| e.level == 0)
-            .map(|e| e.content_hash.clone())
-            .collect();
-        assert!(
-            dec_v2
-                .segments
-                .iter()
-                .all(|s| entry_hashes.contains(&s.writer_id)),
-            "v2 keys are the covered L0 parts' content hashes"
-        );
-    }
-
-    /// The pre-#964 two-fetch dual publish, kept as the reference the
-    /// production single-fetch path is compared against: builds the v1
-    /// (field 11) and v2 (field 13) objects over a folded HEAD exactly as the
-    /// two independent passes did, each pass fetching every entry it covers on
-    /// its own. `fetch_segment_column_stats` is the per-entry, per-pass fetch
-    /// those passes called.
-    async fn reference_dual_publish_bytes(
-        store: &dyn ObjectStoreBackend,
-        head: &SnapshotHead,
-    ) -> (Vec<u8>, Vec<u8>) {
-        let entries = collect_head_entries(store, head).await;
-        let typed = vec![crate::tenant_config::DeclaredTypedColumn {
-            key: "status".to_string(),
-            ty: crate::tenant_config::DeclaredColumnType::I64,
-        }];
-        let part_blake3: Vec<Vec<u8>> = head.parts.iter().map(|p| p.blake3.clone()).collect();
-        let signal_num = signal::to_proto(Signal::Logs) as u32;
-
-        // v1 pass: L0 entries only, tuple-keyed, its own fetch per entry.
-        let mut l0: Vec<ColumnStatsSegment> = Vec::new();
-        for entry in entries.iter().filter(|e| e.level == 0) {
-            l0.push(
-                column_stats_build::fetch_segment_column_stats(
-                    store,
-                    &tenant(),
-                    Signal::Logs,
-                    entry,
-                    &typed,
-                )
-                .await
-                .expect("v1 pass stats"),
-            );
-        }
-        l0.sort_by(|a, b| {
-            (
-                a.ingest_hour_bucket,
-                a.shard,
-                a.writer_id.as_slice(),
-                a.writer_epoch,
-                a.writer_seq,
-            )
-                .cmp(&(
-                    b.ingest_hour_bucket,
-                    b.shard,
-                    b.writer_id.as_slice(),
-                    b.writer_epoch,
-                    b.writer_seq,
-                ))
-        });
-        let v1 =
-            snapshot_format::encode_column_stats(tenant().0, signal_num, part_blake3.clone(), &l0)
-                .expect("reference v1 encodes");
-
-        // v2 pass: every entry, a SECOND fetch for each L0 one, writer_id
-        // overwritten with the covered part's content hash, sorted and deduped.
-        let mut part_segments: Vec<ColumnStatsSegment> = Vec::new();
-        for entry in entries.iter() {
-            let mut seg = column_stats_build::fetch_segment_column_stats(
-                store,
-                &tenant(),
-                Signal::Logs,
-                entry,
-                &typed,
-            )
-            .await
-            .expect("v2 pass stats");
-            seg.writer_id = entry.content_hash.clone();
-            part_segments.push(seg);
-        }
-        sort_and_dedup_part_segments(&mut part_segments);
-        let v2 = snapshot_format::encode_column_stats_v2(
-            tenant().0,
-            signal_num,
-            part_blake3,
-            &part_segments,
-        )
-        .expect("reference v2 encodes");
-
-        (v1, v2)
-    }
-
-    /// Fold `store` at `seal_hour` and assert both published column-stats
-    /// objects are byte-identical to [`reference_dual_publish_bytes`], with the
-    /// record counts the fixture implies (so neither side can be vacuously
-    /// empty).
-    async fn assert_dual_publish_matches_reference(
-        store: &Arc<MemoryStore>,
-        seal_hour: u32,
-        l0_records: usize,
-        all_records: usize,
-        label: &str,
-    ) {
-        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
-        let report = catalog
-            .fold(
-                &tenant(),
-                Signal::Logs,
-                Uuid::new_v4(),
-                now_at_seal(seal_hour),
-                &[],
-                None,
-            )
-            .await
-            .expect("fold");
-        assert_eq!(
-            report.entry_count as usize, all_records,
-            "{label}: fixture entry count"
-        );
-        assert!(report.column_stats_built, "{label}: field 11 built");
-        assert!(report.column_stats_part_built, "{label}: field 13 built");
-
-        let head = read_logs_head(store.as_ref()).await;
-        let (want_v1, want_v2) = reference_dual_publish_bytes(store.as_ref(), &head).await;
-        let limits = crate::snapshot_format::ColumnStatsLimits::default();
-        assert_eq!(
-            snapshot_format::decode_column_stats(&want_v1, &limits)
-                .expect("reference v1 decodes")
-                .segments
-                .len(),
-            l0_records,
-            "{label}: reference v1 covers every L0 entry"
-        );
-        assert_eq!(
-            snapshot_format::decode_column_stats(&want_v2, &limits)
-                .expect("reference v2 decodes")
-                .segments
-                .len(),
-            all_records,
-            "{label}: reference v2 covers every entry"
-        );
-
-        let v1_key = head
-            .column_stats
-            .as_ref()
-            .expect("field 11 ref")
-            .key
-            .clone();
-        let v2_key = head
-            .column_stats_part
-            .as_ref()
-            .expect("field 13 ref")
-            .key
-            .clone();
-        let got_v1 = store
-            .get(&v1_key, GetRange::Full)
-            .await
-            .expect("v1 object present")
-            .data;
-        let got_v2 = store
-            .get(&v2_key, GetRange::Full)
-            .await
-            .expect("v2 object present")
-            .data;
-        assert_eq!(
-            got_v1.as_ref(),
-            want_v1.as_slice(),
-            "{label}: field-11 object bytes"
-        );
-        assert_eq!(
-            got_v2.as_ref(),
-            want_v2.as_slice(),
-            "{label}: field-13 object bytes"
-        );
-    }
-
-    /// Issue #964: folding each covered object ONCE for both publishes is a
-    /// request-count change, never a content change. Both published objects
-    /// stay byte-identical to what the two independent per-pass fetches
-    /// produced, over an L0-only, an L1-only, and a mixed fold.
-    ///
-    /// FLIP (demonstrated): tallying with the wrong declared columns --
-    /// `SegmentColumnStatsCache::segment_column_stats` passing
-    /// `&self.typed_columns[..0]` instead of `self.typed_columns` -- keeps both
-    /// objects publishable but empties every record's `columns`, and the
-    /// "L0 only: field-11 object bytes" `assert_eq!` fails on 93 bytes against
-    /// 178. Mis-keying a record is caught one assertion earlier: dropping
-    /// `segment.writer_id = entry.content_hash.clone()` from the v2 publish, or
-    /// applying it to the v1 record, makes that publish's encoder reject the
-    /// artifact and the `column_stats_part_built` / `column_stats_built`
-    /// assertion fails.
-    #[tokio::test]
-    async fn dual_publish_objects_are_byte_identical_to_the_two_fetch_reference() {
-        // L0 only.
-        let store = Arc::new(MemoryStore::new());
-        set_status_column_config(store.as_ref()).await;
-        publish_logs_segment(store.as_ref(), 1, 10, &[200, 404, 200]).await;
-        publish_logs_segment(store.as_ref(), 2, 10, &[500, 200]).await;
-        assert_dual_publish_matches_reference(&store, 10, 2, 2, "L0 only").await;
-
-        // L1 only: no L0 entry at all, so the v1 object covers nothing while
-        // the v2 object covers both parts.
-        let store = Arc::new(MemoryStore::new());
-        set_status_column_config(store.as_ref()).await;
-        publish_logs_l1(
-            store.as_ref(),
-            0,
-            10,
-            "input-set-seed",
-            &[&[200, 404, 200, 500], &[500, 500, 200]],
-        )
-        .await;
-        assert_dual_publish_matches_reference(&store, 10, 0, 2, "L1 only").await;
-
-        // Mixed: two L0 entries in hour 10, two L1 parts in hour 11. The
-        // compaction is in a different bucket, so it supersedes neither L0
-        // entry and the fold covers all four parts.
-        let store = Arc::new(MemoryStore::new());
-        set_status_column_config(store.as_ref()).await;
-        publish_logs_segment(store.as_ref(), 1, 10, &[200, 404, 200]).await;
-        publish_logs_segment(store.as_ref(), 2, 10, &[500, 200]).await;
-        publish_logs_l1(
-            store.as_ref(),
-            0,
-            11,
-            "input-set-seed",
-            &[&[200, 404], &[500]],
-        )
-        .await;
-        assert_dual_publish_matches_reference(&store, 11, 2, 4, "mixed L0 and L1").await;
-    }
-
-    /// Issue #964: a dual-publishing fold reads each covered object EXACTLY
-    /// ONCE. The v1 (field 11) pass covers the L0 entries and the v2 (field 13)
-    /// pass covers the same L0 entries plus the L1 ones, and each pass used to
-    /// fetch and scan the object itself, so every L0 part cost two GETs.
-    ///
-    /// Counted per object key on a RecordingStore over a no-baseline (rebuild)
-    /// fold of n = 2 L0 entries and m = 2 L1 parts: 4 stats reads, plus the one
-    /// GET the name-postings pass spends before it aborts on the first entry (a
-    /// logs RLOG object is not a metrics RSEG), for 5 in total.
-    ///
-    /// FLIP (pre-fix figures): with each pass fetching for itself the total is
-    /// 2n + m + 1 = 7, with segment A read 3 times and segment B twice.
-    #[tokio::test]
-    async fn dual_publish_reads_each_covered_object_once() {
-        let store = Arc::new(RecordingStore::new());
-        set_status_column_config(store.as_ref()).await;
-
-        let rec_a = publish_logs_segment(store.as_ref(), 1, 10, &[200, 404, 200]).await;
-        let rec_b = publish_logs_segment(store.as_ref(), 2, 10, &[500, 200]).await;
-        let l1 = publish_logs_l1(
-            store.as_ref(),
-            0,
-            11,
-            "input-set-seed",
-            &[&[200, 404], &[500]],
-        )
-        .await;
-        let key_a = keys::reconstruct_data_key(&rec_a).expect("key a");
-        let key_b = keys::reconstruct_data_key(&rec_b).expect("key b");
-        let key_p0 = keys::reconstruct_l1_part_key(&l1, &l1.parts[0]).expect("key p0");
-        let key_p1 = keys::reconstruct_l1_part_key(&l1, &l1.parts[1]).expect("key p1");
-
-        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
-        store.clear_gets();
-        let report = catalog
-            .fold(
-                &tenant(),
-                Signal::Logs,
-                Uuid::new_v4(),
-                now_at_seal(11),
-                &[],
-                None,
-            )
-            .await
-            .expect("fold");
-        assert!(report.rebuilt, "first fold rebuilds from the commit layout");
-        assert_eq!(report.entry_count, 4, "two L0 entries and two L1 parts");
-        assert!(report.column_stats_built, "field 11 built");
-        assert!(report.column_stats_part_built, "field 13 built");
-
-        // Segment A is the first entry in fold order, so it also carries the
-        // name-postings pass's single GET before that pass aborts.
-        let counts = [
-            store.count_gets_of(&key_a),
-            store.count_gets_of(&key_b),
-            store.count_gets_of(&key_p0),
-            store.count_gets_of(&key_p1),
-        ];
-        assert_eq!(
-            counts,
-            [2, 1, 1, 1],
-            "one column-stats read per part (A also carries the postings read); \
-             the two-fetch path reads [3, 2, 1, 1]"
-        );
-        assert_eq!(
-            counts.iter().sum::<usize>(),
-            5,
-            "n + m stats reads plus the one postings read (the two-fetch path: 2n + m + 1 = 7)"
-        );
     }
 
     #[test]

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -89,8 +89,7 @@ pub use snapshot_format::{
     DecodedColumnStats, DecodedPart, DecodedPostings, HEAD_FORMAT_VERSION, MAGIC, NamePostings,
     PartLimits, PostingsLimits, SnapshotFormatError, VERSION, column_stats_segments_concat,
     decode_column_stats, decode_column_stats_header, decode_head, decode_part, decode_postings,
-    encode_column_stats, encode_column_stats_v3, encode_head, encode_part, encode_postings,
-    validate_min_max_presence,
+    encode_column_stats_v3, encode_head, encode_part, encode_postings, validate_min_max_presence,
 };
 pub use tenant_config::{
     DeclaredColumnType, DeclaredTypedColumn, FIXED_LOGS_SQL_COLUMNS,

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -89,7 +89,8 @@ pub use snapshot_format::{
     DecodedColumnStats, DecodedPart, DecodedPostings, HEAD_FORMAT_VERSION, MAGIC, NamePostings,
     PartLimits, PostingsLimits, SnapshotFormatError, VERSION, column_stats_segments_concat,
     decode_column_stats, decode_column_stats_header, decode_head, decode_part, decode_postings,
-    encode_column_stats, encode_head, encode_part, encode_postings, validate_min_max_presence,
+    encode_column_stats, encode_column_stats_v3, encode_head, encode_part, encode_postings,
+    validate_min_max_presence,
 };
 pub use tenant_config::{
     DeclaredColumnType, DeclaredTypedColumn, FIXED_LOGS_SQL_COLUMNS,

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -3,8 +3,10 @@
 //!
 //! ```text
 //! magic           "RCST" (4 bytes)
-//! version         u8 = 1 (ADR-0850, L0-tuple keyed), 2 (ADR-0942, part-keyed)
-//!                      or 3 (ADR-1413, per-part, content-hash keyed)
+//! version         u8 = 3 (ADR-1413, per-part, content-hash keyed), the only
+//!                      accepted read version. 1 (ADR-0850, L0-tuple keyed)
+//!                      and 2 (ADR-0942, part-keyed) are retired: an object
+//!                      carrying either is rejected, never decoded.
 //! reserved        u8[3] = 0
 //! header_len      u32 LE
 //! header          protobuf ravel.catalog.v1.ColumnStatsHeader
@@ -19,19 +21,24 @@
 //! header_crc32c   u32 LE          over magic..header inclusive
 //! ```
 //!
-//! Three envelope versions coexist during the ADR-1413 dual-publish window
-//! (which itself extends the ADR-0942 dual-publish window). The
-//! `ColumnStatsSegment` record shape is frozen and shared; the key model is the
-//! version's. v1 keys each record by the five-field identity tuple (writer_id is
-//! the 16-byte flush-writer uuid) and covers L0 only. v2 keys by the covered
-//! part's content hash, which the writer carries in the `writer_id` slot as 32
-//! bytes (the same slot an L1 `SnapshotEntry` already repurposes for a 32-byte
-//! hash), and covers L0 and L1 uniformly, over the WHOLE tenant/signal. v3
-//! reuses v2's content-hash keying exactly, but the header's `part_blake3`
-//! names exactly one part: the object covers only that part's segments, so its
-//! size scales with one part rather than the whole tenant. The keying is
-//! self-describing in the version byte, so an object read outside its head ref
-//! declares which key model it carries.
+//! v3 is the only version the decoder accepts. ADR-1413 decision 6 retired the
+//! v1 and v2 whole-object forms from both the write and the read path, so a
+//! legacy object carrying either version is rejected as unsupported rather
+//! than decoded. Both are still described below because v3's keying is defined
+//! by reference to theirs, and because `#[cfg(test)]` encoders build them for
+//! the tests that prove the rejection.
+//!
+//! The `ColumnStatsSegment` record shape is frozen and shared; the key model is
+//! the version's. v1 keys each record by the five-field identity tuple
+//! (writer_id is the 16-byte flush-writer uuid) and covers L0 only. v2 keys by
+//! the covered part's content hash, which the writer carries in the `writer_id`
+//! slot as 32 bytes (the same slot an L1 `SnapshotEntry` already repurposes for
+//! a 32-byte hash), and covers L0 and L1 uniformly, over the WHOLE
+//! tenant/signal. v3 reuses v2's content-hash keying exactly, but the header's
+//! `part_blake3` names exactly one part: the object covers only that part's
+//! segments, so its size scales with one part rather than the whole tenant.
+//! The keying is self-describing in the version byte, so a rejected object
+//! still declares which key model it was written under.
 //!
 //! Deliberately reuses `part.rs`'s plain length-delimited-protobuf body
 //! convention rather than `postings.rs`'s hand-rolled varint dictionary:
@@ -112,7 +119,7 @@ pub fn encode_column_stats_v2(
 }
 
 /// The uncompressed, length-delimited protobuf concatenation of `segments`:
-/// exactly the bytes [`frame_column_stats`] compresses, and exactly what a
+/// exactly the bytes `frame_column_stats` compresses, and exactly what a
 /// pre-encode ceiling check must measure to agree with the encoder. Shared by
 /// [`encode_column_stats_v3`]'s ceiling check and the fold's degrade loop
 /// (`ravel_catalog::fold`) so the two can never drift apart on what "over
@@ -127,7 +134,7 @@ pub fn column_stats_segments_concat(segments: &[ColumnStatsSegment]) -> Vec<u8> 
 
 /// Encodes a **v3** (ADR-1413, per-part, content-hash-keyed) column-statistics
 /// object, referenced by `SnapshotPartRef.column_stats` (field 7). Unlike
-/// [`encode_column_stats_v2`], the header's `part_blake3` names exactly the
+/// the retired `encode_column_stats_v2`, the header's `part_blake3` names the
 /// one part this object covers, and `segments` must be exactly that part's
 /// segments (each still carrying its covered part's content hash in
 /// `writer_id`, v2 semantics).

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -71,6 +71,11 @@ pub struct DecodedColumnStats {
 /// production path calls this: it survives to build v1 bytes for the tests that
 /// prove the decoder now rejects them, the read set being exactly `{3}`. Stamps
 /// envelope version 1 explicitly, never [`COLUMN_STATS_WRITE_VERSION`].
+///
+/// `#[cfg(test)]` for the same reason as [`encode_column_stats_v2`]: the bytes
+/// it produces are rejected by `decode_column_stats`, so a non-test caller
+/// could only write an object nothing in the system can read.
+#[cfg(test)]
 pub fn encode_column_stats(
     tenant_hash: [u8; 16],
     signal: u32,
@@ -164,11 +169,15 @@ pub fn encode_column_stats_v3(
     )
 }
 
-/// Envelope framing shared by the public writers and the tests. Parameterised
-/// on `version`, which selects both the stamped version byte and the segment
-/// key model `validate_segments` enforces (v1: five-field tuple; v2:
-/// `content_hash`). Stamps `version` into both the envelope version byte and
-/// the header `format_version`, so the two always agree by construction.
+/// Envelope framing for the retired v1 and v2 writers and the tests.
+/// Parameterised on `version`, which selects both the stamped version byte and
+/// the segment key model `validate_segments` enforces (v1: five-field tuple;
+/// v2: `content_hash`). Stamps `version` into both the envelope version byte
+/// and the header `format_version`, so the two always agree by construction.
+///
+/// `#[cfg(test)]` follows from its only callers being so: v3 frames itself via
+/// [`frame_column_stats_body`], not through this wrapper.
+#[cfg(test)]
 fn encode_column_stats_versioned(
     version: u8,
     tenant_hash: [u8; 16],
@@ -186,6 +195,10 @@ fn encode_column_stats_versioned(
 /// way to reach `decode_column_stats`'s own validation call with hostile input
 /// (every public writer validates first, so an encoder-side test proves
 /// nothing about the decoder).
+///
+/// `#[cfg(test)]` for the same reason as its caller: the live v3 writer frames
+/// through [`frame_column_stats_body`] directly.
+#[cfg(test)]
 fn frame_column_stats(
     version: u8,
     tenant_hash: [u8; 16],

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -61,16 +61,16 @@ pub struct DecodedColumnStats {
 }
 
 /// Encodes a **v1** (ADR-0850, L0-tuple-keyed) column-statistics object, the
-/// `SnapshotHead.column_stats` (field 11) artifact. Validates `segments`
+/// former `SnapshotHead.column_stats` (field 11) artifact. Validates `segments`
 /// against the same rules `decode_column_stats` enforces for v1 (writer_id
 /// width, tuple sort order, no duplicate identity), mirroring `encode_part`'s
 /// defensive-validation precedent: an object this function writes can never
 /// fail its own decode.
 ///
-/// Stamps envelope version 1 explicitly, NOT [`COLUMN_STATS_WRITE_VERSION`]:
-/// the ADR-0942 dual-publish window keeps writing the v1 object byte-for-byte
-/// as before even after the write version moves to 2. The v2 (part-keyed)
-/// artifact is written by [`encode_column_stats_v2`].
+/// Retired format. ADR-1413 decision 6 removed the whole-object publish, so no
+/// production path calls this: it survives to build v1 bytes for the tests that
+/// prove the decoder now rejects them, the read set being exactly `{3}`. Stamps
+/// envelope version 1 explicitly, never [`COLUMN_STATS_WRITE_VERSION`].
 pub fn encode_column_stats(
     tenant_hash: [u8; 16],
     signal: u32,
@@ -81,11 +81,15 @@ pub fn encode_column_stats(
 }
 
 /// Encodes a **v2** (ADR-0942, part-hash-keyed) column-statistics object, the
-/// `SnapshotHead.column_stats_part` (field 13) artifact. Each segment record
-/// must carry its covered part's content hash (blake3) in its `writer_id` slot
-/// as 32 bytes; records are sorted and deduplicated by that hash, not the
-/// five-field identity tuple, so L0 and L1 parts are named uniformly and two L1
-/// parts of one bucket never collide. Stamps [`COLUMN_STATS_WRITE_VERSION`].
+/// former `SnapshotHead.column_stats_part` (field 13) artifact. Each segment
+/// record must carry its covered part's content hash (blake3) in its
+/// `writer_id` slot as 32 bytes; records are sorted and deduplicated by that
+/// hash, not the five-field identity tuple, so L0 and L1 parts are named
+/// uniformly and two L1 parts of one bucket never collide.
+///
+/// Retired format, on the same ADR-1413 decision 6 as [`encode_column_stats`],
+/// and `#[cfg(test)]` because nothing outside the tests that prove the decoder
+/// rejects v2 constructs one.
 #[cfg(test)]
 pub fn encode_column_stats_v2(
     tenant_hash: [u8; 16],

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -44,10 +44,12 @@ use prost::Message;
 use ravel_proto::catalog::v1::column_value::Kind;
 use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsHeader, ColumnStatsSegment, ColumnValue};
 
+#[cfg(test)]
+use super::COLUMN_STATS_WRITE_VERSION;
 use super::error::SnapshotFormatError;
 use super::{
-    COLUMN_STATS_MAGIC, COLUMN_STATS_RESERVED, COLUMN_STATS_WRITE_VERSION,
-    MIN_COLUMN_STATS_ENVELOPE_LEN, ZSTD_LEVEL, column_stats_version_accepted,
+    COLUMN_STATS_MAGIC, COLUMN_STATS_RESERVED, MIN_COLUMN_STATS_ENVELOPE_LEN, ZSTD_LEVEL,
+    column_stats_version_accepted,
 };
 use crate::snapshot_format::ColumnStatsLimits;
 
@@ -84,6 +86,7 @@ pub fn encode_column_stats(
 /// as 32 bytes; records are sorted and deduplicated by that hash, not the
 /// five-field identity tuple, so L0 and L1 parts are named uniformly and two L1
 /// parts of one bucket never collide. Stamps [`COLUMN_STATS_WRITE_VERSION`].
+#[cfg(test)]
 pub fn encode_column_stats_v2(
     tenant_hash: [u8; 16],
     signal: u32,
@@ -758,9 +761,21 @@ mod tests {
 
     #[test]
     fn round_trips() {
-        let segments = vec![segment(1, 0, 1), segment(1, 0, 2), segment(2, 0, 1)];
-        let bytes =
-            encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &segments).expect("encodes");
+        let mut a = segment(1, 0, 1);
+        a.writer_id = vec![0x10; 32];
+        let mut b = segment(1, 0, 2);
+        b.writer_id = vec![0x20; 32];
+        let mut c = segment(2, 0, 1);
+        c.writer_id = vec![0x30; 32];
+        let segments = vec![a, b, c];
+        let bytes = encode_column_stats_v3(
+            [0x11; 16],
+            3,
+            [0x22; 32],
+            &segments,
+            crate::snapshot_format::DEFAULT_MAX_COLUMN_STATS_BYTES,
+        )
+        .expect("encodes");
         let decoded = decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("decodes");
         assert_eq!(decoded.segments, segments);
         assert_eq!(decoded.header.segment_count, 3);
@@ -915,9 +930,11 @@ mod tests {
     #[test]
     fn decode_refuses_duplicate_column_name_in_unvalidated_bytes() {
         let mut seg = segment(1, 0, 1);
+        seg.writer_id = vec![0xAA; 32];
         let dup = seg.columns[0].clone();
         seg.columns.push(dup);
-        let bytes = frame_column_stats(1, [0x11; 16], 3, vec![], &[seg]).expect("frames");
+        let bytes =
+            frame_column_stats(3, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg]).expect("frames");
         let err =
             decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect_err("decode refuses");
         assert_eq!(
@@ -938,13 +955,15 @@ mod tests {
     #[test]
     fn decode_refuses_min_max_with_zero_non_null_in_unvalidated_bytes() {
         let mut seg = segment(1, 0, 1);
+        seg.writer_id = vec![0xAA; 32];
         seg.columns[0].non_null_count = 0;
         seg.columns[0].null_count = 10;
         seg.columns[0].dictionary = vec![];
         seg.columns[0].dictionary_present = false;
         seg.columns[0].sum = None;
         // min/max still populated: inconsistent with an all-null column.
-        let bytes = frame_column_stats(1, [0x11; 16], 3, vec![], &[seg]).expect("frames");
+        let bytes =
+            frame_column_stats(3, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg]).expect("frames");
         let err =
             decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect_err("decode refuses");
         assert_eq!(
@@ -963,9 +982,11 @@ mod tests {
     #[test]
     fn decode_refuses_missing_min_max_with_non_null_rows_in_unvalidated_bytes() {
         let mut seg = segment(1, 0, 1);
+        seg.writer_id = vec![0xAA; 32];
         seg.columns[0].min = None;
         seg.columns[0].max = None;
-        let bytes = frame_column_stats(1, [0x11; 16], 3, vec![], &[seg]).expect("frames");
+        let bytes =
+            frame_column_stats(3, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg]).expect("frames");
         let err =
             decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect_err("decode refuses");
         assert_eq!(
@@ -1058,11 +1079,18 @@ mod tests {
     #[test]
     fn sum_without_dictionary_round_trips() {
         let mut seg = segment(1, 0, 1);
+        seg.writer_id = vec![0x77; 32];
         seg.columns[0].dictionary_present = false;
         seg.columns[0].dictionary = vec![];
         seg.columns[0].sum = Some(45);
-        let bytes = encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &[seg.clone()])
-            .expect("encodes");
+        let bytes = encode_column_stats_v3(
+            [0x11; 16],
+            3,
+            [0x22; 32],
+            &[seg.clone()],
+            crate::snapshot_format::DEFAULT_MAX_COLUMN_STATS_BYTES,
+        )
+        .expect("encodes");
         let decoded = decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("decodes");
         assert_eq!(decoded.segments[0].columns[0].sum, Some(45));
     }
@@ -1108,97 +1136,6 @@ mod tests {
         seg.columns[0].sum = None;
         encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
             .expect("an all-null column may carry no sum");
-    }
-
-    /// The regression that matters for ADR-0942 A1: the existing L0 path must
-    /// stay byte-for-byte readable after the version split. A v1 object decodes
-    /// with EXACT expected field values, not merely `is_ok()`.
-    #[test]
-    fn v1_object_decodes_with_exact_field_values() {
-        let seg = segment(1, 0, 1);
-        let bytes = encode_column_stats(
-            [0x11; 16],
-            3,
-            vec![vec![0x22; 32]],
-            std::slice::from_ref(&seg),
-        )
-        .expect("v1 encodes");
-        // The public writer stamps the write version, which is 1 in A1.
-        assert_eq!(bytes[4], 1, "envelope version byte is the v1 write version");
-        let decoded =
-            decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("v1 decodes");
-        assert_eq!(decoded.header.format_version, 1);
-        assert_eq!(decoded.header.tenant_hash, vec![0x11; 16]);
-        assert_eq!(decoded.header.signal, 3);
-        assert_eq!(decoded.header.part_blake3, vec![vec![0x22; 32]]);
-        assert_eq!(decoded.header.segment_count, 1);
-        assert_eq!(decoded.segments.len(), 1);
-        let out = &decoded.segments[0];
-        assert_eq!(out.ingest_hour_bucket, 1);
-        assert_eq!(out.shard, 0);
-        assert_eq!(out.writer_id, vec![0xAA; 16]);
-        assert_eq!(out.writer_epoch, 1);
-        assert_eq!(out.writer_seq, 1);
-        assert_eq!(out.columns.len(), 1);
-        let col = &out.columns[0];
-        assert_eq!(col.name, "AdvEngineID");
-        assert_eq!(col.declared_type, 2);
-        assert_eq!(col.non_null_count, 10);
-        assert_eq!(col.null_count, 0);
-        assert_eq!(col.min, Some(i64_value(0)));
-        assert_eq!(col.max, Some(i64_value(9)));
-        assert!(col.dictionary_present);
-        assert_eq!(col.dictionary.len(), 10);
-        assert_eq!(col.sum, Some(45));
-    }
-
-    /// ADR-0942: a v2-stamped object must decode today, even though nothing
-    /// writes one, so A2's writer and this decoder cannot disagree the moment
-    /// v2 first appears. Constructed directly via the versioned framing helper
-    /// (no v2 writer needed). This is also the test the "prove-the-test"
-    /// demonstration flips the decoder to break: change the `:115`
-    /// `column_stats_version_accepted(version)` membership check back to
-    /// `version != COLUMN_STATS_WRITE_VERSION` and this fails with
-    /// `ColumnStatsUnsupportedVersion(2)`.
-    #[test]
-    fn v2_stamped_object_decodes() {
-        // A v2 record is keyed by its covered part's content hash, carried in
-        // writer_id as 32 bytes.
-        let mut seg = segment(1, 0, 1);
-        seg.writer_id = vec![0x77; 32];
-        let bytes = encode_column_stats_versioned(
-            2,
-            [0x11; 16],
-            3,
-            vec![vec![0x22; 32]],
-            std::slice::from_ref(&seg),
-        )
-        .expect("v2 framing encodes");
-        assert_eq!(bytes[4], 2, "envelope version byte is v2");
-        let decoded =
-            decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("v2 decodes");
-        assert_eq!(decoded.header.format_version, 2);
-        assert_eq!(decoded.segments, vec![seg]);
-    }
-
-    /// v2 keys by the content hash carried in writer_id, not the rest of the
-    /// tuple: two records sharing every other tuple field but carrying distinct
-    /// content hashes are a valid v2 object with two distinct records (the
-    /// collision the v1 tuple key could not represent for L1, where the reader
-    /// side has no distinguishing writer identity). Codec-level analogue of the
-    /// fold test's "two L1 parts of one bucket produce two distinct records".
-    #[test]
-    fn v2_distinct_content_hash_round_trips() {
-        let mut a = segment(1, 0, 1);
-        a.writer_id = vec![0xA0; 32];
-        let mut b = segment(1, 0, 1); // identical remaining tuple to `a`
-        b.writer_id = vec![0xB0; 32]; // sorts after `a`
-        let bytes =
-            encode_column_stats_v2([0x11; 16], 3, vec![vec![0x22; 32]], &[a.clone(), b.clone()])
-                .expect("two distinct-part records encode under v2");
-        let decoded = decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("decodes");
-        assert_eq!(decoded.segments, vec![a, b]);
-        assert_eq!(decoded.header.format_version, 2);
     }
 
     /// A v2 record whose writer_id is not the 32-byte content hash (here the
@@ -1270,13 +1207,13 @@ mod tests {
         }
     }
 
-    /// The accepted read set is exactly {1, 2, 3} and nothing else across the
-    /// whole u8 domain. The expectation is a hardcoded `1 | 2 | 3`,
+    /// The accepted read set is exactly {3} and nothing else across the
+    /// whole u8 domain. The expectation is a hardcoded `3`,
     /// deliberately NOT `COLUMN_STATS_ACCEPTED_READ_VERSIONS.contains(..)`:
     /// adding a version to the constant later cannot silently widen what is
     /// accepted without this literal changing too.
     #[test]
-    fn accepted_read_set_is_exactly_v1_v2_and_v3() {
+    fn accepted_read_set_is_exactly_v3() {
         for version in 0u8..=255 {
             // The framing helper validates in the version's key model, so give
             // writer_id the width that model requires (v1: 16, v2+: 32).
@@ -1290,11 +1227,11 @@ mod tests {
                 encode_column_stats_versioned(version, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
                     .expect("framing encodes any version byte");
             let decoded = decode_column_stats(&bytes, &ColumnStatsLimits::default());
-            let expected_accept = matches!(version, 1..=3);
+            let expected_accept = version == 3;
             assert_eq!(
                 decoded.is_ok(),
                 expected_accept,
-                "version {version} acceptance must match the hardcoded {{1, 2, 3}} set"
+                "version {version} acceptance must match the hardcoded {{3}} set"
             );
             if !expected_accept {
                 assert_eq!(
@@ -1306,17 +1243,17 @@ mod tests {
     }
 
     /// A header whose self-declared `format_version` disagrees with its accepted
-    /// envelope version byte is rejected: a v2 envelope must not carry a v1
-    /// header. Built by decoding a v2 object, rewriting only the header's
-    /// `format_version` to 1, and re-stamping both CRCs so the object is
-    /// otherwise well-formed and the version disagreement is the sole defect.
+    /// envelope version byte is rejected: a v3 envelope must not carry a header
+    /// claiming a different version. Built by hand-framing a v3 envelope whose
+    /// header's `format_version` is stamped 1, so the version disagreement is
+    /// the sole defect.
     #[test]
     fn header_envelope_version_disagreement_rejected() {
         let seg = segment(1, 0, 1);
-        // Encode a v2 object, then rebuild the envelope with the header claiming
-        // v1 while the envelope byte stays v2.
+        // Hand-frame a v3 envelope, but with the header claiming v1 while the
+        // envelope byte stays v3.
         let header = ColumnStatsHeader {
-            format_version: 1, // disagrees with the v2 envelope byte below
+            format_version: 1, // disagrees with the v3 envelope byte below
             tenant_hash: vec![0x11; 16],
             signal: 3,
             part_blake3: vec![vec![0x22; 32]],
@@ -1328,7 +1265,7 @@ mod tests {
         let body = zstd::bulk::compress(&segments_raw, ZSTD_LEVEL).expect("compress");
         let mut out = Vec::new();
         out.extend_from_slice(&COLUMN_STATS_MAGIC);
-        out.push(2); // v2 envelope
+        out.push(3); // v3 envelope
         out.extend_from_slice(&COLUMN_STATS_RESERVED);
         out.extend_from_slice(&(header_bytes.len() as u32).to_le_bytes());
         out.extend_from_slice(&header_bytes);
@@ -1344,7 +1281,7 @@ mod tests {
             err,
             SnapshotFormatError::ColumnStatsHeaderVersionMismatch {
                 header: 1,
-                envelope: 2,
+                envelope: 3,
             }
         );
     }
@@ -1367,15 +1304,15 @@ mod tests {
         }
     }
 
-    /// A corrupted body under a v2 envelope is caught by the body CRC, a typed
+    /// A corrupted body under a v3 envelope is caught by the body CRC, a typed
     /// error rather than a decode of wrong data.
     #[test]
-    fn corrupt_v2_body_is_typed_error() {
+    fn corrupt_v3_body_is_typed_error() {
         let mut seg = segment(1, 0, 1);
         seg.writer_id = vec![0x77; 32];
         let mut bytes =
-            encode_column_stats_versioned(2, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
-                .expect("v2 framing encodes");
+            encode_column_stats_versioned(3, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
+                .expect("v3 framing encodes");
         // Flip a byte inside the compressed body region (past the header,
         // before the trailing CRCs).
         let mid = bytes.len() / 2;
@@ -1397,8 +1334,17 @@ mod tests {
 
     #[test]
     fn oversized_declared_length_rejected_before_decompress() {
-        let segments = vec![segment(1, 0, 1)];
-        let bytes = encode_column_stats([0x11; 16], 3, vec![], &segments).expect("encodes");
+        let mut seg = segment(1, 0, 1);
+        seg.writer_id = vec![0x77; 32];
+        let segments = vec![seg];
+        let bytes = encode_column_stats_v3(
+            [0x11; 16],
+            3,
+            [0x22; 32],
+            &segments,
+            crate::snapshot_format::DEFAULT_MAX_COLUMN_STATS_BYTES,
+        )
+        .expect("encodes");
         let tiny_limit = ColumnStatsLimits {
             max_column_stats_bytes: 1,
         };

--- a/crates/ravel-catalog/src/snapshot_format/error.rs
+++ b/crates/ravel-catalog/src/snapshot_format/error.rs
@@ -149,20 +149,6 @@ pub enum SnapshotFormatError {
     #[error("malformed varint in postings body")]
     PostingsBadVarint,
 
-    #[error("head column-stats ref blake3 must be 32 bytes, got {0}")]
-    BadColumnStatsRefBlake3Len(usize),
-    #[error("head column-stats ref has an empty key")]
-    EmptyColumnStatsKey,
-    #[error("head column-stats ref part_blake3[{index}] must be 32 bytes, got {actual}")]
-    BadColumnStatsRefPartBlake3Len { index: usize, actual: usize },
-    #[error("head column-stats ref names {stats_parts} parts but head has {head_parts} parts")]
-    ColumnStatsRefPartCountMismatch {
-        stats_parts: usize,
-        head_parts: usize,
-    },
-    #[error("head column-stats ref part_blake3[{index}] does not match parts[{index}].blake3")]
-    ColumnStatsRefPartBlake3Mismatch { index: usize },
-
     #[error("column-stats object is smaller than the minimum envelope prefix: {size} bytes")]
     ColumnStatsTooSmall { size: usize },
     #[error("bad column-stats magic bytes")]

--- a/crates/ravel-catalog/src/snapshot_format/head.rs
+++ b/crates/ravel-catalog/src/snapshot_format/head.rs
@@ -135,37 +135,5 @@ fn validate_head(head: &SnapshotHead) -> Result<(), SnapshotFormatError> {
         }
     }
 
-    if let Some(column_stats) = &head.column_stats {
-        if column_stats.blake3.len() != 32 {
-            return Err(SnapshotFormatError::BadColumnStatsRefBlake3Len(
-                column_stats.blake3.len(),
-            ));
-        }
-        if column_stats.key.is_empty() {
-            return Err(SnapshotFormatError::EmptyColumnStatsKey);
-        }
-        if column_stats.part_blake3.len() != head.parts.len() {
-            return Err(SnapshotFormatError::ColumnStatsRefPartCountMismatch {
-                stats_parts: column_stats.part_blake3.len(),
-                head_parts: head.parts.len(),
-            });
-        }
-        for (index, (stats_hash, part)) in column_stats
-            .part_blake3
-            .iter()
-            .zip(head.parts.iter())
-            .enumerate()
-        {
-            if stats_hash.len() != 32 {
-                return Err(SnapshotFormatError::BadColumnStatsRefPartBlake3Len {
-                    index,
-                    actual: stats_hash.len(),
-                });
-            }
-            if stats_hash != &part.blake3 {
-                return Err(SnapshotFormatError::ColumnStatsRefPartBlake3Mismatch { index });
-            }
-        }
-    }
     Ok(())
 }

--- a/crates/ravel-catalog/src/snapshot_format/mod.rs
+++ b/crates/ravel-catalog/src/snapshot_format/mod.rs
@@ -10,13 +10,12 @@ mod head;
 mod part;
 mod postings;
 
-#[cfg(test)]
-pub use column_stats::encode_column_stats_v2;
 pub use column_stats::{
     ColumnStatsHeaderPeek, DecodedColumnStats, column_stats_segments_concat, decode_column_stats,
-    decode_column_stats_header, encode_column_stats, encode_column_stats_v3,
-    validate_min_max_presence,
+    decode_column_stats_header, encode_column_stats_v3, validate_min_max_presence,
 };
+#[cfg(test)]
+pub use column_stats::{encode_column_stats, encode_column_stats_v2};
 pub use error::SnapshotFormatError;
 pub use head::{HEAD_FORMAT_VERSION, decode_head, encode_head};
 pub use part::{DecodedPart, decode_part, encode_part, encode_part_ranged};

--- a/crates/ravel-catalog/src/snapshot_format/mod.rs
+++ b/crates/ravel-catalog/src/snapshot_format/mod.rs
@@ -10,10 +10,12 @@ mod head;
 mod part;
 mod postings;
 
+#[cfg(test)]
+pub use column_stats::encode_column_stats_v2;
 pub use column_stats::{
     ColumnStatsHeaderPeek, DecodedColumnStats, column_stats_segments_concat, decode_column_stats,
-    decode_column_stats_header, encode_column_stats, encode_column_stats_v2,
-    encode_column_stats_v3, validate_min_max_presence,
+    decode_column_stats_header, encode_column_stats, encode_column_stats_v3,
+    validate_min_max_presence,
 };
 pub use error::SnapshotFormatError;
 pub use head::{HEAD_FORMAT_VERSION, decode_head, encode_head};
@@ -94,28 +96,27 @@ impl Default for PostingsLimits {
 /// (ADR-0850).
 pub const COLUMN_STATS_MAGIC: [u8; 4] = *b"RCST";
 
-/// Column-statistics envelope WRITE version: the version the fold stamps into
-/// every part-hash-keyed (v2) `.cstat` object it writes (ADR-0942 A2). Single
-/// source for the stamped v2 version so a later bump edits one literal.
-///
-/// The field-11 v1 object is NOT stamped from this constant: during the
-/// ADR-0942 dual-publish window the fold keeps writing a v1 (L0-tuple-keyed)
-/// `.cstat` under `SnapshotHead.column_stats` byte-for-byte as before, so
-/// [`column_stats::encode_column_stats`] stamps envelope version 1 explicitly.
-/// This constant governs only the new field-13 v2 object.
+/// Column-statistics envelope version [`column_stats::encode_column_stats_v2`]
+/// stamps. ADR-1413 decision 6 (#1600) retired the v2 whole-object write path
+/// from production: this constant, and `encode_column_stats_v2` itself, exist
+/// only for fixtures exercising `decode_column_stats`'s continued acceptance
+/// (or, pre-#1600 test simulation) of the format a v2 object once carried.
+#[cfg(test)]
 pub const COLUMN_STATS_WRITE_VERSION: u8 = 2;
 
 /// Column-statistics envelope ACCEPTED READ SET: the versions
-/// `decode_column_stats` accepts. v1 is ADR-0850's L0-tuple keying; v2 is
-/// ADR-0942's part-hash keying; v3 is ADR-1413's per-part keying (one part per
-/// object, same content-hash keying as v2). The decoder checks MEMBERSHIP
-/// against this set, never equality against [`COLUMN_STATS_WRITE_VERSION`]:
-/// bumping the write version must not make the decoder reject the older
-/// objects the dual-publish/reader-fallback rule still depends on. Single
+/// `decode_column_stats` accepts. v3 is ADR-1413's per-part keying (one part
+/// per object) and, as of ADR-1413 decision 6 (#1600), the only published
+/// form: v1 (ADR-0850's L0-tuple keying) and v2 (ADR-0942's part-hash keying)
+/// whole-object envelopes are retired from the read path, so a legacy
+/// whole-object `.cstat` a pre-#1600 fold once wrote is never decoded, only
+/// ever left unread. The decoder checks MEMBERSHIP against this set, never
+/// equality against [`COLUMN_STATS_WRITE_VERSION`]: bumping the write version
+/// must not make the decoder reject an object this set still accepts. Single
 /// source for the accepted set so a later version is added in one place. Each
 /// new version is accepted before anything writes one, so a writer and this
 /// decoder cannot disagree the moment it first appears.
-pub const COLUMN_STATS_ACCEPTED_READ_VERSIONS: [u8; 3] = [1, 2, 3];
+pub const COLUMN_STATS_ACCEPTED_READ_VERSIONS: [u8; 1] = [3];
 
 /// Whether `version` is an accepted `.cstat` envelope read version. Membership,
 /// not equality against the write version (ADR-0942).
@@ -189,8 +190,6 @@ mod tests {
             folder_id: vec![0x33; 16],
             created_unix_ns: 0,
             shard_generation_count: 1,
-            column_stats: None,
-            column_stats_part: None,
         }
     }
 
@@ -404,7 +403,7 @@ mod tests {
         assert_eq!(DEFAULT_MAX_POSTINGS_BYTES, 256 << 20);
         assert_eq!(COLUMN_STATS_MAGIC, *b"RCST");
         assert_eq!(COLUMN_STATS_WRITE_VERSION, 2);
-        assert_eq!(COLUMN_STATS_ACCEPTED_READ_VERSIONS, [1, 2, 3]);
+        assert_eq!(COLUMN_STATS_ACCEPTED_READ_VERSIONS, [3]);
         assert_eq!(COLUMN_STATS_RESERVED, [0, 0, 0]);
         assert_eq!(DEFAULT_MAX_COLUMN_STATS_BYTES, 256 << 20);
         assert_eq!(DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES, 10_000);

--- a/crates/ravel-catalog/src/snapshot_resolve.rs
+++ b/crates/ravel-catalog/src/snapshot_resolve.rs
@@ -1140,8 +1140,6 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            column_stats: None,
-            column_stats_part: None,
         }
     }
 
@@ -1287,8 +1285,6 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
-            column_stats: None,
-            column_stats_part: None,
         };
         let head_bytes = snapshot_format::encode_head(&head).expect("encode head");
         let head_key = head_object_key(&tenant, Signal::Metrics);

--- a/crates/ravel-catalog/tests/resharding.rs
+++ b/crates/ravel-catalog/tests/resharding.rs
@@ -406,8 +406,6 @@ async fn head_ahead_of_reader_fails_closed() {
         folder_id: vec![0x22; 16],
         created_unix_ns: 0,
         shard_generation_count: 2,
-        column_stats: None,
-        column_stats_part: None,
     };
     store
         .put(

--- a/crates/ravel-catalog/tests/snapshot_format_corrupt.rs
+++ b/crates/ravel-catalog/tests/snapshot_format_corrupt.rs
@@ -514,8 +514,6 @@ fn base_head() -> SnapshotHead {
         folder_id: vec![0x33; 16],
         created_unix_ns: 1_000,
         shard_generation_count: 1,
-        column_stats: None,
-        column_stats_part: None,
     }
 }
 

--- a/crates/ravel-catalog/tests/snapshot_format_roundtrip.rs
+++ b/crates/ravel-catalog/tests/snapshot_format_roundtrip.rs
@@ -9,8 +9,8 @@ use ravel_catalog::{
     encode_head, encode_part, encode_postings,
 };
 use ravel_proto::catalog::v1::{
-    DeclaredColumnMinMax, DeclaredColumnStatValue, SnapshotColumnStatsRef, SnapshotEntry,
-    SnapshotHead, SnapshotPartRef, SnapshotPostingsRef, declared_column_stat_value::Kind,
+    DeclaredColumnMinMax, DeclaredColumnStatValue, SnapshotEntry, SnapshotHead, SnapshotPartRef,
+    SnapshotPostingsRef, declared_column_stat_value::Kind,
 };
 
 fn entry_key(e: &SnapshotEntry) -> (u32, u32, Vec<u8>, u64, u64) {
@@ -170,30 +170,6 @@ fn arb_postings_ref(
     ]
 }
 
-fn arb_column_stats_ref(
-    parts: &[SnapshotPartRef],
-) -> impl Strategy<Value = Option<SnapshotColumnStatsRef>> + use<> {
-    let part_blake3: Vec<Vec<u8>> = parts.iter().map(|p| p.blake3.clone()).collect();
-    prop_oneof![
-        Just(None),
-        (
-            "[a-z0-9/]{1,40}",
-            prop::collection::vec(any::<u8>(), 32),
-            any::<u64>(),
-            any::<u32>(),
-        )
-            .prop_map(move |(key, blake3, size, segment_count)| {
-                Some(SnapshotColumnStatsRef {
-                    key,
-                    blake3,
-                    size,
-                    segment_count,
-                    part_blake3: part_blake3.clone(),
-                })
-            }),
-    ]
-}
-
 fn arb_head() -> impl Strategy<Value = SnapshotHead> {
     // Each raw part carries a (gap, span) plus its arbitrary content fields.
     // `arb_head` folds the gaps/spans into ascending, strictly-disjoint hour
@@ -234,25 +210,21 @@ fn arb_head() -> impl Strategy<Value = SnapshotHead> {
                     }
                 })
                 .collect();
-            (arb_postings_ref(&parts), arb_column_stats_ref(&parts)).prop_map(
-                move |(postings, column_stats)| {
-                    let watermark_hour = parts.iter().map(|p| p.watermark_hour).max().unwrap_or(0);
-                    SnapshotHead {
-                        format_version: 1,
-                        tenant_hash: vec![0x33u8; 16],
-                        signal: 1,
-                        shard_count: 8,
-                        watermark_hour,
-                        parts: parts.clone(),
-                        postings,
-                        folder_id: folder_id.clone(),
-                        created_unix_ns,
-                        shard_generation_count: 1,
-                        column_stats,
-                        column_stats_part: None,
-                    }
-                },
-            )
+            arb_postings_ref(&parts).prop_map(move |postings| {
+                let watermark_hour = parts.iter().map(|p| p.watermark_hour).max().unwrap_or(0);
+                SnapshotHead {
+                    format_version: 1,
+                    tenant_hash: vec![0x33u8; 16],
+                    signal: 1,
+                    shard_count: 8,
+                    watermark_hour,
+                    parts: parts.clone(),
+                    postings,
+                    folder_id: folder_id.clone(),
+                    created_unix_ns,
+                    shard_generation_count: 1,
+                }
+            })
         })
 }
 

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -2090,8 +2090,8 @@ pub async fn sweep_unreferenced_catalog_objects(
 /// [`read_head_reference`] fails the whole pass on it (fail-closed).
 enum HeadReference {
     /// HEAD is present and decoded: the set of keys it names (every
-    /// `parts[].key`, the optional `postings.key`, and the optional
-    /// column-statistics keys `column_stats.key`/`column_stats_part.key`).
+    /// `parts[].key`, the optional `postings.key`, and each part's optional
+    /// per-part column-statistics key `parts[].column_stats.key`).
     Present(HashSet<String>),
     /// HEAD is absent. There is no anchor to compare against, so rule 5 sweeps
     /// nothing for this (tenant, signal) (a fold rebuilding from no HEAD adopts
@@ -2117,12 +2117,8 @@ async fn read_head_reference(
                      nothing this pass rather than treating a live snapshot as unreferenced"
                 ))
             })?;
-            let mut referenced = HashSet::with_capacity(
-                head.parts.len() * 2
-                    + usize::from(head.postings.is_some())
-                    + usize::from(head.column_stats.is_some())
-                    + usize::from(head.column_stats_part.is_some()),
-            );
+            let mut referenced =
+                HashSet::with_capacity(head.parts.len() * 2 + usize::from(head.postings.is_some()));
             for part in &head.parts {
                 referenced.insert(part.key.clone());
                 // Additive, ADR-1413. `part.column_stats` (field 7,
@@ -2140,24 +2136,6 @@ async fn read_head_reference(
             }
             if let Some(postings) = &head.postings {
                 referenced.insert(postings.key.clone());
-            }
-            // A live snapshot's column-statistics object is an immutable,
-            // reachable object under the same `idx/` prefix this sweep lists
-            // (fold.rs writes `.cstat` there), so omitting it lets the sweep
-            // delete an object a resolvable snapshot still references (#958).
-            // All three carriers are covered: field 11 `column_stats`
-            // (`SnapshotColumnStatsRef`, ADR-0850) and field 13
-            // `column_stats_part` (`SnapshotColumnStatsPartRef`, ADR-0942's
-            // part-hash re-keying) are whole-object refs on the HEAD itself;
-            // `parts[].column_stats` (field 7, ADR-1413) is the per-part v3
-            // ref handled in the loop above. Whichever a HEAD carries names a
-            // `.cstat` key that must be spared exactly like a part or the
-            // postings object.
-            if let Some(column_stats) = &head.column_stats {
-                referenced.insert(column_stats.key.clone());
-            }
-            if let Some(column_stats_part) = &head.column_stats_part {
-                referenced.insert(column_stats_part.key.clone());
             }
             Ok(HeadReference::Present(referenced))
         }
@@ -2720,8 +2698,7 @@ mod tests {
     };
     use ravel_object_store::memory::MemoryStore;
     use ravel_proto::catalog::v1::{
-        SnapshotColumnStatsPartRef, SnapshotColumnStatsRef, SnapshotHead, SnapshotPartRef,
-        SnapshotPostingsRef,
+        SnapshotColumnStatsPartRef, SnapshotHead, SnapshotPartRef, SnapshotPostingsRef,
     };
     use ravel_types::TenantId;
 
@@ -3342,8 +3319,6 @@ mod tests {
             folder_id: vec![0u8; 16],
             created_unix_ns: 0,
             postings,
-            column_stats: None,
-            column_stats_part: None,
             shard_generation_count: 1,
         };
         let bytes = ravel_catalog::encode_head(&head).expect("valid HEAD encodes");
@@ -3357,17 +3332,45 @@ mod tests {
             .expect("seed HEAD");
     }
 
-    /// Like [`put_head`] but also names a column-statistics object through
-    /// field 11 (`SnapshotColumnStatsRef`) and/or field 13
-    /// (`SnapshotColumnStatsPartRef`). Each ref's `part_blake3` mirrors the
-    /// parts' hashes, as `encode_head`'s own validation requires.
-    async fn put_head_with_column_stats(
+    /// Appends a length-delimited field to an already-encoded protobuf
+    /// message. Fields 11 and 13 on `SnapshotHead` (ADR-1413 decision 6,
+    /// #1600) are `reserved` and have no struct field to set, so this is the
+    /// only way to construct a HEAD that still carries one, the way a HEAD
+    /// folded before this change would. `SnapshotHead::decode` (a plain
+    /// `prost::Message::decode`) skips a field number it does not recognize,
+    /// so appending is equivalent to the field having been encoded in its
+    /// original position.
+    fn append_raw_field(
+        mut message_bytes: Vec<u8>,
+        field_number: u32,
+        field_value: &impl prost::Message,
+    ) -> Vec<u8> {
+        prost::encoding::encode_key(
+            field_number,
+            prost::encoding::WireType::LengthDelimited,
+            &mut message_bytes,
+        );
+        let payload = field_value.encode_to_vec();
+        prost::encoding::encode_varint(payload.len() as u64, &mut message_bytes);
+        message_bytes.extend_from_slice(&payload);
+        message_bytes
+    }
+
+    /// Like [`put_head`] but also plants a stale whole-object column-stats ref
+    /// on `field_number` (11 or 13, the retired `SnapshotColumnStatsRef`/
+    /// `SnapshotColumnStatsPartRef` whole-tenant forms), the way a HEAD folded
+    /// before ADR-1413 decision 6 would. Both fields are `reserved` now (no
+    /// struct field to set), so the ref is planted with [`append_raw_field`]
+    /// after `encode_head` produces well-formed bytes for the rest of the
+    /// message. `part_blake3` mirrors the parts' hashes so a decoder that did
+    /// still validate the retired field would find it internally consistent.
+    async fn put_head_with_stale_whole_object_column_stats(
         store: &dyn ObjectStoreBackend,
         tenant: &TenantHash,
         signal: Signal,
         parts: Vec<SnapshotPartRef>,
-        column_stats_key: Option<&str>,
-        column_stats_part_key: Option<&str>,
+        field_number: u32,
+        column_stats_key: &str,
     ) {
         let watermark_hour = parts.iter().map(|p| p.watermark_hour).max().unwrap_or(0);
         let part_blake3: Vec<Vec<u8>> = parts.iter().map(|p| p.blake3.clone()).collect();
@@ -3381,23 +3384,17 @@ mod tests {
             folder_id: vec![0u8; 16],
             created_unix_ns: 0,
             postings: None,
-            column_stats: column_stats_key.map(|key| SnapshotColumnStatsRef {
-                key: key.to_string(),
-                blake3: [9u8; 32].to_vec(),
-                size: 1,
-                segment_count: 1,
-                part_blake3: part_blake3.clone(),
-            }),
-            column_stats_part: column_stats_part_key.map(|key| SnapshotColumnStatsPartRef {
-                key: key.to_string(),
-                blake3: [9u8; 32].to_vec(),
-                size: 1,
-                segment_count: 1,
-                part_blake3: part_blake3.clone(),
-            }),
             shard_generation_count: 1,
         };
         let bytes = ravel_catalog::encode_head(&head).expect("valid HEAD encodes");
+        let stale_ref = SnapshotColumnStatsPartRef {
+            key: column_stats_key.to_string(),
+            blake3: [9u8; 32].to_vec(),
+            size: 1,
+            segment_count: 1,
+            part_blake3,
+        };
+        let bytes = append_raw_field(bytes, field_number, &stale_ref);
         store
             .put(
                 &catalog_head_key(tenant, signal),
@@ -3590,15 +3587,22 @@ mod tests {
         );
     }
 
-    /// #958: a column-statistics `.cstat` object named by `HEAD.column_stats`
-    /// (field 11, ADR-0850) is immutable and reachable and must survive the
-    /// sweep, exactly like a part or the postings object. It lives under the
-    /// `idx/` prefix the sweep lists, so before the fix its key was absent from
-    /// the reachability set and the sweep deleted it. An unrelated old `.cstat`
-    /// not named by HEAD is still swept. The exact surviving/deleted key sets
-    /// are asserted.
+    /// ADR-1413 decision 6 (#1600): a stale `.cstat` object named ONLY by the
+    /// retired whole-tenant field 11 (`HEAD.column_stats`, `SnapshotColumnStatsRef`,
+    /// ADR-0850) is no longer referenced at all -- `read_head_reference` never
+    /// reads field 11 (it has no struct field to read; the proto field is
+    /// `reserved`), so the object is swept once it crosses the protection
+    /// horizon exactly like any other unreferenced `.cstat`, even though a
+    /// pre-#1600 HEAD still carries the raw bytes naming it. The live part
+    /// survives on its own account (`parts[].key`), unaffected by field 11.
+    ///
+    /// Prove-the-test: reintroducing a field-11 fallback read in
+    /// `read_head_reference` makes this fail: `outcome.deleted` becomes 0 and
+    /// the object added back to `referenced` before this fix at
+    /// `crates/ravel-maintain/src/sweep.rs:2138` (there is now no code at all
+    /// reading `head.column_stats`) would again be found there.
     #[tokio::test]
-    async fn catalog_sweep_spares_referenced_column_stats() {
+    async fn catalog_sweep_no_longer_spares_stale_field_eleven_column_stats() {
         let tenant = tenant();
         let signal = Signal::Metrics;
         let store = MemoryStore::new();
@@ -3610,9 +3614,9 @@ mod tests {
             "{}20260101T00.aaaa.csnap",
             catalog_snap_prefix(&tenant, signal)
         );
-        // The live column-stats object HEAD references (fold.rs keys `.cstat`
-        // under `idx/`), and an unrelated stale one no HEAD names.
-        let referenced_cstat = format!(
+        // A `.cstat` only a stale field-11 ref names, and an unrelated stale
+        // one no HEAD field names at all -- both are unreferenced now.
+        let field_eleven_cstat = format!(
             "{}20260101T00.cccc.cstat",
             catalog_idx_prefix(&tenant, signal)
         );
@@ -3621,15 +3625,15 @@ mod tests {
             catalog_idx_prefix(&tenant, signal)
         );
         put_catalog_object(&store, &part).await;
-        put_catalog_object(&store, &referenced_cstat).await;
+        put_catalog_object(&store, &field_eleven_cstat).await;
         put_catalog_object(&store, &stale_cstat).await;
-        put_head_with_column_stats(
+        put_head_with_stale_whole_object_column_stats(
             &store,
             &tenant,
             signal,
             vec![part_ref(&part, part_blake3)],
-            Some(&referenced_cstat),
-            None,
+            11,
+            &field_eleven_cstat,
         )
         .await;
 
@@ -3639,13 +3643,16 @@ mod tests {
                 .await
                 .expect("sweep must succeed");
 
-        // Exact sets: only the stale, unreferenced `.cstat` is deleted; the
-        // part, the referenced `.cstat`, and the HEAD survive.
-        assert_eq!(outcome.deleted, 1, "only the stale column-stats object");
-        assert_eq!(outcome.kept, 2, "the part and the referenced .cstat");
+        // Exact sets: both unreferenced `.cstat` objects are deleted; only the
+        // part survives.
+        assert_eq!(
+            outcome.deleted, 2,
+            "the field-11-only and the wholly-unreferenced column-stats objects"
+        );
+        assert_eq!(outcome.kept, 1, "the part alone");
         assert!(
-            present(&store, &referenced_cstat).await,
-            "a column-stats object the live HEAD names must never be swept (#958)"
+            !present(&store, &field_eleven_cstat).await,
+            "a retired field-11 ref no longer keeps its object alive"
         );
         assert!(
             present(&store, &part).await,
@@ -3657,12 +3664,12 @@ mod tests {
         );
     }
 
-    /// The ADR-0942 part-hash-keyed carrier, field 13
-    /// (`SnapshotColumnStatsPartRef`): a `.cstat` named there is reachable and
-    /// spared just like the field-11 form, so the fix does not depend on which
-    /// field a fold chose to write.
+    /// The ADR-0942 part-hash-keyed carrier, field 13 (`SnapshotColumnStatsPartRef`):
+    /// a stale `.cstat` named only there is equally unreferenced now, so the
+    /// fix does not depend on which retired field a pre-#1600 fold had chosen
+    /// to write.
     #[tokio::test]
-    async fn catalog_sweep_spares_referenced_column_stats_part() {
+    async fn catalog_sweep_no_longer_spares_stale_field_thirteen_column_stats() {
         let tenant = tenant();
         let signal = Signal::Metrics;
         let store = MemoryStore::new();
@@ -3674,19 +3681,19 @@ mod tests {
             "{}20260101T00.aaaa.csnap",
             catalog_snap_prefix(&tenant, signal)
         );
-        let referenced_cstat = format!(
+        let field_thirteen_cstat = format!(
             "{}20260101T00.eeee.cstat",
             catalog_idx_prefix(&tenant, signal)
         );
         put_catalog_object(&store, &part).await;
-        put_catalog_object(&store, &referenced_cstat).await;
-        put_head_with_column_stats(
+        put_catalog_object(&store, &field_thirteen_cstat).await;
+        put_head_with_stale_whole_object_column_stats(
             &store,
             &tenant,
             signal,
             vec![part_ref(&part, part_blake3)],
-            None,
-            Some(&referenced_cstat),
+            13,
+            &field_thirteen_cstat,
         )
         .await;
 
@@ -3696,11 +3703,11 @@ mod tests {
                 .await
                 .expect("sweep must succeed");
 
-        assert_eq!(outcome.deleted, 0, "nothing unreferenced to delete");
-        assert_eq!(outcome.kept, 2, "the part and the field-13 .cstat");
+        assert_eq!(outcome.deleted, 1, "the field-13-only column-stats object");
+        assert_eq!(outcome.kept, 1, "the part alone");
         assert!(
-            present(&store, &referenced_cstat).await,
-            "a field-13 column-stats object the live HEAD names must be spared (#958)"
+            !present(&store, &field_thirteen_cstat).await,
+            "a retired field-13 ref no longer keeps its object alive"
         );
         assert!(
             present(&store, &part).await,
@@ -4106,8 +4113,6 @@ mod tests {
                 folder_id: vec![0u8; 16],
                 created_unix_ns: 0,
                 postings: None,
-                column_stats: None,
-                column_stats_part: None,
                 shard_generation_count: 1,
             };
             Bytes::from(ravel_catalog::encode_head(&head).expect("valid swapped HEAD"))

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -1939,10 +1939,11 @@ pub struct CatalogSweepOutcome {
 ///   between the two reads -- is dropped, so a part a completed fold just
 ///   published is never swept.
 /// - **Reference set from a present, decodable HEAD only.** The referenced set
-///   is HEAD's `parts[].key`, its optional `postings.key`, and its optional
-///   column-statistics keys (`column_stats.key` field 11, `column_stats_part.key`
-///   field 13). An object under the two prefixes but not in that set is
-///   superseded or orphaned.
+///   is HEAD's `parts[].key`, its optional `postings.key`, and each part's
+///   optional per-part column-statistics key (`parts[].column_stats.key`,
+///   field 7). An object under the two prefixes but not in that set is
+///   superseded or orphaned. ADR-1413 decision 6 retired the whole-object
+///   forms, so a legacy v1/v2 `.cstat` is named by no HEAD and is swept.
 /// - **No anchor, no sweep.** An absent HEAD sweeps nothing for the
 ///   (tenant, signal), matching rule 3's neither-record-nor-tombstone bucket
 ///   exactly. This is not an over-abundance of caution: a recovery fold with no

--- a/crates/ravel-sql/tests/logs_stats_load.rs
+++ b/crates/ravel-sql/tests/logs_stats_load.rs
@@ -14,7 +14,7 @@
 //!   an eligible plan would silently turn ADR-0850 off.
 //!
 //! The HEAD and `.cstat` objects are built directly with the public
-//! `encode_head`/`encode_column_stats` codecs (no fold runs), exactly as
+//! `encode_head`/`encode_column_stats_v3` codecs (no fold runs), exactly as
 //! `ravel-catalog`'s own `load_column_stats` test builds them. The metadata
 //! path never fetches a snapshot part or a data object, so neither needs to
 //! exist: the only reads a metadata-answered eligible query makes are the two
@@ -29,14 +29,14 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::displayable;
 use futures::StreamExt;
 use ravel_catalog::{
-    Catalog, CatalogConfig, HEAD_FORMAT_VERSION, SegmentLevel, SegmentRef, Snapshot,
-    encode_column_stats, encode_head,
+    Catalog, CatalogConfig, DEFAULT_MAX_COLUMN_STATS_BYTES, HEAD_FORMAT_VERSION, SegmentLevel,
+    SegmentRef, Snapshot, encode_column_stats_v3, encode_head,
 };
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_proto::catalog::v1::{
-    ColumnStat, ColumnStatsSegment, ColumnValue, DictEntry, SnapshotColumnStatsRef, SnapshotHead,
-    SnapshotPartRef,
+    ColumnStat, ColumnStatsSegment, ColumnValue, DictEntry, SnapshotColumnStatsPartRef,
+    SnapshotHead, SnapshotPartRef,
 };
 use ravel_query::{LogSegmentFetcher, SegmentFetcher};
 use ravel_sql::{DeclaredColumn, DeclaredType, SpanSegmentFetcher, SqlConfig, SqlExecutor};
@@ -54,8 +54,8 @@ const TENANT: TenantHash = TenantHash([7u8; 16]);
 const DECLARED_TYPE_I64: u32 = 2;
 
 /// A fabricated L0 [`SegmentRef`]; the metadata path never fetches the object,
-/// so `data_object_key` need not name a real object. Only the identity fields
-/// join it to the injected `ColumnStatsSegment`.
+/// so `data_object_key` need not name a real object. Only `content_hash` joins
+/// it to the injected `ColumnStatsSegment` (v3 keying, ADR-1413).
 fn seg_ref(seq: u64, sample_count: u64) -> SegmentRef {
     SegmentRef {
         data_object_key: format!("logs/seg-{seq}.rlog"),
@@ -130,7 +130,7 @@ fn stats_segment(seg: &SegmentRef, columns: Vec<ColumnStat>) -> ColumnStatsSegme
     ColumnStatsSegment {
         ingest_hour_bucket: seg.ingest_hour_bucket,
         shard: seg.shard,
-        writer_id: seg.writer_id.as_bytes().to_vec(),
+        writer_id: seg.content_hash.to_vec(),
         writer_epoch: seg.writer_epoch,
         writer_seq: seg.writer_seq,
         columns,
@@ -164,8 +164,14 @@ async fn install_head_and_stats(store: &dyn ObjectStoreBackend, segments: &[Colu
     // object itself is never fetched by the load, so it is not written.
     let part_hash = *blake3::hash(b"part-0").as_bytes();
 
-    let stats_bytes = encode_column_stats(TENANT.0, signal_num, vec![part_hash.to_vec()], segments)
-        .expect("encode column stats");
+    let stats_bytes = encode_column_stats_v3(
+        TENANT.0,
+        signal_num,
+        part_hash,
+        segments,
+        DEFAULT_MAX_COLUMN_STATS_BYTES,
+    )
+    .expect("encode column stats");
     let stats_hash = *blake3::hash(&stats_bytes).as_bytes();
     let stats_key = format!("t/{}/catalog/l/cstat/one.cstat", TENANT.to_hex());
     store
@@ -190,20 +196,18 @@ async fn install_head_and_stats(store: &dyn ObjectStoreBackend, segments: &[Colu
             entry_count: 0,
             watermark_hour: 10,
             min_hour: 0,
-            column_stats: None,
+            column_stats: Some(SnapshotColumnStatsPartRef {
+                key: stats_key,
+                blake3: stats_hash.to_vec(),
+                size: stats_bytes.len() as u64,
+                segment_count: segments.len() as u32,
+                part_blake3: vec![part_hash.to_vec()],
+            }),
         }],
         folder_id: Uuid::new_v4().into_bytes().to_vec(),
         created_unix_ns: 0,
         postings: None,
         shard_generation_count: 1,
-        column_stats: Some(SnapshotColumnStatsRef {
-            key: stats_key,
-            blake3: stats_hash.to_vec(),
-            size: stats_bytes.len() as u64,
-            segment_count: segments.len() as u32,
-            part_blake3: vec![part_hash.to_vec()],
-        }),
-        column_stats_part: None,
     };
     let head_bytes = encode_head(&head).expect("encode head");
     store
@@ -513,9 +517,14 @@ async fn plan_pinned_loads_stats_when_ingest_hour_diverges_from_event_time() {
 
     let signal_num = ravel_commit::signal::to_proto(Signal::Logs) as u32;
     let part_hash = *blake3::hash(b"part-backfilled").as_bytes();
-    let stats_bytes =
-        encode_column_stats(TENANT.0, signal_num, vec![part_hash.to_vec()], &[seg_stats])
-            .expect("encode column stats");
+    let stats_bytes = encode_column_stats_v3(
+        TENANT.0,
+        signal_num,
+        part_hash,
+        &[seg_stats],
+        DEFAULT_MAX_COLUMN_STATS_BYTES,
+    )
+    .expect("encode column stats");
     let stats_hash = *blake3::hash(&stats_bytes).as_bytes();
     let stats_key = format!("t/{}/catalog/l/cstat/backfilled.cstat", TENANT.to_hex());
     store
@@ -545,20 +554,18 @@ async fn plan_pinned_loads_stats_when_ingest_hour_diverges_from_event_time() {
             entry_count: 0,
             watermark_hour: 500_010,
             min_hour: 499_990,
-            column_stats: None,
+            column_stats: Some(SnapshotColumnStatsPartRef {
+                key: stats_key,
+                blake3: stats_hash.to_vec(),
+                size: stats_bytes.len() as u64,
+                segment_count: 1,
+                part_blake3: vec![part_hash.to_vec()],
+            }),
         }],
         folder_id: Uuid::new_v4().into_bytes().to_vec(),
         created_unix_ns: 0,
         postings: None,
         shard_generation_count: 1,
-        column_stats: Some(SnapshotColumnStatsRef {
-            key: stats_key,
-            blake3: stats_hash.to_vec(),
-            size: stats_bytes.len() as u64,
-            segment_count: 1,
-            part_blake3: vec![part_hash.to_vec()],
-        }),
-        column_stats_part: None,
     };
     let head_bytes = encode_head(&head).expect("encode head");
     store

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -488,9 +488,9 @@ and the CAS read/write helpers.
   content-addressed key and swaps HEAD, leaving the old object in place (the
   "orphan part" crash case); without this rule each such fold leaks one object. The rule LISTs the two
   prefixes first, then GETs the current `catalog/<signal>/HEAD`, treats every
-  `parts[].key`, the optional `postings.key`, and the optional
-  column-statistics keys `column_stats.key` (field 11) and
-  `column_stats_part.key` (field 13) as referenced, and deletes any
+  `parts[].key`, the optional `postings.key`, and each part's optional
+  per-part column-statistics key `parts[].column_stats.key` (field 7) as
+  referenced, and deletes any
   object under the two prefixes that HEAD does not name once its
   `last_modified` age exceeds `CompactorConfig::protection_horizon_ns`. A fresh
   re-verify GET of HEAD is taken immediately before the delete loop (the same
@@ -522,66 +522,46 @@ and the CAS read/write helpers.
 ### Per-part column statistics (ADR-1413)
 
 `SnapshotPartRef` carries an additive field 7, `column_stats:
-SnapshotColumnStatsPartRef`, alongside the existing whole-object refs at HEAD
-field 11 (v1, ADR-0850) and field 13 (v2, ADR-0942). It points at a `.cstat`
-envelope version 3: same `RCST` header/body/CRC shape as v1 and v2, keyed by
-content hash exactly as v2 is (`ColumnStatsSegment.writer_id` is the entry's
-own content hash), but scoped to exactly the one snapshot part that owns it
--- `ColumnStatsHeader.part_blake3` has length one, the owning part's hash,
-and `ColumnStatsHeader.segment_count` is that part's segment count. Field 7
-is absent (proto3 default) for a part with no per-part statistics; the reader
-falls back to field 13, then field 11, then to scan (ADR-1413 decision 2).
-Absence is never an error.
+SnapshotColumnStatsPartRef`. It points at a `.cstat` envelope version 3: same
+`RCST` header/body/CRC shape the format has always used, keyed by content
+hash (`ColumnStatsSegment.writer_id` is the entry's own content hash), but
+scoped to exactly the one snapshot part that owns it -- `ColumnStatsHeader.
+part_blake3` has length one, the owning part's hash, and `ColumnStatsHeader.
+segment_count` is that part's segment count. Field 7 is absent (proto3
+default) for a part with no per-part statistics; there is no fallback for
+such a part, it is scanned (ADR-1413 decision 6). Absence is never an error.
 
-**Reader (`Catalog::load_column_stats`, ADR-1413 decision 2).** A query
-resolves its window to an hour range and narrows HEAD's parts to the ones
-`parts_intersecting` that window covers -- the same narrowing
-`load_snapshot` uses for segment refs. For each covered part, independently:
-try that part's own field-7 ref first. If it is present and the v3 object
-loads and decodes, that part's segment lands in the loaded statistics keyed
-by its own content hash and the reader is done with that part -- one GET,
-no whole-object read triggered by it. If the ref is absent, or the GET comes
-back not-found, or the object fails to decode
-(`FetchOutcome::DecodeRefused`, the same warn-once-and-count-once decode
-refusal the whole-object reader already applies, extended per part: logged
-once via `tracing::warn!` and counted once in
-`Catalog::column_stats_decode_refusals`), that part's coverage is deferred
-to the fallback below rather than left silently missing.
+The whole-tenant v1 (`SnapshotColumnStatsRef`, formerly HEAD field 11,
+ADR-0850) and v2 (`SnapshotColumnStatsPartRef` at the whole-tenant scope,
+formerly HEAD field 13, ADR-0942) forms are retired by ADR-1413 decision 6
+(#1600): the fold no longer publishes either at any size, fields 11 and 13
+are `reserved` on `SnapshotHead` (never reused), and the decoder's accepted
+set of `.cstat` envelope versions is exactly `{3}` -- a v1 or v2 object, if
+one somehow still existed, is rejected as an unsupported version rather than
+decoded.
 
-Once every covered part has been tried, if any part still needs coverage the
-reader fetches the whole-tenant field-13 (v2) object once, if HEAD has one,
-and merges every decoded segment in with `.or_insert` -- a part that already
-got its own v3 record keeps it; the whole-object entry only fills a gap. A
-decoded v2 object does not by itself prove every still-needed part was
-answered: the fold's per-entry column-stats build has a warn-and-omit path
-(one segment's build failing degrades that segment out of the published
-object rather than failing the whole fold), so v2 can decode successfully
-while silently missing a covered part's segment. No v2 record identifies
-which physical part it belongs to (its key is the entry's own content hash,
-unrelated to any part's blake3), so the reader cannot check per-part
-coverage directly; instead it compares the number of segments v2 actually
-decoded against the sum of `entry_count` declared across every part on
-HEAD -- the total v2's whole-tenant build claims to cover. Only when that
-comparison shows a shortfall (or the v2 object was absent, refused, or HEAD
-carries no field 13) does the reader also fetch and merge the whole-tenant
-field-11 (v1) object once, the same way and with the same precedence: a part
-already covered by v3 or v2 is never displaced by v1. A part that still has
-no coverage after all three sources is left uncovered: the query scans for
-it, exactly as if no statistics existed for that part at all. A HEAD whose
-parts carry no field-7 ref anywhere (a snapshot folded before ADR-1413)
-never attempts a per-part GET: every covered part is immediately deferred to
-the fallback, so the reader still evaluates the v2-then-v1 coverage check
-described above rather than assuming one whole-object GET always suffices.
+**Reader (`Catalog::load_column_stats`, ADR-1413 decision 2, amended by
+decision 6).** A query resolves its window to an hour range and narrows
+HEAD's parts to the ones `parts_intersecting` that window covers -- the same
+narrowing `load_snapshot` uses for segment refs. For each covered part,
+independently: if it carries a field-7 ref and the v3 object it names loads
+and decodes, that part's segment lands in the loaded statistics keyed by its
+own content hash -- one GET per such part, and no other object is ever
+fetched on its account. If the ref is absent, or the GET comes back
+not-found, or the object fails to decode (`FetchOutcome::DecodeRefused`,
+logged once via `tracing::warn!` and counted once in
+`Catalog::column_stats_decode_refusals`), that part is left with no loaded
+statistics at all: the query scans for it, exactly as if no statistics
+existed for that part. There is no whole-tenant fallback and no
+declared-entry-count coverage comparison to decide whether one is needed --
+per-part coverage is decided per part, from that part's own field-7 ref
+alone.
 
 Cost, in accounted GETs: one HEAD GET, plus exactly one GET per covered part
-that carries its own field-7 ref, plus up to one v2 GET and, when v2 leaves
-a covered part uncovered (absent, refused, missing from HEAD, or decoded
-short of the declared entry-count total), one further v1 GET, each fetched
-at most once per call. A query can therefore legitimately issue both the v2
-and the v1 whole-object GET in the same call -- this is intended behavior
-for a v2 object that omitted a segment via the fold's warn-and-omit path,
-not a cost regression. The reader never issues more than one v2 GET and one
-v1 GET per call regardless of how many parts fall back to it.
+that carries its own field-7 ref, and nothing else. A part without a field-7
+ref, or whose v3 object is absent or refused, costs no additional GET beyond
+the one already spent (or not spent) on it; the query simply scans that
+part's segments directly.
 
 The fold writes one v3 object per part it actually re-encodes this fold
 (never for a part carried forward by reference, since that part's `.csnap`
@@ -603,7 +583,7 @@ bytes."
 
 **Per-part ceiling and degrade (ADR-1413 decisions 3-4, amended
 2026-09-08).** The per-part ceiling is `DEFAULT_MAX_COLUMN_STATS_BYTES` (256
-MiB), the same constant `ColumnStatsLimits` already enforces on the
+MiB), the same constant `ColumnStatsLimits` enforced on the now-retired
 whole-object v1/v2 guard, not a separate per-part formula (ADR-1413's
 rejected alternatives record the proportional bound and why it lost).
 Before compressing, the fold measures the concatenated uncompressed body
@@ -625,23 +605,27 @@ the error (`SnapshotFormatError::ColumnStatsPartOverBound`/
 `CatalogError::ColumnStatsPartOverBound`) and write no object -- there is no
 truncated object for a reader to silently trust.
 
-**Dual-publish window.** The fold keeps writing the v1 (field 11) and v2
-(field 13) whole-object statistics unchanged alongside the new v3 per-part
-objects: retiring field 13 at the first v3 publish would be the
-writers-before-readers change ADR-0066 decision 1 forbids, since an older
-reader that ignores field 7 must still find field 13. The decoder's accepted
-set of `.cstat` envelope versions is `{1, 2, 3}` for this window; the set
-narrows to
-`{2, 3}` and then `{3}` only as field 13's and field 11's own reviewed
-retirement changes, each citing the recorded format floors (ADR-0066
-decision 3), independently of each other.
+**Retirement of the whole-object forms (ADR-1413 decision 6, #1600).** The
+fold no longer writes the v1 or v2 whole-tenant statistics at any size: v3
+per-part objects at field 7 are the only form published. `SnapshotHead`
+fields 11 and 13 are `reserved`, so there is no struct field left to set or
+read for either one; a HEAD encoded today carries neither. This landed as
+one coordinated change across the fold (write side), the reader (decode
+side), and the GC sweep (reachability side) rather than a dual-publish
+window, since the whole-tenant forms had no independent readers left to
+migrate off them first: `load_column_stats`'s only fallback for a
+field-7-less part was the scan path already required for the absent case.
 
 **GC-sweep coverage.** The sweep rule described above
 (`ravel_maintain::sweep::sweep_unreferenced_catalog_objects`) treats HEAD's
-own `column_stats.key` (field 11), `column_stats_part.key` (field 13), and
-every `parts[].column_stats.key` (field 7) as referenced, so a v3 per-part
-object HEAD's current parts list still names is never swept as unreferenced
-while its owning part is live.
+`postings.key` and every `parts[].column_stats.key` (field 7) as referenced.
+It no longer reads `column_stats.key` (field 11) or `column_stats_part.key`
+(field 13) at all -- there is no struct field to read -- so a `.cstat`
+object named only by one of those retired fields on a HEAD written before
+this change is now unreferenced and swept once it crosses the protection
+horizon, exactly like any other orphaned catalog object. A v3 per-part
+object HEAD's current parts list still names is unaffected and is never
+swept as unreferenced while its owning part is live.
 
 ### Idempotency marker body layout
 

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -533,8 +533,8 @@ such a part, it is scanned (ADR-1413 decision 6). Absence is never an error.
 
 The whole-tenant v1 (`SnapshotColumnStatsRef`, formerly HEAD field 11,
 ADR-0850) and v2 (`SnapshotColumnStatsPartRef` at the whole-tenant scope,
-formerly HEAD field 13, ADR-0942) forms are retired by ADR-1413 decision 6
-(#1600): the fold no longer publishes either at any size, fields 11 and 13
+formerly HEAD field 13, ADR-0942) forms are retired by ADR-1413 decision 6:
+the fold no longer publishes either at any size, fields 11 and 13
 are `reserved` on `SnapshotHead` (never reused), and the decoder's accepted
 set of `.cstat` envelope versions is exactly `{3}` -- a v1 or v2 object, if
 one somehow still existed, is rejected as an unsupported version rather than
@@ -560,8 +560,8 @@ alone.
 Cost, in accounted GETs: one HEAD GET, plus exactly one GET per covered part
 that carries its own field-7 ref, and nothing else. A part without a field-7
 ref, or whose v3 object is absent or refused, costs no additional GET beyond
-the one already spent (or not spent) on it; the query simply scans that
-part's segments directly.
+the one already spent (or not spent) on it; the query scans that part's
+segments directly.
 
 The fold writes one v3 object per part it actually re-encodes this fold
 (never for a part carried forward by reference, since that part's `.csnap`
@@ -605,7 +605,7 @@ the error (`SnapshotFormatError::ColumnStatsPartOverBound`/
 `CatalogError::ColumnStatsPartOverBound`) and write no object -- there is no
 truncated object for a reader to silently trust.
 
-**Retirement of the whole-object forms (ADR-1413 decision 6, #1600).** The
+**Retirement of the whole-object forms (ADR-1413 decision 6).** The
 fold no longer writes the v1 or v2 whole-tenant statistics at any size: v3
 per-part objects at field 7 are the only form published. `SnapshotHead`
 fields 11 and 13 are `reserved`, so there is no struct field left to set or

--- a/proto/ravel/catalog.proto
+++ b/proto/ravel/catalog.proto
@@ -122,22 +122,19 @@ message SnapshotHead {
   // record view. Absent/0 = pre-reshard head; readers must never treat
   // absence as an error.
   uint32 shard_generation_count = 10;
-  // Additive, ADR-0850 (logs typed-column statistics). Absent when the
-  // tenant has no configured typed columns (ADR-0090), no eligible L0
-  // segment has been folded yet, or the last fold's column-stats build
-  // failed; readers must never treat absence as an error, and must fall
-  // back to scanning for any statistic this ref does not cover.
-  SnapshotColumnStatsRef column_stats = 11;
-  // Additive, ADR-0942 (re-key .cstat column statistics to snapshot-part
-  // binding). Points at a part-hash-keyed .cstat (envelope v2), joined to a
-  // resolved segment by the covered part's SnapshotPartRef.blake3 rather than
-  // the ADR-0850 five-field identity tuple field 11 carries. Field 12 is
-  // deliberately skipped: ADR-0913 has claimed it for
-  // SnapshotMaterializationRef. Absent means no part-bound statistics have
-  // been built; readers must never treat absence as an error, and must fall
-  // back to scanning for any statistic this ref does not cover. Field 11 is
-  // neither renumbered nor redefined and keeps its ADR-0850 meaning.
-  SnapshotColumnStatsPartRef column_stats_part = 13;
+  // Retired, ADR-1413 decision 6 (#1600). Formerly SnapshotColumnStatsRef
+  // column_stats (ADR-0850 whole-object v1 statistics). The fold no longer
+  // publishes this object at any size; per-part statistics live at
+  // SnapshotPartRef.column_stats (field 7) instead. Never reused.
+  reserved 11;
+  // Field 12 is deliberately skipped: ADR-0913 has claimed it for
+  // SnapshotMaterializationRef.
+  //
+  // Retired, ADR-1413 decision 6 (#1600). Formerly SnapshotColumnStatsPartRef
+  // column_stats_part (ADR-0942 whole-object v2 statistics). The fold no
+  // longer publishes this object at any size; per-part statistics live at
+  // SnapshotPartRef.column_stats (field 7) instead. Never reused.
+  reserved 13;
 }
 
 message SnapshotPartRef {
@@ -154,9 +151,8 @@ message SnapshotPartRef {
   uint32 min_hour = 6;
   // Additive, ADR-1413. The per-part column-statistics object covering
   // exactly this part's segments. Absent (proto3 default) means this part
-  // has no per-part statistics; the reader falls back to the whole-object
-  // ref at SnapshotHead field 13 (ADR-0942), then field 11 (ADR-0850), then
-  // to scan. Absence is never an error.
+  // has no per-part statistics and is scanned: since ADR-1413 decision 6
+  // there is no whole-object fallback. Absence is never an error.
   SnapshotColumnStatsPartRef column_stats = 7;
 }
 
@@ -184,26 +180,14 @@ message SnapshotPostingsHeader {
   uint64 body_uncompressed_len = 7;
 }
 
-// Reference to a column-statistics object (RCST1 envelope), ADR-0850. Bound
-// to the exact set of parts it was built from, the same way
-// SnapshotPostingsRef binds a name-postings object: a column-stats object is
-// only trustworthy against the parts whose blake3 hashes it names here.
-message SnapshotColumnStatsRef {
-  string key = 1;              // full object key of the column-stats object
-  bytes blake3 = 2;             // 32, of the column-stats object's full bytes
-  uint64 size = 3;
-  uint32 segment_count = 4;     // number of segments with an entry in this object
-  repeated bytes part_blake3 = 5;  // covered parts' blake3, same order as parts
-}
-
 // Reference to a part-hash-keyed column-statistics object (RCST envelope,
-// v2), ADR-0942. Mirrors SnapshotColumnStatsRef (field 11) field-for-field;
-// the difference is semantic, not structural: the covered .cstat binds its
-// per-segment statistics to a part's blake3 rather than to the ADR-0850
-// five-field identity tuple, so it covers L1 (and rewrite-output) segments
-// that the tuple key cannot name uniquely. Like SnapshotColumnStatsRef it is
-// bound to the exact set of parts it was built from: it is only trustworthy
-// against the parts whose blake3 hashes it names here.
+// v2 shape, v3 when covering exactly one part), ADR-0942/ADR-1413. Bound to
+// the exact set of parts it was built from, the same way SnapshotPostingsRef
+// binds a name-postings object: a column-stats object is only trustworthy
+// against the parts whose blake3 hashes it names here. Used at
+// SnapshotPartRef.column_stats (field 7); the whole-object v1 and v2 forms
+// this message used to serve at SnapshotHead fields 11 and 13 were retired
+// by ADR-1413 decision 6 (#1600).
 message SnapshotColumnStatsPartRef {
   string key = 1;              // full object key of the column-stats object
   bytes blake3 = 2;             // 32, of the column-stats object's full bytes

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use ravel_catalog::{CatalogConfig, FoldReport, PartLimits};
 use ravel_object_store::{GetRange, ObjectStoreBackend};
-use ravel_proto::catalog::v1::{SnapshotColumnStatsPartRef, SnapshotColumnStatsRef};
+use ravel_proto::catalog::v1::SnapshotColumnStatsPartRef;
 use ravel_types::{Signal, TenantHash, TenantId};
 use uuid::Uuid;
 
@@ -259,22 +259,6 @@ fn render_fold_report(
     out.push_str(&format!("postings_built: {}\n", report.postings_built));
     out.push_str(&format!("postings_bytes: {}\n", report.postings_bytes));
     out.push_str(&format!(
-        "column_stats_built: {}\n",
-        report.column_stats_built
-    ));
-    out.push_str(&format!(
-        "column_stats_bytes: {}\n",
-        report.column_stats_bytes
-    ));
-    out.push_str(&format!(
-        "column_stats_part_built: {}\n",
-        report.column_stats_part_built
-    ));
-    out.push_str(&format!(
-        "column_stats_part_bytes: {}\n",
-        report.column_stats_part_bytes
-    ));
-    out.push_str(&format!(
         "column_stats_part_objects_built: {}\n",
         report.column_stats_part_objects_built
     ));
@@ -376,14 +360,6 @@ pub async fn render_inspect(
     ));
     out.push_str(&format!("created_unix_ns: {}\n", head.created_unix_ns));
     out.push_str(&format!("parts: {}\n", head.parts.len()));
-    out.push_str(&format!(
-        "column_stats (field 11): {}\n",
-        format_column_stats_ref(head.column_stats.as_ref())
-    ));
-    out.push_str(&format!(
-        "column_stats_part (field 13): {}\n",
-        format_column_stats_part_ref(head.column_stats_part.as_ref())
-    ));
 
     let limits = PartLimits::default();
     for (index, part_ref) in head.parts.iter().enumerate() {
@@ -433,20 +409,10 @@ pub async fn render_inspect(
     Ok(())
 }
 
-/// Formats a HEAD-level `SnapshotColumnStatsRef` (field 11, ADR-0850) as a
+/// Formats a `SnapshotColumnStatsPartRef` (per-part field 7, ADR-1413) as a
 /// `key=... size=...` line, or `ABSENT` when the field is unset. Printing
 /// `ABSENT` rather than omitting the line matters: an omitted line and an
 /// unset field are otherwise indistinguishable to a reader (#1598).
-fn format_column_stats_ref(r: Option<&SnapshotColumnStatsRef>) -> String {
-    match r {
-        Some(r) => format!("key={} size={}", r.key, r.size),
-        None => "ABSENT".to_string(),
-    }
-}
-
-/// Formats a `SnapshotColumnStatsPartRef` (HEAD field 13, ADR-0942, or
-/// per-part field 7, ADR-1413 -- both share this message shape) as a
-/// `key=... size=...` line, or `ABSENT` when the field is unset.
 fn format_column_stats_part_ref(r: Option<&SnapshotColumnStatsPartRef>) -> String {
     match r {
         Some(r) => format!("key={} size={}", r.key, r.size),
@@ -715,8 +681,6 @@ mod tests {
             folder_id: vec![0u8; 16],
             created_unix_ns: 0,
             postings: None,
-            column_stats: None,
-            column_stats_part: None,
             shard_generation_count: 1,
         };
         let head_bytes = ravel_catalog::encode_head(&head).expect("encode head");

--- a/services/ravel-cli/tests/catalog.rs
+++ b/services/ravel-cli/tests/catalog.rs
@@ -19,9 +19,7 @@ use ravel_commit::publish::{self, RetryPolicy};
 use ravel_commit::record::{self, NewCommitRecord};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
-use ravel_proto::catalog::v1::{
-    SnapshotColumnStatsPartRef, SnapshotColumnStatsRef, SnapshotHead, SnapshotPartRef,
-};
+use ravel_proto::catalog::v1::{SnapshotColumnStatsPartRef, SnapshotHead, SnapshotPartRef};
 use ravel_types::{Signal, TenantId};
 use uuid::Uuid;
 
@@ -373,20 +371,20 @@ async fn inspect_preserves_partial_output_when_a_part_fetch_fails() {
     );
 }
 
-/// Deliverable 3 (#1598): HEAD field 11 (`SnapshotColumnStatsRef`, ADR-0850),
-/// HEAD field 13 (`SnapshotColumnStatsPartRef`, ADR-0942), and per-part field
-/// 7 (`SnapshotColumnStatsPartRef`, ADR-1413) must each print their key and
-/// size when set. Only the present direction is covered here; the sibling
-/// test below covers absent, because a test that only covers "present"
-/// cannot detect the omitted-line-vs-unset-field ambiguity that motivated
-/// this deliverable.
+/// Deliverable 3 (#1598), narrowed by ADR-1413 decision 6 (#1600): HEAD
+/// fields 11 and 13 (the whole-tenant `SnapshotColumnStatsRef`/
+/// `SnapshotColumnStatsPartRef` forms) are retired and `reserved`, so only
+/// the per-part field 7 (`SnapshotColumnStatsPartRef`, ADR-1413) remains for
+/// `render_inspect` to print. It must print its key and size when set. Only
+/// the present direction is covered here; the sibling test below covers
+/// absent, because a test that only covers "present" cannot detect the
+/// omitted-line-vs-unset-field ambiguity that motivated this deliverable.
 ///
-/// Prove-the-test: delete the `column_stats (field 11)` (or `field 13`, or
-/// `field 7`) `push_str` line from `render_inspect`
-/// (`services/ravel-cli/src/catalog.rs`) and the matching assertion below
-/// fails.
+/// Prove-the-test: delete the `column_stats (field 7)` `push_str` line from
+/// `render_inspect` (`services/ravel-cli/src/catalog.rs`) and the matching
+/// assertion below fails.
 #[tokio::test]
-async fn inspect_prints_column_stats_refs_when_present() {
+async fn inspect_prints_column_stats_ref_when_present() {
     let store = Arc::new(MemoryStore::new());
     let tenant_hash = TenantId::new("acme").hash();
     let head_key = format!(
@@ -410,8 +408,6 @@ async fn inspect_prints_column_stats_refs_when_present() {
         .await
         .expect("seed the part");
 
-    let field11_key = "t/acme/catalog/metrics/idx/present-v1.cstat".to_string();
-    let field13_key = "t/acme/catalog/metrics/idx/present-v2.cstat".to_string();
     let field7_key = "t/acme/catalog/metrics/idx/present-v3.cstat".to_string();
 
     let head = SnapshotHead {
@@ -437,20 +433,6 @@ async fn inspect_prints_column_stats_refs_when_present() {
         }],
         folder_id: Uuid::new_v4().into_bytes().to_vec(),
         created_unix_ns: now_ns(),
-        column_stats: Some(SnapshotColumnStatsRef {
-            key: field11_key.clone(),
-            blake3: vec![11u8; 32],
-            size: 1100,
-            segment_count: 1,
-            part_blake3: vec![blake3::hash(&part_bytes).as_bytes().to_vec()],
-        }),
-        column_stats_part: Some(SnapshotColumnStatsPartRef {
-            key: field13_key.clone(),
-            blake3: vec![13u8; 32],
-            size: 1300,
-            segment_count: 1,
-            part_blake3: vec![],
-        }),
         ..Default::default()
     };
     let head_bytes = ravel_catalog::encode_head(&head).expect("encode a valid head");
@@ -472,31 +454,18 @@ async fn inspect_prints_column_stats_refs_when_present() {
 
     assert!(
         out.contains(&format!(
-            "column_stats (field 11): key={field11_key} size=1100"
-        )),
-        "HEAD field 11 ref not printed: {out}"
-    );
-    assert!(
-        out.contains(&format!(
-            "column_stats_part (field 13): key={field13_key} size=1300"
-        )),
-        "HEAD field 13 ref not printed: {out}"
-    );
-    assert!(
-        out.contains(&format!(
             "column_stats (field 7): key={field7_key} size=700"
         )),
         "per-part field 7 ref not printed: {out}"
     );
 }
 
-/// Deliverable 3's absent direction: when field 11, field 13, and the
-/// per-part field 7 are all unset, the report prints an explicit `ABSENT`
-/// marker for each rather than omitting the line. An omitted line and an
-/// unset field are otherwise indistinguishable to a reader, which is exactly
-/// the ambiguity that hid a real defect (#1598).
+/// Deliverable 3's absent direction: when the per-part field 7 is unset, the
+/// report prints an explicit `ABSENT` marker rather than omitting the line.
+/// An omitted line and an unset field are otherwise indistinguishable to a
+/// reader, which is exactly the ambiguity that hid a real defect (#1598).
 #[tokio::test]
-async fn inspect_prints_absent_marker_for_unset_column_stats_refs() {
+async fn inspect_prints_absent_marker_for_unset_column_stats_ref() {
     let store = Arc::new(MemoryStore::new());
     let tenant_hash = TenantId::new("acme").hash();
     let head_key = format!(
@@ -537,8 +506,6 @@ async fn inspect_prints_absent_marker_for_unset_column_stats_refs() {
         }],
         folder_id: Uuid::new_v4().into_bytes().to_vec(),
         created_unix_ns: now_ns(),
-        column_stats: None,
-        column_stats_part: None,
         ..Default::default()
     };
     let head_bytes = ravel_catalog::encode_head(&head).expect("encode a valid head");
@@ -558,14 +525,6 @@ async fn inspect_prints_absent_marker_for_unset_column_stats_refs() {
     .await
     .expect("inspect succeeds");
 
-    assert!(
-        out.contains("column_stats (field 11): ABSENT"),
-        "HEAD field 11 must print an explicit ABSENT marker: {out}"
-    );
-    assert!(
-        out.contains("column_stats_part (field 13): ABSENT"),
-        "HEAD field 13 must print an explicit ABSENT marker: {out}"
-    );
     assert!(
         out.contains("column_stats (field 7): ABSENT"),
         "per-part field 7 must print an explicit ABSENT marker: {out}"

--- a/services/ravel-cli/tests/catalog_fold_report.rs
+++ b/services/ravel-cli/tests/catalog_fold_report.rs
@@ -190,10 +190,6 @@ async fn fold_human_report_prints_every_fold_report_field() {
         "parts_reused:",
         "postings_built:",
         "postings_bytes:",
-        "column_stats_built:",
-        "column_stats_bytes:",
-        "column_stats_part_built:",
-        "column_stats_part_bytes:",
         "column_stats_part_objects_built:",
         "column_stats_dictionaries_dropped:",
         "layout_drift_count:",
@@ -218,8 +214,13 @@ async fn fold_human_report_prints_every_fold_report_field() {
     let keys = value
         .as_object()
         .expect("FoldReport is a struct, so it serializes to an object");
+    // Deliberately lowered from 23 (ADR-1413 decision 6, #1600): the fold no
+    // longer publishes the whole-object v1/v2 column-stats forms, so
+    // `column_stats_built`/`column_stats_bytes`/`column_stats_part_built`/
+    // `column_stats_part_bytes` are gone from `FoldReport` outright, not
+    // merely renamed.
     assert!(
-        keys.len() >= 23,
+        keys.len() >= 19,
         "expected the derived key set to cover the whole struct, got {} keys; \
          if FoldReport shrank, update this floor deliberately",
         keys.len()
@@ -339,9 +340,7 @@ async fn fold_put_requests_counts_exactly_the_objects_this_fold_writes() {
         "this fixture's payload cannot decode as a real segment, so no postings object is built: {report:?}"
     );
     assert!(
-        !report.column_stats_built
-            && !report.column_stats_part_built
-            && report.column_stats_part_objects_built == 0,
+        report.column_stats_part_objects_built == 0,
         "fixture declares no typed columns, so no column-stats object is built: {report:?}"
     );
     assert_eq!(

--- a/services/ravel-cli/tests/inspect_cstat.rs
+++ b/services/ravel-cli/tests/inspect_cstat.rs
@@ -11,7 +11,7 @@
 
 use ravel_catalog::{
     ColumnStatsLimits, DEFAULT_MAX_COLUMN_STATS_BYTES, decode_column_stats_header,
-    encode_column_stats,
+    encode_column_stats_v3,
 };
 use ravel_cli::catalog::render_inspect_cstat;
 use ravel_proto::catalog::v1::column_value::Kind;
@@ -30,7 +30,9 @@ fn i64_value(v: i64) -> ColumnValue {
 
 /// Mirrors `crates/ravel-catalog/src/snapshot_format/column_stats.rs`'s own
 /// `segment()` test fixture: a single I64 column, 10-entry dictionary,
-/// `sum = 45` (0+1+...+9).
+/// `sum = 45` (0+1+...+9). `writer_id` is 32 bytes: v3 keys segments by
+/// content hash (ADR-1413 decision 6, #1600), not the 16-byte writer
+/// identity v1 used.
 fn fixture_segment() -> ColumnStatsSegment {
     let dictionary: Vec<DictEntry> = (0..10)
         .map(|v| DictEntry {
@@ -41,7 +43,7 @@ fn fixture_segment() -> ColumnStatsSegment {
     ColumnStatsSegment {
         ingest_hour_bucket: 1,
         shard: 0,
-        writer_id: vec![0xAA; 16],
+        writer_id: vec![0xAA; 32],
         writer_epoch: 1,
         writer_seq: 1,
         columns: vec![ColumnStat {
@@ -61,14 +63,20 @@ fn fixture_segment() -> ColumnStatsSegment {
 #[test]
 fn inspect_cstat_prints_exact_header_values_and_dictionary_presence() {
     let segments = vec![fixture_segment()];
-    let bytes = encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &segments)
-        .expect("encodes a valid v1 object");
+    let bytes = encode_column_stats_v3(
+        [0x11; 16],
+        3,
+        [0x22; 32],
+        &segments,
+        DEFAULT_MAX_COLUMN_STATS_BYTES,
+    )
+    .expect("encodes a valid v3 object");
 
     let mut out = String::new();
     render_inspect_cstat(&bytes, &mut out).expect("a valid object under ceiling decodes cleanly");
 
-    assert!(out.contains("envelope_version: 1\n"), "{out}");
-    assert!(out.contains("format_version: 1\n"), "{out}");
+    assert!(out.contains("envelope_version: 3\n"), "{out}");
+    assert!(out.contains("format_version: 3\n"), "{out}");
     assert!(
         out.contains(&format!("tenant_hash: {}\n", hex::encode([0x11; 16]))),
         "{out}"
@@ -108,7 +116,7 @@ fn encode_forged_envelope(header: &ColumnStatsHeader, body: &[u8]) -> Vec<u8> {
     let header_bytes = header.encode_to_vec();
     let mut prefix = Vec::new();
     prefix.extend_from_slice(b"RCST");
-    prefix.push(1u8);
+    prefix.push(3u8);
     prefix.extend_from_slice(&[0u8; 3]);
     prefix.extend_from_slice(&(header_bytes.len() as u32).to_le_bytes());
     prefix.extend_from_slice(&header_bytes);
@@ -125,10 +133,10 @@ fn encode_forged_envelope(header: &ColumnStatsHeader, body: &[u8]) -> Vec<u8> {
 #[test]
 fn inspect_cstat_reports_over_ceiling_without_decompressing() {
     let header = ColumnStatsHeader {
-        format_version: 1,
+        format_version: 3,
         tenant_hash: vec![0x33; 16],
         signal: 2,
-        part_blake3: vec![],
+        part_blake3: vec![vec![0x44; 32]],
         segment_count: 1,
         body_uncompressed_len: DEFAULT_MAX_COLUMN_STATS_BYTES + 1,
     };
@@ -170,8 +178,14 @@ fn inspect_cstat_reports_over_ceiling_without_decompressing() {
 #[test]
 fn inspect_cstat_on_a_truncated_object_returns_a_typed_error_not_a_panic() {
     let segments = vec![fixture_segment()];
-    let bytes = encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &segments)
-        .expect("encodes a valid v1 object");
+    let bytes = encode_column_stats_v3(
+        [0x11; 16],
+        3,
+        [0x22; 32],
+        &segments,
+        DEFAULT_MAX_COLUMN_STATS_BYTES,
+    )
+    .expect("encodes a valid v3 object");
     let truncated = &bytes[..bytes.len() - 5];
 
     let mut out = String::new();
@@ -185,8 +199,14 @@ fn inspect_cstat_on_a_truncated_object_returns_a_typed_error_not_a_panic() {
 #[test]
 fn inspect_cstat_on_a_corrupt_object_returns_a_typed_error_not_a_panic() {
     let segments = vec![fixture_segment()];
-    let mut bytes = encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &segments)
-        .expect("encodes a valid v1 object");
+    let mut bytes = encode_column_stats_v3(
+        [0x11; 16],
+        3,
+        [0x22; 32],
+        &segments,
+        DEFAULT_MAX_COLUMN_STATS_BYTES,
+    )
+    .expect("encodes a valid v3 object");
     // Corrupt the magic so this fails the very first envelope check.
     bytes[0] ^= 0xFF;
 

--- a/services/ravel-server/src/maintain.rs
+++ b/services/ravel-server/src/maintain.rs
@@ -2688,8 +2688,6 @@ mod tests {
             folder_id: vec![0u8; 16],
             created_unix_ns: 0,
             postings: None,
-            column_stats: None,
-            column_stats_part: None,
             shard_generation_count: 1,
         };
         store


### PR DESCRIPTION
Implements ADR-1413 decision 6. The fold now publishes only the v3 per-part
object under SnapshotPartRef field 7. It no longer writes the v1 whole-object
form (SnapshotHead.column_stats, field 11) or the v2 whole-object form
(SnapshotHead.column_stats_part, field 13), at any size. The decoder's
accepted .cstat envelope-version set becomes {3}, and decision 2's fallback
ladder collapses to: a covered part has its field-7 ref and it decodes, or
that part is scanned.

The dual-publish window existed for one reason, which the ADR stated
outright: an older reader that ignores field 7 must still find field 13, so
retiring it earlier would be the writers-before-readers change ADR-0066
decision 1 forbids. The owner directed on 2026-09-10 that no
backward-compatibility constraint applies before v1.0.0, so there is no older
reader and the window has no content.

Measured on the ClickBench reference tenant during the T2 run (#1413), this
is what the retirement stops paying for. Every fold wrote three
column-statistics objects: the v3 per-part object at 83.4 MiB of wire, and
the v1 and v2 whole-object forms at 1.65 and 1.66 GiB. Both whole-object
forms declared roughly 6.5 GB uncompressed, 24.3 times the 256 MiB decode
ceiling, so neither was readable by any reader while both were written on
every fold, and one of the two was not referenced from HEAD at all. Retiring
them saves 3,559,956,752 wire bytes of PUT and about five minutes of fold
wall time per run.

Nothing is migrated. A .cstat is a Class B derived catalog object, so a
tenant's statistics are whatever its next fold produces, and artifacts
already written under fields 11 and 13 become unreferenced and are reclaimed
by the existing sweep lifecycle: read_head_reference stops treating those two
keys as referenced, which is the intended GC rather than a side effect.
Field numbers 11 and 13 are marked reserved and never reused, which holds
regardless of the release boundary because a reused number misdecodes
silently rather than failing.

One correction to an existing test, found while satisfying the
demonstration requirement rather than by review. The task asked for
query_over_k_of_n_parts_issues_exactly_k_per_part_gets_and_no_whole_object_get
to be shown failing against pre-change code. It cannot fail: verified three
ways, against a real pre-#1600 tree, against a loop-target flip, and against
a mutation that fabricates a ref, all leaving it green, because its excluded
part carries no field-7 ref so no fallback path is ever consulted. Its doc
comment claimed otherwise and now states the true situation and points at the
sibling test that does bite. The new
head_with_only_field_thirteen_yields_no_statistics_and_scans carries the
behaviour change and was demonstrated failing both against the pre-change
tree and against a current-code mutation.

services/ravel-server was not in the task's declared scope. Its compile break
is a direct mechanical consequence of the same struct change and blocked the
workspace clippy gate, so it is fixed here rather than worked around.

Refs: #1600
Refs: #1413
