### PR TITLE
ci: repoint the nightly MinIO pulls at quay.io and dedup the rationale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -740,9 +740,7 @@ jobs:
           exit 1
       - name: Create the contract-suite bucket
         run: |
-          # Docker Hub's anonymous pull allowance is per-IP and shared across
-          # every project on a runner, so an unauthenticated pull there fails
-          # unpredictably; quay.io does not share that allowance.
+          # quay.io rationale: see this job's "Start MinIO" step above.
           docker run --rm --network host --entrypoint sh quay.io/minio/mc:latest -c "
             mc alias set local http://localhost:9000 minioadmin minioadmin &&
             mc mb -p local/ravel-object-store-test"
@@ -887,9 +885,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Start MinIO
         run: |
-          # Docker Hub's anonymous pull allowance is per-IP and shared across
-          # every project on a runner, so an unauthenticated pull there fails
-          # unpredictably; quay.io does not share that allowance.
+          # quay.io rationale: see object-store-contract's "Start MinIO" step.
           docker run -d --name minio \
             -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
@@ -909,9 +905,7 @@ jobs:
           exit 1
       - name: Create the bench-smoke bucket
         run: |
-          # Docker Hub's anonymous pull allowance is per-IP and shared across
-          # every project on a runner, so an unauthenticated pull there fails
-          # unpredictably; quay.io does not share that allowance.
+          # quay.io rationale: see object-store-contract's "Start MinIO" step.
           docker run --rm --network host --entrypoint sh quay.io/minio/mc:latest -c "
             mc alias set local http://localhost:9000 minioadmin minioadmin &&
             mc mb -p local/ravel-object-store-test"

--- a/.github/workflows/metricsbench-nightly.yml
+++ b/.github/workflows/metricsbench-nightly.yml
@@ -61,7 +61,7 @@ jobs:
             -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e server /data
+            quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e server /data
       - name: Wait for MinIO to be live
         run: |
           for _ in $(seq 1 30); do
@@ -77,7 +77,7 @@ jobs:
       - name: Create the MetricsBench bucket
         run: |
           docker run --rm --network host --entrypoint sh \
-            minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727 -c "
+            quay.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727 -c "
             mc alias set local http://localhost:9000 minioadmin minioadmin &&
             mc mb -p local/metricsbench"
       - name: Run the MetricsBench ci profile against MinIO

--- a/.github/workflows/metricsbench-nightly.yml
+++ b/.github/workflows/metricsbench-nightly.yml
@@ -57,6 +57,8 @@ jobs:
             --bin metricsbench_ingest --bin metricsbench_report
       - name: Start MinIO
         run: |
+          # quay.io rather than Docker Hub: rationale on ci.yml's
+          # object-store-contract "Start MinIO" step.
           docker run -d --name minio \
             -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin \


### PR DESCRIPTION
Follow-up to the change that moved the two required CI jobs off Docker Hub.
Both items came from review of that PR.

metricsbench-nightly.yml still pulled minio/minio and minio/mc from Docker
Hub, so it carried the same anonymous-pull-allowance exhaustion that took
main red: the allowance is scoped by source IP and shared with every other
project on the runner, and Docker Hub reports it as "pull access denied" for
an image that is public. The nightly is not a required check, so it would
have failed quietly rather than blocking a merge.

Both pulls are digest-pinned, and the pins are unchanged. The review of the
earlier fix expected a registry swap here would need the digest re-resolved.
It does not: quay.io serves both manifests under the identical digest, which
was checked before the change.

    GET https://quay.io/v2/minio/minio/manifests/sha256:14cea493...  200
    GET https://quay.io/v2/minio/mc/manifests/sha256:a7fe349e...     200

A digest is content-addressed, so the same digest on another host is the same
image. The pin is preserved rather than weakened, and the two digests are
byte-identical to what was there before.

The second commit removes three of the four copies of the rationale comment
the earlier fix left in ci.yml. Four copies are four sync obligations in a
repo that treats a stale doc as a bug, so the explanation now appears once on
the first Start MinIO step.

After this, no workflow under .github/ pulls a MinIO image from Docker Hub.

No local gate compiles .github/workflows/, so the nightly's own next run is
the verification for the first commit.

Refs: #1645
