### PR TITLE
ci: pull MinIO from quay.io instead of Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -793,11 +793,14 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Start MinIO
         run: |
+          # Docker Hub's anonymous pull allowance is per-IP and shared across
+          # every project on a runner, so an unauthenticated pull there fails
+          # unpredictably; quay.io does not share that allowance.
           docker run -d --name minio \
             -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:latest server /data
+            quay.io/minio/minio:latest server /data
       - name: Wait for MinIO to be live
         run: |
           for _ in $(seq 1 30); do
@@ -812,7 +815,10 @@ jobs:
           exit 1
       - name: Create the contract-suite bucket
         run: |
-          docker run --rm --network host --entrypoint sh minio/mc:latest -c "
+          # Docker Hub's anonymous pull allowance is per-IP and shared across
+          # every project on a runner, so an unauthenticated pull there fails
+          # unpredictably; quay.io does not share that allowance.
+          docker run --rm --network host --entrypoint sh quay.io/minio/mc:latest -c "
             mc alias set local http://localhost:9000 minioadmin minioadmin &&
             mc mb -p local/ravel-object-store-test"
       # The contract suite's S3/MinIO case is gated on RAVEL_MINIO_URL; set it
@@ -966,11 +972,14 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Start MinIO
         run: |
+          # Docker Hub's anonymous pull allowance is per-IP and shared across
+          # every project on a runner, so an unauthenticated pull there fails
+          # unpredictably; quay.io does not share that allowance.
           docker run -d --name minio \
             -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:latest server /data
+            quay.io/minio/minio:latest server /data
       - name: Wait for MinIO to be live
         run: |
           for _ in $(seq 1 30); do
@@ -985,7 +994,10 @@ jobs:
           exit 1
       - name: Create the bench-smoke bucket
         run: |
-          docker run --rm --network host --entrypoint sh minio/mc:latest -c "
+          # Docker Hub's anonymous pull allowance is per-IP and shared across
+          # every project on a runner, so an unauthenticated pull there fails
+          # unpredictably; quay.io does not share that allowance.
+          docker run --rm --network host --entrypoint sh quay.io/minio/mc:latest -c "
             mc alias set local http://localhost:9000 minioadmin minioadmin &&
             mc mb -p local/ravel-object-store-test"
       # minio_ingest_read_smoke is gated on RAVEL_MINIO_URL, same convention


### PR DESCRIPTION
The object-store-contract and bench-smoke jobs pull minio/minio and
minio/mc with no authentication, and both are failing at the Start MinIO
step:

    docker: Error response from daemon: pull access denied for minio/minio,
    repository does not exist or may require 'docker login': denied:
    requested access to the resource is denied

The image is public. That message is how Docker Hub reports an exhausted
anonymous pull allowance, which is scoped by source IP and shared with every
other project on the runner, so whether a job fails depends on which runner it
lands on.

This is currently failing on main, not only on pull requests: the 19:31 run on
2026-09-11 failed both jobs, while the 13:24 and 11:36 runs passed. A rerun did
not clear it, so the allowance is spent rather than momentarily unlucky. Both
jobs are required checks, so this blocks every merge.

MinIO publishes the same images to quay.io, which does not share that
allowance and needs no credential. Both repositories and the latest tag on each
were checked before this change. All four pulls are repointed there, two per
job: the server container and the mc client that provisions the bucket.

The tag stays latest. Pinning to a specific RELEASE tag is worth doing and is
recorded on the issue, but it changes which MinIO version the tests run
against, so it belongs in its own change. This one swaps the registry and
nothing else, so if it does not fix the failure there is no second variable to
rule out.

No docker login, no retry loop, no mirror, and no new secret: those were the
alternatives considered, and each keeps a dependency this removes outright.

No local gate compiles .github/workflows/, so this is verified only by the
Actions run on this PR. The two jobs it targets are the evidence.

Refs: #1645
