### PR TITLE
docs(fleet): move executor gate logs into the checkout and record the amd64 executor class

### DIFF
--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -97,10 +97,15 @@ Gates: format and lint IN PLACE before the commit you will gate -- run
 `cargo fmt --all` (not just --check) and, where it applies, scoped
 `cargo clippy --fix -p <crate>` -- then verify with `cargo fmt --all
 --check`; cargo clippy --workspace --all-targets -- -D warnings;
-scripts/affected-tests.sh -p <crate> [-p <crate2>]. Pass `--jobs 4` on
-the amd64 executor class and `--jobs 2` on the arm64 (Pi) class when you
-invoke cargo directly; `scripts/gates.sh` caps build jobs on an 8 GB host
-automatically, so this only matters for hand-run cargo commands. Do NOT run
+scripts/affected-tests.sh -p <crate> [-p <crate2>]. Cap cargo's build
+parallelism through the environment, not a flag, because
+`scripts/affected-tests.sh` accepts no `--jobs` and runs cargo at the
+default otherwise: find your executor class with `uname -m` and `nproc`
+(x86_64 with 16 cores is the amd64 class, aarch64 with 4 cores is the
+arm64 Pi class), then prefix every cargo command and every script that
+runs cargo with `CARGO_BUILD_JOBS=4` on amd64 or `CARGO_BUILD_JOBS=2` on
+arm64. `scripts/gates.sh` caps jobs on an 8 GB host by itself; nothing
+else does. Do NOT run
 `cargo test --workspace`: full-workspace tests are verified at merge
 time (verify-dispatch cold gate and PR CI); your job is the blast
 radius of your own change, and affected-tests.sh computes it (the
@@ -118,12 +123,14 @@ Where that file goes is itself a rule, because both wrong answers have
 already cost a task. Run this first, as ONE command, substituting
 nothing:
 
-    mkdir -p .gate-logs && grep -qxF '.gate-logs/' .git/info/exclude || echo '.gate-logs/' >> .git/info/exclude; scripts/guards/check-disk-headroom.sh .gate-logs 5 && df -h /tmp . "$HOME"
+    mkdir -p .gate-logs && git check-ignore -q .gate-logs && scripts/guards/check-disk-headroom.sh .gate-logs 5 && df -h /tmp . "$HOME"
 
-One command because each tool call is its own shell: a variable set in
-one call is empty in the next, which is why this rule fixes the log
-path as literal text instead of building it from `$HOME` or the
-checkout's basename.
+Every step is joined with `&&` so a failure anywhere fails the command:
+`git check-ignore -q .gate-logs` proves the tracked `.gitignore` covers
+the directory before a single log is written there. The path is literal
+text rather than built from `$HOME` or the checkout's basename because
+each tool call is its own shell and a variable set in one call is empty
+in the next.
 
 If the guard exits non-zero, say so in your report and stop rather than
 picking another directory: a host without 5 GB for a log has no room for
@@ -136,13 +143,13 @@ before any gate runs, and three tasks died exactly that way on
 2026-09-12. `/tmp` is the harness's own capture filesystem (issue
 #1526): a run that fills it fails every later Bash call, including
 `true` and `df`, while the host's own disk figures still look healthy.
-Inside the checkout is the only volume with room on that class.
-`.git/info/exclude` is never tracked, so listing `.gate-logs/` there
-keeps the harness's commit-on-death `git add -A` from sweeping the logs
-into a wip commit that the merge script would then fold forward into
-the PR; do not use `.gitignore` for this, since that file is a tracked
-change this task does not own. Quote all three `df` lines (`/tmp`, `.`,
-and `"$HOME"`) in your report.
+Inside the checkout is the only volume with room on that class. The
+repository's tracked `.gitignore` lists `.gate-logs/` and `.dd-tools/`
+(the latter for any `cargo install --root "$PWD/.dd-tools"` tree), next
+to the disk-watchdog marker it already ignores for the same reason: the
+harness's commit-on-death `git add -A` must not sweep them into a wip
+commit that the merge script would then fold forward into the PR. Quote
+all three `df` lines (`/tmp`, `.`, and `"$HOME"`) in your report.
 `CLAUDE_CODE_TMPDIR` is NOT the executor's lever: the harness reads it
 when it creates the per-call capture directory, before the task's first
 Bash call, so exporting it from inside a task changes nothing. Setting it
@@ -178,8 +185,8 @@ commit:
   flipped line in your report. A test that cannot fail proves nothing.
 - **Stray files**: nothing staged that the deliverables do not name
   (scratch scripts, logs, `__pycache__/`, editor droppings). `.gate-logs/`
-  is excluded via `.git/info/exclude`, not `.gitignore`; it must never be
-  force-added (`git add -f`) into a commit.
+  and `.dd-tools/` are covered by the tracked `.gitignore`; never
+  force-add them (`git add -f`) into a commit.
 
 ## Commit before the slow gates, not after
 
@@ -230,7 +237,9 @@ the second survives a kill mid-build.
 
 The Gates template scopes executor tests with affected-tests.sh on
 purpose. A fleet task used to end with `cargo test --workspace` on an
-8 GB 4-core host: 1-2 hours of cold compile and test time per task,
+8 GB 4-core host (the arm64 Pi class; the 16 vCPU amd64 class is roughly
+four times faster, so size by the slower class): 1-2 hours of cold
+compile and test time per task,
 almost all of it re-verifying crates the change cannot affect, and all
 of it re-verified anyway at merge (the orchestrator's cold
 verify-dispatch run and the PR's required CI checks are the trust

--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -97,7 +97,10 @@ Gates: format and lint IN PLACE before the commit you will gate -- run
 `cargo fmt --all` (not just --check) and, where it applies, scoped
 `cargo clippy --fix -p <crate>` -- then verify with `cargo fmt --all
 --check`; cargo clippy --workspace --all-targets -- -D warnings;
-scripts/affected-tests.sh -p <crate> [-p <crate2>]. Do NOT run
+scripts/affected-tests.sh -p <crate> [-p <crate2>]. Pass `--jobs 4` on
+the amd64 executor class and `--jobs 2` on the arm64 (Pi) class when you
+invoke cargo directly; `scripts/gates.sh` caps build jobs on an 8 GB host
+automatically, so this only matters for hand-run cargo commands. Do NOT run
 `cargo test --workspace`: full-workspace tests are verified at merge
 time (verify-dispatch cold gate and PR CI); your job is the blast
 radius of your own change, and affected-tests.sh computes it (the
@@ -115,39 +118,31 @@ Where that file goes is itself a rule, because both wrong answers have
 already cost a task. Run this first, as ONE command, substituting
 nothing:
 
-    LOGDIR="$HOME/gate-logs/$(basename "$PWD")" && mkdir -p "$LOGDIR" &&
-      scripts/guards/check-disk-headroom.sh "$LOGDIR" 5 && df -h /tmp "$LOGDIR"
+    mkdir -p .gate-logs && grep -qxF '.gate-logs/' .git/info/exclude || echo '.gate-logs/' >> .git/info/exclude; scripts/guards/check-disk-headroom.sh .gate-logs 5 && df -h /tmp . "$HOME"
 
-One command because each tool call is its own shell: `LOGDIR` set in one
-call is empty in the next, and the guard was reached with an empty first
-argument, which it read as "no argument" and answered about the current
-directory instead. It now refuses an empty argument, so the split
-version fails loudly rather than passing about the wrong volume, but the
-single command is what you run.
+One command because each tool call is its own shell: a variable set in
+one call is empty in the next, which is why this rule fixes the log
+path as literal text instead of building it from `$HOME` or the
+checkout's basename.
 
 If the guard exits non-zero, say so in your report and stop rather than
 picking another directory: a host without 5 GB for a log has no room for
 the gate either, and the run would die mid-link with a fake compiler
-error. Then redirect every long gate to
-`"$HOME/gate-logs/$(basename "$PWD")/<step>.log"`, spelled out in full
-each time for the same reason: nothing carries over between calls.
-The two constraints that path satisfies, both of which have cost a task:
-it is outside the git checkout, and it is not under `/tmp`. Inside the
-checkout, the harness's commit-on-death runs `git add -A`, so a killed
-task sweeps the log into a wip commit and the merge script folds it
-forward into the PR; `.gitignore` carries no `*.log`, and the executor's
-own stray-files self-check below cannot see a commit the harness makes.
-It is also per-task by construction, since the basename of the checkout
-carries the task id, which matters because several tasks can share a
-host. Under `/tmp`, the evidence says the harness's capture filesystem
-lives there rather than on the host disk: issue #1526 records the error
-(`the temp filesystem at /tmp/claude-996/... is full (0MB free)`) and
-`df -h /` reporting 56 GB available at the start of that same run. Once
-it fills, every Bash call fails with ENOSPC, including `true` and `df`,
-so the task cannot run a command to diagnose itself while the host's own
-disk figures look healthy. That is why `df -h /tmp` is in the block
-above: no run has yet captured it on an executor, and the next incident
-needs the datum this one lacked. Quote both `df` lines in your report.
+error. Then redirect every long gate to `.gate-logs/<step>.log`.
+
+HOME on the amd64 executor class is a 1 GB tmpfs: pointing the log
+directory there makes the disk-headroom guard report 0 GB free and fail
+before any gate runs, and three tasks died exactly that way on
+2026-09-12. `/tmp` is the harness's own capture filesystem (issue
+#1526): a run that fills it fails every later Bash call, including
+`true` and `df`, while the host's own disk figures still look healthy.
+Inside the checkout is the only volume with room on that class.
+`.git/info/exclude` is never tracked, so listing `.gate-logs/` there
+keeps the harness's commit-on-death `git add -A` from sweeping the logs
+into a wip commit that the merge script would then fold forward into
+the PR; do not use `.gitignore` for this, since that file is a tracked
+change this task does not own. Quote all three `df` lines (`/tmp`, `.`,
+and `"$HOME"`) in your report.
 `CLAUDE_CODE_TMPDIR` is NOT the executor's lever: the harness reads it
 when it creates the per-call capture directory, before the task's first
 Bash call, so exporting it from inside a task changes nothing. Setting it
@@ -182,7 +177,9 @@ commit:
   demonstrate the new test failing against the pre-fix code and name the
   flipped line in your report. A test that cannot fail proves nothing.
 - **Stray files**: nothing staged that the deliverables do not name
-  (scratch scripts, logs, `__pycache__/`, editor droppings).
+  (scratch scripts, logs, `__pycache__/`, editor droppings). `.gate-logs/`
+  is excluded via `.git/info/exclude`, not `.gitignore`; it must never be
+  force-added (`git add -f`) into a commit.
 
 ## Commit before the slow gates, not after
 
@@ -337,6 +334,13 @@ if it is missing?
   holds both for the full duration. Dispatch the doc task in parallel,
   dependent only on the design decision (the ADR), not on the code
   landing. Merge order handles any cross-references.
+
+fleet-cp rejects any spec whose text contains a dollar-paren command
+substitution (`$(...)`) or a backtick command substitution with `400 bad
+request: spec contains an unexpanded shell substitution`. Write every
+path in a spec as fixed text, never built from a substitution at
+dispatch time. This is why the Gates template's log-directory command
+above uses a literal `.gate-logs` instead of computing a path.
 
 ## Before dispatch: two mechanical preflights
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ graft/
 # The disk watchdog drops this in the scope directory when it fires; the
 # harness commit-on-death sweeps an unignored file into a wip commit.
 .disk-watchdog-fired
+# Fleet executors write gate logs and any cargo-install tree inside the
+# checkout, because $HOME on the amd64 executor class is a 1 GB tmpfs and
+# /tmp is the harness capture filesystem. Ignored for the same reason as
+# the watchdog marker above: commit-on-death must not sweep them in.
+.gate-logs/
+.dd-tools/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,16 +577,19 @@ into a false green. When you write or edit any such script:
 Facts about the dispatched clone that executors have re-derived by trial
 and error, one wasted turn (or one lost result) at a time:
 
-- Two executor classes exist. The amd64 class (label `arch=amd64`) has 16
-  vCPU, 30 GB RAM, and about 350 GB free on the root volume, but HOME is
-  a 1 GB tmpfs: never write logs or `cargo install` output under HOME on
-  this class, and use `--root "$PWD/.dd-tools"` style paths inside the
-  checkout for any tool install. The arm64 Pi class has 4 cores and 8 GB
-  RAM; keep `--jobs 2` there. See "Long commands and the Bash tool" above
-  for the `timeout` and `--jobs` consequences on the Pi class.
-- Gate logs go to `.gate-logs/` inside the checkout, excluded through
-  `.git/info/exclude` (never `.gitignore`, which would be a tracked
-  change), for the reasons stated in the fleet-task-spec skill.
+- Two executor classes exist; tell them apart with `uname -m` and
+  `nproc`. The amd64 class (label `arch=amd64`, x86_64, 16 vCPU, 30 GB
+  RAM, about 350 GB free on the root volume) has a 1 GB tmpfs as HOME:
+  never write logs or `cargo install` output under HOME there; install
+  tools with `--root "$PWD/.dd-tools"`. The arm64 Pi class (aarch64, 4
+  cores, 8 GB RAM) needs `CARGO_BUILD_JOBS=2` on every cargo command and
+  on every script that runs cargo (`scripts/affected-tests.sh` takes no
+  jobs flag); use `CARGO_BUILD_JOBS=4` on amd64. See "Long commands and
+  the Bash tool" above for the `timeout` consequences.
+- Gate logs go to `.gate-logs/` inside the checkout. The tracked
+  `.gitignore` covers `.gate-logs/` and `.dd-tools/` so the harness's
+  commit-on-death cannot sweep them into a wip commit; the fleet-task-spec
+  skill's setup command checks that with `git check-ignore` first.
 - fleet-cp rejects any dispatch spec whose text contains a dollar-paren
   command substitution or a backtick substitution with `400 bad request`.
   Write every path in a spec as fixed text.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,8 +577,19 @@ into a false green. When you write or edit any such script:
 Facts about the dispatched clone that executors have re-derived by trial
 and error, one wasted turn (or one lost result) at a time:
 
-- The host has 8 GB RAM and 4 cores. See "Long commands and the Bash
-  tool" above for the `timeout` and `--jobs` consequences.
+- Two executor classes exist. The amd64 class (label `arch=amd64`) has 16
+  vCPU, 30 GB RAM, and about 350 GB free on the root volume, but HOME is
+  a 1 GB tmpfs: never write logs or `cargo install` output under HOME on
+  this class, and use `--root "$PWD/.dd-tools"` style paths inside the
+  checkout for any tool install. The arm64 Pi class has 4 cores and 8 GB
+  RAM; keep `--jobs 2` there. See "Long commands and the Bash tool" above
+  for the `timeout` and `--jobs` consequences on the Pi class.
+- Gate logs go to `.gate-logs/` inside the checkout, excluded through
+  `.git/info/exclude` (never `.gitignore`, which would be a tracked
+  change), for the reasons stated in the fleet-task-spec skill.
+- fleet-cp rejects any dispatch spec whose text contains a dollar-paren
+  command substitution or a backtick substitution with `400 bad request`.
+  Write every path in a spec as fixed text.
 - Fresh clones may carry no git identity, and the first `git commit -s`
   fails with "unable to auto-detect email address". Before your first
   commit, run: `git config user.email "fleet-executor@nofire.ai" &&


### PR DESCRIPTION
The fleet-task-spec template sent gate logs to HOME/gate-logs. On the amd64 executors HOME is a 1 GB tmpfs, so the disk-headroom guard fails at 0 GB before any gate runs; three read-only gate tasks died that way on 2026-09-12 before a single cargo command ran.

Logs now go to .gate-logs/ inside the checkout. The tracked .gitignore lists .gate-logs/ and .dd-tools/ (any cargo install --root tree) next to the disk-watchdog marker it already ignores for the same reason, so the harness's commit-on-death git add -A cannot sweep them into a wip commit; the executor setup command asserts this with git check-ignore before writing a log, with every step joined by && so any failure fails the command.

fleet-cp also rejects specs containing a dollar-paren substitution with HTTP 400, so the template no longer derives the log path from the basename of PWD. Executors cap cargo parallelism with CARGO_BUILD_JOBS (4 on amd64, 2 on the arm64 Pi class) because scripts/affected-tests.sh takes no jobs flag, and identify their class with uname -m and nproc. CLAUDE.md's executor facts describe both classes instead of only the 8 GB Pi class, and the task sizing paragraph names the class its figure describes.

Docs-only change plus two .gitignore entries; local gate scoped to one crate.

Refs: #1526

https://claude.ai/code/session_01Xf5UXqVewvzFpkgb1ug3h5
