### PR TITLE
fix(ingest): size flush on object bytes, not buffered bytes

### DIFF
--- a/crates/ravel-ingest/src/budget.rs
+++ b/crates/ravel-ingest/src/budget.rs
@@ -1,10 +1,15 @@
 //! Process-wide ingest buffer byte budget (ADR-0069 decision 1).
 //!
 //! Ravel's memory model is configuration-bounded per tenant and per query, but
-//! nothing bounded the *sum* of buffered ingest state across tenants: the
-//! per-(tenant, shard, signal) buffer cap is ~8 MiB, so the worst case grows
+//! nothing bounded the *sum* of buffered ingest state across tenants: each
+//! per-(tenant, shard, signal) buffer may hold up to the memory backstop
+//! ([`crate::config::buffer_memory_backstop_bytes`]: an eighth of this ceiling,
+//! capped at 64 MiB and never below `target_bytes`), so the worst case grows
 //! with active-tenant count and can exceed an 8 GB host's RAM before any
-//! per-tenant limit trips (ADR-0069 Context). [`IngestByteBudget`] is the one
+//! per-tenant limit trips (ADR-0069 Context). The backstop is derived from the
+//! ceiling configured here, so raising or lowering `--max-ingest-buffer-bytes`
+//! moves the per-buffer bound with it and no single buffer can take a large
+//! share of the budget. [`IngestByteBudget`] is the one
 //! process-wide gauge that bounds it: a request's estimated buffered bytes are
 //! charged at admission (after decode, before buffering), and refunded when the
 //! flush that held them completes or fails.
@@ -143,6 +148,15 @@ impl IngestByteBudget {
         self.limit
     }
 
+    /// The configured ceiling in the form the callers configured it, for a
+    /// router to publish to its shard actors via [`BufferBudgetCeiling`].
+    pub(crate) fn limit(&self) -> IngestByteBudgetLimit {
+        match self.limit {
+            Some(n) => IngestByteBudgetLimit::Bounded(n),
+            None => IngestByteBudgetLimit::Unlimited,
+        }
+    }
+
     /// Cumulative requests shed at the ceiling since process start, for the
     /// `ravel_ingest_buffer_shed_total` counter on `/metrics`.
     pub fn shed_total(&self) -> u64 {
@@ -173,6 +187,49 @@ impl IngestByteBudget {
                 Ok(_) => break,
                 Err(observed) => current = observed,
             }
+        }
+    }
+}
+
+/// The configured ceiling, shared live with every shard actor of one router so
+/// the per-buffer memory backstop
+/// ([`crate::config::buffer_memory_backstop_bytes`]) can be a fraction of the
+/// limit an operator actually set rather than of the default.
+///
+/// It is a shared cell rather than a plain value because the budget arrives
+/// after the actors exist: [`crate::IngestRouter::new`] spawns the shard-actor
+/// factory, and `services/ravel-server` installs the configured budget
+/// afterwards with `with_budget`. Every actor clones this cell and reads it at
+/// trigger time, so the install order does not matter and a later generation's
+/// actors see the same value.
+///
+/// `u64::MAX` encodes [`IngestByteBudgetLimit::Unlimited`]. That makes
+/// `Bounded(u64::MAX)` indistinguishable from `Unlimited`, which costs nothing:
+/// the backstop is capped well below an eighth of `u64::MAX`, so both spellings
+/// derive the identical backstop.
+#[derive(Debug, Clone)]
+pub(crate) struct BufferBudgetCeiling(Arc<AtomicU64>);
+
+/// The `Unlimited` encoding for [`BufferBudgetCeiling`].
+const CEILING_UNLIMITED: u64 = u64::MAX;
+
+impl BufferBudgetCeiling {
+    pub(crate) fn unlimited() -> Self {
+        BufferBudgetCeiling(Arc::new(AtomicU64::new(CEILING_UNLIMITED)))
+    }
+
+    pub(crate) fn set(&self, limit: IngestByteBudgetLimit) {
+        let encoded = match limit {
+            IngestByteBudgetLimit::Bounded(n) => n,
+            IngestByteBudgetLimit::Unlimited => CEILING_UNLIMITED,
+        };
+        self.0.store(encoded, Ordering::Relaxed);
+    }
+
+    pub(crate) fn get(&self) -> IngestByteBudgetLimit {
+        match self.0.load(Ordering::Relaxed) {
+            CEILING_UNLIMITED => IngestByteBudgetLimit::Unlimited,
+            n => IngestByteBudgetLimit::Bounded(n),
         }
     }
 }

--- a/crates/ravel-ingest/src/config.rs
+++ b/crates/ravel-ingest/src/config.rs
@@ -2,6 +2,8 @@
 
 use std::time::Duration;
 
+use crate::budget::IngestByteBudgetLimit;
+
 /// RSEG trailer version every flush emits. ADR-0027 leaves v7 the only
 /// writable version (ADR-0092 bumped it from v6), so this is no longer a
 /// configurable knob; it mirrors `ravel_segment`'s `VERSION_V7` constant, and
@@ -227,11 +229,17 @@ pub(crate) enum FlushClockError {
     RegressionRefused(String),
 }
 
-/// Floor under the per-buffer memory backstop
-/// ([`buffer_memory_backstop_bytes`]). One eighth of the 512 MiB process
-/// ceiling (ADR-0069), so no single (shard, tenant) buffer can take a large
-/// share of the shared budget while it fills toward `target_bytes`.
-const BUFFER_MEMORY_BACKSTOP_FLOOR_BYTES: usize = 64 * 1024 * 1024;
+/// Share of the process-wide ADR-0069 ceiling that one (shard, tenant) buffer
+/// may hold before the memory backstop fires: an eighth, so seven eighths of
+/// the budget stay available to every other tenant while one buffer fills
+/// toward `target_bytes`.
+const BUFFER_MEMORY_BACKSTOP_BUDGET_DIVISOR: u64 = 8;
+
+/// Cap on the per-buffer memory backstop, so an operator who raises
+/// `--max-ingest-buffer-bytes` to tens of gigabytes does not thereby let one
+/// buffer hold gigabytes of RAM. An eighth of the 512 MiB default ceiling, so
+/// the default sizing is unchanged by the cap.
+const BUFFER_MEMORY_BACKSTOP_CAP_BYTES: usize = 64 * 1024 * 1024;
 
 /// The memory a single (shard, tenant) buffer may hold before the size trigger
 /// fires regardless of how few object bytes it would write.
@@ -241,25 +249,63 @@ const BUFFER_MEMORY_BACKSTOP_FLOOR_BYTES: usize = 64 * 1024 * 1024;
 /// labels holds roughly twenty times more RAM than the bytes it contributes to
 /// the object. Without this backstop such a tenant would fill RAM toward the
 /// ADR-0069 shed ceiling instead of flushing, and shedding a write is worse
-/// than writing a smaller object. Never below `target_bytes`, because the
-/// buffered memory of a flush is always at least the object bytes it writes,
-/// so a lower backstop would pre-empt the target it is meant to protect.
-pub(crate) fn buffer_memory_backstop_bytes(config: &IngestConfig) -> usize {
-    BUFFER_MEMORY_BACKSTOP_FLOOR_BYTES.max(config.target_bytes)
+/// than writing a smaller object.
+///
+/// Derived from the ceiling the operator configured, not from the default one:
+/// `--max-ingest-buffer-bytes` is what a shed is measured against, so a
+/// constant backstop calibrated against the default inverts this rationale on
+/// any replica sized below it. At `Bounded(64 MiB)` a constant 64 MiB backstop
+/// lets one label-heavy buffer hold the entire process budget and shed every
+/// other tenant's write until an age trigger releases it.
+/// [`IngestByteBudgetLimit::Unlimited`] has no ceiling to take a share of, so
+/// the cap applies alone: nothing sheds under it, and the cap is what keeps one
+/// buffer's resident memory bounded.
+///
+/// Never below `target_bytes`: a backstop under the target would fire first on
+/// every buffer and make the memory figure, not the object estimate, the
+/// effective size trigger, which is the defect issue #1305 fixed. When an
+/// eighth of the ceiling is itself below `target_bytes` (a ceiling under
+/// `8 * target_bytes`, so under 64 MiB at the default target) `target_bytes`
+/// wins and one buffer's share of the budget is larger than an eighth. That
+/// configuration is already degenerate: a ceiling that holds only a few
+/// target-sized objects sheds on tenant count whatever the backstop does.
+pub(crate) fn buffer_memory_backstop_bytes(
+    config: &IngestConfig,
+    ceiling: IngestByteBudgetLimit,
+) -> usize {
+    let share = match ceiling {
+        IngestByteBudgetLimit::Unlimited => BUFFER_MEMORY_BACKSTOP_CAP_BYTES,
+        IngestByteBudgetLimit::Bounded(limit) => {
+            usize::try_from(limit / BUFFER_MEMORY_BACKSTOP_BUDGET_DIVISOR)
+                .unwrap_or(usize::MAX)
+                .min(BUFFER_MEMORY_BACKSTOP_CAP_BYTES)
+        }
+    };
+    share.max(config.target_bytes)
 }
 
 /// The size trigger, shared by the metrics, log, and span shard actors:
 /// `flush_est_bytes` is the object-bytes estimate for the flush this buffer
 /// would write and gates `target_bytes`; `est_bytes` is the conservative
 /// buffered-memory figure the ADR-0069 ceiling charges and gates only the
-/// memory backstop. Keeping both here keeps one rule in one place rather than
-/// three copies that drift (issue #1305).
+/// memory backstop, whose bound comes from `ceiling`. Keeping both here keeps
+/// one rule in one place rather than three copies that drift (issue #1305).
+///
+/// The backstop can only pre-empt the target when a buffer holds more memory
+/// than the object bytes it would write, which is the case it exists for. The
+/// reverse happens too and the backstop is silent there: a native histogram
+/// charges a flat 16 bytes per point to `est_bytes` while contributing up to
+/// `32 + 8 * (buckets + spans + custom_values)` object bytes, and a log record
+/// with no attributes charges 32 against 48 object bytes. Those buffers reach
+/// `target_bytes` on the object estimate first, which is the intended trigger.
 pub(crate) fn size_trigger_fires(
     flush_est_bytes: usize,
     est_bytes: usize,
     config: &IngestConfig,
+    ceiling: IngestByteBudgetLimit,
 ) -> bool {
-    flush_est_bytes >= config.target_bytes || est_bytes >= buffer_memory_backstop_bytes(config)
+    flush_est_bytes >= config.target_bytes
+        || est_bytes >= buffer_memory_backstop_bytes(config, ceiling)
 }
 
 /// All fields are overridable; defaults match the dev-sizing table.
@@ -403,28 +449,100 @@ mod tests {
             target_bytes: 8 * 1024 * 1024,
             ..IngestConfig::default()
         };
-        let backstop = buffer_memory_backstop_bytes(&cfg);
+        let default_ceiling = IngestByteBudgetLimit::Bounded(512 * 1024 * 1024);
+        let backstop = buffer_memory_backstop_bytes(&cfg, default_ceiling);
         assert_eq!(backstop, 64 * 1024 * 1024);
 
         // Object bytes decide, whatever the buffer holds.
-        assert!(!size_trigger_fires(cfg.target_bytes - 1, 0, &cfg));
-        assert!(size_trigger_fires(cfg.target_bytes, 0, &cfg));
+        assert!(!size_trigger_fires(
+            cfg.target_bytes - 1,
+            0,
+            &cfg,
+            default_ceiling
+        ));
+        assert!(size_trigger_fires(
+            cfg.target_bytes,
+            0,
+            &cfg,
+            default_ceiling
+        ));
         assert!(
-            !size_trigger_fires(0, cfg.target_bytes, &cfg),
+            !size_trigger_fires(0, cfg.target_bytes, &cfg, default_ceiling),
             "buffered bytes at target_bytes no longer fire the trigger"
         );
 
         // Backstop decides when the buffer runs far past the payload it holds.
-        assert!(!size_trigger_fires(0, backstop - 1, &cfg));
-        assert!(size_trigger_fires(0, backstop, &cfg));
+        assert!(!size_trigger_fires(0, backstop - 1, &cfg, default_ceiling));
+        assert!(size_trigger_fires(0, backstop, &cfg, default_ceiling));
 
-        // A target above the floor raises the backstop with it, so the
+        // A target above the cap raises the backstop with it, so the
         // backstop can never pre-empt the trigger it backs.
         let wide = IngestConfig {
             target_bytes: 256 * 1024 * 1024,
             ..IngestConfig::default()
         };
-        assert_eq!(buffer_memory_backstop_bytes(&wide), 256 * 1024 * 1024);
+        assert_eq!(
+            buffer_memory_backstop_bytes(&wide, default_ceiling),
+            256 * 1024 * 1024
+        );
+    }
+
+    /// The backstop is a share of the ceiling an operator configured, not of
+    /// the default one. A replica sized with `--max-ingest-buffer-bytes
+    /// 67108864` must not let one (shard, tenant) buffer hold the whole process
+    /// budget and shed every other tenant's write.
+    #[test]
+    fn memory_backstop_is_a_share_of_the_configured_ceiling() {
+        let cfg = IngestConfig {
+            target_bytes: 8 * 1024 * 1024,
+            ..IngestConfig::default()
+        };
+        let small = 64 * 1024 * 1024_u64;
+        let backstop = buffer_memory_backstop_bytes(&cfg, IngestByteBudgetLimit::Bounded(small));
+        assert_eq!(
+            backstop,
+            8 * 1024 * 1024,
+            "an eighth of the configured ceiling, not the 64 MiB the default ceiling earns"
+        );
+        assert_eq!(
+            backstop as u64 * BUFFER_MEMORY_BACKSTOP_BUDGET_DIVISOR,
+            small,
+            "one buffer holds an eighth of the budget, leaving seven eighths"
+        );
+        assert!(
+            size_trigger_fires(0, backstop, &cfg, IngestByteBudgetLimit::Bounded(small)),
+            "the buffer flushes at an eighth of the budget"
+        );
+        assert!(
+            size_trigger_fires(
+                0,
+                small as usize - 1,
+                &cfg,
+                IngestByteBudgetLimit::Bounded(small)
+            ),
+            "a buffer one byte short of the whole ceiling has long since flushed"
+        );
+
+        // Unlimited has no ceiling to take a share of: the cap alone bounds a
+        // buffer's resident memory, and nothing sheds under it.
+        assert_eq!(
+            buffer_memory_backstop_bytes(&cfg, IngestByteBudgetLimit::Unlimited),
+            64 * 1024 * 1024
+        );
+        // A ceiling far above the default does not raise the backstop with it.
+        assert_eq!(
+            buffer_memory_backstop_bytes(
+                &cfg,
+                IngestByteBudgetLimit::Bounded(64 * 1024 * 1024 * 1024)
+            ),
+            64 * 1024 * 1024
+        );
+        // `Bounded(0)` sheds every non-empty write, so nothing can buffer to a
+        // backstop at all; `target_bytes` is the floor that remains.
+        assert_eq!(
+            buffer_memory_backstop_bytes(&cfg, IngestByteBudgetLimit::Bounded(0)),
+            8 * 1024 * 1024
+        );
     }
 
     #[test]

--- a/crates/ravel-ingest/src/config.rs
+++ b/crates/ravel-ingest/src/config.rs
@@ -227,6 +227,41 @@ pub(crate) enum FlushClockError {
     RegressionRefused(String),
 }
 
+/// Floor under the per-buffer memory backstop
+/// ([`buffer_memory_backstop_bytes`]). One eighth of the 512 MiB process
+/// ceiling (ADR-0069), so no single (shard, tenant) buffer can take a large
+/// share of the shared budget while it fills toward `target_bytes`.
+const BUFFER_MEMORY_BACKSTOP_FLOOR_BYTES: usize = 64 * 1024 * 1024;
+
+/// The memory a single (shard, tenant) buffer may hold before the size trigger
+/// fires regardless of how few object bytes it would write.
+///
+/// The size trigger is stated in object bytes, and the ratio between object
+/// bytes and buffered memory is client-controlled: a series with many short
+/// labels holds roughly twenty times more RAM than the bytes it contributes to
+/// the object. Without this backstop such a tenant would fill RAM toward the
+/// ADR-0069 shed ceiling instead of flushing, and shedding a write is worse
+/// than writing a smaller object. Never below `target_bytes`, because the
+/// buffered memory of a flush is always at least the object bytes it writes,
+/// so a lower backstop would pre-empt the target it is meant to protect.
+pub(crate) fn buffer_memory_backstop_bytes(config: &IngestConfig) -> usize {
+    BUFFER_MEMORY_BACKSTOP_FLOOR_BYTES.max(config.target_bytes)
+}
+
+/// The size trigger, shared by the metrics, log, and span shard actors:
+/// `flush_est_bytes` is the object-bytes estimate for the flush this buffer
+/// would write and gates `target_bytes`; `est_bytes` is the conservative
+/// buffered-memory figure the ADR-0069 ceiling charges and gates only the
+/// memory backstop. Keeping both here keeps one rule in one place rather than
+/// three copies that drift (issue #1305).
+pub(crate) fn size_trigger_fires(
+    flush_est_bytes: usize,
+    est_bytes: usize,
+    config: &IngestConfig,
+) -> bool {
+    flush_est_bytes >= config.target_bytes || est_bytes >= buffer_memory_backstop_bytes(config)
+}
+
 /// All fields are overridable; defaults match the dev-sizing table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IngestConfig {
@@ -236,7 +271,16 @@ pub struct IngestConfig {
     pub shard_count: u32,
     /// Bounded mpsc channel depth per shard.
     pub channel_depth: usize,
-    /// Flush a tenant's buffer once its estimated size reaches this many bytes.
+    /// Flush a tenant's buffer once the object that flush would write is
+    /// estimated to reach this many bytes.
+    ///
+    /// Estimated in object bytes, not in buffered memory (issue #1305): the
+    /// size trigger reads the per-signal flush-size estimator, while the
+    /// process-wide memory ceiling (ADR-0069) keeps charging its own
+    /// conservative figure. The two are no longer one number, so raising this
+    /// to get larger objects no longer weakens the memory ceiling.
+    /// [`buffer_memory_backstop_bytes`] is what bounds the memory a single
+    /// buffer may hold while filling toward this target.
     pub target_bytes: usize,
     /// Flush a tenant's buffer once its oldest point is at least this old.
     pub max_flush_delay: Duration,
@@ -251,9 +295,12 @@ pub struct IngestConfig {
     /// paying a PUT every `max_flush_delay` regardless of how little data it
     /// holds.
     pub max_flush_delay_idle: Duration,
-    /// A buffer at or above this many estimated bytes is never treated as
-    /// idle for the age trigger, even with no strict-mode waiter: it is
-    /// already worth the PUT cost `max_flush_delay` pays for.
+    /// A buffer whose flush would write at least this many object bytes is
+    /// never treated as idle for the age trigger, even with no strict-mode
+    /// waiter: it is already worth the PUT cost `max_flush_delay` pays for.
+    /// Same estimator and same units as `target_bytes` (issue #1305): "worth a
+    /// PUT" is a statement about the object, not about the RAM the buffer
+    /// occupies while building it.
     pub min_flush_bytes: usize,
     /// Retries after the first attempt for the data-object PUT (total
     /// attempts = this + 1). Also bounds retries of the commit-record PUT.
@@ -346,6 +393,39 @@ impl Default for IngestConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The trigger reads the object-bytes estimate, and the memory backstop is
+    /// the bound on the other side: a buffer whose struct headers dwarf its
+    /// payload still flushes before it can hold an unbounded amount of RAM.
+    #[test]
+    fn size_trigger_reads_object_bytes_with_a_memory_backstop() {
+        let cfg = IngestConfig {
+            target_bytes: 8 * 1024 * 1024,
+            ..IngestConfig::default()
+        };
+        let backstop = buffer_memory_backstop_bytes(&cfg);
+        assert_eq!(backstop, 64 * 1024 * 1024);
+
+        // Object bytes decide, whatever the buffer holds.
+        assert!(!size_trigger_fires(cfg.target_bytes - 1, 0, &cfg));
+        assert!(size_trigger_fires(cfg.target_bytes, 0, &cfg));
+        assert!(
+            !size_trigger_fires(0, cfg.target_bytes, &cfg),
+            "buffered bytes at target_bytes no longer fire the trigger"
+        );
+
+        // Backstop decides when the buffer runs far past the payload it holds.
+        assert!(!size_trigger_fires(0, backstop - 1, &cfg));
+        assert!(size_trigger_fires(0, backstop, &cfg));
+
+        // A target above the floor raises the backstop with it, so the
+        // backstop can never pre-empt the trigger it backs.
+        let wide = IngestConfig {
+            target_bytes: 256 * 1024 * 1024,
+            ..IngestConfig::default()
+        };
+        assert_eq!(buffer_memory_backstop_bytes(&wide), 256 * 1024 * 1024);
+    }
 
     #[test]
     fn defaults_match_sizing_table() {

--- a/crates/ravel-ingest/src/log_router.rs
+++ b/crates/ravel-ingest/src/log_router.rs
@@ -19,7 +19,7 @@ use ravel_types::logstream::AttrValue;
 use ravel_types::{CommitToken, TenantHash, shard_for_log};
 use tokio::sync::{mpsc, oneshot};
 
-use crate::budget::{IngestByteBudget, IngestByteBudgetLimit};
+use crate::budget::{BufferBudgetCeiling, IngestByteBudget, IngestByteBudgetLimit};
 use crate::clock::Clock;
 use crate::config::IngestConfig;
 use crate::generation::{DEFAULT_REFRESH_INTERVAL_NS, GenerationSwitch, Routed, load_generations};
@@ -96,6 +96,11 @@ pub struct LogIngestRouter {
     /// `services/ravel-server` installs the configured budget via
     /// [`LogIngestRouter::with_budget`].
     budget: Arc<IngestByteBudget>,
+    /// The ceiling from `budget`, shared with every shard actor this router
+    /// spawns so the per-buffer memory backstop is a fraction of the configured
+    /// limit. Written by [`LogIngestRouter::with_budget`], which runs after the
+    /// actors exist.
+    backstop_ceiling: BufferBudgetCeiling,
     /// Per-stage timing accumulator (ADR-0104 decision 1), shared by `Arc` with
     /// every shard actor and flush task so the seam records into one table the
     /// bench reporter reads via [`LogIngestRouter::stage_timings`]. Present only
@@ -155,6 +160,7 @@ impl LogIngestRouter {
         rng: Arc<dyn RngSource>,
     ) -> Self {
         let metrics = Arc::new(LogIngestMetrics::new(config.shard_count));
+        let backstop_ceiling = BufferBudgetCeiling::unlimited();
         #[cfg(feature = "stage-timing")]
         let stage_timings = Arc::new(LogStageTimings::new());
         let factory = {
@@ -163,6 +169,7 @@ impl LogIngestRouter {
             let rng = Arc::clone(&rng);
             let metrics = Arc::clone(&metrics);
             let indexed_fields = Arc::clone(&indexed_fields);
+            let backstop_ceiling = backstop_ceiling.clone();
             #[cfg(feature = "stage-timing")]
             let stage_timings = Arc::clone(&stage_timings);
             move |shard_count: u32| -> Vec<LogShardHandle> {
@@ -183,6 +190,7 @@ impl LogIngestRouter {
                             Arc::clone(&metrics),
                             rx,
                             Arc::clone(&indexed_fields),
+                            backstop_ceiling.clone(),
                             #[cfg(feature = "stage-timing")]
                             Arc::clone(&stage_timings),
                         );
@@ -206,6 +214,7 @@ impl LogIngestRouter {
             indexed_fields,
             config,
             budget: IngestByteBudget::shared(IngestByteBudgetLimit::Unlimited),
+            backstop_ceiling,
             #[cfg(feature = "stage-timing")]
             stage_timings,
         }
@@ -219,9 +228,13 @@ impl LogIngestRouter {
         Arc::clone(&self.stage_timings)
     }
 
-    /// Installs the shared process-wide ingest buffer byte budget (ADR-0069).
+    /// Installs the shared process-wide ingest buffer byte budget (ADR-0069),
+    /// and publishes its ceiling to this router's shard actors so the
+    /// per-buffer memory backstop is a fraction of the configured limit rather
+    /// than of the default one (issue #1305).
     #[must_use]
     pub fn with_budget(mut self, budget: Arc<IngestByteBudget>) -> Self {
+        self.backstop_ceiling.set(budget.limit());
         self.budget = budget;
         self
     }

--- a/crates/ravel-ingest/src/log_shard.rs
+++ b/crates/ravel-ingest/src/log_shard.rs
@@ -57,7 +57,7 @@ use crate::budget::IngestByteCharge;
 use crate::clock::Clock;
 use crate::config::{
     DrainIntent, FlushClockError, IngestConfig, LOG_SEGMENT_FORMAT_VERSION, MAX_FLUSH_ALL_PASSES,
-    MAX_FLUSH_CLOCK_HOLD_NS, checked_ingest_hour_bucket,
+    MAX_FLUSH_CLOCK_HOLD_NS, checked_ingest_hour_bucket, size_trigger_fires,
 };
 use crate::log_declared_stats::{DeclaredStatAccum, declared_type_tag};
 use crate::log_error::LogWriteError;
@@ -103,8 +103,8 @@ pub(crate) enum LogShardMsg {
     Shutdown { done: oneshot::Sender<()> },
 }
 
-/// Estimated buffered byte cost of one attribute value, for the `est_bytes`
-/// flush-trigger heuristic and the process-wide ingest byte budget it feeds
+/// Estimated buffered byte cost of one attribute value, for the process-wide
+/// ingest byte budget it feeds
 /// (ADR-0069). Every container charges its per-element struct header at its own
 /// nesting level, not only at the top: a `Map` charges
 /// `size_of::<(String, AttrValue)>()` per entry and a `List` charges
@@ -194,6 +194,93 @@ pub(crate) fn est_columnar_bytes(batch: &ColumnarLogBatch) -> usize {
     body + severity_text + stream_attrs + attr_bytes + 32 * batch.num_rows
 }
 
+/// Fixed per-record cost in the object a log flush writes: the two i64
+/// timestamps, severity_num, flags, and the 16-byte trace id with its 8-byte
+/// span id. Above `est_record_bytes`'s own fixed 32 on purpose: that one
+/// registers buffered memory, where the ids sit inside the record struct this
+/// estimator must instead account for in stored form.
+const LOG_RECORD_OBJECT_FIXED_BYTES: usize = 48;
+
+/// Object-side length of one attribute value, the size-trigger counterpart of
+/// [`attr_value_len`] (issue #1305): the same leaf bytes, without the
+/// `AttrValue` and `(String, AttrValue)` struct headers the buffer holds and
+/// the object never stores.
+fn attr_value_object_len(value: &AttrValue) -> usize {
+    match value {
+        AttrValue::Str(s) => s.len(),
+        AttrValue::Bytes(b) => b.len(),
+        AttrValue::I64(_) | AttrValue::F64(_) => 8,
+        AttrValue::Bool(_) => 1,
+        AttrValue::List(items) => items.iter().map(attr_value_object_len).sum(),
+        AttrValue::Map(entries) => entries
+            .iter()
+            .map(|(k, v)| k.len() + attr_value_object_len(v))
+            .sum(),
+    }
+}
+
+/// Estimated bytes one record contributes to the object a log flush writes,
+/// for the size trigger only (`target_bytes` and `min_flush_bytes`, issue
+/// #1305). The memory-side figure stays [`est_record_bytes`], which the
+/// ADR-0069 ceiling charges.
+///
+/// Model: the record's stored payload -- body, severity text, stream attribute
+/// blob, and every attribute key and value byte -- plus
+/// [`LOG_RECORD_OBJECT_FIXED_BYTES`] for the fixed columns. No
+/// `(String, AttrValue)` header appears, because none reaches the object; a
+/// ten-attribute record charges about 560 bytes of struct headers to the
+/// ceiling that the object does not hold, which is what made the size trigger
+/// fire at a fraction of `target_bytes`.
+///
+/// Direction: an upper bound on the bytes the flush writes, for the reason
+/// [`crate::value::IngestPoint::est_object_sample_bytes`] states. RLOG
+/// dictionary-encodes repeated attribute keys and zstd-compresses its column
+/// blocks, both strictly below the raw bytes counted here.
+pub(crate) fn est_record_object_bytes(rec: &NormalizedLogRecord) -> usize {
+    let attr_bytes: usize = rec
+        .attrs
+        .iter()
+        .map(|(k, v)| k.len() + attr_value_object_len(v))
+        .sum();
+    rec.body.len()
+        + rec.severity_text.len()
+        + rec.stream_attrs.len()
+        + attr_bytes
+        + LOG_RECORD_OBJECT_FIXED_BYTES
+}
+
+/// [`est_record_object_bytes`] computed column-wise over a
+/// [`ColumnarLogBatch`] (ADR-0109 decision 6), term for term as
+/// [`est_columnar_bytes`] mirrors [`est_record_bytes`]: the two representations
+/// must give the same size trigger the same number for the same records, or a
+/// tenant's object size would depend on which wire path admitted it.
+pub(crate) fn est_columnar_object_bytes(batch: &ColumnarLogBatch) -> usize {
+    let body = batch.body.data().len();
+    let severity_text = batch.severity_text.data().len();
+    let stream_attrs: usize = batch
+        .stream_refs
+        .iter()
+        .map(|&r| batch.stream_attrs[r as usize].len())
+        .sum();
+
+    let mut attr_bytes = 0usize;
+    for col in &batch.dyn_columns {
+        for cell in &col.cells {
+            attr_bytes += col.name.len() + attr_value_object_len(cell);
+        }
+    }
+    for row in &batch.residual_attrs {
+        for (k, v) in row {
+            attr_bytes += k.len() + attr_value_object_len(v);
+        }
+    }
+
+    body + severity_text
+        + stream_attrs
+        + attr_bytes
+        + LOG_RECORD_OBJECT_FIXED_BYTES * batch.num_rows
+}
+
 /// Type-level bridge from the OTLP-independent [`NormalizedLogRecord`] to the
 /// writer's [`LogRecord`]. Every field maps one to one; there is no data
 /// transformation, only a struct rename.
@@ -234,6 +321,11 @@ enum BufContent {
 struct LogTenantBuf {
     content: BufContent,
     est_bytes: usize,
+    /// Estimated bytes the object this buffer's flush writes will hold, the
+    /// size trigger's own figure (issue #1305, [`est_record_object_bytes`]).
+    /// `est_bytes` above stays the buffered-memory charge behind the ADR-0069
+    /// ceiling.
+    flush_est_bytes: usize,
     oldest_arrival_ns: Option<i64>,
     min_ingest_ts_ns: Option<i64>,
     max_ingest_ts_ns: Option<i64>,
@@ -274,6 +366,7 @@ impl LogTenantBuf {
         arrival_ns: i64,
     ) -> Result<usize, LogWriteError> {
         let bytes_added: usize = records.iter().map(est_record_bytes).sum();
+        let object_bytes_added: usize = records.iter().map(est_record_object_bytes).sum();
         // ADR-0873 wave 5a: fold this write's eligible declared-column extrema
         // in the one pass that already visits the records, on the accepted arms
         // only. Extrema folded for a refused write would be stamped onto the
@@ -296,6 +389,7 @@ impl LogTenantBuf {
         }
         self.note_arrival(arrival_ns);
         self.est_bytes += bytes_added;
+        self.flush_est_bytes += object_bytes_added;
         Ok(bytes_added)
     }
 
@@ -311,6 +405,7 @@ impl LogTenantBuf {
         arrival_ns: i64,
     ) -> Result<usize, LogWriteError> {
         let bytes_added = est_columnar_bytes(&batch);
+        let object_bytes_added = est_columnar_object_bytes(&batch);
         // ADR-0873 wave 5a, on the accepted arms only, for the reason
         // [`Self::merge_rows`] gives: a refused batch's extrema would otherwise
         // be stamped onto a flush that does not carry its rows (issue #1036).
@@ -331,6 +426,7 @@ impl LogTenantBuf {
         }
         self.note_arrival(arrival_ns);
         self.est_bytes += bytes_added;
+        self.flush_est_bytes += object_bytes_added;
         Ok(bytes_added)
     }
 
@@ -1017,7 +1113,6 @@ impl LogShardActor {
         }
         let arrival_ns = self.clock.now_ns();
         let records_len = records.len() as u64;
-        let target_bytes = self.config.target_bytes;
 
         // Grab the timing handle before the mutable buffer borrow so recording
         // `merge` does not clash with the `&mut self.tenants` borrow held below.
@@ -1056,7 +1151,7 @@ impl LogShardActor {
         let should_flush = self
             .tenants
             .get(&tenant)
-            .map(|b| b.est_bytes >= target_bytes)
+            .map(|b| size_trigger_fires(b.flush_est_bytes, b.est_bytes, &self.config))
             .unwrap_or(false);
         if should_flush && let Some(buf) = self.tenants.remove(&tenant) {
             return self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
@@ -1067,7 +1162,7 @@ impl LogShardActor {
     /// The columnar counterpart of [`Self::handle_write`] (ADR-0109 decision 5):
     /// buffers one already-partitioned [`ColumnarLogBatch`] for `tenant`,
     /// refusing fail-loud if the buffer already holds row-major records. The
-    /// flush-trigger accounting (`est_bytes >= target_bytes`), the charge and
+    /// flush-trigger accounting (`flush_est_bytes >= target_bytes`), the charge and
     /// waiter handling, and the size-flush path are identical to the row path,
     /// as is the flush-permit wait it returns (see [`Self::handle_write`]).
     async fn handle_write_columnar(
@@ -1083,7 +1178,6 @@ impl LogShardActor {
         }
         let arrival_ns = self.clock.now_ns();
         let records_len = batch.num_rows as u64;
-        let target_bytes = self.config.target_bytes;
 
         #[cfg(feature = "stage-timing")]
         let merge_timings = Arc::clone(&self.ctx.stage_timings);
@@ -1117,7 +1211,7 @@ impl LogShardActor {
         let should_flush = self
             .tenants
             .get(&tenant)
-            .map(|b| b.est_bytes >= target_bytes)
+            .map(|b| size_trigger_fires(b.flush_est_bytes, b.est_bytes, &self.config))
             .unwrap_or(false);
         if should_flush && let Some(buf) = self.tenants.remove(&tenant) {
             return self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
@@ -1125,14 +1219,18 @@ impl LogShardActor {
         0
     }
 
-    /// A buffer with a strict-mode waiter or at least `min_flush_bytes`
+    /// A buffer with a strict-mode waiter, or one whose flush would write at
+    /// least `min_flush_bytes` of object,
     /// already justifies a PUT on the fast `max_flush_delay` clock; anything
     /// else is idle and waits for the slower `max_flush_delay_idle` instead
-    /// (ADR-0051 section 7). Strict-mode ack latency is unaffected:
+    /// (ADR-0051 section 7). "Worth a PUT" is a claim about the object, so this
+    /// reads the object-bytes estimate, not the buffered-memory charge (issue
+    /// #1305). Strict-mode ack latency is unaffected:
     /// a strict write always leaves `waiters` non-empty for its whole flush
     /// window.
     fn age_threshold_ns(&self, buf: &LogTenantBuf) -> i64 {
-        let has_priority = !buf.waiters.is_empty() || buf.est_bytes >= self.config.min_flush_bytes;
+        let has_priority =
+            !buf.waiters.is_empty() || buf.flush_est_bytes >= self.config.min_flush_bytes;
         if has_priority {
             self.config.max_flush_delay.as_nanos() as i64
         } else {
@@ -2909,10 +3007,15 @@ mod tests {
             records in proptest::collection::vec(record_strategy(), 0..12)
         ) {
             let row_total: usize = records.iter().map(est_record_bytes).sum();
+            let object_total: usize = records.iter().map(est_record_object_bytes).sum();
             let logrecords: Vec<LogRecord> =
                 records.iter().map(|r| to_logseg_record(r.clone())).collect();
             let batch = ColumnarLogBatch::from_records(&logrecords);
             prop_assert_eq!(est_columnar_bytes(&batch), row_total);
+            // The same equality for the size trigger's object-bytes estimate:
+            // a tenant's object size must not depend on which wire path
+            // admitted its records.
+            prop_assert_eq!(est_columnar_object_bytes(&batch), object_total);
         }
     }
 
@@ -2957,8 +3060,10 @@ mod tests {
             attrs,
         };
         let row_total = est_record_bytes(&rec);
+        let object_total = est_record_object_bytes(&rec);
         let batch = ColumnarLogBatch::from_records(&[to_logseg_record(rec)]);
         assert_eq!(est_columnar_bytes(&batch), row_total);
+        assert_eq!(est_columnar_object_bytes(&batch), object_total);
     }
 
     /// ADR-0109 decision 5: a tenant's shard buffer is columnar or row-major,

--- a/crates/ravel-ingest/src/log_shard.rs
+++ b/crates/ravel-ingest/src/log_shard.rs
@@ -53,7 +53,7 @@ use tokio::task::JoinSet;
 use tokio::time::Duration;
 use uuid::Uuid;
 
-use crate::budget::IngestByteCharge;
+use crate::budget::{BufferBudgetCeiling, IngestByteCharge};
 use crate::clock::Clock;
 use crate::config::{
     DrainIntent, FlushClockError, IngestConfig, LOG_SEGMENT_FORMAT_VERSION, MAX_FLUSH_ALL_PASSES,
@@ -955,6 +955,11 @@ pub(crate) struct LogShardActor {
     flushes: JoinSet<()>,
     rx: mpsc::Receiver<LogShardMsg>,
     tenants: HashMap<TenantId, LogTenantBuf>,
+    /// The configured ADR-0069 ceiling, shared live with the router so the
+    /// per-buffer memory backstop is a fraction of the limit the operator set.
+    /// Read at trigger time rather than resolved once, because the router
+    /// installs the budget after the actors are spawned.
+    backstop_ceiling: BufferBudgetCeiling,
 }
 
 impl LogShardActor {
@@ -970,6 +975,7 @@ impl LogShardActor {
         metrics: Arc<LogIngestMetrics>,
         rx: mpsc::Receiver<LogShardMsg>,
         indexed_fields: Arc<IndexedFieldsOverlay>,
+        backstop_ceiling: BufferBudgetCeiling,
         #[cfg(feature = "stage-timing")] stage_timings: Arc<LogStageTimings>,
     ) -> Self {
         let ctx = Arc::new(LogFlushCtx {
@@ -999,6 +1005,7 @@ impl LogShardActor {
             flushes: JoinSet::new(),
             rx,
             tenants: HashMap::new(),
+            backstop_ceiling,
         }
     }
 
@@ -1151,7 +1158,14 @@ impl LogShardActor {
         let should_flush = self
             .tenants
             .get(&tenant)
-            .map(|b| size_trigger_fires(b.flush_est_bytes, b.est_bytes, &self.config))
+            .map(|b| {
+                size_trigger_fires(
+                    b.flush_est_bytes,
+                    b.est_bytes,
+                    &self.config,
+                    self.backstop_ceiling.get(),
+                )
+            })
             .unwrap_or(false);
         if should_flush && let Some(buf) = self.tenants.remove(&tenant) {
             return self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
@@ -1162,9 +1176,10 @@ impl LogShardActor {
     /// The columnar counterpart of [`Self::handle_write`] (ADR-0109 decision 5):
     /// buffers one already-partitioned [`ColumnarLogBatch`] for `tenant`,
     /// refusing fail-loud if the buffer already holds row-major records. The
-    /// flush-trigger accounting (`flush_est_bytes >= target_bytes`), the charge and
-    /// waiter handling, and the size-flush path are identical to the row path,
-    /// as is the flush-permit wait it returns (see [`Self::handle_write`]).
+    /// flush-trigger accounting (`flush_est_bytes >= target_bytes`, or
+    /// `est_bytes` past the memory backstop), the charge and waiter handling,
+    /// and the size-flush path are identical to the row path, as is the
+    /// flush-permit wait it returns (see [`Self::handle_write`]).
     async fn handle_write_columnar(
         &mut self,
         tenant: TenantId,
@@ -1211,7 +1226,14 @@ impl LogShardActor {
         let should_flush = self
             .tenants
             .get(&tenant)
-            .map(|b| size_trigger_fires(b.flush_est_bytes, b.est_bytes, &self.config))
+            .map(|b| {
+                size_trigger_fires(
+                    b.flush_est_bytes,
+                    b.est_bytes,
+                    &self.config,
+                    self.backstop_ceiling.get(),
+                )
+            })
             .unwrap_or(false);
         if should_flush && let Some(buf) = self.tenants.remove(&tenant) {
             return self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
@@ -1484,8 +1506,9 @@ impl LogShardActor {
                 // so that next trigger flushes them (finding 1): `charges` ride
                 // back with the buffer (the byte budget is not refunded, the bytes
                 // are still held), and the whole buffer -- content, declared-column
-                // stats, and the trigger bookkeeping (`est_bytes`,
-                // `oldest_arrival_ns`) -- is preserved intact. Only `waiters` are
+                // stats, and the trigger bookkeeping (`flush_est_bytes`, which
+                // drives the size trigger, `est_bytes`, which drives the memory
+                // backstop, and `oldest_arrival_ns`) -- is preserved intact. Only `waiters` are
                 // acked here and taken out of the re-inserted buffer: a waiter left
                 // in it would be re-acked by the next flush against an
                 // already-answered oneshot. A strict-mode waiter that retries on the
@@ -1770,6 +1793,7 @@ mod tests {
                 Arc::new(IndexedFieldsOverlay::new(Arc::new(
                     crate::log_router::NoIndexedFields,
                 ))),
+                BufferBudgetCeiling::unlimited(),
                 #[cfg(feature = "stage-timing")]
                 Arc::new(LogStageTimings::new()),
             );
@@ -2629,6 +2653,7 @@ mod tests {
             Arc::new(IndexedFieldsOverlay::new(Arc::new(
                 crate::log_router::NoIndexedFields,
             ))),
+            BufferBudgetCeiling::unlimited(),
             #[cfg(feature = "stage-timing")]
             Arc::new(LogStageTimings::new()),
         );

--- a/crates/ravel-ingest/src/router.rs
+++ b/crates/ravel-ingest/src/router.rs
@@ -12,7 +12,7 @@ use ravel_otlp::NormalizedPoint;
 use ravel_types::{CommitToken, Signal, TenantId, shard_for};
 use tokio::sync::{mpsc, oneshot};
 
-use crate::budget::{IngestByteBudget, IngestByteBudgetLimit};
+use crate::budget::{BufferBudgetCeiling, IngestByteBudget, IngestByteBudgetLimit};
 use crate::clock::Clock;
 use crate::config::IngestConfig;
 use crate::error::WriteError;
@@ -137,6 +137,11 @@ pub struct IngestRouter {
     /// `services/ravel-server` installs the configured budget with
     /// [`IngestRouter::with_budget`].
     budget: Arc<IngestByteBudget>,
+    /// The ceiling from `budget`, shared with every shard actor this router
+    /// spawns so the per-buffer memory backstop is a fraction of the configured
+    /// limit. Written by [`IngestRouter::with_budget`], which runs after the
+    /// actors exist.
+    backstop_ceiling: BufferBudgetCeiling,
     /// Per-stage timing accumulator (ADR-0104 decision 1), shared by `Arc` with
     /// every shard actor and flush task so the seam records into one table the
     /// bench reporter reads via [`IngestRouter::stage_timings`]. Present only
@@ -222,6 +227,7 @@ impl IngestRouter {
         // router's fixed shard set (issue #865), so the per-message enqueue and
         // process paths never contend on a shared lock.
         let metrics = Arc::new(IngestMetrics::new(config.shard_count));
+        let backstop_ceiling = BufferBudgetCeiling::unlimited();
         #[cfg(feature = "stage-timing")]
         let stage_timings = Arc::new(MetricStageTimings::new());
         // Each generation's shard-actor set gets a fresh writer identity, so
@@ -231,6 +237,7 @@ impl IngestRouter {
             let clock = Arc::clone(&clock);
             let rng = Arc::clone(&rng);
             let metrics = Arc::clone(&metrics);
+            let backstop_ceiling = backstop_ceiling.clone();
             #[cfg(feature = "stage-timing")]
             let stage_timings = Arc::clone(&stage_timings);
             move |shard_count: u32| -> Vec<ShardHandle> {
@@ -255,6 +262,7 @@ impl IngestRouter {
                             Arc::clone(&metrics),
                             rx,
                             Arc::clone(&flush_floor_ns),
+                            backstop_ceiling.clone(),
                             #[cfg(feature = "stage-timing")]
                             Arc::clone(&stage_timings),
                         );
@@ -276,6 +284,7 @@ impl IngestRouter {
             metrics,
             config,
             budget: IngestByteBudget::shared(IngestByteBudgetLimit::Unlimited),
+            backstop_ceiling,
             #[cfg(feature = "stage-timing")]
             stage_timings,
         }
@@ -294,8 +303,13 @@ impl IngestRouter {
     /// and calls this on each of the metrics, log, and span routers with the
     /// same `Arc`, so a single `--max-ingest-buffer-bytes` ceiling bounds the
     /// buffered-byte sum across every signal.
+    ///
+    /// Also publishes the ceiling to this router's shard actors, so the
+    /// per-buffer memory backstop is a fraction of the configured limit rather
+    /// than of the default one (issue #1305).
     #[must_use]
     pub fn with_budget(mut self, budget: Arc<IngestByteBudget>) -> Self {
+        self.backstop_ceiling.set(budget.limit());
         self.budget = budget;
         self
     }
@@ -704,6 +718,7 @@ impl IngestRouter {
             Arc::clone(&self.metrics),
             rx,
             flush_floor_ns,
+            self.backstop_ceiling.clone(),
             #[cfg(feature = "stage-timing")]
             Arc::clone(&self.stage_timings),
         );

--- a/crates/ravel-ingest/src/shard.rs
+++ b/crates/ravel-ingest/src/shard.rs
@@ -45,7 +45,7 @@ use crate::budget::IngestByteCharge;
 use crate::clock::Clock;
 use crate::config::{
     DrainIntent, FlushClockError, IngestConfig, MAX_FLUSH_ALL_PASSES, MAX_FLUSH_CLOCK_HOLD_NS,
-    SEGMENT_FORMAT_VERSION, checked_ingest_hour_bucket,
+    SEGMENT_FORMAT_VERSION, checked_ingest_hour_bucket, size_trigger_fires,
 };
 use crate::error::WriteError;
 use crate::metrics::{FlushTrigger, IngestMetrics};
@@ -160,6 +160,13 @@ struct TenantBuf {
     /// arrival order that breaks ties.
     exemplars: Vec<IngestExemplar>,
     est_bytes: usize,
+    /// Estimated bytes the object this buffer's flush writes will hold, the
+    /// size trigger's own figure (issue #1305). `est_bytes` above stays the
+    /// buffered-memory charge the ADR-0069 ceiling reads; the two are not
+    /// interchangeable, and on a label-heavy series they differ by more than an
+    /// order of magnitude. See [`IngestPoint::est_object_sample_bytes`] for the
+    /// model and its bound direction.
+    flush_est_bytes: usize,
     oldest_arrival_ns: Option<i64>,
     min_ingest_ts_ns: Option<i64>,
     max_ingest_ts_ns: Option<i64>,
@@ -214,7 +221,12 @@ impl TenantBuf {
     /// [`IngestPoint::est_charge_bytes`] and [`IngestExemplar::est_bytes`]
     /// apply: a `Label` is two `String` headers whatever the strings hold, so
     /// leaving it out understates a label-heavy buffer by roughly an order of
-    /// magnitude and both flush triggers fire late.
+    /// magnitude and the memory ceiling is charged too little.
+    ///
+    /// The same pass also accumulates `flush_est_bytes`, the object-bytes
+    /// estimate the size trigger reads (issue #1305). The returned figure stays
+    /// the memory one: it is what the caller records on the buffered-bytes
+    /// gauge and what the ADR-0069 charge covers.
     ///
     /// Fails loud on a series-id collision (ADR-0005) or a value-kind
     /// mismatch (a series is scalar or
@@ -268,7 +280,9 @@ impl TenantBuf {
 
         self.note_arrival(arrival_ns);
         let mut bytes_added = 0usize;
+        let mut object_bytes_added = 0usize;
         for point in points {
+            object_bytes_added += point.est_object_sample_bytes();
             match self.series.entry(point.series_id) {
                 Entry::Occupied(mut occ) => {
                     occ.get_mut().values.try_push(point.value);
@@ -280,6 +294,7 @@ impl TenantBuf {
                         .map(|l| size_of::<Label>() + l.name.len() + l.value.len())
                         .sum();
                     bytes_added += label_bytes;
+                    object_bytes_added += point.est_object_series_bytes();
                     vac.insert(SeriesAccum {
                         labels: point.labels,
                         values: SeriesAccumValues::new_with(point.value),
@@ -289,6 +304,7 @@ impl TenantBuf {
             bytes_added += 16;
         }
         self.est_bytes += bytes_added;
+        self.flush_est_bytes += object_bytes_added;
         Ok(bytes_added)
     }
 
@@ -304,12 +320,15 @@ impl TenantBuf {
     /// once; keeping the cap costs a map entry per series forever.
     fn absorb_exemplars(&mut self, exemplars: Vec<IngestExemplar>) -> usize {
         let mut bytes_added = 0usize;
+        let mut object_bytes_added = 0usize;
         self.exemplars.reserve(exemplars.len());
         for e in exemplars {
             bytes_added += e.est_bytes();
+            object_bytes_added += e.est_object_bytes();
             self.exemplars.push(e);
         }
         self.est_bytes += bytes_added;
+        self.flush_est_bytes += object_bytes_added;
         bytes_added
     }
 }
@@ -1071,8 +1090,6 @@ impl ShardActor {
         }
         let arrival_ns = self.clock.now_ns();
         let points_len = points.len() as u64;
-        let target_bytes = self.config.target_bytes;
-
         // Grab the timing handle before the mutable buffer borrow so recording
         // `merge` does not clash with the `&mut self.tenants` borrow held below.
         #[cfg(feature = "stage-timing")]
@@ -1118,7 +1135,7 @@ impl ShardActor {
         let should_flush = self
             .tenants
             .get(&tenant)
-            .map(|b| b.est_bytes >= target_bytes)
+            .map(|b| size_trigger_fires(b.flush_est_bytes, b.est_bytes, &self.config))
             .unwrap_or(false);
         if should_flush && let Some(buf) = self.tenants.remove(&tenant) {
             return self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
@@ -1126,10 +1143,13 @@ impl ShardActor {
         0
     }
 
-    /// A buffer with a strict-mode waiter or at least `min_flush_bytes`
+    /// A buffer with a strict-mode waiter, or one whose flush would write at
+    /// least `min_flush_bytes` of object,
     /// already justifies a PUT on the fast age clock; anything else is idle
     /// and waits for the slower `max_flush_delay_idle` instead (ADR-0051
-    /// section 7). Strict-mode ack latency is unaffected: a strict
+    /// section 7). "Worth a PUT" is a claim about the object, so this reads the
+    /// object-bytes estimate, not the buffered-memory charge (issue #1305).
+    /// Strict-mode ack latency is unaffected: a strict
     /// write always leaves `waiters` non-empty for its whole flush window.
     ///
     /// The fast clock itself is either the fixed `max_flush_delay` (2 s
@@ -1142,7 +1162,8 @@ impl ShardActor {
     /// from one that used the fixed value (`IngestMetrics`'s
     /// `flushes_by_age` vs `flushes_by_age_adaptive`).
     fn age_threshold_ns(&self, buf: &TenantBuf) -> (i64, FlushTrigger) {
-        let has_priority = !buf.waiters.is_empty() || buf.est_bytes >= self.config.min_flush_bytes;
+        let has_priority =
+            !buf.waiters.is_empty() || buf.flush_est_bytes >= self.config.min_flush_bytes;
         if !has_priority {
             return (
                 self.config.max_flush_delay_idle.as_nanos() as i64,

--- a/crates/ravel-ingest/src/shard.rs
+++ b/crates/ravel-ingest/src/shard.rs
@@ -41,7 +41,7 @@ use tokio::task::JoinSet;
 use tokio::time::Duration;
 use uuid::Uuid;
 
-use crate::budget::IngestByteCharge;
+use crate::budget::{BufferBudgetCeiling, IngestByteCharge};
 use crate::clock::Clock;
 use crate::config::{
     DrainIntent, FlushClockError, IngestConfig, MAX_FLUSH_ALL_PASSES, MAX_FLUSH_CLOCK_HOLD_NS,
@@ -923,6 +923,11 @@ pub(crate) struct ShardActor {
     flushes: JoinSet<()>,
     rx: mpsc::Receiver<ShardMsg>,
     tenants: HashMap<TenantId, TenantBuf>,
+    /// The configured ADR-0069 ceiling, shared live with the router so the
+    /// per-buffer memory backstop is a fraction of the limit the operator set.
+    /// Read at trigger time rather than resolved once, because the router
+    /// installs the budget after the actors are spawned.
+    backstop_ceiling: BufferBudgetCeiling,
 }
 
 impl ShardActor {
@@ -939,6 +944,7 @@ impl ShardActor {
         metrics: Arc<IngestMetrics>,
         rx: mpsc::Receiver<ShardMsg>,
         flush_floor_ns: Arc<AtomicI64>,
+        backstop_ceiling: BufferBudgetCeiling,
         #[cfg(feature = "stage-timing")] stage_timings: Arc<MetricStageTimings>,
     ) -> Self {
         let rtt = Arc::new(RttTracker::new());
@@ -971,6 +977,7 @@ impl ShardActor {
             flushes: JoinSet::new(),
             rx,
             tenants: HashMap::new(),
+            backstop_ceiling,
         }
     }
 
@@ -1135,7 +1142,14 @@ impl ShardActor {
         let should_flush = self
             .tenants
             .get(&tenant)
-            .map(|b| size_trigger_fires(b.flush_est_bytes, b.est_bytes, &self.config))
+            .map(|b| {
+                size_trigger_fires(
+                    b.flush_est_bytes,
+                    b.est_bytes,
+                    &self.config,
+                    self.backstop_ceiling.get(),
+                )
+            })
             .unwrap_or(false);
         if should_flush && let Some(buf) = self.tenants.remove(&tenant) {
             return self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
@@ -1458,8 +1472,9 @@ impl ShardActor {
                 // so that next trigger flushes them (finding 1): `charges` ride
                 // back with the buffer (the byte budget is not refunded, the bytes
                 // are still held), and the whole buffer -- series, exemplars, and
-                // the trigger bookkeeping (`est_bytes`, `oldest_arrival_ns`) -- is
-                // preserved intact. Only `waiters` are acked here and taken out of
+                // the trigger bookkeeping (`flush_est_bytes`, which drives the
+                // size trigger, `est_bytes`, which drives the memory backstop,
+                // and `oldest_arrival_ns`) -- is preserved intact. Only `waiters` are acked here and taken out of
                 // the re-inserted buffer: a waiter left in it would be re-acked by
                 // the next flush against an already-answered oneshot. A strict-mode
                 // waiter that retries on the 503 re-enqueues rows this buffer still

--- a/crates/ravel-ingest/src/span_router.rs
+++ b/crates/ravel-ingest/src/span_router.rs
@@ -18,7 +18,7 @@ use ravel_otlp::traces_normalize::NormalizedSpan;
 use ravel_types::CommitToken;
 use tokio::sync::{mpsc, oneshot};
 
-use crate::budget::{IngestByteBudget, IngestByteBudgetLimit};
+use crate::budget::{BufferBudgetCeiling, IngestByteBudget, IngestByteBudgetLimit};
 use crate::clock::Clock;
 use crate::config::IngestConfig;
 use crate::generation::{DEFAULT_REFRESH_INTERVAL_NS, GenerationSwitch, Routed, load_generations};
@@ -98,6 +98,11 @@ pub struct SpanIngestRouter {
     /// `services/ravel-server` installs the configured budget via
     /// [`SpanIngestRouter::with_budget`].
     budget: Arc<IngestByteBudget>,
+    /// The ceiling from `budget`, shared with every shard actor this router
+    /// spawns so the per-buffer memory backstop is a fraction of the configured
+    /// limit. Written by [`SpanIngestRouter::with_budget`], which runs after the
+    /// actors exist.
+    backstop_ceiling: BufferBudgetCeiling,
 }
 
 impl SpanIngestRouter {
@@ -112,11 +117,13 @@ impl SpanIngestRouter {
         // seeded-injection caller; routing through the seam still keeps
         // `rand::rng()` and `Uuid::new_v4()` off this production path.
         let rng: Arc<dyn RngSource> = Arc::new(SystemRng);
+        let backstop_ceiling = BufferBudgetCeiling::unlimited();
         let factory = {
             let store = Arc::clone(&store);
             let clock = Arc::clone(&clock);
             let rng = Arc::clone(&rng);
             let metrics = Arc::clone(&metrics);
+            let backstop_ceiling = backstop_ceiling.clone();
             move |shard_count: u32| -> Vec<SpanShardHandle> {
                 let writer_id = rng.new_uuid();
                 let epoch =
@@ -134,6 +141,7 @@ impl SpanIngestRouter {
                             config,
                             Arc::clone(&metrics),
                             rx,
+                            backstop_ceiling.clone(),
                         );
                         tokio::spawn(actor.run());
                         SpanShardHandle {
@@ -154,12 +162,17 @@ impl SpanIngestRouter {
             metrics,
             config,
             budget: IngestByteBudget::shared(IngestByteBudgetLimit::Unlimited),
+            backstop_ceiling,
         }
     }
 
-    /// Installs the shared process-wide ingest buffer byte budget (ADR-0069).
+    /// Installs the shared process-wide ingest buffer byte budget (ADR-0069),
+    /// and publishes its ceiling to this router's shard actors so the
+    /// per-buffer memory backstop is a fraction of the configured limit rather
+    /// than of the default one (issue #1305).
     #[must_use]
     pub fn with_budget(mut self, budget: Arc<IngestByteBudget>) -> Self {
+        self.backstop_ceiling.set(budget.limit());
         self.budget = budget;
         self
     }

--- a/crates/ravel-ingest/src/span_shard.rs
+++ b/crates/ravel-ingest/src/span_shard.rs
@@ -53,7 +53,7 @@ use crate::budget::IngestByteCharge;
 use crate::clock::Clock;
 use crate::config::{
     DrainIntent, FlushClockError, IngestConfig, MAX_FLUSH_ALL_PASSES, MAX_FLUSH_CLOCK_HOLD_NS,
-    SPAN_SEGMENT_FORMAT_VERSION, checked_ingest_hour_bucket,
+    SPAN_SEGMENT_FORMAT_VERSION, checked_ingest_hour_bucket, size_trigger_fires,
 };
 use crate::metrics::FlushTrigger;
 use crate::span_error::SpanWriteError;
@@ -103,6 +103,35 @@ pub(crate) fn est_span_bytes(span: &NormalizedSpan) -> usize {
     span.name.len() + span.status_message.as_ref().map(String::len).unwrap_or(0) + attr_bytes + 64
 }
 
+/// Fixed per-span cost in the object a span flush writes: the two i64
+/// timestamps, the 16-byte trace id, the two 8-byte span ids, and the status
+/// code. The same 64 [`est_span_bytes`] charges, which is already the stored
+/// width of those fields rather than their in-memory width.
+const SPAN_OBJECT_FIXED_BYTES: usize = 64;
+
+/// Estimated bytes one span contributes to the object a span flush writes, for
+/// the size trigger only (`target_bytes` and `min_flush_bytes`, issue #1305).
+/// The memory-side figure stays [`est_span_bytes`], which the ADR-0069 ceiling
+/// charges.
+///
+/// Model: the span's stored payload -- name, status message, and every
+/// attribute key and value byte -- plus [`SPAN_OBJECT_FIXED_BYTES`]. No
+/// `(String, String)` pair header appears, because none reaches the object; a
+/// twenty-attribute span charges nearly a kilobyte of struct headers to the
+/// ceiling that RSPAN does not store.
+///
+/// Direction: an upper bound on the bytes the flush writes, for the reason
+/// [`crate::value::IngestPoint::est_object_sample_bytes`] states. RSPAN interns
+/// repeated attribute keys and compresses its blocks, both strictly below the
+/// raw bytes counted here.
+pub(crate) fn est_span_object_bytes(span: &NormalizedSpan) -> usize {
+    let attr_bytes: usize = span.attrs.iter().map(|(k, v)| k.len() + v.len()).sum();
+    span.name.len()
+        + span.status_message.as_ref().map(String::len).unwrap_or(0)
+        + attr_bytes
+        + SPAN_OBJECT_FIXED_BYTES
+}
+
 /// Type-level bridge from the OTLP-independent [`NormalizedSpan`] to the
 /// writer's [`SpanRecord`]. Every field maps one to one; there is no data
 /// transformation, only a struct rename. In particular `attrs` is already the
@@ -128,6 +157,11 @@ fn to_rspan_record(span: NormalizedSpan) -> SpanRecord {
 struct SpanTenantBuf {
     spans: Vec<NormalizedSpan>,
     est_bytes: usize,
+    /// Estimated bytes the object this buffer's flush writes will hold, the
+    /// size trigger's own figure (issue #1305, [`est_span_object_bytes`]).
+    /// `est_bytes` above stays the buffered-memory charge behind the ADR-0069
+    /// ceiling.
+    flush_est_bytes: usize,
     oldest_arrival_ns: Option<i64>,
     min_ingest_ts_ns: Option<i64>,
     max_ingest_ts_ns: Option<i64>,
@@ -157,8 +191,10 @@ impl SpanTenantBuf {
     fn merge(&mut self, spans: Vec<NormalizedSpan>, arrival_ns: i64) -> usize {
         self.note_arrival(arrival_ns);
         let bytes_added: usize = spans.iter().map(est_span_bytes).sum();
+        let object_bytes_added: usize = spans.iter().map(est_span_object_bytes).sum();
         self.spans.extend(spans);
         self.est_bytes += bytes_added;
+        self.flush_est_bytes += object_bytes_added;
         bytes_added
     }
 }
@@ -642,7 +678,6 @@ impl SpanShardActor {
         }
         let arrival_ns = self.clock.now_ns();
         let spans_len = spans.len() as u64;
-        let target_bytes = self.config.target_bytes;
 
         let buf = self.tenants.entry(tenant.clone()).or_default();
         let bytes_added = buf.merge(spans, arrival_ns);
@@ -659,21 +694,25 @@ impl SpanShardActor {
         let should_flush = self
             .tenants
             .get(&tenant)
-            .map(|b| b.est_bytes >= target_bytes)
+            .map(|b| size_trigger_fires(b.flush_est_bytes, b.est_bytes, &self.config))
             .unwrap_or(false);
         if should_flush && let Some(buf) = self.tenants.remove(&tenant) {
             self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
         }
     }
 
-    /// A buffer with a strict-mode waiter or at least `min_flush_bytes`
+    /// A buffer with a strict-mode waiter, or one whose flush would write at
+    /// least `min_flush_bytes` of object,
     /// already justifies a PUT on the fast `max_flush_delay` clock; anything
     /// else is idle and waits for the slower `max_flush_delay_idle` instead
-    /// (ADR-0051 section 7). Strict-mode ack latency is unaffected:
+    /// (ADR-0051 section 7). "Worth a PUT" is a claim about the object, so this
+    /// reads the object-bytes estimate, not the buffered-memory charge (issue
+    /// #1305). Strict-mode ack latency is unaffected:
     /// a strict write always leaves `waiters` non-empty for its whole flush
     /// window.
     fn age_threshold_ns(&self, buf: &SpanTenantBuf) -> i64 {
-        let has_priority = !buf.waiters.is_empty() || buf.est_bytes >= self.config.min_flush_bytes;
+        let has_priority =
+            !buf.waiters.is_empty() || buf.flush_est_bytes >= self.config.min_flush_bytes;
         if has_priority {
             self.config.max_flush_delay.as_nanos() as i64
         } else {

--- a/crates/ravel-ingest/src/span_shard.rs
+++ b/crates/ravel-ingest/src/span_shard.rs
@@ -49,7 +49,7 @@ use tokio::task::JoinSet;
 use tokio::time::Duration;
 use uuid::Uuid;
 
-use crate::budget::IngestByteCharge;
+use crate::budget::{BufferBudgetCeiling, IngestByteCharge};
 use crate::clock::Clock;
 use crate::config::{
     DrainIntent, FlushClockError, IngestConfig, MAX_FLUSH_ALL_PASSES, MAX_FLUSH_CLOCK_HOLD_NS,
@@ -557,6 +557,11 @@ pub(crate) struct SpanShardActor {
     flushes: JoinSet<()>,
     rx: mpsc::Receiver<SpanShardMsg>,
     tenants: HashMap<TenantId, SpanTenantBuf>,
+    /// The configured ADR-0069 ceiling, shared live with the router so the
+    /// per-buffer memory backstop is a fraction of the limit the operator set.
+    /// Read at trigger time rather than resolved once, because the router
+    /// installs the budget after the actors are spawned.
+    backstop_ceiling: BufferBudgetCeiling,
 }
 
 impl SpanShardActor {
@@ -571,6 +576,7 @@ impl SpanShardActor {
         config: IngestConfig,
         metrics: Arc<SpanIngestMetrics>,
         rx: mpsc::Receiver<SpanShardMsg>,
+        backstop_ceiling: BufferBudgetCeiling,
     ) -> Self {
         let ctx = Arc::new(SpanFlushCtx {
             shard,
@@ -596,6 +602,7 @@ impl SpanShardActor {
             flushes: JoinSet::new(),
             rx,
             tenants: HashMap::new(),
+            backstop_ceiling,
         }
     }
 
@@ -694,7 +701,14 @@ impl SpanShardActor {
         let should_flush = self
             .tenants
             .get(&tenant)
-            .map(|b| size_trigger_fires(b.flush_est_bytes, b.est_bytes, &self.config))
+            .map(|b| {
+                size_trigger_fires(
+                    b.flush_est_bytes,
+                    b.est_bytes,
+                    &self.config,
+                    self.backstop_ceiling.get(),
+                )
+            })
             .unwrap_or(false);
         if should_flush && let Some(buf) = self.tenants.remove(&tenant) {
             self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
@@ -1167,6 +1181,7 @@ mod tests {
                 config,
                 Arc::clone(&metrics),
                 rx,
+                BufferBudgetCeiling::unlimited(),
             );
             let task = tokio::spawn(actor.run());
             Harness {
@@ -1746,6 +1761,7 @@ mod tests {
             exhaustion_config(4),
             Arc::clone(&metrics),
             rx,
+            BufferBudgetCeiling::unlimited(),
         );
         let task = tokio::spawn(actor.run());
 

--- a/crates/ravel-ingest/src/value.rs
+++ b/crates/ravel-ingest/src/value.rs
@@ -8,8 +8,53 @@
 
 use std::sync::Arc;
 
-use ravel_segment::{ExemplarInput, HistogramSample};
+use ravel_segment::{ExemplarInput, HistogramCounts, HistogramSample, HistogramValue};
 use ravel_types::{Exemplar, Label, LabelSet, Sample, SeriesId};
+
+/// Bytes one buffered scalar sample contributes to the object a flush writes,
+/// before any codec runs: the `(i64, f64)` pair ADR-0092 measures as "Raw
+/// `(i64, f64)` is 16 bytes per sample".
+pub(crate) const SCALAR_SAMPLE_OBJECT_BYTES: usize = 16;
+
+/// Bytes one series contributes to the object a flush writes, on top of its
+/// samples and its label bytes: the 16-byte `SERIES_IDS` row and the series'
+/// `SERIES_META` row. ADR-0092 measures the marginal catalog cost at 11.04
+/// bytes per run after zstd, so 32 stays above what the object holds.
+pub(crate) const SERIES_OBJECT_OVERHEAD_BYTES: usize = 32;
+
+/// Bytes one admitted exemplar contributes to the object a flush writes,
+/// before its attributes: ADR-0047's "roughly 40 bytes plus attributes" (the
+/// trace id, the span id, the timestamp, and the value).
+const EXEMPLAR_OBJECT_BYTES: usize = 40;
+
+/// Fixed per-sample cost of a native histogram in the object, before its
+/// buckets: timestamp, scale, zero threshold, sum, count, and zero count.
+const HISTOGRAM_SAMPLE_FIXED_BYTES: usize = 32;
+
+/// Widest stored form of one histogram bucket count, span, or custom boundary.
+/// The writer varint-encodes counts and delta-encodes boundaries, so a flat 8
+/// per element stays above what the object holds.
+const HISTOGRAM_ELEMENT_BYTES: usize = 8;
+
+/// The object-side size of one native-histogram sample, counting each bucket
+/// count, span, and custom boundary at its widest stored width.
+fn histogram_object_bytes(value: &HistogramValue) -> usize {
+    let buckets = match &value.counts {
+        HistogramCounts::Int {
+            positive, negative, ..
+        } => positive.len() + negative.len(),
+        HistogramCounts::Float {
+            positive, negative, ..
+        } => positive.len() + negative.len(),
+    };
+    let spans = value.positive_spans.len() + value.negative_spans.len();
+    let custom = value
+        .custom_values
+        .as_ref()
+        .map(Vec::len)
+        .unwrap_or_default();
+    HISTOGRAM_SAMPLE_FIXED_BYTES + HISTOGRAM_ELEMENT_BYTES * (buckets + spans + custom)
+}
 
 /// One point's value: scalar or native histogram.
 #[derive(Debug, Clone)]
@@ -96,6 +141,27 @@ impl IngestExemplar {
         size_of::<Self>() + attrs
     }
 
+    /// Estimated bytes this exemplar contributes to the object a flush writes,
+    /// for the size trigger only (issue #1305). The memory-side figure is
+    /// [`IngestExemplar::est_bytes`] and stays what the byte budget charges:
+    /// this one drops the `Label` and `Vec` struct headers, which the buffer
+    /// holds and the object never stores, and keeps only the attribute bytes
+    /// that reach LABEL_DICT.
+    ///
+    /// An over-estimate on two counts, both in the chosen direction (see
+    /// [`IngestPoint::est_object_sample_bytes`]): the flush-scoped cap
+    /// (`FlushCtx::admit_exemplars`) drops exemplars this figure already
+    /// counted, and the stored attributes are interned and compressed.
+    pub(crate) fn est_object_bytes(&self) -> usize {
+        let attrs: usize = self
+            .exemplar
+            .filtered_attributes
+            .iter()
+            .map(|l| l.name.len() + l.value.len())
+            .sum();
+        EXEMPLAR_OBJECT_BYTES + attrs
+    }
+
     /// The writer-facing shape: the sample value comes back from its stored
     /// bit pattern (never a decimal round trip, so a NaN payload and -0.0
     /// survive), and attributes flatten to the `(name, value)` pairs the
@@ -163,6 +229,60 @@ impl IngestPoint {
             .sum();
         16 + label_bytes
     }
+
+    /// Estimated bytes this point's sample contributes to the object a flush
+    /// writes, for the size trigger only (`target_bytes` and `min_flush_bytes`,
+    /// issue #1305). Never the memory ceiling: that is
+    /// [`IngestPoint::est_charge_bytes`], which charges what the buffer holds in
+    /// RAM, and the two differ by more than an order of magnitude on a
+    /// label-heavy series. A ten-label series with short values charges about
+    /// 766 bytes per sample to the ceiling and contributes 16 here, so a size
+    /// trigger reading the ceiling figure fires at a few hundred KB of data on a
+    /// nominal 8 MiB `target_bytes` and the mean object size (which sets the
+    /// request cost per stored terabyte) collapses.
+    ///
+    /// Model: the unencoded payload the RSEG writer is handed. One `(i64, f64)`
+    /// pair per scalar sample; for a native histogram, its fixed fields plus its
+    /// bucket counts, spans, and custom boundaries at their widest stored width.
+    /// No `String`, `Vec`, or `Label` struct header appears, because none of
+    /// them reach the object; the series' label bytes and its per-series rows
+    /// are counted once per series by
+    /// [`IngestPoint::est_object_series_bytes`], not per sample.
+    ///
+    /// Direction: this is an UPPER bound on the bytes the flush writes. Every
+    /// codec in the write path moves in one direction from the unencoded
+    /// payload -- delta-plus-zigzag varint timestamps, the integer-model and
+    /// Gorilla value codecs, zstd over the catalog sections, LZ4 over the pages
+    /// -- so the object lands at or under `target_bytes`, never over. That is
+    /// the chosen failure: an object below target costs some request overhead,
+    /// while an object over target costs buffered memory the operator did not
+    /// ask for, on a compressibility ratio the client controls. The other side
+    /// is bounded by the codecs' own reach: ADR-0092's amendment measures 2.50
+    /// to 3.00 bytes per sample on representative value shapes, so the
+    /// overshoot against the 16 counted here is bounded by about 6x rather than
+    /// being open-ended, and the age triggers still bound how long a partly
+    /// filled buffer waits.
+    pub(crate) fn est_object_sample_bytes(&self) -> usize {
+        match &self.value {
+            IngestValue::Scalar(_) => SCALAR_SAMPLE_OBJECT_BYTES,
+            IngestValue::Histogram(sample) => histogram_object_bytes(&sample.value),
+        }
+    }
+
+    /// Estimated bytes this point's series contributes to the object a flush
+    /// writes, charged once per series at its first sighting in a buffer (the
+    /// object holds one label-dictionary entry and one series row per series,
+    /// however many samples that series carries). Label bytes without their
+    /// `Label` headers, for the reason
+    /// [`IngestPoint::est_object_sample_bytes`] gives.
+    pub(crate) fn est_object_series_bytes(&self) -> usize {
+        let label_bytes: usize = self
+            .labels
+            .iter()
+            .map(|l| l.name.len() + l.value.len())
+            .sum();
+        SERIES_OBJECT_OVERHEAD_BYTES + label_bytes
+    }
 }
 
 #[cfg(test)]
@@ -171,11 +291,12 @@ mod tests {
     use super::*;
     use ravel_types::Exemplar;
 
-    use crate::log_shard::est_record_bytes;
-    use crate::span_shard::est_span_bytes;
+    use crate::log_shard::{est_record_bytes, est_record_object_bytes};
+    use crate::span_shard::{est_span_bytes, est_span_object_bytes};
     use ravel_otlp::logs_normalize::NormalizedLogRecord;
     use ravel_otlp::traces_normalize::NormalizedSpan;
     use ravel_rspan::StatusCode;
+    use ravel_segment::{HistogramSpan, ResetHint};
     use ravel_types::logstream::{AttrValue, LogStreamId};
 
     fn labels_of(count: usize) -> LabelSet {
@@ -379,6 +500,101 @@ mod tests {
             "attr_value_len dropped the per-entry header inside a nested Map: \
              {nested_hdr} != {}",
             W * log_pair
+        );
+    }
+
+    /// The size trigger's estimators count payload only. Where the ceiling
+    /// charges a struct header per label, attribute, or span attribute, the
+    /// object-side figure charges the bytes that reach the object and a fixed
+    /// per-record term, on every signal. Exact figures, so widening either
+    /// model has to come here and restate them.
+    #[test]
+    fn object_estimators_count_payload_not_struct_headers() {
+        const W: usize = 8;
+        // `labels_of(8)`: names `k0..k7` (2 bytes) with value "v" (1 byte),
+        // so 24 bytes of label text and 8 * 48 bytes of `Label` headers.
+        let point = point_with(labels_of(W));
+        assert_eq!(point.est_charge_bytes(), 16 + 8 * 48 + 24);
+        assert_eq!(
+            point.est_object_series_bytes(),
+            32 + 24,
+            "series overhead plus label text, no `Label` headers"
+        );
+        assert_eq!(
+            point.est_object_sample_bytes(),
+            16,
+            "one scalar sample is a timestamp and a value"
+        );
+
+        // A ten-label series is the shape issue #1305 measured: the ceiling
+        // charges 480 bytes of headers per point that no object ever holds.
+        let wide = point_with(labels_of(10));
+        let charged = wide.est_charge_bytes() as usize;
+        let object = wide.est_object_series_bytes() + wide.est_object_sample_bytes();
+        assert_eq!(charged, 526);
+        assert_eq!(object, 78);
+
+        // Log record: 8 attributes of ("attr", Str("v")), everything else
+        // empty, so 8 * 5 payload bytes plus the fixed per-record term.
+        let record = log_record_with(W);
+        assert_eq!(est_record_object_bytes(&record), 8 * 5 + 48);
+        assert!(
+            est_record_bytes(&record) > est_record_object_bytes(&record),
+            "the ceiling stays above the object-side figure"
+        );
+
+        // Nested attribute values drop their headers too: one "m" attribute
+        // holding a Map of 8 empty-keyed Bools is 1 key byte and 8 value
+        // bytes over the fixed term.
+        let nested = log_record_with_nested_map(W);
+        assert_eq!(est_record_object_bytes(&nested), 1 + 8 + 48);
+
+        // Span: same 8 attributes, empty name and status message.
+        let span = span_with(W);
+        assert_eq!(est_span_object_bytes(&span), 8 * 5 + 64);
+        assert!(
+            est_span_bytes(&span) > est_span_object_bytes(&span),
+            "the ceiling stays above the object-side figure"
+        );
+    }
+
+    /// A native histogram's object cost grows with its buckets, spans, and
+    /// custom boundaries. The flat 16 bytes the ceiling charges a histogram
+    /// point would make a bucket-heavy tenant's objects arbitrarily larger
+    /// than `target_bytes` if the trigger reused it.
+    #[test]
+    fn histogram_object_bytes_counts_every_element() {
+        let mut value = HistogramValue {
+            scale: 2,
+            zero_threshold: 1e-9,
+            sum: Some(42.5),
+            custom_values: None,
+            positive_spans: vec![HistogramSpan {
+                offset: 0,
+                length: 3,
+            }],
+            negative_spans: vec![],
+            counts: HistogramCounts::Int {
+                zero_count: 1,
+                count: 7,
+                positive: vec![2, 3, 1],
+                negative: vec![],
+            },
+            reset_hint: ResetHint::Unknown,
+        };
+        // 32 fixed, plus 8 per element over 3 bucket counts and 1 span.
+        assert_eq!(histogram_object_bytes(&value), 32 + 8 * 4);
+
+        value.counts = HistogramCounts::Int {
+            zero_count: 1,
+            count: 7,
+            positive: vec![2; 100],
+            negative: vec![1; 20],
+        };
+        assert_eq!(
+            histogram_object_bytes(&value),
+            32 + 8 * (100 + 20 + 1),
+            "a wide histogram costs more than a narrow one"
         );
     }
 

--- a/crates/ravel-ingest/tests/flush_object_size.rs
+++ b/crates/ravel-ingest/tests/flush_object_size.rs
@@ -60,15 +60,40 @@ const BATCHES_BELOW_TARGET: usize = 10;
 const TRIGGERING_BATCH: usize = BATCHES_BELOW_TARGET + 1;
 
 /// Pre-registered band for the flushed object, as a fraction of
-/// `target_bytes`. Upper edge 1.00: the object-bytes estimate is an upper
-/// bound on the stored payload, so an object above `target_bytes` means the
-/// estimate undercounted something the flush wrote. Lower edge 0.10: ADR-0092
-/// puts a merged run's representative cost at 2.50 to 3.00 bytes per sample
-/// against the 16 raw bytes this estimate charges, and the label dictionary
-/// compresses further, so an object below a tenth of the target means the
-/// trigger is firing on something other than payload size.
-const BAND_LOW: f64 = 0.10;
-const BAND_HIGH: f64 = 1.00;
+/// `target_bytes`. This corpus flushes 64_627 bytes, 0.247 of the 262_144
+/// target, measured over `MemoryStore`, whose output is deterministic for a
+/// fixed corpus. The band brackets that measurement rather than bounding
+/// payload sizes in general: a band spanning an order of magnitude accepts a
+/// 2.5x shrink, and the shrink is exactly what a regression here looks like.
+///
+/// What it has to exclude: reintroducing the `size_of::<Label>()` per-label
+/// term into the object-bytes estimator (the defect issue #1305 fixed) takes a
+/// batch's estimate from 25_800 to 73_800, so the trigger fires on batch 4
+/// instead of batch 11 and the object lands near 0.09 of target. Every
+/// batch-count assertion in this file still passes under that defect, because
+/// those are driven by the estimator on both sides; this band is what goes red.
+/// The measurement is recorded rather than asserted to the byte because the
+/// object passes through a compressor, so an exact pin would couple this test
+/// to a zstd version bump rather than to either estimator.
+const BAND_LOW: f64 = 0.20;
+const BAND_HIGH: f64 = 0.30;
+
+/// Memory one batch adds to the buffer figure the backstop reads. Unlike
+/// `PER_POINT_CHARGE`, which the ceiling charges per admitted point, the buffer
+/// counts a series' labels once, the first time it sees that series: 100 *
+/// (480 + 162) label bytes plus 400 * 16 sample bytes.
+const PER_BATCH_BUFFERED: u64 = 70_600;
+
+/// A process-wide ceiling small enough to expose a backstop calibrated against
+/// the 512 MiB default. An eighth of it is 275_000, which is above
+/// `TARGET_BYTES`, so the backstop and not the `target_bytes` floor under it is
+/// what fires, and which falls between the third and fourth batch.
+const SMALL_CEILING: u64 = 2_200_000;
+
+/// Batches whose buffered memory reaches an eighth of `SMALL_CEILING`: three
+/// hold 211_800 and four hold 282_400 against the 275_000 backstop.
+const BATCHES_BELOW_BACKSTOP: usize = 3;
+const BATCHES_TO_BACKSTOP: usize = BATCHES_BELOW_BACKSTOP + 1;
 
 const BASE_TS_NS: i64 = 1_700_000_000_000_000_000;
 
@@ -135,9 +160,19 @@ async fn write_batch(router: &IngestRouter, tenant: &TenantId, index: usize) {
 /// corpus triggered is counted under its own trigger, and whatever is left
 /// buffered at teardown is counted as `flushes_manual`.
 async fn run_batches(batches: usize) -> (IngestMetricsSnapshot, Vec<ObjectMeta>) {
+    run_batches_under_ceiling(batches, IngestByteBudgetLimit::Unlimited).await
+}
+
+/// [`run_batches`] against a router carrying a configured process-wide byte
+/// budget, so the per-buffer memory backstop is a share of `ceiling`.
+async fn run_batches_under_ceiling(
+    batches: usize,
+    ceiling: IngestByteBudgetLimit,
+) -> (IngestMetricsSnapshot, Vec<ObjectMeta>) {
     let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
     let clock = TestClock::new(BASE_TS_NS);
-    let router = IngestRouter::new(config(), Arc::clone(&store), Signal::Metrics, clock);
+    let router = IngestRouter::new(config(), Arc::clone(&store), Signal::Metrics, clock)
+        .with_budget(IngestByteBudget::shared(ceiling));
     let tenant = tenant("acme");
 
     for index in 0..batches {
@@ -208,10 +243,76 @@ async fn size_flush_fills_the_object_toward_target_bytes() {
     );
 }
 
+/// The memory backstop is a share of the ceiling the operator configured, not
+/// of the 512 MiB default. On a replica sized with `--max-ingest-buffer-bytes
+/// 8000000` one label-heavy buffer flushes at an eighth of that budget instead
+/// of filling past the whole of it and shedding every other tenant's write.
+#[tokio::test]
+async fn memory_backstop_tracks_the_configured_ceiling() {
+    // The corpus never approaches target_bytes on the object estimate here:
+    // four batches estimate 103_200 against the 262_144 target, so every flush
+    // this test sees is the backstop's.
+    assert_eq!(SMALL_CEILING / 8, 275_000);
+    assert!(
+        SMALL_CEILING / 8 > TARGET_BYTES as u64,
+        "an eighth of the ceiling, not the target_bytes floor, is the backstop here"
+    );
+    assert_eq!(
+        BATCHES_BELOW_BACKSTOP as u64 * PER_BATCH_BUFFERED,
+        211_800,
+        "three batches stay under the 275_000 backstop"
+    );
+    let held = BATCHES_TO_BACKSTOP as u64 * PER_BATCH_BUFFERED;
+    assert_eq!(held, 282_400, "the fourth batch crosses it");
+    assert!(
+        held < SMALL_CEILING,
+        "the flushing buffer holds {held} bytes, not the whole {SMALL_CEILING}-byte budget"
+    );
+    assert_eq!(
+        held - PER_BATCH_BUFFERED,
+        211_800,
+        "it crossed from within one write of an eighth of the budget"
+    );
+
+    let ceiling = IngestByteBudgetLimit::Bounded(SMALL_CEILING);
+    let (below, _) = run_batches_under_ceiling(BATCHES_BELOW_BACKSTOP, ceiling).await;
+    assert_eq!(below.flushes_by_size, 0);
+    assert_eq!(
+        below.flushes_manual, 1,
+        "three batches were still buffered when teardown flushed them"
+    );
+
+    let (crossing, _) = run_batches_under_ceiling(BATCHES_TO_BACKSTOP, ceiling).await;
+    assert_eq!(
+        crossing.flushes_by_size, 1,
+        "batch {BATCHES_TO_BACKSTOP} takes the buffer past an eighth of the configured ceiling"
+    );
+    assert_eq!(crossing.flushes_manual, 0);
+
+    // The same corpus against a ceiling large enough to earn the 64 MiB cap
+    // keeps buffering: the ceiling, not the corpus, is what moved the trigger.
+    let (roomy, _) = run_batches_under_ceiling(
+        BATCHES_TO_BACKSTOP,
+        IngestByteBudgetLimit::Bounded(512 * 1024 * 1024),
+    )
+    .await;
+    assert_eq!(
+        roomy.flushes_by_size, 0,
+        "an eighth of 512 MiB is 64 MiB, far above the {held} bytes this corpus holds"
+    );
+    assert_eq!(roomy.flushes_manual, 1);
+}
+
 /// The memory ceiling keeps charging `est_charge_bytes` while the trigger
 /// reads the object-bytes estimate: the gauge holds the conservative figure to
 /// the byte across the ten batches that stay under `target_bytes`, then
 /// refunds it when the shutdown flush completes.
+///
+/// That the trigger stays silent over these batches is pinned by
+/// `size_trigger_fires_on_object_bytes_not_buffered_bytes`, which reads its
+/// counters after a shutdown drain. Asserting it here would read the snapshot
+/// while the shard may not have drained its channel, so it would hold under
+/// the defect too.
 #[tokio::test]
 async fn memory_gauge_still_charges_the_conservative_estimate() {
     let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
@@ -225,11 +326,6 @@ async fn memory_gauge_still_charges_the_conservative_estimate() {
         write_batch(&router, &tenant, index).await;
     }
 
-    assert_eq!(
-        router.metrics().snapshot().flushes_by_size,
-        0,
-        "these ten batches stay under target_bytes on the object-bytes estimate"
-    );
     assert_eq!(
         budget.in_flight_bytes(),
         BATCHES_BELOW_TARGET as u64 * POINTS_PER_BATCH as u64 * PER_POINT_CHARGE,

--- a/crates/ravel-ingest/tests/flush_object_size.rs
+++ b/crates/ravel-ingest/tests/flush_object_size.rs
@@ -1,0 +1,245 @@
+//! The size trigger measures the bytes that reach the object, not the bytes
+//! the buffer holds (docs/ingest.md "Flush triggers").
+//!
+//! Two figures are derived from the same buffered points and they are not
+//! interchangeable. The memory ceiling (ADR-0069) charges
+//! `IngestPoint::est_charge_bytes`, which counts the in-memory `Label` struct
+//! headers so the process-wide gauge never undercounts what a buffer holds.
+//! The size trigger charges the object-bytes estimate, which counts only the
+//! payload a flush writes. Driving the trigger from the memory figure fires a
+//! flush at a fraction of `target_bytes`, which is what these tests pin.
+#![allow(clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use common::{TestClock, make_point, tenant};
+use ravel_ingest::{
+    IngestByteBudget, IngestByteBudgetLimit, IngestConfig, IngestMetricsSnapshot, IngestRouter,
+    WriteMode,
+};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectMeta, ObjectStoreBackend, list_all};
+use ravel_otlp::NormalizedPoint;
+use ravel_types::{Signal, TenantId};
+
+/// `target_bytes` for every test here. Small enough that a few thousand
+/// samples reach it, large enough that one batch is a fine-grained step.
+const TARGET_BYTES: usize = 256 * 1024;
+
+/// Distinct series per write, each carrying `SAMPLES_PER_SERIES` samples: the
+/// shape of one buffer window on a metrics tenant, where a scrape contributes
+/// a handful of samples to every series it covers.
+const SERIES_PER_BATCH: usize = 100;
+const SAMPLES_PER_SERIES: usize = 4;
+const POINTS_PER_BATCH: usize = SERIES_PER_BATCH * SAMPLES_PER_SERIES;
+
+/// Ten labels per series: `__name__="http_requests_total"` (8 + 19 bytes) plus
+/// `k0..k8` (2 bytes) each carrying a 13-byte value, so every series holds
+/// 27 + 9 * 15 = 162 bytes of label text.
+const LABELS_PER_SERIES: usize = 10;
+const LABEL_TEXT_BYTES: usize = 162;
+
+/// One point's charge against the memory ceiling, per
+/// `IngestPoint::est_charge_bytes`: 16 bytes for the sample, plus the 48-byte
+/// `Label` struct header for each of the ten labels, plus the label text.
+/// Labels are charged per point there because the estimate bounds what an
+/// admitted request holds before anything is deduplicated.
+const PER_POINT_CHARGE: u64 = 16 + 48 * LABELS_PER_SERIES as u64 + LABEL_TEXT_BYTES as u64;
+
+/// Batches that buffer without reaching `target_bytes`, and the one that
+/// reaches it. The object-bytes estimate charges 32 bytes plus the label text
+/// once per series (194) and 16 bytes per scalar sample, so a batch adds
+/// 100 * (194 + 4 * 16) = 25_800 bytes: ten batches reach 258_000, under the
+/// 262_144 target, and the eleventh crosses it. Hard-coded rather than
+/// computed so a change to either estimator breaks these tests instead of
+/// silently moving the flush point.
+const BATCHES_BELOW_TARGET: usize = 10;
+const TRIGGERING_BATCH: usize = BATCHES_BELOW_TARGET + 1;
+
+/// Pre-registered band for the flushed object, as a fraction of
+/// `target_bytes`. Upper edge 1.00: the object-bytes estimate is an upper
+/// bound on the stored payload, so an object above `target_bytes` means the
+/// estimate undercounted something the flush wrote. Lower edge 0.10: ADR-0092
+/// puts a merged run's representative cost at 2.50 to 3.00 bytes per sample
+/// against the 16 raw bytes this estimate charges, and the label dictionary
+/// compresses further, so an object below a tenth of the target means the
+/// trigger is firing on something other than payload size.
+const BAND_LOW: f64 = 0.10;
+const BAND_HIGH: f64 = 1.00;
+
+const BASE_TS_NS: i64 = 1_700_000_000_000_000_000;
+
+fn config() -> IngestConfig {
+    IngestConfig {
+        shard_count: 1,
+        target_bytes: TARGET_BYTES,
+        // Age can never fire: the injected clock never advances and both age
+        // thresholds sit an hour out, so every flush here is size-triggered.
+        max_flush_delay: Duration::from_secs(3600),
+        max_flush_delay_idle: Duration::from_secs(3600),
+        flush_tick: Duration::from_millis(20),
+        ..IngestConfig::default()
+    }
+}
+
+/// One batch of `SERIES_PER_BATCH` fresh series, `SAMPLES_PER_SERIES` samples
+/// each. Series are numbered globally so no two batches share one, matching a
+/// tenant whose series set turns over across buffer windows.
+fn batch(tenant: &TenantId, batch_index: usize) -> Vec<NormalizedPoint> {
+    let mut points = Vec::with_capacity(POINTS_PER_BATCH);
+    for series in 0..SERIES_PER_BATCH {
+        let series_index = batch_index * SERIES_PER_BATCH + series;
+        let pairs: Vec<(String, String)> = (0..LABELS_PER_SERIES - 1)
+            .map(|i| (format!("k{i}"), format!("instance-{series_index:04}")))
+            .collect();
+        let labels: Vec<(&str, &str)> = pairs
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        for sample in 0..SAMPLES_PER_SERIES {
+            // Millisecond jitter on a 15 s scrape interval: the ordinary
+            // shape, rather than the exactly-periodic best case.
+            let jitter_ms = ((series_index * 7 + sample * 13) % 200) as i64;
+            let ts_ns = BASE_TS_NS + sample as i64 * 15_000_000_000 + jitter_ms * 1_000_000;
+            let value = (series_index * 1_000 + sample * 7) as f64;
+            points.push(make_point(
+                tenant,
+                "http_requests_total",
+                &labels,
+                ts_ns,
+                value,
+            ));
+        }
+    }
+    points
+}
+
+async fn write_batch(router: &IngestRouter, tenant: &TenantId, index: usize) {
+    router
+        .write(
+            tenant.clone(),
+            batch(tenant, index),
+            WriteMode::Buffered,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("buffered write");
+}
+
+/// Writes `batches` batches into a fresh router, then shuts it down. Buffered
+/// writes return before the shard has merged them, so the counters are read
+/// after shutdown, which drains the shard's queue in order: a flush the
+/// corpus triggered is counted under its own trigger, and whatever is left
+/// buffered at teardown is counted as `flushes_manual`.
+async fn run_batches(batches: usize) -> (IngestMetricsSnapshot, Vec<ObjectMeta>) {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let clock = TestClock::new(BASE_TS_NS);
+    let router = IngestRouter::new(config(), Arc::clone(&store), Signal::Metrics, clock);
+    let tenant = tenant("acme");
+
+    for index in 0..batches {
+        write_batch(&router, &tenant, index).await;
+    }
+    // `shutdown` consumes the router, so the counters are read through a
+    // handle cloned out of it beforehand.
+    let metrics = router.metrics_handle();
+    router.shutdown().await;
+    let snapshot = metrics.snapshot();
+    let objects = list_all(store.as_ref(), "t/")
+        .await
+        .expect("list")
+        .into_iter()
+        .filter(|o| o.key.contains("/l0/"))
+        .collect();
+    (snapshot, objects)
+}
+
+/// The trigger fires on the batch that takes the object-bytes estimate past
+/// `target_bytes`, not on the far earlier batch that takes the memory estimate
+/// there. The same corpus charged the memory figure crosses 262_144 during
+/// batch 4 (each batch adds 100 * (480 + 162) label bytes and 400 * 16 sample
+/// bytes, so 70_600 per batch), which is the defect this pins.
+#[tokio::test]
+async fn size_trigger_fires_on_object_bytes_not_buffered_bytes() {
+    let (below, _) = run_batches(BATCHES_BELOW_TARGET).await;
+    assert_eq!(
+        below.flushes_by_size, 0,
+        "{BATCHES_BELOW_TARGET} batches hold the object-bytes estimate under target_bytes"
+    );
+    assert_eq!(
+        below.flushes_manual, 1,
+        "the whole corpus was still buffered when teardown flushed it"
+    );
+
+    let (crossing, _) = run_batches(TRIGGERING_BATCH).await;
+    assert_eq!(
+        crossing.flushes_by_size, 1,
+        "batch {TRIGGERING_BATCH} takes the object-bytes estimate past target_bytes"
+    );
+    assert_eq!(
+        crossing.flushes_manual, 0,
+        "that flush drained the buffer, so teardown had nothing left to write"
+    );
+    assert_eq!(crossing.flushes_by_age, 0);
+    assert_eq!(crossing.flushes_by_age_adaptive, 0);
+}
+
+/// The object that flush writes lands inside the pre-registered band of
+/// `target_bytes`, and it is the only data object the corpus produces.
+#[tokio::test]
+async fn size_flush_fills_the_object_toward_target_bytes() {
+    let (_, objects) = run_batches(TRIGGERING_BATCH).await;
+    assert_eq!(
+        objects.len(),
+        1,
+        "one size-triggered flush over {TRIGGERING_BATCH} batches wrote one object"
+    );
+
+    let size = objects[0].size;
+    let low = (TARGET_BYTES as f64 * BAND_LOW) as u64;
+    let high = (TARGET_BYTES as f64 * BAND_HIGH) as u64;
+    assert!(
+        size >= low && size <= high,
+        "flushed object is {size} bytes, outside the pre-registered band \
+         [{low}, {high}] ({BAND_LOW} to {BAND_HIGH} of target_bytes {TARGET_BYTES})"
+    );
+}
+
+/// The memory ceiling keeps charging `est_charge_bytes` while the trigger
+/// reads the object-bytes estimate: the gauge holds the conservative figure to
+/// the byte across the ten batches that stay under `target_bytes`, then
+/// refunds it when the shutdown flush completes.
+#[tokio::test]
+async fn memory_gauge_still_charges_the_conservative_estimate() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let clock = TestClock::new(BASE_TS_NS);
+    let budget = IngestByteBudget::shared(IngestByteBudgetLimit::Unlimited);
+    let router = IngestRouter::new(config(), Arc::clone(&store), Signal::Metrics, clock)
+        .with_budget(Arc::clone(&budget));
+    let tenant = tenant("acme");
+
+    for index in 0..BATCHES_BELOW_TARGET {
+        write_batch(&router, &tenant, index).await;
+    }
+
+    assert_eq!(
+        router.metrics().snapshot().flushes_by_size,
+        0,
+        "these ten batches stay under target_bytes on the object-bytes estimate"
+    );
+    assert_eq!(
+        budget.in_flight_bytes(),
+        BATCHES_BELOW_TARGET as u64 * POINTS_PER_BATCH as u64 * PER_POINT_CHARGE,
+        "the ceiling charges est_charge_bytes per point, unchanged by the trigger's estimate"
+    );
+
+    router.shutdown().await;
+    assert_eq!(
+        budget.in_flight_bytes(),
+        0,
+        "the flush that drained the buffer refunded every charged byte"
+    );
+}

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -165,22 +165,39 @@ Single task per shard. No locks on the hot path; all state actor-local:
 - `buf: HashMap<SeriesId, SeriesBuf { labels: LabelSet, samples: Vec<Sample> }>`
 - `exemplars: Vec<IngestExemplar>` in arrival order, one per exemplar the wire
   admitted for a series routed to this shard (ADR-0047)
-- `est_bytes`: running estimate (samples * 16 + label bytes on first sight,
-  plus the `IngestExemplar` struct width and its attribute bytes per buffered
-  exemplar). "Label bytes" means what the buffer holds, not what the object
-  will hold: each label costs `size_of::<Label>()` (two `String` headers, 48
-  bytes) plus its name and value bytes. Leaving the header term out
-  understates a ten-label series by roughly 480 bytes against the 200 it
-  counts, so both flush triggers and the process-wide budget below fire late
-  on exactly the label-heavy workloads they exist to bound.
+- `est_bytes`: running estimate of what the BUFFER holds (samples * 16 + label
+  bytes on first sight, plus the `IngestExemplar` struct width and its
+  attribute bytes per buffered exemplar). "Label bytes" means what the buffer
+  holds, not what the object will hold: each label costs `size_of::<Label>()`
+  (two `String` headers, 48 bytes) plus its name and value bytes. Leaving the
+  header term out understates a ten-label series by roughly 480 bytes against
+  the 200 it counts, so the process-wide memory budget below would fire late
+  on exactly the label-heavy workloads it exists to bound.
+- `flush_est_bytes`: running estimate of what the OBJECT will hold, the figure
+  the size trigger reads. Same points, different model: label and attribute
+  text once per series, no struct headers, 16 bytes per scalar sample, and a
+  per-series and per-record fixed term for the columns a writer always
+  emits. The two estimates are not interchangeable. On a ten-label series the
+  buffered figure is roughly 750 bytes per sample against the object figure's
+  16 to 210, so a size trigger reading `est_bytes` fires at a few percent of
+  `target_bytes` and writes objects that multiply the request cost of every
+  stored terabyte. The same split applies on all three signals
+  (`est_record_bytes`/`est_record_object_bytes` for logs,
+  `est_span_bytes`/`est_span_object_bytes` for spans).
 - `oldest_ns`: ingest-arrival time of the oldest buffered point
 - `waiters: Vec<oneshot::Sender<...>>` for strict-mode acks in this flush window
 - writer identity: (writer_id uuid, epoch, next_seq) owned by the process
 
 Loop over `select!`:
 - message received: merge points, push `ack` to waiters (strict) or reply
-  immediately (buffered), flush if `est_bytes >= target_bytes` (default
-  8 MiB). Before merging, each point's series_id is checked against the
+  immediately (buffered), flush if `flush_est_bytes >= target_bytes` (default
+  8 MiB), which is an estimate of the object this flush would write, not of
+  the memory the buffer holds. A memory backstop fires the same flush when
+  `est_bytes` reaches `max(64 MiB, target_bytes)`, so a tenant whose struct
+  headers dwarf its payload still flushes before one buffer can hold an
+  unbounded amount of resident memory; the process-wide ceiling below is the
+  admission-side bound and sheds rather than flushes, so it cannot stand in
+  for this one. Before merging, each point's series_id is checked against the
   canonical label set that id already claims in the buffer; a mismatch
   (hash collision) rejects the point with a typed error and increments
   the series_id_collisions counter instead of silently merging
@@ -188,11 +205,17 @@ Loop over `select!`:
 - flush tick (interval default 200 ms): flush if `oldest_ns` older than an
   age threshold, and buffer non-empty. The threshold is `max_flush_delay`
   (default 2 s) when the buffer has a strict-mode waiter or already holds
-  at least `min_flush_bytes` (default 256 KiB); otherwise the buffer is idle
+  at least `min_flush_bytes` (default 256 KiB) of object bytes, on the same
+  `flush_est_bytes` estimate the size trigger reads; otherwise the buffer is idle
   and the threshold is `max_flush_delay_idle` (default 40 s) instead
   (ADR-0051 section 7). Strict-mode ack latency is unaffected, since a
   strict write always leaves a waiter in the buffer for its whole flush
   window; only a low-volume buffered-mode tenant's PUT cadence changes.
+  ADR-0076 decision 4 sized this tier against a buffer fill rate stated in
+  buffered-memory units, so its worked example reaches `min_flush_bytes`
+  sooner than a buffer does today: the knob is unchanged, the unit it counts
+  is not. Reasoning about how long a tenant takes to reach either threshold
+  starts from the object-bytes model above.
 - channel closed (router dropped): flush the remaining buffer before
   exiting rather than discarding it; points that still fail to flush are
   counted, never silently lost. The drain (`flush_all`, shared with
@@ -585,7 +608,12 @@ Each ingest write charges its estimated buffered bytes into the gauge in the
 router's write path, after decode/normalize/admission and before any shard
 buffer is touched (`IngestPoint::est_charge_bytes`: 16 bytes per sample plus,
 per label, the `Label` struct header and the name/value bytes, plus each
-exemplar's buffered width). The log and span routers charge the same gauge with
+exemplar's buffered width). This ceiling is charged separately from the size
+trigger, which reads the object-bytes estimate described under "Shard actor";
+the two figures answer different questions (how much memory is held, versus
+how large an object a flush would write) and neither substitutes for the
+other. The charge here stays deliberately conservative: undercharging a
+memory ceiling is the unsafe direction. The log and span routers charge the same gauge with
 `est_record_bytes`/`est_span_bytes`, and those apply the identical per-attribute
 rule: each attribute costs its pair struct header (`(String, AttrValue)` for a
 log attribute, `(String, String)` for a span attribute, the latter byte-for-byte
@@ -841,10 +869,10 @@ carries max token per shard).
 |---|---|
 | shard_count | 4 (dev), scale with cores |
 | channel depth | 256 msgs |
-| target_bytes | 8 MiB |
+| target_bytes (object bytes, not buffered memory) | 8 MiB |
 | max_flush_delay | 2 s (`--max-flush-delay`) |
 | max_flush_delay_idle | 40 s (`--max-flush-delay-idle`) |
-| min_flush_bytes | 256 KiB (`--min-flush-bytes`) |
+| min_flush_bytes (object bytes, not buffered memory) | 256 KiB (`--min-flush-bytes`) |
 | put retry budget | 4 attempts, 100ms..2s jittered backoff |
 | max in-flight ingest requests (process-wide) | 1024 (`--max-inflight-ingest-requests`, 0 = unlimited) |
 | max ingest buffer bytes (process-wide, all signals) | 512 MiB (`--max-ingest-buffer-bytes`, 0 = unlimited) |

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -193,11 +193,19 @@ Loop over `select!`:
   immediately (buffered), flush if `flush_est_bytes >= target_bytes` (default
   8 MiB), which is an estimate of the object this flush would write, not of
   the memory the buffer holds. A memory backstop fires the same flush when
-  `est_bytes` reaches `max(64 MiB, target_bytes)`, so a tenant whose struct
-  headers dwarf its payload still flushes before one buffer can hold an
+  `est_bytes` reaches `max(target_bytes, min(64 MiB, ceiling / 8))`, where
+  `ceiling` is the configured `--max-ingest-buffer-bytes`, so a tenant whose
+  struct headers dwarf its payload still flushes before one buffer can hold an
   unbounded amount of resident memory; the process-wide ceiling below is the
   admission-side bound and sheds rather than flushes, so it cannot stand in
-  for this one. Before merging, each point's series_id is checked against the
+  for this one. The backstop is a share of the ceiling rather than a constant
+  because a constant calibrated against the default ceiling inverts on a
+  replica sized below it: one buffer would fill past the whole budget and shed
+  every other tenant's write, and shedding is what the backstop exists to
+  avoid. `--max-ingest-buffer-bytes 0` (unlimited) has no ceiling to take a
+  share of, so the 64 MiB cap applies alone. A ceiling under `8 *
+  target_bytes` leaves `target_bytes` as the backstop, because a backstop
+  under the target would become the effective size trigger. Before merging, each point's series_id is checked against the
   canonical label set that id already claims in the buffer; a mismatch
   (hash collision) rejects the point with a typed error and increments
   the series_id_collisions counter instead of silently merging
@@ -597,12 +605,21 @@ active-series-cap breach.
 
 ## Process-wide ingest buffer byte budget (ADR-0069)
 
-The per-(tenant, shard, signal) buffer cap (~`target_bytes`) bounds each
-tenant, but not their *sum*: a burst of active tenants can grow resident
-memory without any per-tenant limit tripping (ADR-0069). One process-wide
-atomic gauge (`ravel_ingest::IngestByteBudget`) bounds that sum. It is shared
-by `Arc` across the metrics, log, and span routers, so a single ceiling
-covers every signal.
+The per-(tenant, shard, signal) memory backstop described under "Shard actor"
+(`max(target_bytes, min(64 MiB, ceiling / 8))`) bounds each buffer, but not
+their *sum*: a burst of active tenants can grow resident memory without any
+per-tenant limit tripping (ADR-0069). One process-wide atomic gauge
+(`ravel_ingest::IngestByteBudget`) bounds that sum. It is shared by `Arc`
+across the metrics, log, and span routers, so a single ceiling covers every
+signal.
+
+The two are coupled in one direction: the backstop is derived from this
+ceiling, so lowering `--max-ingest-buffer-bytes` lowers the per-buffer bound
+with it and no single buffer can hold a large share of the budget. Sizing a
+replica therefore starts from the ceiling; the per-buffer bound follows. Note
+the worst case is stated over the backstop, not over `target_bytes`: the two
+differ by up to eightfold at the default sizing, so a formula using
+`target_bytes` under-provisions.
 
 Each ingest write charges its estimated buffered bytes into the gauge in the
 router's write path, after decode/normalize/admission and before any shard
@@ -870,6 +887,7 @@ carries max token per shard).
 | shard_count | 4 (dev), scale with cores |
 | channel depth | 256 msgs |
 | target_bytes (object bytes, not buffered memory) | 8 MiB |
+| per-buffer memory backstop (buffered memory, not object bytes) | `max(target_bytes, min(64 MiB, max ingest buffer bytes / 8))`, so 64 MiB at these defaults |
 | max_flush_delay | 2 s (`--max-flush-delay`) |
 | max_flush_delay_idle | 40 s (`--max-flush-delay-idle`) |
 | min_flush_bytes (object bytes, not buffered memory) | 256 KiB (`--min-flush-bytes`) |


### PR DESCRIPTION
The flush size trigger read the memory-ceiling estimator. est_charge_bytes
charges per sample what the buffer holds per series, which is right for
protecting the process memory ceiling and wrong for deciding how big an object
should be. For a ten-label series with short values it charges roughly 766
bytes per sample against a representative 2.50 to 3.00 bytes stored after
compaction, so a nominal 8 MiB target_bytes fired at a few hundred KB of real
data. Mean object size stayed in the tens of kilobytes, and request cost per
stored terabyte is set by mean object size.

This gives the size trigger its own estimator, counting the bytes the object
will actually store: payload text and sample data, with no struct headers,
since a Label header is memory the buffer holds and not a byte the object
writes. est_charge_bytes is untouched and still charges the memory ceiling.

The estimate is deliberately an upper bound on the bytes the flush writes. The
writer varint- and delta-encodes, interns labels and attribute keys, and
compresses blocks, all strictly below the raw counts here, so an object lands
at or under the configured target rather than over it. Under-filling is the
tolerable direction; overshooting the target is not.

Decoupling the trigger from memory removes what used to bound a label-heavy
tenant's buffer, so a memory backstop of max(64 MiB, target_bytes) fires the
flush on either condition. The process-wide admission ceiling could not stand
in for it: that sheds at admission rather than flushing.

All three shard actors and both log representations carried the same defect,
so the rule now lives in one shared function and the three cannot drift apart.

Refs: #1305

ADR-0069's Context states the per-(tenant, shard, signal) buffer cap as ~8 MiB
and derives a worst case of tenants x shards x signals x 8 MiB. That figure is
stale after this change: the per-buffer memory cap is now the backstop,
max(target_bytes, min(64 MiB, max_ingest_buffer_bytes / 8)), which is 64 MiB at
the shipped defaults. The ADR's conclusion is unaffected and in fact
strengthened, since the worst case remains unbounded in active-tenant count,
which is the reasoning that motivates the global gauge it decides on. An ADR is
an immutable record so it is not edited here; the amendment is tracked as a
deliberate follow-up in #1635, along with the point that the cap is now derived
from the configured ceiling rather than being a constant.
